### PR TITLE
server: fix for wrong affinity group count

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3624,27 +3624,27 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             if (domainId != null) {
                 SearchCriteria<AffinityGroupJoinVO> scDomain = buildAffinityGroupSearchCriteria(null, isRecursive, new ArrayList<Long>(), listProjectResourcesCriteria, affinityGroupId,
                         affinityGroupName, affinityGroupType, keyword);
-                List<AffinityGroupJoinVO> groups = listDomainLevelAffinityGroups(scDomain, searchFilter, domainId);
-                affinityGroups.addAll(groups);
-                count += groups.size();
+                Pair<List<AffinityGroupJoinVO>, Integer> groupsPair = listDomainLevelAffinityGroups(scDomain, searchFilter, domainId);
+                affinityGroups.addAll(groupsPair.first());
+                count += groupsPair.second();
             } else {
 
                 for (Long permAcctId : permittedAccounts) {
                     Account permittedAcct = _accountDao.findById(permAcctId);
                     SearchCriteria<AffinityGroupJoinVO> scDomain = buildAffinityGroupSearchCriteria(null, isRecursive, new ArrayList<Long>(), listProjectResourcesCriteria, affinityGroupId,
                             affinityGroupName, affinityGroupType, keyword);
-                    List<AffinityGroupJoinVO> groups = listDomainLevelAffinityGroups(scDomain, searchFilter, permittedAcct.getDomainId());
-                    affinityGroups.addAll(groups);
-                    count += groups.size();
+                    Pair<List<AffinityGroupJoinVO>, Integer> groupsPair = listDomainLevelAffinityGroups(scDomain, searchFilter, permittedAcct.getDomainId());
+                    affinityGroups.addAll(groupsPair.first());
+                    count += groupsPair.second();
                 }
             }
         } else if (((permittedAccounts.isEmpty()) && (domainId != null) && isRecursive)) {
             // list all domain level affinity groups for the domain admin case
             SearchCriteria<AffinityGroupJoinVO> scDomain = buildAffinityGroupSearchCriteria(null, isRecursive, new ArrayList<Long>(), listProjectResourcesCriteria, affinityGroupId, affinityGroupName,
                     affinityGroupType, keyword);
-            List<AffinityGroupJoinVO> groups = listDomainLevelAffinityGroups(scDomain, searchFilter, domainId);
-            affinityGroups.addAll(groups);
-            count += groups.size();
+            Pair<List<AffinityGroupJoinVO>, Integer> groupsPair = listDomainLevelAffinityGroups(scDomain, searchFilter, domainId);
+            affinityGroups.addAll(groupsPair.first());
+            count += groupsPair.second();
         }
 
         return new Pair<List<AffinityGroupJoinVO>, Integer>(affinityGroups, count);
@@ -3745,7 +3745,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         return new Pair<List<AffinityGroupJoinVO>, Integer>(ags, count);
     }
 
-    private List<AffinityGroupJoinVO> listDomainLevelAffinityGroups(SearchCriteria<AffinityGroupJoinVO> sc, Filter searchFilter, long domainId) {
+    private Pair<List<AffinityGroupJoinVO>, Integer> listDomainLevelAffinityGroups(SearchCriteria<AffinityGroupJoinVO> sc, Filter searchFilter, long domainId) {
         List<Long> affinityGroupIds = new ArrayList<Long>();
         Set<Long> allowedDomains = _domainMgr.getDomainParentIds(domainId);
         List<AffinityGroupDomainMapVO> maps = _affinityGroupDomainMapDao.listByDomain(allowedDomains.toArray());
@@ -3769,7 +3769,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             Integer count = uniqueGroupsPair.second();
             if (count.intValue() == 0) {
                 // empty result
-                return new ArrayList<AffinityGroupJoinVO>();
+                return new Pair<>(new ArrayList<AffinityGroupJoinVO>(), 0);
             }
             List<AffinityGroupJoinVO> uniqueGroups = uniqueGroupsPair.first();
             Long[] vrIds = new Long[uniqueGroups.size()];
@@ -3778,9 +3778,9 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 vrIds[i++] = v.getId();
             }
             List<AffinityGroupJoinVO> vrs = _affinityGroupJoinDao.searchByIds(vrIds);
-            return vrs;
+            return new Pair<>(vrs, count);
         } else {
-            return new ArrayList<AffinityGroupJoinVO>();
+            return new Pair<>(new ArrayList<AffinityGroupJoinVO>(), 0);
         }
     }
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3624,25 +3624,30 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             if (domainId != null) {
                 SearchCriteria<AffinityGroupJoinVO> scDomain = buildAffinityGroupSearchCriteria(null, isRecursive, new ArrayList<Long>(), listProjectResourcesCriteria, affinityGroupId,
                         affinityGroupName, affinityGroupType, keyword);
-                affinityGroups.addAll(listDomainLevelAffinityGroups(scDomain, searchFilter, domainId));
+                List<AffinityGroupJoinVO> groups = listDomainLevelAffinityGroups(scDomain, searchFilter, domainId);
+                affinityGroups.addAll(groups);
+                count += groups.size();
             } else {
 
                 for (Long permAcctId : permittedAccounts) {
                     Account permittedAcct = _accountDao.findById(permAcctId);
                     SearchCriteria<AffinityGroupJoinVO> scDomain = buildAffinityGroupSearchCriteria(null, isRecursive, new ArrayList<Long>(), listProjectResourcesCriteria, affinityGroupId,
                             affinityGroupName, affinityGroupType, keyword);
-
-                    affinityGroups.addAll(listDomainLevelAffinityGroups(scDomain, searchFilter, permittedAcct.getDomainId()));
+                    List<AffinityGroupJoinVO> groups = listDomainLevelAffinityGroups(scDomain, searchFilter, permittedAcct.getDomainId());
+                    affinityGroups.addAll(groups);
+                    count += groups.size();
                 }
             }
         } else if (((permittedAccounts.isEmpty()) && (domainId != null) && isRecursive)) {
             // list all domain level affinity groups for the domain admin case
             SearchCriteria<AffinityGroupJoinVO> scDomain = buildAffinityGroupSearchCriteria(null, isRecursive, new ArrayList<Long>(), listProjectResourcesCriteria, affinityGroupId, affinityGroupName,
                     affinityGroupType, keyword);
-            affinityGroups.addAll(listDomainLevelAffinityGroups(scDomain, searchFilter, domainId));
+            List<AffinityGroupJoinVO> groups = listDomainLevelAffinityGroups(scDomain, searchFilter, domainId);
+            affinityGroups.addAll(groups);
+            count += groups.size();
         }
 
