### PR TITLE
Consider maintenance mode as offline for prometheus stats

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -106,9 +106,10 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
                 continue;
             }
             total++;
-            if (host.getStatus() == Status.Up) {
+            if (host.getStatus() == Status.Up && !host.isInMaintenanceStates()) {
                 up++;
-            } else if (host.getStatus() == Status.Disconnected || host.getStatus() == Status.Down) {
+            } else if (host.getStatus() == Status.Disconnected || host.getStatus() == Status.Down ||
+                        host.isInMaintenanceStates()) {
                 down++;
             }
 

--- a/server/src/main/java/com/cloud/api/query/vo/HostJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/HostJoinVO.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.api.query.vo;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import javax.persistence.Column;
@@ -401,5 +402,11 @@ public class HostJoinVO extends BaseViewVO implements InternalIdentity, Identity
 
     public boolean isAnnotated() {
         return StringUtils.isNotBlank(annotation);
+    }
+
+    public boolean isInMaintenanceStates() {
+        return Arrays.asList(
+                    ResourceState.Maintenance, ResourceState.ErrorInMaintenance, ResourceState.PrepareForMaintenance)
+                .contains(getResourceState());
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If the resource state of hypervisor in "Maintenance" then it
should be considered as offline even though the agent state
is "Up". Since its in maintenance mode, it cant be used to
allocate VM's and hence can't be considered towards resource
allocation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Enhancement (improves an existing feature and functionality)


## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Enable prometheus server
Add 127.0.0.1 as allowed Ip so that you can fetch metrics from prometheus

Now fetch the endpoint

```
# http http://127.0.0.1:9595/metrics | grep cloudstack_hosts_total
cloudstack_hosts_total{zone="mgt122-10",filter="online"} 3
cloudstack_hosts_total{zone="mgt122-10",filter="offline"} 0
cloudstack_hosts_total{zone="mgt122-10",filter="total"} 3
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
