### PR TITLE
Consider other conditions while listing templates with id

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3525,6 +3525,15 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             }
         }
 
+        return templateChecks(isIso, hypers, tags, name, keyword, hyperType, onlyReady, bootable, zoneId, showDomr,
+                showRemovedTmpl, parentTemplateId, showUnique, searchFilter, sc);
+
+    }
+
+    private Pair<List<TemplateJoinVO>, Integer> templateChecks(boolean isIso, List<HypervisorType> hypers, Map<String, String> tags, String name, String keyword,
+                                                               HypervisorType hyperType, boolean onlyReady, Boolean bootable, Long zoneId, boolean showDomr,
+                                                               boolean showRemovedTmpl, Long parentTemplateId, Boolean showUnique,
+                                                               Filter searchFilter, SearchCriteria<TemplateJoinVO> sc) {
         if (!isIso) {
             // add hypervisor criteria for template case
             if (hypers != null && !hypers.isEmpty()) {
@@ -3561,12 +3570,8 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sc.addAnd("name", SearchCriteria.Op.EQ, name);
         }
 
-        if (isIso) {
-            sc.addAnd("format", SearchCriteria.Op.EQ, "ISO");
-
-        } else {
-            sc.addAnd("format", SearchCriteria.Op.NEQ, "ISO");
-        }
+        SearchCriteria.Op op = isIso ? Op.EQ : Op.NEQ;
+        sc.addAnd("format", op, "ISO");
 
         if (!hyperType.equals(HypervisorType.None)) {
             sc.addAnd("hypervisorType", SearchCriteria.Op.EQ, hyperType);
@@ -3634,7 +3639,6 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         // VMTemplateDaoImpl.searchForTemplates and understand why we need to
         // specially handle ISO. The original logic is very twisted and no idea
         // about what the code was doing.
-
     }
 
     // findTemplatesByIdOrTempZonePair returns the templates with the given ids if showUnique is true, or else by the TempZonePair


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Many of the searching conditions are not considered when
template id is passed but they are considered only when
template id is not passed. Move other conditions out of else
part so that they will be considered when id is passed.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Without changes

```
(local) mgt01 > list templates templatefilter=all filter=id,hypervisor, id="45be18c7-c0fd-11ea-ba74-067606003392"
{
  "count": 1,
  "template": [
    {
      "hypervisor": "KVM",
      "id": "45be18c7-c0fd-11ea-ba74-067606003392"
    }
  ]
}
(local) mgt01 >
(local) mgt01 >
(local) mgt01 > list templates templatefilter=all filter=id,hypervisor, id="45be18c7-c0fd-11ea-ba74-067606003392" hypervisor=XenServer
{
  "count": 1,
  "template": [
    {
      "hypervisor": "KVM",
      "id": "45be18c7-c0fd-11ea-ba74-067606003392"
    }
  ]
}
```

With changes
```
(local) mgt01 > list templates templatefilter=all filter=id,hypervisor id="d9411172-3832-4fc9-a771-39514e0a9faa" hypervisor=KVM
{
  "count": 1,
  "template": [
    {
      "hypervisor": "KVM",
      "id": "d9411172-3832-4fc9-a771-39514e0a9faa"
    }
  ]
}
(local) mgt01 > list templates templatefilter=all filter=id,hypervisor id="d9411172-3832-4fc9-a771-39514e0a9faa" hypervisor=XenServer
(local) mgt01 >
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
