### PR TITLE
Fixed failed to start instances on Xenserver with dynamic scaling due to default max cpus.

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
@@ -98,7 +98,12 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
         if (userVmVO != null) {
             HostVO host = hostDao.findById(userVmVO.getHostId());
             if (host != null) {
-                to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                // Max cpu cannot be more than host capability
+                if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()))
+                    to.setVcpuMaxLimit(host.getCpus());
+                else {
+                    to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                }
             }
         }
 

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -23,7 +23,8 @@ from marvin.cloudstackAPI import scaleVirtualMachine
 from marvin.lib.utils import cleanup_resources
 from marvin.lib.base import (Account,
                              VirtualMachine,
-                             ServiceOffering)
+                             ServiceOffering,
+                             Configurations)
 from marvin.lib.common import (get_zone,
                                get_template,
                                get_domain)
@@ -81,6 +82,12 @@ class TestScaleVm(cloudstackTestCase):
             cls.services["service_offerings"]["big"]
         )
 
+        Configurations.update(
+            cls.apiclient,
+            name="enable.dynamic.scale.vm",
+            value="true"
+        )
+
         # create a virtual machine
         cls.virtual_machine = VirtualMachine.create(
             cls.apiclient,
@@ -101,6 +108,13 @@ class TestScaleVm(cloudstackTestCase):
             TestScaleVm,
             cls).getClsTestClient().getApiClient()
         cleanup_resources(cls.apiclient, cls._cleanup)
+
+        Configurations.update(
+            cls.apiclient,
+            name="enable.dynamic.scale.vm",
+            value="false"
+        )
+
         return
 
     def setUp(self):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When trying to start an instance with dynamic scaling on Xenserver with a Hypervisor with less than 16 cores, the VM fails to start. This is due to the default max value being set to 16. This PR limits the max vCPUs to what the host is capable of.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Set enable.dynamic.scale.vm to true
Try to start an instance on a Xenserver host with less than 16 cores.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
