### PR TITLE
vmware: use hotPlugMemoryIncrementSize only for valid value

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1627,7 +1627,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             }
 
             // Check increment is multiple of increment size
-            long reminder = requestedMaxMemoryInMb % hotaddIncrementSizeInMb;
+            long reminder = hotaddIncrementSizeInMb > 0 ? requestedMaxMemoryInMb % hotaddIncrementSizeInMb : 0;
             if (reminder != 0) {
                 requestedMaxMemoryInMb = requestedMaxMemoryInMb + hotaddIncrementSizeInMb - reminder;
             }


### PR DESCRIPTION
## Description
Fixes #4343 

When `config.hotPlugMemoryIncrementSize` is zero for a VM (particularly system VMs) current code throws exception,

```
2020-09-25 12:02:56,037 ERROR [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-7:ctx-49f0bbbf job-133/job-137 ctx-fd9070d9) (logid:89f87423) Invocation exception, caused by: com.cloud.utils.exception.CloudRuntimeException: Unable to scale vm due to Unable to execute ScaleVmCommand due to java.lang.ArithmeticException: / by zero
2020-09-25 12:02:56,037 INFO  [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-7:ctx-49f0bbbf job-133/job-137 ctx-fd9070d9) (logid:89f87423) Rethrow exception com.cloud.utils.exception.CloudRuntimeException: Unable to scale vm due to Unable to execute ScaleVmCommand due to java.lang.ArithmeticException: / by zero
2020-09-25 12:02:56,037 DEBUG [c.c.v.VmWorkJobDispatcher] (Work-Job-Executor-7:ctx-49f0bbbf job-133/job-137) (logid:89f87423) Done with run of VM work job: com.cloud.vm.VmWorkReconfigure for VM 22, job origin: 133
2020-09-25 12:02:56,037 ERROR [c.c.v.VmWorkJobDispatcher] (Work-Job-Executor-7:ctx-49f0bbbf job-133/job-137) (logid:89f87423) Unable to complete AsyncJobVO {id:137, userId: 2, accountId: 2, instanceType: null, instanceId: null, cmd: com.cloud.vm.VmWorkReconfigure, cmdInfo: rO0ABXNyAB5jb20uY2xvdWQudm0uVm1Xb3JrUmVjb25maWd1cmXBUEjaULtGKQIABFoACHNhbWVIb3N0TAAQY3VzdG9tUGFyYW1ldGVyc3QAD0xqYXZhL3V0aWwvTWFwO0wAFG5ld1NlcnZpY2VPZmZlcmluZ0lkdAAQTGphdmEvbGFuZy9Mb25nO0wAFG9sZFNlcnZpY2VPZmZlcmluZ0lkcQB-AAJ4cgATY29tLmNsb3VkLnZtLlZtV29ya5-ZtlbwJWdrAgAESgAJYWNjb3VudElkSgAGdXNlcklkSgAEdm1JZEwAC2hhbmRsZXJOYW1ldAASTGphdmEvbGFuZy9TdHJpbmc7eHAAAAAAAAAAAgAAAAAAAAACAAAAAAAAABZ0ABlWaXJ0dWFsTWFjaGluZU1hbmFnZXJJbXBsAHBzcgAOamF2YS5sYW5nLkxvbmc7i-SQzI8j3wIAAUoABXZhbHVleHIAEGphdmEubGFuZy5OdW1iZXKGrJUdC5TgiwIAAHhwAAAAAAAAABNzcQB-AAcAAAAAAAAABw, cmdVersion: 0, status: IN_PROGRESS, processStatus: 0, resultCode: 0, result: null, initMsid: 32987362179843, completeMsid: null, lastUpdated: null, lastPolled: null, created: Fri Sep 25 12:02:46 UTC 2020, removed: null}, job origin:133
com.cloud.utils.exception.CloudRuntimeException: Unable to scale vm due to Unable to execute ScaleVmCommand due to java.lang.ArithmeticException: / by zero
	at com.cloud.vm.VirtualMachineManagerImpl.orchestrateReConfigureVm(VirtualMachineManagerImpl.java:4443)
	at com.cloud.vm.VirtualMachineManagerImpl.reConfigureVm(VirtualMachineManagerImpl.java:4368)
	at com.cloud.vm.VirtualMachineManagerImpl.orchestrateReconfigure(VirtualMachineManagerImpl.java:5590)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.cloud.vm.VmWorkJobHandlerProxy.handleVmWorkJob(VmWorkJobHandlerProxy.java:107)
	at com.cloud.vm.VirtualMachineManagerImpl.handleVmWorkJob(VirtualMachineManagerImpl.java:5610)
	at com.cloud.vm.VmWorkJobDispatcher.runJob(VmWorkJobDispatcher.java:102)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.runInContext(AsyncJobManagerImpl.java:615)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.run(AsyncJobManagerImpl.java:563)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
In code, we are not checking properties - `cpuHotAddEnabled` and `memoryHotAddEnabled` therefore changes can be made for that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
