### PR TITLE
server: fix issue that vm guest os type is reset after updatetemplate

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -2063,6 +2063,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             ex.addProxyObject(String.valueOf(id), "templateId");
             throw ex;
         }
+        long oldGuestOSId = template.getGuestOSId();
 
         verifyTemplateId(id);
 
@@ -2119,7 +2120,6 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         }
 
         if (guestOSId != null) {
-            long oldGuestOSId = template.getGuestOSId();
             GuestOSVO guestOS = _guestOSDao.findById(guestOSId);
 
             if (guestOS == null) {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Steps to reproduce the issue
(1) change vm guest os type
(2) update vm template (guest os type is not changed)
(3) vm guest os type is reset to guest os type of template.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
