### PR TITLE
client: explicitly define SslContextFactory::Server for https

### DIFF
--- a/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
@@ -220,7 +220,7 @@ public class ServerDaemon implements Daemon {
         // Configure SSL
         if (httpsEnable && !Strings.isNullOrEmpty(keystoreFile) && new File(keystoreFile).exists()) {
             // SSL Context
-            final SslContextFactory sslContextFactory = new SslContextFactory();
+            final SslContextFactory sslContextFactory = new SslContextFactory.Server();
 
             // Define keystore path and passwords
             sslContextFactory.setKeyStorePath(keystoreFile);

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,8 @@
         <cs.jaxb.version>2.3.0</cs.jaxb.version>
         <cs.jaxws.version>2.3.2-1</cs.jaxws.version>
         <cs.jersey-bundle.version>1.19.4</cs.jersey-bundle.version>
-        <cs.jetty.version>9.4.26.v20200117</cs.jetty.version>
-        <cs.jetty-maven-plugin.version>9.4.26.v20200117</cs.jetty-maven-plugin.version>
+        <cs.jetty.version>9.4.27.v20200227</cs.jetty.version>
+        <cs.jetty-maven-plugin.version>9.4.27.v20200227</cs.jetty-maven-plugin.version>
         <cs.jna.version>4.0.0</cs.jna.version>
         <cs.joda-time.version>2.10.5</cs.joda-time.version>
         <cs.jpa.version>2.2.1</cs.jpa.version>


### PR DESCRIPTION
Fixes #4199

Latest jetty used in 4.14/master has deprecated `new SslContextFactory();` and requires use of Client|Server. This fixes that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)