### PR TITLE
Prometheus exporter enhancement

### DIFF
--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.cloud.capacity.CapacityVO;
 import com.cloud.capacity.dao.CapacityDaoImpl.SummedCapacity;
 import com.cloud.utils.Pair;
+import com.cloud.utils.Ternary;
 import com.cloud.utils.db.GenericDao;
 
 public interface CapacityDao extends GenericDao<CapacityVO, Long> {
@@ -38,6 +39,8 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
     List<SummedCapacity> findNonSharedStorageForClusterPodZone(Long zoneId, Long podId, Long clusterId);
 
     Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityType, boolean isZone);
+
+    Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag);
 
     List<SummedCapacity> findCapacityBy(Integer capacityType, Long zoneId, Long podId, Long clusterId);
 

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -437,7 +437,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             allocatedSql.append(LEFT_JOIN_VM_TEMPLATE);
         }
         allocatedSql.append(WHERE_STATE_IS_NOT_DESTRUCTIVE);
-        if (zoneId != null){
+        if (zoneId != null) {
             allocatedSql.append(" AND vi.data_center_id = ?");
         }
         if (hostTag != null && ! hostTag.isEmpty()) {
@@ -449,7 +449,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         try {
             // add allocated capacity of zone in result
             pstmt = txn.prepareAutoCloseStatement(allocatedSql.toString());
-            if (zoneId != null){
+            if (zoneId != null) {
                 pstmt.setLong(1, zoneId);
             }
             ResultSet rs = pstmt.executeQuery();

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -37,6 +37,7 @@ import com.cloud.capacity.CapacityVO;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.storage.Storage;
 import com.cloud.utils.Pair;
+import com.cloud.utils.Ternary;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.GenericSearchBuilder;
 import com.cloud.utils.db.JoinBuilder.JoinType;
@@ -198,16 +199,18 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             +
             "from op_host_capacity capacity where cluster_id = ? and capacity_type = ?;";
 
-    private static final String LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE = "SELECT v.data_center_id, SUM(cpu) AS cpucore, " +
+    private static final String LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE_PART1 = "SELECT v.data_center_id, SUM(cpu) AS cpucore, " +
                 "SUM(cpu * speed) AS cpu, SUM(ram_size * 1024 * 1024) AS memory " +
                 "FROM (SELECT vi.data_center_id, (CASE WHEN ISNULL(service_offering.cpu) THEN custom_cpu.value ELSE service_offering.cpu end) AS cpu, " +
                 "(CASE WHEN ISNULL(service_offering.speed) THEN custom_speed.value ELSE service_offering.speed end) AS speed, " +
                 "(CASE WHEN ISNULL(service_offering.ram_size) THEN custom_ram_size.value ELSE service_offering.ram_size end) AS ram_size " +
-                "FROM (((vm_instance vi LEFT JOIN service_offering ON(((vi.service_offering_id = service_offering.id))) " +
-                "LEFT JOIN user_vm_details custom_cpu ON(((custom_cpu.vm_id = vi.id) AND (custom_cpu.name = 'CpuNumber')))) " +
-                "LEFT JOIN user_vm_details custom_speed ON(((custom_speed.vm_id = vi.id) AND (custom_speed.name = 'CpuSpeed')))) " +
-                "LEFT JOIN user_vm_details custom_ram_size ON(((custom_ram_size.vm_id = vi.id) AND (custom_ram_size.name = 'memory')))) " +
-                "WHERE ISNULL(vi.removed) AND vi.state NOT IN ('Destroyed', 'Error', 'Expunging')";
+                "FROM vm_instance vi LEFT JOIN service_offering ON(((vi.service_offering_id = service_offering.id))) " +
+                "LEFT JOIN user_vm_details custom_cpu ON(((custom_cpu.vm_id = vi.id) AND (custom_cpu.name = 'CpuNumber'))) " +
+                "LEFT JOIN user_vm_details custom_speed ON(((custom_speed.vm_id = vi.id) AND (custom_speed.name = 'CpuSpeed'))) " +
+                "LEFT JOIN user_vm_details custom_ram_size ON(((custom_ram_size.vm_id = vi.id) AND (custom_ram_size.name = 'memory'))) ";
+
+    private static final String LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE_PART2 =
+            "WHERE ISNULL(vi.removed) AND vi.state NOT IN ('Destroyed', 'Error', 'Expunging')";
 
     public CapacityDaoImpl() {
         _hostIdTypeSearch = createSearchBuilder();
@@ -423,13 +426,49 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
+    public Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        PreparedStatement pstmt = null;
+        List<SummedCapacity> results = new ArrayList<SummedCapacity>();
+
+        StringBuilder allocatedSql = new StringBuilder(LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE_PART1);
+        if (hostTag != null && ! hostTag.isEmpty()) {
+            allocatedSql.append("LEFT JOIN vm_template ON vm_template.id = vi.vm_template_id ");
+        }
+        allocatedSql.append(LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE_PART2);
+        if (zoneId != null){
+            allocatedSql.append(" AND vi.data_center_id = ?");
+        }
+        if (hostTag != null && ! hostTag.isEmpty()) {
+            allocatedSql.append(" AND (vm_template.template_tag = '").append(hostTag).append("'");
+            allocatedSql.append(" OR service_offering.host_tag = '").append(hostTag).append("')");
+        }
+        allocatedSql.append(" ) AS v GROUP BY v.data_center_id");
+        try {
+            // add allocated capacity of zone in result
+            pstmt = txn.prepareAutoCloseStatement(allocatedSql.toString());
+            if (zoneId != null){
+                pstmt.setLong(1, zoneId);
+            }
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                return new Ternary(rs.getLong(2), rs.getLong(3), rs.getLong(4)); // cpu cores, cpu, memory
+            }
+            return new Ternary(0L, 0L, 0L);
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("DB Exception on: " + allocatedSql, e);
+        }
+    }
+
+    @Override
     public List<SummedCapacity> findCapacityBy(Integer capacityType, Long zoneId, Long podId, Long clusterId) {
 
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<SummedCapacity> results = new ArrayList<SummedCapacity>();
 
-        StringBuilder allocatedSql = new StringBuilder(LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE);
+        StringBuilder allocatedSql = new StringBuilder(LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE_PART1);
+        allocatedSql.append(LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE_PART2);
 
         HashMap<Long, Long> sumCpuCore  = new HashMap<Long, Long>();
         HashMap<Long, Long> sumCpu = new HashMap<Long, Long>();

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.apache.log4j.Logger;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
@@ -433,14 +434,14 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         PreparedStatement pstmt;
 
         StringBuilder allocatedSql = new StringBuilder(LIST_ALLOCATED_CAPACITY_GROUP_BY_CAPACITY_AND_ZONE);
-        if (hostTag != null && ! hostTag.isEmpty()) {
+        if (StringUtils.isNotEmpty(hostTag)) {
             allocatedSql.append(LEFT_JOIN_VM_TEMPLATE);
         }
         allocatedSql.append(WHERE_STATE_IS_NOT_DESTRUCTIVE);
         if (zoneId != null) {
             allocatedSql.append(" AND vi.data_center_id = ?");
         }
-        if (hostTag != null && ! hostTag.isEmpty()) {
+        if (StringUtils.isNotEmpty(hostTag)) {
             allocatedSql.append(" AND (vm_template.template_tag = '").append(hostTag).append("'");
             allocatedSql.append(" OR service_offering.host_tag = '").append(hostTag).append("')");
         }

--- a/engine/schema/src/main/java/com/cloud/user/dao/AccountDao.java
+++ b/engine/schema/src/main/java/com/cloud/user/dao/AccountDao.java
@@ -78,4 +78,5 @@ public interface AccountDao extends GenericDao<AccountVO, Long> {
      */
     long getDomainIdForGivenAccountId(long id);
 
+    int getActiveDomains();
 }

--- a/engine/schema/src/main/java/com/cloud/user/dao/AccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/user/dao/AccountDaoImpl.java
@@ -28,6 +28,7 @@ import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.GenericSearchBuilder;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.db.SearchCriteria.Func;
 import com.cloud.utils.db.SearchCriteria.Op;
 import org.apache.commons.lang3.StringUtils;
 import com.cloud.utils.db.TransactionLegacy;
@@ -54,6 +55,7 @@ public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements A
     protected final SearchBuilder<AccountVO> NonProjectAccountSearch;
     protected final SearchBuilder<AccountVO> AccountByRoleSearch;
     protected final GenericSearchBuilder<AccountVO, Long> AccountIdsSearch;
+    protected final GenericSearchBuilder<AccountVO, Long> ActiveDomainCount;
 
     public AccountDaoImpl() {
         AllFieldsSearch = createSearchBuilder();
@@ -101,6 +103,13 @@ public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements A
         AccountByRoleSearch = createSearchBuilder();
         AccountByRoleSearch.and("roleId", AccountByRoleSearch.entity().getRoleId(), SearchCriteria.Op.EQ);
         AccountByRoleSearch.done();
+
+        ActiveDomainCount = createSearchBuilder(Long.class);
+        ActiveDomainCount.select(null, Func.COUNT, null);
+        ActiveDomainCount.and("domain", ActiveDomainCount.entity().getDomainId(), SearchCriteria.Op.EQ);
+        ActiveDomainCount.and("state", ActiveDomainCount.entity().getState(), SearchCriteria.Op.EQ);
+        ActiveDomainCount.groupBy(ActiveDomainCount.entity().getDomainId());
+        ActiveDomainCount.done();
     }
 
     @Override
@@ -318,5 +327,10 @@ public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements A
         }
     }
 
-
+    @Override
+    public int getActiveDomains() {
+        SearchCriteria<Long> sc = ActiveDomainCount.create();
+        sc.setParameters("state", "enabled");
+        return customSearch(sc, null).size();
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDao.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.cloud.utils.Pair;
+import com.cloud.utils.Ternary;
 import com.cloud.utils.db.GenericDao;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VirtualMachine;
@@ -92,4 +93,8 @@ public interface UserVmDao extends GenericDao<UserVmVO, Long> {
     List<UserVmVO> listByIsoId(Long isoId);
 
     List<Pair<Pair<String, VirtualMachine.Type>, Pair<Long, String>>> getVmsDetailByNames(Set<String> vmNames, String detail);
+
+    List<Ternary<Integer, Integer, Integer>> countVmsBySize(long dcId, int limit);
+
+    int getActiveAccounts(final long dcId);
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDaoImpl.java
@@ -749,7 +749,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                 result.add(new Ternary<Integer, Integer, Integer>(rs.getInt(1), rs.getInt(2), rs.getInt(3)));
             }
         } catch (Exception e) {
-            s_logger.warn("Error counting vms by size", e);
+            s_logger.warn("Error counting vms by size for dcId= " + dcId, e);
         }
         return result;
     }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDaoImpl.java
@@ -40,6 +40,7 @@ import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.tags.dao.ResourceTagDao;
 import com.cloud.user.Account;
 import com.cloud.utils.Pair;
+import com.cloud.utils.Ternary;
 import com.cloud.utils.db.Attribute;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.GenericSearchBuilder;
@@ -75,6 +76,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
     protected SearchBuilder<UserVmVO> AccountDataCenterVirtualSearch;
     protected GenericSearchBuilder<UserVmVO, Long> CountByAccountPod;
     protected GenericSearchBuilder<UserVmVO, Long> CountByAccount;
+    protected GenericSearchBuilder<UserVmVO, Long> CountActiveAccount;
     protected GenericSearchBuilder<UserVmVO, Long> PodsHavingVmsForAccount;
 
     protected SearchBuilder<UserVmVO> UserVmSearch;
@@ -191,6 +193,15 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
         CountByAccount.and("state", CountByAccount.entity().getState(), SearchCriteria.Op.NIN);
         CountByAccount.and("displayVm", CountByAccount.entity().isDisplayVm(), SearchCriteria.Op.EQ);
         CountByAccount.done();
+
+        CountActiveAccount = createSearchBuilder(Long.class);
+        CountActiveAccount.select(null, Func.COUNT, null);
+        CountActiveAccount.and("account", CountActiveAccount.entity().getAccountId(), SearchCriteria.Op.EQ);
+        CountActiveAccount.and("type", CountActiveAccount.entity().getType(), SearchCriteria.Op.EQ);
+        CountActiveAccount.and("dataCenterId", CountActiveAccount.entity().getDataCenterId(), SearchCriteria.Op.EQ);
+        CountActiveAccount.and("state", CountActiveAccount.entity().getState(), SearchCriteria.Op.NIN);
+        CountActiveAccount.groupBy(CountActiveAccount.entity().getAccountId());
+        CountActiveAccount.done();
 
         SearchBuilder<NicVO> nicSearch = _nicDao.createSearchBuilder();
         nicSearch.and("networkId", nicSearch.entity().getNetworkId(), SearchCriteria.Op.EQ);
@@ -720,5 +731,36 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
         }
 
         return vmsDetailByNames;
+    }
+
+    @Override
+    public List<Ternary<Integer, Integer, Integer>> countVmsBySize(long dcId, int limit) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        String sql = "SELECT cpu,ram_size,count(1) AS count FROM (SELECT * FROM user_vm_view WHERE data_center_id = ? AND state NOT IN ('Destroyed', 'Error', 'Expunging') GROUP BY id) AS uvv GROUP BY cpu,ram_size ORDER BY count DESC ";
+        if (limit >= 0)
+            sql = sql + "limit " + limit;
+        PreparedStatement pstmt = null;
+        List<Ternary<Integer, Integer, Integer>> result = new ArrayList<>();
+        try {
+            pstmt = txn.prepareAutoCloseStatement(sql);
+            pstmt.setLong(1, dcId);
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) {
+                result.add(new Ternary<Integer, Integer, Integer>(rs.getInt(1), rs.getInt(2), rs.getInt(3)));
+            }
+        } catch (Exception e) {
+            s_logger.warn("Error counting vms by size", e);
+        }
+        return result;
+    }
+
+    @Override
+    public int getActiveAccounts(final long dcId) {
+        SearchCriteria<Long> sc = CountActiveAccount.create();
+        sc.setParameters("type", VirtualMachine.Type.User);
+        sc.setParameters("state", State.Destroyed, State.Error, State.Expunging, State.Stopped);
+        sc.setParameters("dataCenterId", dcId);
+
+        return customSearch(sc, null).size();
     }
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -133,6 +133,8 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
 
     Long countByZoneAndState(long zoneId, State state);
 
