### PR TITLE
List networks using networkofferingid

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.user.network;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.cloudstack.api.response.NetworkOfferingResponse;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.RoleType;
@@ -88,6 +89,9 @@ public class ListNetworksCmd extends BaseListTaggedResourcesCmd implements UserC
     @Parameter(name = ApiConstants.DISPLAY_NETWORK, type = CommandType.BOOLEAN, description = "list resources by display flag; only ROOT admin is eligible to pass this parameter", since = "4.4", authorized = {RoleType.Admin})
     private Boolean display;
 
+    @Parameter(name = ApiConstants.NETWORK_OFFERING_ID, type = CommandType.UUID, entityType = NetworkOfferingResponse.class, description = "list networks by network offering ID")
+    private Long networkOfferingId;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -142,6 +146,10 @@ public class ListNetworksCmd extends BaseListTaggedResourcesCmd implements UserC
 
     public Boolean getForVpc() {
         return forVpc;
+    }
+
+    public Long getNetworkOfferingId() {
+        return networkOfferingId;
     }
 
     @Override

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -4517,6 +4517,10 @@
 
                     detailView: {
                         name: 'label.network.offering.details',
+                        viewAll: {
+                            label: 'label.networks',
+                            path: 'network'
+                        },
                         actions: {
                             edit: {
                                 label: 'label.edit',

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -946,6 +946,11 @@
                         var data = {};
                         listViewDataProvider(args, data);
 
+                        if ("networkOfferings" in args.context) {
+                            $.extend(data, {
+                                networkofferingid: args.context.networkOfferings[0].id
+                            });
+                        }
                         if ("routers" in args.context) {
                             if ("vpcid" in args.context.routers[0]) {
                                 $.extend(data, {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add extra parameter for listNetworks command to list
all networks using networkofferingid

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Enhancement (improves an existing feature and functionality)

## Screenshots (if appropriate):

## How Has This Been Tested?

```
(local) mgt01 > list networks networkofferingid=85051f32-93a4-4277-8895-a9232e4885f5 filter=name
{
  "count": 4,
  "network": [
    {
      "name": "tier23"
    },
    {
      "name": "tier13"
    },
    {
      "name": "tier22"
    },
    {
      "name": "tier12"
    }
  ]
}
(local) mgt01 >
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
