### PR TITLE
Dont add host back after agent service restart

### DIFF
--- a/agent/src/main/java/com/cloud/agent/Agent.java
+++ b/agent/src/main/java/com/cloud/agent/Agent.java
@@ -420,6 +420,15 @@ public class Agent implements HandlerFactory, IAgentControl {
         }
     }
 
+    protected void cleanupAgentZoneProperties() {
+        // Unset zone, cluster and pod values so that host is not added back
+        // when service is restarted. This will be set to proper values
+        // when host is added back
+        _shell.setPersistentProperty(null, "zone", "");
+        _shell.setPersistentProperty(null, "cluster", "");
+        _shell.setPersistentProperty(null, "pod", "");
+    }
+
     public synchronized void lockStartupTask(final Link link) {
         _startup = new StartupTask(link);
         _timer.schedule(_startup, _startupWait);
@@ -603,6 +612,9 @@ public class Agent implements HandlerFactory, IAgentControl {
                         final ShutdownCommand shutdown = (ShutdownCommand)cmd;
                         s_logger.debug("Received shutdownCommand, due to: " + shutdown.getReason());
                         cancelTasks();
+                        if (shutdown.isRemoveHost()) {
+                            cleanupAgentZoneProperties();
+                        }
                         _reconnectAllowed = false;
                         answer = new Answer(cmd, true, null);
                     } else if (cmd instanceof ReadyCommand && ((ReadyCommand)cmd).getDetails() != null) {

--- a/agent/src/main/java/com/cloud/agent/Agent.java
+++ b/agent/src/main/java/com/cloud/agent/Agent.java
@@ -420,10 +420,14 @@ public class Agent implements HandlerFactory, IAgentControl {
         }
     }
 
+    /**
+     * Cleanup agent zone properties.
+     *
+     * Unset zone, cluster and pod values so that host is not added back
+     * when service is restarted. This will be set to proper values
+     * when host is added back
+     */
     protected void cleanupAgentZoneProperties() {
-        // Unset zone, cluster and pod values so that host is not added back
-        // when service is restarted. This will be set to proper values
-        // when host is added back
         _shell.setPersistentProperty(null, "zone", "");
         _shell.setPersistentProperty(null, "cluster", "");
         _shell.setPersistentProperty(null, "pod", "");

--- a/core/src/main/java/com/cloud/agent/api/ShutdownCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/ShutdownCommand.java
@@ -30,6 +30,7 @@ public class ShutdownCommand extends Command {
 
     private String reason;
     private String detail;
+    private boolean removeHost;
 
     protected ShutdownCommand() {
         super();
@@ -41,6 +42,13 @@ public class ShutdownCommand extends Command {
         this.detail = detail;
     }
 
+    public ShutdownCommand(String reason, String detail, boolean removeHost) {
+        super();
+        this.reason = reason;
+        this.detail = detail;
+        this.removeHost = removeHost;
+    }
+
     /**
      * @return return the reason the agent shutdown.  If Unknown, call getDetail() for any details.
      */
@@ -50,6 +58,10 @@ public class ShutdownCommand extends Command {
 
     public String getDetail() {
         return detail;
+    }
+
+    public boolean isRemoveHost() {
+        return removeHost;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -410,7 +410,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public final static ConfigKey<Long> IOPS_MAX_WRITE_LENGTH = new ConfigKey<Long>(Long.class, "vm.disk.iops.maximum.write.length", "Advanced", "0",
             "Maximum IOPS write burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
 
-    public static final ConfigKey<Boolean> ADD_HOST_ON_SERVICE_RESTART = new ConfigKey<Boolean>(Boolean.class, "add.host.on.service.restart", "Advanced", "true",
+    public static final ConfigKey<Boolean> ADD_HOST_ON_SERVICE_RESTART_KVM = new ConfigKey<Boolean>(Boolean.class, "add.host.on.service.restart.kvm", "Advanced", "true",
             "Indicates whether the host will be added back to cloudstack after restarting agent service on host. If false it wont be added back even after service restart",
             true, ConfigKey.Scope.Global, null);
 
@@ -6383,6 +6383,6 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {SystemVMUseLocalStorage, IOPS_MAX_READ_LENGTH, IOPS_MAX_WRITE_LENGTH,
-                BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH, ADD_HOST_ON_SERVICE_RESTART};
+                BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH, ADD_HOST_ON_SERVICE_RESTART_KVM};
     }
 }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -410,7 +410,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public final static ConfigKey<Long> IOPS_MAX_WRITE_LENGTH = new ConfigKey<Long>(Long.class, "vm.disk.iops.maximum.write.length", "Advanced", "0",
             "Maximum IOPS write burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
 
-    public static final ConfigKey<Boolean> AddHostOnServiceRestart = new ConfigKey<Boolean>(Boolean.class, "add.host.on.service.restart", "Advanced", "true",
+    public static final ConfigKey<Boolean> ADD_HOST_ON_SERVICE_RESTART = new ConfigKey<Boolean>(Boolean.class, "add.host.on.service.restart", "Advanced", "true",
             "Indicates whether the host will be added back to cloudstack after restarting agent service on host. If false it wont be added back even after service restart",
             true, ConfigKey.Scope.Global, null);
 
@@ -6383,6 +6383,6 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {SystemVMUseLocalStorage, IOPS_MAX_READ_LENGTH, IOPS_MAX_WRITE_LENGTH,
-                BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH, AddHostOnServiceRestart};
+                BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH, ADD_HOST_ON_SERVICE_RESTART};
     }
 }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -410,6 +410,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public final static ConfigKey<Long> IOPS_MAX_WRITE_LENGTH = new ConfigKey<Long>(Long.class, "vm.disk.iops.maximum.write.length", "Advanced", "0",
             "Maximum IOPS write burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
 
+    public static final ConfigKey<Boolean> AddHostOnServiceRestart = new ConfigKey<Boolean>(Boolean.class, "add.host.on.service.restart", "Advanced", "true",
+            "Indicates whether the host will be added back to cloudstack after restarting agent service on host. If false it wont be added back even after service restart",
+            true, ConfigKey.Scope.Global, null);
+
     private static final String IOPS_READ_RATE = "IOPS Read";
     private static final String IOPS_WRITE_RATE = "IOPS Write";
     private static final String BYTES_READ_RATE = "Bytes Read";
@@ -6378,6 +6382,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {SystemVMUseLocalStorage, IOPS_MAX_READ_LENGTH, IOPS_MAX_WRITE_LENGTH, BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH};
+        return new ConfigKey<?>[] {SystemVMUseLocalStorage, IOPS_MAX_READ_LENGTH, IOPS_MAX_WRITE_LENGTH,
+                BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH, AddHostOnServiceRestart};
     }
 }

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -477,8 +477,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
 
         _resourceMgr.deleteRoutingHost(host, isForced, isForceDeleteStorage);
         try {
-            ShutdownCommand cmd = AddHostOnServiceRestart.value() ? new ShutdownCommand(ShutdownCommand.DeleteHost, null, false) :
-                    new ShutdownCommand(ShutdownCommand.DeleteHost, "Cleaning up zone/pod/cluster details for host", true);
+            ShutdownCommand cmd = new ShutdownCommand(ShutdownCommand.DeleteHost, null, !AddHostOnServiceRestart.value());
             agentMgr.send(host.getId(), cmd);
         } catch (AgentUnavailableException e) {
             s_logger.warn("Sending ShutdownCommand failed: ", e);

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -67,6 +67,8 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.ssh.SSHCmdHelper;
 import com.trilead.ssh2.Connection;
 
+import static com.cloud.configuration.ConfigurationManagerImpl.AddHostOnServiceRestart;
+
 public abstract class LibvirtServerDiscoverer extends DiscovererBase implements Discoverer, Listener, ResourceStateAdapter {
     private static final Logger s_logger = Logger.getLogger(LibvirtServerDiscoverer.class);
     private final int _waitTime = 5; /* wait for 5 minutes */
@@ -348,6 +350,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
             _hostDao.saveDetails(connectedHost);
             return resources;
         } catch (DiscoveredWithErrorException e) {
+            s_logger.error("DiscoveredWithErrorException caught and rethrowing, message: "+ e.getMessage());
             throw e;
         } catch (Exception e) {
             String msg = " can't setup agent, due to " + e.toString() + " - " + e.getMessage();
@@ -474,7 +477,8 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
 
         _resourceMgr.deleteRoutingHost(host, isForced, isForceDeleteStorage);
         try {
-            ShutdownCommand cmd = new ShutdownCommand(ShutdownCommand.DeleteHost, null);
+            ShutdownCommand cmd = AddHostOnServiceRestart.value() ? new ShutdownCommand(ShutdownCommand.DeleteHost, null, false) :
+                    new ShutdownCommand(ShutdownCommand.DeleteHost, "Cleaning up zone/pod/cluster details for host", true);
             agentMgr.send(host.getId(), cmd);
         } catch (AgentUnavailableException e) {
             s_logger.warn("Sending ShutdownCommand failed: ", e);

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -67,7 +67,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.ssh.SSHCmdHelper;
 import com.trilead.ssh2.Connection;
 
-import static com.cloud.configuration.ConfigurationManagerImpl.ADD_HOST_ON_SERVICE_RESTART;
+import static com.cloud.configuration.ConfigurationManagerImpl.ADD_HOST_ON_SERVICE_RESTART_KVM;
 
 public abstract class LibvirtServerDiscoverer extends DiscovererBase implements Discoverer, Listener, ResourceStateAdapter {
     private static final Logger s_logger = Logger.getLogger(LibvirtServerDiscoverer.class);
@@ -477,7 +477,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
 
         _resourceMgr.deleteRoutingHost(host, isForced, isForceDeleteStorage);
         try {
-            ShutdownCommand cmd = new ShutdownCommand(ShutdownCommand.DeleteHost, null, !ADD_HOST_ON_SERVICE_RESTART.value());
+            ShutdownCommand cmd = new ShutdownCommand(ShutdownCommand.DeleteHost, null, !ADD_HOST_ON_SERVICE_RESTART_KVM.value());
             agentMgr.send(host.getId(), cmd);
         } catch (AgentUnavailableException e) {
             s_logger.warn("Sending ShutdownCommand failed: ", e);

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -67,7 +67,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.ssh.SSHCmdHelper;
 import com.trilead.ssh2.Connection;
 
-import static com.cloud.configuration.ConfigurationManagerImpl.AddHostOnServiceRestart;
+import static com.cloud.configuration.ConfigurationManagerImpl.ADD_HOST_ON_SERVICE_RESTART;
 
 public abstract class LibvirtServerDiscoverer extends DiscovererBase implements Discoverer, Listener, ResourceStateAdapter {
     private static final Logger s_logger = Logger.getLogger(LibvirtServerDiscoverer.class);
@@ -477,7 +477,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
 
         _resourceMgr.deleteRoutingHost(host, isForced, isForceDeleteStorage);
         try {
-            ShutdownCommand cmd = new ShutdownCommand(ShutdownCommand.DeleteHost, null, !AddHostOnServiceRestart.value());
+            ShutdownCommand cmd = new ShutdownCommand(ShutdownCommand.DeleteHost, null, !ADD_HOST_ON_SERVICE_RESTART.value());
             agentMgr.send(host.getId(), cmd);
         } catch (AgentUnavailableException e) {
             s_logger.warn("Sending ShutdownCommand failed: ", e);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes #4218 

If a host is removed from cloudstack, it will be
added back if we restart the agent service on
the host. It should not be added back if manualy
removed.

Provide a global setting "add.host.on.service.restart" with
default value of true. If set to false, the zoneid,
clusterid and podid in agent.properties will be set to
null so that when service is restarted, the agent is not
added back

If true these values will not be set to null so that it
can be still added back on service restart


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)


## Screenshots (if appropriate):

## How Has This Been Tested?
1. Add a host from ui. It will be successfully added
2. Now remove the host
3. Set the global setting `add.host.on.service.restart` to false
3. ssh to host and restart cloudstack-agent service
4. The host is not added back
5. Try to add host from ui again. It will be added


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
