### PR TITLE
Avoid Null pointer at DomainChecker and enhance AssignVMCmd

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AssignVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AssignVMCmd.java
@@ -138,7 +138,7 @@ public class AssignVMCmd extends BaseCmd  {
             e.printStackTrace();
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());
         } catch (Exception e) {
-            e.printStackTrace();
+            s_logger.error("Failed to move vm due to: " + e.getStackTrace());
             if (e.getMessage() != null) {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to move vm due to " + e.getMessage());
             } else if (e.getCause() != null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AssignVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AssignVMCmd.java
@@ -139,7 +139,13 @@ public class AssignVMCmd extends BaseCmd  {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());
         } catch (Exception e) {
             e.printStackTrace();
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to move vm " + e.getMessage());
+            if (e.getMessage() != null) {
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to move vm due to " + e.getMessage());
+            } else if (e.getCause() != null) {
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to move vm due to " + e.getCause());
+            } else {
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to move vm");
+            }
         }
 
     }

--- a/server/src/main/java/com/cloud/acl/DomainChecker.java
+++ b/server/src/main/java/com/cloud/acl/DomainChecker.java
@@ -89,6 +89,11 @@ public class DomainChecker extends AdapterBase implements SecurityChecker {
         if (caller.getState() != Account.State.enabled) {
             throw new PermissionDeniedException(caller + " is disabled.");
         }
+
+        if (domain == null) {
+            throw new PermissionDeniedException(String.format("Provided domain is NULL, cannot check access for account [uuid=%s, name=%s]", caller.getUuid(), caller.getAccountName()));
+        }
+
         long domainId = domain.getId();
 
         if (_accountService.isNormalUser(caller.getId())) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -6138,6 +6138,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("The new account owner " + cmd.getAccountName() + " is disabled.");
         }
 
+        if(cmd.getProjectId() != null && cmd.getDomainId() == null) {
+            throw new InvalidParameterValueException("Please provide a valid domain ID; cannot assign VM to a project if domain ID is NULL.");
+        }
+
         //check caller has access to both the old and new account
         _accountMgr.checkAccess(caller, null, true, oldAccount);
         _accountMgr.checkAccess(caller, null, true, newAccount);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -6138,7 +6138,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("The new account owner " + cmd.getAccountName() + " is disabled.");
         }
 
-        if(cmd.getProjectId() != null && cmd.getDomainId() == null) {
+        if (cmd.getProjectId() != null && cmd.getDomainId() == null) {
             throw new InvalidParameterValueException("Please provide a valid domain ID; cannot assign VM to a project if domain ID is NULL.");
         }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When executing request [assignVirtualMachine](https://cloudstack.apache.org/api/apidocs-4.14/apis/assignVirtualMachine.html) with null `domainID` and a valid `projectID` then a `NullPointerException` happens at [DomainChecker.java](https://github.com/apache/cloudstack/blob/bb73bedb5511880c91abaa409462ba879cb0d7b7/server/src/main/java/com/cloud/acl/DomainChecker.java#L109).

Command example:
```
assign virtualmachine virtualmachineid=vmID projectid=projectID account=admin
```

The `NullPointerException` that is thrown at `DomainChecker` is handled at [AssignVMCmd.java#L142](https://github.com/apache/cloudstack/blob/bb73bedb5511880c91abaa409462ba879cb0d7b7/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AssignVMCmd.java#L142), resulting in the following log message: `Failed to move vm null`.


**My question is:** does it make sense to assign VM to a project with `domainID=null`? If so, then the handling should be different. However, I think that it should not be `null` and therefore I added a proper log message.

Prior to commit 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Request of API command  [assignVirtualMachine](https://cloudstack.apache.org/api/apidocs-4.14/apis/assignVirtualMachine.html) with project ID and `null` domainID.

```
assign virtualmachine virtualmachineid=vmID projectid=projectID account=admin
```