### PR TITLE
Update Java Rados from v0.5.0 to v0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <cs.neethi.version>2.0.4</cs.neethi.version>
         <cs.nitro.version>10.1</cs.nitro.version>
         <cs.opensaml.version>2.6.4</cs.opensaml.version>
-        <cs.rados-java.version>0.5.0</cs.rados-java.version>
+        <cs.rados-java.version>0.6.0</cs.rados-java.version>
         <cs.reflections.version>0.9.12</cs.reflections.version>
         <cs.servicemix.version>3.3.3_1</cs.servicemix.version>
         <cs.servlet.version>4.0.1</cs.servlet.version>


### PR DESCRIPTION
## Description
This PR updates the Java Rados version v0.6.0. The release artifacts are available at: https://search.maven.org/artifact/com.ceph/rados.

Fixes: #4159

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

CloudStack builds successfully and the java-rados v0.6.0 jar has indeed been downloaded from the public repositoy.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
