### PR TITLE
Adding listall to listLdapConfigurations

### DIFF
--- a/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/api/command/LdapListConfigurationCmd.java
+++ b/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/api/command/LdapListConfigurationCmd.java
@@ -55,6 +55,10 @@ public class LdapListConfigurationCmd extends BaseListCmd {
     @Parameter(name = ApiConstants.DOMAIN_ID, type = CommandType.UUID, required = false, entityType = DomainResponse.class, description = "linked domain")
     private Long domainId;
 
+    @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, description = "If set to true, "
+    + " and no domainid specified, list all LDAP configurations irrespective of the linked domain", since = "4.13.2")
+    private Boolean listAll;
+
     public LdapListConfigurationCmd() {
         super();
     }
@@ -116,5 +120,9 @@ public class LdapListConfigurationCmd extends BaseListCmd {
 
     public void setDomainId(final Long domainId) {
         this.domainId = domainId;
+    }
+
+    public boolean listAll() {
+        return listAll != null && listAll;
     }
 }

--- a/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/LdapManagerImpl.java
+++ b/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/LdapManagerImpl.java
@@ -291,7 +291,8 @@ public class LdapManagerImpl implements LdapManager, LdapValidator {
         final String hostname = cmd.getHostname();
         final int port = cmd.getPort();
         final Long domainId = cmd.getDomainId();
-        final Pair<List<LdapConfigurationVO>, Integer> result = _ldapConfigurationDao.searchConfigurations(hostname, port, domainId);
+        final boolean listAll = cmd.listAll();
+        final Pair<List<LdapConfigurationVO>, Integer> result = _ldapConfigurationDao.searchConfigurations(hostname, port, domainId, listAll);
         return new Pair<List<? extends LdapConfigurationVO>, Integer>(result.first(), result.second());
     }
 

--- a/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/dao/LdapConfigurationDao.java
+++ b/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/dao/LdapConfigurationDao.java
@@ -37,5 +37,9 @@ public interface LdapConfigurationDao extends GenericDao<LdapConfigurationVO, Lo
 
     LdapConfigurationVO find(String hostname, int port, Long domainId);
 
+    LdapConfigurationVO find(String hostname, int port, Long domainId, boolean listAll);
+
     Pair<List<LdapConfigurationVO>, Integer> searchConfigurations(String hostname, int port, Long domainId);
+
+    Pair<List<LdapConfigurationVO>, Integer> searchConfigurations(String hostname, int port, Long domainId, boolean listAll);
 }

--- a/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/dao/LdapConfigurationDaoImpl.java
+++ b/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/dao/LdapConfigurationDaoImpl.java
@@ -46,6 +46,7 @@ public class LdapConfigurationDaoImpl extends GenericDaoBase<LdapConfigurationVO
         listGlobalConfigurationsSearch.and("port", listGlobalConfigurationsSearch.entity().getPort(), Op.EQ);
         listGlobalConfigurationsSearch.and("domain_id", listGlobalConfigurationsSearch.entity().getDomainId(),SearchCriteria.Op.NULL);
         listGlobalConfigurationsSearch.done();
+
         listDomainConfigurationsSearch = createSearchBuilder();
         listDomainConfigurationsSearch.and("hostname", listDomainConfigurationsSearch.entity().getHostname(), Op.EQ);
         listDomainConfigurationsSearch.and("port", listDomainConfigurationsSearch.entity().getPort(), Op.EQ);
@@ -62,23 +63,38 @@ public class LdapConfigurationDaoImpl extends GenericDaoBase<LdapConfigurationVO
 
     @Override
     public LdapConfigurationVO find(String hostname, int port, Long domainId) {
-        SearchCriteria<LdapConfigurationVO> sc = getSearchCriteria(hostname, port, domainId);
+        SearchCriteria<LdapConfigurationVO> sc = getSearchCriteria(hostname, port, domainId, false);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public LdapConfigurationVO find(String hostname, int port, Long domainId, boolean listAll) {
+        SearchCriteria<LdapConfigurationVO> sc = getSearchCriteria(hostname, port, domainId, listAll);
         return findOneBy(sc);
     }
 
     @Override
     public Pair<List<LdapConfigurationVO>, Integer> searchConfigurations(final String hostname, final int port, final Long domainId) {
-        SearchCriteria<LdapConfigurationVO> sc = getSearchCriteria(hostname, port, domainId);
+        SearchCriteria<LdapConfigurationVO> sc = getSearchCriteria(hostname, port, domainId, false);
         return searchAndCount(sc, null);
     }
 
-    private SearchCriteria<LdapConfigurationVO> getSearchCriteria(String hostname, int port, Long domainId) {
+    @Override
+    public Pair<List<LdapConfigurationVO>, Integer> searchConfigurations(final String hostname, final int port, final Long domainId, final boolean listAll) {
+        SearchCriteria<LdapConfigurationVO> sc = getSearchCriteria(hostname, port, domainId, listAll);
+        return searchAndCount(sc, null);
+    }
+
+    private SearchCriteria<LdapConfigurationVO> getSearchCriteria(String hostname, int port, Long domainId,boolean listAll) {
         SearchCriteria<LdapConfigurationVO> sc;
-        if (domainId == null) {
-            sc = listDomainConfigurationsSearch.create();
-        } else {
+        if (domainId != null) {
+            // If domainid is present, ignore listall
             sc = listDomainConfigurationsSearch.create();
             sc.setParameters("domain_id", domainId);
+        } else if (listAll) {
+            sc = listDomainConfigurationsSearch.create();
+        } else {
+            sc = listGlobalConfigurationsSearch.create();
         }
         if (hostname != null) {
             sc.setParameters("hostname", hostname);


### PR DESCRIPTION
## Description
Adds the listall parameter to listLdapConfigurations.
If set to true, and no domainid specified, list all LDAP configurations irrespective of the linked domain

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
```
(localhost) 🐱 > list ldapconfigurations listall=true 
{
  "LdapConfiguration": [
    {
      "domainid": "3eca21e9-b1f3-11ea-ba9c-50eb71576f75",
      "hostname": "primate-qa.cloudstack.cloud",
      "port": 389
    },
    {
      "domainid": "2b660440-759f-4490-99ba-cddd9cbff2af",
      "hostname": "primate-qa.cloudstack.cloud",
      "port": 389
    },
    {
      "hostname": "primate-qa.cloudstack.cloud",
      "port": 389
    }
  ],
  "count": 3
}
(localhost) 🐱 > list ldapconfigurations 
{
  "LdapConfiguration": [
    {
      "hostname": "primate-qa.cloudstack.cloud",
      "port": 389
    }
  ],
  "count": 1
}
(localhost) 🐱 > list ldapconfigurations domainid=2b660440-759f-4490-99ba-cddd9cbff2af listall=true 
{
  "LdapConfiguration": [
    {
      "domainid": "2b660440-759f-4490-99ba-cddd9cbff2af",
      "hostname": "primate-qa.cloudstack.cloud",
      "port": 389
    }
  ],
  "count": 1
}

```