### PR TITLE
Trimming string api parameters and disallowing only space as an api parameter value

### DIFF
--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -367,7 +367,7 @@ public class ParamProcessWorker implements DispatchWorker {
                 final List listParam = new ArrayList();
                 final StringTokenizer st = new StringTokenizer(paramObj.toString(), ",");
                 while (st.hasMoreTokens()) {
-                    final String token = st.nextToken();
+                    final String token = st.nextToken().trim();
                     final CommandType listType = annotation.collectionType();
                     switch (listType) {
                     case INTEGER:
@@ -408,8 +408,13 @@ public class ParamProcessWorker implements DispatchWorker {
                     if (paramObj.toString().length() > annotation.length()) {
                         s_logger.error("Value greater than max allowed length " + annotation.length() + " for param: " + field.getName());
                         throw new InvalidParameterValueException("Value greater than max allowed length " + annotation.length() + " for param: " + field.getName());
-                    } else {
-                        field.set(cmdObj, paramObj.toString());
+                    } else{
+                        String trimmedParam = paramObj.toString().trim();
+                        if (trimmedParam.length() == 0){
+                            s_logger.error("Empty string or only spaces are not allowed for " + field.getName());
+                            throw new InvalidParameterValueException("Empty string or only spaces are not allowed for " + field.getName());
+                        }
+                        field.set(cmdObj, trimmedParam);
                     }
                 }
                 break;


### PR DESCRIPTION
## Description
Disallowing only space characters as a string api parameter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
```
(localhost) 🐱 > create project name=' ' displaytext='  '
🙈 Error: (HTTP 431, error code 9999) Unable to execute API command createproject due to invalid value.
Empty string or only spaces are not allowed for name

(localhost) 🐱 > create project name=' abc ' displaytext=' def '
{
  "project": {
    ........
    "displaytext": "def",
    "name": "abc",
    ........
  }
}
```

Works similarly for other APIs