### PR TITLE
server: fix TransactionLegacy DB connection leaks due to DB switching by B&R thread

### DIFF
--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -492,6 +492,7 @@ public class EventTypes {
     public static final String EVENT_VM_BACKUP_RESTORE_VOLUME_TO_VM = "BACKUP.RESTORE.VOLUME.TO.VM";
     public static final String EVENT_VM_BACKUP_SCHEDULE_CONFIGURE = "BACKUP.SCHEDULE.CONFIGURE";
     public static final String EVENT_VM_BACKUP_SCHEDULE_DELETE = "BACKUP.SCHEDULE.DELETE";
+    public static final String EVENT_VM_BACKUP_USAGE_METRIC = "BACKUP.USAGE.METRIC";
 
     // external network device events
     public static final String EVENT_EXTERNAL_NVP_CONTROLLER_ADD = "PHYSICAL.NVPCONTROLLER.ADD";

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageBackupDao.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageBackupDao.java
@@ -20,14 +20,11 @@ package com.cloud.usage.dao;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.cloudstack.backup.Backup;
-
 import com.cloud.usage.UsageBackupVO;
 import com.cloud.utils.db.GenericDao;
-import com.cloud.vm.VirtualMachine;
 
 public interface UsageBackupDao extends GenericDao<UsageBackupVO, Long> {
-    void updateMetrics(VirtualMachine vm, Backup.Metric metric);
-    void removeUsage(Long accountId, Long zoneId, Long backupId);
+    void updateMetrics(Long vmId, Long size, Long virtualSize);
+    void removeUsage(Long accountId, Long vmId, Date eventDate);
     List<UsageBackupVO> getUsageRecords(Long accountId, Date startDate, Date endDate);
 }

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageBackupDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageBackupDaoImpl.java
@@ -45,8 +45,7 @@ public class UsageBackupDaoImpl extends GenericDaoBase<UsageBackupVO, Long> impl
 
     @Override
     public void updateMetrics(final Long vmId, final Long size, final Long virtualSize) {
-        TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
-        try {
+        try (TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB)) {
             SearchCriteria<UsageBackupVO> sc = this.createSearchCriteria();
             sc.addAnd("vmId", SearchCriteria.Op.EQ, vmId);
             UsageBackupVO vo = findOneBy(sc);
@@ -57,8 +56,6 @@ public class UsageBackupDaoImpl extends GenericDaoBase<UsageBackupVO, Long> impl
             }
         } catch (final Exception e) {
             LOGGER.error("Error updating backup metrics: " + e.getMessage(), e);
-        } finally {
-            txn.close();
         }
     }
 

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageBackupDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageBackupDaoImpl.java
@@ -19,69 +19,71 @@ package com.cloud.usage.dao;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
-import org.apache.cloudstack.backup.Backup;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
+import com.cloud.exception.CloudException;
 import com.cloud.usage.UsageBackupVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
-import com.cloud.utils.db.QueryBuilder;
 import com.cloud.utils.db.SearchCriteria;
