### PR TITLE
FIX s2svpn connection stuck on Pending state

### DIFF
--- a/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -562,9 +562,9 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         _accountMgr.checkAccess(caller, null, false, conn);
 
         if (conn.getState() == State.Pending) {
-            throw new InvalidParameterValueException("VPN connection " + id + " cannot be reseted when state is Pending!");
+            conn.setState(State.Disconnected);
         }
-        if (conn.getState() == State.Connected || conn.getState() == State.Error) {
+        if (conn.getState() == State.Connected || conn.getState() == State.Error || conn.getState() == State.Disconnected) {
             stopVpnConnection(id);
         }
         startVpnConnection(id);


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
When we try to reset the site 2 site vpn connection while
the VR's are being restarted, the connection enters the
PENDING state and we cant reset the connection.

So change the state from PENDING to disconnected.

Steps to reproduce the issue

1.create a VPC with a tier (vpc-001-001 in vpc-001), create a vm
2.create a VPC with a tier (vpc-002-001 in vpc-002) with different cidr, create a vm
3.create custom gateway for both vpn
4.enable site-to-site vpn on both vpn, and add vpn connection to each other. both should be "Connected"
5.restart vpc-001 with cleanup and monitor it
6.when the first router is destroyed, go to site-to-site vpn page and reset vpn connection.
7.we will get an error "Resource [DataCenter:1] is unreachable: Unable to apply site 2 site VPN configuration, virtual router is not in the right state"
and vpn connection is stuck at Pending
8.When vpc is restarted, go to site-to-site vpn page and reset vpn connection.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


