### PR TITLE
Host SSVM Debian ISO on download.cloudstack.org

### DIFF
--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -36,7 +36,7 @@
       "disk_size": 2500,
       "disk_interface": "virtio",
       "net_device": "virtio-net",
-      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.5.0-amd64-netinst.iso",
+      "iso_url": "https://download.cloudstack.org/systemvm/debian/debian-10.5.0-amd64-netinst.iso",
       "iso_checksum": "0a6aee1d9aafc1ed095105c052f9fdd65ed00ea9274188c9cd0072c8e6838ab40e246d45a1e6956d74ef1b04a1fc042151762f25412e9ff0cbf49418eef7992e",
       "iso_checksum_type": "sha512",
       "output_directory": "../dist",


### PR DESCRIPTION
## Description
This way we do not depend on Debian keeping the ISO online or changing
URLs which can break our build system(s).

See also: #4243 