### PR TITLE
Adding os type id to the usage record response for virtual machines

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
@@ -88,6 +88,10 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
     @Param(description = "template ID")
     private String templateId;
 
+    @SerializedName(ApiConstants.OS_TYPE_ID)
+    @Param(description = "virtual machine os type id")
+    private Long osTypeId;
+
     @SerializedName("usageid")
     @Param(description = "id of the resource")
     private String usageId;
@@ -196,6 +200,10 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
 
     public void setTemplateId(String templateId) {
         this.templateId = templateId;
+    }
+
+    public void setOsTypeId(Long osTypeId) {
+        this.osTypeId = osTypeId;
     }
 
     public void setUsageId(String usageId) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -3386,6 +3386,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 resourceType = ResourceTag.ResourceObjectType.UserVm;
                 usageRecResponse.setUsageId(vm.getUuid());
                 resourceId = vm.getId();
+                usageRecResponse.setOsTypeId(vm.getGuestOSId());
             }
             //Hypervisor Type
             usageRecResponse.setType(usageRecord.getType());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding the Os Type Id to the CloudStack Api response for listUsageRecords for running and allocated VMs. When attempting to determine what type of VM was being used for a removed VM, the listVirtualMachines Api will not return a result, as the record has been marked removed. For our purposes, the type of OS is still required for usage purposes. This change simply adds that additional element to the output.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
I have been leveraging the Api for retrieving usage information for virtual machines of specific types fairly extensively.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This change simply adds an additional element to the output, and thus should be considered a non-breaking change.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
