### PR TITLE
Allow deleting snapshot on local filesystem

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1655,8 +1655,8 @@ public class KVMStorageProcessor implements StorageProcessor {
                     rbd.close(image);
                     r.ioCtxDestroy(io);
                 }
-            } else if (primaryPool.getType() == StoragePoolType.NetworkFilesystem) {
-                s_logger.info(String.format("Attempting to remove snapshot (id=%s, name=%s, path=%s, storage type=%s) on primary storage", snapshotTO.getId(), snapshotTO.getName(), snapshotTO.getPath(), primaryPool.getType()));
+            } else if (primaryPool.getType() == StoragePoolType.NetworkFilesystem || primaryPool.getType() == StoragePoolType.Filesystem) {
+                s_logger.info(String.format("Deleting snapshot (id=%s, name=%s, path=%s, storage type=%s) on primary storage", snapshotTO.getId(), snapshotTO.getName(), snapshotTO.getPath(), primaryPool.getType()));
                 deleteSnapshotViaManageSnapshotScript(snapshotName, disk);
             } else {
                 s_logger.warn("Operation not implemented for storage pool type of " + primaryPool.getType().toString());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Failed to delete snapashot on local filesystem due to `Operation not implemented for storage pool type of Filesystem`.


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Snapshot a volume stored on local storage
2. delete the snapshot
3. Snapshot operation is not fully executed failing to delete on primary (local) storage.

Log on management server:
```
2020-05-04 02:17:06,719 DEBUG [c.c.s.s.SnapshotManagerImpl] (API-Job-Executor-9:ctx-59e99d59 job-167 ctx-7d1e424f) (logid:ac80ff16) Failed to delete snapshot: 1:com.cloud.utils.exception.CloudRuntimeException: Failed to remove snapshot dd3ea8b2-af27-49ec-ad6a-25e45ce158b5@bf990ccf-7272-4d7b-99af-11ba49fc6e5a
2020-05-04 02:17:06,734 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-9:ctx-59e99d59 job-167) (logid:ac80ff16) Unexpected exception while executing org.apache.cloudstack.api.command.user.snapshot.DeleteSnapshotCmd
com.cloud.utils.exception.CloudRuntimeException: Failed to delete snapshot:com.cloud.utils.exception.CloudRuntimeException: Failed to remove snapshot dd3ea8b2-af27-49ec-ad6a-25e45ce158b5@bf990ccf-7272-4d7b-99af-11ba49fc6e5a
        at com.cloud.storage.snapshot.SnapshotManagerImpl.deleteSnapshot(SnapshotManagerImpl.java:611)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)

```

On KVM agent:
```
2020-05-04 02:17:06,657 WARN  [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ac80ff16) Operation not implemented for storage pool type of Filesystem
2020-05-04 02:17:06,658 ERROR [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ac80ff16) Failed to remove snapshot dd3ea8b2-af27-49ec-ad6a-25e45ce158b5@bf990ccf-7272-4d7b-99af-11ba49fc6e5a, with exception: com.cloud.exception.InternalErrorException: Operation not implemented for storage pool type of Filesystem
```

After the fix, all went well with the snapshot deletion.