### PR TITLE
Display acl name in listNetworks response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -719,6 +719,7 @@ public class ApiConstants {
     public static final String AFFINITY_GROUP_ID = "affinitygroupid";
     public static final String DEPLOYMENT_PLANNER = "deploymentplanner";
     public static final String ACL_ID = "aclid";
+    public static final String ACL_NAME = "aclname";
     public static final String NUMBER = "number";
     public static final String IS_DYNAMICALLY_SCALABLE = "isdynamicallyscalable";
     public static final String ROUTING = "isrouting";

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -239,7 +239,7 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
     private Boolean redundantRouter;
 
     @SerializedName(ApiConstants.ACL_NAME)
-    @Param(description = "ACL name associated with the VPC network")
+    @Param(description = "ACL name associated with the VPC network", since = "4.15.0")
     private String aclName;
 
     public Boolean getDisplayNetwork() {

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -238,6 +238,10 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
     @Param(description = "If the network has redundant routers enabled", since = "4.11.1")
     private Boolean redundantRouter;
 
+    @SerializedName(ApiConstants.ACL_NAME)
+    @Param(description = "ACL name associated with the VPC network")
+    private String aclName;
+
     public Boolean getDisplayNetwork() {
         return displayNetwork;
     }
@@ -457,5 +461,13 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
 
     public void setRedundantRouter(Boolean redundantRouter) {
         this.redundantRouter = redundantRouter;
+    }
+
+    public String getAclName() {
+        return aclName;
+    }
+
+    public void setAclName(String aclName) {
+        this.aclName = aclName;
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2279,6 +2279,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             NetworkACL acl = ApiDBUtils.findByNetworkACLId(network.getNetworkACLId());
             if (acl != null) {
                 response.setAclId(acl.getUuid());
+                response.setAclName(acl.getName());
             }
         }
 


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
Display network acl name along with its id so that we
dont need to make extra api call `listNetworksAcllist`
 to get acl name

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Enhancement (improves an existing feature and functionality)


## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Through cloudmonkey api

```
(local) mgt01 > list networks id=81f5-5f17-488a-be61-7d6ad99 filter=aclname
{
  "count": 1,
  "network": [
    {
      "aclname": "default_allow"
    }
  ]
}
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
