### PR TITLE
Fix "data-server" dns entry in /etc/hosts after a new deployment

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -158,7 +158,7 @@ class CsDhcp(CsDataBag):
         self.add_host("::1", "localhost ip6-localhost ip6-loopback")
         self.add_host("ff02::1", "ip6-allnodes")
         self.add_host("ff02::2", "ip6-allrouters")
-        if self.config.is_router():
+        if self.config.is_router() or self.config.is_dhcp():
             self.add_host(self.config.address().get_guest_ip(), "%s data-server" % CsHelper.get_hostname())
 
     def write_hosts(self):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The DNS entry "data-server" was not added in /etc/hosts.

Since the VR is now considered as a "dhcpsrvr" (?), we need to apply this commit to add this DNS entry. 
**/etc/hosts** is fully rewritten by this script.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #4308
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tried on a VMWare cluster.
<!-- Include details of your testing environment, and the tests you ran to -->
Login into the VR via SSH. Apply the patch.
Deploy a new VM.

Check "data-server" is now listed in /etc/hosts:
```shell
root@r-11-VM:/opt# cat /etc/hosts |grep data-server
10.2.111.18     r-11-VM data-server
```
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
