### PR TITLE
[KVM] Enable PVLAN support on L2 networks

### DIFF
--- a/agent/src/main/java/com/cloud/agent/Agent.java
+++ b/agent/src/main/java/com/cloud/agent/Agent.java
@@ -811,7 +811,10 @@ public class Agent implements HandlerFactory, IAgentControl {
     public void processReadyCommand(final Command cmd) {
         final ReadyCommand ready = (ReadyCommand)cmd;
         // Set human readable sizes;
-        NumbersUtil.enableHumanReadableSizes = ready.getEnableHumanReadableSizes();
+        Boolean humanReadable = ready.getEnableHumanReadableSizes();
+        if (humanReadable != null){
+            NumbersUtil.enableHumanReadableSizes = humanReadable;
+        }
 
         s_logger.info("Processing agent ready command, agent id = " + ready.getHostId());
         if (ready.getHostId() != null) {

--- a/api/src/main/java/com/cloud/agent/api/PvlanSetupCommand.java
+++ b/api/src/main/java/com/cloud/agent/api/PvlanSetupCommand.java
@@ -34,6 +34,7 @@ public class PvlanSetupCommand extends Command {
     private String dhcpIp;
     private Type type;
     private String networkTag;
+    private String pvlanType;
 
     protected PvlanSetupCommand() {
     }
@@ -43,6 +44,7 @@ public class PvlanSetupCommand extends Command {
         this.op = op;
         this.primary = NetUtils.getPrimaryPvlanFromUri(uri);
         this.isolated = NetUtils.getIsolatedPvlanFromUri(uri);
+        this.pvlanType = NetUtils.getPvlanTypeFromUri(uri);
         this.networkTag = networkTag;
     }
 
@@ -115,5 +117,9 @@ public class PvlanSetupCommand extends Command {
 
     public String getNetworkTag() {
         return networkTag;
+    }
+
+    public String getPvlanType() {
+        return pvlanType;
     }
 }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3756,6 +3756,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             try {
                 result = plugNic(network, nicTO, vmTO, context, dest);
                 if (result) {
+                    _userVmMgr.setupVmForPvlan(true, vm.getHostId(), nic);
                     s_logger.debug("Nic is plugged successfully for vm " + vm + " in network " + network + ". Vm  is a part of network now");
                     final long isDefault = nic.isDefaultNic() ? 1 : 0;
                     // insert nic's Id into DB as resource_name
@@ -3863,6 +3864,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             s_logger.debug("Un-plugging nic " + nic + " for vm " + vm + " from network " + network);
             final boolean result = unplugNic(network, nicTO, vmTO, context, dest);
             if (result) {
+                _userVmMgr.setupVmForPvlan(false, vm.getHostId(), nicProfile);
                 s_logger.debug("Nic is unplugged successfully for vm " + vm + " in network " + network);
                 final long isDefault = nic.isDefaultNic() ? 1 : 0;
                 UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NETWORK_OFFERING_REMOVE, vm.getAccountId(), vm.getDataCenterId(), vm.getId(),

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2498,6 +2498,12 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                         } else {
                             uri = BroadcastDomainType.fromString(vlanIdFinal);
                         }
+
+                        if (_networksDao.listByPhysicalNetworkPvlan(physicalNetworkId, uri.toString()).size() > 0) {
+                            throw new InvalidParameterValueException("Network with vlan " + vlanIdFinal +
+                                " already exists or overlaps with other network pvlans in zone " + zoneId);
+                        }
+
                         userNetwork.setBroadcastUri(uri);
                         if (!vlanIdFinal.equalsIgnoreCase(Vlan.UNTAGGED)) {
                             userNetwork.setBroadcastDomainType(BroadcastDomainType.Vlan);

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2508,7 +2508,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                         if (vlanIdFinal.equalsIgnoreCase(Vlan.UNTAGGED)) {
                             throw new InvalidParameterValueException("Cannot support pvlan with untagged primary vlan!");
                         }
-                        URI uri = NetUtils.generateUriForPvlan(vlanIdFinal, isolatedPvlan);
+                        URI uri = NetUtils.generateUriForPvlan(vlanIdFinal, isolatedPvlan, isolatedPvlanType.toString());
                         if (_networksDao.listByPhysicalNetworkPvlan(physicalNetworkId, uri.toString(), isolatedPvlanType).size() > 0) {
                             throw new InvalidParameterValueException("Network with primary vlan " + vlanIdFinal +
                                     " and secondary vlan " + isolatedPvlan + " type " + isolatedPvlanType +

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDao.java
@@ -126,4 +126,6 @@ public interface NetworkDao extends GenericDao<NetworkVO, Long>, StateDao<State,
     List<NetworkVO> listByAccountIdNetworkName(long accountId, String name);
 
     List<NetworkVO> listByPhysicalNetworkPvlan(long physicalNetworkId, String broadcastUri, Network.PVlanType pVlanType);
+
+    List<NetworkVO> listByPhysicalNetworkPvlan(long physicalNetworkId, String broadcastUri);
 }

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
@@ -740,6 +740,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
      *      - The requested exact PVLAN pair exists
      *      - The requested secondary VLAN ID is secondary VLAN ID of an existing PVLAN pair
      *      - The requested secondary VLAN ID is primary VLAN ID of an existing PVLAN pair
+     *      - The requested primary VLAN ID is secondary VLAN ID of an existing PVLAN pair
      */
     protected boolean isNetworkOverlappingRequestedPvlan(Integer existingPrimaryVlan, Integer existingSecondaryVlan, Network.PVlanType existingPvlanType,
                                                          Integer requestedPrimaryVlan, Integer requestedSecondaryVlan, Network.PVlanType requestedPvlanType) {
@@ -749,6 +750,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
         }
         boolean exactMatch = existingPrimaryVlan.equals(requestedPrimaryVlan) && existingSecondaryVlan.equals(requestedSecondaryVlan);
         boolean secondaryVlanUsed = requestedPvlanType != Network.PVlanType.Promiscuous && requestedSecondaryVlan.equals(existingPrimaryVlan) || requestedSecondaryVlan.equals(existingSecondaryVlan);
+        boolean primaryVlanUsed = existingPvlanType != Network.PVlanType.Promiscuous && requestedPrimaryVlan.equals(existingSecondaryVlan);
         boolean isolatedMax = false;
         boolean promiscuousMax = false;
         if (requestedPvlanType == Network.PVlanType.Isolated && existingPrimaryVlan.equals(requestedPrimaryVlan) && existingPvlanType.equals(Network.PVlanType.Isolated)) {
@@ -756,7 +758,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
         } else if (requestedPvlanType == Network.PVlanType.Promiscuous && existingPrimaryVlan.equals(requestedPrimaryVlan) && existingPvlanType == Network.PVlanType.Promiscuous) {
             promiscuousMax = true;
         }
-        return exactMatch || secondaryVlanUsed || isolatedMax || promiscuousMax;
+        return exactMatch || secondaryVlanUsed || primaryVlanUsed || isolatedMax || promiscuousMax;
     }
 
     protected Network.PVlanType getNetworkPvlanType(long networkId, List<Integer> existingPvlan) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -798,14 +798,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             throw new ConfigurationException("Unable to find the router_proxy.sh");
         }
 
-        _ovsPvlanDhcpHostPath = Script.findScript(networkScriptsDir, "ovs-pvlan-dhcp-host.sh");
+        _ovsPvlanDhcpHostPath = Script.findScript(networkScriptsDir, "ovs-pvlan-kvm-dhcp-host.sh");
         if (_ovsPvlanDhcpHostPath == null) {
-            throw new ConfigurationException("Unable to find the ovs-pvlan-dhcp-host.sh");
+            throw new ConfigurationException("Unable to find the ovs-pvlan-kvm-dhcp-host.sh");
         }
 
         _ovsPvlanVmPath = Script.findScript(networkScriptsDir, "ovs-pvlan-kvm-vm.sh");
         if (_ovsPvlanVmPath == null) {
-            throw new ConfigurationException("Unable to find the ovs-pvlan-vm.sh");
+            throw new ConfigurationException("Unable to find the ovs-pvlan-kvm-vm.sh");
         }
 
         String value = (String)params.get("developer");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -803,7 +803,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             throw new ConfigurationException("Unable to find the ovs-pvlan-dhcp-host.sh");
         }
 
-        _ovsPvlanVmPath = Script.findScript(networkScriptsDir, "ovs-pvlan-vm.sh");
+        _ovsPvlanVmPath = Script.findScript(networkScriptsDir, "ovs-pvlan-kvm-vm.sh");
         if (_ovsPvlanVmPath == null) {
             throw new ConfigurationException("Unable to find the ovs-pvlan-vm.sh");
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPvlanSetupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPvlanSetupCommandWrapper.java
@@ -19,22 +19,17 @@
 
 package com.cloud.hypervisor.kvm.resource.wrapper;
 
-import java.util.List;
-
 import org.apache.log4j.Logger;
 import org.joda.time.Duration;
-import org.libvirt.Connect;
-import org.libvirt.LibvirtException;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.PvlanSetupCommand;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
-import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
 import com.cloud.utils.script.Script;
 
-@ResourceWrapper(handles =  PvlanSetupCommand.class)
+@ResourceWrapper(handles = PvlanSetupCommand.class)
 public final class LibvirtPvlanSetupCommandWrapper extends CommandWrapper<PvlanSetupCommand, Answer, LibvirtComputingResource> {
 
     private static final Logger s_logger = Logger.getLogger(LibvirtPvlanSetupCommandWrapper.class);
@@ -45,65 +40,48 @@ public final class LibvirtPvlanSetupCommandWrapper extends CommandWrapper<PvlanS
         final String isolatedPvlan = command.getIsolated();
         final String pvlanType = "-" + command.getPvlanType();
         final String op = command.getOp();
-        final String dhcpName = command.getDhcpName();
         final String dhcpMac = command.getDhcpMac();
-        final String vmMac = command.getVmMac();
+        final String vmMac = command.getVmMac() == null ? dhcpMac : command.getVmMac();
         final String dhcpIp = command.getDhcpIp();
-        boolean add = true;
 
         String opr = "-A";
         if (op.equals("delete")) {
             opr = "-D";
-            add = false;
         }
 
         String result = null;
-        try {
-            final String guestBridgeName = libvirtComputingResource.getGuestBridgeName();
-            final Duration timeout = libvirtComputingResource.getTimeout();
 
-            if (command.getType() == PvlanSetupCommand.Type.DHCP) {
-                final String ovsPvlanDhcpHostPath = libvirtComputingResource.getOvsPvlanDhcpHostPath();
-                final Script script = new Script(ovsPvlanDhcpHostPath, timeout, s_logger);
+        final String guestBridgeName = libvirtComputingResource.getGuestBridgeName();
+        final Duration timeout = libvirtComputingResource.getTimeout();
 
-                if (add) {
-                    final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
-                    final Connect conn = libvirtUtilitiesHelper.getConnectionByVmName(dhcpName);
+        if (command.getType() == PvlanSetupCommand.Type.DHCP) {
+            final String ovsPvlanDhcpHostPath = libvirtComputingResource.getOvsPvlanDhcpHostPath();
+            final Script script = new Script(ovsPvlanDhcpHostPath, timeout, s_logger);
 
-                    final List<InterfaceDef> ifaces = libvirtComputingResource.getInterfaces(conn, dhcpName);
-                    final InterfaceDef guestNic = ifaces.get(0);
-                    script.add(opr, "-b", guestBridgeName, "-p", primaryPvlan, "-i", isolatedPvlan, "-n", dhcpName, "-d", dhcpIp, "-m", dhcpMac, "-I",
-                            guestNic.getDevName());
-                } else {
-                    script.add(opr, "-b", guestBridgeName, "-p", primaryPvlan, "-i", isolatedPvlan, "-n", dhcpName, "-d", dhcpIp, "-m", dhcpMac);
-                }
+            script.add(opr, pvlanType, "-b", guestBridgeName, "-p", primaryPvlan, "-s", isolatedPvlan, "-m", dhcpMac,
+                    "-d", dhcpIp);
+            result = script.execute();
 
-                result = script.execute();
-
-                if (result != null) {
-                    s_logger.warn("Failed to program pvlan for dhcp server with mac " + dhcpMac);
-                    return new Answer(command, false, result);
-                } else {
-                    s_logger.info("Programmed pvlan for dhcp server with mac " + dhcpMac);
-                }
-            } else if (command.getType() == PvlanSetupCommand.Type.VM) {
-                final String ovsPvlanVmPath = libvirtComputingResource.getOvsPvlanVmPath();
-
-                final Script script = new Script(ovsPvlanVmPath, timeout, s_logger);
-                script.add(opr, pvlanType, "-b", guestBridgeName, "-p", primaryPvlan, "-s", isolatedPvlan, "-v", vmMac);
-                result = script.execute();
-
-                if (result != null) {
-                    s_logger.warn("Failed to program pvlan for vm with mac " + vmMac);
-                    return new Answer(command, false, result);
-                } else {
-                    s_logger.info("Programmed pvlan for vm with mac " + vmMac);
-                }
+            if (result != null) {
+                s_logger.warn("Failed to program pvlan for dhcp server with mac " + dhcpMac);
+            } else {
+                s_logger.info("Programmed pvlan for dhcp server with mac " + dhcpMac);
             }
-        } catch (final LibvirtException e) {
-            s_logger.error("Error whislt executing OVS Setup command! ==> " + e.getMessage());
-            return new Answer(command, false, e.getMessage());
         }
+
+        // We run this even for DHCP servers since they're all vms after all
+        final String ovsPvlanVmPath = libvirtComputingResource.getOvsPvlanVmPath();
+        final Script script = new Script(ovsPvlanVmPath, timeout, s_logger);
+        script.add(opr, pvlanType, "-b", guestBridgeName, "-p", primaryPvlan, "-s", isolatedPvlan, "-m", vmMac);
+        result = script.execute();
+
+        if (result != null) {
+            s_logger.warn("Failed to program pvlan for vm with mac " + vmMac);
+            return new Answer(command, false, result);
+        } else {
+            s_logger.info("Programmed pvlan for vm with mac " + vmMac);
+        }
+
         return new Answer(command, true, result);
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPvlanSetupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPvlanSetupCommandWrapper.java
@@ -43,6 +43,7 @@ public final class LibvirtPvlanSetupCommandWrapper extends CommandWrapper<PvlanS
     public Answer execute(final PvlanSetupCommand command, final LibvirtComputingResource libvirtComputingResource) {
         final String primaryPvlan = command.getPrimary();
         final String isolatedPvlan = command.getIsolated();
+        final String pvlanType = "-" + command.getPvlanType();
         final String op = command.getOp();
         final String dhcpName = command.getDhcpName();
         final String dhcpMac = command.getDhcpMac();
@@ -89,7 +90,7 @@ public final class LibvirtPvlanSetupCommandWrapper extends CommandWrapper<PvlanS
                 final String ovsPvlanVmPath = libvirtComputingResource.getOvsPvlanVmPath();
 
                 final Script script = new Script(ovsPvlanVmPath, timeout, s_logger);
-                script.add(opr, "-b", guestBridgeName, "-p", primaryPvlan, "-i", isolatedPvlan, "-v", vmMac);
+                script.add(opr, pvlanType, "-b", guestBridgeName, "-p", primaryPvlan, "-s", isolatedPvlan, "-v", vmMac);
                 result = script.execute();
 
                 if (result != null) {

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -4384,7 +4384,7 @@ public class LibvirtComputingResourceTest {
     @Test
     public void testPvlanSetupCommandVm() {
         final String op = "add";
-        final URI uri = URI.create("http://localhost");
+        final URI uri = URI.create("pvlan://200-p200");
         final String networkTag = "/105";
         final String vmMac = "00:00:00:00";
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -4337,7 +4337,7 @@ public class LibvirtComputingResourceTest {
     @Test
     public void testPvlanSetupCommandDhcpAdd() {
         final String op = "add";
-        final URI uri = URI.create("http://localhost");
+        final URI uri = URI.create("pvlan://200-p200");
         final String networkTag = "/105";
         final String dhcpName = "dhcp";
         final String dhcpMac = "00:00:00:00";
@@ -4345,40 +4345,18 @@ public class LibvirtComputingResourceTest {
 
         final PvlanSetupCommand command = PvlanSetupCommand.createDhcpSetup(op, uri, networkTag, dhcpName, dhcpMac, dhcpIp);
 
-        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
-        final Connect conn = Mockito.mock(Connect.class);
-
         final String guestBridgeName = "br0";
         when(libvirtComputingResource.getGuestBridgeName()).thenReturn(guestBridgeName);
-
         when(libvirtComputingResource.getTimeout()).thenReturn(Duration.ZERO);
+
         final String ovsPvlanDhcpHostPath = "/pvlan";
         when(libvirtComputingResource.getOvsPvlanDhcpHostPath()).thenReturn(ovsPvlanDhcpHostPath);
-        when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
-
-        final List<InterfaceDef> ifaces = new ArrayList<InterfaceDef>();
-        final InterfaceDef nic = Mockito.mock(InterfaceDef.class);
-        ifaces.add(nic);
-
-        try {
-            when(libvirtUtilitiesHelper.getConnectionByVmName(dhcpName)).thenReturn(conn);
-            when(libvirtComputingResource.getInterfaces(conn, dhcpName)).thenReturn(ifaces);
-        } catch (final LibvirtException e) {
-            fail(e.getMessage());
-        }
 
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);
 
         final Answer answer = wrapper.execute(command, libvirtComputingResource);
         assertFalse(answer.getResult());
-
-        verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
-        try {
-            verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(dhcpName);
-        } catch (final LibvirtException e) {
-            fail(e.getMessage());
-        }
     }
 
     @Test
@@ -4404,52 +4382,10 @@ public class LibvirtComputingResourceTest {
         assertFalse(answer.getResult());
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testPvlanSetupCommandDhcpException() {
-        final String op = "add";
-        final URI uri = URI.create("http://localhost");
-        final String networkTag = "/105";
-        final String dhcpName = "dhcp";
-        final String dhcpMac = "00:00:00:00";
-        final String dhcpIp = "127.0.0.1";
-
-        final PvlanSetupCommand command = PvlanSetupCommand.createDhcpSetup(op, uri, networkTag, dhcpName, dhcpMac, dhcpIp);
-
-        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
-
-        final String guestBridgeName = "br0";
-        when(libvirtComputingResource.getGuestBridgeName()).thenReturn(guestBridgeName);
-
-        when(libvirtComputingResource.getTimeout()).thenReturn(Duration.ZERO);
-        final String ovsPvlanDhcpHostPath = "/pvlan";
-        when(libvirtComputingResource.getOvsPvlanDhcpHostPath()).thenReturn(ovsPvlanDhcpHostPath);
-        when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
-
-        try {
-            when(libvirtUtilitiesHelper.getConnectionByVmName(dhcpName)).thenThrow(LibvirtException.class);
-        } catch (final LibvirtException e) {
-            fail(e.getMessage());
-        }
-
-        final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
-        assertNotNull(wrapper);
-
-        final Answer answer = wrapper.execute(command, libvirtComputingResource);
-        assertFalse(answer.getResult());
-
-        verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
-        try {
-            verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(dhcpName);
-        } catch (final LibvirtException e) {
-            fail(e.getMessage());
-        }
-    }
-
     @Test
     public void testPvlanSetupCommandDhcpDelete() {
         final String op = "delete";
-        final URI uri = URI.create("http://localhost");
+        final URI uri = URI.create("pvlan://200-p200");
         final String networkTag = "/105";
         final String dhcpName = "dhcp";
         final String dhcpMac = "00:00:00:00";
@@ -4457,15 +4393,12 @@ public class LibvirtComputingResourceTest {
 
         final PvlanSetupCommand command = PvlanSetupCommand.createDhcpSetup(op, uri, networkTag, dhcpName, dhcpMac, dhcpIp);
 
-        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
-
         final String guestBridgeName = "br0";
         when(libvirtComputingResource.getGuestBridgeName()).thenReturn(guestBridgeName);
-
         when(libvirtComputingResource.getTimeout()).thenReturn(Duration.ZERO);
+
         final String ovsPvlanDhcpHostPath = "/pvlan";
         when(libvirtComputingResource.getOvsPvlanDhcpHostPath()).thenReturn(ovsPvlanDhcpHostPath);
-        when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
 
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);

--- a/scripts/vm/network/ovs-pvlan-kvm-dhcp-host.sh
+++ b/scripts/vm/network/ovs-pvlan-kvm-dhcp-host.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#!/bin/bash
+
+# We're trying to do the impossible here by allowing pvlan on kvm / xen. As only God can do the impossible, and we've got too much ego to
+# admit that we can't, we're just hacking our way around it.
+# We're pretty much crafting two vlan headers, one with the primary vlan and the other with the secondary and with a few fancy rules
+# it managed to work. But take note that the'res no checking over here for secondary vlan overlap. That has to be handled while
+# creating the pvlan!!
+
+exec 2>&1
+
+usage() {
+  printf "Usage: %s: (-A|-D) (-P/I/C) -b <bridge/switch> -p <primary vlan> -s <secondary vlan> -m <VM MAC> -d <DHCP IP> -h \n" $(basename $0) >&2
+  exit 2
+}
+
+br=
+pri_vlan=
+sec_vlan=
+vm_mac=
+dhcp_ip=
+op=
+type=
+
+while getopts 'ADPICb:p:s:m:d:h' OPTION
+do
+  case $OPTION in
+  A)  op="add"
+      ;;
+  D)  op="del"
+      ;;
+  P)  type="P"
+      ;;
+  I)  type="I"
+      ;;
+  C)  type="C"
+      ;;
+  b)  br="$OPTARG"
+      ;;
+  p)  pri_vlan="$OPTARG"
+      ;;
+  s)  sec_vlan="$OPTARG"
+      ;;
+  m)  vm_mac="$OPTARG"
+      ;;
+  d)  dhcp_ip="$OPTARG"
+      ;;
+  h)  usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$op" ]
+then
+    echo Missing operation pararmeter!
+    exit 1
+fi
+
+if [ -z "$type" ]
+then
+    echo Missing pvlan type pararmeter!
+    exit 1
+fi
+
+if [ -z "$br" ]
+then
+    echo Missing parameter bridge!
+    exit 1
+fi
+
+if [ -z "$vm_mac" ]
+then
+    echo Missing parameter VM MAC!
+    exit 1
+fi
+
+if [ -z "$pri_vlan" ]
+then
+    echo Missing parameter primary vlan!
+    exit 1
+fi
+
+if [ -z "$sec_vlan" ]
+then
+    echo Missing parameter secondary vlan!
+    exit 1
+fi
+
+if [ -z "$dhcp_ip" ]
+then
+    echo Missing parameter DHCP IP!
+    exit 1
+fi
+
+find_port() {
+  mac=`echo "$1" | sed -e 's/:/\\\:/g'`
+  port=`ovs-vsctl --column ofport find interface external_ids:attached-mac="$mac" | tr -d ' ' | cut -d ':' -f 2`
+  echo $port
+}
+
+ovs-vsctl set bridge $br protocols=OpenFlow10,OpenFlow11,OpenFlow12,OpenFlow13
+ovs-vsctl set Open_vSwitch . other_config:vlan-limit=2
+
+if [ "$op" == "add" ]
+then
+    dhcp_port=$(find_port $vm_mac)
+
+    ovs-ofctl add-flow $br table=0,priority=200,arp,dl_vlan=$pri_vlan,nw_dst=$dhcp_ip,actions=strip_vlan,resubmit\(,1\)
+    ovs-ofctl add-flow $br table=1,priority=200,arp,dl_vlan=$sec_vlan,nw_dst=$dhcp_ip,actions=strip_vlan,output:$dhcp_port
+
+    ovs-ofctl add-flow $br table=0,priority=100,udp,dl_vlan=$pri_vlan,nw_dst=255.255.255.255,tp_dst=67,actions=strip_vlan,resubmit\(,1\)
+    ovs-ofctl add-flow $br table=1,priority=100,udp,dl_vlan=$sec_vlan,nw_dst=255.255.255.255,tp_dst=67,actions=strip_vlan,output:$dhcp_port
+else
+    ovs-ofctl del-flows --strict $br table=0,priority=200,arp,dl_vlan=$pri_vlan,nw_dst=$dhcp_ip
+    ovs-ofctl del-flows --strict $br table=1,priority=200,arp,dl_vlan=$sec_vlan,nw_dst=$dhcp_ip
+
+    ovs-ofctl del-flows --strict $br table=0,priority=100,udp,dl_vlan=$pri_vlan,nw_dst=255.255.255.255,tp_dst=67
+    ovs-ofctl del-flows --strict $br table=1,priority=100,udp,dl_vlan=$sec_vlan,nw_dst=255.255.255.255,tp_dst=67
+fi

--- a/scripts/vm/network/ovs-pvlan-kvm-vm.sh
+++ b/scripts/vm/network/ovs-pvlan-kvm-vm.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#!/bin/bash
+
+# We're trying to do the impossible here by allowing pvlan on kvm / xen. As only God can do the impossible, and we've got too much ego to
+# admit that we can't, we're just hacking our way around it.
+# We're pretty much crafting two vlan headers, one with the primary vlan and the other with the secondary and with a few fancy rules
+# it managed to work. But take note that the'res no checking over here for secondary vlan overlap. That has to be handled while
+# creating the pvlan!!
+
+usage() {
+  printf "Usage: %s: (-A|-D) (-P/I/C) -b <bridge/switch> -p <primary vlan> -s <secondary vlan> -v <VM MAC> -h \n" $(basename $0) >&2
+  exit 2
+}
+
+br=
+pri_vlan=
+sec_vlan=
+vm_mac=
+op=
+type=
+
+while getopts 'ADPCIb:p:s:i:d:m:v:n:h' OPTION
+do
+  case $OPTION in
+  A)  op="add"
+      ;;
+  D)  op="del"
+      ;;
+  P)  type="P"
+      ;;
+  I)  type="I"
+      ;;
+  C)  type="C"
+      ;;
+  b)  br="$OPTARG"
+      ;;
+  p)  pri_vlan="$OPTARG"
+      ;;
+  s)  sec_vlan="$OPTARG"
+      ;;
+  v)  vm_mac="$OPTARG"
+      ;;
+  h)  usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$op" ]
+then
+    echo Missing operation pararmeter!
+    exit 1
+fi
+
+if [ -z "$type" ]
+then
+    echo Missing pvlan type pararmeter!
+    exit 1
+fi
+
+if [ -z "$br" ]
+then
+    echo Missing parameter bridge!
+    exit 1
+fi
+
+if [ -z "$vm_mac" ]
+then
+    echo Missing parameter VM MAC!
+    exit 1
+fi
+
+if [ -z "$pri_vlan" ]
+then
+    echo Missing parameter primary vlan!
+    exit 1
+fi
+
+if [ -z "$sec_vlan" ]
+then
+    echo Missing parameter secondary vlan!
+    exit 1
+fi
+
+find_port() {
+  mac=`echo "$1" | sed -e 's/:/\\\:/g'`
+  port=`ovs-vsctl --column ofport find interface external_ids:attached-mac="$mac" | tr -d ' ' | cut -d ':' -f 2`
+  echo $port
+}
+
+find_port_group() {
+  ovs-ofctl -O OpenFlow13 dump-groups $br | grep group_id=$1, | sed -e 's/.*actions=//g' -e 's/resubmit(,3)//g' -e 's/output://g' -e 's/^,//g' -e 's/,$//g' -e 's/,,/,/g' -e 's/ //g'
+}
+
+# try to find the physical link to outside, only supports eth and em prefix now
+trunk_port=`ovs-ofctl show $br | egrep "\((eth|em)[0-9]" | cut -d '(' -f 1|tr -d ' '`
+vm_port=$(find_port $vm_mac)
+
+# craft the vlan headers. Adding 4096 as in hex, it must be of the form 0x1XXX
+pri_vlan_header=$((4096 + $pri_vlan))
+sec_vlan_header=$((4096 + $sec_vlan))
+
+# Get the groups for broadcast. Ensure we end the group id with ',' so that we wont accidentally match groupid 111 with 1110.
+# We're using the header value for the pri vlan port group, as anything from a promiscuous device has to go to every device in the vlan.
+# Since we're creating a separate group for just the promiscuous devices, adding 4096 so that it'll be unique. Hence we're restricted to 4096 vlans!
+# Not a big deal because if you have vxlan, why do you even need pvlan!!
+pri_vlan_ports=$(find_port_group $pri_vlan_header)
+# Be smart! If it's an isolated pvlan, why do we need a group for those ports ?
+if [ "$type" != "I" ]
+then
+  sec_vlan_ports=$(find_port_group $sec_vlan)
+fi
+
+add_to_ports() {
+  if [ -z "$1" ]
+  then
+    # To ensure that we don't get trailing commas
+    echo "$2"
+  else
+    # Dont add it if it already exists
+    echo "$1" | grep -w -q "$2" && echo "$1" && return
+    echo "$2,$1"
+  fi
+}
+
+del_from_ports() {
+  # Delete when only, begining, middle and end of string
+  echo "$1" | sed -e "s/^$2$//g" -e "s/^$2,//g" -e "s/,$2$//g" -e "s/,$2,/,/g"
+}
+
+mod_group() {
+  # Ensure that we don't delete the prom port group, because if we do, the rules that have it go away!
+  if [ "$1" == "$pri_vlan" ]
+  then
+    if [ -z "$2" ]
+    then
+      ovs-ofctl -O OpenFlow13 mod-group --may-create $br group_id=$1,type=indirect,bucket=resubmit\(,3\)
+    else
+      ovs-ofctl -O OpenFlow13 mod-group --may-create $br group_id=$1,type=indirect,bucket=resubmit\(,3\),$2
+    fi
+    return
+  fi
+  if [ -z "$2" ]
+  then
+    ovs-ofctl -O OpenFlow13 del-groups $br group_id=$1
+  else
+    ovs-ofctl -O OpenFlow13 mod-group --may-create $br group_id=$1,type=indirect,bucket=$2
+  fi
+}
+
+# Allow the neccessary protocols and QinQ
+ovs-vsctl set bridge $br protocols=OpenFlow10,OpenFlow11,OpenFlow12,OpenFlow13
+ovs-vsctl set Open_vSwitch . other_config:vlan-limit=2
+
+# So that we're friendly to non pvlan devices
+ovs-ofctl add-flow $br priority=0,actions=NORMAL
+
+if [ "$op" == "add" ]
+then
+  # From our pri vlan
+  ovs-ofctl add-flow $br table=0,priority=70,dl_vlan=$pri_vlan,dl_dst=$vm_mac,actions=strip_vlan,resubmit\(,1\)
+  # From promiscuous
+  ovs-ofctl add-flow $br table=1,priority=70,dl_vlan=$pri_vlan,dl_dst=$vm_mac,actions=strip_vlan,output:$vm_port
+  # From others in our own community
+  if [ "$type" == "C" ]
+  then
+    ovs-ofctl add-flow $br table=1,priority=70,dl_vlan=$sec_vlan,dl_dst=$vm_mac,actions=strip_vlan,output:$vm_port
+  fi
+  # If we're promiscuous, accept anything because it's passed the first header
+  if [ "$type" == "P" ]
+  then
+    ovs-ofctl add-flow $br table=1,priority=70,dl_dst=$vm_mac,actions=strip_vlan,output:$vm_port
+  fi
+  # Security101
+  ovs-ofctl add-flow $br table=1,priority=0,actions=drop
+
+  # If the dest isn't on our switch send it out
+  ovs-ofctl add-flow $br table=0,priority=60,dl_vlan=$pri_vlan,dl_src=$vm_mac,actions=output:$trunk_port
+  # QinQ the packet. Outter header is the primary vlan and inner is the secondary
+  ovs-ofctl add-flow -O OpenFlow13 $br table=0,priority=50,vlan_tci=0x0000,dl_src=$vm_mac,actions=push_vlan:0x8100,set_field:$sec_vlan_header-\>vlan_vid,push_vlan:0x8100,set_field:$pri_vlan_header-\>vlan_vid,resubmit:$trunk_port
+
+  # Broadcasats
+  # Create the respective groups
+  # To output anything that comes from a promiscuous device
+  pri_vlan_ports=$(add_to_ports "$pri_vlan_ports" "$vm_port")
+  mod_group $pri_vlan_header $pri_vlan_ports
+  if [ "$type" != "I" ]
+  then
+    # To output anything that comes from the same sec vlan
+    sec_vlan_ports=$(add_to_ports "$sec_vlan_ports" "$vm_port")
+    mod_group $sec_vlan $sec_vlan_ports
+  fi
+  # Group id 9999 for braodcasts sent by a vm on this switch. One  action is to to output it to the trunk port, the other to process it ourselves
+  # Chose 9999 since the vlan range goes upto 4096, so it's more than double of that
+  ovs-ofctl -O OpenFlow13 mod-group --may-create $br group_id=9999,type=all,bucket=action:output:$trunk_port,bucket=action:strip_vlan,resubmit\(,1\)
+  
+  # From a device on the same switch
+  ovs-ofctl add-flow $br table=0,priority=80,dl_vlan=$pri_vlan,dl_src=$vm_mac,dl_dst=ff:ff:ff:ff:ff:ff,actions=group:9999
+  # From our pri vlan
+  ovs-ofctl add-flow $br table=0,priority=70,dl_vlan=$pri_vlan,dl_dst=ff:ff:ff:ff:ff:ff,actions=strip_vlan,resubmit\(,1\)
+  # From a promiscuous device
+  ovs-ofctl add-flow $br table=1,priority=70,dl_vlan=$pri_vlan,dl_dst=ff:ff:ff:ff:ff:ff,actions=strip_vlan,group:$pri_vlan_header
+  if [ "$type" == "C" ]
+  then
+    # Ensure we have the promiscuous port group because if we don't, it'll fail to create the following rule
+    prom_ports=$(find_port_group $pri_vlan)
+    mod_group $pri_vlan $prom_ports
+    # Since it's from a community, gotta braodcast it to all community and promiscuous ports
+    ovs-ofctl add-flow $br table=1,priority=70,dl_vlan=$sec_vlan,dl_dst=ff:ff:ff:ff:ff:ff,actions=strip_vlan,group:$sec_vlan,group:$pri_vlan
+  fi
+  # I'm promiscuous, accept anything because it's passed the first header
+  if [ "$type" == "P" ]
+  then
+    ovs-ofctl add-flow $br table=1,priority=60,dl_dst=ff:ff:ff:ff:ff:ff,actions=strip_vlan,group:$pri_vlan
+  fi
+else
+  # Delete whatever we've added that's vm specific
+  ovs-ofctl del-flows $br --strict table=0,priority=70,dl_vlan=$pri_vlan,dl_dst=$vm_mac
+
+  # Need to ge the vmport from the rules as it's already been removed from the switch
+  vm_port=`ovs-ofctl dump-flows $br | grep "priority=70,dl_vlan=$pri_vlan,dl_dst=$vm_mac" | tr ':' '\n' | tail -n 1`
+  ovs-ofctl del-flows $br --strict table=1,priority=70,dl_vlan=$pri_vlan,dl_dst=$vm_mac
+  if [ "$type" == "C" ]
+  then
+    ovs-ofctl del-flows $br --strict table=1,priority=70,dl_vlan=$sec_vlan,dl_dst=$vm_mac
+  fi
+  if [ "$type" == "P" ]
+  then
+    ovs-ofctl del-flows $br --strict table=1,priority=70,dl_dst=$vm_mac
+  fi
+  ovs-ofctl del-flows $br --strict table=0,priority=60,dl_vlan=$pri_vlan,dl_src=$vm_mac
+  ovs-ofctl del-flows $br --strict table=0,priority=50,vlan_tci=0x0000,dl_src=$vm_mac
+  # For some ovs versions
+  ovs-ofctl del-flows $br --strict table=0,priority=50,vlan_tci=0x0000/0x1fff,dl_src=$vm_mac
+
+  # Remove the port from the groups
+  pri_vlan_ports=$(del_from_ports "$pri_vlan_ports" "$vm_port")
+  mod_group $pri_vlan_header $pri_vlan_ports
+  if [ "$type" != "I" ]
+  then
+    # To output anything that comes from the same sec vlan
+    sec_vlan_ports=$(del_from_ports "$sec_vlan_ports" "$vm_port")
+    mod_group $sec_vlan $sec_vlan_ports
+  fi
+
+  # Remove vm specific rules
+  ovs-ofctl del-flows $br --strict table=0,priority=80,dl_vlan=$pri_vlan,dl_src=$vm_mac,dl_dst=ff:ff:ff:ff:ff:ff
+
+  # If no more vms exist on this host, clear up all the rules
+  result=`ovs-vsctl find port tag=$pri_vlan`
+  if [ -z "$result" ]
+  then
+    ovs-ofctl del-flows $br --strict table=0,priority=70,dl_vlan=$pri_vlan,dl_dst=ff:ff:ff:ff:ff:ff
+    ovs-ofctl del-flows $br --strict table=1,priority=70,dl_vlan=$pri_vlan,dl_dst=ff:ff:ff:ff:ff:ff
+    ovs-ofctl del-flows $br --strict table=1,priority=70,dl_vlan=$sec_vlan,dl_dst=ff:ff:ff:ff:ff:ff
+    ovs-ofctl del-flows $br --strict table=1,priority=60,dl_dst=ff:ff:ff:ff:ff:ff
+    ovs-ofctl -O OpenFlow13 del-groups $br group_id=$pri_vlan
+  fi
+
+  # Remove the remaining rules / groups if there's no vm with pvlan on this host
+  result=`ovs-ofctl dump-flows $br | grep -e "actions=group:9999$"`
+  if [ -z "$result" ]
+  then
+    ovs-ofctl del-flows $br --strict table=1,priority=0
+    ovs-ofctl -O OpenFlow13 del-groups $br group_id=9999
+  fi
+fi

