### PR TITLE
Adding public ip to listKubernetesClusterResponse

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -109,6 +109,8 @@ import com.cloud.network.NetworkService;
 import com.cloud.network.Networks;
 import com.cloud.network.PhysicalNetwork;
 import com.cloud.network.dao.FirewallRulesDao;
+import com.cloud.network.dao.IPAddressDao;
+import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.dao.PhysicalNetworkDao;
@@ -215,6 +217,8 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
     protected NetworkOrchestrationService networkMgr;
     @Inject
     protected NetworkDao networkDao;
+    @Inject
+    protected IPAddressDao ipAddressDao;
     @Inject
     protected CapacityManager capacityManager;
     @Inject
@@ -610,6 +614,13 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         response.setEndpoint(kubernetesCluster.getEndpoint());
         response.setNetworkId(ntwk.getUuid());
         response.setAssociatedNetworkName(ntwk.getName());
+        if (ntwk.getGuestType() == Network.GuestType.Isolated) {
+            List<IPAddressVO> ipAddresses = ipAddressDao.listByAssociatedNetwork(ntwk.getId(), true);
+            if (ipAddresses != null && ipAddresses.size() == 1) {
+                response.setIpAddress(ipAddresses.get(0).getAddress().addr());
+                response.setIpAddressId(ipAddresses.get(0).getUuid());
+            }
+        }
         List<UserVmResponse> vmResponses = new ArrayList<UserVmResponse>();
         List<KubernetesClusterVmMapVO> vmList = kubernetesClusterVmMapDao.listByClusterId(kubernetesCluster.getId());
         ResponseView respView = ResponseView.Restricted;

--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
@@ -133,6 +133,14 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
     @Param(description = "the list of virtualmachine associated with this Kubernetes cluster")
     private List<UserVmResponse> virtualMachines;
 
+    @SerializedName(ApiConstants.IP_ADDRESS)
+    @Param(description = "Public IP Address of the cluster")
+    private String ipAddress;
+
+    @SerializedName(ApiConstants.IP_ADDRESS_ID)
+    @Param(description = "Public IP Address ID of the cluster")
+    private String ipAddressId;
+
     public KubernetesClusterResponse() {
     }
 
@@ -323,5 +331,13 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
 
     public List<UserVmResponse> getVirtualMachines() {
         return virtualMachines;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public void setIpAddressId(String ipAddressId) {
+        this.ipAddressId = ipAddressId;
     }
 }


### PR DESCRIPTION
## Description
Adding public ip to listKubernetesClusterResponse to make life easier as well as enhance the UI 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
```
(localcloud) SBCM5> > list kubernetesclusters 
{
  "count": 1,
  "kubernetescluster": [
    {
      ..........
      "ipaddress": "10.1.36.3",
      "ipaddressid": "a961de46-6a77-4e20-b078-2870853286a2",
     ..........
    }
  ]
}

```