### PR TITLE
fix test failure

### DIFF
--- a/systemvm/agent/scripts/ssvm-check.sh
+++ b/systemvm/agent/scripts/ssvm-check.sh
@@ -118,7 +118,7 @@ fi
 # check for connectivity to the management server
 echo ================================================
 echo Management server is $MGMTSERVER.  Checking connectivity.
-socatout=$(echo | socat - TCP:$MGMTSERVER:8250,connect-timeout=3 2>&1)
+socatout=$(echo | socat - TCP:$MGMTSERVER:8250,connect-timeout=3 | tr -d '\0' 2>&1)
 if [ $? -eq 0 ]
 then
     echo "Good: Can connect to management server port 8250"
@@ -141,6 +141,6 @@ else
 fi
 
 echo ================================================
-echo Tests Complete.  Look for ERROR or WARNING above.
+echo Tests Complete. Look for ERROR or WARNING above.
 
 exit 0

--- a/test/integration/smoke/test_ssvm.py
+++ b/test/integration/smoke/test_ssvm.py
@@ -874,6 +874,8 @@ class TestSSVMs(cloudstackTestCase):
         # Wait for the agent to be up
         self.waitForSystemVMAgent(ssvm_response.name)
 
+        # Wait until NFS stores mounted before running the script
+        time.sleep(30)
         # Call to verify cloud process is running
         self.test_03_ssvm_internals()
 


### PR DESCRIPTION
## Description
test_ssvm fails on VMWare fixes: https://github.com/apache/cloudstack/issues/4261
Running the ssvm-check.sh script on the Secondary storage VM produces the following error message:
```
command substitution: ignored null byte in input
```
as null characters were being passed, which caused the test to fail. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

