### PR TITLE
vmware: search unmanaged instances using hypervisor name

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -16,9 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.vmware.resource;
 
-import static com.cloud.utils.HumanReadableJson.getHumanReadableBytesJson;
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -16,6 +16,9 @@
 // under the License.
 package com.cloud.hypervisor.vmware.resource;
 
+import static com.cloud.utils.HumanReadableJson.getHumanReadableBytesJson;
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -316,8 +319,8 @@ import com.vmware.vim25.VirtualEthernetCardDistributedVirtualPortBackingInfo;
 import com.vmware.vim25.VirtualEthernetCardNetworkBackingInfo;
 import com.vmware.vim25.VirtualEthernetCardOpaqueNetworkBackingInfo;
 import com.vmware.vim25.VirtualIDEController;
-import com.vmware.vim25.VirtualMachineConfigSpec;
 import com.vmware.vim25.VirtualMachineBootOptions;
+import com.vmware.vim25.VirtualMachineConfigSpec;
 import com.vmware.vim25.VirtualMachineFileInfo;
 import com.vmware.vim25.VirtualMachineFileLayoutEx;
 import com.vmware.vim25.VirtualMachineFileLayoutExFileInfo;
@@ -7069,7 +7072,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VmwareHypervisorHost hyperHost = getHyperHost(context);
 
             String vmName = cmd.getInstanceName();
