### PR TITLE
Preventing port 53 being added as lb rule when dns service is availab…

### DIFF
--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -29,6 +29,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.cloud.offerings.NetworkOfferingServiceMapVO;
+import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.command.user.loadbalancer.CreateLBHealthCheckPolicyCmd;
 import org.apache.cloudstack.api.command.user.loadbalancer.CreateLBStickinessPolicyCmd;
@@ -208,6 +210,8 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
     FirewallManager _firewallMgr;
     @Inject
     NetworkDao _networkDao;
+    @Inject
+    NetworkOfferingServiceMapDao _networkOfferingServiceDao;
     @Inject
     FirewallRulesDao _firewallDao;
     @Inject
@@ -1598,65 +1602,73 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         // LoadBalancer result = _elbMgr.handleCreateLoadBalancerRule(lb,
         // lbOwner, lb.getNetworkId());
         LoadBalancer result = null;
-        if (result == null) {
-            IpAddress systemIp = null;
-            NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
-            if (off.isElasticLb() && ipVO == null && network.getVpcId() == null) {
-                systemIp = _ipAddrMgr.assignSystemIp(networkId, lbOwner, true, false);
-                if (systemIp != null) {
-                    ipVO = _ipAddressDao.findById(systemIp.getId());
+        IpAddress systemIp = null;
+        NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
+
+        if (srcPortStart == 53 && ipVO.isSourceNat()) {
+            List<NetworkOfferingServiceMapVO> offeringServices = _networkOfferingServiceDao.listByNetworkOfferingId(network.getNetworkOfferingId());
+            for (NetworkOfferingServiceMapVO serviceMapVo: offeringServices) {
+                if (serviceMapVo.getService().equals(Service.Dns.getName())) {
+                    throw new InvalidParameterValueException("Error adding load balancer rule, cannot add port 53 with network service offering having DNS service and Source NAT.");
                 }
             }
+        }
 
-            // Validate ip address
-            if (ipVO == null) {
-                throw new InvalidParameterValueException("Unable to create load balance rule; can't find/allocate source IP");
-            } else if (ipVO.isOneToOneNat()) {
-                throw new NetworkRuleConflictException("Can't do load balance on ip address: " + ipVO.getAddress());
+        if (off.isElasticLb() && ipVO == null && network.getVpcId() == null) {
+            systemIp = _ipAddrMgr.assignSystemIp(networkId, lbOwner, true, false);
+            if (systemIp != null) {
+                ipVO = _ipAddressDao.findById(systemIp.getId());
+            }
+        }
+
+        // Validate ip address
+        if (ipVO == null) {
+            throw new InvalidParameterValueException("Unable to create load balance rule; can't find/allocate source IP");
+        } else if (ipVO.isOneToOneNat()) {
+            throw new NetworkRuleConflictException("Can't do load balance on ip address: " + ipVO.getAddress());
+        }
+
+        boolean performedIpAssoc = false;
+        try {
+            if (ipVO.getAssociatedWithNetworkId() == null) {
+                boolean assignToVpcNtwk = network.getVpcId() != null && ipVO.getVpcId() != null && ipVO.getVpcId().longValue() == network.getVpcId();
+                if (assignToVpcNtwk) {
+                    // set networkId just for verification purposes
+                    _networkModel.checkIpForService(ipVO, Service.Lb, networkId);
+
+                    s_logger.debug("The ip is not associated with the VPC network id=" + networkId + " so assigning");
+                    ipVO = _ipAddrMgr.associateIPToGuestNetwork(ipAddrId, networkId, false);
+                    performedIpAssoc = true;
+                }
+            } else {
+                _networkModel.checkIpForService(ipVO, Service.Lb, null);
             }
 
-            boolean performedIpAssoc = false;
-            try {
-                if (ipVO.getAssociatedWithNetworkId() == null) {
-                    boolean assignToVpcNtwk = network.getVpcId() != null && ipVO.getVpcId() != null && ipVO.getVpcId().longValue() == network.getVpcId();
-                    if (assignToVpcNtwk) {
-                        // set networkId just for verification purposes
-                        _networkModel.checkIpForService(ipVO, Service.Lb, networkId);
+            if (ipVO.getAssociatedWithNetworkId() == null) {
+                throw new InvalidParameterValueException("Ip address " + ipVO + " is not assigned to the network " + network);
+            }
 
-                        s_logger.debug("The ip is not associated with the VPC network id=" + networkId + " so assigning");
-                        ipVO = _ipAddrMgr.associateIPToGuestNetwork(ipAddrId, networkId, false);
-                        performedIpAssoc = true;
-                    }
-                } else {
-                    _networkModel.checkIpForService(ipVO, Service.Lb, null);
-                }
+            result = createPublicLoadBalancer(xId, name, description, srcPortStart, defPortStart, ipVO.getId(), protocol, algorithm, openFirewall, CallContext.current(),
+                    lbProtocol, forDisplay);
+        } catch (Exception ex) {
+            s_logger.warn("Failed to create load balancer due to ", ex);
+            if (ex instanceof NetworkRuleConflictException) {
+                throw (NetworkRuleConflictException)ex;
+            }
 
-                if (ipVO.getAssociatedWithNetworkId() == null) {
-                    throw new InvalidParameterValueException("Ip address " + ipVO + " is not assigned to the network " + network);
-                }
+            if (ex instanceof InvalidParameterValueException) {
+                throw (InvalidParameterValueException)ex;
+            }
 
-                result = createPublicLoadBalancer(xId, name, description, srcPortStart, defPortStart, ipVO.getId(), protocol, algorithm, openFirewall, CallContext.current(),
-                        lbProtocol, forDisplay);
-            } catch (Exception ex) {
-                s_logger.warn("Failed to create load balancer due to ", ex);
-                if (ex instanceof NetworkRuleConflictException) {
-                    throw (NetworkRuleConflictException)ex;
-                }
-
-                if (ex instanceof InvalidParameterValueException) {
-                    throw (InvalidParameterValueException)ex;
-                }
-
-            } finally {
-                if (result == null && systemIp != null) {
-                    s_logger.debug("Releasing system IP address " + systemIp + " as corresponding lb rule failed to create");
-                    _ipAddrMgr.handleSystemIpRelease(systemIp);
-                }
-                // release ip address if ipassoc was perfored
-                if (performedIpAssoc) {
-                    ipVO = _ipAddressDao.findById(ipVO.getId());
-                    _vpcMgr.unassignIPFromVpcNetwork(ipVO.getId(), networkId);
-                }
+        } finally {
+            if (result == null && systemIp != null) {
+                s_logger.debug("Releasing system IP address " + systemIp + " as corresponding lb rule failed to create");
+                _ipAddrMgr.handleSystemIpRelease(systemIp);
+            }
+            // release ip address if ipassoc was perfored
+            if (performedIpAssoc) {
+                ipVO = _ipAddressDao.findById(ipVO.getId());
+                _vpcMgr.unassignIPFromVpcNetwork(ipVO.getId(), networkId);
             }
         }
 

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -264,6 +264,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
     @Inject
     NicSecondaryIpDao _nicSecondaryIpDao;
 
+    private static final int DNS_PORT = 53;
     // Will return a string. For LB Stickiness this will be a json, for
     // autoscale this will be "," separated values
     @Override
@@ -1605,7 +1606,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         IpAddress systemIp = null;
         NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
 
-        if (srcPortStart == 53 && ipVO.isSourceNat()) {
+        if (srcPortStart == DNS_PORT && ipVO.isSourceNat()) {
             List<NetworkOfferingServiceMapVO> offeringServices = _networkOfferingServiceDao.listByNetworkOfferingId(network.getNetworkOfferingId());
             for (NetworkOfferingServiceMapVO serviceMapVo: offeringServices) {
                 if (serviceMapVo.getService().equals(Service.Dns.getName())) {


### PR DESCRIPTION
…le in network offering

## Description
<!--- Describe your changes in detail -->
Throwing an error when port 53 is added to a load balancer when DNS is available on the network service offering.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #4285 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Try to add port 53 as a public port as a load balancer rule, an error will be returned.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