--- a/server/src/test/java/com/cloud/network/dao/NetworkDaoTest.java
+++ b/server/src/test/java/com/cloud/network/dao/NetworkDaoTest.java
@@ -52,4 +52,14 @@ public class NetworkDaoTest extends TestCase {
         Assert.assertFalse(dao.isNetworkOverlappingRequestedPvlan(existingPrimaryVlan, existingSecondaryVlan, Network.PVlanType.Community,
                 existingPrimaryVlan, requestedVlan, Network.PVlanType.Community));
     }
+
+    public void testNetworkOverlappingVlanPvlanTrue() {
+        Assert.assertTrue(dao.isNetworkOverlappingRequestedPvlan(existingPrimaryVlan, existingSecondaryVlan, existingPrimaryVlan));
+        Assert.assertTrue(dao.isNetworkOverlappingRequestedPvlan(existingPrimaryVlan, existingSecondaryVlan, existingSecondaryVlan));
+    }
+
+    public void testNetworkOverlappingVlanPvlanFalse() {
+        Assert.assertFalse(dao.isNetworkOverlappingRequestedPvlan(existingPrimaryVlan, existingSecondaryVlan, requestedVlan));
+    }
+
 }

--- a/server/src/test/java/com/cloud/vpc/dao/MockNetworkDaoImpl.java
+++ b/server/src/test/java/com/cloud/vpc/dao/MockNetworkDaoImpl.java
@@ -250,4 +250,9 @@ public class MockNetworkDaoImpl extends GenericDaoBase<NetworkVO, Long> implemen
     public List<NetworkVO> listByPhysicalNetworkPvlan(long physicalNetworkId, String broadcastUri, Network.PVlanType pVlanType) {
         return null;
     }
