### PR TITLE
Retry redfish requests

### DIFF
--- a/plugins/outofbandmanagement-drivers/redfish/src/main/java/org/apache/cloudstack/outofbandmanagement/driver/redfish/RedfishOutOfBandManagementDriver.java
+++ b/plugins/outofbandmanagement-drivers/redfish/src/main/java/org/apache/cloudstack/outofbandmanagement/driver/redfish/RedfishOutOfBandManagementDriver.java
@@ -51,6 +51,10 @@ public class RedfishOutOfBandManagementDriver extends AdapterBase implements Out
     public static final ConfigKey<Boolean> USE_HTTPS = new ConfigKey<Boolean>("Advanced", Boolean.class, "redfish.use.https", "true",
             "Use HTTPS/SSL for all connections.", true, ConfigKey.Scope.Global);
 
+    public static final ConfigKey<Integer> REDFISHT_REQUEST_MAX_RETRIES = new ConfigKey<Integer>("Advanced", Integer.class, "redfish.retries", "2",
+            "Number of retries allowed if a Redfish REST request experiment connection issues. If set to 0 (zero) there will be no retries.", true, ConfigKey.Scope.Global);
+
+
     private static final String HTTP_STATUS_OK = String.valueOf(HttpStatus.SC_OK);
 
     @Override
@@ -74,7 +78,7 @@ public class RedfishOutOfBandManagementDriver extends AdapterBase implements Out
         String username = outOfBandOptions.get(OutOfBandManagement.Option.USERNAME);
         String password = outOfBandOptions.get(OutOfBandManagement.Option.PASSWORD);
         String hostAddress = outOfBandOptions.get(OutOfBandManagement.Option.ADDRESS);
-        RedfishClient redfishClient = new RedfishClient(username, password, USE_HTTPS.value(), IGNORE_SSL_CERTIFICATE.value());
+        RedfishClient redfishClient = new RedfishClient(username, password, USE_HTTPS.value(), IGNORE_SSL_CERTIFICATE.value(), REDFISHT_REQUEST_MAX_RETRIES.value());
 
         RedfishClient.RedfishPowerState powerState = null;
         if (cmd.getPowerOperation() == OutOfBandManagement.PowerOperation.STATUS) {
@@ -114,7 +118,7 @@ public class RedfishOutOfBandManagementDriver extends AdapterBase implements Out
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {IGNORE_SSL_CERTIFICATE, USE_HTTPS};
+        return new ConfigKey<?>[] {IGNORE_SSL_CERTIFICATE, USE_HTTPS, REDFISHT_REQUEST_MAX_RETRIES};
     }
 
 }

