### PR TITLE
Cleanup download urls when SSVM destroyed

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/ImageStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/ImageStoreDao.java
@@ -40,4 +40,6 @@ public interface ImageStoreDao extends GenericDao<ImageStoreVO, Long> {
     List<ImageStoreVO> listImageStores();
 
     List<ImageStoreVO> listImageCacheStores();
+
+    List<ImageStoreVO> listStoresByZoneId(long zoneId);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/ImageStoreDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/ImageStoreDaoImpl.java
@@ -134,4 +134,10 @@ public class ImageStoreDaoImpl extends GenericDaoBase<ImageStoreVO, Long> implem
         return listBy(sc);
     }
 
+    @Override
+    public List<ImageStoreVO> listStoresByZoneId(long zoneId) {
+        SearchCriteria<ImageStoreVO> sc = createSearchCriteria();
+        sc.addAnd("dcId", SearchCriteria.Op.EQ, zoneId);
+        return listBy(sc);
+    }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/TemplateDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/TemplateDataStoreDao.java
@@ -91,4 +91,6 @@ public interface TemplateDataStoreDao extends GenericDao<TemplateDataStoreVO, Lo
     TemplateDataStoreVO getReadyBypassedTemplate(long templateId);
 
     boolean isTemplateMarkedForDirectDownload(long templateId);
+
+    List<TemplateDataStoreVO> listTemplateDownloadUrlsByStoreId(long storeId);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/VolumeDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/VolumeDataStoreDao.java
@@ -53,4 +53,6 @@ public interface VolumeDataStoreDao extends GenericDao<VolumeDataStoreVO, Long>,
     List<VolumeDataStoreVO> listByVolumeState(Volume.State... states);
 
     boolean updateVolumeId(long srcVolId, long destVolId);
+
+    List<VolumeDataStoreVO> listVolumeDownloadUrlsByZoneId(long zoneId);
 }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
@@ -144,6 +144,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         downloadTemplateSearch.and("download_url", downloadTemplateSearch.entity().getExtractUrl(), Op.NNULL);
         downloadTemplateSearch.and("download_url_created", downloadTemplateSearch.entity().getExtractUrlCreated(), Op.NNULL);
         downloadTemplateSearch.and("destroyed", downloadTemplateSearch.entity().getDestroyed(), SearchCriteria.Op.EQ);
+        downloadTemplateSearch.and("store_id", downloadTemplateSearch.entity().getDataStoreId(), Op.EQ);
         downloadTemplateSearch.done();
 
         directDownloadTemplateSeach = createSearchBuilder();
@@ -540,6 +541,14 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
     public List<TemplateDataStoreVO> listTemplateDownloadUrls() {
         SearchCriteria<TemplateDataStoreVO> sc = downloadTemplateSearch.create();
         sc.setParameters("destroyed", false);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<TemplateDataStoreVO> listTemplateDownloadUrlsByStoreId(long storeId) {
+        SearchCriteria<TemplateDataStoreVO> sc = downloadTemplateSearch.create();
+        sc.setParameters("destroyed", false);
+        sc.setParameters("store_id", storeId);
         return listBy(sc);
     }
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/VolumeDataStoreDaoImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/VolumeDataStoreDaoImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.utils.db.Filter;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -103,6 +104,7 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
         downloadVolumeSearch.and("download_url", downloadVolumeSearch.entity().getExtractUrl(), Op.NNULL);
         downloadVolumeSearch.and("download_url_created", downloadVolumeSearch.entity().getExtractUrlCreated(), Op.NNULL);
         downloadVolumeSearch.and("destroyed", downloadVolumeSearch.entity().getDestroyed(), SearchCriteria.Op.EQ);
+        downloadVolumeSearch.and("zone_id", downloadVolumeSearch.entity().getZoneId(), Op.EQ);
         downloadVolumeSearch.done();
 
         uploadVolumeSearch = createSearchBuilder();
@@ -213,7 +215,13 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
         SearchCriteria<VolumeDataStoreVO> sc = volumeSearch.create();
         sc.setParameters("volume_id", volumeId);
         sc.setParameters("destroyed", false);
-        return findOneBy(sc);
+        return findVolumeby(sc);
+    }
+
+    private VolumeDataStoreVO findVolumeby(SearchCriteria<VolumeDataStoreVO> sc) {
+        Filter filter = new Filter(VolumeDataStoreVO.class, "created", false, 0L, 1L);
+        List<VolumeDataStoreVO> results = searchIncludingRemoved(sc, filter, null, false);
+        return results.size() == 0 ? null : results.get(0);
     }
 
     @Override