+
+    @Override
+    public List<NetworkVO> listByPhysicalNetworkPvlan(long physicalNetworkId, String broadcastUri) {
+        return null;
+    }
 }

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -1562,6 +1562,7 @@ class TestPrivateVlansL2Networks(cloudstackTestCase):
         # Supported hypervisor = Vmware using dvSwitches for guest traffic
         isVmware = False
         isDvSwitch = False
+        isKVM = False
         if cls.hypervisor.lower() in ["vmware"]:
             isVmware = True
             clusters = Cluster.list(cls.apiclient, zoneid=cls.zone.id, hypervisor=cls.hypervisor)
@@ -1571,8 +1572,10 @@ class TestPrivateVlansL2Networks(cloudstackTestCase):
                     isDvSwitch = True
                     break
 
-        supported = isVmware and isDvSwitch
-        cls.vmwareHypervisorDvSwitchesForGuestTrafficNotPresent = not supported
+        isKVM = cls.hypervisor.lower() in ["kvm"]
+
+        supported = isVmware and isDvSwitch or isKVM
+        cls.unsupportedHardware = not supported
 
         cls._cleanup = []
 
@@ -1730,7 +1733,7 @@ class TestPrivateVlansL2Networks(cloudstackTestCase):
         return vm_ip, eth_device
 
     @attr(tags=["advanced", "advancedns", "smoke", "pvlan"], required_hardware="true")
