### PR TITLE
Modify alter view to drop/create view

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41400to41500.sql
@@ -75,7 +75,8 @@ ALTER TABLE `cloud`.`project_invitations`
     ADD CONSTRAINT `uc_project_invitations__project_id_account_id_user_id` UNIQUE (`project_id`, `account_id`,`user_id`);
 
 -- Alter project_invitation_view to incorporate user_id as a field
-ALTER VIEW `cloud`.`project_invitation_view` AS
+DROP VIEW IF EXISTS `cloud`.`project_invitation_view`;
+CREATE VIEW `cloud`.`project_invitation_view` AS
     select
         project_invitations.id,
         project_invitations.uuid,
@@ -107,7 +108,8 @@ ALTER VIEW `cloud`.`project_invitation_view` AS
         `cloud`.`user` ON project_invitations.user_id = user.id;
 
 -- Alter project_account_view to incorporate user id
-ALTER VIEW `cloud`.`project_account_view` AS
+DROP VIEW IF EXISTS `cloud`.`project_account_view`;
+CREATE VIEW `cloud`.`project_account_view` AS
     select
         project_account.id,
         account.id account_id,
@@ -140,7 +142,9 @@ ALTER VIEW `cloud`.`project_account_view` AS
             left join
         `cloud`.`user` ON (project_account.user_id = user.id);
 
-ALTER VIEW `cloud`.`project_view` AS
+-- Alter project_view to incorporate user id
+DROP VIEW IF EXISTS `cloud`.`project_view`;
+CREATE VIEW `cloud`.`project_view` AS
     select
         projects.id,
         projects.uuid,
@@ -197,7 +201,8 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervis
 
 ALTER TABLE `cloud`.`image_store` ADD COLUMN `readonly` boolean DEFAULT false COMMENT 'defines status of image store';
 
-ALTER VIEW `cloud`.`image_store_view` AS
+DROP VIEW IF EXISTS `cloud`.`image_store_view`;
+CREATE VIEW `cloud`.`image_store_view` AS
     select
         image_store.id,
         image_store.uuid,


### PR DESCRIPTION
## Description
As a best practice, it is better to drop and create a new view as opposed to altering a view. The PR addresses changing alter view to re-creation of the views after being dropped


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Run upgrade test:
1. deployed a 4.14 setup
2. Created some projects, added/invites a few users
3. Upgraded to 4.15
4. listed projects, project invitations to verify that they are still intact
