### PR TITLE
[VMware] Explicitly controlling VM hardware version

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ClusterMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ClusterMO.java
@@ -94,7 +94,7 @@ public class ClusterMO extends BaseMO implements VmwareHypervisorHost {
         return null;
     }
 
-    private ClusterConfigInfoEx getClusterConfigInfo() throws Exception {
+    public ClusterConfigInfoEx getClusterConfigInfo() throws Exception {
         ClusterConfigInfoEx configInfo = (ClusterConfigInfoEx)_context.getVimClient().getDynamicProperty(_mor, "configurationEx");
         return configInfo;
     }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatacenterMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatacenterMO.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 
 import com.vmware.vim25.CustomFieldStringValue;
+import com.vmware.vim25.DatacenterConfigInfo;
 import com.vmware.vim25.DVPortgroupConfigInfo;
 import com.vmware.vim25.DistributedVirtualSwitchPortConnection;
 import com.vmware.vim25.DynamicProperty;
@@ -507,5 +508,10 @@ public class DatacenterMO extends BaseMO {
     public boolean ensureCustomFieldDef(String fieldName) throws Exception {
         CustomFieldsManagerMO cfmMo = new CustomFieldsManagerMO(_context, _context.getServiceContent().getCustomFieldsManager());
         return cfmMo.ensureCustomFieldDef("Datacenter", fieldName) > 0;
+    }
+
+    public DatacenterConfigInfo getDatacenterConfigInfo() throws Exception {
+        DatacenterConfigInfo configInfo = (DatacenterConfigInfo)_context.getVimClient().getDynamicProperty(_mor, "configuration");
+        return configInfo;
     }
 }


### PR DESCRIPTION
## Description
Set the VM hardware version on new VM deployments as set by the administrator on vCenter at cluster or datacenter level by the 'Edit Default VM Compatibility' action:

![image](https://user-images.githubusercontent.com/5295080/83207449-9bedb780-a129-11ea-9cc1-e41f368cd01e.png)

On VM deployments:
- Check cluster level VM hardware version If it is set, then is used as the new VM hardware version
- If cluster level VM hardware version not set, check the datacenter VM hardware version. If it is set, then it is used as the new VM hardware version.
- If both cluster or datacenter VM hardware version not set, then VM hardware version not set for the new VM

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
