### PR TITLE
server: check guest os preference of last host when start a vm

### DIFF
--- a/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -89,10 +89,12 @@ import com.cloud.exception.AffinityConflictException;
 import com.cloud.exception.ConnectionException;
 import com.cloud.exception.InsufficientServerCapacityException;
 import com.cloud.gpu.GPU;
+import com.cloud.host.DetailVO;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
 import com.cloud.host.dao.HostDao;
+import com.cloud.host.dao.HostDetailsDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.org.Cluster;
@@ -102,6 +104,7 @@ import com.cloud.resource.ResourceState;
 import com.cloud.service.ServiceOfferingDetailsVO;
 import com.cloud.service.dao.ServiceOfferingDetailsDao;
 import com.cloud.storage.DiskOfferingVO;
+import com.cloud.storage.GuestOSVO;
 import com.cloud.storage.ScopeType;
 import com.cloud.storage.Storage;
 import com.cloud.storage.StorageManager;
@@ -165,6 +168,8 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
     private long _hostReservationReleasePeriod = 60L * 60L * 1000L; // one hour by default
     @Inject
     protected VMReservationDao _reservationDao;
+    @Inject
+    HostDetailsDao _hostDetailsDao;
 
     private static final long INITIAL_RESERVATION_RELEASE_CHECKER_DELAY = 30L * 1000L; // thirty seconds expressed in milliseconds
     protected long _nodeId = -1;
@@ -411,14 +416,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 }
             } else {
                 if (host.getStatus() == Status.Up && host.getResourceState() == ResourceState.Enabled) {
-                    boolean hostTagsMatch = true;
-                    if(offering.getHostTag() != null){
-                        _hostDao.loadHostTags(host);
-                        if (!(host.getHostTags() != null && host.getHostTags().contains(offering.getHostTag()))) {
-                            hostTagsMatch = false;
-                        }
-                    }
-                    if (hostTagsMatch) {
+                    if (checkVmProfileAndHost(vmProfile, host)) {
                         long cluster_id = host.getClusterId();
                         ClusterDetailsVO cluster_detail_cpu = _clusterDetailsDao.findDetail(cluster_id,
                                 "cpuOvercommitRatio");
@@ -489,8 +487,6 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                         } else {
                             s_logger.debug("The last host of this VM does not have enough capacity");
                         }
-                    } else {
-                        s_logger.debug("Service Offering host tag does not match the last host of this VM");
                     }
                 } else {
                     s_logger.debug("The last host of this VM is not UP or is not enabled, host status is: " + host.getStatus().name() + ", host resource state is: " +
@@ -567,6 +563,31 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         }
 
         return null;
+    }
+
+    private boolean checkVmProfileAndHost(final VirtualMachineProfile vmProfile, final HostVO host) {
+        ServiceOffering offering = vmProfile.getServiceOffering();
+        if (offering.getHostTag() != null) {
+            _hostDao.loadHostTags(host);
+            if (!(host.getHostTags() != null && host.getHostTags().contains(offering.getHostTag()))) {
+                s_logger.debug("Service Offering host tag does not match the last host of this VM");
+                return false;
+            }
+        }
+        long guestOSId = vmProfile.getTemplate().getGuestOSId();
+        GuestOSVO guestOS = _guestOSDao.findById(guestOSId);
+        if (guestOS != null) {
+            long guestOSCategoryId = guestOS.getCategoryId();
+            DetailVO hostDetail = _hostDetailsDao.findDetail(host.getId(), "guest.os.category.id");
+            if (hostDetail != null) {
+                String guestOSCategoryIdString = hostDetail.getValue();
+                if (String.valueOf(guestOSCategoryId) != guestOSCategoryIdString) {
+                    s_logger.debug("The last host has different guest.os.category.id than guest os category of VM, skipping");
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

If vm has last host_id specified, cloudstack will try to start vm on it at first.
However, host tag is checked, but guest os preference is not checked.

for new vm, it will be deployed to the preferred host as we expect.


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

Fixes: https://github.com/apache/cloudstack/issues/3554#issuecomment-564001531


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
