### PR TITLE
Allow searching networks using name in api

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
@@ -88,6 +88,9 @@ public class ListNetworksCmd extends BaseListTaggedResourcesCmd implements UserC
     @Parameter(name = ApiConstants.DISPLAY_NETWORK, type = CommandType.BOOLEAN, description = "list resources by display flag; only ROOT admin is eligible to pass this parameter", since = "4.4", authorized = {RoleType.Admin})
     private Boolean display;
 
+    @Parameter(name=ApiConstants.NAME, type=CommandType.STRING, description="list networks  by name")
+    private String networkName;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -142,6 +145,10 @@ public class ListNetworksCmd extends BaseListTaggedResourcesCmd implements UserC
 
     public Boolean getForVpc() {
         return forVpc;
+    }
+
+    public String getNetworkName() {
+        return networkName;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -1551,6 +1551,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
         Map<String, String> tags = cmd.getTags();
         Boolean forVpc = cmd.getForVpc();
         Boolean display = cmd.getDisplay();
+        String networkName = cmd.getNetworkName();
 
         // 1) default is system to false if not specified
         // 2) reset parameter to false if it's specified by the regular user
@@ -1680,28 +1681,28 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
             if (!permittedAccounts.isEmpty()) {
                 //get account level networks
                 networksToReturn.addAll(listAccountSpecificNetworks(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, aclType,
-                        skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display), searchFilter, permittedAccounts));
+                        skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, networkName), searchFilter, permittedAccounts));
                 //get domain level networks
                 if (domainId != null) {
                     networksToReturn.addAll(listDomainLevelNetworks(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, aclType, true,
-                            restartRequired, specifyIpRanges, vpcId, tags, display), searchFilter, domainId, false));
+                            restartRequired, specifyIpRanges, vpcId, tags, display, networkName), searchFilter, domainId, false));
                 }
             } else {
                 //add account specific networks
                 networksToReturn.addAll(listAccountSpecificNetworksByDomainPath(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, aclType,
-                        skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display), searchFilter, path, isRecursive));
+                        skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, networkName), searchFilter, path, isRecursive));
                 //add domain specific networks of domain + parent domains
                 networksToReturn.addAll(listDomainSpecificNetworksByDomainPath(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, aclType,
-                        skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display), searchFilter, path, isRecursive));
+                        skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, networkName), searchFilter, path, isRecursive));
                 //add networks of subdomains
                 if (domainId == null) {
                     networksToReturn.addAll(listDomainLevelNetworks(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, aclType, true,
-                            restartRequired, specifyIpRanges, vpcId, tags, display), searchFilter, caller.getDomainId(), true));
+                            restartRequired, specifyIpRanges, vpcId, tags, display, networkName), searchFilter, caller.getDomainId(), true));
                 }
             }
         } else {
             networksToReturn = _networksDao.search(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, null, skipProjectNetworks,
-                    restartRequired, specifyIpRanges, vpcId, tags, display), searchFilter);
+                    restartRequired, specifyIpRanges, vpcId, tags, display, networkName), searchFilter);
         }
 
         if (supportedServicesStr != null && !supportedServicesStr.isEmpty() && !networksToReturn.isEmpty()) {
@@ -1749,7 +1750,8 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
     }
 
     private SearchCriteria<NetworkVO> buildNetworkSearchCriteria(SearchBuilder<NetworkVO> sb, String keyword, Long id, Boolean isSystem, Long zoneId, String guestIpType, String trafficType,
-            Long physicalNetworkId, String aclType, boolean skipProjectNetworks, Boolean restartRequired, Boolean specifyIpRanges, Long vpcId, Map<String, String> tags, Boolean display) {
+            Long physicalNetworkId, String aclType, boolean skipProjectNetworks, Boolean restartRequired, Boolean specifyIpRanges, Long vpcId, Map<String, String> tags, Boolean display,
+                                                                 String networkName) {
 
         SearchCriteria<NetworkVO> sc = sb.create();
 
@@ -1807,6 +1809,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
 
         if (vpcId != null) {
             sc.addAnd("vpcId", SearchCriteria.Op.EQ, vpcId);
+        }
+
+        if (networkName != null) {
+            sc.addAnd("name", Op.EQ, networkName);
         }
 
         if (tags != null && !tags.isEmpty()) {


### PR DESCRIPTION
## Description
Add a new parameter "name" to search for network using its name

(local) 🐵 > list networks name=shared-network
{
  "count": 1,
  "network": [
    {
      "acltype": "Domain",
      "broadcastdomaintype": "Vlan",
      "broadcasturi": "vlan://113",
      "canusefordeploy": true,
      "cidr": "10.1.1.0/24",
      "details": {},
      "displaynetwork": true,
      "displaytext": "shared-network",
      "dns1": "8.8.8.8",
      "domain": "ROOT",

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Through cloudmonkey api

```
(local) 🐵 > list networks name=shared-network
{
  "count": 1,
  "network": [
    {
      "acltype": "Domain",
      "broadcastdomaintype": "Vlan",
      "broadcasturi": "vlan://113",
      "canusefordeploy": true,
      "cidr": "10.1.1.0/24",
      "details": {},
      "displaynetwork": true,
      "displaytext": "shared-network",
      "dns1": "8.8.8.8",
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
