### PR TITLE
Broadcast URI not set to vxlan, but vlan (Fix #3040)

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2279,7 +2279,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         }
 
         if (vlanSpecified) {
-            URI uri = BroadcastDomainType.fromString(vlanId);
+            URI uri = encodeVlanIdIntoBroadcastUri(vlanId, pNtwk);
             //don't allow to specify vlan tag used by physical network for dynamic vlan allocation
             if (!(bypassVlanOverlapCheck && ntwkOff.getGuestType() == GuestType.Shared) && _dcDao.findVnet(zoneId, pNtwk.getId(), BroadcastDomainType.getValue(uri)).size() > 0) {
                 throw new InvalidParameterValueException("The VLAN tag " + vlanId + " is already being used for dynamic vlan allocation for the guest network in zone "
@@ -2424,7 +2424,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                             //Logical router's UUID provided as VLAN_ID
                             userNetwork.setVlanIdAsUUID(vlanIdFinal); //Set transient field
                         } else {
-                            uri = BroadcastDomainType.fromString(vlanIdFinal);
+                            uri = encodeVlanIdIntoBroadcastUri(vlanIdFinal, pNtwk);
                         }
                         userNetwork.setBroadcastUri(uri);
                         if (!vlanIdFinal.equalsIgnoreCase(Vlan.UNTAGGED)) {
@@ -2473,6 +2473,21 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         CallContext.current().setEventDetails("Network Id: " + network.getId());
         CallContext.current().putContextParameter(Network.class, network.getUuid());
         return network;
+    }
+
+    /**
+     * Encodes VLAN/VXLAN ID into a Broadcast URI according to the isolation method from the Physical Network.
+     * @return Broadcast URI, e.g. 'vlan://vlan_ID' or 'vxlan://vlxan_ID'
+     */
+    protected URI encodeVlanIdIntoBroadcastUri(String vlanId, PhysicalNetwork pNtwk) {
+        if(StringUtils.isNotBlank(pNtwk.getIsolationMethods().get(0))) {
+            String isolationMethod = pNtwk.getIsolationMethods().get(0).toLowerCase();
+            String vxlan = BroadcastDomainType.Vxlan.toString().toLowerCase();
+            if(isolationMethod.equals(vxlan)) {
+                return BroadcastDomainType.encodeStringIntoBroadcastUri(vlanId, BroadcastDomainType.Vxlan);
+            }
+        }
+        return BroadcastDomainType.fromString(vlanId);
     }
 
   /**

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2480,6 +2480,10 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
      * @return Broadcast URI, e.g. 'vlan://vlan_ID' or 'vxlan://vlxan_ID'
      */
     protected URI encodeVlanIdIntoBroadcastUri(String vlanId, PhysicalNetwork pNtwk) {
+        if (pNtwk == null) {
+            throw new InvalidParameterValueException(String.format("Failed to encode VLAN/VXLAN %s into a Broadcast URI. Physical Network cannot be null.", vlanId));
+        }
+
         if(StringUtils.isNotBlank(pNtwk.getIsolationMethods().get(0))) {
             String isolationMethod = pNtwk.getIsolationMethods().get(0).toLowerCase();
             String vxlan = BroadcastDomainType.Vxlan.toString().toLowerCase();

--- a/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
+++ b/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
@@ -521,6 +521,11 @@ public class NetworkOrchestratorTest extends TestCase {
         encodeVlanIdIntoBroadcastUriPrepareAndTest("vxlan://123", "vlan", "vxlan", "vxlan://123");
     }
 
+    @Test(expected = InvalidParameterValueException.class)
+    public void encodeVlanIdIntoBroadcastUriTestNullNetwork() {
+        URI resultUri = testOrchastrator.encodeVlanIdIntoBroadcastUri("vxlan://123", null);
+    }
+
     private void encodeVlanIdIntoBroadcastUriPrepareAndTest(String vlanId, String isolationMethod, String expectedIsolation, String expectedUri) {
         PhysicalNetworkVO physicalNetwork = new PhysicalNetworkVO();
         List<String> isolationMethods = new ArrayList<>();

--- a/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
+++ b/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
@@ -22,12 +22,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.network.dao.PhysicalNetworkVO;
+import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
@@ -463,4 +466,70 @@ public class NetworkOrchestratorTest extends TestCase {
         testOrchastrator.validateLockedRequestedIp(ipVoSpy, lockedIp);
     }
 
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestVxlan() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("123", "VXLAN", "vxlan", "vxlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestVlan() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("123", "VLAN", "vlan", "vlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestEmpty() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("123", "", "vlan", "vlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestNull() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("123", null, "vlan", "vlan://123");
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void encodeVlanIdIntoBroadcastUriTestEmptyVlanId() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("", "vxlan", "vlan", "vlan://123");
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void encodeVlanIdIntoBroadcastUriTestNullVlanId() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest(null, "vlan", "vlan", "vlan://123");
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void encodeVlanIdIntoBroadcastUriTestBlankVlanId() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest(" ", "vlan", "vlan", "vlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestNullVlanIdWithSchema() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("vlan://123", "vlan", "vlan", "vlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestNullVlanIdWithSchemaIsolationVxlan() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("vlan://123", "vxlan", "vlan", "vlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestNullVxlanIdWithSchema() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("vxlan://123", "vxlan", "vxlan", "vxlan://123");
+    }
+
+    @Test
+    public void encodeVlanIdIntoBroadcastUriTestNullVxlanIdWithSchemaIsolationVlan() {
+        encodeVlanIdIntoBroadcastUriPrepareAndTest("vxlan://123", "vlan", "vxlan", "vxlan://123");
+    }
+
+    private void encodeVlanIdIntoBroadcastUriPrepareAndTest(String vlanId, String isolationMethod, String expectedIsolation, String expectedUri) {
+        PhysicalNetworkVO physicalNetwork = new PhysicalNetworkVO();
+        List<String> isolationMethods = new ArrayList<>();
+        isolationMethods.add(isolationMethod);
+        physicalNetwork.setIsolationMethods(isolationMethods);
+
+        URI resultUri = testOrchastrator.encodeVlanIdIntoBroadcastUri(vlanId, physicalNetwork);
+
+        Assert.assertEquals(expectedIsolation, resultUri.getScheme());
+        Assert.assertEquals(expectedUri, resultUri.toString());
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR sets properly Broadcast URI to `vxlan://vxlan_id` when the physical network is of VXLAN.

Fixes: #3040

Description of issue #3040:
> Advanced Network zone with VXLAN is created. When creating a guest network and setting the VNI this is set for the network:
>     broadcast_uri: vlan://1000
>     isolation_uri: vlan://1000
> 
> STEPS TO REPRODUCE
> 
>     Create a Advanced Zone with VXLAN
>     Create a guest network
>     See that broadcast is set to vlan and not vxlan

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
**Prior to the fix:**
![image](https://user-images.githubusercontent.com/5025148/86156620-9f83ae00-badc-11ea-972a-6e54cc3141c0.png)

**After the fix:**
![image](https://user-images.githubusercontent.com/5025148/86156657-ad393380-badc-11ea-86dc-146fa15eece1.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Create a Advanced Zone with VXLAN
2. Create a guest network
3. See that broadcast uri is set to vxlan

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
