### PR TITLE
Create Event in case of OOBM failure

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTask.java
+++ b/server/src/main/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTask.java
@@ -47,11 +47,11 @@ public class PowerOperationTask implements Runnable {
         try {
             service.executePowerOperation(host, powerOperation, null);
         } catch (Exception e) {
-            LOG.warn(String.format("Out-of-band management background task operation=%s for host id=%d name=%s failed with: %s",
-                    powerOperation.name(), host.getId(), host.getName(), e.getMessage()));
+            LOG.warn(String.format("Out-of-band management background task operation=%s for host %s failed with: %s",
+                    powerOperation.name(), host.getName(), e.getMessage()));
 
             String eventMessage = String
-                    .format("Error while issuing out-of-band management action (%s) for host (id: %d, name: %s)", powerOperation.name(), host.getId(), host.getName());
+                    .format("Error while issuing out-of-band management action %s for host: %s", powerOperation.name(), host.getName());
 
             ActionEventUtils.onCreatedActionEvent(CallContext.current().getCallingUserId(), CallContext.current().getCallingAccountId(), EventVO.LEVEL_WARN,
                     EventTypes.EVENT_HOST_OUTOFBAND_MANAGEMENT_ACTION, true, eventMessage);

--- a/server/src/main/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTask.java
+++ b/server/src/main/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTask.java
@@ -17,7 +17,11 @@
 
 package org.apache.cloudstack.outofbandmanagement;
 
+import com.cloud.event.ActionEventUtils;
+import com.cloud.event.EventTypes;
+import com.cloud.event.EventVO;
 import com.cloud.host.Host;
+import org.apache.cloudstack.context.CallContext;
 import org.apache.log4j.Logger;
 
 public class PowerOperationTask implements Runnable {
@@ -43,8 +47,14 @@ public class PowerOperationTask implements Runnable {
         try {
             service.executePowerOperation(host, powerOperation, null);
         } catch (Exception e) {
-            LOG.warn(String.format("Out-of-band management background task operation=%s for host id=%d failed with: %s",
-                    powerOperation.name(), host.getId(), e.getMessage()));
+            LOG.warn(String.format("Out-of-band management background task operation=%s for host id=%d name=%s failed with: %s",
+                    powerOperation.name(), host.getId(), host.getName(), e.getMessage()));
+
+            String eventMessage = String
+                    .format("Error while issuing out-of-band management action (%s) for host (id: %d, name: %s)", powerOperation.name(), host.getId(), host.getName());
+
+            ActionEventUtils.onCreatedActionEvent(CallContext.current().getCallingUserId(), CallContext.current().getCallingAccountId(), EventVO.LEVEL_WARN,
+                    EventTypes.EVENT_HOST_OUTOFBAND_MANAGEMENT_ACTION, true, eventMessage);
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Out of band power operations are constantly issued to assess the host power status. However, if such actions fail the Admins receive a warning message on the log. In order to help Admins to easily track such failures, this PR creates an Event each time an Out-of-band power operation fails.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)