### PR TITLE
Fixed removal of hosts from certsmap when running certificate auto-renew

### DIFF
--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
@@ -97,6 +97,12 @@ public interface HostDao extends GenericDao<HostVO, Long>, StateDao<Status, Stat
 
     List<HostVO> listByType(Type type);
 
+    /**
+     * Finds a host by ip address, excludes removed hosts.
+     *
+     * @param ip The ip address to match on
+     * @return One matched host
+     */
     HostVO findByIp(String ip);
 
     /**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When a host connects to a management server, the host IP address and the certificate are stored in memory on the management server. This mapping is checked periodically to determine if any certificates are due to expire.

Before a certificate is renewed, a few checks are done to determine if the host is connected to the management server by fetching the host record from the database. The problem here is if the wrong record is fetched, the host is not checked for renewal.

This PR improves the host record fetch from the database by looking only at hosts that are not removed.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #4129 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This has been tested by setting the ca.framework.cert.validity.period and ca.framework.cert.expiry.alert.period to the same value. This is to ensure that a certificate is up for renewal as soon as it is issued.
Then watch the management server logs to see if auto-renewal happens.

This has also been tested by using two management servers and reprovisioning host security keys from the second management server and still having the certs auto-renew. 

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