@@ -313,6 +321,14 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
     public List<VolumeDataStoreVO> listVolumeDownloadUrls() {
         SearchCriteria<VolumeDataStoreVO> sc = downloadVolumeSearch.create();
         sc.setParameters("destroyed", false);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<VolumeDataStoreVO> listVolumeDownloadUrlsByZoneId(long zoneId) {
+        SearchCriteria<VolumeDataStoreVO> sc = downloadVolumeSearch.create();
+        sc.setParameters("destroyed", false);
+        sc.setParameters("zone_id", zoneId);
         return listBy(sc);
     }
 

--- a/plugins/storage/image/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackImageStoreDriverImpl.java
+++ b/plugins/storage/image/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackImageStoreDriverImpl.java
@@ -71,7 +71,8 @@ public class CloudStackImageStoreDriverImpl extends NfsImageStoreDriverImpl {
         // Create Symlink at ssvm
         String path = installPath;
         String uuid = UUID.randomUUID().toString() + "." + format.getFileExtension();
-        CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)store).getMountPoint(), path, uuid, dataObject.getTO());
+        CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)store).getMountPoint(),
+                                                                path, uuid, dataObject == null ? null: dataObject.getTO());
         Answer ans = null;
         if (ep == null) {
             String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -3296,15 +3296,14 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
     }
 
