### PR TITLE
Allow to configure root disk size via Service Offering (diskoffering of type Service).

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateServiceOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateServiceOfferingCmd.java
@@ -127,6 +127,9 @@ public class CreateServiceOfferingCmd extends BaseCmd {
     @Parameter(name = ApiConstants.SERVICE_OFFERING_DETAILS, type = CommandType.MAP, description = "details for planner, used to store specific parameters")
     private Map details;
 
+    @Parameter(name = ApiConstants.ROOT_DISK_SIZE, type = CommandType.LONG, since = "4.15", description = "the Root disk size in GB.")
+    private Long rootDiskSize;
+
     @Parameter(name = ApiConstants.BYTES_READ_RATE, type = CommandType.LONG, required = false, description = "bytes read rate of the disk offering")
     private Long bytesReadRate;
 
@@ -322,6 +325,10 @@ public class CreateServiceOfferingCmd extends BaseCmd {
             }
         }
         return detailsMap;
+    }
+
+    public Long getRootDiskSize() {
+        return rootDiskSize;
     }
 
     public Long getBytesReadRate() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
@@ -87,6 +87,13 @@ public class ResizeVolumeCmd extends BaseAsyncCmd implements UserCmd {
         this.maxIops = maxIops;
     }
 
+    public ResizeVolumeCmd(Long id, Long minIops, Long maxIops, long diskOfferingId) {
+        this.id = id;
+        this.minIops = minIops;
+        this.maxIops = maxIops;
+        this.newDiskOfferingId = diskOfferingId;
+    }
+
     //TODO use the method getId() instead of this one.
     public Long getEntityId() {
         return id;

--- a/api/src/main/java/org/apache/cloudstack/api/response/ServiceOfferingResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ServiceOfferingResponse.java
@@ -200,6 +200,10 @@ public class ServiceOfferingResponse extends BaseResponse {
     @Param(description = "the vsphere storage policy tagged to the service offering in case of VMware", since = "4.15")
     private String vsphereStoragePolicy;
 
+    @SerializedName(ApiConstants.ROOT_DISK_SIZE)
+    @Param(description = "Root disk size in GB", since = "4.15")
+    private Long rootDiskSize;
+
     public ServiceOfferingResponse() {
     }
 
@@ -468,4 +472,7 @@ public class ServiceOfferingResponse extends BaseResponse {
         this.vsphereStoragePolicy = vsphereStoragePolicy;
     }
 
+    public void setRootDiskSize(Long rootDiskSize) {
+        this.rootDiskSize = rootDiskSize;
+    }
 }

--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
@@ -402,6 +402,7 @@ CREATE VIEW `cloud`.`service_offering_view` AS
         `disk_offering`.`iops_write_rate_max` AS `iops_write_rate_max`,
         `disk_offering`.`iops_write_rate_max_length` AS `iops_write_rate_max_length`,
         `disk_offering`.`cache_mode` AS `cache_mode`,
+        `disk_offering`.`disk_size` AS `root_disk_size`,
         `service_offering`.`cpu` AS `cpu`,
         `service_offering`.`speed` AS `speed`,
         `service_offering`.`ram_size` AS `ram_size`,
@@ -815,7 +816,6 @@ INSERT INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_vers
 INSERT INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '6.7.1', 'solaris11_64Guest', 328, now(), 0);
 INSERT INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '6.7.2', 'solaris11_64Guest', 328, now(), 0);
 INSERT INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '6.7.3', 'solaris11_64Guest', 328, now(), 0);
-
 
 -- Add  VMware Photon (64 bit)     as support guest os
 INSERT INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (329, UUID(), 7, 'VMware Photon (64 bit)', now());

--- a/server/src/main/java/com/cloud/api/query/dao/ServiceOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ServiceOfferingJoinDaoImpl.java
@@ -113,6 +113,7 @@ public class ServiceOfferingJoinDaoImpl extends GenericDaoBase<ServiceOfferingJo
         offeringResponse.setObjectName("serviceoffering");
         offeringResponse.setIscutomized(offering.isDynamic());
         offeringResponse.setCacheMode(offering.getCacheMode());
