### PR TITLE
Update cloud-set-guest-password.in

### DIFF
--- a/setup/bindir/cloud-set-guest-password.in
+++ b/setup/bindir/cloud-set-guest-password.in
@@ -29,7 +29,7 @@ user=root
 # Add network provider variables here (default means that interface for network manager is eth0)
 NETPLAN=/etc/netplan
 IFUPDOWN=/etc/network/interfaces
-NETMAN=/etc/sysconfig/network-scripts/ifcfg-eth0
+NETMAN=/etc/sysconfig/network-scripts
 
 # Add dhcp variables
 PASSWORD_SERVER_PORT=8080
@@ -68,7 +68,7 @@ if [ -f "$IFUPDOWN" ]; then
 fi
 
 # OS is using network interfaces
-if [ -f "$NETMAN" ]; then
+if [ -d "$NETMAN" ]; then
         logger -t "cloud" "Operating System is using network manager"
 
         PASSWORD_SERVER_IP=$(nmcli -f IP4.GATEWAY device show eth0 | sed 's/ //g' | awk '{split($0,a,":"); print a[2]}')

--- a/setup/bindir/cloud-set-guest-password.in
+++ b/setup/bindir/cloud-set-guest-password.in
@@ -32,7 +32,10 @@ IFUPDOWN=/etc/network/interfaces
 NETMAN=/etc/sysconfig/network-scripts/ifcfg-eth0
 
 # Add dhcp variables
-PASSWORD_SERVER_PORT=8080                                                                                                                                                                                                                    password_received=0                                                                                                                                                                                                                          error_count=0
+PASSWORD_SERVER_PORT=8080
+password_received=0
+error_count=0
+file_count=0
 
 # OS is using netplan
 if [ -d "$NETPLAN" ]; then
@@ -50,7 +53,6 @@ if [ -f "$IFUPDOWN" ]; then
         logger -t "cloud" "Operating System is using ifupdown"
 
         DHCP_FOLDERS="/var/lib/dhclient/* /var/lib/dhcp3/* /var/lib/dhcp/*"
-        file_count=0
 
         for DHCP_FILE in $DHCP_FOLDERS; do
                 if [ -f $DHCP_FILE ]; then

--- a/setup/bindir/cloud-set-guest-password.in
+++ b/setup/bindir/cloud-set-guest-password.in
@@ -26,6 +26,9 @@
 # Modify this line to specify the user (default is root)
 user=root
 
+# Detect main interface name
+NETINT=$(ip -o -4 route show to default | awk '{print $5}')
+
 # Add network provider variables here (default means that interface for network manager is eth0)
 NETPLAN=/etc/netplan
 IFUPDOWN=/etc/network/interfaces
@@ -41,7 +44,7 @@ file_count=0
 if [ -d "$NETPLAN" ]; then
         logger -t "cloud" "Operating System is using netplan"
 
-        PASSWORD_SERVER_IP=$(netplan ip leases eth0 | grep SERVER_ADDRESS | awk '{split($0,a,"="); print a[2]}')
+        PASSWORD_SERVER_IP=$(netplan ip leases $NETINT | grep SERVER_ADDRESS | awk '{split($0,a,"="); print a[2]}')
 
         if [ -n "$PASSWORD_SERVER_IP" ]; then
                  logger -t "cloud" "Found password server IP $PASSWORD_SERVER_IP in netplan config"
@@ -71,7 +74,7 @@ fi
 if [ -d "$NETMAN" ]; then
         logger -t "cloud" "Operating System is using network manager"
 
-        PASSWORD_SERVER_IP=$(nmcli -f IP4.GATEWAY device show eth0 | sed 's/ //g' | awk '{split($0,a,":"); print a[2]}')
+        PASSWORD_SERVER_IP=$(nmcli -f IP4.GATEWAY device show $NETINT | sed 's/ //g' | awk '{split($0,a,":"); print a[2]}')
         if [ -n "$PASSWORD_SERVER_IP" ]; then
                 logger -t "cloud" "Found password server IP $PASSWORD_SERVER_IP in nmcli output"
         fi

--- a/setup/bindir/cloud-set-guest-password.in
+++ b/setup/bindir/cloud-set-guest-password.in
@@ -26,25 +26,56 @@
 # Modify this line to specify the user (default is root)
 user=root
 
