### PR TITLE
Removed check on SSLEngine client mode

### DIFF
--- a/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -135,7 +135,6 @@ public class RootCAProviderTest {
     public void testCreateSSLEngineWithoutAuthStrictness() throws Exception {
         overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "false");
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
-        Assert.assertFalse(e.getUseClientMode());
         Assert.assertFalse(e.getNeedClientAuth());
     }
 
@@ -143,7 +142,6 @@ public class RootCAProviderTest {
     public void testCreateSSLEngineWithAuthStrictness() throws Exception {
         overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "true");
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
-        Assert.assertFalse(e.getUseClientMode());
         Assert.assertTrue(e.getNeedClientAuth());
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The SSL engine defaults to "Server mode" when doing handshaking. This PR removes the check on the mode which was causing tests to fail.

This behavior was changed in OpenJDK 11.0.8
```
JDK-8245077: Default SSLEngine Created in Server Role
=====================================================
In JDK 11 and later, `javax.net.ssl.SSLEngine` by default used client
mode when handshaking.  As a result, the set of default enabled
protocols may differ to what is expected. `SSLEngine` would usually be
used in server mode. From this JDK release onwards, `SSLEngine` will
default to server mode. The
`javax.net.ssl.SSLEngine.setUseClientMode(boolean mode)` method may be
used to configure the mode.
```

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This was tested by building Cloudstack and allowing the tests to run.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