-import com.cloud.utils.db.Transaction;
-import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionLegacy;
-import com.cloud.utils.db.TransactionStatus;
-import com.cloud.vm.VirtualMachine;
 
 @Component
 public class UsageBackupDaoImpl extends GenericDaoBase<UsageBackupVO, Long> implements UsageBackupDao {
     public static final Logger LOGGER = Logger.getLogger(UsageBackupDaoImpl.class);
-    protected static final String GET_USAGE_RECORDS_BY_ACCOUNT = "SELECT id, zone_id, account_id, domain_id, vm_id, backup_offering_id, size, protected_size, created, removed FROM cloud_usage.usage_backup WHERE " +
+    protected static final String UPDATE_DELETED = "UPDATE usage_backup SET removed = ? WHERE account_id = ? AND vm_id = ? and removed IS NULL";
+    protected static final String GET_USAGE_RECORDS_BY_ACCOUNT = "SELECT id, zone_id, account_id, domain_id, vm_id, backup_offering_id, size, protected_size, created, removed FROM usage_backup WHERE " +
             " account_id = ? AND ((removed IS NULL AND created <= ?) OR (created BETWEEN ? AND ?) OR (removed BETWEEN ? AND ?) " +
             " OR ((created <= ?) AND (removed >= ?)))";
 
     @Override
-    public void updateMetrics(final VirtualMachine vm, Backup.Metric metric) {
-        boolean result = Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<Boolean>() {
-            @Override
-            public Boolean doInTransaction(final TransactionStatus status) {
-                final QueryBuilder<UsageBackupVO> qb = QueryBuilder.create(UsageBackupVO.class);
-                qb.and(qb.entity().getVmId(), SearchCriteria.Op.EQ, vm.getId());
-                final UsageBackupVO entry = findOneBy(qb.create());
-                if (entry == null) {
-                    return false;
-                }
-                entry.setSize(metric.getBackupSize());
-                entry.setProtectedSize(metric.getDataSize());
-                return update(entry.getId(), entry);
+    public void updateMetrics(final Long vmId, final Long size, final Long virtualSize) {
+        TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
+        try {
+            SearchCriteria<UsageBackupVO> sc = this.createSearchCriteria();
+            sc.addAnd("vmId", SearchCriteria.Op.EQ, vmId);
+            UsageBackupVO vo = findOneBy(sc);
+            if (vo != null) {
+                vo.setSize(size);
+                vo.setProtectedSize(virtualSize);
+                update(vo.getId(), vo);
             }
-        });
-        if (!result) {
-            LOGGER.trace("Failed to update backup metrics for VM ID: " + vm.getId());
+        } catch (final Exception e) {
+            LOGGER.error("Error updating backup metrics: " + e.getMessage(), e);
+        } finally {
+            txn.close();
         }
     }
 
     @Override
-    public void removeUsage(Long accountId, Long zoneId, Long vmId) {
-        boolean result = Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<Boolean>() {
-            @Override
-            public Boolean doInTransaction(final TransactionStatus status) {
-                final QueryBuilder<UsageBackupVO> qb = QueryBuilder.create(UsageBackupVO.class);
-                qb.and(qb.entity().getAccountId(), SearchCriteria.Op.EQ, accountId);
-                qb.and(qb.entity().getZoneId(), SearchCriteria.Op.EQ, zoneId);
-                qb.and(qb.entity().getVmId(), SearchCriteria.Op.EQ, vmId);
-                final UsageBackupVO entry = findOneBy(qb.create());
-                return remove(qb.create()) > 0;
+    public void removeUsage(Long accountId, Long vmId, Date eventDate) {
+        TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
+        try {
+            txn.start();
+            try (PreparedStatement pstmt = txn.prepareStatement(UPDATE_DELETED);) {
+                if (pstmt != null) {
+                    pstmt.setString(1, DateUtil.getDateDisplayString(TimeZone.getTimeZone("GMT"), eventDate));
+                    pstmt.setLong(2, accountId);
+                    pstmt.setLong(3, vmId);
+                    pstmt.executeUpdate();
+                }
+            } catch (SQLException e) {
+                LOGGER.error("Error removing UsageBackupVO: " + e.getMessage(), e);
+                throw new CloudException("Remove backup usage exception: " + e.getMessage(), e);
             }
-        });
-        if (!result) {
-            LOGGER.warn("Failed to remove usage entry for backup of VM ID: " + vmId);
+            txn.commit();
+        } catch (Exception e) {
+            txn.rollback();
+            LOGGER.error("Exception caught while removing UsageBackupVO: " + e.getMessage(), e);
+        } finally {
+            txn.close();
         }
     }
 

--- a/plugins/backup/dummy/src/main/java/org/apache/cloudstack/backup/DummyBackupProvider.java
+++ b/plugins/backup/dummy/src/main/java/org/apache/cloudstack/backup/DummyBackupProvider.java
@@ -87,8 +87,13 @@ public class DummyBackupProvider extends AdapterBase implements BackupProvider {
     public Map<VirtualMachine, Backup.Metric> getBackupMetrics(Long zoneId, List<VirtualMachine> vms) {
         final Map<VirtualMachine, Backup.Metric> metrics = new HashMap<>();
         final Backup.Metric metric = new Backup.Metric(1000L, 100L);
+        if (vms == null || vms.isEmpty()) {
+            return metrics;
+        }
         for (VirtualMachine vm : vms) {
-            metrics.put(vm, metric);
+            if (vm != null) {
+                metrics.put(vm, metric);
+            }
         }
         return metrics;
     }

--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/VeeamBackupProvider.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/VeeamBackupProvider.java
@@ -216,9 +216,12 @@ public class VeeamBackupProvider extends AdapterBase implements BackupProvider, 
     @Override
     public Map<VirtualMachine, Backup.Metric> getBackupMetrics(final Long zoneId, final List<VirtualMachine> vms) {
         final Map<VirtualMachine, Backup.Metric> metrics = new HashMap<>();
+        if (vms == null || vms.isEmpty()) {
+            return metrics;
+        }
         final Map<String, Backup.Metric> backendMetrics = getClient(zoneId).getBackupMetrics();
         for (final VirtualMachine vm : vms) {
-            if (!backendMetrics.containsKey(vm.getUuid())) {
+            if (vm == null || !backendMetrics.containsKey(vm.getUuid())) {
                 continue;
             }
             metrics.put(vm, backendMetrics.get(vm.getUuid()));

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -1081,7 +1081,10 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     }
 
     private boolean isBackupEvent(String eventType) {
-        return eventType != null && (eventType.equals(EventTypes.EVENT_VM_BACKUP_OFFERING_ASSIGN) || eventType.equals(EventTypes.EVENT_VM_BACKUP_OFFERING_REMOVE));
+        return eventType != null && (
+                eventType.equals(EventTypes.EVENT_VM_BACKUP_OFFERING_ASSIGN) ||
+                eventType.equals(EventTypes.EVENT_VM_BACKUP_OFFERING_REMOVE) ||
+                eventType.equals(EventTypes.EVENT_VM_BACKUP_USAGE_METRIC));
     }
 
     private void createVMHelperEvent(UsageEventVO event) {
@@ -1913,7 +1916,9 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             final UsageBackupVO backupVO = new UsageBackupVO(zoneId, accountId, domainId, vmId, backupOfferingId, created);
             usageBackupDao.persist(backupVO);
         } else if (EventTypes.EVENT_VM_BACKUP_OFFERING_REMOVE.equals(event.getType())) {
-            usageBackupDao.removeUsage(accountId, zoneId, vmId);
+            usageBackupDao.removeUsage(accountId, vmId, event.getCreateDate());
+        } else if (EventTypes.EVENT_VM_BACKUP_USAGE_METRIC.equals(event.getType())) {
+            usageBackupDao.updateMetrics(vmId, event.getSize(), event.getVirtualSize());
         }
     }
 


### PR DESCRIPTION
The TransactionLegacy instances are tracked by TransactionMBeanImpl in a
concurrent hashmap. Even when TransactionLegacy instances are closed,
the hashmap keep the references and makes it hard for the closed instances
to be garbage collected. This adds code to remove the TransactionLegacy
instance from the mbean when the instance is close().

    NOTE: This only happens when the new B&R feature is enabled in 4.14.0.0, the sync thread seems to get stuck while performing DB query and ends up consuming most of the TransactionLegacy instances

Related: https://github.com/apache/cloudstack/issues/3987

Leaks seen by MAT:
![Screenshot from 2020-06-01 16-47-01](https://user-images.githubusercontent.com/95203/83434109-7b8a6980-a457-11ea-88a5-30375dcc20cc.png)

The MBean explore shows a steady increase in  the leaks:
![Screenshot from 2020-06-01 22-21-32](https://user-images.githubusercontent.com/95203/83434055-69103000-a457-11ea-9501-fb3c20256a4c.png)

server: fix leak by moving backup usage updation via usage events

BackupSync task would switch between databases to update backup usage
metrics in the cloud_usage.usage_backup table. The current framework
and the usage in ManagedContext causes database connection
(LegacyTransaction) leaks. When the thread runs faster, the issue is
easily reproducible and checking via heap dump analysis or using JMX
MBeans. This fixes by moving the task of backup data updation for
usage data to the usage server by publishing usage events instead of
switching between databases in a local thread while in a
ManagedContextRunnable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

With this PR, graph over a 24+hrs period shows no leaks:
![Screenshot from 2020-06-04 08-14-10](https://user-images.githubusercontent.com/95203/83709118-7c7bf080-a63b-11ea-8aa2-7ffe5d046501.png)

