### PR TITLE
Enhance KVM running VM snapshot exception log

### DIFF
--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -1106,7 +1106,8 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             if (hosts != null && !hosts.isEmpty()) {
                 HostVO host = hosts.get(0);
                 if (!hostSupportSnapsthotForVolume(host, volume)) {
-                    throw new CloudRuntimeException("KVM Snapshot is not supported: " + host.getId());
+                    throw new CloudRuntimeException(
+                            "KVM Snapshot is not supported for Running VMs. It is disabled by default due to a possible volume corruption in certain cases. To enable it set global settings kvm.snapshot.enabled to True. See the documentation for more details.");
                 }
             }
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
By default it is not possible to snapshot volumes from Running VMs on KVM hosts; such action launches the following exception:

```
2020-06-03 11:44:54,714 DEBUG [c.c.s.s.SnapshotManagerImpl] (qtp164332069-24:ctx-2a36c5e0 ctx-a0d2d92c) (logid:430624b7) Snapshot is not supported on host Host[-1-Routing] for the volume org.apache.cloudstack.storage.volume.VolumeObject@73c6838c attached to the vm VM[User|i-2-52-VM]
2020-06-03 11:44:54,804 ERROR [c.c.a.ApiServer] (qtp164332069-24:ctx-2a36c5e0 ctx-a0d2d92c) (logid:430624b7) unhandled exception executing api command: [Ljava.lang.String;@2e3a5424
com.cloud.utils.exception.CloudRuntimeException: KVM Snapshot is not supported
```

However, it is possible to snapshot KVM Running VMs if setting global settings `kvm.snapshot.enabled` to `True`. For more details on this,  please see the documentation at [KVM volume Snapshot specifics](
http://docs.cloudstack.apache.org/en/latest/adminguide/storage.html?highlight=kvm.snapshot.enabled#kvm-volume-snapshot-specifics) section.

Currently, the log message is not clear about why KVM does not support it. This PR enhances the log message so the user knows why there is such a limitation.

```
KVM Snapshot is not supported for Running VMs. It is disabled by default due to a possible volume corruption in certain cases. To enable it set global settings kvm.snapshot.enabled to True. See the documentation for more details.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)