### PR TITLE
add support for XCP-ng 7/8 to create it's heartbeat LVM properly

### DIFF
--- a/scripts/vm/hypervisor/xenserver/setup_heartbeat_sr.sh
+++ b/scripts/vm/hypervisor/xenserver/setup_heartbeat_sr.sh
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,7 +17,7 @@
 # under the License.
 
 #set -x
- 
+
 usage() {
   echo "Usage: $(basename $0) [uuid of this host] [uuid of the sr to place the heartbeat]"
 
@@ -40,7 +40,7 @@ if [ `xe host-list | grep $1 | wc -l` -ne 1 ]; then
   exit 0
 fi
 
-if [ `xe sr-list uuid=$2 | wc -l`  -eq 0 ]; then 
+if [ `xe sr-list uuid=$2 | wc -l`  -eq 0 ]; then
   echo "#4# Unable to find SR with uuid: $2"
   exit 0
 fi
@@ -60,7 +60,7 @@ if [ "$srtype" == "nfs" ];then
     date=`date +%s`
     echo "$date" > $filename
   fi
-else 
+else
   dir=/dev/VG_XenStorage-$2
   link=$dir/hb-$1
   lv=`lvscan | grep $link`
@@ -72,14 +72,10 @@ else
       fi
       rm $link -f
     fi
-    if [ -f /etc/redhat-release ] && grep -q "XenServer release 7." /etc/redhat-release; then
+    if [ -f /etc/redhat-release ] && grep -q -E "(XenServer|XCP-ng) release (7|8)." /etc/redhat-release; then
         lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M --config global{metadata_read_only=0}
     else
-        if [ -f /etc/redhat-release ] && grep -q "XCP-ng release 8." /etc/redhat-release; then
-            lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M --config global{metadata_read_only=0}
-        else
-            lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M
-        fi
+        lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M
     fi
     if [ $? -ne 0 ]; then
       echo "#6# Unable to create heartbeat volume hb-$1"

--- a/scripts/vm/hypervisor/xenserver/setup_heartbeat_sr.sh
+++ b/scripts/vm/hypervisor/xenserver/setup_heartbeat_sr.sh
@@ -75,7 +75,11 @@ else
     if [ -f /etc/redhat-release ] && grep -q "XenServer release 7." /etc/redhat-release; then
         lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M --config global{metadata_read_only=0}
     else
-        lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M
+        if [ -f /etc/redhat-release ] && grep -q "XCP-ng release 8." /etc/redhat-release; then
+            lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M --config global{metadata_read_only=0}
+        else
+            lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M
+        fi
     fi
     if [ $? -ne 0 ]; then
       echo "#6# Unable to create heartbeat volume hb-$1"


### PR DESCRIPTION
## Description

`/opt/cloud/bin/setup_heartbeat_sr.sh` line 75 tests for “XenServer release 7.” in `/etc/redhat-release` which contains “XCP-ng release 8.0.0 (xenenterprise)” in my case so the `lvcreate` statement doesn’t contain the required options

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #3281

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Adding an iSCSI endpoint now succeeds with XCP-ng 8.0.0. I've left the previous XenServer logic alone just added the XCP-ng test case into the else block.  This could definitely be fine tuned by someone who's more intimate with these scripts but I just wanted the issue fixed without interfering in the logic.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
