### PR TITLE
server: Update use_bytes of storage pools

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/StoragePoolVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/StoragePoolVO.java
@@ -195,6 +195,10 @@ public class StoragePoolVO implements StoragePool {
         return updateTime;
     }
 
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
     @Override
     public long getDataCenterId() {
         return dataCenterId;

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProvider;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -1027,8 +1028,13 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                             storagePoolStats.put(pool.getId(), (StorageStats)answer);
 
                             // Seems like we have dynamically updated the pool size since the prev. size and the current do not match
-                            if (_storagePoolStats.get(poolId) != null && _storagePoolStats.get(poolId).getCapacityBytes() != ((StorageStats)answer).getCapacityBytes()) {
+                            if (pool.getCapacityBytes() != ((StorageStats)answer).getCapacityBytes() ||
+                                    pool.getUsedBytes() != ((StorageStats)answer).getByteUsed()) {
                                 pool.setCapacityBytes(((StorageStats)answer).getCapacityBytes());
+                                if (pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY)) {
+                                    pool.setUsedBytes(((StorageStats) answer).getByteUsed());
+                                    pool.setUpdateTime(new Date());
+                                }
                                 _storagePoolDao.update(pool.getId(), pool);
                             }
                         }

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -151,7 +151,6 @@ import com.cloud.org.Grouping.AllocationState;
 import com.cloud.resource.ResourceState;
 import com.cloud.server.ConfigurationServer;
 import com.cloud.server.ManagementServer;
-import com.cloud.server.StatsCollector;
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.Volume.Type;
@@ -1730,31 +1729,21 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             return true;
         }
 
-        StatsCollector sc = StatsCollector.getInstance();
         double storageUsedThreshold = CapacityManager.StorageCapacityDisableThreshold.valueIn(pool.getDataCenterId());
-        if (sc != null) {
-            long totalSize = pool.getCapacityBytes();
-            StorageStats stats = sc.getStoragePoolStats(pool.getId());
-            if (stats == null) {
-                stats = sc.getStorageStats(pool.getId());
-            }
-            if (stats != null) {
-                double usedPercentage = ((double)stats.getByteUsed() / (double)totalSize);
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Checking pool " + pool.getId() + " for storage, totalSize: " + toHumanReadableSize(pool.getCapacityBytes()) + ", usedBytes: " + toHumanReadableSize(stats.getByteUsed()) + ", usedPct: " + usedPercentage
-                            + ", disable threshold: " + storageUsedThreshold);
-                }
-                if (usedPercentage >= storageUsedThreshold) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Insufficient space on pool: " + pool.getId() + " since its usage percentage: " + usedPercentage + " has crossed the pool.storage.capacity.disablethreshold: "
-                                + storageUsedThreshold);
-                    }
-                    return false;
-                }
-            }
-            return true;
+        long totalSize = pool.getCapacityBytes();
+        double usedPercentage = ((double)pool.getUsedBytes() / (double)totalSize);
+        if (s_logger.isDebugEnabled()) {
+            s_logger.debug("Checking pool " + pool.getId() + " for storage, totalSize: " + pool.getCapacityBytes() + ", usedBytes: " + pool.getUsedBytes() +
+                    ", usedPct: " + usedPercentage + ", disable threshold: " + storageUsedThreshold);
         }
-        return false;
+        if (usedPercentage >= storageUsedThreshold) {
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug("Insufficient space on pool: " + pool.getId() + " since its usage percentage: " + usedPercentage +
+                        " has crossed the pool.storage.capacity.disablethreshold: " + storageUsedThreshold);
+            }
+            return false;
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Update the used_bytes for all default primary storage pools
Also, get used_bytes of storage pool from the database instead of
memory

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Below sql query should return the latest used bytes of the storage pol
```
mysql> select * from storage_pool\G
*************************** 1. row ***************************
                   id: 1
                 name: primary1
                 uuid: 74d0b-9e65-3183-8345-e749fcd0e
            pool_type: NetworkFilesystem
                 port: 2049
       data_center_id: 1
               pod_id: NULL
           cluster_id: NULL
           used_bytes: 10363076608
       capacity_bytes: 52709818368
         host_address: 10.135.122.14
            user_info: NULL
                 path: /data/primary1
              created: 2020-07-10 09:27:51
              removed: NULL
          update_time: 2020-09-30 10:50:19
               status: Up
storage_provider_name: DefaultPrimary
                scope: ZONE
           hypervisor: KVM
              managed: 0
        capacity_iops: NULL
1 row in set (0.01 sec)
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
