### PR TITLE
Prevent NullPointerException on GenericDaoBase

### DIFF
--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -56,7 +56,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 
-import org.apache.commons.lang.ObjectUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.utils.DateUtil;

--- a/framework/db/src/test/java/com/cloud/utils/db/GenericDaoBaseTest.java
+++ b/framework/db/src/test/java/com/cloud/utils/db/GenericDaoBaseTest.java
@@ -20,21 +20,44 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.persistence.EntityExistsException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GenericDaoBaseTest {
     @Mock
     ResultSet resultSet;
+    @Mock
+    SQLException mockedSQLException;
+
+    private static final String INTEGRITY_CONSTRAINT_VIOLATION = "23000";
+    private static final int DUPLICATE_ENTRY_ERRO_CODE = 1062;
+
+    @Before
+    public void prepareTests() throws SQLException {
+        Mockito.when(resultSet.getObject(1)).thenReturn(false);
+        Mockito.when(resultSet.getBoolean(1)).thenReturn(false);
+        Mockito.when(resultSet.getObject(1)).thenReturn((short) 1);
+        Mockito.when(resultSet.getShort(1)).thenReturn((short) 1);
+        Mockito.when(resultSet.getObject(1)).thenReturn(0.1f);
+        Mockito.when(resultSet.getFloat(1)).thenReturn(0.1f);
+        Mockito.when(resultSet.getObject(1)).thenReturn(0.1d);
+        Mockito.when(resultSet.getDouble(1)).thenReturn(0.1d);
+        Mockito.when(resultSet.getObject(1)).thenReturn(1l);
+        Mockito.when(resultSet.getLong(1)).thenReturn(1l);
+        Mockito.when(resultSet.getInt(1)).thenReturn(1);
+        Mockito.when(resultSet.getObject(1)).thenReturn((byte) 1);
+        Mockito.when(resultSet.getByte(1)).thenReturn((byte) 1);
+    }
 
     @Test
     public void getObjectBoolean() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(false);
-        Mockito.when(resultSet.getBoolean(1)).thenReturn(false);
         Assert.assertFalse(GenericDaoBase
                 .getObject(Boolean.class, resultSet, 1));
         Mockito.verify(resultSet).getBoolean(1);
@@ -42,8 +65,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveBoolean() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(false);
-        Mockito.when(resultSet.getBoolean(1)).thenReturn(false);
         Assert.assertFalse(GenericDaoBase
                 .getObject(boolean.class, resultSet, 1));
         Mockito.verify(resultSet).getBoolean(1);
@@ -51,8 +72,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveShort() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn((short) 1);
-        Mockito.when(resultSet.getShort(1)).thenReturn((short) 1);
         Assert.assertEquals(Short.valueOf((short) 1),
                 GenericDaoBase.getObject(short.class, resultSet, 1));
         Mockito.verify(resultSet).getShort(1);
@@ -60,8 +79,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectShort() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn((short) 1);
-        Mockito.when(resultSet.getShort(1)).thenReturn((short) 1);
         Assert.assertEquals(Short.valueOf((short) 1),
                 GenericDaoBase.getObject(Short.class, resultSet, 1));
         Mockito.verify(resultSet).getShort(1);
@@ -69,8 +86,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectFloat() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(0.1f);
-        Mockito.when(resultSet.getFloat(1)).thenReturn(0.1f);
         Assert.assertEquals(0.1f,
                 GenericDaoBase.getObject(Float.class, resultSet, 1), 0.1);
         Mockito.verify(resultSet).getFloat(1);
@@ -78,8 +93,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveFloat() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(0.1f);
-        Mockito.when(resultSet.getFloat(1)).thenReturn(0.1f);
         Assert.assertEquals(0.1f,
                 GenericDaoBase.getObject(float.class, resultSet, 1), 0.1);
         Mockito.verify(resultSet).getFloat(1);
@@ -87,8 +100,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveDouble() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(0.1d);
-        Mockito.when(resultSet.getDouble(1)).thenReturn(0.1d);
         Assert.assertEquals(0.1d,
                 GenericDaoBase.getObject(double.class, resultSet, 1), 0.1);
         Mockito.verify(resultSet).getDouble(1);
@@ -96,8 +107,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectDouble() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(0.1d);
-        Mockito.when(resultSet.getDouble(1)).thenReturn(0.1d);
         Assert.assertEquals(0.1d,
                 GenericDaoBase.getObject(Double.class, resultSet, 1), 0.1);
         Mockito.verify(resultSet).getDouble(1);
@@ -105,8 +114,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectLong() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(1l);
-        Mockito.when(resultSet.getLong(1)).thenReturn(1l);
         Assert.assertEquals((Long) 1l,
                 GenericDaoBase.getObject(Long.class, resultSet, 1));
         Mockito.verify(resultSet).getLong(1);
@@ -114,8 +121,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveLong() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(1l);
-        Mockito.when(resultSet.getLong(1)).thenReturn(1l);
         Assert.assertEquals((Long) 1l,
                 GenericDaoBase.getObject(long.class, resultSet, 1));
         Mockito.verify(resultSet).getLong(1);
@@ -123,8 +128,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveInt() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(1l);
-        Mockito.when(resultSet.getInt(1)).thenReturn(1);
         Assert.assertEquals((Integer) 1,
                 GenericDaoBase.getObject(int.class, resultSet, 1));
         Mockito.verify(resultSet).getInt(1);
@@ -132,8 +135,6 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectInteger() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn(1l);
-        Mockito.when(resultSet.getInt(1)).thenReturn(1);
         Assert.assertEquals((Integer) 1,
                 GenericDaoBase.getObject(Integer.class, resultSet, 1));
         Mockito.verify(resultSet).getInt(1);
@@ -141,11 +142,44 @@ public class GenericDaoBaseTest {
 
     @Test
     public void getObjectPrimitiveByte() throws SQLException {
-        Mockito.when(resultSet.getObject(1)).thenReturn((byte) 1);
-        Mockito.when(resultSet.getByte(1)).thenReturn((byte) 1);
         Assert.assertTrue((byte) 1 == GenericDaoBase.getObject(byte.class,
                 resultSet, 1));
         Mockito.verify(resultSet).getByte(1);
+    }
+
+    @Test
+    public void handleEntityExistsExceptionTestNoMatchForEntityExists() {
+        Mockito.when(mockedSQLException.getErrorCode()).thenReturn(123);
+        Mockito.when(mockedSQLException.getSQLState()).thenReturn("123");
+        GenericDaoBase.handleEntityExistsException(mockedSQLException);
+    }
+
+    @Test
+    public void handleEntityExistsExceptionTestIntegrityConstraint() {
+        Mockito.when(mockedSQLException.getErrorCode()).thenReturn(123);
+        Mockito.when(mockedSQLException.getSQLState()).thenReturn(INTEGRITY_CONSTRAINT_VIOLATION);
+        GenericDaoBase.handleEntityExistsException(mockedSQLException);
+    }
+
+    @Test
+    public void handleEntityExistsExceptionTestIntegrityConstraintNull() {
+        Mockito.when(mockedSQLException.getErrorCode()).thenReturn(123);
+        Mockito.when(mockedSQLException.getSQLState()).thenReturn(null);
+        GenericDaoBase.handleEntityExistsException(mockedSQLException);
+    }
+
+    @Test
+    public void handleEntityExistsExceptionTestDuplicateEntryErrorCode() {
+        Mockito.when(mockedSQLException.getErrorCode()).thenReturn(DUPLICATE_ENTRY_ERRO_CODE);
+        Mockito.when(mockedSQLException.getSQLState()).thenReturn("123");
+        GenericDaoBase.handleEntityExistsException(mockedSQLException);
+    }
+
+    @Test(expected = EntityExistsException.class)
+    public void handleEntityExistsExceptionTestExpectEntityExistsException() {
+        Mockito.when(mockedSQLException.getErrorCode()).thenReturn(DUPLICATE_ENTRY_ERRO_CODE);
+        Mockito.when(mockedSQLException.getSQLState()).thenReturn(INTEGRITY_CONSTRAINT_VIOLATION);
+        GenericDaoBase.handleEntityExistsException(mockedSQLException);
     }
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Recently I had a few DB connection/transaction issues on a test environment and one of the log messages was the following `NullPointerException`:

```
2020-08-12 22:48:33,250 WARN  [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-1:null) (logid:) Caught: 
java.lang.NullPointerException
        at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:853)
        at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:809)
        at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:1365)
```

Looking further we can see that the null pointer was caused due to a null Object calling _equals_ method. A simple fix would be to use the static final not-null Object calling the `Object.equals` method.

This PR also extracted the duplicated code that could cause `NullPointerException` and added unit tests to ensure that no `NullPointerException` will be thrown.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)