### PR TITLE
Fixes issue b/w Legacy and Primate UI wrt SessionID

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.servlet.ServletConfig;
@@ -50,7 +51,6 @@ import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 import com.cloud.user.Account;
 import com.cloud.user.AccountService;
 import com.cloud.user.User;
-
 import com.cloud.utils.HttpUtils;
 import com.cloud.utils.StringUtils;
 import com.cloud.utils.db.EntityManager;
@@ -259,6 +259,22 @@ public class ApiServlet extends HttpServlet {
                 userId = (Long)session.getAttribute("userid");
                 final String account = (String) session.getAttribute("account");
                 final Object accountObj = session.getAttribute("accountobj");
+                if (session.getAttribute(ApiConstants.SESSIONKEY) != null) {
+                    Cookie[] cookies = req.getCookies();
+                    if (cookies != null) {
+                        HttpSession finalSession = session;
+                        List<Cookie> sessionKeys = Arrays.stream(cookies).filter(cookie ->  cookie.getName().equals(ApiConstants.SESSIONKEY)
+                                && cookie.getValue().equals(finalSession.getAttribute(ApiConstants.SESSIONKEY))).collect(Collectors.toList());
+                        Cookie validCookie = sessionKeys.get(0);
+                        for (Cookie cookie : cookies) {
+                            if (cookie.getName().equals(ApiConstants.SESSIONKEY)) {
+                                if (cookie.getValue() != null && !cookie.getValue().equals(validCookie.getValue())) {
+                                    cookie.setValue((String) validCookie.getValue());
+                                }
+                            }
+                        }
+                    }
+                }
                 if (!HttpUtils.validateSessionKey(session, params, req.getCookies(), ApiConstants.SESSIONKEY)) {
                     try {
                         session.invalidate();


### PR DESCRIPTION
## Description
When operating with both the legacy and Primate UI, due to clash in the sessionIDs generated during logins, one is unable to log in to Legacy UI once logged into Primate
Fix: If it is not a new session, then we use the latest session key (session ID in the cookies) for validation 
Addresses issue: https://github.com/apache/cloudstack/issues/4136

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
