### PR TITLE
Ubuntu 20.04: Fix issue while build package on ubuntu 20.04

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: extra
 Maintainer: Wido den Hollander <wido@widodh.nl>
 Build-Depends: debhelper (>= 9), openjdk-11-jdk | java11-sdk | java11-jdk | zulu-11, genisoimage,
- python-mysql.connector, maven (>= 3) | maven3, python (>= 2.7), python3 (>= 3), lsb-release, dh-systemd, python-setuptools
+ python-mysql.connector | python3-mysql.connector, maven (>= 3) | maven3, python (>= 2.7), python3 (>= 3), lsb-release, dh-systemd, python-setuptools
 Standards-Version: 3.8.1
 Homepage: http://www.cloudstack.org/
 


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

error:
    dpkg-checkbuilddeps: error: Unmet build dependencies: python-mysql.connector

root cause: python-mysql.connector is not valid any more in ubuntu 20.04
    root@buildbox-ubuntu20:~# dpkg -l |grep connector
    ii  python3-mysql.connector               8.0.15-2build1                    all          pure Python implementation of MySQL Client/Server protocol (Python3)

solution: use python3-mysql.connector instead

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
