### PR TITLE
support for data migration of incremental snaps on xen

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -179,7 +179,7 @@ public class DataMigrationUtility {
         List<TemplateDataStoreVO> templates = templateDataStoreDao.listByStoreId(srcDataStore.getId());
         for (TemplateDataStoreVO template : templates) {
             VMTemplateVO templateVO = templateDao.findById(template.getTemplateId());
-            if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && !templateVO.isPublicTemplate() &&
+            if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && templateVO != null && !templateVO.isPublicTemplate() &&
                     templateVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator) {
                 files.add(templateFactory.getTemplate(template.getTemplateId(), srcDataStore));
             }
@@ -197,7 +197,7 @@ public class DataMigrationUtility {
         for (SnapshotDataStoreVO snapshot : snapshots) {
             SnapshotVO snapshotVO = snapshotDao.findById(snapshot.getSnapshotId());
             if (snapshot.getState() == ObjectInDataStoreStateMachine.State.Ready &&
-                    snapshotVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator
+                    snapshotVO != null && snapshotVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator
                     && snapshot.getParentSnapshotId() == 0 ) {
                 SnapshotInfo snap = snapshotFactory.getSnapshot(snapshotVO.getSnapshotId(), DataStoreRole.Image);
                 files.add(snap);

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -36,6 +36,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.TemplateDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.storage.ImageStoreService;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
@@ -47,6 +48,7 @@ import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreVO;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
 import com.cloud.host.dao.HostDao;
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.SnapshotVO;
 import com.cloud.storage.VMTemplateVO;
@@ -79,7 +81,6 @@ public class DataMigrationUtility {
     HostDao hostDao;
     @Inject
     SnapshotDao snapshotDao;
-
     /**
      *  This function verifies if the given image store contains data objects that are not in any of the following states:
      *  "Ready" "Allocated", "Destroying", "Destroyed", "Failed". If this is the case, and if the migration policy is complete,
@@ -115,7 +116,7 @@ public class DataMigrationUtility {
     protected Long getFileSize(DataObject file, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain) {
         Long size = file.getSize();
         Pair<List<SnapshotInfo>, Long> chain = snapshotChain.get(file);
-        if (file instanceof SnapshotInfo && chain.first() != null) {
+        if (file instanceof SnapshotInfo && chain.first() != null && !chain.first().isEmpty()) {
             size = chain.second();
         }
         return size;
@@ -178,7 +179,8 @@ public class DataMigrationUtility {
         List<TemplateDataStoreVO> templates = templateDataStoreDao.listByStoreId(srcDataStore.getId());
         for (TemplateDataStoreVO template : templates) {
             VMTemplateVO templateVO = templateDao.findById(template.getTemplateId());
-            if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && !templateVO.isPublicTemplate()) {
+            if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && !templateVO.isPublicTemplate() &&
+                    templateVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator) {
                 files.add(templateFactory.getTemplate(template.getTemplateId(), srcDataStore));
             }
         }
@@ -194,7 +196,9 @@ public class DataMigrationUtility {
         List<SnapshotDataStoreVO> snapshots = snapshotDataStoreDao.listByStoreId(srcDataStore.getId(), DataStoreRole.Image);
         for (SnapshotDataStoreVO snapshot : snapshots) {
             SnapshotVO snapshotVO = snapshotDao.findById(snapshot.getSnapshotId());
-            if (snapshot.getState() == ObjectInDataStoreStateMachine.State.Ready && snapshot.getParentSnapshotId() == 0 ) {
+            if (snapshot.getState() == ObjectInDataStoreStateMachine.State.Ready &&
+                    snapshotVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator
+                    && snapshot.getParentSnapshotId() == 0 ) {
                 SnapshotInfo snap = snapshotFactory.getSnapshot(snapshotVO.getSnapshotId(), DataStoreRole.Image);
                 files.add(snap);
             }
@@ -230,7 +234,10 @@ public class DataMigrationUtility {
         List<VolumeDataStoreVO> volumes = volumeDataStoreDao.listByStoreId(srcDataStore.getId());
         for (VolumeDataStoreVO volume : volumes) {
             if (volume.getState() == ObjectInDataStoreStateMachine.State.Ready) {
-                files.add(volumeFactory.getVolume(volume.getVolumeId(), srcDataStore));
+                VolumeInfo volumeInfo = volumeFactory.getVolume(volume.getVolumeId(), srcDataStore);
+                if (volumeInfo != null && volumeInfo.getHypervisorType() != Hypervisor.HypervisorType.Simulator) {
+                    files.add(volumeInfo);
+                }
             }
         }
         return files;

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -393,7 +393,6 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
             if (meanStdDevCurrent > threshold && storageCapacityBelowThreshold(storageCapacities, destDatastoreId)) {
                 return true;
             }
-            return  true;
         } else {
             if (storageCapacityBelowThreshold(storageCapacities, destDatastoreId)) {
                 return true;
@@ -404,7 +403,8 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
 
     private boolean storageCapacityBelowThreshold(Map<Long, Pair<Long, Long>> storageCapacities, Long destStoreId) {
         Pair<Long, Long> imageStoreCapacity = storageCapacities.get(destStoreId);
-        if (imageStoreCapacity != null && (imageStoreCapacity.first() / (imageStoreCapacity.second() * 1.0)) <= imageStoreCapacityThreshold) {
+        long usedCapacity = imageStoreCapacity.second() - imageStoreCapacity.first();
+        if (imageStoreCapacity != null && (usedCapacity / (imageStoreCapacity.second() * 1.0)) <= imageStoreCapacityThreshold) {
             s_logger.debug("image store: " + destStoreId + " has sufficient capacity to proceed with migration of file");
             return true;
         }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/SnapshotDataStoreVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/SnapshotDataStoreVO.java
@@ -291,4 +291,8 @@ public class SnapshotDataStoreVO implements StateObject<ObjectInDataStoreStateMa
     public void setVolumeId(Long volumeId) {
         this.volumeId = volumeId;
     }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/TemplateDataStoreVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/TemplateDataStoreVO.java
@@ -402,4 +402,7 @@ public class TemplateDataStoreVO implements StateObject<ObjectInDataStoreStateMa
         this.extractUrlCreated = extractUrlCreated;
     }
 
+    public void setCreated(Date created) {
+        this.created = created;
+    }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/VolumeDataStoreVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/VolumeDataStoreVO.java
@@ -381,4 +381,8 @@ public class VolumeDataStoreVO implements StateObject<ObjectInDataStoreStateMach
     public void setExtractUrlCreated(Date extractUrlCreated) {
         this.extractUrlCreated = extractUrlCreated;
     }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
 }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/SecondaryStorageServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/SecondaryStorageServiceImpl.java
@@ -216,9 +216,7 @@ public class SecondaryStorageServiceImpl implements SecondaryStorageService {
                 }
                 snapshotStoreDao.update(destSnapshotStore.getId(), destSnapshotStore);
             }
-        }
-
-        if (destData instanceof VolumeInfo) {
+        } else if (destData instanceof VolumeInfo) {
             VolumeDataStoreVO srcVolume = volumeDataStoreDao.findByStoreVolume(srcData.getDataStore().getId(), srcData.getId());
             VolumeDataStoreVO destVolume = volumeDataStoreDao.findByStoreVolume(destData.getDataStore().getId(), destData.getId());
             if (srcVolume != null && destVolume != null) {
@@ -226,15 +224,15 @@ public class SecondaryStorageServiceImpl implements SecondaryStorageService {
                 destVolume.setCreated(srcVolume.getCreated());
                 volumeDataStoreDao.update(destVolume.getId(), destVolume);
             }
-        }
-
-        if (destData instanceof TemplateInfo) {
+        } else if (destData instanceof TemplateInfo) {
             TemplateDataStoreVO srcTemplate = templateStoreDao.findByStoreTemplate(srcData.getDataStore().getId(), srcData.getId());
             TemplateDataStoreVO destTemplate = templateStoreDao.findByStoreTemplate(destData.getDataStore().getId(), destData.getId());
             if (srcTemplate != null && destTemplate != null) {
                 destTemplate.setCreated(srcTemplate.getCreated());
                 templateStoreDao.update(destTemplate.getId(), destTemplate);
             }
+        } else {
+            s_logger.debug("Unsupported data object type");
         }
     }
 }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/SecondaryStorageServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/SecondaryStorageServiceImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.cloudstack.storage.image;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -88,11 +89,29 @@ public class SecondaryStorageServiceImpl implements SecondaryStorageService {
         DataObject destDataObject = null;
         try {
             if (srcDataObject instanceof SnapshotInfo && snapshotChain != null && snapshotChain.containsKey(srcDataObject)) {
+                List<String> parentSnapshotPaths = new ArrayList<>();
                 for (SnapshotInfo snapshotInfo : snapshotChain.get(srcDataObject).first()) {
+                    if (!parentSnapshotPaths.isEmpty() && parentSnapshotPaths.contains(snapshotInfo.getPath())) {
+                        parentSnapshotPaths.add(snapshotInfo.getPath());
+                        SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findByStoreSnapshot(DataStoreRole.Image, srcDatastore.getId(), snapshotInfo.getSnapshotId());
+                        if (snapshotStore == null) {
+                            res.setResult("Failed to find snapshot " + snapshotInfo.getUuid() + " on store: " + srcDatastore.getName());
+                            res.setSuccess(false);
+                            future.complete(res);
+                            break;
+                        }
+                        snapshotStore.setDataStoreId(destDatastore.getId());
+                        snapshotStoreDao.update(snapshotStore.getId(), snapshotStore);
+                        continue;
+                    }
+                    parentSnapshotPaths.add(snapshotInfo.getPath());
                     destDataObject = destDatastore.create(snapshotInfo);
                     snapshotInfo.processEvent(ObjectInDataStoreStateMachine.Event.MigrateDataRequested);
                     destDataObject.processEvent(ObjectInDataStoreStateMachine.Event.MigrateDataRequested);
                     migrateJob(future, snapshotInfo, destDataObject, destDatastore);
+                    if (future.get() != null && future.get().isFailed()) {
+                        break;
+                    }
                 }
             } else {
                 // Check if template in destination store, if yes, do not proceed
@@ -163,26 +182,13 @@ public class SecondaryStorageServiceImpl implements SecondaryStorageService {
                 if (destData != null) {
                     destData.getDataStore().delete(destData);
                 }
-
             } else {
                 if (destData instanceof  VolumeInfo) {
                     ((VolumeInfo) destData).processEventOnly(ObjectInDataStoreStateMachine.Event.OperationSuccessed, answer);
                 } else {
                     destData.processEvent(ObjectInDataStoreStateMachine.Event.OperationSuccessed, answer);
                 }
-                if (destData instanceof SnapshotInfo) {
-                    SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findBySourceSnapshot(srcData.getId(), DataStoreRole.Image);
-                    SnapshotDataStoreVO destSnapshotStore = snapshotStoreDao.findBySnapshot(srcData.getId(), DataStoreRole.Image);
-                    destSnapshotStore.setPhysicalSize(snapshotStore.getPhysicalSize());
-                    snapshotStoreDao.update(destSnapshotStore.getId(), destSnapshotStore);
-                }
-
-                if (destData instanceof VolumeInfo) {
-                    VolumeDataStoreVO srcVolume = volumeDataStoreDao.findByStoreVolume(srcData.getDataStore().getId(), srcData.getId());
-                    VolumeDataStoreVO destVolume = volumeDataStoreDao.findByStoreVolume(destData.getDataStore().getId(), destData.getId());
-                    destVolume.setPhysicalSize(srcVolume.getPhysicalSize());
-                    volumeDataStoreDao.update(destVolume.getId(), destVolume);
-                }
+                updateDataObject(srcData, destData);
                 s_logger.debug("Deleting source data");
                 srcData.getDataStore().delete(srcData);
                 s_logger.debug("Successfully migrated "+srcData.getUuid());
@@ -198,6 +204,39 @@ public class SecondaryStorageServiceImpl implements SecondaryStorageService {
         return null;
     }
 
+    private void updateDataObject(DataObject srcData, DataObject destData) {
+        if (destData instanceof SnapshotInfo) {
+            SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findBySourceSnapshot(srcData.getId(), DataStoreRole.Image);
+            SnapshotDataStoreVO destSnapshotStore = snapshotStoreDao.findBySnapshot(srcData.getId(), DataStoreRole.Image);
+            if (snapshotStore != null && destSnapshotStore != null) {
+                destSnapshotStore.setPhysicalSize(snapshotStore.getPhysicalSize());
+                destSnapshotStore.setCreated(snapshotStore.getCreated());
+                if (snapshotStore.getParentSnapshotId() != destSnapshotStore.getParentSnapshotId()) {
+                    destSnapshotStore.setParentSnapshotId(snapshotStore.getParentSnapshotId());
+                }
+                snapshotStoreDao.update(destSnapshotStore.getId(), destSnapshotStore);
+            }
+        }
+
+        if (destData instanceof VolumeInfo) {
+            VolumeDataStoreVO srcVolume = volumeDataStoreDao.findByStoreVolume(srcData.getDataStore().getId(), srcData.getId());
+            VolumeDataStoreVO destVolume = volumeDataStoreDao.findByStoreVolume(destData.getDataStore().getId(), destData.getId());
+            if (srcVolume != null && destVolume != null) {
+                destVolume.setPhysicalSize(srcVolume.getPhysicalSize());
+                destVolume.setCreated(srcVolume.getCreated());
+                volumeDataStoreDao.update(destVolume.getId(), destVolume);
+            }
+        }
+
+        if (destData instanceof TemplateInfo) {
+            TemplateDataStoreVO srcTemplate = templateStoreDao.findByStoreTemplate(srcData.getDataStore().getId(), srcData.getId());
+            TemplateDataStoreVO destTemplate = templateStoreDao.findByStoreTemplate(destData.getDataStore().getId(), destData.getId());
+            if (srcTemplate != null && destTemplate != null) {
+                destTemplate.setCreated(srcTemplate.getCreated());
+                templateStoreDao.update(destTemplate.getId(), destTemplate);
+            }
+        }
+    }
 }
 
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -392,11 +392,8 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         Answer answer = null;
         EndPoint endPoint = null;
         List<Long> epIds = ssvmWithLeastMigrateJobs();
-        Long epId = null;
-        if (!epIds.isEmpty()) {
-            epId = epIds.get(0);
-        }
-        if (epId == null) {
+
+        if (epIds.isEmpty()) {
             Collections.shuffle(eps);
             endPoint = eps.get(0);
         } else {
@@ -405,7 +402,7 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
                 Collections.shuffle(remainingEps);
                 endPoint = remainingEps.get(0);
             } else {
-                endPoint = _defaultEpSelector.getEndPointFromHostId(epId);
+                endPoint = _defaultEpSelector.getEndPointFromHostId(epIds.get(0));
             }
         }
         CommandExecLogVO execLog = new CommandExecLogVO(endPoint.getId(), _secStorageVmDao.findByInstanceName(hostDao.findById(endPoint.getId()).getName()).getId(), "DataMigrationCommand", 1);

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/PremiumSecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/PremiumSecondaryStorageManagerImpl.java
@@ -191,7 +191,7 @@ public class PremiumSecondaryStorageManagerImpl extends SecondaryStorageManagerI
     private void scaleDownSSVMOnLoad(List<SecondaryStorageVmVO> alreadyRunning, List<CommandExecLogVO> activeCmds,
                                List<CommandExecLogVO> copyCmdsInPipeline)  {
         int halfLimit = Math.round((float) (alreadyRunning.size() * migrateCapPerSSVM) / 2);
-        if ((copyCmdsInPipeline.size() < halfLimit && alreadyRunning.size() * _capacityPerSSVM - activeCmds.size() > (_standbyCapacity + 5)) && alreadyRunning.size() > 1) {
+        if (alreadyRunning.size() > 1 && ( copyCmdsInPipeline.size() < halfLimit && (activeCmds.size() < (((alreadyRunning.size() -1) * _capacityPerSSVM)/2)) )) {
             Collections.reverse(alreadyRunning);
             for(SecondaryStorageVmVO vm : alreadyRunning) {
                 long count = activeCmds.stream().filter(cmd -> cmd.getInstanceId() == vm.getId()).count();

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -1302,7 +1302,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             File destFile = new File(getDir(destStore.getUrl(), _nfsVersion), destData.getPath());
 
             if (srcFile == null) {
-                return new CopyCmdAnswer("Can't find source file at path: "+ srcData.getPath() +"on datastore: "+ srcDataStore.getUuid() +" to initiate file transfer");
+                return new CopyCmdAnswer("Can't find source file at path: "+ srcData.getPath() +" on datastore: "+ srcDataStore.getUuid() +" to initiate file transfer");
             }
             ImageFormat format = getTemplateFormat(srcFile.getName());
             if (srcData instanceof TemplateObjectTO || srcData instanceof VolumeObjectTO) {

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -1309,6 +1309,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 File srcDir = null;
                 if (srcFile.isFile() || srcFile.getName().contains(".")) {
                     srcDir = new File(srcFile.getParent());
+                } else if (!srcFile.isFile() && !srcFile.isDirectory()) {
+                    srcDir = new File(srcFile.getParent());
                 }
                 File destDir = null;
                 if (destFile.isFile()) {
@@ -1351,7 +1353,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 if (srcFile.isFile()) {
                     newVol.setPath(destData.getPath() + File.separator + srcFile.getName());
                 } else {
-                    newVol.setPath(destData.getPath());
+                    newVol.setPath(srcData.getPath());
                 }
                 newVol.setSize(getVirtualSize(srcFile, format));
                 retObj = newVol;

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -1300,16 +1300,16 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         try {
             File srcFile = new File(getDir(srcStore.getUrl(), _nfsVersion), srcData.getPath());
             File destFile = new File(getDir(destStore.getUrl(), _nfsVersion), destData.getPath());
-            ImageFormat format = getTemplateFormat(srcFile.getName());
 
             if (srcFile == null) {
-                return new CopyCmdAnswer("Can't find src file:" + srcFile);
+                return new CopyCmdAnswer("Can't find source file at path: "+ srcData.getPath() +"on datastore: "+ srcDataStore.getUuid() +" to initiate file transfer");
             }
+            ImageFormat format = getTemplateFormat(srcFile.getName());
             if (srcData instanceof TemplateObjectTO || srcData instanceof VolumeObjectTO) {
                 File srcDir = null;
                 if (srcFile.isFile() || srcFile.getName().contains(".")) {
                     srcDir = new File(srcFile.getParent());
-                } else if (!srcFile.isFile() && !srcFile.isDirectory()) {
+                } else if (!srcFile.isDirectory()) {
                     srcDir = new File(srcFile.getParent());
                 }
                 File destDir = null;


### PR DESCRIPTION
## Description
PR attempts to fix and enhance the following:
- On Xen, there are instances when the child snapshot is basically only a database entry with the file path pointing to the parent snapshot - handle this scenario such that a new entry is created for such incremental snapshots and delete the snapshot from source datastore during data migration
- Wrt scaling down of SSVM, revised the logic to prevent quick scaling down of the SSVMs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
- Conducted tests on xen of files 
Tests on xen for snapshots with child snaps having install path same as that as parent snapshot
```
Before Migration:
-----------------------

MariaDB [cloud]> select * from snapshot_store_ref where store_role = 'Image' and volume_id =11 and state <> 'Destroyed' order by parent_snapshot_id\G
*************************** 1. row ***************************
                id: 497
          store_id: 1
       snapshot_id: 63
           created: 2020-10-10 07:00:08
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 52531712
parent_snapshot_id: 0
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-10 13:25:24
         volume_id: 11
*************************** 2. row ***************************
                id: 375
          store_id: 1
       snapshot_id: 67
           created: 2020-10-10 07:00:09
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 0
parent_snapshot_id: 63
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-08 06:54:57
         volume_id: 11
*************************** 3. row ***************************
                id: 381
          store_id: 1
       snapshot_id: 70
           created: 2020-10-10 07:00:11
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 0
parent_snapshot_id: 67
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-08 06:55:14
         volume_id: 11
*************************** 4. row ***************************
                id: 472
          store_id: 1
       snapshot_id: 74
           created: 2020-10-10 07:32:57
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 0
parent_snapshot_id: 70
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-10 07:32:57
         volume_id: 11

After migration:
---------------

MariaDB [cloud]> select * from snapshot_store_ref where store_role = 'Image' and volume_id =11 and state <> 'Destroyed' order by parent_snapshot_id\G
*************************** 1. row ***************************
                id: 510
          store_id: 5
       snapshot_id: 63
           created: 2020-10-10 07:00:08
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 52531712
parent_snapshot_id: 0
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-12 04:11:10
         volume_id: 11
*************************** 2. row ***************************
                id: 375
          store_id: 5
       snapshot_id: 67
           created: 2020-10-10 07:00:09
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 0
parent_snapshot_id: 63
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-08 06:54:57
         volume_id: 11
*************************** 3. row ***************************
                id: 381
          store_id: 5
       snapshot_id: 70
           created: 2020-10-10 07:00:11
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 0
parent_snapshot_id: 67
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-08 06:55:14
         volume_id: 11
*************************** 4. row ***************************
                id: 472
          store_id: 5
       snapshot_id: 74
           created: 2020-10-10 07:32:57
      last_updated: NULL
            job_id: NULL
        store_role: Image
              size: 52428800
     physical_size: 0
parent_snapshot_id: 70
      install_path: snapshots/2/11/d05a2c2f-6885-4932-b5a0-d11f82129a48.vhd
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2020-10-10 07:32:57
         volume_id: 11


```

Tested on xen, vmware and KVM
Tests for SSVM scale down:
Updated following global setting values:
secstorage.capacity.standby: 4
secstorage.session.max: 10

1. Added 7 entries to the cmd_exec_log table, to simulate scaling up operation - Successfully scaled - the new SSVM spawned continues to exist until the number of cmds drops below threshold
2. Deleted entries from cmd_exec_log table, such that only 4 entries were present in the table - successfully triggered scale down - as the total number of cmds in the table has dropped below half the defined max limit (10/2 = 5)
3. Simulated another scale up operation by adding entries to the cmd_exec log table, added entries to the second (new) SSVM however the total number of commands in the table is below threshold - does NOT scale down SSVM as a command is running on it - as expected


