### PR TITLE
server: Purge all cookies on logout, set /client path on login

### DIFF
--- a/plugins/user-authenticators/saml2/src/main/java/org/apache/cloudstack/saml/SAMLUtils.java
+++ b/plugins/user-authenticators/saml2/src/main/java/org/apache/cloudstack/saml/SAMLUtils.java
@@ -280,7 +280,7 @@ public class SAMLUtils {
             resp.addCookie(new Cookie("timezone", URLEncoder.encode(timezone, HttpUtils.UTF_8)));
         }
         resp.addCookie(new Cookie("userfullname", URLEncoder.encode(loginResponse.getFirstName() + " " + loginResponse.getLastName(), HttpUtils.UTF_8).replace("+", "%20")));
-        resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly", ApiConstants.SESSIONKEY, loginResponse.getSessionKey()));
+        resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=/", ApiConstants.SESSIONKEY, loginResponse.getSessionKey()));
     }
 
     /**

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -213,7 +213,7 @@ public class ApiServlet extends HttpServlet {
                     try {
                         responseString = apiAuthenticator.authenticate(command, params, session, remoteAddress, responseType, auditTrailSb, req, resp);
                         if (session != null && session.getAttribute(ApiConstants.SESSIONKEY) != null) {
-                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=%s", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY), req.getContextPath().split("/api")[0]));
+                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=%s", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY), req.getContextPath().split("api")[0]));
                         }
                     } catch (ServerApiException e) {
                         httpResponseCode = e.getErrorCode().getHttpCode();

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -213,7 +213,7 @@ public class ApiServlet extends HttpServlet {
                     try {
                         responseString = apiAuthenticator.authenticate(command, params, session, remoteAddress, responseType, auditTrailSb, req, resp);
                         if (session != null && session.getAttribute(ApiConstants.SESSIONKEY) != null) {
-                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY)));
+                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=/client", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY)));
                         }
                     } catch (ServerApiException e) {
                         httpResponseCode = e.getErrorCode().getHttpCode();
@@ -238,9 +238,14 @@ public class ApiServlet extends HttpServlet {
                             } catch (final IllegalStateException ignored) {
                             }
                         }
-                        Cookie sessionKeyCookie = new Cookie(ApiConstants.SESSIONKEY, "");
-                        sessionKeyCookie.setMaxAge(0);
-                        resp.addCookie(sessionKeyCookie);
+                        final Cookie[] cookies = req.getCookies();
+                        if (cookies != null)
+                            for (final Cookie cookie : cookies) {
+                                cookie.setValue("");
+                                cookie.setMaxAge(0);
+                                resp.addCookie(cookie);
+                            }
+                        }
                     }
                     HttpUtils.writeHttpResponse(resp, responseString, httpResponseCode, responseType, ApiServer.JSONcontentType.value());
                     return;

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -213,7 +213,7 @@ public class ApiServlet extends HttpServlet {
                     try {
                         responseString = apiAuthenticator.authenticate(command, params, session, remoteAddress, responseType, auditTrailSb, req, resp);
                         if (session != null && session.getAttribute(ApiConstants.SESSIONKEY) != null) {
-                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=%s", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY), req.getContextPath().split("api")[0]));
+                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=/", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY)));
                         }
                     } catch (ServerApiException e) {
                         httpResponseCode = e.getErrorCode().getHttpCode();

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -239,7 +239,7 @@ public class ApiServlet extends HttpServlet {
                             }
                         }
                         final Cookie[] cookies = req.getCookies();
-                        if (cookies != null)
+                        if (cookies != null) {
                             for (final Cookie cookie : cookies) {
                                 cookie.setValue("");
                                 cookie.setMaxAge(0);

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -213,7 +213,7 @@ public class ApiServlet extends HttpServlet {
                     try {
                         responseString = apiAuthenticator.authenticate(command, params, session, remoteAddress, responseType, auditTrailSb, req, resp);
                         if (session != null && session.getAttribute(ApiConstants.SESSIONKEY) != null) {
-                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=/client", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY)));
+                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly;Path=%s", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY), req.getContextPath().split("/api")[0]));
                         }
                     } catch (ServerApiException e) {
                         httpResponseCode = e.getErrorCode().getHttpCode();


### PR DESCRIPTION
This will purge all the cookies on logout including multiple sessionkey
cookies if passed. On login, this will restrict sessionkey cookie
(httponly) to the /client path like the JSESSIONID cookie.

Fixes #4136

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

Needs manual testing