### PR TITLE
server: Do not resize volume of running vm on KVM host if host is not Up or not Enabled

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1192,8 +1192,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
             /* Do not resize volume of running vm on KVM host if host is not Up or not Enabled */
             if (currentSize != newSize && userVm.getState() == State.Running && userVm.getHypervisorType() == HypervisorType.KVM) {
+                if (userVm.getHostId() == null) {
+                    throw new InvalidParameterValueException("Cannot find the hostId of running vm " + userVm.getUuid());
+                }
                 HostVO host = _hostDao.findById(userVm.getHostId());
-                if (host.getStatus() != Status.Up) {
+                if (host == null) {
+                    throw new InvalidParameterValueException("The KVM host where vm is running does not exist");
+                } else if (host.getStatus() != Status.Up) {
                     throw new InvalidParameterValueException("The KVM host where vm is running is not Up");
                 } else if (host.getResourceState() != ResourceState.Enabled) {
                     throw new InvalidParameterValueException("The KVM host where vm is running is not Enabled");

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -109,11 +109,13 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.StorageUnavailableException;
 import com.cloud.gpu.GPU;
 import com.cloud.host.HostVO;
+import com.cloud.host.Status;
 import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.HypervisorCapabilitiesVO;
 import com.cloud.hypervisor.dao.HypervisorCapabilitiesDao;
 import com.cloud.org.Grouping;
+import com.cloud.resource.ResourceState;
 import com.cloud.serializer.GsonHelper;
 import com.cloud.server.ResourceTag;
 import com.cloud.server.TaggedResourceService;
@@ -1186,6 +1188,16 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             /* Xen only works offline, SR does not support VDI.resizeOnline */
             if (currentSize != newSize && _volsDao.getHypervisorType(volume.getId()) == HypervisorType.XenServer && !userVm.getState().equals(State.Stopped)) {
                 throw new InvalidParameterValueException(errorMsg);
+            }
+
+            /* Do not resize volume of running vm on KVM host if host is not Up or not Enabled */
+            if (currentSize != newSize && userVm.getState() == State.Running && userVm.getHypervisorType() == HypervisorType.KVM) {
+                HostVO host = _hostDao.findById(userVm.getHostId());
+                if (host.getStatus() != Status.Up) {
+                    throw new InvalidParameterValueException("The KVM host where vm is running is not Up");
+                } else if (host.getResourceState() != ResourceState.Enabled) {
+                    throw new InvalidParameterValueException("The KVM host where vm is running is not Enabled");
+                }
             }
         }
 


### PR DESCRIPTION
##  Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

If we resize a volume of a vm running on a host which is not Up or not Enable, the job will be scheduled to another normal host. Then the volume will be resized by "qemu-img resize" instead of "virsh blockresize", the image might be corrupted after resize.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
