### PR TITLE
Dynamic roles improvements

### DIFF
--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -184,6 +184,7 @@ public class EventTypes {
     public static final String EVENT_ROLE_CREATE = "ROLE.CREATE";
     public static final String EVENT_ROLE_UPDATE = "ROLE.UPDATE";
     public static final String EVENT_ROLE_DELETE = "ROLE.DELETE";
+    public static final String EVENT_ROLE_IMPORT = "ROLE.IMPORT";
     public static final String EVENT_ROLE_PERMISSION_CREATE = "ROLE.PERMISSION.CREATE";
     public static final String EVENT_ROLE_PERMISSION_UPDATE = "ROLE.PERMISSION.UPDATE";
     public static final String EVENT_ROLE_PERMISSION_DELETE = "ROLE.PERMISSION.DELETE";
@@ -689,6 +690,7 @@ public class EventTypes {
         entityEventDetails.put(EVENT_ROLE_CREATE, Role.class);
         entityEventDetails.put(EVENT_ROLE_UPDATE, Role.class);
         entityEventDetails.put(EVENT_ROLE_DELETE, Role.class);
+        entityEventDetails.put(EVENT_ROLE_IMPORT, Role.class);
         entityEventDetails.put(EVENT_ROLE_PERMISSION_CREATE, RolePermission.class);
         entityEventDetails.put(EVENT_ROLE_PERMISSION_UPDATE, RolePermission.class);
         entityEventDetails.put(EVENT_ROLE_PERMISSION_DELETE, RolePermission.class);

--- a/api/src/main/java/org/apache/cloudstack/acl/Role.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/Role.java
@@ -24,4 +24,5 @@ public interface Role extends InternalIdentity, Identity {
     String getName();
     RoleType getRoleType();
     String getDescription();
+    boolean isDefault();
 }

--- a/api/src/main/java/org/apache/cloudstack/acl/RoleService.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/RoleService.java
@@ -18,6 +18,7 @@
 package org.apache.cloudstack.acl;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.cloudstack.acl.RolePermission.Permission;
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -39,13 +40,17 @@ public interface RoleService {
 
     Role createRole(String name, RoleType roleType, String description);
 
+    Role createRole(String name, Role role, String description);
+
+    Role importRole(String name, RoleType roleType, String description, List<Map<String, Object>> rules, boolean forced);
+
     Role updateRole(Role role, String name, RoleType roleType, String description);
 
     boolean deleteRole(Role role);
 
     RolePermission findRolePermission(Long id);
 
-    RolePermission findRolePermissionByUuid(String uuid);
+    RolePermission findRolePermissionByRoleIdAndRule(Long roleId, String rule);
 
     RolePermission createRolePermission(Role role, Rule rule, Permission permission, String description);
 
@@ -77,4 +82,6 @@ public interface RoleService {
     List<Role> findRolesByType(RoleType roleType);
 
     List<RolePermission> findAllPermissionsBy(Long roleId);
+
+    Permission getRolePermission(String permission);
 }

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -478,6 +478,7 @@ public class ApiConstants {
     public static final String ROLE_NAME = "rolename";
     public static final String PERMISSION = "permission";
     public static final String RULE = "rule";
+    public static final String RULES = "rules";
     public static final String RULE_ID = "ruleid";
     public static final String RULE_ORDER = "ruleorder";
     public static final String USER = "user";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiServerService.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiServerService.java
@@ -43,4 +43,5 @@ public interface ApiServerService {
 
     public Class<?> getCmdClass(String cmdName);
 
+    public boolean isValidApiName(String apiName);
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/ImportRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/ImportRoleCmd.java
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.admin.acl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.acl.Rule;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.ApiServerService;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.RoleResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.commons.collections.MapUtils;
+
+import com.cloud.user.Account;
+import com.google.common.base.Strings;
+
+@APICommand(name = ImportRoleCmd.APINAME, description = "Imports a role based on provided map of rule permissions", responseObject = RoleResponse.class,
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,
+        since = "4.15.0",
+        authorized = {RoleType.Admin})
+public class ImportRoleCmd extends RoleCmd {
+    public static final String APINAME = "importRole";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true,
+            description = "Creates a role with this unique name", validations = {ApiArgValidator.NotNullOrEmpty})
+    private String roleName;
+
+    @Parameter(name = ApiConstants.RULES, type = CommandType.MAP, required = true,
+            description = "Rules param list, rule and permission is must. Example: rules[0].rule=create*&rules[0].permission=allow&rules[0].description=create%20rule&rules[1].rule=list*&rules[1].permission=allow&rules[1].description=listing")
+    private Map rules;
+
+    @Parameter(name = ApiConstants.FORCED, type = CommandType.BOOLEAN,
+            description = "Force create a role with the same name. This overrides the role type, description and rule permissions for the existing role. Default is false.")
+    private Boolean forced;
+
+    @Inject
+    ApiServerService _apiServer;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public String getRoleName() {
+        return roleName;
+    }
+
+    // Returns list of rule maps. Each map corresponds to a rule with the details in the keys: rule, permission & description
+    public List<Map<String, Object>> getRules() {
+        if (MapUtils.isEmpty(rules)) {
+            return null;
+        }
+
+        List<Map<String, Object>> rulesDetails = new ArrayList<>();
+        Collection rulesCollection = rules.values();
+        Iterator iter = rulesCollection.iterator();
+        while (iter.hasNext()) {
+            HashMap<String, String> detail = (HashMap<String, String>)iter.next();
+            Map<String, Object> ruleDetails = new HashMap<>();
+            String rule = detail.get(ApiConstants.RULE);
+            if (Strings.isNullOrEmpty(rule)) {
+                throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Empty rule provided in rules param");
+            }
+            if (!rule.contains("*") && !_apiServer.isValidApiName(rule)) {
+                throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Invalid api name: " + rule + " provided in rules param");
+            }
+            ruleDetails.put(ApiConstants.RULE, new Rule(rule));
+
+            String permission = detail.get(ApiConstants.PERMISSION);
+            if (Strings.isNullOrEmpty(permission)) {
+                throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Invalid permission: "+ permission + " provided in rules param");
+            }
+            ruleDetails.put(ApiConstants.PERMISSION, roleService.getRolePermission(permission));
+
+            String description = detail.get(ApiConstants.DESCRIPTION);
+            if (!Strings.isNullOrEmpty(permission)) {
+                ruleDetails.put(ApiConstants.DESCRIPTION, description);
+            }
+
+            rulesDetails.add(ruleDetails);
+        }
+        return rulesDetails;
+    }
+
+    public boolean isForced() {
+        return (forced != null) ? forced : false;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + BaseCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return Account.ACCOUNT_ID_SYSTEM;
+    }
+
+    @Override
+    public void execute() {
+        if (getRoleType() == null) {
+            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Invalid role type provided");
+        }
+
+        CallContext.current().setEventDetails("Role: " + getRoleName() + ", type: " + getRoleType() + ", description: " + getRoleDescription());
+        Role role = roleService.importRole(getRoleName(), getRoleType(), getRoleDescription(), getRules(), isForced());
+        if (role == null) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to import role");
+        }
+        setupResponse(role);
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/ListRolesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/ListRolesCmd.java
@@ -97,6 +97,7 @@ public class ListRolesCmd extends BaseCmd {
             roleResponse.setRoleName(role.getName());
             roleResponse.setRoleType(role.getRoleType());
             roleResponse.setDescription(role.getDescription());
+            roleResponse.setIsDefault(role.isDefault());
             roleResponse.setObjectName("role");
             roleResponses.add(roleResponse);
         }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/RoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/RoleCmd.java
@@ -18,10 +18,40 @@
 package org.apache.cloudstack.api.command.admin.acl;
 
 import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.RoleResponse;
 
+import com.google.common.base.Strings;
+
 public abstract class RoleCmd extends BaseCmd {
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.TYPE, type = CommandType.STRING, description = "The type of the role, valid options are: Admin, ResourceAdmin, DomainAdmin, User")
+    private String roleType;
+
+    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "The description of the role")
+    private String roleDescription;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public RoleType getRoleType() {
+        if (!Strings.isNullOrEmpty(roleType)) {
+            return RoleType.fromString(roleType);
+        }
+        return null;
+    }
+
+    public String getRoleDescription() {
+        return roleDescription;
+    }
 
     protected void setupResponse(final Role role) {
         final RoleResponse response = new RoleResponse();

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/UpdateRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/UpdateRoleCmd.java
@@ -18,7 +18,6 @@
 package org.apache.cloudstack.api.command.admin.acl;
 
 import com.cloud.user.Account;
-import com.google.common.base.Strings;
 import org.apache.cloudstack.acl.Role;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
@@ -49,9 +48,6 @@ public class UpdateRoleCmd extends RoleCmd {
     @Parameter(name = ApiConstants.NAME, type = BaseCmd.CommandType.STRING, description = "creates a role with this unique name")
     private String roleName;
 
-    @Parameter(name = ApiConstants.TYPE, type = BaseCmd.CommandType.STRING, description = "The type of the role, valid options are: Admin, ResourceAdmin, DomainAdmin, User")
-    private String roleType;
-
     @Parameter(name = ApiConstants.DESCRIPTION, type = BaseCmd.CommandType.STRING, description = "The description of the role")
     private String roleDescription;
 
@@ -65,17 +61,6 @@ public class UpdateRoleCmd extends RoleCmd {
 
     public String getRoleName() {
         return roleName;
-    }
-
-    public RoleType getRoleType() {
-        if (!Strings.isNullOrEmpty(roleType)) {
-            return RoleType.fromString(roleType);
-        }
-        return null;
-    }
-
-    public String getRoleDescription() {
-        return roleDescription;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/response/RoleResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/RoleResponse.java
@@ -43,6 +43,10 @@ public class RoleResponse extends BaseResponse {
     @Param(description = "the description of the role")
     private String roleDescription;
 
+    @SerializedName(ApiConstants.IS_DEFAULT)
+    @Param(description = "true if role is default, false otherwise")
+    private Boolean isDefault;
+
     public void setId(String id) {
         this.id = id;
     }
@@ -59,5 +63,9 @@ public class RoleResponse extends BaseResponse {
 
     public void setDescription(String description) {
         this.roleDescription = description;
+    }
+
+    public void setIsDefault(Boolean isDefault) {
+        this.isDefault = isDefault;
     }
 }

--- a/api/src/test/java/org/apache/cloudstack/api/command/test/CreateRoleCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/test/CreateRoleCmdTest.java
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.test;
+
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RoleService;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.command.admin.acl.CreateRoleCmd;
+import org.apache.cloudstack.api.response.RoleResponse;
+import org.apache.cloudstack.api.ServerApiException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.Mockito.when;
+
+public class CreateRoleCmdTest {
+    private CreateRoleCmd createRoleCmd;
+    private RoleService roleService;
+    private Role role;
+
+    @Before
+    public void setUp() {
+        roleService = Mockito.spy(RoleService.class);
+        createRoleCmd = new CreateRoleCmd();
+        ReflectionTestUtils.setField(createRoleCmd,"roleService",roleService);
+        ReflectionTestUtils.setField(createRoleCmd,"roleName","testuser");
+        ReflectionTestUtils.setField(createRoleCmd,"roleDescription","User test");
+        role = Mockito.mock(Role.class);
+    }
+
+    @Test
+    public void testCreateRoleWithRoleType() {
+        ReflectionTestUtils.setField(createRoleCmd,"roleType", "User");
+        when(role.getId()).thenReturn(1L);
+        when(role.getUuid()).thenReturn("12345-abcgdkajd");
+        when(role.getDescription()).thenReturn("User test");
+        when(role.getName()).thenReturn("testuser");
+        when(role.getRoleType()).thenReturn(RoleType.User);
+        when(roleService.createRole(createRoleCmd.getRoleName(), createRoleCmd.getRoleType(), createRoleCmd.getRoleDescription())).thenReturn(role);
+        createRoleCmd.execute();
+        RoleResponse response = (RoleResponse) createRoleCmd.getResponseObject();
+        Assert.assertEquals((String) ReflectionTestUtils.getField(response, "roleName"), role.getName());
+        Assert.assertEquals((String) ReflectionTestUtils.getField(response, "roleDescription"), role.getDescription());
+    }
+
+    @Test
+    public void testCreateRoleWithExistingRole() {
+        ReflectionTestUtils.setField(createRoleCmd,"roleId",1L);
+        when(roleService.findRole(createRoleCmd.getRoleId())).thenReturn(role);
+        Role newRole = Mockito.mock(Role.class);
+        when(newRole.getId()).thenReturn(2L);
+        when(newRole.getUuid()).thenReturn("67890-xyztestid");
+        when(newRole.getDescription()).thenReturn("User test");
+        when(newRole.getName()).thenReturn("testuser");
+        when(newRole.getRoleType()).thenReturn(RoleType.User);
+        when(roleService.createRole(createRoleCmd.getRoleName(), role, createRoleCmd.getRoleDescription())).thenReturn(newRole);
+        createRoleCmd.execute();
+        RoleResponse response = (RoleResponse) createRoleCmd.getResponseObject();
+        Assert.assertEquals((String) ReflectionTestUtils.getField(response, "roleName"), newRole.getName());
+        Assert.assertEquals((String) ReflectionTestUtils.getField(response, "roleDescription"), newRole.getDescription());
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void testCreateRoleWithNonExistingRole() {
+        ReflectionTestUtils.setField(createRoleCmd,"roleId",1L);
+        when(roleService.findRole(createRoleCmd.getRoleId())).thenReturn(null);
+        createRoleCmd.execute();
+        Assert.fail("An exception should have been thrown: " + ServerApiException.class);
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void testCreateRoleValidateNeitherRoleIdNorTypeParameters() {
+        createRoleCmd.execute();
+        Assert.fail("An exception should have been thrown: " + ServerApiException.class);
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void testCreateRoleValidateBothRoleIdAndTypeParameters() {
+        ReflectionTestUtils.setField(createRoleCmd,"roleId",1L);
+        ReflectionTestUtils.setField(createRoleCmd,"roleType", "User");
+        createRoleCmd.execute();
+        Assert.fail("An exception should have been thrown: " + ServerApiException.class);
+    }
+}

--- a/api/src/test/java/org/apache/cloudstack/api/command/test/ImportRoleCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/test/ImportRoleCmdTest.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.test;
+
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RoleService;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.command.admin.acl.ImportRoleCmd;
+import org.apache.cloudstack.api.response.RoleResponse;
+import org.apache.cloudstack.api.ServerApiException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cloud.exception.InvalidParameterValueException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+public class ImportRoleCmdTest {
+    private ImportRoleCmd importRoleCmd;
+    private RoleService roleService;
+    private Role role;
+
+    @Before
+    public void setUp() {
+        roleService = Mockito.spy(RoleService.class);
+        importRoleCmd = new ImportRoleCmd();
+        ReflectionTestUtils.setField(importRoleCmd,"roleService",roleService);
+        ReflectionTestUtils.setField(importRoleCmd,"roleName","Test User");
+        ReflectionTestUtils.setField(importRoleCmd,"roleType", "User");
+        ReflectionTestUtils.setField(importRoleCmd,"roleDescription","test user imported");
+        role = Mockito.mock(Role.class);
+    }
+
+    @Test
+    public void testImportRoleSuccess() {
+        Map<String, Map<String, String>> rules = new HashMap<String, Map<String, String>>();
+
+        //Rule 1
+        Map<String, String> rule1 = new HashMap<String, String>();
+        rule1.put(ApiConstants.RULE, "list*");
+        rule1.put(ApiConstants.PERMISSION, "allow");
+        rule1.put(ApiConstants.DESCRIPTION, "listing apis");
+        rules.put("key1", rule1);
+
+        //Rule 2
+        Map<String, String> rule2 = new HashMap<String, String>();
+        rule2.put(ApiConstants.RULE, "update*");
+        rule2.put(ApiConstants.PERMISSION, "deny");
+        rule2.put(ApiConstants.DESCRIPTION, "no update allowed");
+        rules.put("key2", rule2);
+
+        //Rule 3
+        Map<String, String> rule3 = new HashMap<String, String>();
+        rule3.put(ApiConstants.RULE, "get*");
+        rule3.put(ApiConstants.PERMISSION, "allow");
+        rule3.put(ApiConstants.DESCRIPTION, "get details");
+        rules.put("key3", rule3);
+
+        ReflectionTestUtils.setField(importRoleCmd,"rules",rules);
+
+        when(role.getUuid()).thenReturn("12345-abcgdkajd");
+        when(role.getDescription()).thenReturn("test user imported");
+        when(role.getName()).thenReturn("Test User");
+        when(role.getRoleType()).thenReturn(RoleType.User);
+        when(roleService.importRole(anyString(),any(), anyString(), any(), anyBoolean())).thenReturn(role);
+
+        importRoleCmd.execute();
+        RoleResponse response = (RoleResponse) importRoleCmd.getResponseObject();
+        Assert.assertEquals((String) ReflectionTestUtils.getField(response, "roleName"), role.getName());
+        Assert.assertEquals((String) ReflectionTestUtils.getField(response, "roleDescription"), role.getDescription());
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testImportRoleInvalidRule() {
+        Map<String, Map<String, String>> rules = new HashMap<String, Map<String, String>>();
+        Map<String, String> rule = new HashMap<String, String>();
+        rule.put(ApiConstants.RULE, "*?+test*");
+        rule.put(ApiConstants.PERMISSION, "allow");
+        rule.put(ApiConstants.DESCRIPTION, "listing apis");
+        rules.put("key1", rule);
+        ReflectionTestUtils.setField(importRoleCmd,"rules",rules);
+
+        importRoleCmd.execute();
+        Assert.fail("An exception should have been thrown: " + InvalidParameterValueException.class);
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void testImportRoleInvalidPermission() {
+        Map<String, Map<String, String>> rules = new HashMap<String, Map<String, String>>();
+        Map<String, String> rule = new HashMap<String, String>();
+        rule.put(ApiConstants.RULE, "list*");
+        rule.put(ApiConstants.PERMISSION, "pass");
+        rule.put(ApiConstants.DESCRIPTION, "listing apis");
+        rules.put("key1", rule);
+        ReflectionTestUtils.setField(importRoleCmd,"rules",rules);
+
+        importRoleCmd.execute();
+        Assert.fail("An exception should have been thrown: " + ServerApiException.class);
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41400to41500.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41400to41500.java
@@ -22,8 +22,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -65,6 +68,7 @@ public class Upgrade41400to41500 implements DbUpgrade {
     @Override
     public void performDataMigration(Connection conn) {
         updateSystemVmTemplates(conn);
+        addRolePermissionsForNewReadOnlyAndSupportRoles(conn);
     }
 
     @SuppressWarnings("serial")
@@ -233,6 +237,288 @@ public class Upgrade41400to41500 implements DbUpgrade {
             }
         }
         LOG.debug("Updating System Vm Template IDs Complete");
+    }
+
+    private void addRolePermissionsForNewReadOnlyAndSupportRoles(final Connection conn) {
+        addRolePermissionsForReadOnlyAdmin(conn);
+        addRolePermissionsForReadOnlyUser(conn);
+        addRolePermissionsForSupportAdmin(conn);
+        addRolePermissionsForSupportUser(conn);
+    }
+
+    private void addRolePermissionsForReadOnlyAdmin(final Connection conn) {
+        LOG.debug("Adding role permissions for new read-only admin role");
+        try {
+            PreparedStatement pstmt = conn.prepareStatement("SELECT id FROM `cloud`.`roles` WHERE name = 'Read-Only Admin - Default' AND is_default = 1");
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                long readOnlyAdminRoleId = rs.getLong(1);
+                int readOnlyAdminSortOrder = 0;
+                Map<String, String> readOnlyAdminRules = new LinkedHashMap<>();
+                readOnlyAdminRules.put("list*", "ALLOW");
+                readOnlyAdminRules.put("getUploadParamsFor*", "DENY");
+                readOnlyAdminRules.put("get*", "ALLOW");
+                readOnlyAdminRules.put("cloudianIsEnabled", "ALLOW");
+                readOnlyAdminRules.put("queryAsyncJobResult", "ALLOW");
+                readOnlyAdminRules.put("quotaIsEnabled", "ALLOW");
+                readOnlyAdminRules.put("quotaTariffList", "ALLOW");
+                readOnlyAdminRules.put("quotaSummary", "ALLOW");
+                readOnlyAdminRules.put("*", "DENY");
+
+                for (Map.Entry<String, String> readOnlyAdminRule : readOnlyAdminRules.entrySet()) {
+                    pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, ?, ?) ON DUPLICATE KEY UPDATE rule=rule");
+                    pstmt.setLong(1, readOnlyAdminRoleId);
+                    pstmt.setString(2, readOnlyAdminRule.getKey());
+                    pstmt.setString(3, readOnlyAdminRule.getValue());
+                    pstmt.setLong(4, readOnlyAdminSortOrder++);
+                    pstmt.executeUpdate();
+                }
+            }
+
+            if (rs != null && !rs.isClosed())  {
+                rs.close();
+            }
+            if (pstmt != null && !pstmt.isClosed())  {
+                pstmt.close();
+            }
+            LOG.debug("Successfully added role permissions for new read-only admin role");
+        } catch (final SQLException e) {
+            LOG.error("Exception while adding role permissions for read-only admin role: " + e.getMessage());
+            throw new CloudRuntimeException("Exception while adding role permissions for read-only admin role: " + e.getMessage(), e);
+        }
+    }
+
+    private void addRolePermissionsForReadOnlyUser(final Connection conn) {
+        LOG.debug("Adding role permissions for new read-only user role");
+        try {
+            PreparedStatement pstmt = conn.prepareStatement("SELECT id FROM `cloud`.`roles` WHERE name = 'Read-Only User - Default' AND is_default = 1");
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                long readOnlyUserRoleId = rs.getLong(1);
+                int readOnlyUserSortOrder = 0;
+
+                pstmt = conn.prepareStatement("SELECT rule FROM `cloud`.`role_permissions` WHERE role_id = 4 AND permission = 'ALLOW' AND rule LIKE 'list%' ORDER BY sort_order");
+                ResultSet rsRolePermissions = pstmt.executeQuery();
+
+                while (rsRolePermissions.next()) {
+                    String rule = rsRolePermissions.getString(1);
+                    pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                    pstmt.setLong(1, readOnlyUserRoleId);
+                    pstmt.setString(2, rule);
+                    pstmt.setLong(3, readOnlyUserSortOrder++);
+                    pstmt.executeUpdate();
+                }
+
+                pstmt = conn.prepareStatement("SELECT rule FROM `cloud`.`role_permissions` WHERE role_id = 4 AND permission = 'ALLOW' AND rule LIKE 'get%' AND rule NOT LIKE 'getUploadParamsFor%' ORDER BY sort_order");
+                rsRolePermissions = pstmt.executeQuery();
+
+                while (rsRolePermissions.next()) {
+                    String rule = rsRolePermissions.getString(1);
+                    pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                    pstmt.setLong(1, readOnlyUserRoleId);
+                    pstmt.setString(2, rule);
+                    pstmt.setLong(3, readOnlyUserSortOrder++);
+                    pstmt.executeUpdate();
+                }
+
+                List<String> readOnlyUserRulesAllowed = new ArrayList<>();
+                readOnlyUserRulesAllowed.add("cloudianIsEnabled");
+                readOnlyUserRulesAllowed.add("queryAsyncJobResult");
+                readOnlyUserRulesAllowed.add("quotaIsEnabled");
+                readOnlyUserRulesAllowed.add("quotaTariffList");
+                readOnlyUserRulesAllowed.add("quotaSummary");
+
+                for(String readOnlyUserRule : readOnlyUserRulesAllowed) {
+                    pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                    pstmt.setLong(1, readOnlyUserRoleId);
+                    pstmt.setString(2, readOnlyUserRule);
+                    pstmt.setLong(3, readOnlyUserSortOrder++);
+                    pstmt.executeUpdate();
+                }
+
+                pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, '*', 'DENY', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                pstmt.setLong(1, readOnlyUserRoleId);
+                pstmt.setLong(2, readOnlyUserSortOrder);
+                pstmt.executeUpdate();
+
+                if (rsRolePermissions != null && !rsRolePermissions.isClosed())  {
+                    rsRolePermissions.close();
+                }
+            }
+
+            if (rs != null && !rs.isClosed())  {
+                rs.close();
+            }
+            if (pstmt != null && !pstmt.isClosed())  {
+                pstmt.close();
+            }
+            LOG.debug("Successfully added role permissions for new read-only user role");
+        } catch (final SQLException e) {
+            LOG.error("Exception while adding role permissions for read-only user role: " + e.getMessage());
+            throw new CloudRuntimeException("Exception while adding role permissions for read-only user role: " + e.getMessage(), e);
+        }
+    }
+
+    private void addRolePermissionsForSupportAdmin(final Connection conn) {
+        LOG.debug("Adding role permissions for new support admin role");
+        try {
+            PreparedStatement pstmt = conn.prepareStatement("SELECT id FROM `cloud`.`roles` WHERE name = 'Support Admin - Default' AND is_default = 1");
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                long supportAdminRoleId = rs.getLong(1);
+                int supportAdminSortOrder = 0;
+
+                pstmt = conn.prepareStatement("SELECT id FROM `cloud`.`roles` WHERE name = 'Read-Only Admin - Default' AND is_default = 1");
+                ResultSet rsReadOnlyAdmin = pstmt.executeQuery();
+                if (rsReadOnlyAdmin.next()) {
+                    long readOnlyAdminRoleId = rsReadOnlyAdmin.getLong(1);
+                    pstmt = conn.prepareStatement("SELECT rule FROM `cloud`.`role_permissions` WHERE role_id = ? AND permission = 'ALLOW' ORDER BY sort_order");
+                    pstmt.setLong(1, readOnlyAdminRoleId);
+                    ResultSet rsRolePermissions = pstmt.executeQuery();
+
+                    while (rsRolePermissions.next()) {
+                        String rule = rsRolePermissions.getString(1);
+                        pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                        pstmt.setLong(1, supportAdminRoleId);
+                        pstmt.setString(2, rule);
+                        pstmt.setLong(3, supportAdminSortOrder++);
+                        pstmt.executeUpdate();
+                    }
+
+                    List<String> supportAdminRulesAllowed = new ArrayList<>();
+                    supportAdminRulesAllowed.add("prepareHostForMaintenance");
+                    supportAdminRulesAllowed.add("cancelHostMaintenance");
+                    supportAdminRulesAllowed.add("enableStorageMaintenance");
+                    supportAdminRulesAllowed.add("cancelStorageMaintenance");
+                    supportAdminRulesAllowed.add("createServiceOffering");
+                    supportAdminRulesAllowed.add("createDiskOffering");
+                    supportAdminRulesAllowed.add("createNetworkOffering");
+                    supportAdminRulesAllowed.add("createVPCOffering");
+                    supportAdminRulesAllowed.add("startVirtualMachine");
+                    supportAdminRulesAllowed.add("stopVirtualMachine");
+                    supportAdminRulesAllowed.add("rebootVirtualMachine");
+                    supportAdminRulesAllowed.add("startKubernetesCluster");
+                    supportAdminRulesAllowed.add("stopKubernetesCluster");
+                    supportAdminRulesAllowed.add("createVolume");
+                    supportAdminRulesAllowed.add("attachVolume");
+                    supportAdminRulesAllowed.add("detachVolume");
+                    supportAdminRulesAllowed.add("uploadVolume");
+                    supportAdminRulesAllowed.add("attachIso");
+                    supportAdminRulesAllowed.add("detachIso");
+                    supportAdminRulesAllowed.add("registerTemplate");
+                    supportAdminRulesAllowed.add("registerIso");
+
+                    for(String supportAdminRule : supportAdminRulesAllowed) {
+                        pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                        pstmt.setLong(1, supportAdminRoleId);
+                        pstmt.setString(2, supportAdminRule);
+                        pstmt.setLong(3, supportAdminSortOrder++);
+                        pstmt.executeUpdate();
+                    }
+
+                    pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, '*', 'DENY', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                    pstmt.setLong(1, supportAdminRoleId);
+                    pstmt.setLong(2, supportAdminSortOrder);
+                    pstmt.executeUpdate();
+
+                    if (rsRolePermissions != null && !rsRolePermissions.isClosed())  {
+                        rsRolePermissions.close();
+                    }
+                }
+
+                if (rsReadOnlyAdmin != null && !rsReadOnlyAdmin.isClosed())  {
+                    rsReadOnlyAdmin.close();
+                }
+            }
+
+            if (rs != null && !rs.isClosed())  {
+                rs.close();
+            }
+            if (pstmt != null && !pstmt.isClosed())  {
+                pstmt.close();
+            }
+            LOG.debug("Successfully added role permissions for new support admin role");
+        } catch (final SQLException e) {
+            LOG.error("Exception while adding role permissions for support admin role: " + e.getMessage());
+            throw new CloudRuntimeException("Exception while adding role permissions for support admin role: " + e.getMessage(), e);
+        }
+    }
+
+    private void addRolePermissionsForSupportUser(final Connection conn) {
+        LOG.debug("Adding role permissions for new support user role");
+        try {
+            PreparedStatement pstmt = conn.prepareStatement("SELECT id FROM `cloud`.`roles` WHERE name = 'Support User - Default' AND is_default = 1");
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                long supportUserRoleId = rs.getLong(1);
+                int supportUserSortOrder = 0;
+
+                pstmt = conn.prepareStatement("SELECT id FROM `cloud`.`roles` WHERE name = 'Read-Only User - Default' AND is_default = 1");
+                ResultSet rsReadOnlyUser = pstmt.executeQuery();
+                if (rsReadOnlyUser.next()) {
+                    long readOnlyUserRoleId = rsReadOnlyUser.getLong(1);
+                    pstmt = conn.prepareStatement("SELECT rule FROM `cloud`.`role_permissions` WHERE role_id = ? AND permission = 'ALLOW' ORDER BY sort_order");
+                    pstmt.setLong(1, readOnlyUserRoleId);
+                    ResultSet rsRolePermissions = pstmt.executeQuery();
+                    while (rsRolePermissions.next()) {
+                        String rule = rsRolePermissions.getString(1);
+                        pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                        pstmt.setLong(1, supportUserRoleId);
+                        pstmt.setString(2, rule);
+                        pstmt.setLong(3, supportUserSortOrder++);
+                        pstmt.executeUpdate();
+                    }
+
+                    List<String> supportUserRulesAllowed = new ArrayList<>();
+                    supportUserRulesAllowed.add("startVirtualMachine");
+                    supportUserRulesAllowed.add("stopVirtualMachine");
+                    supportUserRulesAllowed.add("rebootVirtualMachine");
+                    supportUserRulesAllowed.add("startKubernetesCluster");
+                    supportUserRulesAllowed.add("stopKubernetesCluster");
+                    supportUserRulesAllowed.add("createVolume");
+                    supportUserRulesAllowed.add("attachVolume");
+                    supportUserRulesAllowed.add("detachVolume");
+                    supportUserRulesAllowed.add("uploadVolume");
+                    supportUserRulesAllowed.add("attachIso");
+                    supportUserRulesAllowed.add("detachIso");
+                    supportUserRulesAllowed.add("registerTemplate");
+                    supportUserRulesAllowed.add("registerIso");
+                    supportUserRulesAllowed.add("getUploadParamsFor*");
+
+                    for(String supportUserRule : supportUserRulesAllowed) {
+                        pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, ?, 'ALLOW', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                        pstmt.setLong(1, supportUserRoleId);
+                        pstmt.setString(2, supportUserRule);
+                        pstmt.setLong(3, supportUserSortOrder++);
+                        pstmt.executeUpdate();
+                    }
+
+                    pstmt = conn.prepareStatement("INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) VALUES (UUID(), ?, '*', 'DENY', ?) ON DUPLICATE KEY UPDATE rule=rule");
+                    pstmt.setLong(1, supportUserRoleId);
+                    pstmt.setLong(2, supportUserSortOrder);
+                    pstmt.executeUpdate();
+
+                    if (rsRolePermissions != null && !rsRolePermissions.isClosed())  {
+                        rsRolePermissions.close();
+                    }
+                }
+
+                if (rsReadOnlyUser != null && !rsReadOnlyUser.isClosed())  {
+                    rsReadOnlyUser.close();
+                }
+            }
+
+            if (rs != null && !rs.isClosed())  {
+                rs.close();
+            }
+            if (pstmt != null && !pstmt.isClosed())  {
+                pstmt.close();
+            }
+            LOG.debug("Successfully added role permissions for new support user role");
+        } catch (final SQLException e) {
+            LOG.error("Exception while adding role permissions for support user role: " + e.getMessage());
+            throw new CloudRuntimeException("Exception while adding role permissions for support user role: " + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/engine/schema/src/main/java/org/apache/cloudstack/acl/RoleVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/acl/RoleVO.java
@@ -51,6 +51,9 @@ public class RoleVO implements Role {
     @Column(name = "description")
     private String description;
 
+    @Column(name = "is_default")
+    private boolean isDefault = false;
+
     @Column(name = GenericDao.REMOVED_COLUMN)
     private Date removed;
 
@@ -73,6 +76,10 @@ public class RoleVO implements Role {
     @Override
     public String getUuid() {
         return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
     }
 
     @Override
@@ -102,5 +109,9 @@ public class RoleVO implements Role {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public boolean isDefault() {
+        return isDefault;
     }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RoleDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RoleDao.java
@@ -18,6 +18,7 @@
 package org.apache.cloudstack.acl.dao;
 
 import com.cloud.utils.db.GenericDao;
+
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.RoleVO;
 
@@ -26,4 +27,6 @@ import java.util.List;
 public interface RoleDao extends GenericDao<RoleVO, Long> {
     List<RoleVO> findAllByName(String roleName);
     List<RoleVO> findAllByRoleType(RoleType type);
+    List<RoleVO> findByName(String roleName);
+    RoleVO findByNameAndType(String roleName, RoleType type);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RoleDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RoleDaoImpl.java
@@ -20,6 +20,7 @@ package org.apache.cloudstack.acl.dao;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
+
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.RoleVO;
 import org.springframework.stereotype.Component;
@@ -30,6 +31,7 @@ import java.util.List;
 public class RoleDaoImpl extends GenericDaoBase<RoleVO, Long> implements RoleDao {
     private final SearchBuilder<RoleVO> RoleByNameSearch;
     private final SearchBuilder<RoleVO> RoleByTypeSearch;
+    private final SearchBuilder<RoleVO> RoleByNameAndTypeSearch;
 
     public RoleDaoImpl() {
         super();
@@ -41,6 +43,11 @@ public class RoleDaoImpl extends GenericDaoBase<RoleVO, Long> implements RoleDao
         RoleByTypeSearch = createSearchBuilder();
         RoleByTypeSearch.and("roleType", RoleByTypeSearch.entity().getRoleType(), SearchCriteria.Op.EQ);
         RoleByTypeSearch.done();
+
+        RoleByNameAndTypeSearch = createSearchBuilder();
+        RoleByNameAndTypeSearch.and("roleName", RoleByNameAndTypeSearch.entity().getName(), SearchCriteria.Op.EQ);
+        RoleByNameAndTypeSearch.and("roleType", RoleByNameAndTypeSearch.entity().getRoleType(), SearchCriteria.Op.EQ);
+        RoleByNameAndTypeSearch.done();
     }
 
     @Override
@@ -55,5 +62,20 @@ public class RoleDaoImpl extends GenericDaoBase<RoleVO, Long> implements RoleDao
         SearchCriteria<RoleVO> sc = RoleByTypeSearch.create();
         sc.setParameters("roleType", type);
         return listBy(sc);
+    }
+
+    @Override
+    public List<RoleVO> findByName(String roleName) {
+        SearchCriteria<RoleVO> sc = RoleByNameSearch.create();
+        sc.setParameters("roleName", roleName);
+        return listBy(sc);
+    }
+
+    @Override
+    public RoleVO findByNameAndType(String roleName, RoleType type) {
+        SearchCriteria<RoleVO> sc = RoleByNameAndTypeSearch.create();
+        sc.setParameters("roleName", roleName);
+        sc.setParameters("roleType", type);
+        return findOneBy(sc);
     }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RolePermissionsDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RolePermissionsDao.java
@@ -56,4 +56,12 @@ public interface RolePermissionsDao extends GenericDao<RolePermissionVO, Long> {
      * @return returns list of role permissions
      */
     List<RolePermissionVO> findAllByRoleIdSorted(Long roleId);
+
+    /**
+     * Returns role permission for a given role and rule
+     * @param roleId the ID of the role
+     * @param roleId rule for the role
+     * @return returns role permission
+     */
+    RolePermissionVO findByRoleIdAndRule(Long roleId, String rule);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RolePermissionsDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/acl/dao/RolePermissionsDaoImpl.java
@@ -44,11 +44,17 @@ import java.util.Set;
 public class RolePermissionsDaoImpl extends GenericDaoBase<RolePermissionVO, Long> implements RolePermissionsDao {
     protected static final Logger LOGGER = Logger.getLogger(RolePermissionsDaoImpl.class);
 
+    private final SearchBuilder<RolePermissionVO> RolePermissionsSearchByRoleAndRule;
     private final SearchBuilder<RolePermissionVO> RolePermissionsSearch;
     private Attribute sortOrderAttribute;
 
     public RolePermissionsDaoImpl() {
         super();
+
+        RolePermissionsSearchByRoleAndRule = createSearchBuilder();
+        RolePermissionsSearchByRoleAndRule.and("roleId", RolePermissionsSearchByRoleAndRule.entity().getRoleId(), SearchCriteria.Op.EQ);
+        RolePermissionsSearchByRoleAndRule.and("rule", RolePermissionsSearchByRoleAndRule.entity().getRule(), SearchCriteria.Op.EQ);
+        RolePermissionsSearchByRoleAndRule.done();
 
         RolePermissionsSearch = createSearchBuilder();
         RolePermissionsSearch.and("uuid", RolePermissionsSearch.entity().getUuid(), SearchCriteria.Op.EQ);
@@ -173,5 +179,13 @@ public class RolePermissionsDaoImpl extends GenericDaoBase<RolePermissionVO, Lon
             return Collections.emptyList();
         }
         return rolePermissionList;
+    }
+
+    @Override
+    public RolePermissionVO findByRoleIdAndRule(final Long roleId, final String rule) {
+        final SearchCriteria<RolePermissionVO> sc = RolePermissionsSearchByRoleAndRule.create();
+        sc.setParameters("roleId", roleId);
+        sc.setParameters("rule", rule);
+        return findOneBy(sc);
     }
 }

--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500-cleanup.sql
@@ -18,3 +18,6 @@
 --;
 -- Schema upgrade cleanup from 4.14.0.0 to 4.15.0.0
 --;
+
+-- remove the old NetApp storage APIs (unsupported since 4.12) from role_permissions
+DELETE from `cloud`.`role_permissions` WHERE rule IN ('createPool', 'modifyPool', 'deletePool', 'listPools', 'associateLun', 'dissociateLun', 'createLunOnFiler', 'destroyLunOnFiler', 'listLunsOnFiler', 'createVolumeOnFiler', 'destroyVolumeOnFiler', 'listVolumesOnFiler');

--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
@@ -18,3 +18,12 @@
 --;
 -- Schema upgrade from 4.14.0.0 to 4.15.0.0
 --;
+
+ALTER TABLE `cloud`.`roles` ADD COLUMN `is_default` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'is this a default role';
+UPDATE `cloud`.`roles` SET `is_default` = 1 WHERE id IN (1, 2, 3, 4);
+
+-- Updated Default CloudStack roles with read-only and support admin and user roles
+INSERT INTO `cloud`.`roles` (`uuid`, `name`, `role_type`, `description`, `is_default`) VALUES (UUID(), 'Read-Only Admin - Default', 'Admin', 'Default read-only admin role', 1);
+INSERT INTO `cloud`.`roles` (`uuid`, `name`, `role_type`, `description`, `is_default`) VALUES (UUID(), 'Read-Only User - Default', 'User', 'Default read-only user role', 1);
+INSERT INTO `cloud`.`roles` (`uuid`, `name`, `role_type`, `description`, `is_default`) VALUES (UUID(), 'Support Admin - Default', 'Admin', 'Default support admin role', 1);
+INSERT INTO `cloud`.`roles` (`uuid`, `name`, `role_type`, `description`, `is_default`) VALUES (UUID(), 'Support User - Default', 'User', 'Default support user role', 1);

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -1204,6 +1204,17 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         }
     }
 
+    @Override
+    public boolean isValidApiName(String apiName) {
+        if (apiName == null || apiName.isEmpty())
+            return false;
+
+        if (!s_apiNameCmdClassMap.containsKey(apiName))
+            return false;
+
+        return true;
+    }
+
     // FIXME: rather than isError, we might was to pass in the status code to give more flexibility
     private void writeResponse(final HttpResponse resp, final String responseText, final int statusCode, final String responseType, final String reasonPhrase) {
         try {

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -102,11 +102,28 @@ class Role:
         """Create role"""
         cmd = createRole.createRoleCmd()
         cmd.name = services["name"]
-        cmd.type = services["type"]
+        if "type" in services:
+            cmd.type = services["type"]
+        if "roleid" in services:
+            cmd.roleid = services["roleid"]
         if "description" in services:
             cmd.description = services["description"]
 
         return Role(apiclient.createRole(cmd).__dict__)
+
+    @classmethod
+    def importRole(cls, apiclient, services, domainid=None):
+        """Import role"""
+        cmd = importRole.importRoleCmd()
+        cmd.name = services["name"]
+        cmd.type = services["type"]
+        cmd.rules = services["rules"]
+        if "description" in services:
+            cmd.description = services["description"]
+        if "forced" in services:
+            cmd.type = services["forced"]
+
+        return Role(apiclient.importRole(cmd).__dict__)
 
     def delete(self, apiclient):
         """Delete Role"""


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR addresses the below improvements for current Dynamic roles functionality.
- Create a role from any of the existing role, using new parameter roleid in createRole API.
- Import a role with its rules, using a new importRole API.
- New default roles for Read-Only and Support Admin & User.
- No modifications (update or delete) allowed for Default roles.

- Cleanup of old NetApp APIs from role_permissions table.

UI changes PR: https://github.com/apache/cloudstack-primate/pull/353

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
**Manual Tests using API**

- Create a role using existing role.

http://myms:8080/client/api?command=createRole&response=json&name=Test%20CloneUser01&description=Test%20CloneUser01&roleid=ca9871c2-8ea7-11ea-944e-c2865825b006

{"createroleresponse":{"role":{"id":"c3888c27-66b6-4a39-96ee-9883fef326ba","name":"Test CloneUser01","type":"User","description":"Test CloneUser01"}}}

- Create a role using both role type and role id.

http://myms:8080/client/api?command=createRole&response=json&type=Admin&name=Test%20CloneResourceAdmin&description=Test%20CloneResourceAdmin&roleid=ca984d00-8ea7-11ea-944e-c2865825b006

{"createroleresponse":{"uuidList":[],"errorcode":431,"cserrorcode":9999,"errortext":"Both role type and role ID should not be specified"}}

- Create a role without role type and role id.

http://myms:8080/client/api?command=createRole&response=json&name=Test%20CloneResourceAdmin&description=Test%20CloneResourceAdmin

{"createroleresponse":{"uuidList":[],"errorcode":431,"cserrorcode":9999,"errortext":"Neither role type nor role ID is provided"}}

- Import role

http://myms:8080/client/api?command=importRole&response=json&name=ImportTestUser&type=User&description=Test%20Import%20Role&rules[0].rule=create*&rules[0].permission=allow&rules[0].description=create%20rule&rules[1].rule=list*&rules[1].permission=allow&rules[1].description=listing&forced=true

{"importroleresponse":{"role":{"id":"8306f86d-ab33-48b8-8263-535a0da5be04","name":"ImportTestUser","type":"User","description":"Test Import Role"}}}

- Import role with same name without force

http://myms:8080/client/api?command=importRole&response=json&name=ImportTestUser&type=User&description=Test%20Import1%20Role&rules[0].rule=create*&rules[0].permission=allow&rules[0].description=create%20rule&rules[1].rule=list*&rules[1].permission=allow&rules[1].description=listings

{"importroleresponse":{"uuidList":[],"errorcode":530,"cserrorcode":4250,"errortext":"Role already exists"}}

**Unit Tests**

[INFO] Running org.apache.cloudstack.api.command.test.ImportRoleCmdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s - in org.apache.cloudstack.api.command.test.ImportRoleCmdTest
[INFO] Running org.apache.cloudstack.api.command.test.CreateRoleCmdTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.apache.cloudstack.api.command.test.CreateRoleCmdTest

**Smoke Tests**

=== TestName: test_default_role_deletion | Status : SUCCESS ===

=== TestName: test_role_account_acls | Status : SUCCESS ===

=== TestName: test_role_account_acls_multiple_mgmt_servers | Status : SUCCESS ===

=== TestName: test_role_inuse_deletion | Status : SUCCESS ===

_**=== TestName: test_role_lifecycle_clone | Status : SUCCESS ===**_

=== TestName: test_role_lifecycle_create | Status : SUCCESS ===

=== TestName: test_role_lifecycle_delete | Status : SUCCESS ===

_**=== TestName: test_role_lifecycle_import | Status : SUCCESS ===**_

=== TestName: test_role_lifecycle_list | Status : SUCCESS ===

=== TestName: test_role_lifecycle_update | Status : SUCCESS ===

=== TestName: test_role_lifecycle_update_role_inuse | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_concurrent_updates | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_create | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_delete | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_list | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_update | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_update_permission | Status : SUCCESS ===

=== TestName: test_rolepermission_lifecycle_update_permission_negative | Status : SUCCESS ===
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
