### PR TITLE
Handle with VM snapshot events

### DIFF
--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -995,7 +995,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         } else if (isSecurityGroupEvent(eventType)) {
             createSecurityGroupEvent(event);
         } else if (isVmSnapshotEvent(eventType)) {
-            createVMSnapshotEvent(event);
+            handleVMSnapshotEvent(event);
         } else if (isVmSnapshotOnPrimaryEvent(eventType)) {
             createVmSnapshotOnPrimaryEvent(event);
         } else if (isBackupEvent(eventType)) {
@@ -1889,27 +1889,91 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         }
     }
 
-    private void createVMSnapshotEvent(UsageEventVO event) {
-        Long vmId = event.getResourceId();
-        Long volumeId = event.getTemplateId();
-        Long offeringId = event.getOfferingId();
-        Long zoneId = event.getZoneId();
-        Long accountId = event.getAccountId();
-        //Size could be null for VM snapshot delete events
-        long size = (event.getSize() == null) ? 0 : event.getSize();
-        Date created = event.getCreateDate();
+    /**
+     * Handles Vm Snapshot create and delete events:
+     * <ul>
+     *     <li>EventTypes#EVENT_VM_SNAPSHOT_CREATE</li>
+     *     <li>EventTypes#EVENT_VM_SNAPSHOT_DELETE</li>
+     * </ul>
+     * if the event received by this method is neither add nor remove, we ignore it.
+     */
+    protected void handleVMSnapshotEvent(UsageEventVO event) {
+        switch (event.getType()) {
+            case EventTypes.EVENT_VM_SNAPSHOT_CREATE:
+                createUsageVMSnapshot(event);
+                break;
+            case EventTypes.EVENT_VM_SNAPSHOT_DELETE:
+                deleteUsageVMSnapshot(event);
+                break;
+            default:
+                s_logger.debug(String.format("The event [type=%s, zoneId=%s, accountId=%s, resourceName=%s, diskOfferingId=%s, createDate=%s] is neither of type [%s] nor [%s]",
+                        event.getType(), event.getZoneId(), event.getAccountId(), event.getResourceName(), event.getOfferingId(), event.getCreateDate(), EventTypes.EVENT_VM_SNAPSHOT_CREATE, EventTypes.EVENT_VM_SNAPSHOT_DELETE));
+        }
+    }
+
+    /**
+     * Creates an entry for the Usage VM Snapshot.
+     */
+    protected void createUsageVMSnapshot(UsageEventVO event) {
+        long accountId = event.getAccountId();
         Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
-        Long domainId = acct.getDomainId();
+        long domainId = acct.getDomainId();
+        Long offeringId = event.getOfferingId();
+        long vmId = event.getResourceId();
+        long volumeId = event.getTemplateId();
+        long zoneId = event.getZoneId();
+        Date created = event.getCreateDate();
+        long size = (event.getSize() == null) ? 0 : event.getSize();
 
         UsageEventDetailsVO detailVO = _usageEventDetailsDao.findDetail(event.getId(), UsageEventVO.DynamicParameters.vmSnapshotId.name());
         Long vmSnapshotId = null;
         if (detailVO != null) {
             String snapId = detailVO.getValue();
-             vmSnapshotId = Long.valueOf(snapId);
+            vmSnapshotId = Long.valueOf(snapId);
         }
+        s_logger.debug(String.format("Creating usage VM Snapshot for VM id [%s] assigned to account [%s] domain [%s], zone [%s], and created at [%s]", vmId, accountId, domainId, zoneId,
+                event.getCreateDate()));
         UsageVMSnapshotVO vsVO = new UsageVMSnapshotVO(volumeId, zoneId, accountId, domainId, vmId, offeringId, size, created, null);
         vsVO.setVmSnapshotId(vmSnapshotId);
         _usageVMSnapshotDao.persist(vsVO);
+    }
+
+    /**
+     * Find and delete, if exists, usage VM Snapshots entries
+     */
+    protected void deleteUsageVMSnapshot(UsageEventVO event) {
+        long accountId = event.getAccountId();
+        Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
+        Long domainId = acct.getDomainId();
+        Long diskOfferingId = event.getOfferingId();
+        long vmId = event.getResourceId();
+        long zoneId = event.getZoneId();
+        List<UsageVMSnapshotVO> usageVMSnapshots = findUsageVMSnapshots(accountId, zoneId, domainId, vmId, diskOfferingId);
+        if (CollectionUtils.isEmpty(usageVMSnapshots)){
+            s_logger.warn(String.format("No usage entry for VM snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s] was found.",
+                    vmId, accountId, domainId, zoneId));
+            if (usageVMSnapshots.size() > 1) {
+                s_logger.warn(String.format("More than one usage entry for VM snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s]; marking them all as deleted.", vmId,
+                        accountId, domainId, zoneId));
+            }
+        }
+        for (UsageVMSnapshotVO vmSnapshots : usageVMSnapshots) {
+            s_logger.debug(String.format("Deleting VM Snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s] that was created at [%s].", vmSnapshots.getVmId(),
+                    vmSnapshots.getAccountId(), vmSnapshots.getDomainId(), vmSnapshots.getZoneId(), vmSnapshots.getCreated()));
+            vmSnapshots.setProcessed(event.getCreateDate());
+            _usageVMSnapshotDao.update(vmSnapshots);
+        }
+    }
+
+    protected List<UsageVMSnapshotVO> findUsageVMSnapshots(long accountId, long zoneId, long domainId, long vmId, Long diskOfferingId) {
+        SearchCriteria<UsageVMSnapshotVO> sc = _usageVMSnapshotDao.createSearchCriteria();
+        sc.addAnd("zoneId", SearchCriteria.Op.EQ, zoneId);
+        sc.addAnd("accountId", SearchCriteria.Op.EQ, accountId);
+        sc.addAnd("domainId", SearchCriteria.Op.EQ, domainId);
+        sc.addAnd("vmId", SearchCriteria.Op.EQ, vmId);
+        sc.addAnd("diskOfferingId", SearchCriteria.Op.EQ, diskOfferingId);
+        sc.addAnd("processed", SearchCriteria.Op.NULL);
+        return _usageVMSnapshotDao.search(sc, null);
     }
 
     private void createVmSnapshotOnPrimaryEvent(UsageEventVO event) {

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -1952,10 +1952,10 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (CollectionUtils.isEmpty(usageVMSnapshots)){
             s_logger.warn(String.format("No usage entry for VM snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s] was found.",
                     vmId, accountId, domainId, zoneId));
-            if (usageVMSnapshots.size() > 1) {
-                s_logger.warn(String.format("More than one usage entry for VM snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s]; marking them all as deleted.", vmId,
-                        accountId, domainId, zoneId));
-            }
+        }
+        if (usageVMSnapshots.size() > 1) {
+            s_logger.warn(String.format("More than one usage entry for VM snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s]; marking them all as deleted.", vmId,
+                    accountId, domainId, zoneId));
         }
         for (UsageVMSnapshotVO vmSnapshots : usageVMSnapshots) {
             s_logger.debug(String.format("Deleting VM Snapshot for VM id [%s] assigned to account [%s] domain [%s] and zone [%s] that was created at [%s].", vmSnapshots.getVmId(),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
On these days, when a VM snapshot is deleted, the `cloudstack-usage` still seeing that snapshot as active and continues billing this deleted snapshot. This PR proposes new methods to handle with `vm_snapshot_create` and `vm_snapshot_delete` events.   
Also, add some unit tests to cover those new methods.  

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

<!--- ## Screenshots (if appropriate): -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I don't know why the `cloudstack-usage` duplicate entries for vm_snapshot. I think this is a bug and I'll fix it in a future PR.  
To run tests,  I create a VM snapshot and used the `cloudmonkey` to list usageRecords type=25.  

**Created at 14:12**
```
() 🐱 > list usagerecords startdate=2020-08-08 enddate=2020-08-08 type=25
{
  "count": 2,
  "usagerecord": [
    {
      "account": "admin",
      "description": "VMSnapshot usage Id: 1 (7b63f2f0-61fc-4034-8438-26e8989e3503)  for VM VM-ccb8b3d9-18aa-40c3-8e13-adde2de9b34b (ccb8b3d9-18aa-40c3-8e13-adde2de9b34b)",
      "enddate": "2020-08-08'T'14:13:31+00:00",
      "name": "i-2-5-VM_VS_20200808141157",
      "rawusage": "0.025106",
      "size": 214749184,
      "startdate": "2020-08-08'T'14:12:01+00:00",
      "usage": "0.025106 Hrs",
      "usagetype": 25,
      "virtualmachineid": "ccb8b3d9-18aa-40c3-8e13-adde2de9b34b",
    },
    {
      "account": "admin",
      "description": "VMSnapshot usage Id: 1 (7b63f2f0-61fc-4034-8438-26e8989e3503)  for VM VM-ccb8b3d9-18aa-40c3-8e13-adde2de9b34b (ccb8b3d9-18aa-40c3-8e13-adde2de9b34b)",
      "enddate": "2020-08-08'T'14:13:31+00:00",
      "name": "i-2-5-VM_VS_20200808141157",
      "rawusage": "0.025106",
      "size": 214749184,
      "startdate": "2020-08-08'T'14:12:01+00:00",
      "usage": "0.025106 Hrs",
      "usagetype": 25,
      "virtualmachineid": "ccb8b3d9-18aa-40c3-8e13-adde2de9b34b",
    }
  ]
}
```

**Deleted at 14:18**
```
() 🐱 > list usagerecords startdate=2020-08-08 enddate=2020-08-08 type=25
{
  "count": 4,
  "usagerecord": [
    {
      "account": "admin",
      "description": "VMSnapshot usage Id: 1 (7b63f2f0-61fc-4034-8438-26e8989e3503)  for VM VM-ccb8b3d9-18aa-40c3-8e13-adde2de9b34b (ccb8b3d9-18aa-40c3-8e13-adde2de9b34b)",
      "enddate": "2020-08-08'T'14:13:31+00:00",
      "name": "i-2-5-VM_VS_20200808141157",
      "rawusage": "0.025106",
      "size": 214749184,
      "startdate": "2020-08-08'T'14:12:01+00:00",
      "usage": "0.025106 Hrs",
      "usagetype": 25,
      "virtualmachineid": "ccb8b3d9-18aa-40c3-8e13-adde2de9b34b",
    },
    {
      "account": "admin",
      "description": "VMSnapshot usage Id: 1 (7b63f2f0-61fc-4034-8438-26e8989e3503)  for VM VM-ccb8b3d9-18aa-40c3-8e13-adde2de9b34b (ccb8b3d9-18aa-40c3-8e13-adde2de9b34b)",
      "enddate": "2020-08-08'T'14:13:31+00:00",
      "name": "i-2-5-VM_VS_20200808141157",
      "rawusage": "0.025106",
      "size": 214749184,
      "startdate": "2020-08-08'T'14:12:01+00:00",
      "usage": "0.025106 Hrs",
      "usagetype": 25,
      "virtualmachineid": "ccb8b3d9-18aa-40c3-8e13-adde2de9b34b",
    },
    {
      "account": "admin",
      "description": "VMSnapshot usage Id: 1 (7b63f2f0-61fc-4034-8438-26e8989e3503)  for VM VM-ccb8b3d9-18aa-40c3-8e13-adde2de9b34b (ccb8b3d9-18aa-40c3-8e13-adde2de9b34b)",
      "enddate": "2020-08-08'T'14:18:31+00:00",
      "name": "i-2-5-VM_VS_20200808141157",
      "rawusage": "0.083337",
      "size": 214749184,
      "startdate": "2020-08-08'T'14:13:31+00:00",
      "usage": "0.083337 Hrs",
      "usagetype": 25,
      "virtualmachineid": "ccb8b3d9-18aa-40c3-8e13-adde2de9b34b",
    },
    {
      "account": "admin",
      "description": "VMSnapshot usage Id: 1 (7b63f2f0-61fc-4034-8438-26e8989e3503)  for VM VM-ccb8b3d9-18aa-40c3-8e13-adde2de9b34b (ccb8b3d9-18aa-40c3-8e13-adde2de9b34b)",
      "enddate": "2020-08-08'T'14:18:31+00:00",
      "name": "i-2-5-VM_VS_20200808141157",
      "rawusage": "0.083337",
      "size": 214749184,
      "startdate": "2020-08-08'T'14:13:31+00:00",
      "usage": "0.083337 Hrs",
      "usagetype": 25,
      "virtualmachineid": "ccb8b3d9-18aa-40c3-8e13-adde2de9b34b",
    }
  ]
}
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