-# Add your DHCP lease folders here
-DHCP_FOLDERS="/var/lib/dhclient/* /var/lib/dhcp3/* /var/lib/dhcp/*"
-PASSWORD_SERVER_PORT=8080
-password_received=0
-file_count=0
-error_count=0
+# Add network provider variables here (default means that interface for network manager is eth0)
+NETPLAN=/etc/netplan
+IFUPDOWN=/etc/network/interfaces
+NETMAN=/etc/sysconfig/network-scripts/ifcfg-eth0
 
-for DHCP_FILE in $DHCP_FOLDERS; do
-	if [ -f $DHCP_FILE ]; then
-		file_count=$((file_count+1))
-		PASSWORD_SERVER_IP=$(grep dhcp-server-identifier $DHCP_FILE | tail -1 | awk '{print $NF}' | tr -d '\;')
+# Add dhcp variables
+PASSWORD_SERVER_PORT=8080                                                                                                                                                                                                                    password_received=0                                                                                                                                                                                                                          error_count=0
 
-		if [ -n "$PASSWORD_SERVER_IP" ]; then
-			logger -t "cloud" "Found password server IP $PASSWORD_SERVER_IP in $DHCP_FILE"
-                        break
-		fi
-	fi
-done
+# OS is using netplan
+if [ -d "$NETPLAN" ]; then
+        logger -t "cloud" "Operating System is using netplan"
 
+        PASSWORD_SERVER_IP=$(netplan ip leases eth0 | grep SERVER_ADDRESS | awk '{split($0,a,"="); print a[2]}')
+
+        if [ -n "$PASSWORD_SERVER_IP" ]; then
+                 logger -t "cloud" "Found password server IP $PASSWORD_SERVER_IP in netplan config"
+        fi
+fi
+
+# OS is using ifupdown
+if [ -f "$IFUPDOWN" ]; then
+        logger -t "cloud" "Operating System is using ifupdown"
+
+        DHCP_FOLDERS="/var/lib/dhclient/* /var/lib/dhcp3/* /var/lib/dhcp/*"
+        file_count=0
+
+        for DHCP_FILE in $DHCP_FOLDERS; do
+                if [ -f $DHCP_FILE ]; then
+                        file_count=$((file_count+1))
+                        PASSWORD_SERVER_IP=$(grep dhcp-server-identifier $DHCP_FILE | tail -1 | awk '{print $NF}' | tr -d '\;')
+
+                        if [ -n "$PASSWORD_SERVER_IP" ]; then
+                                logger -t "cloud" "Found password server IP $PASSWORD_SERVER_IP in $DHCP_FILE"
+                                break
+                        fi
+                fi
+        done
+fi
+
+# OS is using network interfaces
+if [ -f "$NETMAN" ]; then
+        logger -t "cloud" "Operating System is using network manager"
+
+        PASSWORD_SERVER_IP=$(nmcli -f IP4.GATEWAY device show eth0 | sed 's/ //g' | awk '{split($0,a,":"); print a[2]}')
+        if [ -n "$PASSWORD_SERVER_IP" ]; then
+                logger -t "cloud" "Found password server IP $PASSWORD_SERVER_IP in nmcli output"
+        fi
+fi
+
+#start sequence
 if [ -z "$PASSWORD_SERVER_IP" ] ; then
          logger -t "cloud" "Unable to determine the password server, falling back to data-server"
          PASSWORD_SERVER_IP=data-server


### PR DESCRIPTION
## Description
Adaptation of the original script to be able to work with netplan, network manager and ifupdown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Changes have been tested in Cloudstack V 4.13 with the following operating systems and network providers :

- Ubuntu 16.04 with ifupdown (/etc/network/interfaces)
- Ubuntu 18.04 with netplan
- Ubuntu 20.04 with netplan
- Debian 10 with ifupdown (/etc/network/interfaces)
- Debian 9 with ifupdown (/etc/network/interfaces)
- CentOS 8 with network manager (/etc/sysconfig/network-scripts/ifcfg-eth0)
- CentOS 7 with network manager (/etc/sysconfig/network-scripts/ifcfg-eth0)

<!-- Include details of your testing environment, and the tests you ran to -->

Create a new vm from template with password feature enabled and log in the vm with provided password.

Stop the vm, change the password with the feature, start the vm and log in the vm with provided password.

<!-- see how your change affects other areas of the code, etc. -->
N/A

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