-    @skipTestIf("vmwareHypervisorDvSwitchesForGuestTrafficNotPresent")
+    @skipTestIf("unsupportedHardware")
     def test_l2_network_pvlan_connectivity(self):
         try:
             vm_community1_one = self.deploy_vm_multiple_nics("vmcommunity1one", self.l2_pvlan_community1)
@@ -1788,6 +1791,7 @@ class TestPrivateVlansL2Networks(cloudstackTestCase):
             # Isolated PVLAN checks
             same_isolated = self.is_vm_l2_isolated_from_dest(vm_isolated1, vm_isolated1_eth, vm_isolated2_ip)
             isolated_to_community_isolated = self.is_vm_l2_isolated_from_dest(vm_isolated1, vm_isolated1_eth, vm_community1_one_ip)
+            isolated_to_promiscuous_isolated = self.is_vm_l2_isolated_from_dest(vm_isolated1, vm_isolated1_eth, vm_promiscuous1_ip)
 
             self.assertTrue(
                 same_isolated,
@@ -1796,6 +1800,10 @@ class TestPrivateVlansL2Networks(cloudstackTestCase):
             self.assertTrue(
                 isolated_to_community_isolated,
                 "VMs on isolated PVLANs must be isolated on layer 2 to Vms on community PVLAN"
+            )
+            self.assertFalse(
+                isolated_to_promiscuous_isolated,
+                "VMs on isolated PVLANs must not be isolated on layer 2 to Vms on promiscuous PVLAN",
             )
 
             # Promiscuous PVLAN checks

--- a/utils/src/main/java/com/cloud/utils/UriUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UriUtils.java
@@ -630,7 +630,7 @@ public class UriUtils {
         if (Strings.isNullOrEmpty(pvlanRange)) {
             return expandedVlans;
         }
-        String[] parts = pvlanRange.split("-i");
+        String[] parts = pvlanRange.split("-\\w");
         expandedVlans.add(Integer.parseInt(parts[0]));
         expandedVlans.add(Integer.parseInt(parts[1]));
         return expandedVlans;

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -1471,6 +1471,24 @@ public class NetUtils {
         return URI.create("pvlan://" + primaryVlan + "-i" + isolatedPvlan);
     }
 
+    public static URI generateUriForPvlan(final String primaryVlan, final String isolatedPvlan, final String isolatedPvlanType) {
+        // Defaulting to isolated for backward compatibility
+        if (isolatedPvlan.length() < 1) {
+            return generateUriForPvlan(primaryVlan, isolatedPvlan);
+        }
+        char type = isolatedPvlanType.charAt(0);
+        switch(type) {
+            case 'c':
+            case 'C':
+                return URI.create("pvlan://" + primaryVlan + "-c" + isolatedPvlan);
+            case 'p':
+            case 'P':
+                return URI.create("pvlan://" + primaryVlan + "-p" + primaryVlan);
+            default :
+                return generateUriForPvlan(primaryVlan, isolatedPvlan);
+        }
+    }
+
     public static String getPrimaryPvlanFromUri(final URI uri) {
         final String[] vlans = uri.getHost().split("-");
         if (vlans.length < 1) {
@@ -1487,6 +1505,31 @@ public class NetUtils {
         for (final String vlan : vlans) {
             if (vlan.startsWith("i")) {
                 return vlan.replace("i", " ").trim();
+            }
+            if (vlan.startsWith("p")) {
+                return vlan.replace("p", " ").trim();
+            }
+            if (vlan.startsWith("c")) {
+                return vlan.replace("c", " ").trim();
+            }
+        }
+        return null;
+    }
+
+    public static String getPvlanTypeFromUri(final URI uri) {
+        final String[] vlans = uri.getHost().split("-");
+        if (vlans.length < 2) {
+            return null;
+        }
+        for (final String vlan : vlans) {
+            if (vlan.startsWith("i")) {
+                return "I";
+            }
+            if (vlan.startsWith("p")) {
+                return "P";
+            }
+            if (vlan.startsWith("c")) {
+                return "C";
             }
         }
         return null;

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -249,8 +249,18 @@ public class NetUtilsTest {
     }
 
     @Test
-    public void testGenerateUriForPvlan() {
+    public void testGenerateUriForIsolatedPvlan() {
         assertEquals("pvlan://123-i456", NetUtils.generateUriForPvlan("123", "456").toString());
+    }
+
+    @Test
+    public void testGenerateUriForCommunityPvlan() {
+        assertEquals("pvlan://123-c456", NetUtils.generateUriForPvlan("123", "456", "Community").toString());
+    }
+
+    @Test
+    public void testGenerateUriForPromiscuousPvlan() {
+        assertEquals("pvlan://123-p123", NetUtils.generateUriForPvlan("123", "123", "promiscuous").toString());
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This is an extention of #3732 for kvm. 
This is restricted to ovs > 2.9.2
Since Xen uses ovs 2.6, pvlan is unsupported.
This also fixes issues of vms on the same pvlan unable to communicate if they're on the same host
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
- Create L2 network selecting a VLAN ID and secondary VLAN ID as well as the PVLAN type. The connectivity is as expected


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
