### PR TITLE
Name public network appropriately to avoid conflicts

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
@@ -198,7 +198,7 @@ public class HypervisorHostHelper {
         if (UNTAGGED_VLAN_NAME.equalsIgnoreCase(vlanId)) {
             return "cloud.public.untagged";
         } else {
-            return "cloud.public." + vlanId;
+            return "cloud.public." + vlanId + ".";
         }
     }
 

--- a/vmware-base/src/test/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
+++ b/vmware-base/src/test/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
@@ -548,7 +548,7 @@ public class HypervisorHostHelperTest {
     public void testGetPublicNetworkNamePrefixTaggedVlan() throws Exception {
         vlanId = "1234";
         String publicNetworkPrefix = HypervisorHostHelper.getPublicNetworkNamePrefix(vlanId);
-        assertEquals("cloud.public.1234", publicNetworkPrefix);
+        assertEquals("cloud.public.1234.", publicNetworkPrefix);
     }
 
     @Test


### PR DESCRIPTION
## Description
Multiple public networks with vlan IDs starting with the ID sequence can lead to possible conflicts and may result in associating IP to the wrong NIC. 
Addresses issue: https://github.com/apache/cloudstack/issues/4247


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

