### PR TITLE
Fixed double slash in secret breaking db insert

### DIFF
--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -1824,8 +1824,7 @@ var processPropertiesInImagestoreObject = function(jsonObj) {
     Replace the + and / symbols by - and _ to have URL-safe base64 going to the API
     It's hacky, but otherwise we'll confuse java.net.URI which splits the incoming URI
     */
-        secret = secret.replace("+", "-");
-        secret = secret.replace("/", "_");
+        secret = secret.replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, '');
 
         if (id != null && secret != null) {
             monitor = id + ":" + secret + "@" + monitor;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #4147 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

From the front end, add RBD primary storage pool with a secrect with 2 slashes next to each other - no error.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
