### PR TITLE
VMware: Guest OS Mappings fix

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
@@ -18,3 +18,7 @@
 --;
 -- Schema upgrade from 4.14.0.0 to 4.15.0.0
 --;
+
+
+-- Fix Debian 10 32-bit hypervisor mappings on VMware, debian10-32bit OS ID in guest_os table is 292, not 282
+UPDATE `guest_os_hypervisor` SET guest_os_id=292 WHERE guest_os_id=282 AND hypervisor_type="VMware" AND guest_os_name="debian10Guest";

--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
@@ -21,4 +21,6 @@
 
 
 -- Fix Debian 10 32-bit hypervisor mappings on VMware, debian10-32bit OS ID in guest_os table is 292, not 282
-UPDATE `guest_os_hypervisor` SET guest_os_id=292 WHERE guest_os_id=282 AND hypervisor_type="VMware" AND guest_os_name="debian10Guest";
+UPDATE `cloud`.`guest_os_hypervisor` SET guest_os_id=292 WHERE guest_os_id=282 AND hypervisor_type="VMware" AND guest_os_name="debian10Guest";
+-- Fix CentOS 32-bit mapping for VMware 5.5, 
+UPDATE `cloud`.`guest_os_hypervisor` SET guest_os_name='centosGuest' where hypervisor_type="VMware" and hypervisor_version="5.5" and guest_os_name="centos6Guest";

--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
@@ -22,5 +22,5 @@
 
 -- Fix Debian 10 32-bit hypervisor mappings on VMware, debian10-32bit OS ID in guest_os table is 292, not 282
 UPDATE `cloud`.`guest_os_hypervisor` SET guest_os_id=292 WHERE guest_os_id=282 AND hypervisor_type="VMware" AND guest_os_name="debian10Guest";
--- Fix CentOS 32-bit mapping for VMware 5.5, 
+-- Fix CentOS 32-bit mapping for VMware 5.5 which does not have a centos6Guest but only centosGuest and centos64Guest
 UPDATE `cloud`.`guest_os_hypervisor` SET guest_os_name='centosGuest' where hypervisor_type="VMware" and hypervisor_version="5.5" and guest_os_name="centos6Guest";


### PR DESCRIPTION
In past, we added Debian 10 32bit guest_os entry with ID 292, (282 is RHEL 7.3) but then added (by mistake) entries in guest_os_hypervisor table for VMware and "debian10Guest" that points to guest_os_id 282 (RHEL 7.3), instead of 292 (Debian10)

Also fix centos6Guest mapping for Vmware 5.5 which does not exist in that version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Bug example (for VMware 6.5, but same for 6.7, 6.7.1.2.3)
![image](https://user-images.githubusercontent.com/45762285/86249433-97487300-bbaf-11ea-8a9d-10a5c19d3aaa.png)


## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/45762285/86249627-d676c400-bbaf-11ea-907f-547f8f44b27f.png)

![image](https://user-images.githubusercontent.com/45762285/86249649-e1c9ef80-bbaf-11ea-8abf-0f1abcd285fa.png)
