### PR TITLE
Failed to update host password if username/password is not saved in db

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -3929,6 +3929,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         // get all the hosts in this cluster
         final List<HostVO> hosts = _resourceMgr.listAllHostsInCluster(command.getClusterId());
 
+        String userNameWithoutSpaces = StringUtils.deleteWhitespace(command.getUsername());
+        if (StringUtils.isBlank(userNameWithoutSpaces)) {
+            throw new InvalidParameterValueException("Username should be non empty string");
+        }
+
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
@@ -3938,7 +3943,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                     }
                     // update password for this host
                     final DetailVO nv = _detailsDao.findDetail(h.getId(), ApiConstants.USERNAME);
-                    if (nv.getValue().equals(command.getUsername())) {
+                    if (nv == null) {
+                        final DetailVO nvu = new DetailVO(h.getId(), ApiConstants.USERNAME, userNameWithoutSpaces);
+                        _detailsDao.persist(nvu);
+                        final DetailVO nvp = new DetailVO(h.getId(), ApiConstants.PASSWORD, DBEncryptionUtil.encrypt(command.getPassword()));
+                        _detailsDao.persist(nvp);
+                    } else if (nv.getValue().equals(userNameWithoutSpaces)) {
                         final DetailVO nvp = _detailsDao.findDetail(h.getId(), ApiConstants.PASSWORD);
                         nvp.setValue(DBEncryptionUtil.encrypt(command.getPassword()));
                         _detailsDao.persist(nvp);
@@ -3986,6 +3996,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         if (!supportedHypervisors.contains(host.getHypervisorType())) {
             throw new InvalidParameterValueException("This operation is not supported for this hypervisor type");
         }
+
+        String userNameWithoutSpaces = StringUtils.deleteWhitespace(cmd.getUsername());
+        if (StringUtils.isBlank(userNameWithoutSpaces)) {
+            throw new InvalidParameterValueException("Username should be non empty string");
+        }
+
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
@@ -3994,7 +4010,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                 }
                 // update password for this host
                 final DetailVO nv = _detailsDao.findDetail(host.getId(), ApiConstants.USERNAME);
-                if (nv.getValue().equals(cmd.getUsername())) {
+                if (nv == null) {
+                    final DetailVO nvu = new DetailVO(host.getId(), ApiConstants.USERNAME, userNameWithoutSpaces);
+                    _detailsDao.persist(nvu);
+                    final DetailVO nvp = new DetailVO(host.getId(), ApiConstants.PASSWORD, DBEncryptionUtil.encrypt(cmd.getPassword()));
+                    _detailsDao.persist(nvp);
+                } else if (nv.getValue().equals(userNameWithoutSpaces)) {
                     final DetailVO nvp = _detailsDao.findDetail(host.getId(), ApiConstants.PASSWORD);
                     nvp.setValue(DBEncryptionUtil.encrypt(cmd.getPassword()));
                     _detailsDao.persist(nvp);


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

If the entries for a host in host_details table are missing then we cant update the
password of the host using the cloudmonkey command
This can happen because host was removed earlier resulting in deletion
of entries in the database

This commit fixes the issue

(local) mgt01 > update hostpassword
hostid=50436ac8-b73a-4eaf-bbab-7adbd9a50870 username=root
password=cloudstack
{
  "success": true
}

Now the entries should be added in host_details table as well


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Using cloudmonkey api updateHost

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