+    Long countByZoneAndStateAndHostTag(long dcId, State state, String hostTag);
+
     List<VMInstanceVO> listNonRemovedVmsByTypeAndNetwork(long networkId, VirtualMachine.Type... types);
 
     /**

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -823,7 +823,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
                 return rs.getLong(1);
             }
         } catch (Exception e) {
-            s_logger.warn("Error counting vms by host tag", e);
+            s_logger.warn(String.format("Error counting vms by host tag for dcId= %s, hostTag= %s", dcId, hostTag), e);
         }
         return 0L;
     }

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -121,9 +121,9 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         int total = 0;
         int up = 0;
         int down = 0;
-        Map<String, Integer> total_hosts = new HashMap<>();
-        Map<String, Integer> up_hosts = new HashMap<>();
-        Map<String, Integer> down_hosts = new HashMap<>();
+        Map<String, Integer> totalHosts = new HashMap<>();
+        Map<String, Integer> upHosts = new HashMap<>();
+        Map<String, Integer> downHosts = new HashMap<>();
 
         for (final HostVO host : hostDao.listAll()) {
             if (host == null || host.getType() != Host.Type.Routing || host.getDataCenterId() != dcId) {
@@ -144,18 +144,18 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             List<String> hostTags = _hostTagsDao.gethostTags(host.getId());
             String hosttags = StringUtils.join(hostTags, ",");
             for (String tag : hostTags) {
-                Integer current = total_hosts.get(tag) != null ? total_hosts.get(tag) : 0;
-                total_hosts.put(tag, current + 1);
+                Integer current = totalHosts.get(tag) != null ? totalHosts.get(tag) : 0;
+                totalHosts.put(tag, current + 1);
             }
             if (host.getStatus() == Status.Up) {
                 for (String tag : hostTags) {
-                    Integer current = up_hosts.get(tag) != null ? up_hosts.get(tag) : 0;
-                    up_hosts.put(tag, current + 1);
+                    Integer current = upHosts.get(tag) != null ? upHosts.get(tag) : 0;
+                    upHosts.put(tag, current + 1);
                 }
             } else if (host.getStatus() == Status.Disconnected || host.getStatus() == Status.Down) {
                 for (String tag : hostTags) {
-                    Integer current = down_hosts.get(tag) != null ? down_hosts.get(tag) : 0;
-                    down_hosts.put(tag, current + 1);
+                    Integer current = downHosts.get(tag) != null ? downHosts.get(tag) : 0;
+                    downHosts.put(tag, current + 1);
                 }
             }
 
@@ -219,22 +219,22 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         metricsList.add(new ItemHost(zoneName, zoneUuid, ONLINE, up, null));
         metricsList.add(new ItemHost(zoneName, zoneUuid, OFFLINE, down, null));
         metricsList.add(new ItemHost(zoneName, zoneUuid, TOTAL, total, null));
-        for (Map.Entry<String, Integer> entry : total_hosts.entrySet()) {
+        for (Map.Entry<String, Integer> entry : totalHosts.entrySet()) {
             String tag = entry.getKey();
             Integer count = entry.getValue();
             metricsList.add(new ItemHost(zoneName, zoneUuid, TOTAL, count, tag));
-            if (up_hosts.get(tag) != null) {
-                metricsList.add(new ItemHost(zoneName, zoneUuid, ONLINE, up_hosts.get(tag), tag));
+            if (upHosts.get(tag) != null) {
+                metricsList.add(new ItemHost(zoneName, zoneUuid, ONLINE, upHosts.get(tag), tag));
             } else {
                 metricsList.add(new ItemHost(zoneName, zoneUuid, ONLINE, 0, tag));
             }
-            if (down_hosts.get(tag) != null) {
-                metricsList.add(new ItemHost(zoneName, zoneUuid, OFFLINE, down_hosts.get(tag), tag));
+            if (downHosts.get(tag) != null) {
+                metricsList.add(new ItemHost(zoneName, zoneUuid, OFFLINE, downHosts.get(tag), tag));
             } else {
                 metricsList.add(new ItemHost(zoneName, zoneUuid, OFFLINE, 0, tag));
             }
         }
-        for (Map.Entry<String, Integer> entry : total_hosts.entrySet()) {
+        for (Map.Entry<String, Integer> entry : totalHosts.entrySet()) {
             String tag = entry.getKey();
             Ternary<Long, Long, Long> allocatedCapacityByTag = capacityDao.findCapacityByZoneAndHostTag(dcId, tag);
             metricsList.add(new ItemVMCore(zoneName, zoneUuid, null, null, null, ALLOCATED, allocatedCapacityByTag.first(), 0, tag));

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -251,10 +252,12 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             }
             metricsList.add(new ItemVM(zoneName, zoneUuid, state.name().toLowerCase(), count));
         }
-        List<String> allHostTags = new ArrayList<String>();
-        for (final HostVO host : hostDao.listAll()) {
-            allHostTags.addAll(_hostTagsDao.gethostTags(host.getId()));
-        }
+
+        List<String> allHostTags = hostDao.listAll().stream()
+                .flatMap( h -> _hostTagsDao.gethostTags(h.getId()).stream())
+                .distinct()
+                .collect(Collectors.toList());
+
         for (final State state : State.values()) {
             for (final String hosttag : allHostTags) {
                 final Long count = vmDao.countByZoneAndStateAndHostTag(dcId, state, hosttag);

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -142,7 +142,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             int isDedicated = (dr != null) ? 1 : 0;
             metricsList.add(new ItemHostIsDedicated(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), isDedicated));
 
-            List<String> hostTags = _hostTagsDao.gethostTags(host.getId());
+            List<String> hostTags = _hostTagsDao.getHostTags(host.getId());
             String hosttags = StringUtils.join(hostTags, ",");
             for (String tag : hostTags) {
                 Integer current = totalHosts.get(tag) != null ? totalHosts.get(tag) : 0;
@@ -254,7 +254,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         }
 
         List<String> allHostTags = hostDao.listAll().stream()
-                .flatMap( h -> _hostTagsDao.gethostTags(h.getId()).stream())
+                .flatMap( h -> _hostTagsDao.getHostTags(h.getId()).stream())
                 .distinct()
                 .collect(Collectors.toList());
 

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -61,6 +61,7 @@ import com.cloud.storage.StorageStats;
 import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
+import com.cloud.utils.StringUtils;
 import com.cloud.utils.component.Manager;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.vm.VirtualMachine.State;
@@ -141,6 +142,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             metricsList.add(new ItemHostIsDedicated(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), isDedicated));
 
             List<String> hostTags = _hostTagsDao.gethostTags(host.getId());
+            String hosttags = StringUtils.join(hostTags, ",");
             for (String tag : hostTags) {
                 Integer current = total_hosts.get(tag) != null ? total_hosts.get(tag) : 0;
                 total_hosts.put(tag, current + 1);
@@ -170,48 +172,48 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             final String cpuFactor = String.valueOf(CapacityManager.CpuOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO cpuCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU);
             if (cpuCapacity != null) {
-                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, cpuCapacity.getUsedCapacity()));
-                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, cpuCapacity.getTotalCapacity()));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, cpuCapacity.getUsedCapacity(), hosttags));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, cpuCapacity.getTotalCapacity(), hosttags));
             } else {
-                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, 0L));
-                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, 0L));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, 0L, hosttags));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, 0L, hosttags));
             }
 
             final String memoryFactor = String.valueOf(CapacityManager.MemOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO memCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_MEMORY);
             if (memCapacity != null) {
-                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, memCapacity.getUsedCapacity(), isDedicated));
-                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, memCapacity.getTotalCapacity(), isDedicated));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, memCapacity.getUsedCapacity(), isDedicated, hosttags));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, memCapacity.getTotalCapacity(), isDedicated, hosttags));
             } else {
-                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, 0L, isDedicated));
-                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, 0L, isDedicated));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, 0L, isDedicated, hosttags));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, 0L, isDedicated, hosttags));
             }
 
             metricsList.add(new ItemHostVM(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), vmDao.listByHostId(host.getId()).size()));
 
             final CapacityVO coreCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU_CORE);
             if (coreCapacity != null) {
-                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), USED, coreCapacity.getUsedCapacity(), isDedicated));
-                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), TOTAL, coreCapacity.getTotalCapacity(), isDedicated));
+                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), USED, coreCapacity.getUsedCapacity(), isDedicated, hosttags));
+                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), TOTAL, coreCapacity.getTotalCapacity(), isDedicated, hosttags));
             } else {
-                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), USED, 0L, isDedicated));
-                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), TOTAL, 0L, isDedicated));
+                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), USED, 0L, isDedicated, hosttags));
+                metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), TOTAL, 0L, isDedicated, hosttags));
             }
         }
 
         final List<CapacityDaoImpl.SummedCapacity> cpuCapacity = capacityDao.findCapacityBy((int) Capacity.CAPACITY_TYPE_CPU, dcId, null, null);
         if (cpuCapacity != null && cpuCapacity.size() > 0) {
-            metricsList.add(new ItemHostCpu(zoneName, zoneUuid, null, null, null, null, ALLOCATED, cpuCapacity.get(0).getAllocatedCapacity() != null ? cpuCapacity.get(0).getAllocatedCapacity() : 0));
+            metricsList.add(new ItemHostCpu(zoneName, zoneUuid, null, null, null, null, ALLOCATED, cpuCapacity.get(0).getAllocatedCapacity() != null ? cpuCapacity.get(0).getAllocatedCapacity() : 0, ""));
         }
 
         final List<CapacityDaoImpl.SummedCapacity> memCapacity = capacityDao.findCapacityBy((int) Capacity.CAPACITY_TYPE_MEMORY, dcId, null, null);
         if (memCapacity != null && memCapacity.size() > 0) {
-            metricsList.add(new ItemHostMemory(zoneName, zoneUuid, null, null, null, null, ALLOCATED, memCapacity.get(0).getAllocatedCapacity() != null ? memCapacity.get(0).getAllocatedCapacity() : 0, 0));
+            metricsList.add(new ItemHostMemory(zoneName, zoneUuid, null, null, null, null, ALLOCATED, memCapacity.get(0).getAllocatedCapacity() != null ? memCapacity.get(0).getAllocatedCapacity() : 0, 0, ""));
         }
 
         final List<CapacityDaoImpl.SummedCapacity> coreCapacity = capacityDao.findCapacityBy((int) Capacity.CAPACITY_TYPE_CPU_CORE, dcId, null, null);
         if (coreCapacity != null && coreCapacity.size() > 0) {
-            metricsList.add(new ItemVMCore(zoneName, zoneUuid, null, null, null, ALLOCATED, coreCapacity.get(0).getAllocatedCapacity() != null ? coreCapacity.get(0).getAllocatedCapacity() : 0, 0));
+            metricsList.add(new ItemVMCore(zoneName, zoneUuid, null, null, null, ALLOCATED, coreCapacity.get(0).getAllocatedCapacity() != null ? coreCapacity.get(0).getAllocatedCapacity() : 0, 0, ""));
         }
 
         metricsList.add(new ItemHost(zoneName, zoneUuid, ONLINE, up, null));
@@ -525,8 +527,9 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         String filter;
         long core = 0;
         int isDedicated;
+        String hosttags;
 
-        public ItemVMCore(final String zn, final String zu, final String hn, final String hu, final String hip, final String fl, final Long cr, final int dedicated) {
+        public ItemVMCore(final String zn, final String zu, final String hn, final String hu, final String hip, final String fl, final Long cr, final int dedicated, final String tags) {
             super("cloudstack_host_vms_cores_total");
             zoneName = zn;
             zoneUuid = zu;
@@ -538,6 +541,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
                 core = cr;
             }
             isDedicated = dedicated;
+            hosttags = tags;
         }
 
         @Override
@@ -545,7 +549,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             if (StringUtils.isAllEmpty(hostName, ip)) {
                 return String.format("%s{zone=\"%s\",filter=\"%s\"} %d", name, zoneName, filter, core);
             }
-            return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\",filter=\"%s\",dedicated=\"%d\"} %d", name, zoneName, hostName, ip, filter, isDedicated, core);
+            return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\",filter=\"%s\",dedicated=\"%d\",tags=\"%s\"} %d", name, zoneName, hostName, ip, filter, isDedicated, hosttags, core);
         }
     }
 
@@ -558,8 +562,9 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         String overProvisioningFactor;
         String filter;
         double mhertz;
+        String hosttags;
 
-        public ItemHostCpu(final String zn, final String zu, final String hn, final String hu, final String hip, final String of, final String fl, final double mh) {
+        public ItemHostCpu(final String zn, final String zu, final String hn, final String hu, final String hip, final String of, final String fl, final double mh, final String tags) {
             super("cloudstack_host_cpu_usage_mhz_total");
             zoneName = zn;
             zoneUuid = zu;
@@ -569,6 +574,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             overProvisioningFactor = of;
             filter = fl;
             mhertz = mh;
+            hosttags = tags;
         }
 
         @Override
@@ -576,7 +582,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             if (StringUtils.isAllEmpty(hostName, ip)) {
                 return String.format("%s{zone=\"%s\",filter=\"%s\"} %.2f", name, zoneName, filter, mhertz);
             }
-            return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\",overprovisioningfactor=\"%s\",filter=\"%s\"} %.2f", name, zoneName, hostName, ip, overProvisioningFactor, filter, mhertz);
+            return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\",overprovisioningfactor=\"%s\",filter=\"%s\",tags=\"%s\"} %.2f", name, zoneName, hostName, ip, overProvisioningFactor, filter, hosttags, mhertz);
         }
     }
 
@@ -590,8 +596,9 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         String filter;
         double miBytes;
         int isDedicated;
+        String hosttags;
 
-        public ItemHostMemory(final String zn, final String zu, final String hn, final String hu, final String hip, final String of, final String fl, final double membytes, final int dedicated) {
+        public ItemHostMemory(final String zn, final String zu, final String hn, final String hu, final String hip, final String of, final String fl, final double membytes, final int dedicated, final String tags) {
             super("cloudstack_host_memory_usage_mibs_total");
             zoneName = zn;
             zoneUuid = zu;
@@ -602,6 +609,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             filter = fl;
             miBytes = membytes / (1024.0 * 1024.0);
             isDedicated = dedicated;
+            hosttags = tags;
         }
 
         @Override
@@ -609,7 +617,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             if (StringUtils.isAllEmpty(hostName, ip)) {
                 return String.format("%s{zone=\"%s\",filter=\"%s\"} %.2f", name, zoneName, filter, miBytes);
             }
-            return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\",overprovisioningfactor=\"%s\",filter=\"%s\",dedicated=\"%d\"} %.2f", name, zoneName, hostName, ip, overProvisioningFactor, filter, isDedicated, miBytes);
+            return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\",overprovisioningfactor=\"%s\",filter=\"%s\",dedicated=\"%d\",tags=\"%s\"} %.2f", name, zoneName, hostName, ip, overProvisioningFactor, filter, isDedicated, hosttags, miBytes);
         }
     }
 

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -60,7 +60,7 @@ import com.cloud.storage.StorageStats;
 import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
-import com.cloud.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.component.Manager;
 import com.cloud.utils.component.ManagerBase;
@@ -536,7 +536,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
 
         @Override
         public String toMetricsString() {
-            if (! Strings.isNullOrEmpty(hosttags)) {
+            if (StringUtils.isNotEmpty(hosttags)) {
                 name = "cloudstack_hosts_total_by_tag";
                 return String.format("%s{zone=\"%s\",filter=\"%s\",tags=\"%s\"} %d", name, zoneName, state, hosttags, total);
             }
@@ -573,7 +573,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         @Override
         public String toMetricsString() {
             if (StringUtils.isAllEmpty(hostName, ip)) {
-                if (Strings.isNullOrEmpty(hosttags)) {
+                if (StringUtils.isEmpty(hosttags)) {
                     return String.format("%s{zone=\"%s\",filter=\"%s\"} %d", name, zoneName, filter, core);
                 } else {
                     name = "cloudstack_host_vms_cores_total_by_tag";
@@ -613,7 +613,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         @Override
         public String toMetricsString() {
             if (StringUtils.isAllEmpty(hostName, ip)) {
-                if (Strings.isNullOrEmpty(hosttags)) {
+                if (StringUtils.isEmpty(hosttags)) {
                     return String.format("%s{zone=\"%s\",filter=\"%s\"} %.2f", name, zoneName, filter, mhertz);
                 } else {
                     name = "cloudstack_host_cpu_usage_mhz_total_by_tag";
@@ -653,7 +653,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         @Override
         public String toMetricsString() {
             if (StringUtils.isAllEmpty(hostName, ip)) {
-                if (Strings.isNullOrEmpty(hosttags)) {
+                if (StringUtils.isEmpty(hosttags)) {
                     return String.format("%s{zone=\"%s\",filter=\"%s\"} %.2f", name, zoneName, filter, miBytes);
                 } else {
                     name = "cloudstack_host_memory_usage_mibs_total_by_tag";

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -36,7 +36,6 @@ import org.apache.log4j.Logger;
 import com.cloud.alert.AlertManager;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.DomainJoinDao;
-import com.cloud.api.query.dao.HostJoinDao;
 import com.cloud.api.query.dao.StoragePoolJoinDao;
 import com.cloud.api.query.vo.DomainJoinVO;
 import com.cloud.api.query.vo.StoragePoolJoinVO;
@@ -54,6 +53,7 @@ import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
 import com.cloud.host.dao.HostDao;
+import com.cloud.host.dao.HostTagsDao;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.storage.ImageStore;
 import com.cloud.storage.StorageStats;
@@ -84,8 +84,6 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     private DataCenterDao dcDao;
     @Inject
     private HostDao hostDao;
-    @Inject
-    private HostJoinDao hostJoinDao;
     @Inject
     private VMInstanceDao vmDao;
     @Inject

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServer.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServer.java
@@ -30,4 +30,7 @@ public interface PrometheusExporterServer extends Manager {
 
     ConfigKey<String> PrometheusExporterAllowedAddresses = new ConfigKey<>("Advanced", String.class, "prometheus.exporter.allowed.ips", "127.0.0.1",
             "List of comma separated prometheus server ips (with no spaces) that should be allowed to access the URLs", true);
+
+    ConfigKey<Integer> PrometheusExporterOfferingCountLimit = new ConfigKey<>("Advanced", Integer.class, "prometheus.exporter.offering.output.limit", "-1",
+            "Limit the number of output for cloudstack_vms_total_by_size to the provided value. -1 for unlimited output.", true);
 }

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
@@ -112,7 +112,8 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
         return new ConfigKey<?>[] {
                 EnablePrometheusExporter,
                 PrometheusExporterServerPort,
-                PrometheusExporterAllowedAddresses
+                PrometheusExporterAllowedAddresses,
+                PrometheusExporterOfferingCountLimit
         };
     }
 }

--- a/systemvm/debian/root/version
+++ b/systemvm/debian/root/version
@@ -1,1 +1,0 @@
-prometheus-exporter-enhancement-20211213T174523

--- a/systemvm/debian/root/version
+++ b/systemvm/debian/root/version
@@ -1,0 +1,1 @@
+prometheus-exporter-enhancement-20211213T174523


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

In this pull request, I added new functionality to Cloudstack prometheus exporter. To see the differences please check the testing section.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This pull request contains seven commits. Except for the dfb35e5224 commit, they are all added new functionality to the Prometheus. In the subsequent sections, I will describe every commit functionality. I tested them in my test environment with three management servers, one DB node (MySQL), and two KVM hypervisor.

### 1. Export count of total/up/down hosts by tags 0dbe9e78a3660bef73451c6d56f4826509833f2b

1. Enable Prometheus.
2. Add tag to the host.
3. Run `curl http://127.0.0.1:9595/metrics | grep cloudstack_hosts_total`

Output Before Changes:
```
cloudstack_hosts_total{zone="mgt122-60",filter="online"} 2
cloudstack_hosts_total{zone="mgt122-60",filter="offline"} 0
cloudstack_hosts_total{zone="mgt122-60",filter="total"} 2
```

Output After Changes:
```
cloudstack_hosts_total{zone="mgt122-60",filter="online"} 2
cloudstack_hosts_total{zone="mgt122-60",filter="offline"} 0
cloudstack_hosts_total{zone="mgt122-60",filter="total"} 2
cloudstack_hosts_total{zone="mgt122-60",filter="total",tags="tage1"} 1
cloudstack_hosts_total{zone="mgt122-60",filter="online",tags="tage1"} 1
cloudstack_hosts_total{zone="mgt122-60",filter="offline",tags="tage1"} 0 
```
### 2. Export count of vms by state and host tag e6a81d16d9f11db6bb4fd2b0ab38194961ce516b

1. Enable Prometheus.
2. Add tag to the host.
3. Run `curl http://127.0.0.1:9595/metrics | grep cloudstack_vms_total_by_tag`

After changes, the following line added to the Prometheus output:
```
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="starting",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="running",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="stopping",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="stopped",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="destroyed",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="expunging",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="migrating",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="error",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="unknown",tags="tage1"} 0
cloudstack_vms_total_by_tag{zone="mgt122-60",filter="shutdown",tags="tage1"} 0
```

### 3. Add host tags to host cpu/cores/memory usage in Prometheus exporter eefd9f197352653f74aff73ccfffc4dd86d56b0d

1. Enable Prometheus.
2. Add tag to the host.
3. Run following command and justify output with the expected results. `curl http://127.0.0.1:9595/metrics | grep cloudstack_host_vms_cores_total`
4. repeat step three for `cloudstack_host_cpu_usage_mhz_total` and `cloudstack_host_memory_usage_mibs_total`

Output Before Changes:
```
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="used",dedicated="0"} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="total",dedicated="0"} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="used",dedicated="0"} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="total",dedicated="0"} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",filter="allocated"} 4
cloudstack_host_vms_cores_total_by_tag\{zone="mgt122-60",filter="allocated",tags="tage1"} 0
```

Output After Changes:
```
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="used",dedicated="0",tags="tage1"} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="total",dedicated="0",tags="tage1"} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="used",dedicated="0",tags=""} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="total",dedicated="0",tags=""} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",filter="allocated"} 4 
```

### 4. Cloudstack Prometheus exporter: Add allocated capacity group by host tag. a489e3c6b269279df5fbff32a708d9ed0296a40e

1. Enable Prometheus.
2. Add tag to the host.
3. Run `curl http://127.0.0.1:9595/metrics | grep cloudstack_host_vms_cores_total`

Output Before Changes:
```
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="used",dedicated="0"} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="total",dedicated="0"} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="used",dedicated="0"} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="total",dedicated="0"} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",filter="allocated"} 4
cloudstack_host_vms_cores_total_by_tag\{zone="mgt122-60",filter="allocated",tags="tage1"} 0
```

Output After Changes:
```
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="used",dedicated="0",tags="tage1"} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node75",ip="10.135.122.75",filter="total",dedicated="0",tags="tage1"} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="used",dedicated="0",tags=""} 2
cloudstack_host_vms_cores_total\{zone="mgt122-60",hostname="node74",ip="10.135.122.74",filter="total",dedicated="0",tags=""} 4
cloudstack_host_vms_cores_total\{zone="mgt122-60",filter="allocated"} 4
cloudstack_host_vms_cores_total_by_tag\{zone="mgt122-60",filter="allocated",tags="tage1"} 0
```

### 5. Show count of Active domains on grafana de08479da13b7b3f3eb467fc3798c6734f0e6fb7

============== Scenario One ==============
1. Enable Prometheus.
2. Run `curl http://127.0.0.1:9595/metrics | grep cloudstack_active_domains_total`. Output is:
```
cloudstack_active_domains_total{zone="mgt122-60"} 1
```
3. Create a new domain
4. Repeat step two. The output will not change.
5. Add a new account to the domain created in step three.
6. Repeat step two. The output will change to:
```
cloudstack_active_domains_total{zone="mgt122-60"} 2
```
============== Scenario Two ==============
1. Use previous environment
2. Disable all account in domain created in step 3 of Scenario one.
3. Repeat step two of Scenario one. The output will change to:
``` 
cloudstack_active_domains_total{zone="mgt122-60"} 1
```

### 6. Show count of Active accounts and vms by size on grafana d7aa19f0f850dfd5eea5c4f51a6529d39c2daf88
============== Scenario One ==============
1. Enable Prometheus.
2. Run `curl http://127.0.0.1:9595/metrics | grep cloudstack_active_accounts_total`. output is:
```
cloudstack_active_accounts_total{zone="mgt122-60"} 1
```
3. Create a new account
4. Repeat step two. The output will change to:
```
cloudstack_active_accounts_total\{zone="mgt122-60"} 2
```
============== Scenario Two ==============
1. Enable Prometheus.
2. Run `curl http://127.0.0.1:9595/metrics | grep cloudstack_vms_total_by_size`. output is:
```
cloudstack_vms_total_by_size\{zone="mgt122-60",cpu="1",memory="512"} 2
```
3. Add new instance with different offering
4. Repeat step two. The output will change to:
```
cloudstack_vms_total_by_size{zone="mgt122-60",cpu="1",memory="512"} 2
cloudstack_vms_total_by_size\{zone="mgt122-60",cpu="1",memory="1024"} 1
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
