### PR TITLE
Make internaldns1 optional for zone creation

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/zone/CreateZoneCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/zone/CreateZoneCmd.java
@@ -58,7 +58,7 @@ public class CreateZoneCmd extends BaseCmd {
     @Parameter(name = ApiConstants.GUEST_CIDR_ADDRESS, type = CommandType.STRING, description = "the guest CIDR address for the Zone")
     private String guestCidrAddress;
 
-    @Parameter(name = ApiConstants.INTERNAL_DNS1, type = CommandType.STRING, required = true, description = "the first internal DNS for the Zone")
+    @Parameter(name = ApiConstants.INTERNAL_DNS1, type = CommandType.STRING, description = "the first internal DNS for the Zone")
     private String internalDns1;
 
     @Parameter(name = ApiConstants.INTERNAL_DNS2, type = CommandType.STRING, description = "the second internal DNS for the Zone")

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -1418,7 +1418,9 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
             buf.append(" bootproto=dhcp");
         }
         DataCenterVO dc = _dcDao.findById(profile.getVirtualMachine().getDataCenterId());
-        buf.append(" internaldns1=").append(dc.getInternalDns1());
+        if (dc.getInternalDns1() != null) {
+            buf.append(" internaldns1=").append(dc.getInternalDns1());
+        }
         if (dc.getInternalDns2() != null) {
             buf.append(" internaldns2=").append(dc.getInternalDns2());
         }

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -1198,7 +1198,9 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         }
 
         DataCenterVO dc = _dcDao.findById(profile.getVirtualMachine().getDataCenterId());
-        buf.append(" internaldns1=").append(dc.getInternalDns1());
+        if (dc.getInternalDns1() != null) {
+            buf.append(" internaldns1=").append(dc.getInternalDns1());
+        }
         if (dc.getInternalDns2() != null) {
             buf.append(" internaldns2=").append(dc.getInternalDns2());
         }

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -8529,9 +8529,6 @@
                                             internaldns1: {
                                                 label: 'label.internal.dns.1',
                                                 isEditable: true,
-                                                validation: {
-                                                    required: true
-                                                }
                                             },
                                             internaldns2: {
                                                 label: 'label.internal.dns.2',

--- a/ui/scripts/zoneWizard.js
+++ b/ui/scripts/zoneWizard.js
@@ -488,7 +488,6 @@
                     internaldns1: {
                         label: 'label.internal.dns.1',
                         validation: {
-                            required: true,
                             ipv4: true
                         },
                         desc: 'message.tooltip.internal.dns.1'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Make internaldns1 optional for zone creation

    As of now internaldns1 is mandatory field while creating
    a zone. Sometimes we dont have internaldns1 and so make
    this field as optional

Since this is optional, the original behaviour is still retained and nothing breaks
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Before the change

```
(local) mgt01 > create zone
Missing arguments: networktype internaldns1 dns1 name
(local) mgt01 >
```

After the change
```
(local) 🐱 > create zone
💩 Missing required parameters:  dns1, name, networktype
(local) 🐱 >
```

In systemvms
```
root@s-175-VM:~# cat /etc/resolv.conf
nameserver 8.8.4.4
nameserver 8.8.8.8
root@s-175-VM:~# vi /var/log/messages
root@s-175-VM:~# cat /etc/dnsmasq-resolv.conf
nameserver 8.8.4.4
nameserver 8.8.8.8
```

After destroying
```
root@s-176-VM:~# cat /etc/resolv.conf
nameserver 8.8.8.8
root@s-176-VM:~#
root@s-176-VM:~# cat /etc/dnsmasq-resolv.conf
nameserver 8.8.8.8
root@s-176-VM:~#
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
