### PR TITLE
Fixed failed to start instances on Xenserver with dynamic scaling due to default max cpus.

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
@@ -98,7 +98,12 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
         if (userVmVO != null) {
             HostVO host = hostDao.findById(userVmVO.getHostId());
             if (host != null) {
-                to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                // Max cpu cannot be more than host capability
+                if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()))
+                    to.setVcpuMaxLimit(host.getCpus());
+                else {
+                    to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
+                }
             }
         }
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
@@ -99,9 +99,16 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
             HostVO host = hostDao.findById(userVmVO.getHostId());
             if (host != null) {
                 // Max cpu cannot be more than host capability
-                if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()))
+                if (host.getCpus() < MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId())) {
+                    String message = String.valueOf(new StringBuilder()
+                            .append("Ignoring global max vCPUs limit (from global setting xen.vm.vcpu.max) on vm ")
+                            .append(vm.getUuid()).append(" and setting VM max vCPU to host pCPU max: ")
+                            .append(host.getCpus())
+                            .append(". Requested number of virtual CPUs exceeds number of host physical CPUs"));
+                    logger.info(message);
                     to.setVcpuMaxLimit(host.getCpus());
-                else {
+                } else {
+                    logger.info("Setting vm: " + vm.getUuid() + " max vCPU limit (from global setting xen.vm.vcpu.max) to: " + MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
                     to.setVcpuMaxLimit(MaxNumberOfVCPUSPerVM.valueIn(host.getClusterId()));
                 }
             }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When trying to start an instance with dynamic scaling on a Xenserver Hypervisor with less than 16 cores, the VM fails to start. This is due to the default max value being set to 16. This PR limits the max vCPUs to what the host is capable of.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Set enable.dynamic.scale.vm to true
Try to start an instance on a Xenserver host with less than 16 cores.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
