### PR TITLE
List VMs by Security Group & HA

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ListVMsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ListVMsCmd.java
@@ -21,6 +21,7 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.cloudstack.api.command.user.UserCmd;
+import org.apache.cloudstack.api.response.SecurityGroupResponse;
 import org.apache.cloudstack.api.response.UserResponse;
 import org.apache.log4j.Logger;
 
@@ -134,6 +135,12 @@ public class ListVMsCmd extends BaseListTaggedResourcesCmd implements UserCmd {
     @Parameter(name = ApiConstants.USER_ID, type = CommandType.UUID, entityType = UserResponse.class, required = false, description = "the user ID that created the VM and is under the account that owns the VM")
     private Long userId;
 
+    @Parameter(name = ApiConstants.SECURITY_GROUP_ID, type = CommandType.UUID, entityType = SecurityGroupResponse.class, description = "the security group ID", since = "4.15")
+    private Long securityGroupId;
+
+    @Parameter(name = ApiConstants.HA_ENABLE, type = CommandType.BOOLEAN, description = "list by the High Availability offering; true if filtering VMs with HA enabled; false for VMs with HA disabled", since = "4.15")
+    private Boolean haEnabled;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -210,6 +217,14 @@ public class ListVMsCmd extends BaseListTaggedResourcesCmd implements UserCmd {
 
     public Long getStorageId() {
         return storageId;
+    }
+
+    public Long getSecurityGroupId() {
+        return securityGroupId;
+    }
+
+    public Boolean getHaEnabled() {
+        return haEnabled;
     }
 
     public EnumSet<VMDetails> getDetails() throws InvalidParameterValueException {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1024,7 +1024,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sc.setParameters("serviceOfferingId", serviceOffId);
         }
 
-        if(securityGroupId != null) {
+        if (securityGroupId != null) {
             sc.setParameters("securityGroupId", securityGroupId);
         }
 
@@ -1032,7 +1032,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sc.setParameters("display", display);
         }
 
-        if (display != null) {
+        if (isHaEnabled != null) {
             sc.setParameters("haEnabled", isHaEnabled);
         }
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -919,6 +919,8 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         Object affinityGroupId = cmd.getAffinityGroupId();
         Object keyPairName = cmd.getKeyPairName();
         Object serviceOffId = cmd.getServiceOfferingId();
+        Object securityGroupId = cmd.getSecurityGroupId();
+        Object isHaEnabled = cmd.getHaEnabled();
         Object pod = null;
         Object hostId = null;
         Object storageId = null;
@@ -948,6 +950,12 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         if (display != null) {
             sb.and("display", sb.entity().isDisplayVm(), SearchCriteria.Op.EQ);
         }
+
+        if (isHaEnabled != null) {
+            sb.and("haEnabled", sb.entity().isHaEnabled(), SearchCriteria.Op.EQ);
+        }
+
+
         if (groupId != null && (Long)groupId != -1) {
             sb.and("instanceGroupId", sb.entity().getInstanceGroupId(), SearchCriteria.Op.EQ);
         }
@@ -968,16 +976,16 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sb.and("poolId", sb.entity().getPoolId(), SearchCriteria.Op.EQ);
         }
 
-        if (affinityGroupId != null) {
-            sb.and("affinityGroupId", sb.entity().getAffinityGroupId(), SearchCriteria.Op.EQ);
-        }
-
         if (keyPairName != null) {
             sb.and("keyPairName", sb.entity().getKeypairName(), SearchCriteria.Op.EQ);
         }
 
         if (!isRootAdmin) {
             sb.and("displayVm", sb.entity().isDisplayVm(), SearchCriteria.Op.EQ);
+        }
+
+        if (securityGroupId != null) {
+            sb.and("securityGroupId", sb.entity().getSecurityGroupId(), SearchCriteria.Op.EQ);
         }
 
         // populate the search criteria with the values passed in
@@ -1016,8 +1024,16 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sc.setParameters("serviceOfferingId", serviceOffId);
         }
 
+        if(securityGroupId != null) {
+            sc.setParameters("securityGroupId", securityGroupId);
+        }
+
         if (display != null) {
             sc.setParameters("display", display);
+        }
+
+        if (display != null) {
+            sc.setParameters("haEnabled", isHaEnabled);
         }
 
         if (ids != null && !ids.isEmpty()) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
List VMs by "security group ID" and/or "ha enabled"

Improve List VMs command allowing to list VMs filtering by security group or HA enabled.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
List VMs via API with different combinations. All worked fine.
- filter vms with security group ID
`list virtualmachines filter=id,name,haenable,securitygroup listall=true securitygroupid=<SG UUID>`

- list VMs according to the HA enabled
`list virtualmachines filter=id,name,haenable,securitygroup listall=true haenable=true`
`list virtualmachines filter=id,name,haenable,securitygroup listall=true haenable=false`

- combione both added parameters
`list virtualmachines filter=id,name,haenable,securitygroup listall=true haenable=false securitygroupid=<SG UUID>`
`list virtualmachines filter=id,name,haenable,securitygroup listall=true haenable=true securitygroupid=<SG UUID>`
`list virtualmachines filter=id,name,haenable,securitygroup listall=true haenable=false securitygroupid=<SG UUID2>`
`list virtualmachines filter=id,name,haenable,securitygroup listall=true haenable=true securitygroupid=<SG UUID2>`

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
