### PR TITLE
Including instance details in KubernetesClusterResponse

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -385,6 +385,7 @@ public class ApiConstants {
     public static final String VIRTUAL_MACHINE_NAME = "virtualmachinename";
     public static final String VIRTUAL_MACHINE_ID_IP = "vmidipmap";
     public static final String VIRTUAL_MACHINE_COUNT = "virtualmachinecount";
+    public static final String VIRTUAL_MACHINES = "virtualmachines";
     public static final String USAGE_ID = "usageid";
     public static final String USAGE_TYPE = "usagetype";
     public static final String INCLUDE_TAGS = "includetags";

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -610,24 +610,25 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         response.setEndpoint(kubernetesCluster.getEndpoint());
         response.setNetworkId(ntwk.getUuid());
         response.setAssociatedNetworkName(ntwk.getName());
-        List<UserVmResponse> vmIds = new ArrayList<UserVmResponse>();
+        List<UserVmResponse> vmResponses = new ArrayList<UserVmResponse>();
         List<KubernetesClusterVmMapVO> vmList = kubernetesClusterVmMapDao.listByClusterId(kubernetesCluster.getId());
         ResponseView respView = ResponseView.Restricted;
         Account caller = CallContext.current().getCallingAccount();
         if (accountService.isRootAdmin(caller.getId())) {
             respView = ResponseView.Full;
         }
+        final String responseName = "virtualmachine";
         if (vmList != null && !vmList.isEmpty()) {
             for (KubernetesClusterVmMapVO vmMapVO : vmList) {
                 UserVmJoinVO userVM = userVmJoinDao.findById(vmMapVO.getVmId());
                 if (userVM != null) {
-                    UserVmResponse vmResponse = ApiDBUtils.newUserVmResponse(respView, "virtualmachine", userVM,
+                    UserVmResponse vmResponse = ApiDBUtils.newUserVmResponse(respView, responseName, userVM,
                         EnumSet.noneOf(VMDetails.class), caller);
-                    vmIds.add(vmResponse);
+                    vmResponses.add(vmResponse);
                 }
             }
         }
-        response.setVirtualMachineIds(vmIds);
+        response.setVirtualMachines(vmResponses);
         return response;
     }
 

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,8 @@ import javax.naming.ConfigurationException;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiConstants.VMDetails;
+import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.command.user.kubernetes.cluster.CreateKubernetesClusterCmd;
 import org.apache.cloudstack.api.command.user.kubernetes.cluster.DeleteKubernetesClusterCmd;
 import org.apache.cloudstack.api.command.user.kubernetes.cluster.GetKubernetesClusterConfigCmd;
@@ -49,6 +52,7 @@ import org.apache.cloudstack.api.command.user.kubernetes.cluster.UpgradeKubernet
 import org.apache.cloudstack.api.response.KubernetesClusterConfigResponse;
 import org.apache.cloudstack.api.response.KubernetesClusterResponse;
 import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.api.response.UserVmResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -61,7 +65,9 @@ import org.apache.log4j.Logger;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.NetworkOfferingJoinDao;
 import com.cloud.api.query.dao.TemplateJoinDao;
+import com.cloud.api.query.dao.UserVmJoinDao;
 import com.cloud.api.query.vo.NetworkOfferingJoinVO;
+import com.cloud.api.query.vo.UserVmJoinVO;
 import com.cloud.capacity.CapacityManager;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterDetailsVO;
@@ -144,10 +150,8 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.utils.net.NetUtils;
-import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
-import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.google.common.base.Strings;
 
@@ -194,7 +198,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
     @Inject
     protected VMInstanceDao vmInstanceDao;
     @Inject
-    protected UserVmDao userVmDao;
+    protected UserVmJoinDao userVmJoinDao;
     @Inject
     protected NetworkOfferingDao networkOfferingDao;
     @Inject
@@ -606,13 +610,20 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         response.setEndpoint(kubernetesCluster.getEndpoint());
         response.setNetworkId(ntwk.getUuid());
         response.setAssociatedNetworkName(ntwk.getName());
-        List<String> vmIds = new ArrayList<String>();
+        List<UserVmResponse> vmIds = new ArrayList<UserVmResponse>();
         List<KubernetesClusterVmMapVO> vmList = kubernetesClusterVmMapDao.listByClusterId(kubernetesCluster.getId());
+        ResponseView respView = ResponseView.Restricted;
+        Account caller = CallContext.current().getCallingAccount();
+        if (accountService.isRootAdmin(caller.getId())) {
+            respView = ResponseView.Full;
+        }
         if (vmList != null && !vmList.isEmpty()) {
             for (KubernetesClusterVmMapVO vmMapVO : vmList) {
-                UserVmVO userVM = userVmDao.findById(vmMapVO.getVmId());
+                UserVmJoinVO userVM = userVmJoinDao.findById(vmMapVO.getVmId());
                 if (userVM != null) {
-                    vmIds.add(userVM.getUuid());
+                    UserVmResponse vmResponse = ApiDBUtils.newUserVmResponse(respView, "virtualmachine", userVM,
+                        EnumSet.noneOf(VMDetails.class), caller);
+                    vmIds.add(vmResponse);
                 }
             }
         }

--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
@@ -317,11 +317,11 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
         this.serviceOfferingName = serviceOfferingName;
     }
 
