### PR TITLE
Fixing searchAndCount searchAndDistinctCount when sc is null

### DIFF
--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
@@ -165,7 +165,6 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
 
         HostTypeCountSearch = createSearchBuilder();
         HostTypeCountSearch.and("type", HostTypeCountSearch.entity().getType(), SearchCriteria.Op.EQ);
-        HostTypeCountSearch.and("removed", HostTypeCountSearch.entity().getRemoved(), SearchCriteria.Op.NULL);
         HostTypeCountSearch.done();
 
         HostTypeZoneCountSearch = createSearchBuilder();

--- a/engine/schema/src/main/java/com/cloud/network/as/dao/AutoScaleVmGroupVmMapDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/as/dao/AutoScaleVmGroupVmMapDaoImpl.java
@@ -33,7 +33,7 @@ public class AutoScaleVmGroupVmMapDaoImpl extends GenericDaoBase<AutoScaleVmGrou
 
         SearchCriteria<AutoScaleVmGroupVmMapVO> sc = createSearchCriteria();
         sc.addAnd("vmGroupId", SearchCriteria.Op.EQ, vmGroupId);
-        return getCount(sc);
+        return getCountIncludingRemoved(sc);
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/vm/dao/DomainRouterDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/DomainRouterDaoImpl.java
@@ -189,7 +189,6 @@ public class DomainRouterDaoImpl extends GenericDaoBase<DomainRouterVO, Long> im
     public Integer countAllByRole(final Role role) {
         final SearchCriteria<DomainRouterVO> sc = createSearchCriteria();
         sc.addAnd("role", SearchCriteria.Op.EQ, role);
-        sc.addAnd("removed", Op.NULL);
         return getCount(sc);
     }
 

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/ImageStoreDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/ImageStoreDaoImpl.java
@@ -117,7 +117,6 @@ public class ImageStoreDaoImpl extends GenericDaoBase<ImageStoreVO, Long> implem
     public Integer countAllImageStores() {
         SearchCriteria<ImageStoreVO> sc = createSearchCriteria();
         sc.addAnd("role", SearchCriteria.Op.EQ, DataStoreRole.Image);
-        sc.addAnd("removed", SearchCriteria.Op.NULL);
         return getCount(sc);
     }
 

--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -1312,7 +1312,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     @DB()
     public Pair<List<T>, Integer> searchAndCount(final SearchCriteria<T> sc, final Filter filter) {
         List<T> objects = search(sc, filter, null, false);
-        Integer count = getCount(sc, false);
+        Integer count = getCount(sc);
         // Count cannot be less than the result set but can be higher due to pagination, see CLOUDSTACK-10320
         if (count < objects.size()) {
             count = objects.size();
@@ -1324,7 +1324,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     @DB()
     public Pair<List<T>, Integer> searchAndDistinctCount(final SearchCriteria<T> sc, final Filter filter) {
         List<T> objects = search(sc, filter, null, false);
-        Integer count = getDistinctCount(sc, false);
+        Integer count = getDistinctCount(sc);
         // Count cannot be 0 if there is at least a result in the list, see CLOUDSTACK-10320
         if (count == 0 && !objects.isEmpty()) {
             // Cannot assume if it's more than one since the count is distinct vs search
@@ -1337,7 +1337,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     @DB()
     public Pair<List<T>, Integer> searchAndDistinctCount(final SearchCriteria<T> sc, final Filter filter, final String[] distinctColumns) {
         List<T> objects = search(sc, filter, null, false);
-        Integer count = getDistinctCount(sc, distinctColumns, false);
+        Integer count = getDistinctCount(sc, distinctColumns);
         // Count cannot be 0 if there is at least a result in the list, see CLOUDSTACK-10320
         if (count == 0 && !objects.isEmpty()) {
             // Cannot assume if it's more than one since the count is distinct vs search
@@ -1928,14 +1928,12 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         return sc;
     }
 
-    public Integer getDistinctCount(SearchCriteria<T> sc, boolean removed) {
-        if (!removed) {
-            sc = checkAndSetRemovedIsNull(sc);
-        }
-        return getDistinctCount(sc);
+    public Integer getDistinctCount(SearchCriteria<T> sc) {
+        sc = checkAndSetRemovedIsNull(sc);
+        return getDistinctCountIncludingRemoved(sc);
     }
 
-    public Integer getDistinctCount(SearchCriteria<T> sc) {
+    public Integer getDistinctCountIncludingRemoved(SearchCriteria<T> sc) {
         String clause = sc != null ? sc.getWhereClause() : null;
         if (clause != null && clause.length() == 0) {
             clause = null;
@@ -1993,14 +1991,12 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         }
     }
 
-    public Integer getDistinctCount(SearchCriteria<T> sc, String[] distinctColumns, boolean removed) {
-        if (!removed) {
-            sc = checkAndSetRemovedIsNull(sc);
-        }
-        return getDistinctCount(sc, distinctColumns);
+    public Integer getDistinctCount(SearchCriteria<T> sc, String[] distinctColumns) {
+        sc = checkAndSetRemovedIsNull(sc);
+        return getDistinctCountIncludingRemoved(sc, distinctColumns);
     }
 
-    public Integer getDistinctCount(SearchCriteria<T> sc, String[] distinctColumns) {
+    public Integer getDistinctCountIncludingRemoved(SearchCriteria<T> sc, String[] distinctColumns) {
         String clause = sc != null ? sc.getWhereClause() : null;
         if (Strings.isNullOrEmpty(clause)) {
             clause = null;
@@ -2047,19 +2043,15 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     }
 
     public Integer countAll() {
-        SearchCriteria<T> sc = null;
-        sc = checkAndSetRemovedIsNull(sc);
-        return getCount(sc);
-    }
-
-    public Integer getCount(SearchCriteria<T> sc, boolean removed) {
-        if (!removed) {
-            sc = checkAndSetRemovedIsNull(sc);
-        }
-        return getCount(sc);
+        return getCount(null);
     }
 
     public Integer getCount(SearchCriteria<T> sc) {
+        sc = checkAndSetRemovedIsNull(sc);
+        return getCountIncludingRemoved(sc);
+    }
+
+    public Integer getCountIncludingRemoved(SearchCriteria<T> sc) {
         String clause = sc != null ? sc.getWhereClause() : null;
         if (clause != null && clause.length() == 0) {
             clause = null;

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -503,7 +503,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
     @Override
     public Pair<List<TemplateJoinVO>, Integer> searchIncludingRemovedAndCount(final SearchCriteria<TemplateJoinVO> sc, final Filter filter) {
         List<TemplateJoinVO> objects = searchIncludingRemoved(sc, filter, null, false);
-        Integer count = getCount(sc);
+        Integer count = getCountIncludingRemoved(sc);
         return new Pair<List<TemplateJoinVO>, Integer>(objects, count);
     }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/apache/cloudstack/issues/4372

Ensures that the count returned by searchAndCount searchAndDistinctCount do not include removed items
Before, it would return the count of removed items  as well when the search criteria is null (since sc is created and modified in search which doesn't reflect when it tires to get the count)
Also refactored a bit to make life easieer for the next person who comes along

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Before :
```
(localcloud) SBCM5> > list roles filter=
{
  "count": 11,
  "role": [
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {}
  ]
}
```
After : 
```
(localcloud) SBCM5> > list roles filter=
{
  "count": 9,
  "role": [
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {}
  ]
}

```