### PR TITLE
Cleanup domain details when domain is deleted

### DIFF
--- a/server/src/main/java/com/cloud/user/DomainManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/DomainManagerImpl.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
+import com.cloud.domain.dao.DomainDetailsDao;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.command.admin.domain.ListDomainChildrenCmd;
 import org.apache.cloudstack.api.command.admin.domain.ListDomainsCmd;
@@ -124,6 +125,8 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
     private NetworkDomainDao _networkDomainDao;
     @Inject
     private ConfigurationManager _configMgr;
+    @Inject
+    private DomainDetailsDao _domainDetailsDao;
 
     @Inject
     MessageBus _messageBus;
@@ -333,6 +336,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
                     s_logger.debug("Domain specific Virtual IP ranges " + " are successfully released as a part of domain id=" + domain.getId() + " cleanup.");
                 }
 
+                cleanupDomainDetails(domain.getId());
                 cleanupDomainOfferings(domain.getId());
                 CallContext.current().putContextParameter(Domain.class, domain.getUuid());
                 return true;
@@ -445,6 +449,10 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
             throw e;
         }
         _messageBus.publish(_name, MESSAGE_REMOVE_DOMAIN_EVENT, PublishScope.LOCAL, domain);
+    }
+
+    protected void cleanupDomainDetails(Long domainId) {
+        _domainDetailsDao.deleteDetails(domainId);
     }
 
     protected void cleanupDomainOfferings(Long domainId) {

--- a/server/src/test/java/com/cloud/user/DomainManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/DomainManagerImplTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import com.cloud.domain.dao.DomainDetailsDao;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
@@ -92,6 +93,8 @@ public class DomainManagerImplTest {
     MessageBus _messageBus;
     @Mock
     ConfigurationManager _configMgr;
+    @Mock
+    DomainDetailsDao _domainDetailsDao;
 
     @Spy
     @InjectMocks
@@ -191,6 +194,7 @@ public class DomainManagerImplTest {
         domainManager.deleteDomain(DOMAIN_ID, testDomainCleanup);
         Mockito.verify(domainManager).deleteDomain(domain, testDomainCleanup);
         Mockito.verify(domainManager).removeDomainWithNoAccountsForCleanupNetworksOrDedicatedResources(domain);
+        Mockito.verify(domainManager).cleanupDomainDetails(DOMAIN_ID);
         Mockito.verify(domainManager).cleanupDomainOfferings(DOMAIN_ID);
         Mockito.verify(lock).unlock();
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Cleanup domain details when domain is deleted

    When domain is deleted, all the settings configured under
    the domain scope still exists in domain_details table.
    All the entries for the domain should be deleted as well

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Before the fix
```
mysql> select name,state from domain where id=254;
+--------+--------+
| name   | state  |
+--------+--------+
| domain | Active |
+--------+--------+
1 row in set (0.00 sec)

mysql> select * from domain_details where domain_id=254;
+----+-----------+---------------------------------+--------------------------+
| id | domain_id | name                            | value                    |
+----+-----------+---------------------------------+--------------------------+
| 11 |       254 | allow.duplicate.networkname     | WRXXfK4XO7HPzDmQ0MGAGw== |
| 12 |       254 | allow.empty.start.end.ipaddress | Ia4BIOohYf4W5C5FwOJe+A== |
| 13 |       254 | allow.user.expunge.recover.vm   | nRTlX/+K9wqesxm9x1zwmQ== |
+----+-----------+---------------------------------+--------------------------+
3 rows in set (0.00 sec)

mysql> select name,state from domain where id=254;
+--------+----------+
| name   | state    |
+--------+----------+
| domain | Inactive |
+--------+----------+
1 row in set (0.00 sec)

mysql> select * from domain_details where domain_id=254;
+----+-----------+---------------------------------+--------------------------+
| id | domain_id | name                            | value                    |
+----+-----------+---------------------------------+--------------------------+
| 11 |       254 | allow.duplicate.networkname     | WRXXfK4XO7HPzDmQ0MGAGw== |
| 12 |       254 | allow.empty.start.end.ipaddress | Ia4BIOohYf4W5C5FwOJe+A== |
| 13 |       254 | allow.user.expunge.recover.vm   | nRTlX/+K9wqesxm9x1zwmQ== |
+----+-----------+---------------------------------+--------------------------+
3 rows in set (0.00 sec)
```

After the fix

```
mysql> select name,state from domain where id=255;
+--------+--------+
| name   | state  |
+--------+--------+
| domain | Active |
+--------+--------+
1 row in set (0.00 sec)

mysql> select * from domain_details where domain_id=255;
+----+-----------+---------------------------------+--------------------------+
| id | domain_id | name                            | value                    |
+----+-----------+---------------------------------+--------------------------+
| 14 |       255 | allow.duplicate.networkname     | dXYs8M+ZfwHYzPwSPgjk7g== |
| 15 |       255 | allow.empty.start.end.ipaddress | kjjnH9Y+qmGfwdF11eSobg== |
| 16 |       255 | allow.user.expunge.recover.vm   | 6oE1TAZHn+o64seAhLHDng== |
+----+-----------+---------------------------------+--------------------------+
3 rows in set (0.00 sec)

mysql> select name,state from domain where id=255;
+--------+----------+
| name   | state    |
+--------+----------+
| domain | Inactive |
+--------+----------+
1 row in set (0.00 sec)

mysql> select * from domain_details where domain_id=255;
Empty set (0.00 sec)

mysql>
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
