### PR TITLE
kvm: newer qemu-img and libvirt 6.0 expects backing file format

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -150,6 +150,8 @@ public class QemuImg {
         s.add("-f");
         if (backingFile != null) {
             s.add(backingFile.getFormat().toString());
+            s.add("-F");
+            s.add(backingFile.getFormat().toString());
             s.add("-b");
             s.add(backingFile.getFileName());
         } else {


### PR DESCRIPTION
Newer libvirt 6.0 expects the backing file to be specified, or when creating volume with qemu-img specify backing file format otherwise VM deployment fails.

https://libvirt.org/kbase/backing_chains.html

Tested on Ubuntu 20.04/arm64 on a raspberrypi4.

TODO: check and use the -F format parameter depending on libvirt version, otherwise this param would fail on older systems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)