### PR TITLE
Fix sed command failure in Mac OS.

### DIFF
--- a/tools/apidoc/build-apidoc.sh
+++ b/tools/apidoc/build-apidoc.sh
@@ -56,13 +56,23 @@ then
        exit 1
 fi
 
+# Default case for Linux sed, just use "-i"
+sedi='-i'
+case "$(uname)" in
+  # For macOS, use two parameters
+  Darwin*) sedi='-i ""'
+esac
+
+# Expand the parameters in the actual call to "sed"
+sed  -e 's/foo/bar/' target.file
+
 set -e
 (cd "$DISTDIR/xmldoc"
  cp "$thisdir"/*.java .
  cp "$thisdir"/*.xsl .
  sed -e 's,%API_HEADER%,All APIs,g' "$thisdir/generatetoc_header.xsl" >generatetoc.xsl
- sed -i "s/%ACS_RELEASE%/${ACS_RELEASE}/g" generatetoc.xsl
- sed -i "s/%ACS_RELEASE%/${ACS_RELEASE}/g" generatecommands.xsl
+ sed $sedi "s/%ACS_RELEASE%/${ACS_RELEASE}/g" generatetoc.xsl
+ sed $sedi "s/%ACS_RELEASE%/${ACS_RELEASE}/g" generatecommands.xsl
 
  PLATFORM=`uname -s`
  if [[ "$PLATFORM" =~ .*WIN.* ]]


### PR DESCRIPTION
## Description

apidoc build failed in Mac OS because of sed in-place command. It is a minor change that fixed this issue. More information  [here](https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux?answertab=active#tab-top)

Fixes: #3247
Fixes: #3312

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
I tested this feature in Mac and Ubuntu
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