+
         if (offeringDetails != null && !offeringDetails.isEmpty()) {
             String vsphereStoragePolicyId = offeringDetails.get(ApiConstants.STORAGE_POLICY);
             if (vsphereStoragePolicyId != null) {
@@ -121,6 +122,9 @@ public class ServiceOfferingJoinDaoImpl extends GenericDaoBase<ServiceOfferingJo
                     offeringResponse.setVsphereStoragePolicy(vsphereStoragePolicyVO.getName());
             }
         }
+
+        offeringResponse.setRootDiskSize(offering.getRootDiskSize());
+
         return offeringResponse;
     }
 

--- a/server/src/main/java/com/cloud/api/query/vo/ServiceOfferingJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/ServiceOfferingJoinVO.java
@@ -190,6 +190,9 @@ public class ServiceOfferingJoinVO extends BaseViewVO implements InternalIdentit
     @Column(name = "vsphere_storage_policy")
     String vsphereStoragePolicy;
 
+    @Column(name = "root_disk_size")
+    private Long rootDiskSize;
+
     public ServiceOfferingJoinVO() {
     }
 
@@ -363,7 +366,6 @@ public class ServiceOfferingJoinVO extends BaseViewVO implements InternalIdentit
 
     public Long getIopsWriteRateMaxLength() { return iopsWriteRateMaxLength; }
 
-
     public boolean isDynamic() {
         return cpu == null || speed == null || ramSize == null;
     }
@@ -392,4 +394,7 @@ public class ServiceOfferingJoinVO extends BaseViewVO implements InternalIdentit
         return vsphereStoragePolicy;
     }
 
+    public Long getRootDiskSize() {
+        return rootDiskSize ;
+    }
 }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -430,6 +430,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
     private static final Set<Provider> VPC_ONLY_PROVIDERS = Sets.newHashSet(Provider.VPCVirtualRouter, Provider.JuniperContrailVpcRouter, Provider.InternalLbVm);
 
+    private static final long GiB_TO_BYTES = 1024 * 1024 * 1024;
+
     @Override
     public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
         final String maxVolumeSizeInGbString = _configDao.getValue(Config.MaxVolumeSize.key());
