### PR TITLE
kvm: qemu-img convert -s to backup snapshot is deprecated

### DIFF
--- a/scripts/storage/qcow2/managesnapshot.sh
+++ b/scripts/storage/qcow2/managesnapshot.sh
@@ -153,7 +153,7 @@ destroy_snapshot() {
     lvm lvremove -f "${vg}/${snapshotname}-cow"
   elif [ -f $disk ]; then
      #delete all the existing snapshots
-     $qemu_img snapshot -l $disk |tail -n +3|awk '{print $1}'|xargs -I {} $qemu_img snapshot -d {} $disk >&2
+     $qemu_img snapshot -l $disk |tail -n +3|awk '{print $2}'|xargs -I {} $qemu_img snapshot -d {} $disk >&2
      if [ $? -gt 0 ]
      then
        failed=2
@@ -223,7 +223,7 @@ backup_snapshot() {
       return 1
     fi
 
-    $qemu_img convert -f qcow2 -O qcow2 -s $snapshotname $disk $destPath/$destName >& /dev/null
+    $qemu_img convert -f qcow2 -O qcow2 -l snapshot.name=$snapshotname $disk $destPath/$destName >& /dev/null
     if [ $? -gt 0 ]
     then
       printf "Failed to backup $snapshotname for disk $disk to $destPath\n" >&2


### PR DESCRIPTION
This fixes the qemu-img convert command to use the support way to create
qcow2 file from a snapshot name of a qcow2 volume using the `-l
snapshot.name=<name>` as the `-s <snapshot name` is no longer supported
in newer qemu-img.

Tested on Ubuntu 20.04, needs testing on CentOS8 cc @davidjumani @shwstppr and regression testing on CentOS7 and Ubuntu 16.04/18.04 cc @wido @GabrielBrascher 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)