### PR TITLE
Maximum data volumes limit is picked from "default" version of hypervisor, instead of actual hypervisor version

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3097,7 +3097,11 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         Integer maxDataVolumesSupported = null;
         if (host != null) {
             _hostDao.loadDetails(host);
-            maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(host.getHypervisorType(), host.getDetail("product_version"));
+            String hypervisorVersion = host.getDetail("product_version");
+            if (org.apache.commons.lang.StringUtils.isBlank(hypervisorVersion)) {
+                hypervisorVersion = host.getHypervisorVersion();
+            }
+            maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(host.getHypervisorType(), hypervisorVersion);
         } else {
             HypervisorType hypervisorType = vm.getHypervisorType();
             if (hypervisorType != null && CollectionUtils.isNotEmpty(supportingDefaultHV) && supportingDefaultHV.contains(hypervisorType)) {


### PR DESCRIPTION
Description
-------------
<!--- Describe your changes in detail -->
Fix to pick the max data volumes limit using the actual hypervisor version, instead of "default" version

Changes:
- Use the hypervisor version in the host table when product_version parameter in host details doesn't exist or is empty


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #4101 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Create VM and attach disk, verified the max data disks limit is picked from hypervisor version

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
