### PR TITLE
Fix Usage failed to get pid

### DIFF
--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -278,12 +278,14 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             throw new ConfigurationException("Unhandled exception configuring UsageManager " + e.toString());
         }
 
+        String processName;
         try {
-            String processName = ManagementFactory.getRuntimeMXBean().getName();
+            processName = ManagementFactory.getRuntimeMXBean().getName();
             _pid = Integer.parseInt(processName.split("@")[0]);
         } catch (Exception e) {
-            s_logger.error("Unable to get process pid ", e);
-            throw new ConfigurationException("Unable to get process pid " + e.toString());
+            String msg = String.format("Unable to get process Id for %s!", processName);
+            s_logger.debug(msg , e);
+            throw new ConfigurationException(msg, e);
         }
         return true;
     }

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import java.lang.management.ManagementFactory;
+
 import org.apache.cloudstack.quota.QuotaAlertManager;
 import org.apache.cloudstack.quota.QuotaManager;
 import org.apache.cloudstack.quota.QuotaStatement;
@@ -275,7 +277,14 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             s_logger.error("Unhandled exception configuring UsageManger", e);
             throw new ConfigurationException("Unhandled exception configuring UsageManager " + e.toString());
         }
-        _pid = Integer.parseInt(System.getProperty("pid"));
+
+        try {
+            String processName = ManagementFactory.getRuntimeMXBean().getName();
+            _pid = Integer.parseInt(processName.split("@")[0]);
+        } catch (Exception e) {
+            s_logger.error("Unable to get process pid ", e);
+            throw new ConfigurationException("Unable to get process pid " + e.toString());
+        }
         return true;
     }
 

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -33,8 +33,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import java.lang.management.ManagementFactory;
-
 import org.apache.cloudstack.quota.QuotaAlertManager;
 import org.apache.cloudstack.quota.QuotaManager;
 import org.apache.cloudstack.quota.QuotaStatement;
@@ -280,8 +278,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
 
         String processName = null;
         try {
-            processName = ManagementFactory.getRuntimeMXBean().getName();
-            _pid = Integer.parseInt(processName.split("@")[0]);
+            _pid = (int) ProcessHandle.current().pid();
         } catch (Exception e) {
             String msg = String.format("Unable to get process Id for %s!", processName);
             s_logger.debug(msg , e);

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -276,13 +276,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             throw new ConfigurationException("Unhandled exception configuring UsageManager " + e.toString());
         }
 
-        String processName = null;
         try {
             _pid = (int) ProcessHandle.current().pid();
         } catch (Exception e) {
-            String msg = String.format("Unable to get process Id for %s!", processName);
-            s_logger.debug(msg , e);
-            throw new ConfigurationException(msg + " " + e.toString());
+            String msg = String.format("Unable to get process Id for %s!", e.toString());
+            s_logger.debug(msg);
+            throw new ConfigurationException(msg);
         }
         return true;
     }

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -278,14 +278,14 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             throw new ConfigurationException("Unhandled exception configuring UsageManager " + e.toString());
         }
 
-        String processName;
+        String processName = null;
         try {
             processName = ManagementFactory.getRuntimeMXBean().getName();
             _pid = Integer.parseInt(processName.split("@")[0]);
         } catch (Exception e) {
             String msg = String.format("Unable to get process Id for %s!", processName);
             s_logger.debug(msg , e);
-            throw new ConfigurationException(msg, e);
+            throw new ConfigurationException(msg + " " + e.toString());
         }
         return true;
     }


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
cloudstack-usage use System.getProperty("pid") to get the process PID
System.getProperty cannot get the Pid, which will cause the service to stay in the config stage. Cannot continue to start, and there will be no log output.

This PR uses ManagementFactory instead of System.getProperty to get Pid, and throws an exception when Pid cannot be obtained

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
