### PR TITLE
Returning nic details in KubernetesClusterResponse

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -634,7 +634,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
                 UserVmJoinVO userVM = userVmJoinDao.findById(vmMapVO.getVmId());
                 if (userVM != null) {
                     UserVmResponse vmResponse = ApiDBUtils.newUserVmResponse(respView, responseName, userVM,
-                        EnumSet.noneOf(VMDetails.class), caller);
+                        EnumSet.of(VMDetails.nics), caller);
                     vmResponses.add(vmResponse);
                 }
             }


### PR DESCRIPTION
## Description
Adds nic details in KubernetesClusterResponse
Needed when the cluster is created on a shared network

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
```
(localcloud) SBCM5> > list kubernetesclusters 
{
  "count": 1,
  "kubernetescluster": [
    {
      "name": "k8sNew",
      .....
      "virtualmachines": [
        {
          "displayname": "k8sNew-master-175b10034fe",
          .....
          "nic": [
            {
              "broadcasturi": "vlan://7",
              "extradhcpoption": [],
              "gateway": "10.1.63.254",
              "id": "b400c7d3-0e92-4520-ad1f-2872553de4cc",
              "ipaddress": "10.1.39.61",
              "isdefault": true,
              "isolationuri": "vlan://7",
              "macaddress": "1e:00:18:00:00:29",
              "netmask": "255.255.224.0",
              "networkid": "6df796e2-57d5-4f14-8a66-e72b955ec749",
              "networkname": "sh",
              "secondaryip": [],
              "traffictype": "Guest",
              "type": "Shared"
            }
           .....
          ]
      ],
      "zoneid": "2a606f6d-d56e-47a5-9d6a-c432e7c972bf",
      "zonename": "ref-trl-1897-k-M7-david-jumani"
    }
  ]
}
```