### PR TITLE
Improved kvmvmactivitycheck.sh output

### DIFF
--- a/scripts/vm/hypervisor/kvm/kvmvmactivity.sh
+++ b/scripts/vm/hypervisor/kvm/kvmvmactivity.sh
@@ -99,7 +99,7 @@ fi
 
 # Second check: disk activity check
 cd $MountPoint
-latestUpdateTime=$(stat -c %Y $(echo $UUIDList | sed 's/,/ /g') | sort -nr | head -1)
+latestUpdateTime=$(stat -c %Y $(echo $UUIDList | sed 's/,/ /g') 2> /dev/null | sort -nr | head -1)
 
 if [ ! -f $acFile ]; then
     echo "$SuspectTime:$latestUpdateTime:$MSTime" > $acFile


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When scripts/vm/hypervisor/kvm/**kvmvmactivity.sh** is called with an incorrect file name, an error is printed which is then interpreted as output from the script. 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
When an incorrect file name is passed the script prints out:
```
stat: cannot stat ‘b51d7336-d964-44ee-be60-bf62783dabc’: No such file or directory
=====> DEAD <======
```

The KVMHAVMActivityChecker.java checkingHB() process is expecting just
`=====> DEAD <======`
but gets the unexpected error message and interprets the file as alive.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested by calling the script with a correct file name and getting
`=====> ALIVE <=====`
 and an incorrect file name and getting
`=====> DEAD <======`

`/usr/share/cloudstack-common/scripts/vm/hypervisor/kvm/kvmvmactivity.sh -i 1.1.1.1 -p /some/primary/storage/pool -m /some/mount/point -h 1.2.3.4 -u some-file-name -t 1591090179 -d 1591090176 `

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
