### PR TITLE
Added nfs minor version support on SSVM

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/to/NfsTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/NfsTO.java
@@ -24,7 +24,7 @@ public class NfsTO implements DataStoreTO {
     private DataStoreRole _role;
     private String uuid;
     private static final String pathSeparator = "/";
-    private Integer nfsVersion;
+    private String nfsVersion;
 
     public NfsTO() {
 
@@ -73,11 +73,11 @@ public class NfsTO implements DataStoreTO {
         return pathSeparator;
     }
 
-    public Integer getNfsVersion() {
+    public String getNfsVersion() {
         return nfsVersion;
     }
 
-    public void setNfsVersion(Integer nfsVersion) {
+    public void setNfsVersion(String nfsVersion) {
         this.nfsVersion = nfsVersion;
     }
 }

--- a/core/src/main/java/com/cloud/agent/api/GetStorageStatsCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/GetStorageStatsCommand.java
@@ -55,7 +55,7 @@ public class GetStorageStatsCommand extends StorageNfsVersionCommand {
         this.store = store;
     }
 
-    public GetStorageStatsCommand(DataStoreTO store, Integer nfsVersion) {
+    public GetStorageStatsCommand(DataStoreTO store, String nfsVersion) {
         super(nfsVersion);
         this.store = store;
     }

--- a/core/src/main/java/com/cloud/agent/api/storage/ListTemplateCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/storage/ListTemplateCommand.java
@@ -31,7 +31,7 @@ public class ListTemplateCommand extends StorageCommand {
         this.store = store;
     }
 
-    public ListTemplateCommand(DataStoreTO store, Integer nfsVersion) {
+    public ListTemplateCommand(DataStoreTO store, String nfsVersion) {
         super(nfsVersion);
         this.store = store;
     }

--- a/core/src/main/java/com/cloud/agent/api/storage/StorageCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/storage/StorageCommand.java
@@ -24,7 +24,7 @@ public abstract class StorageCommand extends StorageNfsVersionCommand {
         super();
     }
 
-    protected StorageCommand(Integer nfsVersion){
+    protected StorageCommand(String nfsVersion){
         super(nfsVersion);
     }
 

--- a/core/src/main/java/com/cloud/agent/api/storage/StorageNfsVersionCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/storage/StorageNfsVersionCommand.java
@@ -26,18 +26,18 @@ public abstract class StorageNfsVersionCommand extends Command {
         super();
     }
 
-    protected StorageNfsVersionCommand(Integer nfsVersion){
+    protected StorageNfsVersionCommand(String nfsVersion){
         super();
         this.nfsVersion = nfsVersion;
     }
 
-    private Integer nfsVersion;
+    private String nfsVersion;
 
-    public Integer getNfsVersion() {
+    public String getNfsVersion() {
         return nfsVersion;
     }
 
-    public void setNfsVersion(Integer nfsVersion) {
+    public void setNfsVersion(String nfsVersion) {
         this.nfsVersion = nfsVersion;
     }
 

--- a/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
@@ -55,7 +55,7 @@ public class TemplateOrVolumePostUploadCommand {
 
     private long accountId;
 
-    private Integer nfsVersion;
+    private String nfsVersion;
 
     public TemplateOrVolumePostUploadCommand(long entityId, String entityUUID, String absolutePath, String checksum, String type, String name, String imageFormat, String dataTo,
             String dataToRole) {
@@ -201,11 +201,11 @@ public class TemplateOrVolumePostUploadCommand {
         return accountId;
     }
 
-    public Integer getNfsVersion() {
+    public String getNfsVersion() {
         return nfsVersion;
     }
 
-    public void setNfsVersion(Integer nfsVersion) {
+    public void setNfsVersion(String nfsVersion) {
         this.nfsVersion = nfsVersion;
     }
 

--- a/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
@@ -73,9 +73,9 @@ public interface CapacityManager {
                     "If set to true, creates VMs as full clones on ESX hypervisor",
                     true,
                     ConfigKey.Scope.StoragePool);
-    static final ConfigKey<Integer> ImageStoreNFSVersion =
-            new ConfigKey<Integer>(
-                    Integer.class,
+    static final ConfigKey<String> ImageStoreNFSVersion =
+            new ConfigKey<String>(
+                    String.class,
                     "secstorage.nfs.version",
                     "Advanced",
                     null,

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -671,7 +671,7 @@ public class TemplateServiceImpl implements TemplateService {
     }
 
     private Map<String, TemplateProp> listTemplate(DataStore ssStore) {
-        Integer nfsVersion = imageStoreDetailsUtil.getNfsVersion(ssStore.getId());
+        String nfsVersion = imageStoreDetailsUtil.getNfsVersion(ssStore.getId());
         ListTemplateCommand cmd = new ListTemplateCommand(ssStore.getTO(), nfsVersion);
         EndPoint ep = _epSelector.select(ssStore);
         Answer answer = null;

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/NfsImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/NfsImageStoreDriverImpl.java
@@ -36,12 +36,11 @@ public abstract class NfsImageStoreDriverImpl extends BaseImageStoreDriverImpl {
      * @param imgStoreId store id
      * @return "secstorage.nfs.version" associated value for imgStoreId in image_store_details table if exists, null if not
      */
-    protected Integer getNfsVersion(long imgStoreId){
+    protected String getNfsVersion(long imgStoreId){
         Map<String, String> imgStoreDetails = _imageStoreDetailsDao.getDetails(imgStoreId);
         String nfsVersionKey = CapacityManager.ImageStoreNFSVersion.key();
         if (imgStoreDetails != null && imgStoreDetails.containsKey(nfsVersionKey)){
-            String nfsVersionParam = imgStoreDetails.get(nfsVersionKey);
-            return (nfsVersionParam != null ? Integer.valueOf(nfsVersionParam) : null);
+            return imgStoreDetails.get(nfsVersionKey);
         }
         return null;
     }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -994,7 +994,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         continue;
                     }
 
-                    Integer nfsVersion = imageStoreDetailsUtil.getNfsVersion(store.getId());
+                    String nfsVersion = imageStoreDetailsUtil.getNfsVersion(store.getId());
                     GetStorageStatsCommand command = new GetStorageStatsCommand(store.getTO(), nfsVersion);
                     EndPoint ssAhost = _epSelector.select(store);
                     if (ssAhost == null) {

--- a/server/src/main/java/com/cloud/storage/ImageStoreDetailsUtil.java
+++ b/server/src/main/java/com/cloud/storage/ImageStoreDetailsUtil.java
@@ -42,11 +42,10 @@ public class ImageStoreDetailsUtil {
      * Retrieve global secondary storage NFS version default value
      * @return global default value
      */
-    protected Integer getGlobalDefaultNfsVersion(){
+    protected String getGlobalDefaultNfsVersion(){
         ConfigurationVO globalNfsVersion = configurationDao.findByName(CapacityManager.ImageStoreNFSVersion.key());
         Preconditions.checkState(globalNfsVersion != null, "Unable to find global NFS version for version key " + CapacityManager.ImageStoreNFSVersion.key());
-        String value = globalNfsVersion.getValue();
-        return (value != null ? Integer.valueOf(value) : null);
+        return globalNfsVersion.getValue();
     }
     /**
      * Obtain NFS protocol version (if provided) for a store id, if not use default config value<br/>
@@ -54,12 +53,11 @@ public class ImageStoreDetailsUtil {
      * @return {@code null} if {@code secstorage.nfs.version} is not found for storeId <br/>
      * {@code X} if {@code secstorage.nfs.version} is found found for storeId
      */
-    public Integer getNfsVersion(long storeId) throws NumberFormatException {
+    public String getNfsVersion(long storeId) throws NumberFormatException {
 
         final Map<String, String> storeDetails = imageStoreDetailsDao.getDetails(storeId);
         if (storeDetails != null && storeDetails.containsKey(CapacityManager.ImageStoreNFSVersion.key())) {
-            final String version = storeDetails.get(CapacityManager.ImageStoreNFSVersion.key());
-            return (version != null ? Integer.valueOf(version) : null);
+            return storeDetails.get(CapacityManager.ImageStoreNFSVersion.key());
         }
 
         return getGlobalDefaultNfsVersion();
@@ -68,11 +66,11 @@ public class ImageStoreDetailsUtil {
 
     /**
      * Obtain NFS protocol version (if provided) for a store uuid.<br/>
-     * @param resourceId image store id
+     * @param storeUuid image store id
      * @return {@code null} if {@code secstorage.nfs.version} is not found for storeUuid <br/>
      * {@code X} if {@code secstorage.nfs.version} is found found for storeUuid
      */
-    public Integer getNfsVersionByUuid(String storeUuid){
+    public String getNfsVersionByUuid(String storeUuid){
         ImageStoreVO imageStore = imageStoreDao.findByUuid(storeUuid);
         if (imageStore != null){
             return getNfsVersion(imageStore.getId());

--- a/server/src/test/java/com/cloud/storage/ImageStoreDetailsUtilTest.java
+++ b/server/src/test/java/com/cloud/storage/ImageStoreDetailsUtilTest.java
@@ -37,8 +37,8 @@ public class ImageStoreDetailsUtilTest {
 
     private final static long STORE_ID = 1l;
     private final static String STORE_UUID = "aaaa-aaaa-aaaa-aaaa";
-    private final static Integer NFS_VERSION = 3;
-    private final static Integer NFS_VERSION_DEFAULT = 2;
+    private final static String NFS_VERSION = "3";
+    private final static String NFS_VERSION_DEFAULT = "2";
 
     ImageStoreDetailsUtil imageStoreDetailsUtil = new ImageStoreDetailsUtil();
 
@@ -69,7 +69,7 @@ public class ImageStoreDetailsUtilTest {
 
     @Test
     public void testGetNfsVersion(){
-        Integer nfsVersion = imageStoreDetailsUtil.getNfsVersion(STORE_ID);
+        String nfsVersion = imageStoreDetailsUtil.getNfsVersion(STORE_ID);
         assertEquals(NFS_VERSION, nfsVersion);
     }
 
@@ -79,7 +79,7 @@ public class ImageStoreDetailsUtilTest {
         imgStoreDetails.put("other.prop", "propValue");
         when(imgStoreDetailsDao.getDetails(STORE_ID)).thenReturn(imgStoreDetails);
 
-        Integer nfsVersion = imageStoreDetailsUtil.getNfsVersion(STORE_ID);
+        String nfsVersion = imageStoreDetailsUtil.getNfsVersion(STORE_ID);
         assertEquals(NFS_VERSION_DEFAULT, nfsVersion);
     }
 
@@ -88,26 +88,26 @@ public class ImageStoreDetailsUtilTest {
         Map<String, String> imgStoreDetails = new HashMap<String, String>();
         when(imgStoreDetailsDao.getDetails(STORE_ID)).thenReturn(imgStoreDetails);
 
-        Integer nfsVersion = imageStoreDetailsUtil.getNfsVersion(STORE_ID);
+        String nfsVersion = imageStoreDetailsUtil.getNfsVersion(STORE_ID);
         assertEquals(NFS_VERSION_DEFAULT, nfsVersion);
     }
 
     @Test
     public void testGetNfsVersionByUuid(){
-        Integer nfsVersion = imageStoreDetailsUtil.getNfsVersionByUuid(STORE_UUID);
+        String nfsVersion = imageStoreDetailsUtil.getNfsVersionByUuid(STORE_UUID);
         assertEquals(NFS_VERSION, nfsVersion);
     }
 
     @Test
     public void testGetNfsVersionByUuidNoImgStore(){
         when(imgStoreDao.findByUuid(STORE_UUID)).thenReturn(null);
-        Integer nfsVersion = imageStoreDetailsUtil.getNfsVersionByUuid(STORE_UUID);
+        String nfsVersion = imageStoreDetailsUtil.getNfsVersionByUuid(STORE_UUID);
         assertEquals(NFS_VERSION_DEFAULT, nfsVersion);
     }
 
     @Test
     public void testGetGlobalDefaultNfsVersion(){
-        Integer globalDefaultNfsVersion = imageStoreDetailsUtil.getGlobalDefaultNfsVersion();
+        String globalDefaultNfsVersion = imageStoreDetailsUtil.getGlobalDefaultNfsVersion();
         assertEquals(NFS_VERSION_DEFAULT, globalDefaultNfsVersion);
     }
 }

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -323,7 +323,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                     setupCmd = new SecStorageSetupCommand(ssStore.getTO(), secUrl, certs);
                 }
 
-                Integer nfsVersion = imageStoreDetailsUtil.getNfsVersion(ssStore.getId());
+                String nfsVersion = imageStoreDetailsUtil.getNfsVersion(ssStore.getId());
                 setupCmd.setNfsVersion(nfsVersion);
 
                 //template/volume file upload key
@@ -1204,7 +1204,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         if (dc.getDns2() != null) {
             buf.append(" dns2=").append(dc.getDns2());
         }
-        Integer nfsVersion = imageStoreDetailsUtil != null ? imageStoreDetailsUtil.getNfsVersion(secStore.getId()) : null;
+        String nfsVersion = imageStoreDetailsUtil != null ? imageStoreDetailsUtil.getNfsVersion(secStore.getId()) : null;
         buf.append(" nfsVersion=").append(nfsVersion);
 
         String bootArgs = buf.toString();

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/LocalNfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/LocalNfsSecondaryStorageResource.java
@@ -53,7 +53,7 @@ public class LocalNfsSecondaryStorageResource extends NfsSecondaryStorageResourc
     }
 
     @Override
-    synchronized public String getRootDir(String secUrl, Integer nfsVersion) {
+    synchronized public String getRootDir(String secUrl, String nfsVersion) {
         try {
             URI uri = new URI(secUrl);
             String dir = mountUri(uri, nfsVersion);
@@ -66,7 +66,7 @@ public class LocalNfsSecondaryStorageResource extends NfsSecondaryStorageResourc
     }
 
     @Override
-    protected void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
+    protected void mount(String localRootPath, String remoteDevice, URI uri, String nfsVersion) {
         ensureLocalRootPathExists(localRootPath, uri);
 
         if (mountExists(localRootPath, uri)) {

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/LocalSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/LocalSecondaryStorageResource.java
@@ -72,7 +72,7 @@ public class LocalSecondaryStorageResource extends ServerResourceBase implements
     }
 
     @Override
-    public String getRootDir(String url, Integer nfsVersion) {
+    public String getRootDir(String url, String nfsVersion) {
         return getRootDir();
 
     }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -232,7 +232,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     private String _storageIp;
     private String _storageNetmask;
     private String _storageGateway;
-    private Integer _nfsVersion;
+    private String _nfsVersion;
     private final List<String> nfsIps = new ArrayList<String>();
     protected String _parent = "/mnt/SecStorage";
     final private String _tmpltpp = "template.properties";
@@ -262,18 +262,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
      * @param params
      * @return nfsVersion value if exists, null in other case
      */
-    public static Integer retrieveNfsVersionFromParams(Map<String, Object> params) {
-        Integer nfsVersion = null;
-        if (params.get("nfsVersion") != null) {
-            String nfsVersionParam = (String)params.get("nfsVersion");
-            try {
-                nfsVersion = Integer.valueOf(nfsVersionParam);
-            } catch (NumberFormatException e){
-                s_logger.error("Couldn't cast " + nfsVersionParam + " to integer");
-                return null;
-            }
-        }
-        return nfsVersion;
+    public static String retrieveNfsVersionFromParams(Map<String, Object> params) {
+        return (String)params.get("nfsVersion");
     }
 
     @Override
@@ -965,7 +955,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         return new CopyCmdAnswer("");
     }
 
-    protected File getFile(String path, String nfsPath, Integer nfsVersion) {
+    protected File getFile(String path, String nfsPath, String nfsVersion) {
         String filePath = getRootDir(nfsPath, nfsVersion) + File.separator + path;
         File f = new File(filePath);
         if (!f.exists()) {
@@ -1097,7 +1087,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         return Long.parseLong(StringUtils.substringAfterLast(StringUtils.substringBeforeLast(key, S3Utils.SEPARATOR), S3Utils.SEPARATOR));
     }
 
-    private String determineStorageTemplatePath(final String storagePath, String dataPath, Integer nfsVersion) {
+    private String determineStorageTemplatePath(final String storagePath, String dataPath, String nfsVersion) {
         return join(asList(getRootDir(storagePath, nfsVersion), dataPath), File.separator);
     }
 
@@ -2444,7 +2434,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     }
 
     @Override
-    synchronized public String getRootDir(String secUrl, Integer nfsVersion) {
+    synchronized public String getRootDir(String secUrl, String nfsVersion) {
         if (!_inSystemVM) {
             return _parent;
         }
@@ -2786,7 +2776,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
      * @return name of folder in _parent that device was mounted.
      * @throws UnknownHostException
      */
-    protected String mountUri(URI uri, Integer nfsVersion) throws UnknownHostException {
+    protected String mountUri(URI uri, String nfsVersion) throws UnknownHostException {
         String uriHostIp = getUriHostIp(uri);
         String nfsPath = uriHostIp + ":" + uri.getPath();
 
@@ -2807,7 +2797,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         return dir;
     }
 
-    protected void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
+    protected void mount(String localRootPath, String remoteDevice, URI uri, String nfsVersion) {
         s_logger.debug("mount " + uri.toString() + " on " + localRootPath + ((nfsVersion != null) ? " nfsVersion=" + nfsVersion : ""));
         ensureLocalRootPathExists(localRootPath, uri);
 
@@ -2823,7 +2813,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         checkForVolumesDir(localRootPath);
     }
 
-    protected void attemptMount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
+    protected void attemptMount(String localRootPath, String remoteDevice, URI uri, String nfsVersion) {
         String result;
         s_logger.debug("Make cmdline call to mount " + remoteDevice + " at " + localRootPath + " based on uri " + uri + ((nfsVersion != null) ? " nfsVersion=" + nfsVersion : ""));
         Script command = new Script(!_inSystemVM, "mount", _timeout, s_logger);

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/SecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/SecondaryStorageResource.java
@@ -23,6 +23,6 @@ import com.cloud.resource.ServerResource;
  */
 public interface SecondaryStorageResource extends ServerResource {
 
-    String getRootDir(String cmd, Integer nfsVersion);
+    String getRootDir(String cmd, String nfsVersion);
 
 }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -93,7 +93,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     StorageLayer _storage;
     public Map<String, Processor> _processors;
     private long _processTimeout;
-    private Integer _nfsVersion;
+    private String _nfsVersion;
 
     public class Completion implements DownloadCompleteCallback {
         private final String jobId;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR adds minor version support when mounting nfs on the SSVM as requested in #2861 

The global setting "secstorage.nfs.version" has been changed to use String data type which allows any minor version to be specified.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This was tested by changing the global setting values and restarting the SSVM, then verifying if the secondary storage was mounted with the specified version by logging into the SSVM and typing "mount" at the cli.

Tested with SSVM running on KVM, Xenserver and VMWare hosts.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
