### PR TITLE
kvm: pre-add 32 PCI controller for hot-plug issue

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -443,6 +443,11 @@ public class LibvirtVMDef {
                     devicesBuilder.append(dev.toString());
                 }
             }
+            devicesBuilder.append("<controller type='pci' model='pcie-root'/>\n");
+            for (int i = 0; i < 32; i++) {
+              devicesBuilder.append("<controller type='pci' model='pcie-root-port'/>\n");
+            }
+            devicesBuilder.append("<controller type='pci' model='pcie-to-pci-bridge'/>\n");
             devicesBuilder.append("</devices>\n");
             return devicesBuilder.toString();
         }


### PR DESCRIPTION
On newer libvirt/qemu it seems PCI hot-plugging could be an issue as
seen in:

https://www.suse.com/support/kb/doc/?id=000019383
https://bugs.launchpad.net/nova/+bug/1836065

As per the default machine doc, it advises to pre-allocate PCI
controllers on the machine and pcie-to-pci-bridge based controller
for legacy PCI models:
https://libvirt.org/pci-hotplug.html#x86_64-q35

This patch introduces the concept as a workaround until a proper fix is
done (ideally in the upstream libvirt/qemu projects). Until then client
code can add 32 PCI controllers and a pcie-to-pci-bridge controller.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

On this env:
```
# virsh version
Compiled against library: libvirt 6.0.0
Using library: libvirt 6.0.0
Using API: QEMU 6.0.0
Running hypervisor: QEMU 4.2.0
```
I was unable to add nic to a VM (beyond 3 nics) and got the error "No more available PCI slots". After this workaround/fix I was able to add nic and disks to the VM. (The VM was using virtio-scsi for disks and virtio based nics on PCI controller)