-    private void cleanupDownloadUrls(VMInstanceVO systemVm) {
+    private void cleanupDownloadUrlsInZone(final long zoneId) {
         // clean download URLs when destroying ssvm
-        // clean only the volumes and templates of the zone
-        // to which ssvm belongs to
-        for (VolumeDataStoreVO volume :_volumeStoreDao.listVolumeDownloadUrlsByZoneId(systemVm.getDataCenterId())) {
+        // clean only the volumes and templates of the zone to which ssvm belongs to
+        for (VolumeDataStoreVO volume :_volumeStoreDao.listVolumeDownloadUrlsByZoneId(zoneId)) {
             volume.setExtractUrl(null);
             _volumeStoreDao.update(volume.getId(), volume);
         }
-        for (ImageStoreVO imageStore : _imgStoreDao.listStoresByZoneId(systemVm.getDataCenterId())) {
+        for (ImageStoreVO imageStore : _imgStoreDao.listStoresByZoneId(zoneId)) {
             for (TemplateDataStoreVO template : _vmTemplateStoreDao.listTemplateDownloadUrlsByStoreId(imageStore.getId())) {
                 template.setExtractUrl(null);
                 template.setExtractUrlCreated(null);
@@ -3330,7 +3329,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     protected SecondaryStorageVmVO destroySecondaryStorageVm(final long instanceId) {
         final SecondaryStorageVmVO secStorageVm = _secStorageVmDao.findById(instanceId);
-        cleanupDownloadUrls(secStorageVm);
+        cleanupDownloadUrlsInZone(secStorageVm.getDataCenterId());
         if (_secStorageVmMgr.destroySecStorageVm(instanceId)) {
             return secStorageVm;
         }

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -554,6 +554,10 @@ import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
+import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreVO;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
@@ -840,6 +844,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     private DpdkHelper dpdkHelper;
     @Inject
     private PrimaryDataStoreDao _primaryDataStoreDao;
+    @Inject
+    private VolumeDataStoreDao _volumeStoreDao;
+    @Inject
+    private TemplateDataStoreDao _vmTemplateStoreDao;
 
     private LockMasterListener _lockMasterListener;
     private final ScheduledExecutorService _eventExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("EventChecker"));
@@ -3288,13 +3296,29 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
     }
 
+    private void cleanupDownloadUrls(VMInstanceVO systemVm) {
+        // clean download URLs when destroying ssvm
+        // clean only the volumes and templates of the zone
+        // to which ssvm belongs to
+        for (VolumeDataStoreVO volume :_volumeStoreDao.listVolumeDownloadUrlsByZoneId(systemVm.getDataCenterId())) {
+            volume.setExtractUrl(null);
+            _volumeStoreDao.update(volume.getId(), volume);
+        }
+        for (ImageStoreVO imageStore : _imgStoreDao.listStoresByZoneId(systemVm.getDataCenterId())) {
+            for (TemplateDataStoreVO template : _vmTemplateStoreDao.listTemplateDownloadUrlsByStoreId(imageStore.getId())) {
+                template.setExtractUrl(null);
+                template.setExtractUrlCreated(null);
+                _vmTemplateStoreDao.update(template.getId(), template);
+            }
+        }
+    }
+
     private SecondaryStorageVmVO startSecondaryStorageVm(final long instanceId) {
         return _secStorageVmMgr.startSecStorageVm(instanceId);
     }
 
     private SecondaryStorageVmVO stopSecondaryStorageVm(final VMInstanceVO systemVm, final boolean isForced)
             throws ResourceUnavailableException, OperationTimedoutException, ConcurrentOperationException {
-
         _itMgr.advanceStop(systemVm.getUuid(), isForced);
         return _secStorageVmDao.findById(systemVm.getId());
     }
@@ -3306,6 +3330,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     protected SecondaryStorageVmVO destroySecondaryStorageVm(final long instanceId) {
         final SecondaryStorageVmVO secStorageVm = _secStorageVmDao.findById(instanceId);
+        cleanupDownloadUrls(secStorageVm);
         if (_secStorageVmMgr.destroySecStorageVm(instanceId)) {
             return secStorageVm;
         }

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -545,6 +545,9 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
                 if (tmpltStoreRef != null) {
                     if (tmpltStoreRef.getDownloadState() == com.cloud.storage.VMTemplateStorageResourceAssoc.Status.DOWNLOADED) {
                         tmpltStore = (ImageStoreEntity)store;
+                        if (tmpltStoreRef.getExtractUrl() != null) {
+                            return tmpltStoreRef.getExtractUrl();
+                        }
                         break;
                     }
                 }

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -106,7 +106,6 @@ import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.ImageStoreDetailsUtil;
 import com.cloud.storage.Storage;
-import com.cloud.storage.UploadVO;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.storage.dao.StoragePoolHostDao;
@@ -747,9 +746,6 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 if (_allocLock.lock(ACQUIRE_GLOBAL_LOCK_TIMEOUT_FOR_SYNC)) {
                     try {
                         secStorageVm = startNew(dataCenterId, role);
-                        for (UploadVO upload : _uploadDao.listAll()) {
-                            _uploadDao.expunge(upload.getId());
-                        }
                     } finally {
                         _allocLock.unlock();
                     }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
@@ -309,12 +309,15 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
 
         //We just need to remove the UUID.vhd
         String extractUrl = cmd.getExtractUrl();
-        command.add("unlink /var/www/html/userdata/" + extractUrl.substring(extractUrl.lastIndexOf(File.separator) + 1));
-        String result = command.execute();
-        if (result != null) {
-            // FIXME - Ideally should bail out if you cant delete symlink. Not doing it right now.
-            // This is because the ssvm might already be destroyed and the symlinks do not exist.
-            s_logger.warn("Error in deleting symlink :" + result);
+        String result;
+        if (extractUrl != null) {
+            command.add("unlink /var/www/html/userdata/" + extractUrl.substring(extractUrl.lastIndexOf(File.separator) + 1));
+            result = command.execute();
+            if (result != null) {
+                // FIXME - Ideally should bail out if you cant delete symlink. Not doing it right now.
+                // This is because the ssvm might already be destroyed and the symlinks do not exist.
+                s_logger.warn("Error in deleting symlink :" + result);
+            }
         }
 
         // If its a volume also delete the Hard link since it was created only for the purpose of download.


### PR DESCRIPTION
## Description
1. When SSVM is destroyed the downloaded urls of
   template and volumes are not cleaned and because
   of that we cant download the templates/volumes
   using the download_url link

2. cleanup volumes in secondary storage when ssvm is destroyed

3. It should clean up the download urls for the templates belonging to the zone where ssvm is running

Steps to test

Before the fix

(1) download template (check download_url in template_store_ref table).
(2) destroy ssvm
(3) download template again
(4) It will fail to download

After the fix

1. Download template
2. Destroy ssvm
3. This will cleanup the download_url in template_store_ref table
4. Try to download template again
5. Download will be successful

Test case 2

Before the fix

1. create a vm
2. stop a vm
3. download volume
   Volume stored in
   https://10.1.1.2/userdata/2dc15926-eaa4-49f8-9d3c-e71bdbe9d39f.qcow2
4. start/stop ssvm
5. start/stop vm
6. download volume
   Volume stored in
   https://10.1.1.2/userdata/2dc15926-eaa4-49f8-9d3c-e71bdbe9d39f.qcow2

Expected result
volumes in step3 and step 5 are different

Actual result
volumes in step 3 and 5 are same.

After the fix

volumes in step 3 and 5 are different

step 3: http://10.11.1.2/userdata/7237c056-2a45-426b-b12e-13da9adab644.qcow2

Step 5: http://10.11.1.2/userdata/9da05f2a-2abc-42b8-9adc-c0e41f36f0c4.qcow2

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
