### PR TITLE
Ubuntu 20.04: restart libvirtd instead of libvirt-bin

### DIFF
--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -592,8 +592,11 @@ class libvirtConfigUbuntu(serviceCfgBase):
             cfo.addEntry("group", "\"root\"")
             cfo.save()
 
-            self.syscfg.svo.stopService("libvirt-bin")
-            self.syscfg.svo.enableService("libvirt-bin")
+            if os.path.exists("/lib/systemd/system/libvirtd.service"):
+                bash("systemctl restart libvirtd")
+            else:
+                self.syscfg.svo.stopService("libvirt-bin")
+                self.syscfg.svo.enableService("libvirt-bin")
             if os.path.exists("/lib/systemd/system/libvirt-bin.socket"):
                 bash("systemctl stop libvirt-bin.socket")
             return True


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

libvirt-bin does not exist any more in Ubuntu 20.04, restart libvirtd instead of libvirt-bin after configuration when add a host.

in summary:
ubuntu 16.04: libvirt-bin
ubuntu 18.04: libvirt-bin and libvirtd (they are same)
ubuntu 20.04: libvirtd

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