-            List<VirtualMachineMO> vmMos = hyperHost.listVmsOnHyperHost(vmName);
+            List<VirtualMachineMO> vmMos = hyperHost.listVmsOnHyperHostWithHypervisorName(vmName);
 
             for (VirtualMachineMO vmMo : vmMos) {
                 if (vmMo == null) {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ClusterMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ClusterMO.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -217,13 +218,13 @@ public class ClusterMO extends BaseMO implements VmwareHypervisorHost {
     }
 
     @Override
-    public synchronized List<VirtualMachineMO> listVmsOnHyperHost(String vmName) throws Exception {
+    public synchronized List<VirtualMachineMO> listVmsOnHyperHostWithHypervisorName(String vmName) throws Exception {
         List<VirtualMachineMO> vms = new ArrayList<>();
         List<ManagedObjectReference> hosts = _context.getVimClient().getDynamicProperty(_mor, "host");
-        if (hosts != null && hosts.size() > 0) {
+        if (CollectionUtils.isNotEmpty(hosts)) {
             for (ManagedObjectReference morHost : hosts) {
                 HostMO hostMo = new HostMO(_context, morHost);
-                vms.addAll(hostMo.listVmsOnHyperHost(vmName));
+                vms.addAll(hostMo.listVmsOnHyperHostWithHypervisorName(vmName));
             }
         }
         return vms;

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VmwareHypervisorHost.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VmwareHypervisorHost.java
@@ -53,7 +53,7 @@ public interface VmwareHypervisorHost {
 
     String getHyperHostDefaultGateway() throws Exception;
 
-    List<VirtualMachineMO> listVmsOnHyperHost(String name) throws Exception;
+    List<VirtualMachineMO> listVmsOnHyperHostWithHypervisorName(String name) throws Exception;
 
     VirtualMachineMO findVmOnHyperHost(String name) throws Exception;
 


### PR DESCRIPTION
## Description
VMware code keeps a cache of existing VMs on a hypervisor host using `cloud.vm.internal.name` property of the VM. Searching for unmanaged instances/VMs on a host might not return an expected result when this property differs from the actual name of the VM.

To reproduce:

- Deploy a VM in vCenter
- Set custom attribute for the VM with key = `cloud.vm.internal.name` and value = `Anything different than VM name`
- listUnmanagedInstance API fails when `name` parameter with name of the VM
- importUnmanagedInstance API fails for the VM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

With API using cmk

VM in vcenter having a different name and custom attribute `cloud.vm.internal.name`
![Screenshot from 2020-09-21 12-27-04](https://user-images.githubusercontent.com/153340/93739561-3789c300-fc06-11ea-8541-9552b9000f2f.png)

Both listUnmanagedInstance and importUnmanagedInstance
```
> list unmanagedinstances clusterid=5c46e61a-4f4e-478a-8479-613156747764 name=clone
{
  "count": 1,
  "unmanagedinstance": [
    {
      "clusterid": "5c46e61a-4f4e-478a-8479-613156747764",
      "cpucorepersocket": 1,
      "cpunumber": 1,
      "cpuspeed": 0,
      "disk": [
        {
          "capacity": 2147483648,
          "controller": "ide",
          "controllerunit": 0,
          "datastorehost": "10.10.0.16",
          "datastorename": "4a4b464bbcc83578bc6ce35ded34010a",
          "datastorepath": "/acs/primary/pr4328-t2806-vmware-67u3/pr4328-t2806-vmware-67u3-esxi-pri2",
          "datastoretype": "NFS",
          "id": "10-3001",
          "imagepath": "[4a4b464bbcc83578bc6ce35ded34010a] clone/clone_5.vmdk",
          "label": "Hard disk 1",
          "position": 1
        }
      ],
      "hostid": "2ea89a56-df8f-416d-9e9c-0ca35c78a631",
      "memory": 512,
      "name": "clone",
      "nic": [
        {
          "adaptertype": "E1000",
          "id": "Network adapter 1",
          "macaddress": "02:00:6a:49:00:02",
          "networkname": "cloud.guest.1539.200.1-vSwitch1",
          "vlanid": 1539
        }
      ],
      "osdisplayname": "CentOS 4/5 or later (64-bit)",
      "osid": "centos64Guest",
      "powerstate": "PowerOn"
    }
  ]
}
```


```
> import unmanagedinstance clusterid=5c46e61a-4f4e-478a-8479-613156747764 name=clone templateid=bfc585bb-fbd0-11ea-bdc1-1e00f10138c3 serviceofferingid=bd10b24c-b742-4602-86e5-7bbb56c1329a 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2020-09-21T06:56:08+0000",
    "details": {
      "dataDiskController": "osdefault",
      "deployvm": "true",
      "nicAdapter": "E1000",
      "rootDiskController": "ide"
    },
    "displayname": "clone",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "bfa279ba-fbd0-11ea-bdc1-1e00f10138c3",
    "guestosid": "bfef14e9-fbd0-11ea-bdc1-1e00f10138c3",
    "haenable": false,
    "hostid": "2ea89a56-df8f-416d-9e9c-0ca35c78a631",
    "hostname": "10.10.4.114",
    "hypervisor": "VMware",
    "id": "51989767-5ad2-4899-bfe9-253bca09bc59",
    "instancename": "clone",
    "isdynamicallyscalable": false,
    "memory": 512,
    "name": "clone",
    "nic": [
      {
        "broadcasturi": "vlan://1539",
        "extradhcpoption": [],
        "id": "a393a281-e61c-4633-b85f-fe5b83e60d06",
        "isdefault": true,
        "isolationuri": "vlan://1539",
        "macaddress": "02:00:6a:49:00:02",
        "networkid": "eeb8147d-f1af-4d0b-afa4-4936b3720952",
        "networkname": "t1net",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "CentOS 5.3 (64-bit)",
    "ostypeid": "bfef14e9-fbd0-11ea-bdc1-1e00f10138c3",
    "passwordenabled": false,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "serviceofferingid": "bd10b24c-b742-4602-86e5-7bbb56c1329a",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "bfc585bb-fbd0-11ea-bdc1-1e00f10138c3",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "d6e87cc2-fbd0-11ea-bdc1-1e00f10138c3",
    "username": "admin",
    "zoneid": "72b53dda-ceb4-49da-9c19-9b1a4a7a143c",
    "zonename": "pr4328-t2806-vmware-67u3"
  }
}
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
