### PR TITLE
Allow domain admins to create offering without mentioning domainid

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2503,11 +2503,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
         final Account account = _accountDao.findById(user.getAccountId());
         if (account.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
-            if (filteredDomainIds.isEmpty()) {
-                throw new InvalidParameterValueException(String.format("Unable to create public service offering by admin: %s because it is domain-admin", user.getUuid()));
-            }
             if (tags != null || hostTag != null) {
-                throw new InvalidParameterValueException(String.format("Unable to create service offering with storage tags or host tags by admin: %s because it is domain-admin", user.getUuid()));
+                throw new InvalidParameterValueException(String.format("Unable to create service offering with storage tags or host tags by user: %s because it is domain-admin", user.getUsername()));
+            }
+            if (CollectionUtils.isEmpty(filteredDomainIds)) {
+                filteredDomainIds.add(account.getDomainId());
             }
             for (Long domainId : filteredDomainIds) {
                 if (!_domainDao.isChildDomain(account.getDomainId(), domainId)) {
@@ -2937,11 +2937,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
         final Account account = _accountDao.findById(user.getAccountId());
         if (account.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
-            if (filteredDomainIds.isEmpty()) {
-                throw new InvalidParameterValueException(String.format("Unable to create public disk offering by admin: %s because it is domain-admin", user.getUuid()));
-            }
             if (tags != null) {
-                throw new InvalidParameterValueException(String.format("Unable to create disk offering with storage tags by admin: %s because it is domain-admin", user.getUuid()));
+                throw new InvalidParameterValueException(String.format("Unable to create disk offering with storage tags by user: %s because it is domain-admin", user.getUsername()));
+            }
+            if (CollectionUtils.isEmpty(filteredDomainIds)) {
+                filteredDomainIds.add(account.getDomainId());
             }
             for (Long domainId : filteredDomainIds) {
                 if (domainId == null || !_domainDao.isChildDomain(account.getDomainId(), domainId)) {

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -28,7 +28,6 @@ export default {
       docHelp: 'adminguide/service_offerings.html#compute-and-disk-service-offerings',
       icon: 'cloud',
       permission: ['listServiceOfferings', 'listDomains'],
-      params: { isrecursive: 'true' },
       columns: ['name', 'displaytext', 'cpunumber', 'cpuspeed', 'memory', 'domain', 'zone', 'order'],
       details: () => {
         var fields = ['name', 'id', 'displaytext', 'offerha', 'provisioningtype', 'storagetype', 'iscustomized', 'limitcpuuse', 'cpunumber', 'cpuspeed', 'memory', 'hosttags', 'tags', 'domain', 'zone', 'created']
@@ -117,7 +116,6 @@ export default {
       icon: 'hdd',
       docHelp: 'adminguide/service_offerings.html#compute-and-disk-service-offerings',
       permission: ['listDiskOfferings', 'listDomains'],
-      params: { isrecursive: 'true' },
       columns: ['name', 'displaytext', 'disksize', 'domain', 'zone', 'order'],
       details: () => {
         var fields = ['name', 'id', 'displaytext', 'disksize', 'provisioningtype', 'storagetype', 'iscustomized', 'tags', 'domain', 'zone', 'created']


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Part 1:
While creating disk/service offering by domains we need to
specify domain id else it wont be created. Provide an enhancement
so that we dont need to pass domainid and it will be taken
from the callers user similar to other api's

Another bug fix

Part2:
Currently while creating any offering, we need to
specify a domain id or a list of domain id.
If an offering is created on a domain then all its child
domains should see it and all the parents domain
should see it as well but it should not be visible
to sibling domain

isrecursive=true ensures that all child domains can see it
but if a service offering is created for the domain at the leaf
of the domain path then its parent cant see it if isrecurise
is true. so we need to pass isrecursive=false so that the
parent domain can see the child offerings

### Cloudmonkey works fine but the issue is only with UI


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Without the UI fix

![withoutfix](https://user-images.githubusercontent.com/10645273/86450174-6ab06a80-bd19-11ea-8de0-46c214829e62.png)


After the UI fix

![withfix](https://user-images.githubusercontent.com/10645273/86450194-72700f00-bd19-11ea-9e82-eb600dc5da26.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested both from cloudmonkey for part1 and part2 and UI for part2

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

Part 1
Cloudmonkey api before fix

```
(test1) 🐵 > create serviceoffering name=without-domainid displaytext=without-domaindi
Error 431: Unable to create public service offering by admin: cff2f496-0ab1-4aa9-8447-e89be9e42b10 because it is domain-admin
(test1) 🐵 > create diskoffering name=without-domain displaytext=without-domain disksize=10
Error 431: Unable to create public disk offering by admin: cff2f496-0ab1-4aa9-8447-e89be9e42b10 because it is domain-admin
(test1) 🐵 >
```

After the fix

```
(test1) 🐵 > list domains filter=name
{
  "count": 1,
  "domain": [
    {
      "name": "test1"
    }
  ]
}
(test1) 🐵 > create serviceoffering name=without-domain displaytext=without-domain
{
  "serviceoffering": {
    "created": "2020-07-02T13:17:39+0000",
    "defaultuse": false,
    "displaytext": "without-domain",
    "domain": "test1",
    "domainid": "c14ffcea-e197-4d6f-b8ff-2ffb854cd443",
    "id": "e7bb6b10-060b-4d8a-aec2-831691e868ac",
    "iscustomized": true,
    "issystem": false,
    "isvolatile": false,
    "limitcpuuse": false,
    "name": "without-domain",
    "offerha": false,
    "provisioningtype": "thin",
    "serviceofferingdetails": {
      "domainid": "2"
    },
    "storagetype": "shared"
  }
}
(test1) 🐵 > create diskoffering name=without-domain displaytext=without-domain disksize=10
{
  "diskoffering": {
    "created": "2020-07-02T13:18:32+0000",
    "disksize": 10,
    "displayoffering": true,
    "displaytext": "without-domain",
    "domain": "/test1/",
    "domainid": "c14ffcea-e197-4d6f-b8ff-2ffb854cd443",
    "id": "552c9c4a-04af-4d6b-b50d-2dd0cb374668",
    "iscustomized": false,
    "name": "without-domain",
    "provisioningtype": "thin",
    "storagetype": "shared"
  }
}
```


Part 2

cloudmonkey api working as expected without any changes.

```
(test11) 🐵 > list diskofferings listall=true filter=name isrecursive=true
{
  "count": 6,
  "diskoffering": [
    {
      "name": "Small"
    },
    {
      "name": "Medium"
    },
    {
      "name": "Large"
    },
    {
      "name": "Custom"
    },
    {
      "name": "test-11only"
    },
    {
      "name": "test-11andtest2"
    }
  ]
}
```


```
(test11) 🐵 > list diskofferings listall=true filter=name
{
  "count": 9,
  "diskoffering": [
    {
      "name": "Small"
    },
    {
      "name": "Medium"
    },
    {
      "name": "Large"
    },
    {
      "name": "Custom"
    },
    {
      "name": "test1only"
    },
    {
      "name": "test-11only"
    },
    {
      "name": "test1-and-11"
    },
    {
      "name": "root-test1-test11"
    },
    {
      "name": "test-11andtest2"
    }
  ]
}
```