### PR TITLE
packaging: enable Parallel Collector GC for management server

### DIFF
--- a/packaging/systemd/cloudstack-management.default
+++ b/packaging/systemd/cloudstack-management.default
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-JAVA_OPTS="-Djava.security.properties=/etc/cloudstack/management/java.security.ciphers -Djava.awt.headless=true -Dcom.sun.management.jmxremote=false -XX:+UseParallelGC -Xmx2G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/cloudstack/management/ -XX:ErrorFile=/var/log/cloudstack/management/cloudstack-management.err "
+JAVA_OPTS="-Djava.security.properties=/etc/cloudstack/management/java.security.ciphers -Djava.awt.headless=true -Dcom.sun.management.jmxremote=false -Xmx2G -XX:+UseParallelGC -XX:MaxGCPauseMillis=500 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/cloudstack/management/ -XX:ErrorFile=/var/log/cloudstack/management/cloudstack-management.err "
 
 CLASSPATH="/usr/share/cloudstack-management/lib/*:/etc/cloudstack/management:/usr/share/cloudstack-common:/usr/share/cloudstack-management/setup:/usr/share/cloudstack-management:/usr/share/java/mysql-connector-java.jar"
 

--- a/packaging/systemd/cloudstack-management.default
+++ b/packaging/systemd/cloudstack-management.default
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-JAVA_OPTS="-Djava.security.properties=/etc/cloudstack/management/java.security.ciphers -Djava.awt.headless=true -Dcom.sun.management.jmxremote=false -Xmx2G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/cloudstack/management/ -XX:ErrorFile=/var/log/cloudstack/management/cloudstack-management.err "
+JAVA_OPTS="-Djava.security.properties=/etc/cloudstack/management/java.security.ciphers -Djava.awt.headless=true -Dcom.sun.management.jmxremote=false -XX:+UseParallelGC -Xmx2G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/cloudstack/management/ -XX:ErrorFile=/var/log/cloudstack/management/cloudstack-management.err "
 
 CLASSPATH="/usr/share/cloudstack-management/lib/*:/etc/cloudstack/management:/usr/share/cloudstack-common:/usr/share/cloudstack-management/setup:/usr/share/cloudstack-management:/usr/share/java/mysql-connector-java.jar"
 


### PR DESCRIPTION
The default GC algorithm G1 that is enabled by default with Java11
serves well on multiprocessor machines with large amount of memory where
GC is probablistic with low pauses, where response time is more
important than throughput and GC is kept shorter.

The CloudStack management server is largely a multi-threaded server
application that handles and orchestrates several network requests, and
has the default max. heap size of only 2G that can be considered a
small/medium application from a heap size perspective. Perhaps a more
aggresive GC algorithm such as ParallelGC as used in Java8 and before
(that is previous CloudStack releases) would serve better for throughput
and cause more aggressive GC.

This PR propose a change in default GC algorithm to avoid OOM issues.

Reference: https://docs.oracle.com/en/java/javase/11/gctuning/available-collectors.html#GUID-13943556-F521-4287-AAAA-AE5DE68777CD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

# How this was tested

Heap activity for Java11 with G1 (default GC algorithm):
![Screenshot from 2020-10-15 04-03-40](https://user-images.githubusercontent.com/95203/96081587-4008ad00-0ed7-11eb-9003-8b2e85cd2cdb.png)

Heap activity seen after switching to ParallelGC:
![Screenshot from 2020-10-15 06-19-04](https://user-images.githubusercontent.com/95203/96081629-59a9f480-0ed7-11eb-8505-b2f89548d023.png)
... and over time with some constant load (listApis calls to simulate Primate logins every 1s, all GC/heap graphs look stable):
![Screenshot from 2020-10-15 10-47-16](https://user-images.githubusercontent.com/95203/96081657-721a0f00-0ed7-11eb-9854-d5402ba1e9cc.png)

Heap, thread etc activities with the ParallelGC and max pause time setting (500ms):
![Screenshot from 2020-10-15 16-00-56](https://user-images.githubusercontent.com/95203/96112071-b0c3bf80-0eff-11eb-85e3-9773e703ec2d.png)
