### PR TITLE
Add vpcid in usage network response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
@@ -144,6 +144,10 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
     @Param(description = "True if the resource is default")
     private Boolean isDefault;
 
+    @SerializedName("vpcid")
+    @Param(description = "id of the vpc")
+    private String vpcId;
+
     public UsageRecordResponse() {
         tags = new LinkedHashSet<ResourceTagResponse>();
     }
@@ -275,5 +279,9 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
 
     public String getDomainName(){
         return domainName;
+    }
+
+    public void setVpcId(String vpcId) {
+        this.vpcId = vpcId;
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -1568,7 +1568,7 @@ public class ApiDBUtils {
     }
 
     public static VpcVO findVpcById(long vpcId) {
-        return s_vpcDao.findById(vpcId);
+        return s_vpcDao.findByIdIncludingRemoved(vpcId);
     }
 
     public static SnapshotPolicy findSnapshotPolicyById(long policyId) {

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -1568,6 +1568,10 @@ public class ApiDBUtils {
     }
 
     public static VpcVO findVpcById(long vpcId) {
+        return s_vpcDao.findById(vpcId);
+    }
+
+    public static VpcVO findVpcByIdIncludingRemoved(long vpcId) {
         return s_vpcDao.findByIdIncludingRemoved(vpcId);
     }
 

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -3477,7 +3477,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                     resourceType = ResourceObjectType.Network;
                     if (network.getTrafficType() == TrafficType.Public) {
                         VirtualRouter router = ApiDBUtils.findDomainRouterById(usageRecord.getUsageId());
-                        Vpc vpc = ApiDBUtils.findVpcById(router.getVpcId());
+                        Vpc vpc = ApiDBUtils.findVpcByIdIncludingRemoved(router.getVpcId());
                         usageRecResponse.setVpcId(vpc.getUuid());
                         resourceId = vpc.getId();
                     } else {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -3475,8 +3475,15 @@ public class ApiResponseHelper implements ResponseGenerator {
                 network = _entityMgr.findByIdIncludingRemoved(NetworkVO.class, usageRecord.getNetworkId().toString());
                 if (network != null) {
                     resourceType = ResourceObjectType.Network;
-                    resourceId = network.getId();
-                    usageRecResponse.setNetworkId(network.getUuid());
+                    if (network.getTrafficType() == TrafficType.Public) {
+                        VirtualRouter router = ApiDBUtils.findDomainRouterById(usageRecord.getUsageId());
+                        Vpc vpc = ApiDBUtils.findVpcById(router.getVpcId());
+                        usageRecResponse.setVpcId(vpc.getUuid());
+                        resourceId = vpc.getId();
+                    } else {
+                        usageRecResponse.setNetworkId(network.getUuid());
+                        resourceId = network.getId();
+                    }
                     usageRecResponse.setResourceName(network.getName());
                 }
             }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Currently vpcid is not displayed in listUsageRecords response.
Add the vpcid so that we can see to which vpc, the network belongs


 list usagerecords startdate=2020-01-01 enddate=2020-08-01
```
{
      "account": "admin",
      "accountid": "40ec-c28e-11ea-9a43-06103377",
      "description": "Bytes received by network null (324e0-ca0f-4762-9850-de5f5c411) using router r-7-VM (ef9-00d7-43e8-8819-9f23226)",
      "domain": "ROOT",
      "domainid": "04c6-c28e-11ea-9a43-0613377",
      "enddate": "2020-07-27'T'23:59:59+00:00",
      "rawusage": "77776",
      "startdate": "2020-07-27'T'00:00:00+00:00",
      "tags": [],
      "type": "DomainRouter",
      "usage": "77776 bytes received",
      "usageid": "ef96c-00d7-43e8-8819-9f236226",
      "usagetype": 5,
      "vpcid": "d187a-69a3-4153-88ac-3c7c2de31", >>>>>>>>>>>>>>>>>>>>>
      "zoneid": "8ad-7db1-4a1a-9030-db0e62"
    },
```

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
