### PR TITLE
db: add support for MySQL 8

### DIFF
--- a/client/conf/db.properties.in
+++ b/client/conf/db.properties.in
@@ -39,7 +39,7 @@ db.cloud.testWhileIdle=true
 db.cloud.timeBetweenEvictionRunsMillis=40000
 db.cloud.minEvictableIdleTimeMillis=240000
 db.cloud.poolPreparedStatements=false
-db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
 
 # CloudStack database SSL settings
 db.cloud.useSSL=false

--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseCreator.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseCreator.java
@@ -104,8 +104,10 @@ public class DatabaseCreator {
             List<String> queries = new ArrayList<String>();
             queries.add(String.format("drop database if exists `%s`", dbName));
             queries.add(String.format("create database `%s`", dbName));
-            queries.add(String.format("GRANT ALL ON %s.* to '%s'@`localhost` identified by '%s'", dbName, username, password));
-            queries.add(String.format("GRANT ALL ON %s.* to '%s'@`%%` identified by '%s'", dbName, username, password));
+            queries.add(String.format("CREATE USER IF NOT EXISTS %s@`localhost` identified by '%s'", username, password));
+            queries.add(String.format("CREATE USER IF NOT EXISTS %s@`%%` identified by '%s'", username, password));
+            queries.add(String.format("GRANT ALL ON %s.* to '%s'@`localhost`", dbName, username));
+            queries.add(String.format("GRANT ALL ON %s.* to '%s'@`%%`", dbName, username));
 
             for (String query : queries) {
                 runQuery(host, port, rootPassword, query, dryRun);

--- a/setup/db/create-database-simulator.sql
+++ b/setup/db/create-database-simulator.sql
@@ -20,8 +20,8 @@ DROP DATABASE IF EXISTS `simulator`;
 
 CREATE DATABASE `simulator`;
 
-GRANT ALL ON simulator.* to cloud@`localhost` identified by 'cloud';
-GRANT ALL ON simulator.* to cloud@`%` identified by 'cloud';
+GRANT ALL ON simulator.* to cloud@`localhost`;
+GRANT ALL ON simulator.* to cloud@`%`;
 
 GRANT process ON *.* TO cloud@`localhost`;
 GRANT process ON *.* TO cloud@`%`;

--- a/setup/db/create-database.sql
+++ b/setup/db/create-database.sql
@@ -55,10 +55,11 @@ DROP DATABASE IF EXISTS `cloud`;
 
 CREATE DATABASE `cloud`;
 
-CREATE USER cloud identified by 'cloud';
+CREATE USER cloud@`localhost` identified by 'cloud';
+CREATE USER cloud@`%` identified by 'cloud';
 
-GRANT ALL ON cloud.* to cloud@`localhost` identified by 'cloud';
-GRANT ALL ON cloud.* to cloud@`%` identified by 'cloud';
+GRANT ALL ON cloud.* to cloud@`localhost`;
+GRANT ALL ON cloud.* to cloud@`%`;
 
 GRANT process ON *.* TO cloud@`localhost`;
 GRANT process ON *.* TO cloud@`%`;

--- a/utils/conf/db.properties
+++ b/utils/conf/db.properties
@@ -44,8 +44,7 @@ db.cloud.testWhileIdle=true
 db.cloud.timeBetweenEvictionRunsMillis=40000
 db.cloud.minEvictableIdleTimeMillis=240000
 db.cloud.poolPreparedStatements=false
-db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLimit=4096&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
-
+db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLimit=4096&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE,NO_ENGINE_SUBSTITUTION'
 # usage database settings
 db.usage.username=cloud
 db.usage.password=cloud

--- a/utils/conf/db.properties
+++ b/utils/conf/db.properties
@@ -44,7 +44,8 @@ db.cloud.testWhileIdle=true
 db.cloud.timeBetweenEvictionRunsMillis=40000
 db.cloud.minEvictableIdleTimeMillis=240000
 db.cloud.poolPreparedStatements=false
-db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLimit=4096&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE,NO_ENGINE_SUBSTITUTION'
+db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLimit=4096&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
+
 # usage database settings
 db.usage.username=cloud
 db.usage.password=cloud


### PR DESCRIPTION
- Splits commands to create user and grant access on database, the old
statement is no longer supported by MySQL 8.x
- `NO_AUTO_CREATE_USER` is no longer supported by MySQL 8.x so remove
that from db.properties conn parameters

For mysql-server 8.x setup the following changes were added/tested to
make it work with CloudStack in /etc/mysql/mysql.conf.d/mysqld.cnf and
then restart the mysql-server process:

    server_id = 1
    sql-mode="STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE,NO_ENGINE_SUBSTITUTION"
    innodb_rollback_on_timeout=1
    innodb_lock_wait_timeout=600
    max_connections=1000
    log-bin=mysql-bin
    binlog-format = 'ROW'

    default-authentication-plugin=mysql_native_password

Notice the last line above, this is to reset the old password-based
authentication used by MySQL 5.x.

Developers can set empty password as follows:

    > sudo mysql -u root
    ALTER USER 'root'@'localhost' IDENTIFIED BY '';
mysql8-deploydb

Tested on Ubuntu 20.04 for a local Primate setup.