### PR TITLE
RabbitMQ log enhancement

### DIFF
--- a/plugins/event-bus/rabbitmq/src/main/java/org/apache/cloudstack/mom/rabbitmq/RabbitMQEventBus.java
+++ b/plugins/event-bus/rabbitmq/src/main/java/org/apache/cloudstack/mom/rabbitmq/RabbitMQEventBus.java
@@ -21,11 +21,14 @@ package org.apache.cloudstack.mom.rabbitmq;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 
 import javax.naming.ConfigurationException;
 
@@ -358,8 +361,8 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
         if (s_connection == null) {
             try {
                 return createConnection();
-            } catch (Exception e) {
-                s_logger.error("Failed to create a connection to AMQP server due to " + e.getMessage());
+            } catch (KeyManagementException | NoSuchAlgorithmException | IOException  | TimeoutException e) {
+                s_logger.error(String.format("Failed to create a connection to AMQP server [AMQP host:%s, port:%d] due to: %s", amqpHost, port, e));
                 throw e;
             }
         } else {
@@ -367,8 +370,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
         }
     }
 
-    private synchronized Connection createConnection() throws Exception {
-        try {
+    private synchronized Connection createConnection() throws KeyManagementException, NoSuchAlgorithmException, IOException, TimeoutException {
             ConnectionFactory factory = new ConnectionFactory();
             factory.setUsername(username);
             factory.setPassword(password);
@@ -389,9 +391,6 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
             connection.addBlockedListener(blockedConnectionHandler);
             s_connection = connection;
             return s_connection;
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     private synchronized void closeConnection() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The handling of the exception of RabbitMQ `getConnection()` method can be improved.
Example of issues that I have noticed:
```
Failed to create a connection to AMQP server due to null
```

Not all exceptions hold a message; therefore, some exceptions might result in a `null` output instead of the Exception message/stack.

With the fix, the error message looks like:
```
Failed to create a connection to AMQP server [AMQP host:amqp.host.org, port:123] due to: java.net.UnknownHostException: amqp.host.org: Name or service not known
Failed to create a connection to AMQP server [AMQP host:null, port:null] due to: java.net.ConnectException: Connection refused (Connection refused)
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->