### PR TITLE
Prevent null pointer on listPublicIpAddress cmd

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1983,11 +1983,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         final SearchBuilder<VlanVO> vlanSearch = _vlanDao.createSearchBuilder();
         vlanSearch.and("vlanType", vlanSearch.entity().getVlanType(), SearchCriteria.Op.EQ);
+        vlanSearch.and("removed", vlanSearch.entity().getRemoved(), SearchCriteria.Op.NULL);
         sb.join("vlanSearch", vlanSearch, sb.entity().getVlanId(), vlanSearch.entity().getId(), JoinBuilder.JoinType.INNER);
-
-        SearchBuilder<DataCenterVO> zoneSearchBuilder = _dcDao.createSearchBuilder();
-        zoneSearchBuilder.and("removed", zoneSearchBuilder.entity().getRemoved(), SearchCriteria.Op.NULL);
-        sb.join("removed_zone_filter", zoneSearchBuilder, sb.entity().getDataCenterId(), zoneSearchBuilder.entity().getId(), JoinBuilder.JoinType.INNER);
 
         if (isAllocated != null && isAllocated == true) {
             sb.and("allocated", sb.entity().getAllocatedTime(), SearchCriteria.Op.NNULL);

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1985,6 +1985,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         vlanSearch.and("vlanType", vlanSearch.entity().getVlanType(), SearchCriteria.Op.EQ);
         sb.join("vlanSearch", vlanSearch, sb.entity().getVlanId(), vlanSearch.entity().getId(), JoinBuilder.JoinType.INNER);
 
+        SearchBuilder<DataCenterVO> zoneSearchBuilder = _dcDao.createSearchBuilder();
+        zoneSearchBuilder.and("removed", zoneSearchBuilder.entity().getRemoved(), SearchCriteria.Op.NULL);
+        sb.join("removed_zone_filter", zoneSearchBuilder, sb.entity().getDataCenterId(), zoneSearchBuilder.entity().getId(), JoinBuilder.JoinType.INNER);
+
         if (isAllocated != null && isAllocated == true) {
             sb.and("allocated", sb.entity().getAllocatedTime(), SearchCriteria.Op.NNULL);
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I reproduced this in a production environment that had been upgraded from 4.9 to 4.11 and then to 4.13.  

If the environment has `data centers` and `VLANs` removed, sends an API request with the command `listPublicIpAddress` and allocatedOnly=false we can see this error:
```
2020-07-29 08:15:16,224 ERROR [c.c.a.ApiServer] (qtp504527234-1307:ctx-d9b6eb3f ctx-a0add444) (logid:b94eb35a) unhandled exception executing api command: [Ljava.lang.String;@6177c5d4
java.lang.NullPointerException
```

This occurs because `ManagementService.searchForIPAddresses` returns IP addresses from those deleted `data centers`. And then we have a Null Pointer exception when building the `createIPAddressResponse`.  
This PR prevents this null pointer exception by doing an `INNER_JOIN` with `data_center` table were `removed` is null.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
To test this, I run the `listPublicIpAddrescomand` with `allocatedOnly = false` using `cloudmonkey` to make the request
**Before the fix:**
```
cloudmonkey listpublicipaddresses allocatedonly=false
Error: (HTTP 530, error code 9999) <nil>
```

**After the fix:**
```
cloudmonkey listpublicipaddresses allocatedonly=false
{
  "count": 755,
  "publicipaddress": [...]
}
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
