### PR TITLE
scalekubernetesclustercmd: Making id a required field [NPE Fix]

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/command/user/kubernetes/cluster/ScaleKubernetesClusterCmd.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/command/user/kubernetes/cluster/ScaleKubernetesClusterCmd.java
@@ -57,7 +57,7 @@ public class ScaleKubernetesClusterCmd extends BaseAsyncCmd {
     /////////////////////////////////////////////////////
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
-    @Parameter(name = ApiConstants.ID, type = CommandType.UUID,
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, required = true,
             entityType = KubernetesClusterResponse.class,
             description = "the ID of the Kubernetes cluster")
     private Long id;


### PR DESCRIPTION
## Description
Calling scaleKubernetesCluster without passing id leads to an NPE.
This fixes it by making id a required field
```
2020-10-14 07:21:42,384 DEBUG [c.c.a.ApiServlet] (qtp1136419747-1767:ctx-891b1ffe) (logid:540851f6) ===START===  103.252.26.201 -- GET  command=scaleKubernetesCluster&response=json&sessionkey=6OIs3d7CiMpwiLGldPTTRyp6A4M
2020-10-14 07:21:42,393 DEBUG [c.c.a.ApiServer] (qtp1136419747-1767:ctx-891b1ffe ctx-6211cc7c) (logid:540851f6) CIDRs from which account 'Acct[27ef5ba2-5fe0-11ea-9a56-1e006800018c-admin]' is allowed to perform API calls: 0.0.0.0/0,::/0
2020-10-14 07:21:42,399 ERROR [c.c.a.ApiServer] (qtp1136419747-1767:ctx-891b1ffe ctx-6211cc7c) (logid:540851f6) unhandled exception executing api command: [Ljava.lang.String;@48aca284
java.lang.NullPointerException
	at org.apache.cloudstack.api.command.user.kubernetes.cluster.ScaleKubernetesClusterCmd.getEventDescription(ScaleKubernetesClusterCmd.java:98)
	at com.cloud.api.ApiServer.queueCommand(ApiServer.java:714)
	at com.cloud.api.ApiServer.handleRequest(ApiServer.java:583)
	at com.cloud.api.ApiServlet.processRequestInContext(ApiServlet.java:310)
	at com.cloud.api.ApiServlet$1.run(ApiServlet.java:130)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:56)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:103)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:53)
	at com.cloud.api.ApiServlet.processRequest(ApiServlet.java:127)
	at com.cloud.api.ApiServlet.doGet(ApiServlet.java:89)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:645)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
	at org.eclipse.jetty.servlet.ServletHolder$NotAsyncServlet.service(ServletHolder.java:1386)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:755)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:547)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:590)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1607)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1297)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:485)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1577)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1212)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:767)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:500)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:547)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:270)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:388)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:834)
2020-10-14 07:21:42,408 DEBUG [c.c.a.ApiServlet] (qtp1136419747-1767:ctx-891b1ffe ctx-6211cc7c) (logid:540851f6) ===END===  103.252.26.201 -- GET  command=scaleKubernetesCluster&response=json&sessionkey=6OIs3d7CiMpwiLGldPTTRyp6A4M
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
### Before
```
scale kubernetescluster 
🙈 Error: (HTTP 530, error code 9999) <nil>
```

### After
```
scale kubernetescluster 
💩 Missing required parameters:  id
```