### PR TITLE
Changing dependency from python3-distutils to python3-distutils-extra

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.cloudstack.org/
 
 Package: cloudstack-common
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, genisoimage, nfs-common, python3-pip, python3-distutils, python3-netaddr
+Depends: ${misc:Depends}, ${python3:Depends}, genisoimage, nfs-common, python3-pip, python3-distutils-extra, python3-netaddr
 Conflicts: cloud-scripts, cloud-utils, cloud-system-iso, cloud-console-proxy, cloud-daemonize, cloud-deps, cloud-python, cloud-setup
 Description: A common package which contains files which are shared by several CloudStack packages
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.cloudstack.org/
 
 Package: cloudstack-common
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, genisoimage, nfs-common, python3-pip, python3-distutils-extra, python3-netaddr
+Depends: ${misc:Depends}, ${python3:Depends}, genisoimage, nfs-common, python3-pip, python3-distutils | python3-distutils-extra, python3-netaddr
 Conflicts: cloud-scripts, cloud-utils, cloud-system-iso, cloud-console-proxy, cloud-daemonize, cloud-deps, cloud-python, cloud-setup
 Description: A common package which contains files which are shared by several CloudStack packages
 


### PR DESCRIPTION
## Description
Changing dependency from python3-distutils to python3-distutils-extra to continue supporting Ubuntu 16.04

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
