### PR TITLE
enable update tags on disk offerings

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -77,6 +77,13 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
             since = "4.13")
     private String zoneIds;
 
+    @Parameter(name = ApiConstants.TAGS,
+            type = CommandType.STRING,
+            description = "Comma-separated list of tags to be added to disk offering",
+            since = "4.15")
+    private String tags;
+
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -159,6 +166,10 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
             validZoneIds.addAll(_configService.getDiskOfferingZones(id));
         }
         return validZoneIds;
+    }
+
+    public String getTags() {
+        return tags;
     }
 
 /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -79,7 +79,7 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.TAGS,
             type = CommandType.STRING,
-            description = "Comma-separated list of tags to be added to disk offering",
+            description = "comma-separated list of tags for the disk offering, tags should match with existing storage pool tags",
             since = "4.15")
     private String tags;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.admin.offering;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -80,6 +81,7 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
     @Parameter(name = ApiConstants.TAGS,
             type = CommandType.STRING,
             description = "comma-separated list of tags for the disk offering, tags should match with existing storage pool tags",
+            authorized = {RoleType.Admin},
             since = "4.15")
     private String tags;
 

--- a/engine/schema/src/main/java/com/cloud/storage/DiskOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/DiskOfferingVO.java
@@ -364,7 +364,7 @@ public class DiskOfferingVO implements DiskOffering {
         return created;
     }
 
-    protected void setTags(String tags) {
+    public void setTags(String tags) {
         this.tags = tags;
     }
 

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3211,7 +3211,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         if (tags != null){
             if(tags.isBlank()){
                 diskOffering.setTags(null);
-            }else {
+            } else {
                 diskOffering.setTags(tags);
             }
         }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3102,6 +3102,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final Boolean displayDiskOffering = cmd.getDisplayOffering();
         final List<Long> domainIds = cmd.getDomainIds();
         final List<Long> zoneIds = cmd.getZoneIds();
+        final String tags = cmd.getTags();
 
         // Check if diskOffering exists
         final DiskOffering diskOfferingHandle = _entityMgr.findById(DiskOffering.class, diskOfferingId);
@@ -3183,7 +3184,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             throw new InvalidParameterValueException(String.format("Unable to update disk offering: %s by id user: %s because it is not root-admin or domain-admin", diskOfferingHandle.getUuid(), user.getUuid()));
         }
 
-        final boolean updateNeeded = name != null || displayText != null || sortKey != null || displayDiskOffering != null;
+        final boolean updateNeeded = name != null || displayText != null || sortKey != null || displayDiskOffering != null || tags != null;
         final boolean detailsUpdateNeeded = !filteredDomainIds.equals(existingDomainIds) || !filteredZoneIds.equals(existingZoneIds);
         if (!updateNeeded && !detailsUpdateNeeded) {
             return _diskOfferingDao.findById(diskOfferingId);
@@ -3207,30 +3208,13 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             diskOffering.setDisplayOffering(displayDiskOffering);
         }
 
