### PR TITLE
Fixed VM scaling test on Xenserver

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
@@ -98,7 +98,18 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
         if (userVmVO != null) {
             HostVO host = hostDao.findById(userVmVO.getHostId());
             if (host != null) {
-                to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId())) {
+                    String message = String.valueOf(new StringBuilder()
+                            .append("Ignoring global max vCPUs limit (from global setting xen.vm.vcpu.max) on vm ")
+                            .append(vm.getUuid()).append(" and setting VM max vCPU to host pCPU max: ")
+                            .append(host.getCpus())
+                            .append(". Requested number of virtual CPUs exceeds number of host physical CPUs"));
+                    logger.info(message);
+                    to.setVcpuMaxLimit(host.getCpus());
+                } else {
+                    logger.info("Setting vm: " + vm.getUuid() + " max vCPU limit (from global setting xen.vm.vcpu.max) to: " + MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                    to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                }
             }
         }
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
@@ -97,20 +97,7 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
         UserVmVO userVmVO = userVmDao.findById(vm.getId());
         if (userVmVO != null) {
             HostVO host = hostDao.findById(userVmVO.getHostId());
-            if (host != null) {
-                if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId())) {
-                    String message = String.valueOf(new StringBuilder()
-                            .append("Ignoring global max vCPUs limit (from global setting xen.vm.vcpu.max) on vm ")
-                            .append(vm.getUuid()).append(" and setting VM max vCPU to host pCPU max: ")
-                            .append(host.getCpus())
-                            .append(". Requested number of virtual CPUs exceeds number of host physical CPUs"));
-                    logger.info(message);
-                    to.setVcpuMaxLimit(host.getCpus());
-                } else {
-                    logger.info("Setting vm: " + vm.getUuid() + " max vCPU limit (from global setting xen.vm.vcpu.max) to: " + MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
-                    to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
-                }
-            }
+            setMaxVCPUs(host, vm, to);
         }
 
         to.setBootloader(bt);
@@ -135,6 +122,23 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
         }
 
         return to;
+    }
+
+    private void setMaxVCPUs(HostVO host, VirtualMachineProfile vm, VirtualMachineTO to) {
+        if (host != null) {
+            if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId())) {
+                String message = String.valueOf(new StringBuilder()
+                        .append("Ignoring global max vCPUs limit (from global setting xen.vm.vcpu.max) on vm ")
+                        .append(vm.getUuid()).append(" and setting VM max vCPU to host pCPU max: ")
+                        .append(host.getCpus())
+                        .append(". Requested number of virtual CPUs exceeds number of host physical CPUs"));
+                logger.info(message);
+                to.setVcpuMaxLimit(host.getCpus());
+            } else {
+                logger.info("Setting vm: " + vm.getUuid() + " max vCPU limit (from global setting xen.vm.vcpu.max) to: " + MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+            }
+        }
     }
 
     @Override

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -23,7 +23,8 @@ from marvin.cloudstackAPI import scaleVirtualMachine
 from marvin.lib.utils import cleanup_resources
 from marvin.lib.base import (Account,
                              VirtualMachine,
-                             ServiceOffering)
+                             ServiceOffering,
+                             Configurations)
 from marvin.lib.common import (get_zone,
                                get_template,
                                get_domain)
@@ -81,6 +82,12 @@ class TestScaleVm(cloudstackTestCase):
             cls.services["service_offerings"]["big"]
         )
 
+        Configurations.update(
+            cls.apiclient,
+            name="enable.dynamic.scale.vm",
+            value="true"
+        )
+
         # create a virtual machine
         cls.virtual_machine = VirtualMachine.create(
             cls.apiclient,
@@ -101,6 +108,13 @@ class TestScaleVm(cloudstackTestCase):
             TestScaleVm,
             cls).getClsTestClient().getApiClient()
         cleanup_resources(cls.apiclient, cls._cleanup)
+
+        Configurations.update(
+            cls.apiclient,
+            name="enable.dynamic.scale.vm",
+            value="false"
+        )
+
         return
 
     def setUp(self):


### PR DESCRIPTION
## Description

If a VM is started before setting the global var enable.dynamic.scale.vm to true, scaling is not possible on the specific VM until it is stopped and started again. Setting the global var before starting the VM solves the problem. The template also needs dynamic scaling enabled. But after checking those variables the VM instance would still fail due to the default max vCPUs being set to 16.

<!--- Describe your changes in detail -->
Fixes: #4237 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Run the Marvin test - scaling works fine.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
