### PR TITLE
Fixing unable to create account when passing account parameter

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1077,7 +1077,16 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 if (accountUUID == null) {
                     accountUUID = UUID.randomUUID().toString();
                 }
-                AccountVO account = createAccount(accountNameFinal, accountType, roleId, domainIdFinal, networkDomain, details, accountUUID);
+
+                Account account = null;
+                if (accountNameFinal == userName) {
+                    account = createAccount(accountNameFinal, accountType, roleId, domainIdFinal, networkDomain, details, accountUUID);
+                } else {
+                    account = _accountDao.findActiveAccount(accountNameFinal, domainIdFinal);
+                    if (account != null) {
+                        throw new InvalidParameterValueException("The specified account: " + accountNameFinal + " does not exist");
+                    }
+                }
                 long accountId = account.getId();
 
                 // create the first user for the account


### PR DESCRIPTION
## Description
While creating an account, and passing the account parameter, it does not create a user within the given account. Instead it throws an error that the account exists

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
TODO