### PR TITLE
Create template from detached data-disks on VMWare

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -1187,13 +1187,14 @@ public class VmwareStorageProcessor implements StorageProcessor {
 
         String details = null;
         VirtualMachineMO vmMo = null;
+        VirtualMachineMO workerVmMo = null;
         VmwareContext context = hostService.getServiceContext(cmd);
         try {
             VmwareHypervisorHost hyperHost = hostService.getHyperHost(context, cmd);
             if (volume.getVmName() == null) {
                 ManagedObjectReference secMorDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, volume.getDataStore().getUuid());
                 DatastoreMO dsMo = new DatastoreMO(hyperHost.getContext(), secMorDs);
-                VirtualMachineMO workerVmMo = HypervisorHostHelper.createWorkerVM(hyperHost, dsMo, "workervm"+volume.getUuid());
+                workerVmMo = HypervisorHostHelper.createWorkerVM(hyperHost, dsMo, "workervm"+volume.getUuid());
                 if (workerVmMo == null) {
                     throw new Exception("Unable to find created worker VM");
                 }
@@ -1247,9 +1248,9 @@ public class VmwareStorageProcessor implements StorageProcessor {
             return new CopyCmdAnswer(details);
         } finally {
             try {
-                if (volume.getVmName() == null && vmMo != null) {
-                    vmMo.detachAllDisks();
-                    vmMo.destroy();
+                if (volume.getVmName() == null && workerVmMo != null) {
+                    workerVmMo.detachAllDisks();
+                    workerVmMo.destroy();
                 }
             } catch (Throwable e) {
                 s_logger.warn("Failed to destroy worker VM created for detached volume");

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -1253,7 +1253,7 @@ public class VmwareStorageProcessor implements StorageProcessor {
                     workerVmMo.destroy();
                 }
             } catch (Throwable e) {
-                s_logger.warn("Failed to destroy worker VM created for detached volume");
+                s_logger.error("Failed to destroy worker VM created for detached volume");
             }
         }
     }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -1186,31 +1186,42 @@ public class VmwareStorageProcessor implements StorageProcessor {
         String volumePath = volume.getPath();
 
         String details = null;
-
+        VirtualMachineMO vmMo = null;
         VmwareContext context = hostService.getServiceContext(cmd);
         try {
             VmwareHypervisorHost hyperHost = hostService.getHyperHost(context, cmd);
-
-            VirtualMachineMO vmMo = hyperHost.findVmOnHyperHost(volume.getVmName());
-            if (vmMo == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Unable to find the owner VM for CreatePrivateTemplateFromVolumeCommand on host " + hyperHost.getHyperHostName() +
-                            ", try within datacenter");
+            if (volume.getVmName() == null) {
+                ManagedObjectReference secMorDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, volume.getDataStore().getUuid());
+                DatastoreMO dsMo = new DatastoreMO(hyperHost.getContext(), secMorDs);
+                VirtualMachineMO workerVmMo = HypervisorHostHelper.createWorkerVM(hyperHost, dsMo, "workervm"+volume.getUuid());
+                if (workerVmMo == null) {
+                    throw new Exception("Unable to find created worker VM");
                 }
-                vmMo = hyperHost.findVmOnPeerHyperHost(volume.getVmName());
-
+                vmMo = workerVmMo;
+                String vmdkDataStorePath = VmwareStorageLayoutHelper.getLegacyDatastorePathFromVmdkFileName(dsMo, volumePath + ".vmdk");
+                vmMo.attachDisk(new String[] {vmdkDataStorePath}, secMorDs);
+            } else {
+                vmMo = hyperHost.findVmOnHyperHost(volume.getVmName());
                 if (vmMo == null) {
-                    // This means either the volume is on a zone wide storage pool or VM is deleted by external entity.
-                    // Look for the VM in the datacenter.
-                    ManagedObjectReference dcMor = hyperHost.getHyperHostDatacenter();
-                    DatacenterMO dcMo = new DatacenterMO(context, dcMor);
-                    vmMo = dcMo.findVm(volume.getVmName());
-                }
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("Unable to find the owner VM for CreatePrivateTemplateFromVolumeCommand on host " + hyperHost.getHyperHostName() +
+                                ", try within datacenter");
+                    }
+                    vmMo = hyperHost.findVmOnPeerHyperHost(volume.getVmName());
 
-                if (vmMo == null) {
-                    String msg = "Unable to find the owner VM for volume operation. vm: " + volume.getVmName();
-                    s_logger.error(msg);
-                    throw new Exception(msg);
+                    if (vmMo == null) {
+                        // This means either the volume is on a zone wide storage pool or VM is deleted by external entity.
+                        // Look for the VM in the datacenter.
+                        ManagedObjectReference dcMor = hyperHost.getHyperHostDatacenter();
+                        DatacenterMO dcMo = new DatacenterMO(context, dcMor);
+                        vmMo = dcMo.findVm(volume.getVmName());
+                    }
+
+                    if (vmMo == null) {
+                        String msg = "Unable to find the owner VM for volume operation. vm: " + volume.getVmName();
+                        s_logger.error(msg);
+                        throw new Exception(msg);
+                    }
                 }
             }
 
@@ -1234,6 +1245,15 @@ public class VmwareStorageProcessor implements StorageProcessor {
 
             details = "create template from volume exception: " + VmwareHelper.getExceptionMessage(e);
             return new CopyCmdAnswer(details);
+        } finally {
+            try {
+                if (volume.getVmName() == null && vmMo != null) {
+                    vmMo.detachAllDisks();
+                    vmMo.destroy();
+                }
+            } catch (Throwable e) {
+                s_logger.warn("Failed to destroy worker VM created for detached volume");
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Creation of templates from detached data disks results in a Null Pointer Exception on VMWare, as it expects the volume to be attached to a VM.
To fix this behavior and make it consistent with other hypervisors, creation of the template from the volume in case not attached to a VM is facilitated by creating a worker VM, attaching the disk to the worker VM, creating the template from it, and then destroying the VM.

### Steps to reproduce the issue:
1. Create / Upload a volume
2. Attach the volume to a VM
3. Detach the volume
4. Initiate template creation from the volume

Fails with following exception:
```
2020-08-14 07:05:00,157 DEBUG [c.c.r.ResourceLimitManagerImpl] (API-Job-Executor-15:ctx-691a4a4c job-86 ctx-54b7bef5) (logid:4a57991e) Updating resource Type = template count for Account = 2 Operation = decreasing Amount = 1
2020-08-14 07:05:00,159 DEBUG [c.c.r.ResourceLimitManagerImpl] (API-Job-Executor-15:ctx-691a4a4c job-86 ctx-54b7bef5) (logid:4a57991e) Updating resource Type = secondary_storage count for Account = 2 Operation = decreasing Amount = (5.00 GB) 5368709120
2020-08-14 07:05:00,168 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-15:ctx-691a4a4c job-86) (logid:4a57991e) Unexpected exception while executing org.apache.cloudstack.api.command.admin.template.CreateTemplateCmdByAdmin
com.cloud.utils.exception.CloudRuntimeException: Failed to create templatecreate template from volume exception: Exception: java.lang.NullPointerException
Message: null

    at com.cloud.template.TemplateManagerImpl.createPrivateTemplate(TemplateManagerImpl.java:1699)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
    at org.apache.cloudstack.network.contrail.management.EventUtils$EventInterceptor.invoke(EventUtils.java:107)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
    at com.cloud.event.ActionEventInterceptor.invoke(ActionEventInterceptor.java:51)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
    at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:95)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
    at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212)
    at com.sun.proxy.$Proxy197.createPrivateTemplate(Unknown Source)
    at org.apache.cloudstack.api.command.user.template.CreateTemplateCmd.execute(CreateTemplateCmd.java:305)
    at com.cloud.api.ApiDispatcher.dispatch(ApiDispatcher.java:156)
    at com.cloud.api.ApiAsyncJobDispatcher.runJob(ApiAsyncJobDispatcher.java:108)
    at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.runInContext(AsyncJobManagerImpl.java:615)
    at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
    at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
    at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
    at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
    at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
    at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.run(AsyncJobManagerImpl.java:563)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:834)
2020-08-14 07:05:00,172 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (API-Job-Executor-15:ctx-691a4a4c job-86) (logid:4a57991e) Complete async job-86, jobStatus: FAILED, resultCode: 530, result: org.apache.cloudstack.api.response.ExceptionResponse/null/{"uuidList":[],"errorcode":"530","errortext":"Failed to create templatecreate template from volume exception: Exception: java.lang.NullPointerException
Message: null
"}
```

SSVM logs:
```
2020-08-21 05:07:00,160 INFO  [vmware.mo.HostMO] (agentRequest-Handler-10:job-417, cmd: CopyCommand) VM null not found in host cache
2020-08-21 05:07:00,230 ERROR [storage.resource.VmwareStorageProcessor] (agentRequest-Handler-10:job-417, cmd: CopyCommand) Unexpecpted exception
java.lang.NullPointerException
        at com.cloud.hypervisor.vmware.mo.HypervisorHostHelper.findVmFromObjectContent(HypervisorHostHelper.java:160)
        at com.cloud.hypervisor.vmware.mo.ClusterMO.findVmOnHyperHost(ClusterMO.java:242)
        at com.cloud.hypervisor.vmware.mo.HostMO.findVmOnPeerHyperHost(HostMO.java:591)
        at com.cloud.storage.resource.VmwareStorageProcessor.createTemplateFromVolume(VmwareStorageProcessor.java:1209)
        at com.cloud.storage.resource.StorageSubsystemCommandHandlerBase.execute(StorageSubsystemCommandHandlerBase.java:107)
        at com.cloud.storage.resource.VmwareStorageSubsystemCommandHandler.execute(VmwareStorageSubsystemCommandHandler.java:197)
        at com.cloud.storage.resource.StorageSubsystemCommandHandlerBase.handleStorageCommands(StorageSubsystemCommandHandlerBase.java:58)
        at com.cloud.storage.resource.VmwareSecondaryStorageResourceHandler.executeRequest(VmwareSecondaryStorageResourceHandler.java:115)
        at com.cloud.storage.resource.PremiumSecondaryStorageResource.executeRequest(PremiumSecondaryStorageResource.java:57)
        at com.cloud.agent.Agent.processRequest(Agent.java:645)
        at com.cloud.agent.Agent$AgentRequestHandler.doTask(Agent.java:1060)
```
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Tested by following the above steps mentioned (for reproducing the error) and resulted in successful creation of template from the detached volume. Also tested creation of template of Root volume of a stopped VM, to ensure no regression.

