### PR TITLE
server: don't export B&R APIs if feature is not enabled globally

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
+++ b/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
@@ -38,7 +38,7 @@ public interface BackupManager extends BackupService, Configurable, PluggableSer
     ConfigKey<Boolean> BackupFrameworkEnabled = new ConfigKey<>("Advanced", Boolean.class,
             "backup.framework.enabled",
             "false",
-            "Is backup and recovery framework enabled. Restart management server on global value change.", false, ConfigKey.Scope.Zone);
+            "Is backup and recovery framework enabled.", false, ConfigKey.Scope.Zone);
 
     ConfigKey<String> BackupProviderPlugin = new ConfigKey<>("Advanced", String.class,
             "backup.framework.provider.plugin",

--- a/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
+++ b/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
@@ -38,7 +38,7 @@ public interface BackupManager extends BackupService, Configurable, PluggableSer
     ConfigKey<Boolean> BackupFrameworkEnabled = new ConfigKey<>("Advanced", Boolean.class,
             "backup.framework.enabled",
             "false",
-            "Is backup and recovery framework enabled.", true, ConfigKey.Scope.Zone);
+            "Is backup and recovery framework enabled. Restart management server on global value change.", true, ConfigKey.Scope.Zone);
 
     ConfigKey<String> BackupProviderPlugin = new ConfigKey<>("Advanced", String.class,
             "backup.framework.provider.plugin",

--- a/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
+++ b/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
@@ -38,7 +38,7 @@ public interface BackupManager extends BackupService, Configurable, PluggableSer
     ConfigKey<Boolean> BackupFrameworkEnabled = new ConfigKey<>("Advanced", Boolean.class,
             "backup.framework.enabled",
             "false",
-            "Is backup and recovery framework enabled. Restart management server on global value change.", true, ConfigKey.Scope.Zone);
+            "Is backup and recovery framework enabled. Restart management server on global value change.", false, ConfigKey.Scope.Zone);
 
     ConfigKey<String> BackupProviderPlugin = new ConfigKey<>("Advanced", String.class,
             "backup.framework.provider.plugin",

--- a/developer/developer-prefill.sql
+++ b/developer/developer-prefill.sql
@@ -114,15 +114,20 @@ INSERT INTO `cloud`.`configuration` (category, instance, component, name, value)
             VALUES ('Advanced', 'DEFAULT', 'management-server',
             'ping.timeout', '2.0');
 
--- Enable dynamic RBAC by default for fresh deployments
+-- Enable dynamic RBAC by default for developers
 INSERT INTO `cloud`.`configuration` (category, instance, component, name, value)
             VALUES ('Advanced', 'DEFAULT', 'RoleService',
             'dynamic.apichecker.enabled', 'true');
 
--- Enable RootCA auth strictness for fresh deployments
+-- Enable RootCA auth strictness for developers
 INSERT INTO `cloud`.`configuration` (category, instance, component, name, value)
             VALUES ('Advanced', 'DEFAULT', 'RootCAProvider',
             'ca.plugin.root.auth.strictness', 'true');
+
+-- Enable B&R feature for developers
+INSERT INTO `cloud`.`configuration` (category, instance, component, name, value)
+            VALUES ('Advanced', 'DEFAULT', 'BackupService',
+            'backup.framework.enabled', 'true');
 
 -- Add developer configuration entry; allows management server to be run as a user other than "cloud"
 INSERT INTO `cloud`.`configuration` (category, instance, component, name, value)

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -769,6 +769,19 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
     @Override
     public List<Class<?>> getCommands() {
         final List<Class<?>> cmdList = new ArrayList<Class<?>>();
+        if (!BackupFrameworkEnabled.value()) {
+            boolean featureEnabled = false;
+            for (final DataCenter dataCenter : dataCenterDao.listAllZones()) {
+                if (BackupFrameworkEnabled.valueIn(dataCenter.getId())) {
+                    featureEnabled = true;
+                    break;
+                }
+            }
+            if (!featureEnabled) {
+                return cmdList;
+            }
+        }
+
         // Offerings
         cmdList.add(ListBackupProvidersCmd.class);
         cmdList.add(ListBackupProviderOfferingsCmd.class);

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -736,7 +736,7 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
     }
 
     public boolean isDisabled(final Long zoneId) {
-        return !BackupFrameworkEnabled.valueIn(zoneId);
+        return !(BackupFrameworkEnabled.value() && BackupFrameworkEnabled.valueIn(zoneId));
     }
 
     private void validateForZone(final Long zoneId) {
@@ -770,16 +770,7 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
     public List<Class<?>> getCommands() {
         final List<Class<?>> cmdList = new ArrayList<Class<?>>();
         if (!BackupFrameworkEnabled.value()) {
-            boolean featureEnabled = false;
-            for (final DataCenter dataCenter : dataCenterDao.listAllZones()) {
-                if (BackupFrameworkEnabled.valueIn(dataCenter.getId())) {
-                    featureEnabled = true;
-                    break;
-                }
-            }
-            if (!featureEnabled) {
-                return cmdList;
-            }
+            return cmdList;
         }
 
         // Offerings

--- a/test/integration/smoke/test_backup_recovery_dummy.py
+++ b/test/integration/smoke/test_backup_recovery_dummy.py
@@ -85,6 +85,8 @@ class TestDummyBackupAndRecovery(cloudstackTestCase):
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
+        if self.hypervisor.lower() != 'simulator':
+            raise self.skipTest("Skipping test cases which must only run for Simulator")
         self.cleanup = []
 
     def tearDown(self):

--- a/test/integration/smoke/test_backup_recovery_dummy.py
+++ b/test/integration/smoke/test_backup_recovery_dummy.py
@@ -36,6 +36,9 @@ class TestDummyBackupAndRecovery(cloudstackTestCase):
         cls.services["mode"] = cls.zone.networktype
         cls.hypervisor = cls.testClient.getHypervisorInfo()
         cls.domain = get_domain(cls.api_client)
+        cls._cleanup = []
+        if cls.hypervisor.lower() != 'simulator':
+            raise cls.skipTest("Skipping test cases which must only run for Simulator")
         cls.template = get_template(cls.api_client, cls.zone.id, cls.services["ostype"])
         if cls.template == FAILED:
             assert False, "get_template() failed to return template with description %s" % cls.services["ostype"]
@@ -49,7 +52,6 @@ class TestDummyBackupAndRecovery(cloudstackTestCase):
         cls._cleanup = [cls.offering, cls.account]
 
         # Check backup configuration values, set them to enable the dummy provider
-
         backup_enabled_cfg = Configurations.list(cls.api_client, name='backup.framework.enabled', zoneid=cls.zone.id)
         backup_provider_cfg = Configurations.list(cls.api_client, name='backup.framework.provider.plugin', zoneid=cls.zone.id)
         cls.backup_enabled = backup_enabled_cfg[0].value


### PR DESCRIPTION
This change will ensure that B&R APIs are not exported if the feature is not enabled globally. Make it non-dynamic to require restarting of mgmt server which is needed for the background sync task to be setup or not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)