### PR TITLE
Fixed guest vlan range going missing when using zone wizard

### DIFF
--- a/ui/scripts/zoneWizard.js
+++ b/ui/scripts/zoneWizard.js
@@ -4173,7 +4173,7 @@
                     } else if (args.data.returnedZone.networktype == "Advanced") { //update VLAN in physical network(s) in advanced zone
                         var physicalNetworksHavingGuestIncludingVlan = [];
                         $(args.data.physicalNetworks).each(function() {
-                            if (this.guestConfiguration != null && this.guestConfiguration.vlanRangeStart != null && this.guestConfiguration.vlanRangeStart.length > 0) {
+                            if (args.data.guestTraffic != null && args.data.guestTraffic.vlanRangeStart != null && args.data.guestTraffic.vlanRangeStart.length > 0) {
                                 physicalNetworksHavingGuestIncludingVlan.push(this);
                             }
                         });
@@ -4186,10 +4186,10 @@
                             var updatedCount = 0;
                             $(physicalNetworksHavingGuestIncludingVlan).each(function() {
                                 var vlan;
-                                if (this.guestConfiguration.vlanRangeEnd == null || this.guestConfiguration.vlanRangeEnd.length == 0)
-                                    vlan = this.guestConfiguration.vlanRangeStart;
+                                if (args.data.guestTraffic.vlanRangeEnd == null || args.data.guestTraffic.vlanRangeEnd.length == 0)
+                                    vlan = args.data.guestTraffic.vlanRangeStart;
                                 else
-                                    vlan = this.guestConfiguration.vlanRangeStart + "-" + this.guestConfiguration.vlanRangeEnd;
+                                    vlan = args.data.guestTraffic.vlanRangeStart + "-" + args.data.guestTraffic.vlanRangeEnd;
 
                                 var originalId = this.id;
                                 var returnedId;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes #4039 - Guest Vlan range will be lost when deploying ZONE
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested by creating an advanced zone with the wizard and then checking if the vlan range was set for guest traffic on the physical network.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
