### PR TITLE
vmware: volume utilisation is always zero

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -3766,7 +3766,6 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                                     VolumeStatsEntry vse = statEntry.get(chainInfo);
                                     if (vse != null) {
                                         vse.setPhysicalSize(vse.getPhysicalSize() + physicalsize);
-                                        vse.setVirtualSize(vse.getVirtualSize() + virtualsize);
                                     }
                                 } else {
                                     VolumeStatsEntry vse = new VolumeStatsEntry(chainInfo, physicalsize, virtualsize);

--- a/server/src/main/java/com/cloud/api/query/ViewResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/query/ViewResponseHelper.java
@@ -268,7 +268,7 @@ public class ViewResponseHelper {
 
     public static List<VolumeResponse> createVolumeResponse(ResponseView view, VolumeJoinVO... volumes) {
         Hashtable<Long, VolumeResponse> vrDataList = new Hashtable<Long, VolumeResponse>();
-        DecimalFormat df = new DecimalFormat("0.00");
+        DecimalFormat df = new DecimalFormat("0.0%");
         for (VolumeJoinVO vr : volumes) {
             VolumeResponse vrData = vrDataList.get(vr.getId());
             if (vrData == null) {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
@@ -356,6 +356,7 @@ public class DatastoreMO extends BaseMO {
         FileQueryFlags fqf = new FileQueryFlags();
         fqf.setFileSize(true);
         fqf.setFileOwner(true);
+        fqf.setFileType(true);
         fqf.setModification(true);
         searchSpec.setDetails(fqf);
         searchSpec.setSearchCaseInsensitive(false);


### PR DESCRIPTION
- This fixes issues of virtual size to be twice in case the disk is a linked-clone root disk. The virtual size of root disk (first in chain) must be used.
- Fixes to report the physical size for a volume whose stat is being collected

After the fix utilisation is seen as below:
![Screenshot from 2020-07-28 18-07-08](https://user-images.githubusercontent.com/95203/88666305-8717ab00-d0fd-11ea-8470-e9757467264c.png)

Logs also show valid values like:
```
2020-07-28 12:17:09,296 DEBUG [c.c.h.v.m.DatastoreMO] (DirectAgent-38:ctx-1a415fb5 10.10.4.235, cmd: GetVolumeStatsCommand) (logid:7c3f9cb8) File found = ROOT-3.vmdk, size=157134848
2020-07-28 12:17:09,471 DEBUG [c.c.h.v.m.DatastoreMO] (DirectAgent-38:ctx-1a415fb5 10.10.4.235, cmd: GetVolumeStatsCommand) (logid:7c3f9cb8) File found = b86db0909f7236d7acb343b0572bca65.vmdk, size=1201016832
2020-07-28 12:17:09,656 DEBUG [c.c.h.v.m.DatastoreMO] (DirectAgent-38:ctx-1a415fb5 10.10.4.235, cmd: GetVolumeStatsCommand) (logid:7c3f9cb8) File found = 2aee4824309444cba11c0508f33181ad.vmdk, size=0
2020-07-28 12:17:09,831 DEBUG [c.c.h.v.m.DatastoreMO] (DirectAgent-38:ctx-1a415fb5 10.10.4.235, cmd: GetVolumeStatsCommand) (logid:7c3f9cb8) File found = ROOT-4.vmdk, size=11329536
2020-07-28 12:17:10,040 DEBUG [c.c.h.v.m.DatastoreMO] (DirectAgent-38:ctx-1a415fb5 10.10.4.235, cmd: GetVolumeStatsCommand) (logid:7c3f9cb8) File found = 970775ec1cf233c08d6a3f0aaac9bec6.vmdk, size=1023160320
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)