### PR TITLE
Handle listProjects API to list projects with user as members when listAll=true

### DIFF
--- a/server/src/main/java/com/cloud/acl/AffinityGroupAccessChecker.java
+++ b/server/src/main/java/com/cloud/acl/AffinityGroupAccessChecker.java
@@ -80,8 +80,8 @@ public class AffinityGroupAccessChecker extends DomainChecker {
                   //check if the group belongs to a project
                     User user = CallContext.current().getCallingUser();
                     ProjectVO project = _projectDao.findByProjectAccountId(group.getAccountId());
-                    ProjectAccount userProjectAccount = _projectAccountDao.findByProjectIdUserId(project.getId(), user.getAccountId(), user.getId());
                     if (project != null) {
+                        ProjectAccount userProjectAccount = _projectAccountDao.findByProjectIdUserId(project.getId(), user.getAccountId(), user.getId());
                         if (userProjectAccount != null) {
                             if (AccessType.ModifyProject.equals(accessType) && _projectAccountDao.canUserModifyProject(project.getId(), user.getAccountId(), user.getId())) {
                                 return true;

--- a/server/src/main/java/com/cloud/acl/DomainChecker.java
+++ b/server/src/main/java/com/cloud/acl/DomainChecker.java
@@ -61,6 +61,7 @@ import com.cloud.user.AccountService;
 import com.cloud.user.User;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.component.AdapterBase;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
 public class DomainChecker extends AdapterBase implements SecurityChecker {
@@ -199,6 +200,9 @@ public class DomainChecker extends AdapterBase implements SecurityChecker {
     private boolean checkOperationPermitted(Account caller, ControlledEntity entity) {
         User user = CallContext.current().getCallingUser();
         Project project = projectDao.findByProjectAccountId(entity.getAccountId());
+        if (project == null) {
+            throw new CloudRuntimeException("Unable to find project to which the entity belongs to");
+        }
         ProjectAccount projectUser = _projectAccountDao.findByProjectIdUserId(project.getId(), user.getAccountId(), user.getId());
         String apiCommandName = CallContext.current().getApiName();
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1486,8 +1486,6 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sb.and().op("userId", sb.entity().getUserId(), Op.EQ);
             sb.or("userIdNull", sb.entity().getUserId(), Op.NULL);
             sb.cp();
-        } else {
-            sb.and("userIdNull", sb.entity().getUserId(), Op.NULL);
         }
 
         SearchCriteria<ProjectJoinVO> sc = sb.create();

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1479,7 +1479,13 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         }
 
         if (accountId != null) {
-            sb.and("accountId", sb.entity().getAccountId(), SearchCriteria.Op.EQ);
+            if (userId == null) {
+                sb.and().op("accountId", sb.entity().getAccountId(), SearchCriteria.Op.EQ);
+                sb.and("userIdNull", sb.entity().getUserId(), Op.NULL);
+                sb.cp();
+            } else {
+                sb.and("accountId", sb.entity().getAccountId(), SearchCriteria.Op.EQ);
+            }
         }
 
         if (userId != null) {

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -1658,6 +1658,9 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
             if (owner.getType() != Account.ACCOUNT_TYPE_PROJECT && networkOwner.getType() == Account.ACCOUNT_TYPE_PROJECT) {
                 User user = CallContext.current().getCallingUser();
                 Project project = projectDao.findByProjectAccountId(network.getAccountId());
+                if (project == null) {
+                    throw new CloudRuntimeException("Unable to find project to which the network belongs to");
+                }
                 ProjectAccount projectAccountUser = _projectAccountDao.findByProjectIdUserId(project.getId(), user.getAccountId(), user.getId());
                 if (projectAccountUser != null) {
                     if (!_projectAccountDao.canUserAccessProjectAccount(user.getAccountId(), user.getId(), network.getAccountId())) {

--- a/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
@@ -239,6 +239,9 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager {
         }
 
         User user = validateUser(userId, accountId, domainId);
+        if (user != null) {
+            owner = _accountDao.findById(user.getAccountId());
+        }
 
         //do resource limit check
         _resourceLimitMgr.checkResourceLimit(owner, ResourceType.project);
@@ -559,9 +562,11 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager {
         }
         User user = CallContext.current().getCallingUser();
         ProjectVO project = _projectDao.findByProjectAccountId(accountId);
-        ProjectAccount userProjectAccount = _projectAccountDao.findByProjectIdUserId(project.getId(), user.getAccountId(), user.getId());
-        if (userProjectAccount != null) {
-            return _projectAccountDao.canUserAccessProjectAccount(user.getAccountId(), user.getId(), accountId);
+        if (project != null) {
+            ProjectAccount userProjectAccount = _projectAccountDao.findByProjectIdUserId(project.getId(), user.getAccountId(), user.getId());
+            if (userProjectAccount != null) {
+                return _projectAccountDao.canUserAccessProjectAccount(user.getAccountId(), user.getId(), accountId);
+            }
         }
         return _projectAccountDao.canAccessProjectAccount(caller.getId(), accountId);
     }


### PR DESCRIPTION
## Description
1. When listAll is true, listProjects API doesn't list projects that have users as members
2. Added defensive checks to overcome NPEs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


## How Has This Been Tested?
This has been verified using the cmk and UI
There exists 7 projects:
```
MariaDB [cloud]> select name, account_id, user_id, created, removed from project_view where removed is NULL;
+--------------+------------+---------+---------------------+---------+
| name         | account_id | user_id | created             | removed |
+--------------+------------+---------+---------------------+---------+
| Project2     |          4 |    NULL | 2020-09-09 10:08:52 | NULL    |
| Project2     |          5 |       6 | 2020-09-09 10:08:52 | NULL    |
| p3           |          2 |    NULL | 2020-09-09 11:43:50 | NULL    |
| p3           |          5 |       5 | 2020-09-09 11:43:50 | NULL    |
| Project1     |          2 |    NULL | 2020-09-09 12:36:03 | NULL    |
| Project1     |          5 |       5 | 2020-09-09 12:36:03 | NULL    |
| p1           |          2 |       2 | 2020-09-09 13:16:11 | NULL    |
| p1           |          5 |       5 | 2020-09-09 13:16:11 | NULL    |
| d1           |         12 |       8 | 2020-09-09 13:21:38 | NULL    |
| p1           |          2 |       2 | 2020-09-09 13:16:11 | NULL    |
| p1           |          5 |       5 | 2020-09-09 13:16:11 | NULL    |
| p4           |         15 |      10 | 2020-09-10 05:54:44 | NULL    |
| p41useradmin |         17 |      12 | 2020-09-10 06:23:43 | NULL    |
| Project1     |          2 |    NULL | 2020-09-09 12:36:03 | NULL    |
| Project1     |          5 |       5 | 2020-09-09 12:36:03 | NULL    |
+--------------+------------+---------+---------------------+---------+

```
Before fix:
```
(localcloud) SBCM5> > list projects filter=account,owner,name,id, listall=true 
{
  "count": 2,
  "project": [
    {
      "id": "cab2a46a-8250-4825-85ff-e18e7275eb18",
      "name": "p3",
      "owner": [
        {
          "account": "admin"
        }
      ]
    },
    {
      "id": "f0e64573-3483-4e4c-8164-c92e9efda80f",
      "name": "Project2",
      "owner": [
        {
          "account": "ACSUser"
        }
      ]
    }
  ]
}
```
With fix:
```
(localcloud) SBCM5> > list projects filter=account,owner,name,id, listall=true 
{
  "count": 7,
  "project": [
    {
      "id": "0f4a6c4f-a95e-4ea2-b840-e16eedf1085a",
      "name": "p41useradmin",
      "owner": [
        {
          "account": "u4",
          "user": "u41",
          "userid": "9d523792-a777-45c2-8b34-84052b8d4b34"
        }
      ]
    },
    {
      "id": "352b9a95-cc6e-412f-ad1a-7671eaebfdff",
      "name": "p4",
      "owner": [
        {
          "account": "u3",
          "user": "u3",
          "userid": "41d2a5e2-f45f-479b-bc2b-3c911d2b7b46"
        }
      ]
    },
    {
      "id": "02b5bc7b-a1e7-4e77-860e-99fd5fb30ec3",
      "name": "d1",
      "owner": [
        {
          "account": "dom1",
          "user": "dom1",
          "userid": "a534379c-804d-4a45-bf09-73e784adacb0"
        }
      ]
    },
    {
      "id": "7ab34cd7-2403-477a-a3cf-9d03c517345c",
      "name": "p1",
      "owner": [
        {
          "account": "admin",
          "user": "admin",
          "userid": "e125c80a-eebf-11ea-ba61-1e006a013aee"
        },
        {
          "account": "user1",
          "user": "user1",
          "userid": "705136fe-2c09-4031-873f-835ee3dfad02"
        }
      ]
    },
    {
      "id": "f5884fbe-9ce1-4315-9a76-c1564d13dac0",
      "name": "Project1",
      "owner": [
        {
          "account": "admin"
        },
        {
          "account": "user1",
          "user": "user1",
          "userid": "705136fe-2c09-4031-873f-835ee3dfad02"
        }
      ]
    },
    {
      "id": "cab2a46a-8250-4825-85ff-e18e7275eb18",
      "name": "p3",
      "owner": [
        {
          "account": "admin"
        }
      ]
    },
    {
      "id": "f0e64573-3483-4e4c-8164-c92e9efda80f",
      "name": "Project2",
      "owner": [
        {
          "account": "ACSUser"
        }
      ]
    }
  ]
}

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