--- a/utils/src/main/java/org/apache/cloudstack/utils/redfish/RedfishClient.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/redfish/RedfishClient.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -71,6 +72,7 @@ public class RedfishClient {
     private String password;
     private boolean useHttps;
     private boolean ignoreSsl;
+    private int redfishRequestMaxRetries;
 
     private final static String SYSTEMS_URL_PATH = "redfish/v1/Systems/";
     private final static String COMPUTER_SYSTEM_RESET_URL_PATH = "/Actions/ComputerSystem.Reset";
@@ -81,6 +83,8 @@ public class RedfishClient {
     private final static String ODATA_ID = "@odata.id";
     private final static String MEMBERS = "Members";
     private final static String EXPECTED_HTTP_STATUS = "2XX";
+    private final static int WAIT_FOR_REQUEST_RETRY = 3;
+
 
     /**
      * Redfish Command type: </br>
@@ -126,11 +130,12 @@ public class RedfishClient {
         ForceOff, ForceOn, ForceRestart, GracefulRestart, GracefulShutdown, Nmi, On, PowerCycle, PushPowerButton
     }
 
-    public RedfishClient(String username, String password, boolean useHttps, boolean ignoreSsl) {
+    public RedfishClient(String username, String password, boolean useHttps, boolean ignoreSsl, int redfishRequestRetries) {
         this.username = username;
         this.password = password;
         this.useHttps = useHttps;
         this.ignoreSsl = ignoreSsl;
+        this.redfishRequestMaxRetries = redfishRequestRetries;
     }
 
     protected String buildRequestUrl(String hostAddress, RedfishCmdType cmd, String resourceId) {
@@ -213,8 +218,31 @@ public class RedfishClient {
         try {
             return client.execute(httpReq);
         } catch (IOException e) {
-            throw new RedfishException(String.format("Failed to execute POST request [URL: %s] due to exception.", url, e));
+            if (redfishRequestMaxRetries == 0) {
+                throw new RedfishException(String.format("Failed to execute HTTP %s request [URL: %s] due to exception.", httpReq.getMethod(), url), e);
+            }
+            return retryHttpRequest(url, httpReq, client);
         }
+    }
+
+    protected HttpResponse retryHttpRequest(String url, HttpRequestBase httpReq, HttpClient client) {
+        LOGGER.error(String.format("Failed to execute HTTP %s request [URL: %s]. Executing the request again.", httpReq.getMethod(), url));
+        for (int attempt = 1; attempt < redfishRequestMaxRetries + 1; attempt++) {
+            try {
+                TimeUnit.SECONDS.sleep(WAIT_FOR_REQUEST_RETRY);
+                LOGGER.debug(String.format("Retry HTTP %s request [URL: %s], attempt %d/%d.", httpReq.getMethod(), url, attempt, redfishRequestMaxRetries));
+                return client.execute(httpReq);
+            } catch (IOException | InterruptedException e) {
+                if (attempt == redfishRequestMaxRetries) {
+                    throw new RedfishException(String.format("Failed to execute HTTP %s request attempt %d/%d [URL: %s] due to exception %s", httpReq.getMethod(), attempt, redfishRequestMaxRetries,url, e));
+                } else {
+                    LOGGER.error(
+                            String.format("Failed to execute HTTP %s request attempt %d/%d [URL: %s] due to exception %s", httpReq.getMethod(), attempt, redfishRequestMaxRetries,
+                                    url, e));
+                }
+            }
+        }
+        throw new RedfishException(String.format("Failed to execute HTTP %s request [URL: %s].", httpReq.getMethod(), url));
     }
 
     /**

--- a/utils/src/main/java/org/apache/cloudstack/utils/redfish/RedfishClient.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/redfish/RedfishClient.java
@@ -83,7 +83,7 @@ public class RedfishClient {
     private final static String ODATA_ID = "@odata.id";
     private final static String MEMBERS = "Members";
     private final static String EXPECTED_HTTP_STATUS = "2XX";
-    private final static int WAIT_FOR_REQUEST_RETRY = 1;
+    private final static int WAIT_FOR_REQUEST_RETRY = 2;
 
 
     /**
@@ -219,7 +219,7 @@ public class RedfishClient {
             return client.execute(httpReq);
         } catch (IOException e) {
             if (redfishRequestMaxRetries == 0) {
-                throw new RedfishException(String.format("Failed to execute HTTP %s request [URL: %s] due to exception.", httpReq.getMethod(), url), e);
+                throw new RedfishException(String.format("Failed to execute HTTP %s request [URL: %s] due to exception %s.", httpReq.getMethod(), url, e), e);
             }
             return retryHttpRequest(url, httpReq, client);
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

It is not common, but HTTP requests can fail due to connection issues. In order to mitigate such situations and also improve logging, this PR enhances the Redfish request handling by adding an execution flow for re-trying HTTP requests; the retry happens only if the global settings `redfish.retries` is set to 1 or more retries; default is of 2 (two). One can disable the retries by setting `redfish.retries` to 0 (zero).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Configured a test environment to ignore SSL while using HTTPS for Redfish requests. In such cases, IOExcetions will happen on a higher frequency than any other setup due to the exception `javax.net.ssl.SSLHandshakeException: Remote host terminated the handshake`.

The following log shows GET requests that failed a couple of times, the successful request happened at the third attempt:

```
Failed to execute HTTP GET request [URL: https://oob-redfish.net/redfish/v1/Systems/]. Executing the request again.
Retry HTTP GET request [URL: https://oob-redfish.net/redfish/v1/Systems/], attempt 1/2.
Failed to execute HTTP GET request retry attempt 1/2 [URL: https://oob-redfish.net/redfish/v1/Systems/] due to exception javax.net.ssl.SSLHandshakeException: Remote host terminated the handshake
Retry HTTP GET request [URL: https://oob-redfish.com/redfish/v1/Systems/], attempt 2/2.
Successfully executed HTTP GET request [URL: https://oob-redfish.net/redfish/v1/Systems/].
Retrieved System ID 'System.Embedded.1' with request 'GET: https://oob-redfish.com/redfish/v1/Systems/'
Retrieved System power state 'On' with request 'GET: https://oob-redfish.com/redfish/v1/Systems/System.Embedded.1'
```

**Note:** Ignoring SSL is not ideal but the redfish out-of-band driver works fine in such case (we have been using it for a couple of months already). However, SSLHandshakeException (_grandchild_ class of IOException) exceptions can be thrown. Nonetheless, ADMINS should have the freedom to still use Refish requests in such cases therefore it was and it has been working OK.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