-        return new Pair<List<AffinityGroupJoinVO>, Integer>(affinityGroups, affinityGroups.size());
+        return new Pair<List<AffinityGroupJoinVO>, Integer>(affinityGroups, count);
 
     }
 


### PR DESCRIPTION
## Description
Fixes wrong `count` in `listAffinityGroup` API.
API was returning the count of `AffinityGroupJoinVO` records.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
With a running environment,
**Before fix** - count is equal to VM count for the affinity groups
```
(local) 🐱 > list affinitygroups 
{
  "affinitygroup": [
    {
      "account": "admin",
      "domain": "ROOT",
      "domainid": "1db59a3e-b131-11ea-94f6-645d8651f45a",
      "id": "b878f4e6-fbcd-44f3-9a95-ad8102fd14da",
      "name": "bvcn",
      "type": "host anti-affinity",
      "virtualmachineIds": [
        "0c6bee5e-2d50-4b7a-b26f-30bff5818777"
      ]
    },
    {
      "account": "admin",
      "domain": "ROOT",
      "domainid": "1db59a3e-b131-11ea-94f6-645d8651f45a",
      "id": "10b78b41-8fe4-47c1-8972-3bedd0690fd3",
      "name": "hfd",
      "type": "host anti-affinity",
      "virtualmachineIds": [
        "0c6bee5e-2d50-4b7a-b26f-30bff5818777",
        "f4ca8c20-4887-4bc1-a532-b39cf140c4e4"
      ]
    },
    {
      "account": "admin",
      "domain": "ROOT",
      "domainid": "1db59a3e-b131-11ea-94f6-645d8651f45a",
      "id": "63d02962-ac8a-419a-bb88-eabec223828d",
      "name": "dfsf",
      "type": "host anti-affinity",
      "virtualmachineIds": [
        "0c6bee5e-2d50-4b7a-b26f-30bff5818777",
        "f4ca8c20-4887-4bc1-a532-b39cf140c4e4",
        "cf8d9565-b1c5-40f0-a436-56a52fc86106"
      ]
    }
  ],
  "count": 6
}

```
**After fix** - actual count of affinity groups
```
{
  "affinitygroup": [
    {
      "account": "admin",
      "domain": "ROOT",
      "domainid": "1db59a3e-b131-11ea-94f6-645d8651f45a",
      "id": "b878f4e6-fbcd-44f3-9a95-ad8102fd14da",
      "name": "bvcn",
      "type": "host anti-affinity",
      "virtualmachineIds": [
        "0c6bee5e-2d50-4b7a-b26f-30bff5818777"
      ]
    },
    {
      "account": "admin",
      "domain": "ROOT",
      "domainid": "1db59a3e-b131-11ea-94f6-645d8651f45a",
      "id": "10b78b41-8fe4-47c1-8972-3bedd0690fd3",
      "name": "hfd",
      "type": "host anti-affinity",
      "virtualmachineIds": [
        "0c6bee5e-2d50-4b7a-b26f-30bff5818777",
        "f4ca8c20-4887-4bc1-a532-b39cf140c4e4"
      ]
    },
    {
      "account": "admin",
      "domain": "ROOT",
      "domainid": "1db59a3e-b131-11ea-94f6-645d8651f45a",
      "id": "63d02962-ac8a-419a-bb88-eabec223828d",
      "name": "dfsf",
      "type": "host anti-affinity",
      "virtualmachineIds": [
        "0c6bee5e-2d50-4b7a-b26f-30bff5818777",
        "f4ca8c20-4887-4bc1-a532-b39cf140c4e4",
        "cf8d9565-b1c5-40f0-a436-56a52fc86106"
      ]
    }
  ],
  "count": 3
}

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
