### PR TITLE
kvm: bump jna version to latest

### DIFF
--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>jna</artifactId>
             <version>${cs.jna.version}</version>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>${cs.jna.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <cs.jersey-bundle.version>1.19.4</cs.jersey-bundle.version>
         <cs.jetty.version>9.4.26.v20200117</cs.jetty.version>
         <cs.jetty-maven-plugin.version>9.4.26.v20200117</cs.jetty-maven-plugin.version>
-        <cs.jna.version>4.0.0</cs.jna.version>
+        <cs.jna.version>5.5.0</cs.jna.version>
         <cs.joda-time.version>2.10.5</cs.joda-time.version>
         <cs.jpa.version>2.2.1</cs.jpa.version>
         <cs.jsch.version>0.1.55</cs.jsch.version>


### PR DESCRIPTION
This fixes issue for cloudstack-agent to make connections to libvirt
on arm64 boards.

The jna-platform provides non-default (x86_64) mappings, read more:
https://github.com/java-native-access/jna/blob/master/www/PlatformLibrary.md

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)