### PR TITLE
ui: call logout before login to clear old sessionkey cookies

### DIFF
--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -280,6 +280,15 @@
 
                 var loginCmdText = array1.join("");
 
+                // Logout before login is called to purge any duplicate sessionkey cookies
+                // to handle edge cases around upgrades and using legacy UI with Primate
+                $.ajax({
+                    url: createURL('logout'),
+                    async: false,
+                    success: function() {},
+                    error: function() {}
+                });
+
                 $.ajax({
                     type: "POST",
                     data: "command=login" + loginCmdText + "&response=json",


### PR DESCRIPTION
This handle edge cases of upgrades and when legacy UI is used along with
Primate or any UI sharing cookies. The specific case it fixes involves
removal of duplicate sessionkey cookies.

Fixes #4324 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

1. Logout and create a fake sessionkey cookie using `$.cookie('sessionkey', '123')`
2. Try to login, login will fail and in the request two sessionkey cookies will be seen passed: 
![Screenshot from 2020-09-14 15-23-22](https://user-images.githubusercontent.com/95203/93077577-a1eeb080-f6a6-11ea-97d1-ef0b989342ca.png)

With the fix, when logout is called the API will clear sessionkey cookie (which is httponly so only the backend/server can remove it); and login works. This will cover issues after upgrades and when using legacy UI with Primate:

![Screenshot from 2020-09-14 16-25-26](https://user-images.githubusercontent.com/95203/93077767-ee39f080-f6a6-11ea-86aa-08557995ef80.png)