@@ -2471,7 +2473,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         return createServiceOffering(userId, cmd.isSystem(), vmType, cmd.getServiceOfferingName(), cpuNumber, memory, cpuSpeed, cmd.getDisplayText(),
                 cmd.getProvisioningType(), localStorageRequired, offerHA, limitCpuUse, volatileVm, cmd.getTags(), cmd.getDomainIds(), cmd.getZoneIds(), cmd.getHostTag(),
-                cmd.getNetworkRate(), cmd.getDeploymentPlanner(), details, isCustomizedIops, cmd.getMinIops(), cmd.getMaxIops(),
+                cmd.getNetworkRate(), cmd.getDeploymentPlanner(), details, cmd.getRootDiskSize(), isCustomizedIops, cmd.getMinIops(), cmd.getMaxIops(),
                 cmd.getBytesReadRate(), cmd.getBytesReadRateMax(), cmd.getBytesReadRateMaxLength(),
                 cmd.getBytesWriteRate(), cmd.getBytesWriteRateMax(), cmd.getBytesWriteRateMaxLength(),
                 cmd.getIopsReadRate(), cmd.getIopsReadRateMax(), cmd.getIopsReadRateMaxLength(),
@@ -2482,7 +2484,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     protected ServiceOfferingVO createServiceOffering(final long userId, final boolean isSystem, final VirtualMachine.Type vmType,
             final String name, final Integer cpu, final Integer ramSize, final Integer speed, final String displayText, final String provisioningType, final boolean localStorageRequired,
             final boolean offerHA, final boolean limitResourceUse, final boolean volatileVm, String tags, final List<Long> domainIds, List<Long> zoneIds, final String hostTag,
-            final Integer networkRate, final String deploymentPlanner, final Map<String, String> details, final Boolean isCustomizedIops, Long minIops, Long maxIops,
+            final Integer networkRate, final String deploymentPlanner, final Map<String, String> details, Long rootDiskSizeInGiB, final Boolean isCustomizedIops, Long minIops, Long maxIops,
             Long bytesReadRate, Long bytesReadRateMax, Long bytesReadRateMaxLength,
             Long bytesWriteRate, Long bytesWriteRateMax, Long bytesWriteRateMaxLength,
             Long iopsReadRate, Long iopsReadRateMax, Long iopsReadRateMaxLength,
@@ -2543,6 +2545,12 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         }
 
+        if (rootDiskSizeInGiB != null && rootDiskSizeInGiB <= 0L) {
+            throw new InvalidParameterValueException(String.format("The Root disk size is of %s GB but it must be greater than 0.", rootDiskSizeInGiB));
+        } else if (rootDiskSizeInGiB != null) {
+            long rootDiskSizeInBytes = rootDiskSizeInGiB * GiB_TO_BYTES;
+            offering.setDiskSize(rootDiskSizeInBytes);
+        }
 
         offering.setCustomizedIops(isCustomizedIops);
         offering.setMinIops(minIops);

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -32,11 +32,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.DiskOfferingVO;
+import com.cloud.storage.VMTemplateVO;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.VMTemplateDao;
 import org.apache.cloudstack.api.BaseCmd.HTTPMethod;
 import org.apache.cloudstack.api.command.user.vm.UpdateVMCmd;
+import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,6 +88,9 @@ public class UserVmManagerImplTest {
 
     @Mock
     private ServiceOfferingDao _serviceOfferingDao;
+
+    @Mock
+    private DiskOfferingDao diskOfferingDao;
 
     @Mock
     private ServiceOfferingVO serviceOfferingVO;
@@ -131,7 +142,17 @@ public class UserVmManagerImplTest {
     @Mock
     private UserVO callerUser;
 
+    @Mock
+    private VMTemplateDao templateDao;
+
     private long vmId = 1l;
+
+    private static final long GiB_TO_BYTES = 1024 * 1024 * 1024;
+
+    private Map<String, String> customParameters = new HashMap<>();
+
+    private DiskOfferingVO smallerDisdkOffering = prepareDiskOffering(5l * GiB_TO_BYTES, 1l, 1L, 2L);
+    private DiskOfferingVO largerDisdkOffering = prepareDiskOffering(10l * GiB_TO_BYTES, 2l, 10L, 20L);
 
     @Before
     public void beforeTest() {
@@ -144,6 +165,8 @@ public class UserVmManagerImplTest {
 
         Mockito.when(callerAccount.getType()).thenReturn(Account.ACCOUNT_TYPE_ADMIN);
         CallContext.register(callerUser, callerAccount);
+
+        customParameters.put(VmDetailConstants.ROOT_DISK_SIZE, "123");
     }
 
     @After
@@ -379,5 +402,160 @@ public class UserVmManagerImplTest {
         assertTrue(userVmManagerImpl.isValidKeyValuePair("key-1=value1"));
         assertTrue(userVmManagerImpl.isValidKeyValuePair("param:key-2=value2"));
         assertTrue(userVmManagerImpl.isValidKeyValuePair("my.config.v0=False"));
+    }
+
+    @Test
+    public void configureCustomRootDiskSizeTest() {
+        String vmDetailsRootDiskSize = "123";
+        Map<String, String> customParameters = new HashMap<>();
+        customParameters.put(VmDetailConstants.ROOT_DISK_SIZE, vmDetailsRootDiskSize);
+        long expectedRootDiskSize = 123l * GiB_TO_BYTES;
+        long offeringRootDiskSize = 0l;
+        prepareAndRunConfigureCustomRootDiskSizeTest(customParameters, expectedRootDiskSize, 1, offeringRootDiskSize);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void configureCustomRootDiskSizeTestExpectExceptionZero() {
+        String vmDetailsRootDiskSize = "0";
+        Map<String, String> customParameters = new HashMap<>();
+        customParameters.put(VmDetailConstants.ROOT_DISK_SIZE, vmDetailsRootDiskSize);
+        long expectedRootDiskSize = 0l;
+        long offeringRootDiskSize = 0l;
+        prepareAndRunConfigureCustomRootDiskSizeTest(customParameters, expectedRootDiskSize, 1, offeringRootDiskSize);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void configureCustomRootDiskSizeTestExpectExceptionNegativeNum() {
+        String vmDetailsRootDiskSize = "-123";
+        Map<String, String> customParameters = new HashMap<>();
+        customParameters.put(VmDetailConstants.ROOT_DISK_SIZE, vmDetailsRootDiskSize);
+        long expectedRootDiskSize = -123l * GiB_TO_BYTES;
+        long offeringRootDiskSize = 0l;
+        prepareAndRunConfigureCustomRootDiskSizeTest(customParameters, expectedRootDiskSize, 1, offeringRootDiskSize);
+    }
+
+    @Test
+    public void configureCustomRootDiskSizeTestEmptyParameters() {
+        Map<String, String> customParameters = new HashMap<>();
+        long expectedRootDiskSize = 99l * GiB_TO_BYTES;
+        long offeringRootDiskSize = 0l;
+        prepareAndRunConfigureCustomRootDiskSizeTest(customParameters, expectedRootDiskSize, 1, offeringRootDiskSize);
+    }
+
+    @Test
+    public void configureCustomRootDiskSizeTestEmptyParametersAndOfferingRootSize() {
+        Map<String, String> customParameters = new HashMap<>();
+        long expectedRootDiskSize = 10l * GiB_TO_BYTES;
+        long offeringRootDiskSize = 10l * GiB_TO_BYTES;;
+
+        prepareAndRunConfigureCustomRootDiskSizeTest(customParameters, expectedRootDiskSize, 1, offeringRootDiskSize);
+    }
+
+    private void prepareAndRunConfigureCustomRootDiskSizeTest(Map<String, String> customParameters, long expectedRootDiskSize, int timesVerifyIfHypervisorSupports, Long offeringRootDiskSize) {
+        VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
+        Mockito.when(template.getId()).thenReturn(1l);
+        Mockito.when(template.getSize()).thenReturn(99L * GiB_TO_BYTES);
+        ServiceOfferingVO offering = Mockito.mock(ServiceOfferingVO.class);
+        Mockito.when(offering.getId()).thenReturn(1l);
+        Mockito.when(templateDao.findById(Mockito.anyLong())).thenReturn(template);
+
+        DiskOfferingVO diskfferingVo = Mockito.mock(DiskOfferingVO.class);
+        Mockito.when(diskOfferingDao.findById(Mockito.anyLong())).thenReturn(diskfferingVo);
+
+        Mockito.when(diskfferingVo.getDiskSize()).thenReturn(offeringRootDiskSize);
+
+        long rootDiskSize = userVmManagerImpl.configureCustomRootDiskSize(customParameters, template, Hypervisor.HypervisorType.KVM, offering);
+
+        Assert.assertEquals(expectedRootDiskSize, rootDiskSize);
+        Mockito.verify(userVmManagerImpl, Mockito.times(timesVerifyIfHypervisorSupports)).verifyIfHypervisorSupportsRootdiskSizeOverride(Mockito.any());
+    }
+
+    @Test
+    public void verifyIfHypervisorSupportRootdiskSizeOverrideTest() {
+        Hypervisor.HypervisorType[] hypervisorTypeArray = Hypervisor.HypervisorType.values();
+        int exceptionCounter = 0;
+        int expectedExceptionCounter = hypervisorTypeArray.length - 4;
+
+        for(int i = 0; i < hypervisorTypeArray.length; i++) {
+            if (Hypervisor.HypervisorType.KVM == hypervisorTypeArray[i]
+                    || Hypervisor.HypervisorType.XenServer == hypervisorTypeArray[i]
+                    || Hypervisor.HypervisorType.VMware == hypervisorTypeArray[i]
+                    || Hypervisor.HypervisorType.Simulator == hypervisorTypeArray[i]) {
+                userVmManagerImpl.verifyIfHypervisorSupportsRootdiskSizeOverride(hypervisorTypeArray[i]);
+            } else {
+                try {
+                    userVmManagerImpl.verifyIfHypervisorSupportsRootdiskSizeOverride(hypervisorTypeArray[i]);
+                } catch (InvalidParameterValueException e) {
+                    exceptionCounter ++;
+                }
+            }
+        }
+
+        Assert.assertEquals(expectedExceptionCounter, exceptionCounter);
+    }
+
+    @Test (expected = InvalidParameterValueException.class)
+    public void prepareResizeVolumeCmdTestRootVolumeNull() {
+        DiskOfferingVO newRootDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        DiskOfferingVO currentRootDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        userVmManagerImpl.prepareResizeVolumeCmd(null, currentRootDiskOffering, newRootDiskOffering);
+    }
+
+    @Test (expected = InvalidParameterValueException.class)
+    public void prepareResizeVolumeCmdTestCurrentRootDiskOffering() {
+        DiskOfferingVO newRootDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        VolumeVO rootVolumeOfVm = Mockito.mock(VolumeVO.class);
+        userVmManagerImpl.prepareResizeVolumeCmd(rootVolumeOfVm, null, newRootDiskOffering);
+    }
+
+    @Test (expected = InvalidParameterValueException.class)
+    public void prepareResizeVolumeCmdTestNewRootDiskOffering() {
+        VolumeVO rootVolumeOfVm = Mockito.mock(VolumeVO.class);
+        DiskOfferingVO currentRootDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        userVmManagerImpl.prepareResizeVolumeCmd(rootVolumeOfVm, currentRootDiskOffering, null);
+    }
+
+    @Test
+    public void prepareResizeVolumeCmdTestNewOfferingLarger() {
+        prepareAndRunResizeVolumeTest(2L, 10L, 20L, smallerDisdkOffering, largerDisdkOffering);
+    }
+
+    @Test
+    public void prepareResizeVolumeCmdTestSameOfferingSize() {
+        prepareAndRunResizeVolumeTest(null, 1L, 2L, smallerDisdkOffering, smallerDisdkOffering);
+    }
+
+    @Test
+    public void prepareResizeVolumeCmdTestOfferingRootSizeZero() {
+        DiskOfferingVO rootSizeZero = prepareDiskOffering(0l, 3l, 100L, 200L);
+        prepareAndRunResizeVolumeTest(null, 100L, 200L, smallerDisdkOffering, rootSizeZero);
+    }
+
+    @Test (expected = InvalidParameterValueException.class)
+    public void prepareResizeVolumeCmdTestNewOfferingSmaller() {
+        prepareAndRunResizeVolumeTest(2L, 10L, 20L, largerDisdkOffering, smallerDisdkOffering);
+    }
+
+    private void prepareAndRunResizeVolumeTest(Long expectedOfferingId, long expectedMinIops, long expectedMaxIops, DiskOfferingVO currentRootDiskOffering, DiskOfferingVO newRootDiskOffering) {
+        long rootVolumeId = 1l;
+        VolumeVO rootVolumeOfVm = Mockito.mock(VolumeVO.class);
+        Mockito.when(rootVolumeOfVm.getId()).thenReturn(rootVolumeId);
+
+        ResizeVolumeCmd resizeVolumeCmd = userVmManagerImpl.prepareResizeVolumeCmd(rootVolumeOfVm, currentRootDiskOffering, newRootDiskOffering);
+
+        Assert.assertEquals(rootVolumeId, resizeVolumeCmd.getId().longValue());
+        Assert.assertEquals(expectedOfferingId, resizeVolumeCmd.getNewDiskOfferingId());
+        Assert.assertEquals(expectedMinIops, resizeVolumeCmd.getMinIops().longValue());
+        Assert.assertEquals(expectedMaxIops, resizeVolumeCmd.getMaxIops().longValue());
+    }
+
+    private DiskOfferingVO prepareDiskOffering(long rootSize, long diskOfferingId, long offeringMinIops, long offeringMaxIops) {
+        DiskOfferingVO newRootDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        Mockito.when(newRootDiskOffering.getDiskSize()).thenReturn(rootSize);
+        Mockito.when(newRootDiskOffering.getId()).thenReturn(diskOfferingId);
+        Mockito.when(newRootDiskOffering.getMinIops()).thenReturn(offeringMinIops);
+        Mockito.when(newRootDiskOffering.getMaxIops()).thenReturn(offeringMaxIops);
+        Mockito.when(newRootDiskOffering.getName()).thenReturn("OfferingName");
+        return newRootDiskOffering;
     }
 }

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -437,6 +437,14 @@
                                         isBoolean: true,
                                         isChecked: false
                                     },
+                                    rootDiskSize: {
+                                        label: 'label.root.disk.size',
+                                        docID: 'helpRootDiskSizeGb',
+                                        validation: {
+                                            required: false,
+                                            number: true
+                                        }
+                                    },
                                     storageTags: {
                                         label: 'label.storage.tags',
                                         docID: 'helpComputeOfferingStorageType',
@@ -872,6 +880,12 @@
                                 $.extend(data, {
                                     offerha: (args.data.offerHA == "on")
                                 });
+
+                                if (args.data.rootDiskSize != null && args.data.rootDiskSize > 0) {
+                                    $.extend(data, {
+                                        rootDiskSize: args.data.rootDiskSize
+                                    });
+                                }
 
                                 if (args.data.storageTags != null && args.data.storageTags.length > 0) {
                                     $.extend(data, {

--- a/ui/scripts/docs.js
+++ b/ui/scripts/docs.js
@@ -1066,6 +1066,10 @@ cloudStack.docs = {
         desc: 'Volume size in GB (1GB = 1,073,741,824 bytes)',
         externalLink: ''
     },
+    helpRootDiskSizeGb: {
+        desc: 'Root disk size in GB',
+        externalLink: ''
+    },
     // Add VPC
     helpVPCName: {
         desc: 'A name for the new VPC',


### PR DESCRIPTION
## Description
Service Offering allows ADMINs to set multiple parameters such as IOPS, memory, and CPU; however, we still are not able to configure the Root Disk size of a VM via service Offering.

This PR adds control over the Root disk size and therefore helps providers that want to enforce the root disk size in the same way that it is done with compute offering.

**How does it work?**
- If the Service Offering is created without setting root disk size, all operations over root volume size are done as currently.
- If a Service Offering is created with a root disk size, then there are some (intentionally) limitations under the root disk size resizing, as the following ones:
```
1. Users cannot deploy VMs with custom root disk size when using such offerings
2. Users cannot resize the VM root disk size when using such offerings
3. the Root Volume of such VMs can only be resized when changing to another Service Offering with a Root disk size equals or larger than the current one.
4. Users can change the VM offering to a service offering with a Root size of 0GB (default), and then customize the volume size.
```

To easily view all possible service offering resizing, the following table shows if such offering migration is supported:

| # | Service Offering Root size | new Service Offering Root | Does support offering resize? |
|---|----------------------------|---------------------------|-------------------------------|
| 1 | 0GB (default)              | Any                       | YES                           |
| 2 | 5GB                        | 5GB                       | YES                           |
| 3 | 5GB                        | 10GB                      | YES                           |
| 4 | 10GB                       | 5GB                       | NO                            |
| 5 | Any                        | 0GB                       | YES                           |

**How users can resize the root volume if the VM was deployed with a Root disk size configured via its Service offering?**
- Users/Admins can at any time change to an offering with the default root disk size of 0; on such case, then it would be possible to resize as it is done nowadays.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Setting root disk size for service offering via UI
![image](https://user-images.githubusercontent.com/5025148/94064212-b70ec200-fdbf-11ea-99fe-ba242b30357f.png)

## How Has This Been Tested?
Tests:
Created the following service offerings (via API and also via UI):

-  0GB - default behavior with no Root Disk Size  configured
-  5GB - 5GB Root
- 10GB - 10GB Root
- 15GB - 15GB Root

Executed following tests

**1. Test root volume resize.**
_Expected result: not allowed to resize_
Steps:
a - deploy a VM with any of the root size configured offerings (e.g. 5GB)
b - Change root volume size
c - not allowed

**2. Test resize via service offering.**
_Expected result: allow 5GB -> 10GB, and 10 GB -> 15, fail to "dowsize" from 10GB -> 5GB_
Steps:
a - deploy VM with offering 5GB
b - Stop VM
c - Change Service offering to 10GB
d - Change offering back to 5GB, fails (as expected)
e - Change offering to 15GB

**3. Test resize via offering to a Service offering with the default root size (0 GB) and then customize the volume**
_Expected result: allow 5GB -> 0GB, successfully change the root volume to a custom size_
Steps:
a - deploy VM with offering 5GB
b - Stop VM
c - Change Service offering to 0GB
d - resize volume to custom size, e.g 50 GB



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
