### PR TITLE
Changing test_pvlan vlan id to prevent conflict with smoke tests env config

### DIFF
--- a/test/integration/smoke/test_pvlan.py
+++ b/test/integration/smoke/test_pvlan.py
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,8 +35,8 @@ class TestPVLAN(cloudstackTestCase):
 
     zoneId = 1
     networkOfferingId = 7
-    vlan = 1234
-    isolatedpvlan = 567
+    vlan = 2468
+    isolatedpvlan = 864
 
     def setUp(self):
         self.apiClient = self.testClient.getApiClient()
@@ -51,8 +51,8 @@ class TestPVLAN(cloudstackTestCase):
         createNetworkCmd.gateway = "10.10.10.1"
         createNetworkCmd.startip = "10.10.10.10"
         createNetworkCmd.gateway = "10.10.10.20"
-        createNetworkCmd.vlan = "1234"
-        createNetworkCmd.isolatedpvlan = "567"
+        createNetworkCmd.vlan = self.vlan
+        createNetworkCmd.isolatedpvlan = self.isolatedpvlan
         createNetworkCmd.zoneid = self.zoneId
         createNetworkCmd.networkofferingid = self.networkOfferingId
         createNetworkResponse = self.apiClient.createNetwork(createNetworkCmd)
@@ -60,9 +60,10 @@ class TestPVLAN(cloudstackTestCase):
         self.broadcasttype = createNetworkResponse.broadcastdomaintype
         self.broadcasturi = createNetworkResponse.broadcasturi
 
+        braodcasturi = "pvlan://{0}-i{1}".format(self.vlan, self.isolatedpvlan)
         self.assertIsNotNone(createNetworkResponse.id, "Network failed to create")
         self.assertTrue(createNetworkResponse.broadcastdomaintype, "Pvlan")
-        self.assertTrue(createNetworkResponse.broadcasturi, "pvlan://1234-i567")
+        self.assertTrue(createNetworkResponse.broadcasturi, braodcasturi)
 
         self.debug("Clean up test pvlan network")
         deleteNetworkCmd = deleteNetwork.deleteNetworkCmd()


### PR DESCRIPTION
## Description

Changing test_pvlan vlan id to prevent conflict with env config while running smoke tests
Previously failed due to intermittent errors while running smoke tests 
```
The VLAN tag 1234 is already being used for dynamic vlan allocation for the guest network in zone
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Run the smoke tests and see :wink: 