-    public void setVirtualMachineIds(List<UserVmResponse> virtualMachines) {
+    public void setVirtualMachines(List<UserVmResponse> virtualMachines) {
         this.virtualMachines = virtualMachines;
     }
 
-    public List<UserVmResponse> getVirtualMachineIds() {
+    public List<UserVmResponse> getVirtualMachines() {
         return virtualMachines;
     }
 }

--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
@@ -129,9 +129,9 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
     @Param(description = "URL end point for the Kubernetes cluster dashboard UI")
     private String consoleEndpoint;
 
-    @SerializedName(ApiConstants.VIRTUAL_MACHINE_IDS)
-    @Param(description = "the list of virtualmachine IDs associated with this Kubernetes cluster")
-    private List<String> virtualMachineIds;
+    @SerializedName(ApiConstants.VIRTUAL_MACHINES)
+    @Param(description = "the list of virtualmachine associated with this Kubernetes cluster")
+    private List<UserVmResponse> virtualMachines;
 
     public KubernetesClusterResponse() {
     }
@@ -317,13 +317,11 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
         this.serviceOfferingName = serviceOfferingName;
     }
 
-    public void setVirtualMachineIds(List<String> virtualMachineIds) {
-        this.virtualMachineIds = virtualMachineIds;
+    public void setVirtualMachineIds(List<UserVmResponse> virtualMachines) {
+        this.virtualMachines = virtualMachines;
     }
 
-    ;
-
-    public List<String> getVirtualMachineIds() {
-        return virtualMachineIds;
+    public List<UserVmResponse> getVirtualMachineIds() {
+        return virtualMachines;
     }
 }

--- a/test/integration/smoke/test_kubernetes_clusters.py
+++ b/test/integration/smoke/test_kubernetes_clusters.py
@@ -749,9 +749,9 @@ class TestKubernetesCluster(cloudstackTestCase):
                         self.deleteKubernetesCluster(cluster_id)
                     else:
                         forceDeleted = True
-                        for cluster_vm_id in cluster.virtualmachineids:
+                        for cluster_vm in cluster.virtualmachines:
                             cmd = destroyVirtualMachine.destroyVirtualMachineCmd()
-                            cmd.id = cluster_vm_id
+                            cmd.id = cluster_vm.id
                             cmd.expunge = True
                             self.apiclient.destroyVirtualMachine(cmd)
                         cmd = deleteNetwork.deleteNetworkCmd()


### PR DESCRIPTION
## Description
Returning list of virtual machine nodes of a cluster rather than just their IDs. Simplifies the UI as well (Reduces API calls and checks post 4.15 release in primate for backward compatibility)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

```
(kubeadmin) 🐱 > list kubernetesclusters id=3d2d10cd-db04-4c4f-87f0-7405d45333e8 
{
  "count": 1,
  "kubernetescluster": [
    {
      .....
      "name": "cluster-1",
      "virtualmachines": [
        {
          .....
          "displayname": "cluster-1-master-1754f2cc2da",
          .....
        },
        {
         .....
          "displayname": "cluster-1-node-1754f2cd5f1",
          .....
        }
      ],
    }
  ]
}
```