-        // Note: tag editing commented out for now;keeping the code intact,
-        // might need to re-enable in next releases
-        // if (tags != null)
-        // {
-        // if (tags.trim().isEmpty() && diskOfferingHandle.getTags() == null)
-        // {
-        // //no new tags; no existing tags
-        // diskOffering.setTagsArray(csvTagsToList(null));
-        // }
-        // else if (!tags.trim().isEmpty() && diskOfferingHandle.getTags() !=
-        // null)
-        // {
-        // //new tags + existing tags
-        // List<String> oldTags = csvTagsToList(diskOfferingHandle.getTags());
-        // List<String> newTags = csvTagsToList(tags);
-        // oldTags.addAll(newTags);
-        // diskOffering.setTagsArray(oldTags);
-        // }
-        // else if(!tags.trim().isEmpty())
-        // {
-        // //new tags; NO existing tags
-        // diskOffering.setTagsArray(csvTagsToList(tags));
-        // }
-        // }
+        if (tags != null){
+            if(tags.isBlank()){
+                diskOffering.setTags(null);
+            }else {
+                diskOffering.setTags(tags);
+            }
+        }
 
         if (updateNeeded && !_diskOfferingDao.update(diskOfferingId, diskOffering)) {
             return null;

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -56,6 +57,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import com.cloud.api.query.dao.NetworkOfferingJoinDao;
 import com.cloud.api.query.vo.NetworkOfferingJoinVO;
@@ -87,6 +89,7 @@ import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.projects.ProjectManager;
+import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.Account;
@@ -108,6 +111,7 @@ public class ConfigurationManagerTest {
 
     private static final Logger s_logger = Logger.getLogger(ConfigurationManagerTest.class);
 
+    @Spy
     @InjectMocks
     ConfigurationManagerImpl configurationMgr = new ConfigurationManagerImpl();
 
@@ -163,11 +167,12 @@ public class ConfigurationManagerTest {
     ImageStoreDao _imageStoreDao;
     @Mock
     ConfigurationDao _configDao;
+    @Mock
+    DiskOfferingVO diskOfferingVOMock;
 
     VlanVO vlan = new VlanVO(Vlan.VlanType.VirtualNetwork, "vlantag", "vlangateway", "vlannetmask", 1L, "iprange", 1L, 1L, null, null, null);
 
     private static final String MAXIMUM_DURATION_ALLOWED = "3600";
-
     @Mock
     Network network;
     @Mock
@@ -937,5 +942,34 @@ public class ConfigurationManagerTest {
     @Test
     public void validateMaximumIopsAndBytesLengthTestDefaultLengthConfigs() {
         configurationMgr.validateMaximumIopsAndBytesLength(36000l, 36000l, 36000l, 36000l);
+    }
+
+    @Test
+    public void shouldUpdateDiskOfferingTests(){
+        Assert.assertTrue(configurationMgr.shouldUpdateDiskOffering(Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean(), Mockito.anyString()));
+        Assert.assertTrue(configurationMgr.shouldUpdateDiskOffering(Mockito.anyString(), nullable(String.class), nullable(Integer.class), nullable(Boolean.class), nullable(String.class)));
+        Assert.assertTrue(configurationMgr.shouldUpdateDiskOffering(nullable(String.class), Mockito.anyString(), nullable(Integer.class), nullable(Boolean.class), nullable(String.class)));
+        Assert.assertTrue(configurationMgr.shouldUpdateDiskOffering(nullable(String.class), nullable(String.class), Mockito.anyInt(), nullable(Boolean.class), nullable(String.class)));
+        Assert.assertTrue(configurationMgr.shouldUpdateDiskOffering(nullable(String.class), nullable(String.class), nullable(int.class), Mockito.anyBoolean(), nullable(String.class)));
+        Assert.assertTrue(configurationMgr.shouldUpdateDiskOffering(nullable(String.class), nullable(String.class), nullable(int.class), nullable(Boolean.class), Mockito.anyString()));
+    }
+
+    @Test
+    public void shouldUpdateDiskOfferingTestFalse(){
+        Assert.assertFalse(configurationMgr.shouldUpdateDiskOffering(null, null, null, null, null));
+    }
+
+    @Test
+    public void updateDiskOfferingTagsIfIsNotNullTestWhenTagsIsNull(){
+        Mockito.doNothing().when(configurationMgr).updateDiskOfferingTagsIfIsNotNull(null, diskOfferingVOMock);
+        this.configurationMgr.updateDiskOfferingTagsIfIsNotNull(null, diskOfferingVOMock);
+        Mockito.verify(configurationMgr, Mockito.times(1)).updateDiskOfferingTagsIfIsNotNull(null, diskOfferingVOMock);
+    }
+    @Test
+    public void updateDiskOfferingTagsIfIsNotNullTestWhenTagsIsNotNull(){
+        String tags = "tags";
+        Mockito.doNothing().when(configurationMgr).updateDiskOfferingTagsIfIsNotNull(tags, diskOfferingVOMock);
+        this.configurationMgr.updateDiskOfferingTagsIfIsNotNull(tags, diskOfferingVOMock);
+        Mockito.verify(configurationMgr, Mockito.times(1)).updateDiskOfferingTagsIfIsNotNull(tags, diskOfferingVOMock);
     }
 }

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -2613,7 +2613,8 @@
                                     var data = {
                                         id: args.context.diskOfferings[0].id,
                                         name: args.data.name,
-                                        displaytext: args.data.displaytext
+                                        displaytext: args.data.displaytext,
+                                        tags: args.data.tags
                                     };
                                     $.ajax({
                                         url: createURL('updateDiskOffering'),
@@ -2939,7 +2940,41 @@
                                         label: 'label.cache.mode'
                                     },
                                     tags: {
-                                        label: 'label.storage.tags'
+                                        label: 'label.storage.tags',
+                                        docID: 'helpPrimaryStorageTags',
+                                        isEditable: true,
+                                        isTokenInput: true,
+                                        dataProvider: function(args) {
+                                            $.ajax({
+                                                url: createURL("listStorageTags"),
+                                                dataType: "json",
+                                                success: function(json) {
+                                                    var item = json.liststoragetagsresponse.storagetag;
+                                                    var tags = [];
+
+                                                    if (item != null)
+                                                    {
+                                                        tags = $.map(item, function(tag) {
+                                                            return {
+                                                                id: tag.name,
+                                                                name: tag.name
+                                                            };
+                                                        });
+                                                    }
+
+                                                    args.response.success({
+                                                        data: tags,
+                                                        hintText: _l('hint.type.part.storage.tag'),
+                                                        noResultsText: _l('hint.no.storage.tags')
+                                                    });
+                                                },
+                                                error: function(XMLHttpResponse) {
+                                                    var errorMsg = parseXMLHttpResponse(XMLHttpResponse);
+
+                                                    args.response.error(errorMsg);
+                                                }
+                                            });
+                                        }
                                     },
                                     domain: {
                                         label: 'label.domain'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

On this PR [#2636]((https://github.com/apache/cloudstack/pull/2636)), @rafaelweingartner proposed a consistent validation mechanism to select a storage pool to deploy a volume when a virtual machine is deployed or when a new data disk is allocated.
The following table presents the scenarios when the storage_pool supports or not a new data disk.

| #	| Disk offering tags	| Storage tags	| Does the storage support the disk offering?	|
|---| ---					| ---			| ---											|
| 1	| A,B					| A				| NO											|
| 2	| A,B,C					| A,B,C,D,X		| YES											|
| 3	| A,B,C					| X,Y,Z			| NO											|
| 4	| null					| A,S,D			| YES											|
| 5	| A						| null			| NO											|
| 6	| null					| null			| YES											|


With that in mind, this PR enables `updateDiskOfferingCmd` to edit storage pool tags for `diskoffering`. Thus, providing greater control to ADMINS decide where disks will be allocated.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![Screenshot from 2020-06-30 14-51-39](https://user-images.githubusercontent.com/19981369/86246469-694c3a00-bb81-11ea-9c62-484fa2e56704.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

To test the PR i created 2 storage pools.
Storage Pools:
- spool01 	        with tag hdd
- spool02		with tag hdd2

And create one disk Offering:
- Test 		without tag

#### Test 01
- Create a volume using Test diskoffering
- Attach the volume to an instance
- Update the disk's diskoffering to another one that has a tag that does not have a corresponding Storage pool
- Detach the volume
- try to migrate the disk

**Expected:** we expect an exception since no storage tags match with the diskoffering tag
**Result:** 
```
Migration target pool [null, tags:null] has no matching tags for volume [small, uuid:ce026b50-8b04-44d6-bb66-3d324b64ca7d, tags:fake]
```

#### Test 02
- Using the same volume from Test 01
- Update the disk's diskoffering tag to hdd2
- try to migrate the disk to spool02

**Expected:** Migrate the volume to spool02 storage.
**Result:** all good, as expected

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
