### PR TITLE
Add quick test attribute

### DIFF
--- a/test/integration/component/maint/test_ha_pool_maintenance.py
+++ b/test/integration/component/maint/test_ha_pool_maintenance.py
@@ -144,7 +144,7 @@ class testHaPoolMaintenance(cloudstackTestCase):
         return
 
     @attr(tags=["advanced", "cl", "advancedns", "sg",
-                "basic", "eip", "simulator", "multihost"])
+                "basic", "eip", "simulator", "multihost", "storage"])
     def test_ha_with_storage_maintenance(self):
         """put storage in maintenance mode and start ha vm and check usage"""
         # Steps

--- a/test/integration/component/maint/test_vpc.py
+++ b/test/integration/component/maint/test_vpc.py
@@ -278,7 +278,7 @@ class TestVPC(cloudstackTestCase):
         sshClient.execute(command)
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs", "test"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "test", "vpc"], required_hardware="true")
     def test_01_create_tier_Vmxnet3(self):
         """
             Test to create vpc tier with nic type as Vmxnet3

--- a/test/integration/component/maint/test_vpc_host_maintenance.py
+++ b/test/integration/component/maint/test_vpc_host_maintenance.py
@@ -434,7 +434,7 @@ class TestVMLifeCycleHostmaintenance(cloudstackTestCase):
                 )
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "vpc"])
     def test_01_enable_maintenance_with_vpc_nw(self):
         """ Test enable Maintenance Mode on Hosts which have VPC elements
         """
@@ -523,7 +523,7 @@ class TestVMLifeCycleHostmaintenance(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "vpc"])
     def test_02_cancel_maintenance(self):
         """ Test cancel Maintenance Mode on the above Hosts + Migrate VMs Back
         """
@@ -612,7 +612,7 @@ class TestVMLifeCycleHostmaintenance(cloudstackTestCase):
         #  TODO: Check for the network connectivity
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "vpc"])
     def test_03_reconnect_host(self):
         """ Test reconnect Host which has VPC elements
         """

--- a/test/integration/component/maint/test_vpc_on_host_maintenance.py
+++ b/test/integration/component/maint/test_vpc_on_host_maintenance.py
@@ -194,7 +194,7 @@ class TestVPCHostMaintenance(cloudstackTestCase):
         self.debug("VPC network validated - %s" % network.name)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "vpc"])
     def test_01_create_vpc_host_maintenance(self):
         """ Test VPC when host is in maintenance mode
         """

--- a/test/integration/component/maint/test_zone_level_local_storage_setting.py
+++ b/test/integration/component/maint/test_zone_level_local_storage_setting.py
@@ -395,7 +395,7 @@ class TestSystemVmLocalStorage(cloudstackTestCase):
                 "check local and shared service offerings for %s" %
                 value)
 
-    @attr(tags=["advanced", "basic"])
+    @attr(tags=["advanced", "basic", "storage"])
     @data('consoleproxy', 'secondarystoragevm')
     def test_02_system_vm_storage(self, value):
         """ Check if system vms are honouring zone level setting
@@ -463,7 +463,7 @@ class TestSystemVmLocalStorage(cloudstackTestCase):
                 name="secstorage.service.offering")
 
     @attr(tags=["advanced", "basic"])
-    @data('consoleproxy', 'secondarystoragevm')
+    @data('consoleproxy', 'secondarystoragevm', "storage")
     def test_03_custom_so(self, value):
         """
         update global setting with system offering and check if it is being

--- a/test/integration/component/test_VirtualRouter_alerts.py
+++ b/test/integration/component/test_VirtualRouter_alerts.py
@@ -113,7 +113,7 @@ class TestVRServiceFailureAlerting(cloudstackTestCase):
         return
 
     @attr(hypervisor="xenserver")
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "routers"], required_hardware="true")
     def test_01_VRServiceFailureAlerting(self):
 
         if self.zone.networktype == "Basic":

--- a/test/integration/component/test_acl_isolatednetwork.py
+++ b/test/integration/component/test_acl_isolatednetwork.py
@@ -358,7 +358,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to createNetwork as admin user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_01_createNetwork_admin(self):
 
 	"""
@@ -381,7 +381,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "Admin User is not able to create a network for himself")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_02_createNetwork_admin_foruserinsamedomain(self):
 
 	"""
@@ -405,7 +405,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Admin User is not able to create a network for other users in his domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_03_createNetwork_admin_foruserinotherdomain(self):
 
 	"""
@@ -431,7 +431,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to createNetwork as domain admin user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_04_createNetwork_domaindmin(self):
 
 	"""
@@ -454,7 +454,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "Domain admin User is not able to create a network for himself")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_05_createNetwork_domaindmin_foruserinsamedomain(self):
 
 	"""
@@ -478,7 +478,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Domain admin User is not able to create a network for other users in his domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_06_createNetwork_domaindmin_foruserinsubdomain(self):
 
 	"""
@@ -502,7 +502,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Domain admin User is not able to create a network for other users in his sub domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_07_createNetwork_domaindmin_forcrossdomainuser(self):
 
 	"""
@@ -529,7 +529,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to createNetwork as regular user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_08_createNetwork_user(self):
 
 	"""
@@ -552,7 +552,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "User is not able to create a network for himself")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_09_createNetwork_user_foruserinsamedomain(self):
 
 	"""
@@ -578,7 +578,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.UNABLE_TO_LIST_NETWORK_ACCOUNT):
         	    self.fail("Error message validation failed when when User tries to create network for other users in his domain ")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_10_createNetwork_user_foruserinotherdomain(self):
 
 	"""
@@ -607,7 +607,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to Deploying VM in a network as admin user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_11_deployvm_admin(self):
 
 	"""
@@ -631,7 +631,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "Admin User is not able to deploy VM in his own network")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_12_deployvm_admin_foruserinsamedomain(self):
 
 	"""
@@ -656,7 +656,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Admin User is not able to deploy VM for users in his domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_13_deployvm_admin_foruserinotherdomain(self):
 
 	"""
@@ -681,7 +681,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Admin User is not able to deploy VM for users users in other domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_13_1_deployvm_admin_foruserinotherdomain_crossnetwork(self):
 
 	"""
@@ -709,7 +709,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to deploying VM as domain admin user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_14_deployvm_domaindmin(self):
 
 	"""
@@ -733,7 +733,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "Domain admin User is not able to deploy VM for himself")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_15_deployvm_domaindmin_foruserinsamedomain(self):
 
 	"""
@@ -757,7 +757,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Domain admin User is not able to deploy VM for other users in his domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_16_deployvm_domaindmin_foruserinsubdomain(self):
 
 	"""
@@ -781,7 +781,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Domain admin User is not able to deploy vm for himself")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_17_deployvm_domaindmin_forcrossdomainuser(self):
 
 	"""
@@ -808,7 +808,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NO_PERMISSION_TO_OPERATE_DOMAIN):
         	    self.fail("Error message validation failed when Domain admin tries to deploy vm for users not in hos domain ")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_17_1_deployvm_domainadmin_foruserinotherdomain_crossnetwork(self):
 
 	"""
@@ -836,7 +836,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to deploying VM as regular user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_18_deployvm_user(self):
 
 	"""
@@ -859,7 +859,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "User is not able to deploy vm for himself")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_19_deployvm_user_foruserinsamedomain(self):
 
 	"""
@@ -886,7 +886,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NO_PERMISSION_TO_OPERATE_ACCOUNT):
         	    self.fail("Error message validation failed when Regular user tries to deploy vm for other users in his domain ")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_20_deployvm_user_foruserincrossdomain(self):
 
 	"""
@@ -913,7 +913,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NO_PERMISSION_TO_OPERATE_ACCOUNT):
         	    self.fail("Error message validation failed when Regular user tries to deploy vm for users not in his domain ")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_20_1_deployvm_user_incrossnetwork(self):
 
 	"""
@@ -939,7 +939,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to restart Network as admin user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_21_restartNetwork_admin(self):
 
 	"""
@@ -955,7 +955,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "Admin User is not able to restart network he owns")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_22_restartNetwork_admin_foruserinsamedomain(self):
 
 	"""
@@ -970,7 +970,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Admin User is not able to restart network owned by users his domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_23_restartNetwork_admin_foruserinotherdomain(self):
 
 	"""
@@ -987,7 +987,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating to restart Network as domain admin user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_24_restartNetwork_domaindmin(self):
 
 	"""
@@ -1003,7 +1003,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "Domain admin User is not able to restart network for himself")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_25_restartNetwork_domaindmin_foruserinsamedomain(self):
 
 	"""
@@ -1017,7 +1017,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Domain admin User is not able to restart network for other users in his domain")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_26_restartNetwork_domaindmin_foruserinsubdomain(self):
 
 	"""
@@ -1031,7 +1031,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     True,
                     "Domain admin User is not able to restart network he owns")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_27_restartNetwork_domaindmin_forcrossdomainuser(self):
 
 	"""
@@ -1050,7 +1050,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
 
 ## Test cases relating restart network as regular user
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_28_restartNetwork_user(self):
 
 	"""
@@ -1065,7 +1065,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                     "User is not able to restart network he owns")
 
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_29_restartNetwork_user_foruserinsamedomain(self):
 
 	"""
@@ -1082,7 +1082,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NO_PERMISSION_TO_OPERATE_ACCOUNT):
         	    self.fail("Error message validation failed when Regular user tries to restart network for users in his domain ")
 
-    @attr("simulator_only",tags=[ "advanced"],required_hardware="false")
+    @attr("simulator_only",tags=[ "advanced", "networks"],required_hardware="false")
     def test_30_restartNetwork_user_foruserinotherdomain(self):
 
 	"""

--- a/test/integration/component/test_acl_isolatednetwork_delete.py
+++ b/test/integration/component/test_acl_isolatednetwork_delete.py
@@ -343,7 +343,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
 
 ## Test cases relating to delete Network as admin user
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_admin(self):
 	"""
         Validate that Admin should be able to delete network he owns
@@ -359,7 +359,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
                     "Admin User is not able to restart network he owns")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_admin_foruserinsamedomain(self):
 
 	"""
@@ -375,7 +375,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
                     None,
                     "Admin User is not able to delete network owned by users his domain")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_admin_foruserinotherdomain(self):
 
         # Validate that Admin should be able to delete network for users in his sub domain
@@ -391,7 +391,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
 
 ## Test cases relating to delete Network as domain admin user
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_domaindmin(self):
 	"""
         Validate that Domain admin should be able to delete network for himslef
@@ -407,7 +407,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
                     "Domain admin User is not able to delete a network he owns")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_domaindmin_foruserinsamedomain(self):
 
 	"""
@@ -422,7 +422,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
                     None,
                     "Domain admin User is not able to delete a network that is owned by user in the same domain")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_domaindmin_foruserinsubdomain(self):
 
 	"""
@@ -438,7 +438,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
                     None,
                     "Domain admin User is not able to delete a network that is owned by user in the subdomain")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_domaindmin_forcrossdomainuser(self):
 
 	"""
@@ -458,7 +458,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
 
 ## Test cases relating deleting network as regular user
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_user(self):
 
 	"""
@@ -475,7 +475,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
                     "User is not able to delete a network he owns")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_user_foruserinsamedomain(self):
 
 	"""
@@ -492,7 +492,7 @@ class TestIsolatedNetworkDelete(cloudstackTestCase):
 		if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NO_PERMISSION_TO_OPERATE_ACCOUNT):
                     self.fail("Regular user is allowed to delete network for users in his domain ")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deleteNetwork_user_foruserinotherdomain(self):
 
 	"""

--- a/test/integration/component/test_acl_sharednetwork.py
+++ b/test/integration/component/test_acl_sharednetwork.py
@@ -343,7 +343,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine in shared network with scope=all
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_all_domainuser(self):
         """
         Validate that regular user in a domain is allowed to deploy VM in a shared network created with scope="all"
@@ -369,7 +369,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     "User in a domain under ROOT failed to deploy VM in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_all_domainadminuser(self):
         """
         Validate that regular user in "ROOT" domain is allowed to deploy VM in a shared network created with scope="all"
@@ -396,7 +396,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     "Admin User in a domain under ROOT failed to deploy VM in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_all_subdomainuser(self):
         """
         Validate that regular user in any subdomain is allowed to deploy VM in a shared network created with scope="all"
@@ -421,7 +421,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "User in a domain under ROOT failed to deploy VM in a shared network with scope=all")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_all_subdomainadminuser(self):
         """
         Validate that regular user in a subdomain under ROOT is allowed to deploy VM in a shared network created with scope="all"
@@ -447,7 +447,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     "Admin User in a domain under ROOT failed to deploy VM in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_all_ROOTuser(self):
         """
         Validate that regular user in ROOT domain is allowed to deploy VM in a shared network created with scope="all"
@@ -472,7 +472,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "User in ROOT domain failed to deploy VM in a shared network with scope=all")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_all_ROOTadmin(self):
         """
         Validate that admin user in ROOT domain is allowed to deploy VM in a shared network created with scope="all"
@@ -498,7 +498,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine in shared network with scope=Domain and no subdomain access
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_domainuser(self):
         """
         Validate that regular user in a domain is allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -525,7 +525,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     "User in a domain that has a shared network with no subdomain access failed to deploy VM in a shared network with scope=domain with no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_domainadminuser(self):
         """
         Validate that admin user in a domain is allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -551,7 +551,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "Admin User in a  domain that has a shared network with no subdomain access failed to deploy VM in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_subdomainuser(self):
         """
         Validate that regular user in a subdomain is NOT allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -578,7 +578,7 @@ class TestSharedNetwork(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NOT_AVAILABLE_IN_DOMAIN):
                     self.fail("Error message validation failed when Subdomain user tries to deploy VM in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_subdomainadminuser(self):
         """
         Validate that admin user in a subdomain is NOT allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -607,7 +607,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_parentdomainuser(self):
         """
         Validate that user in the parent domain is NOT allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -635,7 +635,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     self.fail("Error message validation failed when Parent domain user tries to deploy VM in a shared network with scope=domain with no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_parentdomainadminuser(self):
         """
         Validate that admin user in the parent domain is NOT allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -664,7 +664,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_ROOTuser(self):
         """
         Validate that user in ROOT domain is NOT allowed to deploy VM in a shared network created with scope="domain" and no subdomain access
@@ -693,7 +693,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_nosubdomainaccess_ROOTadmin(self):
         """
         Validate that admin in ROOT domain is NOT allowed to deploy VM in a shared network created with scope="domain" and no subdomain access 
@@ -724,7 +724,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine in shared network with scope=Domain and with subdomain access
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_domainuser(self):
         """
         Validate that regular user in a domain is allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for the domain
@@ -751,7 +751,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     "User in a domain that has a shared network with subdomain access failed to deploy VM in a shared network with scope=domain with no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_domainadminuser(self):
         """
         Validate that admin user in a domain is allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for the domain
@@ -777,7 +777,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "Admin User in a  domain that has a shared network with subdomain access failed to deploy VM in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_subdomainuser(self):
         """
         Validate that regular user in a subdomain is allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access  for the parent domain
@@ -802,7 +802,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "User in a subdomain that has a shared network with subdomain access failed to deploy VM in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_subdomainadminuser(self):
         """
         Validate that an admin user in a subdomain is allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for the parent domain
@@ -827,7 +827,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "Admin User in a subdomain that has a shared network with subdomain access failed to deploy VM in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_parentdomainuser(self):
         """
         Validate that regular user in a parent domain is NOT allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for the domain
@@ -855,7 +855,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     self.fail("Error message validation failed when Parent domain's user tries to deploy VM in a shared network with scope=domain with subdomain access ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_parentdomainadminuser(self):
         """
         Validate that admin user in a parent domain is NOT allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for any domain
@@ -884,7 +884,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_ROOTuser(self):
         """
         Validate that regular user in ROOT domain is NOT allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for any domain
@@ -912,7 +912,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     self.fail("Error message validation failed when ROOT domain's user tries to deploy VM in a shared network with scope=domain with subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_domain_withsubdomainaccess_ROOTadmin(self):
         """
         Validate that admin user in ROOT domain is NOT allowed to deploy VM in a shared network created with scope="domain" and  with subdomain access for any domain
@@ -943,7 +943,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine in shared network with scope=account
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_account_domainuser(self):
         """
         Validate that any other user in same domain is NOT allowed to deploy VM in a shared network created with scope="account" for an account
@@ -972,7 +972,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_account_domainadminuser(self):
         """
         Validate that an admin user under the same domain but belonging to a different account is allowed to deploy VM in a shared network created with scope="account" for an account
@@ -1000,7 +1000,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     self.fail("Error message validation failed when User from same domain but different account tries to deploy VM in a shared network with scope=account")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_account_user(self):
         """
         Validate that regular user in the account is allowed to deploy VM in a shared network created with scope="account" for an account
@@ -1026,7 +1026,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     True,
                     "User in the account that has a shared network with scope=account failed to deploy a VM in this shared network")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_account_differentdomain(self):
         """
         Validate that regular user from a domain different from that of the account is NOT allowed to deploy VM in a shared network created with scope="account" for an account
@@ -1055,7 +1055,7 @@ class TestSharedNetwork(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_account_ROOTuser(self):
         """
         Validate that user in ROOT domain is NOT allowed to deploy VM in a shared network created with scope="account" for an account
@@ -1083,7 +1083,7 @@ class TestSharedNetwork(cloudstackTestCase):
                     self.fail("Error message validation failed when ROOT domain's  user tries to deploy VM in a shared network with scope=account ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_scope_account_ROOTadmin(self):
         """
         Validate that admin user in ROOT domain is NOT allowed to deploy VM in a shared network created with scope="account" for an account

--- a/test/integration/component/test_acl_sharednetwork_deployVM-impersonation.py
+++ b/test/integration/component/test_acl_sharednetwork_deployVM-impersonation.py
@@ -342,7 +342,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as ROOT admin for other users in shared network with scope=all
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_all_domainuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for other users in a shared network with scope=all
@@ -371,7 +371,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "ROOT admin is not able to deploy a VM for other users in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_all_domainadminuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for a domain admin users in a shared network with scope=all
@@ -400,7 +400,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "ROOT admin is not able to deploy a VM for a domain admin users in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_all_subdomainuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for any user in a subdomain in a shared network with scope=all
@@ -426,7 +426,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "ROOT admin is not able to deploy a VM for any user in a subdomain in a shared network with scope=all")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_all_subdomainadminuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for admin user in a domain in a shared network with scope=all
@@ -453,7 +453,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "ROOT admin is not able to deploy a VM for admin user in a domain in a shared network with scope=all")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_all_ROOTuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for user in ROOT domain in a shared network with scope=all
@@ -482,7 +482,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as ROOT admin for other users in shared network with scope=Domain and no subdomain access
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_domainuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for domain user in a shared network with scope=domain with no subdomain access
@@ -511,7 +511,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "ROOT admin is not able to deploy a VM for domain user in a shared network with scope=domain with no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_domainadminuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for domain admin user in a shared network with scope=domain with no subdomain access
@@ -539,7 +539,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "ROOT admin is not able to deploy a VM for domain admin user in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_subdomainuser(self):
 	"""
 	 Valiate that ROOT admin is NOT able to deploy a VM for sub domain user in a shared network with scope=domain with no subdomain access
@@ -570,7 +570,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when ROOT admin tries to deploy a VM for sub domain user in a shared network with scope=domain with no subdomain access ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_subdomainadminuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for sub domain admin user in a shared network with scope=domain with no subdomain access
@@ -600,7 +600,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
         	    self.fail("Error message validation failed when ROOT admin tries to deploy a VM for sub domain admin user in a shared network with scope=domain with no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_parentdomainuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for parent domain user in a shared network with scope=domain with no subdomain access
@@ -630,7 +630,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
         	    self.fail("Error message validation failed when  ROOT admin tries to deploy a VM for parent domain user in a shared network with scope=domain with no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_parentdomainadminuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for parent domain admin user in a shared network with scope=domain with no subdomain access
@@ -661,7 +661,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_nosubdomainaccess_ROOTuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for parent domain admin user in a shared network with scope=domain with no subdomain access
@@ -692,7 +692,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as ROOT admin for other users in shared network with scope=Domain and with subdomain access
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_domainuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for domain user in a shared network with scope=domain with subdomain access
@@ -721,7 +721,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "ROOT admin is NOT able to deploy a VM for domain user in a shared network with scope=domain with subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_domainadminuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for domain admin user in a shared network with scope=domain with subdomain access
@@ -749,7 +749,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
 		    "ROOT admin is not able to deploy a VM for domain admin user in a shared network with scope=domain with subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_subdomainuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for subdomain user in a shared network with scope=domain with subdomain access
@@ -776,7 +776,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "ROOT admin is not able to deploy a VM for subdomain user in a shared network with scope=domain with subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_subdomainadminuser(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for subdomain admin user in a shared network with scope=domain with subdomain access
@@ -803,7 +803,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "ROOT admin is not able to deploy a VM for subdomain admin user in a shared network with scope=domain with subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_parentdomainuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for parent domain user in a shared network with scope=domain with subdomain access
@@ -832,7 +832,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
          	if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NOT_AVAILABLE_IN_DOMAIN):
                     self.fail("Error message validation failed when ROOT admin tries to deploy a VM for parent domain user in a shared network with scope=domain with subdomain access ")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_parentdomainadminuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for parent domain admin user in a shared network with scope=domain with subdomain access
@@ -862,7 +862,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when ROOT admin tries to deploy a VM for parent domain admin user in a shared network with scope=domain with subdomain access ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_domain_withsubdomainaccess_ROOTuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for user in ROOT domain in a shared network with scope=domain with subdomain access
@@ -894,7 +894,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as ROOT admin for other users in shared network with scope=account
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_account_domainuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for user in the same domain but in a different account in a shared network with scope=account
@@ -924,7 +924,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when ROOT admin tries to deploy a VM for user in the same domain but in a different account in a shared network with scope=account")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_account_domainadminuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for admin user in the same domain but in a different account in a shared network with scope=account
@@ -953,7 +953,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                 if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.UNABLE_TO_USE_NETWORK):
                     self.fail("Error message validation failed when ROOT admin tries to deploy a VM for admin user in the same domain but in a different account in a shared network with scope=account")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_account_user(self):
 	"""
 	Valiate that ROOT admin is able to deploy a VM for regular user in a shared network with scope=account
@@ -981,7 +981,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "ROOT admin is not able to deploy a VM for regular user in a shared network with scope=account")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_account_differentdomain(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for a admin user in a shared network with scope=account which the admin user does not have access to
@@ -1011,7 +1011,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when ROOT admin tries to deploy a VM for a admin user in a shared network with scope=account which the admin user does not have access to ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_admin_scope_account_ROOTuser(self):
 	"""
 	Valiate that ROOT admin is NOT able to deploy a VM for a user in ROOT domain in a shared network with scope=account which the user does not have access to
@@ -1042,7 +1042,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as Domain admin for other users in shared network with scope=all
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_all_domainuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for a domain user in a shared network with scope=all
@@ -1070,7 +1070,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "Domain admin is not able to deploy a VM for a domain user in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_all_domainadminuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for a domain admin user in a shared network with scope=all
@@ -1098,7 +1098,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "Domain admin is not able to deploy a VM for a domain admin user in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_all_subdomainuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for a sub domain user in a shared network with scope=all
@@ -1124,7 +1124,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Domain admin is not able to deploy a VM for a sub domain user in a shared network with scope=all")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_all_subdomainadminuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for a sub domain admin user in a shared network with scope=all
@@ -1150,7 +1150,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Domain admin is not able to deploy a VM for a sub domain admin user in a shared network with scope=all")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_all_ROOTuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for user in ROOT domain in a shared network with scope=all
@@ -1179,7 +1179,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin is NOT able to deploy a VM for user in ROOT domain in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_all_crossdomainuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for user in other domain in a shared network with scope=all
@@ -1209,7 +1209,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as Domain admin for other users in shared network with scope=Domain and no subdomain access
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_domainuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for domain user in a shared network with scope=Domain and no subdomain access
@@ -1237,7 +1237,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "Domain admin is not able to deploy a VM for domain user in a shared network with scope=Domain and no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_domainadminuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for domain admin user in a shared network with scope=Domain and no subdomain access
@@ -1265,7 +1265,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Admin User in a  domain that has a shared network with no subdomain access failed to Deploy VM in a shared network with scope=domain with no subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_subdomainuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for sub domain user in a shared network with scope=Domain and no subdomain access
@@ -1295,7 +1295,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for sub domain user in a shared network with scope=Domain and no subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_subdomainadminuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for sub domain admin user in a shared network with scope=Domain and no subdomain access
@@ -1325,7 +1325,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for sub domain admin user in a shared network with scope=Domain and no subdomain access ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_parentdomainuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for parent domain user in a shared network with scope=Domain and no subdomain access
@@ -1355,7 +1355,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for parent domain user in a shared network with scope=Domain and no subdomain access ")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_parentdomainadminuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for parent domain admin user in a shared network with scope=Domain and no subdomain access
@@ -1386,7 +1386,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_nosubdomainaccess_ROOTuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for user in ROOT domain in a shared network with scope=Domain and no subdomain access
@@ -1418,7 +1418,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as Domain admin for other users in shared network with scope=Domain and with subdomain access
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_domainuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for regular user in domain in a shared network with scope=Domain and subdomain access
@@ -1446,7 +1446,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     "Domain admin is not able to deploy a VM for regular user in domain in a shared network with scope=Domain and subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_domainadminuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for admin user in domain in a shared network with scope=Domain and subdomain access
@@ -1473,7 +1473,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Domain admin is not able to deploy a VM for admin user in domain in a shared network with scope=Domain and subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_subdomainuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for regular user in subdomain in a shared network with scope=Domain and subdomain access
@@ -1499,7 +1499,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Domain admin is not able to deploy a VM for regular user in subdomain in a shared network with scope=Domain and subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_subdomainadminuser(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for admin user in subdomain in a shared network with scope=Domain and subdomain access
@@ -1525,7 +1525,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Domain admin is not able to deploy a VM for admin user in subdomain in a shared network with scope=Domain and subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_parentdomainuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for regular user in parent domain in a shared network with scope=Domain and subdomain access
@@ -1553,7 +1553,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
          	if not CloudstackAclException.verifyMsginException(e,CloudstackAclException.NOT_AVAILABLE_IN_DOMAIN):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for regular user in parent domain in a shared network with scope=Domain and subdomain access")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_parentdomainadminuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for admin user in parent domain in a shared network with scope=Domain and subdomain access
@@ -1583,7 +1583,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for admin user in parent domain in a shared network with scope=Domain and subdomain access")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_domain_withsubdomainaccess_ROOTuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for user in ROOT domain in a shared network with scope=Domain and subdomain access
@@ -1614,7 +1614,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as Domain admin for other users in shared network with scope=account
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_account_domainuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for user in the same domain but belonging to a different account in a shared network with scope=account
@@ -1643,7 +1643,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for user in the same domain but belonging to a different account in a shared network with scope=account")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_account_domainadminuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for an admin user in the same domain but belonging to a different account in a shared network with scope=account
@@ -1672,7 +1672,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for user in the same domain but belonging to a different account in a shared network with scope=account")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_account_user(self):
 	"""
 	Valiate that Domain admin is able to deploy a VM for an regular user in a shared network with scope=account
@@ -1699,7 +1699,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     True,
                     "Domain admin is not able to deploy a VM for an regular user in a shared network with scope=account")
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_account_differentdomain(self):
 	"""
 	Valiate that Domain admin is able NOT able to deploy a VM for an regular user from a differnt domain in a shared network with scope=account
@@ -1728,7 +1728,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Domain admin tries to deploy a VM for an regular user from a differnt domain in a shared network with scope=account")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_domainadmin_scope_account_ROOTuser(self):
 	"""
 	Valiate that Domain admin is NOT able to deploy a VM for an regular user in ROOT domain in a shared network with scope=account
@@ -1758,7 +1758,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
 
 ## Test cases relating to deploying Virtual Machine as Regular user for other users in shared network with scope=all
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_regularuser_scope_all_anotherusersamedomain(self):
 	"""
 	Valiate that regular user is able NOT able to deploy a VM for another user in the same  domain in a shared network with scope=all
@@ -1787,7 +1787,7 @@ class TestSharedNetworkImpersonation(cloudstackTestCase):
                     self.fail("Error message validation failed when Regular user tries to deploy a VM for another user in the same domain in a shared network with scope=all")
 
 
-    @attr("simulator_only",tags=["advanced"],required_hardware="false")
+    @attr("simulator_only",tags=["advanced", "networks"],required_hardware="false")
     def test_deployVM_in_sharedNetwork_as_regularuser_scope_all_crossdomain(self):
 	"""
 	Valiate that regular user is able NOT able to deploy a VM for another user in a different domain in a shared network with scope=all

--- a/test/integration/component/test_add_remove_network.py
+++ b/test/integration/component/test_add_remove_network.py
@@ -324,7 +324,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     @data("isolated","shared")
     def test_01_add_nw_running_vm(self, value):
         """Add network to running VM"""
@@ -356,7 +356,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     @data("isolated","shared")
     def test_02_add_nw_stopped_vm(self, value):
         """Add network to stopped VM"""
@@ -387,7 +387,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     @data("isolated","shared")
     def test_03_add_nw_multiple_times(self, value):
         """Add same network multiple times to running VM"""
@@ -428,7 +428,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     @data("isolated")
     def test_04_vpc_nw_running_vm(self, value):
         """Add VPC network to running VM belonging to isolated network"""
@@ -475,7 +475,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
         vpc_off.update(self.apiclient, state='Disabled')
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     @data("isolated")
     def test_05_add_vpc_nw_stopped_vm(self, value):
         """Add VPC network to stopped VM belonging to isolated network"""
@@ -517,7 +517,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_06_add_nw_ipaddress_running_vm(self):
         """Add network and ip address to running VM"""
 
@@ -545,7 +545,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
         self.addNetworkToVm(self.shared_network, virtual_machine,ipaddress = ipaddress)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_10_add_nw_invalid_ipaddress_running_vm(self):
         """Add network with invalid ip address to running VM"""
 
@@ -564,7 +564,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     @data("isolated","shared")
     def test_14_add_nw_different_account(self, value):
         """Add network to running VM"""
@@ -604,7 +604,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
             self.fail("User was able to add NIC, test failed! This issue has been hit: CLOUDSTACK-10071")
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_24_add_nw_different_domain(self):
         """Add network to running VM"""
 
@@ -665,7 +665,7 @@ class TestAddNetworkToVirtualMachine(cloudstackTestCase):
             self.debug("Operation failed with exception %s" % e.exception)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_25_add_nw_above_account_limit(self):
         """Add network to VM with maximum network limit reached"""
 
@@ -824,7 +824,7 @@ class TestRemoveNetworkFromVirtualMachine(cloudstackTestCase):
                         len(self.nics))
         return self.nics
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_07_remove_nic_running_vm(self):
         """Remove nic from running VM"""
 
@@ -866,7 +866,7 @@ class TestRemoveNetworkFromVirtualMachine(cloudstackTestCase):
         self.debug("events: %s" % events)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_08_remove_default_nic(self):
         """Test Remove default nic of running VM"""
 
@@ -889,7 +889,7 @@ class TestRemoveNetworkFromVirtualMachine(cloudstackTestCase):
             self.debug("Removing default nic of vm failed")
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_09_remove_foreign_nic(self):
         """Remove nic which does not belong to VM"""
 
@@ -920,7 +920,7 @@ class TestRemoveNetworkFromVirtualMachine(cloudstackTestCase):
             self.debug("Operation failed with exception: %s" % e.exception)
         return
 
-    @attr(tags = ["advanced"], required_hardware="true")
+    @attr(tags = ["advanced", "networks"], required_hardware="true")
     def test_29_remove_nic_CS22503(self):
         """Test to verify remove nic from vm if the nic ip is same as another vm ip in another network"""
 
@@ -1023,7 +1023,7 @@ class TestRemoveNetworkFromVirtualMachine(cloudstackTestCase):
             self.fail("Failed to delete the nic from vm")
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_30_remove_nic_reattach(self):
         """
          Test to verify vm start after NIC removal and reattach
@@ -1210,7 +1210,7 @@ class TestUpdateVirtualMachineNIC(cloudstackTestCase):
                         len(self.nics))
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_11_update_nic_running_vm(self):
         """update default nic of running VM"""
 
@@ -1275,7 +1275,7 @@ class TestUpdateVirtualMachineNIC(cloudstackTestCase):
         self.debug("events: %s" % events)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_12_make_default_nic_as_default(self):
         """Try to set default nic of vm again as default"""
 
@@ -1305,7 +1305,7 @@ class TestUpdateVirtualMachineNIC(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_13_set_foreign_nic_as_default(self):
         """set nic which does not belong to VM as its default one"""
 
@@ -1406,7 +1406,7 @@ class TestFailureScenariosAddNetworkToVM(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_15_add_nic_wrong_vm_id(self):
         """Add network to vm with wrong vm id"""
 
@@ -1425,7 +1425,7 @@ class TestFailureScenariosAddNetworkToVM(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_16_add_nic_wrong_network_id(self):
         """Add network to vm with wrong network id"""
 
@@ -1444,7 +1444,7 @@ class TestFailureScenariosAddNetworkToVM(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_17_add_nic_different_zone(self):
         """Add network to vm where both belong to different zones"""
 
@@ -1491,7 +1491,7 @@ class TestFailureScenariosAddNetworkToVM(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["invalid"])
+    @attr(tags = ["invalid", "networks"])
     def test_18_add_nic_basic_zone(self):
         """Add network to vm in basic zone"""
 
@@ -1543,7 +1543,7 @@ class TestFailureScenariosAddNetworkToVM(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_26_add_nic_insufficient_permission(self):
         """Try to add network to vm with insufficient permission"""
 
@@ -1651,7 +1651,7 @@ class TestFailureScenariosRemoveNicFromVM(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_19_remove_nic_wrong_vm_id(self):
         """Try to remove nic from a vm providing wrong vm id to API"""
 
@@ -1684,7 +1684,7 @@ class TestFailureScenariosRemoveNicFromVM(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_20_remove_nic_wrong_nic_id(self):
         """Try to remove nic from a vm providing wrong nic id to API"""
 
@@ -1717,7 +1717,7 @@ class TestFailureScenariosRemoveNicFromVM(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_27_remove_nic_insufficient_permission(self):
         """Try to remove nic from vm with insufficient permission"""
 
@@ -1836,7 +1836,7 @@ class TestFailureScenariosUpdateVirtualMachineNIC(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_21_update_nic_wrong_vm_id(self):
         """update default nic of vm providing wrong vm id to the API"""
 
@@ -1881,7 +1881,7 @@ class TestFailureScenariosUpdateVirtualMachineNIC(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_22_update_nic_wrong_nic_id(self):
         """update default nic of vm providing wrong nic id to the API"""
 
@@ -1927,7 +1927,7 @@ class TestFailureScenariosUpdateVirtualMachineNIC(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_23_update_nic_incorrect_vm_state(self):
         """update default nic of vm when vm is state is not Running or Stopped"""
 
@@ -1996,7 +1996,7 @@ class TestFailureScenariosUpdateVirtualMachineNIC(cloudstackTestCase):
                     e.exception)
         return
 
-    @attr(tags = ["advanced", "dvs"])
+    @attr(tags = ["advanced", "dvs", "networks"])
     def test_28_update_nic_insufficient_permission(self):
         """Try to update default nic of vm with insufficient permission"""
 

--- a/test/integration/component/test_advancedsg_networks.py
+++ b/test/integration/component/test_advancedsg_networks.py
@@ -118,7 +118,7 @@ class TestCreateZoneSG(cloudstackTestCase):
                         % listzones[0].securitygroupsenabled)
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_01_createZone_secGrp_enabled(self):
         """ Test to verify Advance Zone with security group enabled can be created"""
 
@@ -136,7 +136,7 @@ class TestCreateZoneSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_02_createZone_secGrp_disabled(self):
         """ Test to verify Advance Zone created with flag
             securitygroupsenabled=False"""
@@ -293,7 +293,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_03_createIsolatedNetwork(self):
         """ Test Isolated Network """
 
@@ -330,7 +330,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
                         Exception: %s" % e)
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_04_createSharedNetwork_withoutSG(self):
         """ Test Shared Network creation without Security Group Service Provider in Network Offering"""
 
@@ -373,7 +373,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
                         Exception: %s" % e)
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_05_deployVM_SharedwithSG(self):
         """ Test VM deployment in shared networks with SecurityGroup Provider """
 
@@ -452,7 +452,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
         self.debug("Virtual Machine created: %s" % virtual_machine.id)
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_06_SharedNwSGAccountSpecific(self):
         """ Test Account specific shared network creation with SG"""
 
@@ -534,7 +534,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_07_SharedNwSG_DomainWide_SubdomainAcccess(self):
         """ Test Domain wide shared network with SG, with subdomain access set True"""
 
@@ -604,7 +604,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
         return
 
     @unittest.skip("Skip - Failing - WIP")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_08_SharedNwSGAccountSpecific_samevlan_samesubnet(self):
         """ Test Account specific shared network creation with SG in multiple accounts
             with same subnet and vlan"""
@@ -674,7 +674,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
         return
 
     @unittest.skip("Skip - Failing - WIP")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_09_SharedNwDomainWide_samevlan_samesubnet(self):
         """ Test Domain wide shared network creation with SG in different domains
             with same vlan and same subnet"""
@@ -752,7 +752,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_10_deleteSharedNwSGAccountSpecific_InUse(self):
         """ Test delete Account specific shared network creation with SG which is in use"""
 
@@ -805,7 +805,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_11_deleteSharedNwSG_DomainWide_InUse(self):
         """ Test delete Domain wide shared network with SG which is in use"""
 
@@ -860,7 +860,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_29_deleteSharedNwSG_ZoneWide_InUse(self):
         """ Test delete Zone wide shared network with SG which is in use"""
 
@@ -907,7 +907,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
         self.cleanup_vms.append(vm)
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_12_deleteSharedNwSGAccountSpecific_NotInUse(self):
         """ Test delete Account specific shared network creation with SG which is not in use"""
 
@@ -949,7 +949,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_13_deleteSharedNwSG_DomainWide_NotInUse(self):
         """ Test delete Domain wide shared network with SG which is not in use"""
 
@@ -993,7 +993,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_30_deleteSharedNwSG_ZoneWide_NotInUse(self):
         """ Test delete zone wide shared network with SG which is not in use"""
 
@@ -1030,7 +1030,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test__14_createSharedNwWithSG_withoutParams(self):
         """ Test create shared network with SG without specifying necessary parameters"""
 
@@ -1075,7 +1075,7 @@ class TestNetworksInAdvancedSG(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test__15_createVPC(self):
         """ Test create VPC in advanced SG enabled zone"""
 
@@ -1313,7 +1313,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
         status = os.system("%s -i %s" %(file2, config_file))
         return status
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test__16_AccountSpecificNwAccess(self):
         """ Test account specific network access of users"""
 
@@ -1408,7 +1408,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test__17_DomainSpecificNwAccess(self):
         """ Test domain specific network access of users"""
 
@@ -1519,7 +1519,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
         return
 
     @data("account", "domain")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_18_DeployVM_NoFreeIPs(self, value):
         """ Test deploy VM in account/domain specific SG enabled shared network when no free IPs are available"""
 
@@ -1582,7 +1582,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_19_DeployVM_DefaultSG(self):
         """ Test deploy VM in default security group"""
 
@@ -1623,7 +1623,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
         return
 
     @data("default", "custom")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_20_DeployVM_SecGrp_sharedNetwork(self, value):
         """ Test deploy VM in default/custom security group and shared network"""
 
@@ -1679,7 +1679,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_24_DeployVM_Multiple_Shared_Networks(self):
         """ Test deploy VM in multiple zone wide shared networks"""
 
@@ -1727,7 +1727,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_25_Deploy_Multiple_VM_Different_Shared_Networks_Same_SG(self):
         """ Test deploy Multiple VMs in different shared networks but same security group"""
 
@@ -1795,7 +1795,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_26_Destroy_Deploy_VM_NoFreeIPs(self):
         """ Test destroy VM in zone wide shared nw when IPs are full and then try to deploy vm"""
 
@@ -1859,7 +1859,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
         return
 
     @data("stopStart","reboot")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_27_start_stop_vm(self, value):
         """ Test start and stop vm"""
 
@@ -1928,7 +1928,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
         return
 
     @data("recover","expunge")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_28_destroy_recover_expunge_vm(self, value):
         """ Test start and stop vm"""
 
@@ -2018,7 +2018,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_31_Deploy_VM_multiple_shared_networks_sg(self):
         """ Test deploy VM in multiple SG enabled shared networks"""
 
@@ -2068,7 +2068,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
 
     @unittest.skip("Testing pending on multihost setup")
     @data("account","domain","zone")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_33_VM_Migrate_SharedNwSG(self, value):
         """ Test migration of VM deployed in Account specific shared network"""
 
@@ -2143,7 +2143,7 @@ class TestNetworksInAdvancedSG_VmOperations(cloudstackTestCase):
         self.assertEqual(vm_list[0].hostid, hosts_to_migrate[0].id, "VM host id does not reflect the migration")
         return
 
-    @attr(tags=["advancedsg"], required_hardware="false")
+    @attr(tags=["advancedsg", "networks"], required_hardware="false")
     def test_34_DeployVM_in_SecondSGNetwork(self):
         """
         @Desc: VM Cannot deploy to second network in advanced SG network
@@ -2416,7 +2416,7 @@ class TestSecurityGroups_BasicSanity(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_21_DeployVM_WithoutSG(self):
         """ Test deploy VM without passing any security group id"""
 
@@ -2509,7 +2509,7 @@ class TestSecurityGroups_BasicSanity(cloudstackTestCase):
                          )
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_22_DeployVM_With_Custom_SG(self):
         """ Test deploy VM by passing custom security group id"""
 
@@ -2602,7 +2602,7 @@ class TestSecurityGroups_BasicSanity(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_23_DeployVM_MultipleSG(self):
         """ Test deploy VM in multiple security groups"""
 
@@ -2694,7 +2694,7 @@ class TestSecurityGroups_BasicSanity(cloudstackTestCase):
                          )
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_32_delete_default_security_group(self):
         """ Test Delete the default security group when No VMs are deployed"""
 
@@ -2863,7 +2863,7 @@ class TestSharedNetworkOperations(cloudstackTestCase):
         return
 
     @data("account","domain","zone")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_34_restart_shared_network_sg(self, value):
         """ Test restart account/domain/zone wide shared network"""
 
@@ -2914,7 +2914,7 @@ class TestSharedNetworkOperations(cloudstackTestCase):
 
     @unittest.skip("Testing pending on multihost setup")
     @data("account","domain","zone")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_35_Enable_Host_Maintenance(self, value):
         """ Test security group rules of VM after putting host in maintenance mode"""
 
@@ -3165,7 +3165,7 @@ class TestAccountBasedIngressRules(cloudstackTestCase):
         return
 
     @data("accessByIp","accessByName")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_36_ssh_vm_other_sg(self, value):
         """ Test access VM in other security group from vm in one security group"""
 
@@ -3221,7 +3221,7 @@ class TestAccountBasedIngressRules(cloudstackTestCase):
             )
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_37_ping_vm_other_sg(self):
         """ Test access VM in other security group from vm in one security group"""
 
@@ -3275,7 +3275,7 @@ class TestAccountBasedIngressRules(cloudstackTestCase):
         return
 
     @data("accessByIp","accessByName")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_38_ssh_vm_other_sg_new_vm(self, value):
         """ Test access VM in other security group from a new vm in one security group"""
 
@@ -3343,7 +3343,7 @@ class TestAccountBasedIngressRules(cloudstackTestCase):
         return
 
     @data("accessByIp","accessByName")
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_39_ssh_vm_other_sg_from_multiple_sg_vm(self, value):
         """ Test access VM in other security group from vm belonging to multiple security groups"""
 
@@ -3411,7 +3411,7 @@ class TestAccountBasedIngressRules(cloudstackTestCase):
             )
         return
 
-    @attr(tags = ["advancedsg"])
+    @attr(tags = ["advancedsg", "networks"])
     def test_40_ssh_vm_other_sg_reboot(self):
         """ Test access VM in other security group from vm in one security group before and after reboot"""
 

--- a/test/integration/component/test_browse_templates.py
+++ b/test/integration/component/test_browse_templates.py
@@ -1443,7 +1443,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
         )
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_01_Browser_template_Life_cycle_tpath(self):
         """
         Test Browser_template_Life_cycle
@@ -1505,7 +1505,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
 #            self.fail("Exception occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_02_SSVM_Life_Cycle_With_Browser_Template_TPath(self):
         """
         Test SSVM_Life_Cycle_With_Browser_template_TPath 
@@ -1552,7 +1552,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
             self.fail("Exception occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_03_Browser_template_upload_multiple_zones(self):
         """
         Test Browser_template_upload_multiple_zones
@@ -1571,7 +1571,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
             self.fail("Exception occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_04_Browser_template_ResetVM_With_Deleted_Template(self):
         """
         Test Browser_template_upload_ResetVM_With_Deleted_Template
@@ -1592,7 +1592,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
             self.fail("Exception occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_05_Browser_Upload_Template_with_all_API_parameters(self):
         """
         Test Browser_Upload_Template with all API parameters
@@ -1620,7 +1620,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
 
 
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_06_Browser_Upload_template_resource_limits(self):
         """
         Test Browser Upload Template Resource limits
@@ -1643,7 +1643,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
             self.fail("Exception occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_07_Browser_Upload_template_secondary_storage_resource_limits(self):
         """
         Test Browser_Upload_Template Secondary Storage Resource limits
@@ -1673,7 +1673,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
             self.fail("Exception occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_08_Browser_Upload_template_resource_limits_after_deletion(self):
         """
         Test Browser_Upload_Template Resource limits after template deletion
@@ -1693,7 +1693,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
             self.fail("Exceptione occurred  : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="true")
     def test_09_Browser_Upload_Volume_secondary_storage_resource_limits_after_deletion(self):
         """
         Test Browser_Upload_Template Secondary Storage Resource limits after template deletion
@@ -1722,7 +1722,7 @@ class TestBrowseUploadVolume(cloudstackTestCase):
         return
 
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="false")
     def test_browser_upload_template_incomplete(self):
         """
         Test browser based incomplete template upload, followed by SSVM destroy. Template should go to UploadAbandoned state and get cleaned up.

--- a/test/integration/component/test_browse_templates2.py
+++ b/test/integration/component/test_browse_templates2.py
@@ -167,7 +167,7 @@ class TestBrowseUploadTemplate(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "templates"], required_hardware="false")
     def test_browser_upload_template_incomplete(self):
         """
         Test browser based incomplete template upload, followed by SSVM destroy. Template should go to UploadAbandoned state and get cleaned up.

--- a/test/integration/component/test_deploy_vgpu_vm.py
+++ b/test/integration/component/test_deploy_vgpu_vm.py
@@ -223,7 +223,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             # cls.k200_vgpu_service_offering
         ]
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def setUp(self):
         self.testdata = self.testClient.getParsedTestDataConfig()
         self.apiclient = self.testClient.getApiClient()
@@ -247,7 +247,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return(vgpucapacity)
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def vgpu_serviceoffering_creation(self, gtype, nvidiamodel):
         if gtype == "nonvgpuoffering" and nvidiamodel == "None":
             self.service_offering = ServiceOffering.create(
@@ -308,7 +308,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             )
         return(self.service_offering)
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def check_for_vGPU_resource(
             self,
             hostid,
@@ -382,7 +382,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         )
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def deploy_vGPU_windows_vm(self, vgpuofferingid, vgput):
         """
         Validate vGPU K1 windows instances
@@ -441,7 +441,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             )
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def delete_vgpu_service_offering(self, serviceoffering):
         """
         delete vGPU Service Offering
@@ -460,7 +460,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         )
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def check_for_vm(self, vgpucard, vgpuofferingid, vmid):
         list_vm_response = list_virtual_machines(
             self.apiclient,
@@ -488,7 +488,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
                         (vm.id, vgpucard))
         return(list_vm_response[0])
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def destroy_vm(self):
         """Destroy Virtual Machine
         """
@@ -518,7 +518,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         )
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def stop_vm(self):
         """Stop Virtual Machine
         """
@@ -529,7 +529,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             self.fail("Failed to stop VM: %s" % e)
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def start_vm(self):
         """Start Virtual Machine
         """
@@ -564,7 +564,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         )
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def serviceoffering_upgrade(
             self,
             sourcetype,
@@ -614,7 +614,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         self.destroy_vm()
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def vm_snapshot_serviceoffering_upgrade(
             self,
             sourcetype,
@@ -664,7 +664,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         self.destroy_vm()
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def deploy_vm(self, type, model):
 
         self.vgpuoffering = self.vgpu_serviceoffering_creation(type, model)
@@ -1351,7 +1351,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         self.verify_vm(vm_vgpu_card)
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def vm_snapshot_vgpu(
             self,
             vmcard,
@@ -1472,7 +1472,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
                 self.fail(
                     "list host details with K1 Passthrough vgpu are not correct")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_02_create_deploy_windows_vm_with_k100_vgpu_service_offering(self):
         """Test to create and deploy vm with K100 vGPU service offering"""
 
@@ -1488,7 +1488,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K100",
             "Group of NVIDIA Corporation GK107GL [GRID K1] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_03_create_deploy_windows_vm_with_k120q_vgpu_service_offering(
             self):
         """Test to create and deploy vm with K120Q vGPU service offering"""
@@ -1505,7 +1505,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K120Q",
             "Group of NVIDIA Corporation GK107GL [GRID K1] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_04_create_deploy_windows_vm_with_k140q_vgpu_service_offering(
             self):
         """Test to create and deploy vm with K140Q vGPU service offering"""
@@ -1522,7 +1522,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K140Q",
             "Group of NVIDIA Corporation GK107GL [GRID K1] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_05_create_deploy_windows_vm_with_k1_passthrough_vgpu_service_offering(
             self):
         """Test to create and deploy vm with K1 passthrough vGPU service offering"""
@@ -1539,7 +1539,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "passthrough",
             "Group of NVIDIA Corporation GK107GL [GRID K1] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_06_create_deploy_windows_vm_with_k2_passthrough_vgpu_service_offering(
             self):
         """Test to create and deploy vm with K2 pasthrough vGPU service offering"""
@@ -1556,7 +1556,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "passthrough",
             "Group of NVIDIA Corporation GK104GL [GRID K2] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_07_create_deploy_windows_vm_with_k260q_vgpu_service_offering(
             self):
         """Test to create and deploy vm with K260Q vGPU service offering"""
@@ -1573,7 +1573,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K260Q",
             "Group of NVIDIA Corporation GK104GL [GRID K2] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_08_create_deploy_windows_vm_with_k240q_vgpu_service_offering(
             self):
         """   Test to create and deploy vm with K240Q vGPU service offering """
@@ -1590,7 +1590,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K240Q",
             "Group of NVIDIA Corporation GK104GL [GRID K2] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_09_create_deploy_windows_vm_with_k220q_vgpu_service_offering(
             self):
         """  Test to create and deploy vm with K220Q vGPU service offering """
@@ -1607,7 +1607,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K220Q",
             "Group of NVIDIA Corporation GK104GL [GRID K2] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_10_create_deploy_windows_vm_with_k200_vgpu_service_offering(self):
         """   Test to create and deploy vm with K200 vGPU service offering  """
 
@@ -1623,7 +1623,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "GRID K200",
             "Group of NVIDIA Corporation GK104GL [GRID K2] GPUs")
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_11_add_nonvgpu_host_to_vgpucluster(self):
         """   Test to add non vGPU host to an existing cluster  """
         countx = 0
@@ -1733,7 +1733,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
                 # Cleanup Host
         self.cleanup.append(nongpuhost)
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_12_validate_deployed_vGPU_windows_vm(self):
         """ Test deploy virtual machine
         """
@@ -1754,7 +1754,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         self.__class__.vmlifecycletest = 1
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_13_stop_vGPU_windows_vm(self):
         """ Test stop virtual machine
         """
@@ -1773,7 +1773,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_14_start_vGPU_windows_vm(self):
         """ Test start virtual machine
         """
@@ -1792,7 +1792,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_15_restore_vGPU_windows_vm(self):
         """Test restore Virtual Machine
         """
@@ -1810,7 +1810,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_16_reboot_vGPU_windows_vm(self):
         """ Test reboot virtual machine
         """
@@ -1828,7 +1828,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_17_create_k1_vm_snapshot_wo_memory(self):
         """Test to create VM snapshots
         """
@@ -1846,7 +1846,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_18_revert_k1_vm_snapshot_wo_memory(self):
         """Test to revert VM snapshots
         """
@@ -1866,7 +1866,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_19_delete_k1_vm_snapshot_wo_memory(self):
         """Test to delete vm snapshots
         """
@@ -1886,7 +1886,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_20_create_k2_vm_snapshot_with_memory(self):
         """Test to create VM snapshots
         """
@@ -1902,7 +1902,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_21_revert_k2_vm_snapshot_with_memory(self):
         """Test to revert VM snapshots
         """
@@ -1922,7 +1922,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_22_delete_k2_vm_snapshot_with_memory(self):
         """Test to delete vm snapshots
         """
@@ -1942,7 +1942,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_23_vm_snapshot_without_memory_from_k1_vgpu_nonvgpu_vgpu(self):
         """Test to verify VM snapshot from vGPU to non vgpu to vGPU snap
         """
@@ -1971,7 +1971,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_24_vm_snapshot_without_memory_from_nonvgpu_k1vgpu_nonvgpu(self):
         """Test to verify VM snapshot from non vGPU snap to vGPU snap to non vGPU snap
         """
@@ -2000,7 +2000,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_25_vm_snapshot_without_memory_from_k2vgpu_k1vgpu_k2vgpu(self):
         """Test to verify VM snapshot from K2 vGPU snap to K1 vGPU snap to K2 vGPU snap
         """
@@ -2029,7 +2029,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_26_destroy_vGPU_windows_vm(self):
         """Test destroy Virtual Machine
         """
@@ -2056,7 +2056,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_27_recover_vGPU_windows_vm(self):
         """Test recover Virtual Machine
         """
@@ -2101,7 +2101,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_29_nonvgpuvm_k2vgpuvm_offline(self):
         """Test to change service from non vgpu to vgpu K200"""
         k200capacity = self.check_host_vgpu_capacity(
@@ -2119,7 +2119,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_30_K2_vgpuvm_vgpuvm_offline(self):
         """Test to change service from vgpu K200 to vgpu K240Q"""
         k240qcapacity = self.check_host_vgpu_capacity(
@@ -2141,7 +2141,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_31_K1_vgpuvm_vgpuvm_offline(self):
         """Test to change service from K1 vgpu K120Q to K1 vgpu K140Q"""
 
@@ -2165,7 +2165,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_32_nonvgpuvm_k1vgpuvm_offline(self):
         """Test to change service from non vgpu to vgpu K100"""
 
@@ -2183,7 +2183,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_33_K2_vgpuvm_nonvgpuvm_offline(self):
         """Test to change service from non vgpu to vgpu K240Q"""
 
@@ -2202,7 +2202,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_34_K1_vgpuvm_nonvgpuvm_offline(self):
         """Test to change service from non vgpu to vgpu K140Q"""
 
@@ -2222,7 +2222,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
 
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_35_K140Q_vgpuvm_K240Q_vgpuvm_offline(self):
         """Test to change service from K1 vgpu K140Q to K2 vgpu K240Q"""
 
@@ -2245,7 +2245,7 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             "Group of NVIDIA Corporation GK104GL [GRID K2] GPUs")
         return
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', "deploy-vm"], required_hardware="true")
     def test_36_K240Q_vgpuvm_K140Q_vgpuvm_offline(self):
         """Test to change service from K2 vgpu K240Q to K1 vgpu K140Q"""
 

--- a/test/integration/component/test_deploy_vm_userdata_multi_nic.py
+++ b/test/integration/component/test_deploy_vm_userdata_multi_nic.py
@@ -121,7 +121,7 @@ class TestDeployVmWithUserDataMultiNic(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["simulator", "devcloud", "basic", "advanced"], required_hardware="false")
+    @attr(tags=["simulator", "devcloud", "basic", "advanced", "deploy-vm"], required_hardware="false")
     def test_deployvm_multinic(self):
         """Test userdata update when non default nic is without userdata for deploy and update
         """

--- a/test/integration/component/test_deploy_vm_userdata_reg.py
+++ b/test/integration/component/test_deploy_vm_userdata_reg.py
@@ -105,7 +105,7 @@ class TestDeployVmWithUserData(cloudstackTestCase):
         self.hypervisor = self.testClient.getHypervisorInfo()
 
 
-    @attr(tags=["simulator", "devcloud", "basic", "advanced"], required_hardware="true")
+    @attr(tags=["simulator", "devcloud", "basic", "advanced", "deploy-vm"], required_hardware="true")
     def test_deployvm_userdata_post(self):
         """Test userdata as POST, size > 2k
         """

--- a/test/integration/component/test_dhcp_dns_offload.py
+++ b/test/integration/component/test_dhcp_dns_offload.py
@@ -399,7 +399,7 @@ class TestDeployVMs(cloudstackTestCase):
                 return False
         return True
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_01_createNetworks_TC3(self):
 
         """
@@ -429,7 +429,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.services["network2"]["name"] = name
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_02_deployVM_nw_without_services_TC6(self):
         """
         1.Create shared network without any services
@@ -470,7 +470,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_03_deployVM_with_userdata_TC7(self):
         """
         1.Create shared network without any services
@@ -518,7 +518,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_04_deploy_win_VM_with_userdata_TC8(self):
         """
         1.Create shared network without any services
@@ -558,7 +558,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.list_nics(self.vm_id)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_06_deployVM_with_userdata_TC11(self):
         """
         1.Create shared network with DHCP,DNS and userdata services provided by VR
@@ -612,7 +612,7 @@ class TestDeployVMs(cloudstackTestCase):
                         It might have got from external dhcp server in that network")
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_07_deployVM_with_userdata_VR_TC12(self):
         """
         1.Create shared network with only userdata service and VR as the provider
@@ -629,7 +629,7 @@ class TestDeployVMs(cloudstackTestCase):
             self.debug("NO creation failed as expected with error message %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_09_StopStartVMAndGetVMIpAddress_TC16(self):
         """
         1.Create shared network without any services
@@ -700,7 +700,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_10_RebootVMAndGetVMIpAddress_TC17(self):
         """
         1.Create shared network without any services
@@ -770,7 +770,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_11_DestroyVMAndGetVMIpAddress_TC18(self):
         """
         1.Create shared network without any services
@@ -842,7 +842,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_12_ReInstallVMAndGetVMIpAddress_TC19(self):
         """
         1.Create shared network without any services
@@ -911,7 +911,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_13_MigrateVMAndGetVMIpAddress_TC20(self):
         """
         1.Create shared network without any services
@@ -982,7 +982,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_14_VM_with_password_enabled_template_TC24(self):
         """
         1.Create shared network without any services
@@ -1019,7 +1019,7 @@ class TestDeployVMs(cloudstackTestCase):
                       (self.vm.ssh_ip, e))
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_15_reset_password_TC27(self):
         """
         1.Create shared network without any services
@@ -1065,7 +1065,7 @@ class TestDeployVMs(cloudstackTestCase):
                       (self.vm.ssh_ip, e))
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_16_deployVM_with_sshkeys_TC26(self):
         """
         1.Create shared network without any services
@@ -1105,7 +1105,7 @@ class TestDeployVMs(cloudstackTestCase):
                       (self.vm.ssh_ip, e))
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_17_reset_sshkeys_TC29(self):
         """
         1.Create shared network without any services
@@ -1167,7 +1167,7 @@ class TestDeployVMs(cloudstackTestCase):
                       (self.vm.ssh_ip, e))
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_18_reset_password_verify_after_vm_restart_TC36(self):
         """
         1.Create shared network without any services
@@ -1224,7 +1224,7 @@ class TestDeployVMs(cloudstackTestCase):
             self.fail("SSH into vm failed with the same password after vm stop start")
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_19_reset_sshkeys_verify_after_vm_restartTC37(self):
         """
         1.Create shared network without any services
@@ -1295,7 +1295,7 @@ class TestDeployVMs(cloudstackTestCase):
             self.fail("SSH into vm failed with new ssh keypair after vm stop start")
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_20_verify_VM_metadata_TC30(self):
         """
         1.Create shared network without any services
@@ -1338,7 +1338,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_21_StopStartVM_verify_ConfigDrive_TC31(self):
         """
         1.Create shared network without any services
@@ -1413,7 +1413,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_22_RebootVM_verify_ConfigDrive_TC32(self):
         """
         1.Create shared network without any services
@@ -1487,7 +1487,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_23_DestroyVM_verify_ConfigDrive_TC33(self):
         """
         1.Create shared network without any services
@@ -1563,7 +1563,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_24_ReInstallVM_verify_ConfigDrive_TC34(self):
         """
         1.Create shared network without any services
@@ -1637,7 +1637,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_25_MigrateVMVM_verify_ConfigDrive_TC35(self):
         """
         1.Create shared network without any services
@@ -1716,7 +1716,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_26_DeployVM_verify_IPFetchEvent_TC56(self):
         """
         1.Create shared network without any services
@@ -1764,7 +1764,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_27_StopStartVM_verify_IPFetchEvent_TC57(self):
         """
         1.Create shared network without any services
@@ -1822,7 +1822,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_28_RebootVM_verify_IPFetchEvent_TC58(self):
         """
         1.Create shared network without any services
@@ -1879,7 +1879,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_29_deployVM_In_Two_Networks_TC49(self):
         """
         1.Create shared network without any services
@@ -1938,7 +1938,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_30_deployVM_In_Two_Networks_TC50(self):
         """
         1.Create shared network without any services
@@ -2004,7 +2004,7 @@ class TestDeployVMs(cloudstackTestCase):
         self.verifyMetaData(metadata)
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_31_deployVM_with_userdataByVR_TC38(self):
         """
         1.Create shared network with userdata service and VR as the provider
@@ -2055,7 +2055,7 @@ class TestDeployVMs(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_32_restart_network_TC6(self):
         """
         1.Create shared network without any services
@@ -2099,7 +2099,7 @@ class TestDeployVMs(cloudstackTestCase):
             self.fail("Failed restarting shared network without any services")
         return
 
-    @attr(tags=["advanced"], required_hardware='True')
+    @attr(tags=["advanced", "networks"], required_hardware='True')
     def test_33_verify_config_params_TC65(self):
         """
         #@desc: Validate external dhcp config parameters against invalid values

--- a/test/integration/component/test_dynamic_compute_offering.py
+++ b/test/integration/component/test_dynamic_compute_offering.py
@@ -109,7 +109,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_create_normal_compute_offering(self):
         """ Create normal compute offering with non zero values for cpu,
             cpu number and memory"""
@@ -138,7 +138,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
         self.cleanup_co.append(serviceOffering)
         return
 
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_create_dynamic_compute_offering(self):
         """ Create dynamic compute offering with cpunumber, cpuspeed and memory
             not specified"""
@@ -167,7 +167,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
         self.cleanup_co.append(serviceOffering)
         return
 
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_create_dynamic_compute_offering_no_cpunumber(self):
         """ Create dynamic compute offering with only cpunumber unspecified"""
 
@@ -189,7 +189,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
             self.debug("Compute Offering Creation failed as expected")
         return
 
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_create_dynamic_compute_offering_no_cpuspeed(self):
         """ Create dynamic compute offering with only cpuspeed unspecified"""
 
@@ -211,7 +211,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
             self.debug("Compute Offering Creation failed as expected")
         return
 
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_create_dynamic_compute_offering_no_memory(self):
         """ Create dynamic compute offering with only memory unspecified"""
 
@@ -234,7 +234,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_deploy_virtual_machines_static_offering(self, value):
         """Test deploy VM with static offering"""
 
@@ -303,7 +303,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_deploy_virtual_machines_dynamic_offering(self, value):
         """Test deploy VM with dynamic compute offering"""
 
@@ -394,7 +394,7 @@ class TestDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_check_vm_stats(self, value):
         """Deploy VM with dynamic service offering and check VM stats"""
 
@@ -555,7 +555,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_change_so_stopped_vm_static_to_static(self, value):
         """Test scale stopped VM from static offering to static offering"""
 
@@ -625,7 +625,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_change_so_stopped_vm_static_to_dynamic(self, value):
         """Test scale stopped VM from static offering to dynamic offering"""
 
@@ -722,7 +722,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_change_so_stopped_vm_dynamic_to_static(self, value):
         """Test scale stopped VM from dynamic offering to static offering"""
 
@@ -795,7 +795,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_change_so_stopped_vm_dynamic_to_dynamic(self, value):
         """Test scale stopped VM from dynamic offering to dynamic offering"""
 
@@ -888,7 +888,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"],required_hardware="true")
+    @attr(tags=["basic", "advanced", "service-offerings"],required_hardware="true")
     def test_change_so_running_vm_static_to_static(self, value):
         """Test scale running VM from static offering to static offering"""
 
@@ -960,7 +960,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"],required_hardware="true")
+    @attr(tags=["basic", "advanced", "service-offerings"],required_hardware="true")
     def test_change_so_running_vm_static_to_dynamic(self, value):
         """Test scale running VM from static offering to dynamic offering"""
 
@@ -1066,7 +1066,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"],required_hardware="true")
+    @attr(tags=["basic", "advanced", "service-offerings"],required_hardware="true")
     def test_change_so_running_vm_dynamic_to_static(self, value):
         """Test scale running VM from dynamic offering to static offering"""
 
@@ -1143,7 +1143,7 @@ class TestScaleVmDynamicServiceOffering(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"],required_hardware="true")
+    @attr(tags=["basic", "advanced", "service-offerings"],required_hardware="true")
     def test_change_so_running_vm_dynamic_to_dynamic(self, value):
         """Test scale running VM from dynamic offering to dynamic offering"""
 
@@ -1313,7 +1313,7 @@ class TestAccountLimits(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_max_account_cpus_deploy_VM(self, value):
         """Test cpu limits of account while deploying VM with dynamic
            compute offering"""
@@ -1374,7 +1374,7 @@ class TestAccountLimits(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_max_account_cpus_scale_VM(self, value):
         """Test cpu limits of account while scaling VM with dynamic
            compute offering"""
@@ -1451,7 +1451,7 @@ class TestAccountLimits(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_max_account_memory_deploy_VM(self, value):
         """Test memory limits of account while deploying VM with dynamic
            compute offering"""
@@ -1512,7 +1512,7 @@ class TestAccountLimits(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"])
+    @attr(tags=["basic", "advanced", "service-offerings"])
     def test_max_account_memory_scale_VM(self, value):
         """Test memory limits of account while scaling VM with
            dynamic compute offering"""
@@ -1653,7 +1653,7 @@ class TestAffinityGroup(cloudstackTestCase):
         return
 
     @data(ADMIN_ACCOUNT, USER_ACCOUNT)
-    @attr(tags=["basic", "advanced"], BugId="7180", required_hardware="true")
+    @attr(tags=["basic", "advanced", "service-offerings"], BugId="7180", required_hardware="true")
     def test_deploy_VM_with_affinity_group(self, value):
         """Test deploy VMs with affinity group and dynamic compute offering"""
 

--- a/test/integration/component/test_egress_fw_rules.py
+++ b/test/integration/component/test_egress_fw_rules.py
@@ -368,7 +368,7 @@ class TestEgressFWRules(cloudstackTestCase):
         self.assertEqual(validateList(self.vm_list)[0], PASS, "vm list validation failed, vm list is %s" % self.vm_list)
         self.assertEqual(str(self.vm_list[0].state).lower(),'running',"VM state should be running, it is %s" % self.vm_list[0].state)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_01_egress_fr1(self):
         """Test By-default the communication from guest n/w to public n/w is allowed.
         """
@@ -390,7 +390,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['0']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_01_1_egress_fr1(self):
         """Test By-default the communication from guest n/w to public n/w is NOT allowed.
         """
@@ -405,7 +405,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['100']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_01_2_egress_fr1(self):
         """Test egress rule with /32 CIDR of a VM, and check other VM in the
            network does not have public access
@@ -426,7 +426,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     negative_test=False)
         # If failed probably we've hit this issue: CLOUDSTACK-10075
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_02_egress_fr2(self):
         """Test Allow Communication using Egress rule with CIDR + Port Range + Protocol.
         """
@@ -443,7 +443,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['100']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_02_1_egress_fr2(self):
         """Test Allow Communication using Egress rule with CIDR + Port Range + Protocol.
         """
@@ -460,7 +460,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['0']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_02_2_egress_fr2(self):
         """Test Allow Communication using Egress rule with /32 CIDR + Port Range + Protocol.
         """
@@ -477,7 +477,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['0']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_03_egress_fr3(self):
         """Test Communication blocked with network that is other than specified
         """
@@ -498,7 +498,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "[]",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_03_1_egress_fr3(self):
         """Test Communication blocked with network that is other than specified
         """
@@ -519,7 +519,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['failed:']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_04_egress_fr4(self):
         """Test Create Egress rule and check the Firewall_Rules DB table
         """
@@ -556,7 +556,7 @@ class TestEgressFWRules(cloudstackTestCase):
                          "DB results not matching, expected: 1, found: %s" % qresultset[0][0])
 
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_04_1_egress_fr4(self):
         """Test Create Egress rule and check the Firewall_Rules DB table
         """
@@ -593,7 +593,7 @@ class TestEgressFWRules(cloudstackTestCase):
                          "DB results not matching, expected: 0, found: %s" % qresultset[0][0])
 
     @unittest.skip("Skip")
-    @attr(tags=["advanced", "NotRun"])
+    @attr(tags=["advanced", "NotRun", "routers", "networks"])
     def test_05_egress_fr5(self):
         """Test Create Egress rule and check the IP tables
         """
@@ -612,7 +612,7 @@ class TestEgressFWRules(cloudstackTestCase):
 
 
     @unittest.skip("Skip")
-    @attr(tags=["advanced", "NotRun"])
+    @attr(tags=["advanced", "NotRun", "routers", "networks"])
     def test_05_1_egress_fr5(self):
         """Test Create Egress rule and check the IP tables
         """
@@ -630,7 +630,7 @@ class TestEgressFWRules(cloudstackTestCase):
         #TODO: Query VR for expected route rules.
 
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_06_egress_fr6(self):
         """Test Create Egress rule without CIDR
         """
@@ -646,7 +646,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['100']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_06_1_egress_fr6(self):
         """Test Create Egress rule without CIDR
         """
@@ -662,7 +662,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['0']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_07_egress_fr7(self):
         """Test Create Egress rule without End Port
         """
@@ -678,7 +678,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['failed:']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_07_1_egress_fr7(self):
         """Test Create Egress rule without End Port
         """
@@ -695,7 +695,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     negative_test=False)
 
     @unittest.skip("Skip")
-    @attr(tags=["advanced", "NotRun"])
+    @attr(tags=["advanced", "NotRun", "networks"])
     def test_08_egress_fr8(self):
         """Test Port Forwarding and Egress Conflict
         """
@@ -707,7 +707,7 @@ class TestEgressFWRules(cloudstackTestCase):
         self.createEgressRule(cidr=TestEgressFWRules.zone.guestcidraddress)
 
     @unittest.skip("Skip")
-    @attr(tags=["advanced", "NotRun"])
+    @attr(tags=["advanced", "NotRun", "routers", "networks"])
     def test_08_1_egress_fr8(self):
         """Test Port Forwarding and Egress Conflict
         """
@@ -719,7 +719,7 @@ class TestEgressFWRules(cloudstackTestCase):
         self.createEgressRule(cidr=TestEgressFWRules.zone.guestcidraddress)
 
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_09_egress_fr9(self):
         """Test Delete Egress rule
         """
@@ -743,7 +743,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['0']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_09_1_egress_fr9(self):
         """Test Delete Egress rule
         """
@@ -768,7 +768,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     negative_test=False)
 
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_10_egress_fr10(self):
         """Test Invalid CIDR and Invalid Port ranges
         """
@@ -779,7 +779,7 @@ class TestEgressFWRules(cloudstackTestCase):
         self.create_vm()
         self.assertRaises(Exception, self.createEgressRule, cidr='10.2.2.0/24')
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_10_1_egress_fr10(self):
         """Test Invalid CIDR and Invalid Port ranges
         """
@@ -791,7 +791,7 @@ class TestEgressFWRules(cloudstackTestCase):
         self.assertRaises(Exception, self.createEgressRule, cidr='10.2.2.0/24')
 
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_11_egress_fr11(self):
         """Test Regression on Firewall + PF + LB + SNAT
         """
@@ -801,7 +801,7 @@ class TestEgressFWRules(cloudstackTestCase):
         # 3. All should work fine.
         self.create_vm(pfrule=True)
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_11_1_egress_fr11(self):
         """Test Regression on Firewall + PF + LB + SNAT
         """
@@ -811,7 +811,7 @@ class TestEgressFWRules(cloudstackTestCase):
         # 3. All should work fine.
         self.create_vm(pfrule=True, egress_policy=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_12_egress_fr12(self):
         """Test Reboot Router
         """
@@ -828,7 +828,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['100']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_12_1_egress_fr12(self):
         """Test Reboot Router
         """
@@ -845,7 +845,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['0']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_13_egress_fr13(self):
         """Test Redundant Router : Master failover
         """
@@ -900,7 +900,7 @@ class TestEgressFWRules(cloudstackTestCase):
                                     "['100']",
                                     negative_test=False)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_13_1_egress_fr13(self):
         """Test Redundant Router : Master failover
         """

--- a/test/integration/component/test_egress_rules.py
+++ b/test/integration/component/test_egress_rules.py
@@ -196,7 +196,7 @@ class TestDefaultSecurityGroupEgress(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_deployVM_InDefaultSecurityGroup(self):
         """Test deploy VM in default security group with no egress rules
         """
@@ -350,7 +350,7 @@ class TestAuthorizeIngressRule(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_authorizeIngressRule(self):
         """Test authorize ingress rule
         """
@@ -507,7 +507,7 @@ class TestDefaultGroupEgress(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_01_default_group_with_egress(self):
         """Test default group with egress rule before VM deploy and ping, ssh
         """
@@ -704,7 +704,7 @@ class TestDefaultGroupEgressAfterDeploy(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_01_default_group_with_egress(self):
         """ Test default group with egress rule added after vm deploy and ping,
             ssh test
@@ -882,7 +882,7 @@ class TestRevokeEgressRule(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_revoke_egress_rule(self):
         """Test revoke security group egress rule
         """
@@ -1164,7 +1164,7 @@ class TestInvalidAccountAuthroize(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_invalid_account_authroize(self):
         """Test invalid account authroize
         """
@@ -1289,7 +1289,7 @@ class TestMultipleAccountsEgressRuleNeg(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_multiple_account_egress_rule_negative(self):
         """Test multiple account egress rules negative case
         """
@@ -1537,7 +1537,7 @@ class TestMultipleAccountsEgressRule(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_multiple_account_egress_rule_positive(self):
         """Test multiple account egress rules positive case
         """
@@ -1821,7 +1821,7 @@ class TestStartStopVMWithEgressRule(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_start_stop_vm_egress(self):
         """ Test stop start Vm with egress rules
         """
@@ -2011,7 +2011,7 @@ class TestInvalidParametersForEgress(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["sg", "eip", "advancedsg"])
+    @attr(tags = ["sg", "eip", "advancedsg", "routers", "networks"])
     def test_invalid_parameters(self):
         """ Test invalid parameters for egress rules
         """

--- a/test/integration/component/test_escalations_isos.py
+++ b/test/integration/component/test_escalations_isos.py
@@ -135,7 +135,7 @@ class TestIsos(cloudstackTestCase):
                                                                                           ))
         return return_flag
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_01_list_isos_pagination(self):
         """
         @Desc: Test to List ISO's pagination
@@ -289,7 +289,7 @@ class TestIsos(cloudstackTestCase):
         del self.services["iso"]["zoneid"]
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_02_download_iso(self):
         """
         @Desc: Test to Download ISO
@@ -404,7 +404,7 @@ class TestIsos(cloudstackTestCase):
         del self.services["iso"]["isextractable"]
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_03_edit_iso_details(self):
         """
         @Desc: Test to Edit ISO name, displaytext, OSType
@@ -588,7 +588,7 @@ class TestIsos(cloudstackTestCase):
         del self.services["iso"]["zoneid"]
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_04_copy_iso(self):
         """
         @Desc: Test to copy ISO from one zone to another

--- a/test/integration/component/test_escalations_networks.py
+++ b/test/integration/component/test_escalations_networks.py
@@ -146,7 +146,7 @@ class TestNetworks_1(cloudstackTestCase):
                     (exp_val, act_val))
         return return_flag
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_01_list_networks_pagination(self):
         """
         @Desc: Test List Networks pagination
@@ -274,7 +274,7 @@ class TestNetworks_1(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_02_create_network_without_sourcenat(self):
         """
         @Desc: Test create network if supported services doesn't have sourcenat
@@ -310,7 +310,7 @@ class TestNetworks_1(cloudstackTestCase):
             "networkoffering"] = self.network_offering.id
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_03_list_vpc_pagination(self):
         """
         @Desc: Test create vpc with network domain as parameter
@@ -431,7 +431,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_04_create_vpc_with_networkdomain(self):
         """
         @Desc: Test create vpc with network domain as parameter
@@ -480,7 +480,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_05_list_network_offerings_with_and_without_vpc(self):
         """
         @Desc: Test list network offerings for vpc true and false parameters
@@ -602,7 +602,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_06_create_network_in_vpc(self):
         """
         @Desc: Test create network in vpc and verify VPC name
@@ -769,7 +769,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_07_create_delete_network(self):
         """
         @Desc: Test delete network
@@ -875,7 +875,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_08_update_network(self):
         """
         @Desc: Test update network
@@ -997,7 +997,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_09_list_virtual_machines_single_network(self):
         """
         @Desc: Test update network
@@ -1126,7 +1126,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_10_list_networks_in_vpc(self):
         """
         @Desc: Test list networks in vpc and verify VPC name
@@ -1271,7 +1271,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_11_update_vpc(self):
         """
         @Desc: Test create vpc with network domain as parameter
@@ -1370,7 +1370,7 @@ class TestNetworks_1(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_12_list_create_delete_networkACL(self):
         """
         @Desc: Test create network in vpc and verify VPC name
@@ -1668,7 +1668,7 @@ class TestNetworks_2(cloudstackTestCase):
                     (exp_val, act_val))
         return return_flag
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_13_list_vpc_byid(self):
         """
         @summary: Test List VPC with Id
@@ -1762,7 +1762,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_14_list_public_ipaddress_by_associated_networkid(self):
         """
         @summary: Test List Public IPAddress with associatednetworkid
@@ -1908,7 +1908,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_15_list_privategateway_byvpcid(self):
         """
         @summary: Test List PrivateGateway by vpcid
@@ -2028,7 +2028,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_16_create_list_delete_egressfirewallrule_bynetworkid(self):
         """
         @summary: Test Create List Delete Egress Firewall Rule by Network ID
@@ -2180,7 +2180,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_17_restart_vpc(self):
         """
         @summary: Test to restart VPC
@@ -2257,7 +2257,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_18_create_list_vpn_gateway(self):
         """
         @Desc: Test to Create and list Vpn Gateway by VPCid
@@ -2367,7 +2367,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_19_create_list_reset_delete_vpnconnections(self):
         """
         @Desc: Test to List Create Reset and Delete VPN Customer
@@ -2617,7 +2617,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_20_list_capabilities(self):
         """
         @summary: Test List Capabilities
@@ -2640,7 +2640,7 @@ class TestNetworks_2(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_21_listNetworkacls_by_privategateway_aclid(self):
         """
         @summary: Test to list Networkacllists by private gateway aclid

--- a/test/integration/component/test_escalations_routers.py
+++ b/test/integration/component/test_escalations_routers.py
@@ -99,7 +99,7 @@ class TestVR(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers"], required_hardware="true")
     def test_01_FTPModulesInVR(self):
         """
         @desc: Verify FTP modules are loaded in VR of advance zone

--- a/test/integration/component/test_escalations_templates.py
+++ b/test/integration/component/test_escalations_templates.py
@@ -177,7 +177,7 @@ class TestTemplates(cloudstackTestCase):
                 retries = retries - 1
         raise Exception("Template download failed exception.")
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_01_list_templates_pagination(self):
         """
         @Desc: Test to List Templates pagination
@@ -307,7 +307,7 @@ class TestTemplates(cloudstackTestCase):
         del self.services["privatetemplate"]["ostype"]
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_02_download_template(self):
         """
         @Desc: Test to Download Template
@@ -399,7 +399,7 @@ class TestTemplates(cloudstackTestCase):
         del self.services["privatetemplate"]["isextractable"]
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_03_edit_template_details(self):
         """
         @Desc: Test to Edit Template name, displaytext, OSType
@@ -686,7 +686,7 @@ class TestTemplates(cloudstackTestCase):
         del self.services["privatetemplate"]["ostype"]
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "templates"], required_hardware="true")
     def test_04_copy_template(self):
         """
         @Desc: Test to copy Template from one zone to another

--- a/test/integration/component/test_invalid_gw_nm.py
+++ b/test/integration/component/test_invalid_gw_nm.py
@@ -77,7 +77,7 @@ class TestIsolatedNetworkInvalidGw(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "networks"], required_hardware="false")
     def test_isolated_nw_invalid_gw(self):
 
         self.debug("Trying to create a network with Gateway as 192.168.3.0. This should fail")

--- a/test/integration/component/test_ip_reservation.py
+++ b/test/integration/component/test_ip_reservation.py
@@ -162,7 +162,7 @@ class TestIpReservation(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers"])
     def test_vm_create_after_reservation(self):
         """ Test creating VM in network after IP reservation
         # steps
@@ -206,7 +206,7 @@ class TestIpReservation(cloudstackTestCase):
             self.fail("VM creation failed, cannot validate the condition: %s" % e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_vm_create_outside_cidr_after_reservation(self):
         """ Test create VM outside the range of reserved IPs
         # steps
@@ -238,7 +238,7 @@ class TestIpReservation(cloudstackTestCase):
             self.debug("exception as IP is outside of guestvmcidr %s" % e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_update_cidr_multiple_vms_not_all_inclusive(self):
         """ Test reserve IP range such that one of the VM is not included
         # steps
@@ -274,7 +274,7 @@ class TestIpReservation(cloudstackTestCase):
             isolated_network.update(self.apiclient, guestvmcidr=guest_vm_cidr)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_update_cidr_single_vm_not_inclusive(self):
         """ Test reserving IP range in network such that existing VM is outside the range
         # steps
@@ -305,7 +305,7 @@ class TestIpReservation(cloudstackTestCase):
         return
 
     @data(NAT_RULE, STATIC_NAT_RULE)
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="true")
     def test_nat_rules(self, value):
         """ Test NAT rules working with IP reservation
         # steps
@@ -368,7 +368,7 @@ class TestIpReservation(cloudstackTestCase):
         return
 
     @unittest.skip("Skip - WIP")
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_RVR_network(self):
         """ Test IP reservation in network with RVR
         # steps
@@ -446,7 +446,7 @@ class TestIpReservation(cloudstackTestCase):
             self.fail("VM creation failed, cannot validate the condition: %s" % e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_ip_reservation_in_multiple_networks_same_account(self):
         """ Test IP reservation in multiple networks created in same account
         # steps
@@ -608,7 +608,7 @@ class TestRestartNetwork(cloudstackTestCase):
         return
 
     @data(True, False)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_restart_network_with_cleanup(self, value):
         """ Test IP reservation rules with network restart operation
         # steps
@@ -732,7 +732,7 @@ class TestUpdateIPReservation(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @data("existingVmInclusive", "existingVmExclusive")
+    @data("existingVmInclusive", "existingVmExclusive", "routers", "networks")
     @attr(tags=["advanced"])
     def test_update_network_guestvmcidr(self, value):
         """ Test updating guest vm cidr of the network after
@@ -882,7 +882,7 @@ class TestRouterOperations(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_reservation_after_router_restart(self):
         """ Test IP reservation working before and after router is restarted
         # steps
@@ -918,7 +918,7 @@ class TestRouterOperations(cloudstackTestCase):
         self.assertEqual(networks[0].cidr, guest_vm_cidr, "guestvmcidr should match after router reboot")
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "routers", "networks"])
     def test_destroy_recreate_router(self):
         """ Test IP reservation working after destroying and recreating router
         # steps
@@ -1062,7 +1062,7 @@ class TestFailureScnarios(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_network_not_implemented(self):
         # steps
         # 1. update guestvmcidr of isolated network (non persistent)
@@ -1081,7 +1081,7 @@ class TestFailureScnarios(cloudstackTestCase):
             isolated_network.update(self.apiclient, guestvmcidr="10.1.1.0/26")
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_vm_create_after_reservation(self):
         # steps
         # 1. create vm in persistent isolated network with ip in guestvmcidr
@@ -1140,7 +1140,7 @@ class TestFailureScnarios(cloudstackTestCase):
             self.skipTest("VM creation fails, cannot validate the condition: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_reservation_after_router_restart(self):
         # steps
         # 1. update guestvmcidr of persistent isolated network
@@ -1193,7 +1193,7 @@ class TestFailureScnarios(cloudstackTestCase):
         self.assertEqual(networks[0].cidr, guest_vm_cidr, "guestvmcidr should match after router reboot")
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers", "networks"], required_hardware="false")
     def test_vm_create_outside_cidr_after_reservation(self):
         # steps
         # 1. update guestvmcidr of persistent isolated network

--- a/test/integration/component/test_lb_secondary_ip.py
+++ b/test/integration/component/test_lb_secondary_ip.py
@@ -165,7 +165,7 @@ class TestAssignLBRule(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_01_lb_rule_for_primary_ip(self):
         """Create LB rule for primary IP
 
@@ -218,7 +218,7 @@ class TestAssignLBRule(cloudstackTestCase):
         self.assertEqual(lb_rule.id, lbrules[0].id, "LB rules does not match")
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_02_lb_rule_for_primary_ip(self):
         """Create LB rule for secondary IP
 
@@ -271,7 +271,7 @@ class TestAssignLBRule(cloudstackTestCase):
         self.assertEqual(lb_rule.id, lbrules[0].id, "LB rules does not match")
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_03_lb_rule_for_primary_and_secondary_ip(self):
         """Create LB rule for primary and secondary IP
 
@@ -328,7 +328,7 @@ class TestAssignLBRule(cloudstackTestCase):
         self.assertEqual(lb_rule.id, lbrules[0].id, "LB rules does not match")
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_04_lb_rule_primary_secondary_multiple_vms(self):
         """Create LB rule for primary and secondary IPs of multiple VMs
 
@@ -492,7 +492,7 @@ class TestFailureScenarios(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_05_lb_rule_wrong_vm_id(self):
         """Try to assign LB rule to secondary IP by giving wrong vm id
 
@@ -530,7 +530,7 @@ class TestFailureScenarios(cloudstackTestCase):
                            vmidipmap=vmidipmap)
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_06_lb_rule_wrong_vm_ip(self):
         """Try to assign LB rule to secondary IP by giving wrong ip
 
@@ -569,7 +569,7 @@ class TestFailureScenarios(cloudstackTestCase):
         return
 
     @unittest.skip("Failing-WIP")
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_07_lb_rule_used_ip(self):
         """Try to assign secondary IP to lb rule which is already assigned to another
            LB rule
@@ -632,7 +632,7 @@ class TestFailureScenarios(cloudstackTestCase):
                             vmidipmap=vmidipmap)
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_08_lb_rule_remove_used_ip(self):
         """Try to remove secondary IP with load balancer rule configured for it
 
@@ -755,7 +755,7 @@ class TestListLBRuleInstances(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_09_lbvmips_true(self):
         """List load balancer instances by passing lbvmips flag True
 
@@ -812,7 +812,7 @@ class TestListLBRuleInstances(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "networks"], required_hardware="false")
     def test_10_lbvmips_false(self):
         """List load balancer instances by passing lbvmips flag False
 
@@ -1014,7 +1014,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_11_ssh_to_secondary_ip(self):
         """SSH to VM using LB rule assigned to secondary IP of VM
 
@@ -1046,7 +1046,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
         return
 
     @unittest.skip("Failing-WIP")
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_12_ssh_to_primary_secondary_ip(self):
         """SSH to VM using LB rule assigned to primary and secondary IP of VM
 
@@ -1092,7 +1092,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
                       )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_13_delete_lb_rule(self):
         """SSH to VM after deleting LB rule
 
@@ -1134,7 +1134,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
                       )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_14_remove_lb_rule_secondary_ip(self):
         """ssh to vm after removing secondary ip from load balancer rule
 
@@ -1185,7 +1185,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
             self.fail("Exception during SSH : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_15_remove_lb_rule_primary_ip(self):
         """ssh to vm after removing secondary ip from load balancer rule
 
@@ -1236,7 +1236,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
             self.fail("Exception during SSH : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_16_delete_vm_from_lb_rule(self):
         """ssh to vm after removing secondary ip from load balancer rule
 
@@ -1287,7 +1287,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
                       )
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_20_destroy_recover_vm(self):
         """Verify LB rules after destroying and recovering VM
 
@@ -1339,7 +1339,7 @@ class TestLbRuleFunctioning(cloudstackTestCase):
                           with secondary ip assigned to lb rule")
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_21_modify_lb_rule_algorithm(self):
         """Verify LB rule functioning with different algorithm
 
@@ -1527,7 +1527,7 @@ class TestNetworkOperations(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_17_restart_router(self):
         """Verify LB rules after restarting router VM
 
@@ -1593,7 +1593,7 @@ class TestNetworkOperations(cloudstackTestCase):
             self.fail("Exception during SSH : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_18_restart_network_cleanup_true(self):
         """Verfy LB rules after restarting the network with cleanup flag set to True
 
@@ -1653,7 +1653,7 @@ class TestNetworkOperations(cloudstackTestCase):
             self.fail("Exception during SSH : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_19_restart_network_cleanup_false(self):
         """Verfy LB rules after restarting the network with cleanup flag set to False
 
@@ -1713,7 +1713,7 @@ class TestNetworkOperations(cloudstackTestCase):
             self.fail("Exception during SSH : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_22_network_gc(self):
         """Verify LB rule functioning to secondary IP after network GC
 
@@ -1901,7 +1901,7 @@ class TestExternalLoadBalancer(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advancedns", "provisioning"], required_hardware="true")
+    @attr(tags=["advancedns", "provisioning", "networks"], required_hardware="true")
     def test_23_lb_rule_functioning_with_netscaler(self):
         """Verify LB rule functioning for secondary IP with LB handled
            through Netscaler device

--- a/test/integration/component/test_migrate_vol_to_maintained_pool.py
+++ b/test/integration/component/test_migrate_vol_to_maintained_pool.py
@@ -91,7 +91,7 @@ class TestMigrationMaintainedPool(cloudstackTestCase):
         return
 
 
-    @attr(tags=["advanced", "basic", "multipool", "storagemotion", "xenserver"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "multipool", "storagemotion", "xenserver", "storage"], required_hardware="false")
     def test_02_migrate_volume_to_maintenance_pool(self):
             """
              Trying to migrate a volume to a pool in maintenance mode should fail

--- a/test/integration/component/test_multiple_ip_ranges.py
+++ b/test/integration/component/test_multiple_ip_ranges.py
@@ -125,7 +125,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_01_add_ip_same_cidr(self):
         """Test add guest ip range in the existing cidr
         """
@@ -176,7 +176,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
         self.verify_vlan_range(new_vlan2_res, self.services["vlan_ip_range"])
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_02_add_ip_diff_cidr(self):
         """Test add ip range in a new cidr
 
@@ -214,7 +214,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
         self.verify_vlan_range(new_vlan_res, self.services["vlan_ip_range"])
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_03_del_ip_range(self):
         """Test delete ip range
 
@@ -264,7 +264,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
                 msg="Failed to delete IP range")
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_04_add_noncontiguous_ip_range(self):
         """Test adding non-contiguous ip range in existing cidr
 
@@ -319,7 +319,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
         self.verify_vlan_range(new_vlan_res, self.services["vlan_ip_range"])
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_05_add_overlapped_ip_range(self):
         """Test adding overlapped ip range in existing cidr
 
@@ -384,7 +384,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
                     guest traffic, but it allowed")
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_06_add_ip_range_overlapped_with_two_ranges(self):
         """Test adding overlapped ip range with two existing cidr
 
@@ -458,7 +458,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
                     traffic, but it allowed")
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_07_add_iprange_superset(self):
         """Test adding ip range superset to existing CIDR
 
@@ -522,7 +522,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
             "CS should not allow adding ip range superset to existing CIDR")
         return
 
-    @attr(tags=["sg"])
+    @attr(tags=["sg", "networks"])
     def test_08_add_iprange_subset(self):
         """Test adding ip range subset to existing CIDR
 

--- a/test/integration/component/test_multiple_ips_per_nic.py
+++ b/test/integration/component/test_multiple_ips_per_nic.py
@@ -286,7 +286,7 @@ class TestBasicOperations(cloudstackTestCase):
         return
 
     @data(SHARED_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_add_ip_to_nic(self, value):
         """ Add secondary IP to NIC of a VM"""
 
@@ -362,7 +362,7 @@ class TestBasicOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_remove_ip_from_nic(self, value):
         """ Remove secondary IP from NIC of a VM"""
 
@@ -442,7 +442,7 @@ class TestBasicOperations(cloudstackTestCase):
                 e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_remove_invalid_ip(self):
         """ Remove invalid ip"""
 
@@ -463,7 +463,7 @@ class TestBasicOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_list_nics(self, value):
         """Test listing nics associated with the ip address"""
 
@@ -577,7 +577,7 @@ class TestBasicOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_operations_non_root_admin_api_client(self, value):
         """Test basic operations using non root admin apii client"""
 
@@ -756,7 +756,7 @@ class TestNetworkRules(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced", "dvs"])
+    @attr(tags=["advanced", "dvs", "networks"])
     def test_add_PF_rule(self, value):
         """ Add secondary IP to NIC of a VM"""
 
@@ -847,7 +847,7 @@ class TestNetworkRules(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced", "dvs"])
+    @attr(tags=["advanced", "dvs", "networks"])
     def test_delete_PF_nat_rule(self, value):
         """ Add secondary IP to NIC of a VM"""
 
@@ -935,7 +935,7 @@ class TestNetworkRules(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced", "dvs"])
+    @attr(tags=["advanced", "dvs", "networks"])
     def test_disassociate_ip_mapped_to_secondary_ip_through_PF_rule(
             self,
             value):
@@ -1007,7 +1007,7 @@ class TestNetworkRules(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced", "dvs"])
+    @attr(tags=["advanced", "dvs", "networks"])
     def test_add_static_nat_rule(self, value):
         """ Add secondary IP to NIC of a VM"""
 
@@ -1109,7 +1109,7 @@ class TestNetworkRules(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced", "dvs"])
+    @attr(tags=["advanced", "dvs", "networks"])
     def test_disable_static_nat(self, value):
         """ Add secondary IP to NIC of a VM"""
 
@@ -1296,7 +1296,7 @@ class TestVmNetworkOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_delete_vm(self, value):
         """ Test delete VM and verify network rules are cleaned up"""
 
@@ -1405,7 +1405,7 @@ class TestVmNetworkOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_recover_vm(self, value):
         """ Test recover VM operation with VM having secondary IPs"""
 
@@ -1515,7 +1515,7 @@ class TestVmNetworkOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_network_restart_cleanup_true(self, value):
         """Test network restart (cleanup True) with VM having secondary IPs and related network rules"""
 
@@ -1609,7 +1609,7 @@ class TestVmNetworkOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_network_restart_cleanup_false(self, value):
         """Test network restart (cleanup True) with VM having secondary IPs and related network rules"""
 
@@ -1703,7 +1703,7 @@ class TestVmNetworkOperations(cloudstackTestCase):
         return
 
     @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_reboot_router_VM(self, value):
         """ Test reboot router and persistence of network rules"""
 

--- a/test/integration/component/test_multiple_public_interfaces.py
+++ b/test/integration/component/test_multiple_public_interfaces.py
@@ -129,7 +129,7 @@ class TestPortForwarding(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "smoke", "networks"], required_hardware="true")
     def test_port_forwarding_on_ip_from_non_src_nat_ip_range(self):
         """Test for port forwarding on a IP which is in pubic IP range different
            from public IP range that has source NAT IP associated with network
@@ -288,7 +288,7 @@ class TestStaticNat(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "smoke", "networks"], required_hardware="true")
     def test_static_nat_on_ip_from_non_src_nat_ip_range(self):
         """Test for static nat on a IP which is in pubic IP range different
            from public IP range that has source NAT IP associated with network
@@ -450,7 +450,7 @@ class TestRouting(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "smoke", "networks"], required_hardware="true")
     def test_routing_tables(self):
         """Test routing table in case we have IP associated with a network which is in
             different pubic IP range from that of public IP range that has source NAT IP.
@@ -708,7 +708,7 @@ class TestIptables(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "smoke", "networks"], required_hardware="true")
     def test_iptable_rules(self):
         """Test iptable rules in case we have IP associated with a network which is in
             different pubic IP range from that of public IP range that has source NAT IP.
@@ -1032,7 +1032,7 @@ class TestVPCPortForwarding(cloudstackTestCase):
         except:
                 self.fail('Unable to create VM in a Network=%s' % network.name)
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks"], required_hardware="true")
     def test_network_services_VPC_CreatePF(self):
         """ Test Create VPC PF rules on acquired public ip when VpcVirtualRouter is Running
         """
@@ -1270,7 +1270,7 @@ class TestVPCStaticNat(cloudstackTestCase):
                 self.fail("Failed to enable static NAT on IP: %s - %s" % (
                                                     public_ip.ipaddress.ipaddress, e))
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks"], required_hardware="true")
     def test_network_services_VPC_CreatePF(self):
         """ Test Create VPC PF rules on acquired public ip when VpcVirtualRouter is Running
         """

--- a/test/integration/component/test_network_offering.py
+++ b/test/integration/component/test_network_offering.py
@@ -238,7 +238,7 @@ class TestNOVirtualRouter(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "service-offerings"], required_hardware="false")
     def test_01_network_off_without_conserve_mode(self):
         """Test Network offering with Conserve mode off and VR - All services
         """
@@ -483,7 +483,7 @@ class TestNOVirtualRouter(cloudstackTestCase):
                             )
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "service-offerings"], required_hardware="false")
     def test_02_network_off_with_conserve_mode(self):
         """Test Network offering with Conserve mode ON and VR - All services
         """
@@ -750,7 +750,7 @@ class TestNOVirtualRouter(cloudstackTestCase):
                             )
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "service-offerings"], required_hardware="false")
     def test_03_network_off_CS5332(self):
         """
         @Desc: Test Network offering with Custom system offering for VR
@@ -864,7 +864,7 @@ class TestNOVirtualRouter(cloudstackTestCase):
         self.debug("Deployed VM in network: %s" % self.network.id)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "service-offerings"], required_hardware="false")
     def test_04_network_without_domain_CS19303(self):
         """
         @Desc: Errors editing a network without a network domain specified
@@ -983,7 +983,7 @@ class TestNetworkUpgrade(cloudstackTestCase):
         return
 
     @attr(speed = "slow")
-    @attr(tags=["advancedns"], required_hardware="true")
+    @attr(tags=["advancedns", "service-offerings"], required_hardware="true")
     def test_01_nwupgrade_netscaler_conserve_on(self):
         """Test Nw upgrade to netscaler lb service and conserve mode ON
         """
@@ -1183,7 +1183,7 @@ class TestNetworkUpgrade(cloudstackTestCase):
         return
 
     @attr(speed = "slow")
-    @attr(tags=["advancedns"], required_hardware="true")
+    @attr(tags=["advancedns", "service-offerings"], required_hardware="true")
     def test_02_nwupgrade_netscaler_conserve_off(self):
         """Test Nw upgrade to netscaler lb service and conserve mode OFF
         """
@@ -1402,7 +1402,7 @@ class TestNOWithOnlySourceNAT(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "service-offerings"], required_hardware="false")
     def test_create_network_with_snat(self):
         """Test to create a network with SourceNAT service only"""
 

--- a/test/integration/component/test_non_contiguous_vlan.py
+++ b/test/integration/component/test_non_contiguous_vlan.py
@@ -82,7 +82,7 @@ class Services():
                         }
 
 
-@attr(tags = ["simulator", "advanced"])
+@attr(tags = ["simulator", "advanced", "networks"])
 class TestNonContiguousVLANRanges(cloudstackTestCase):
     """
     Test to add non contiguous vlan ranges into existing physical network

--- a/test/integration/component/test_persistent_networks.py
+++ b/test/integration/component/test_persistent_networks.py
@@ -229,7 +229,7 @@ class TestPersistentNetworks(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_network_state_after_destroying_vms(self):
         # steps
         # 1. Create an isolated persistent network
@@ -298,7 +298,7 @@ class TestPersistentNetworks(cloudstackTestCase):
             self.fail(exceptionMessage)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_shared_network_offering_with_persistent(self):
         # steps
         # 1. create shared network offering with persistent field enabled
@@ -315,7 +315,7 @@ class TestPersistentNetworks(cloudstackTestCase):
         except Exception:
             pass
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_persistent_network_offering_with_VPCVR_services(self):
         # steps
         # 1. create network offering with persistent field enabled and
@@ -333,7 +333,7 @@ class TestPersistentNetworks(cloudstackTestCase):
                 with VPCVR services: %s" %
                 e)
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_list_persistent_network_offering(self):
         # steps
         # 1. create isolated network offering with ispersistent True
@@ -359,7 +359,7 @@ class TestPersistentNetworks(cloudstackTestCase):
         return
 
     @data("LB-VR", "LB-NS")
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="true")
     def test_upgrade_to_persistent_services_VR(self, value):
 
         # This test is run against two networks (one with LB as virtual router
@@ -507,7 +507,7 @@ class TestPersistentNetworks(cloudstackTestCase):
             self.fail(exceptionMessage)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_upgrade_network_VR_to_PersistentRVR(self):
         # steps
         # 1. create isolated network with network offering which has
@@ -626,7 +626,7 @@ class TestPersistentNetworks(cloudstackTestCase):
             self.fail(exceptionMessage)
         return
 
-    @attr(tags=["advanced", "advancedns"])
+    @attr(tags=["advanced", "advancedns", "networks"])
     def test_upgrade_network_NS_to_persistent_NS(self):
         # steps
         # 1. create isolated network with network offering which
@@ -754,7 +754,7 @@ class TestPersistentNetworks(cloudstackTestCase):
         return
 
     @data("LB-VR", "LB-Netscaler")
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="true")
     def test_pf_nat_rule_persistent_network(self, value):
 
         # This test shall run with two scenarios, one with LB services
@@ -872,7 +872,7 @@ class TestPersistentNetworks(cloudstackTestCase):
                 (virtual_machine.id, ipaddress.ipaddress.ipaddress))
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_persistent_network_with_RVR(self):
         # steps
         # 1. create account and isolated network with network
@@ -982,7 +982,7 @@ class TestPersistentNetworks(cloudstackTestCase):
                 (virtual_machine.id, ipaddress.ipaddress.ipaddress))
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_vm_deployment_two_persistent_networks(self):
         # steps
         # 1. Deploy VM in two persistent networks
@@ -1143,7 +1143,7 @@ class TestPersistentNetworks(cloudstackTestCase):
                 (virtual_machine.id, ipaddress_nw_2.ipaddress.ipaddress))
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_vm_deployment_persistent_and_non_persistent_networks(self):
         # steps
         # 1. create account and create two networks in it
@@ -1264,7 +1264,7 @@ class TestPersistentNetworks(cloudstackTestCase):
                 (virtual_machine.id, ipaddress_nw_2.ipaddress.ipaddress))
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_change_persistent_network_to_non_persistent(self):
         # steps
         # 1. Create a persistent network and deploy VM in it
@@ -1372,7 +1372,7 @@ class TestPersistentNetworks(cloudstackTestCase):
             self.fail(exceptionMessage)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_delete_account(self):
         # steps
         # 1. create persistent network and deploy VM in it
@@ -1461,7 +1461,7 @@ class TestPersistentNetworks(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_volume_delete_event_errorState(self):
         """
         @summary: Test volume delete event generation in error state condition
@@ -1683,7 +1683,7 @@ class TestAssignVirtualMachine(cloudstackTestCase):
         return
 
     @data("VR", "RVR", "LB-NS")
-    @attr(tags=["advanced", "advancedns"])
+    @attr(tags=["advanced", "advancedns", "networks"])
     def test_assign_vm_different_account_VR(self, value):
 
         # This test shall be run with three types of persistent networks
@@ -1861,7 +1861,7 @@ class TestProjectAccountOperations(cloudstackTestCase):
         return
 
     @data("locked", "disabled")
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_account_operations(self, value):
         # steps
         # 1. create account and create persistent network in it
@@ -1943,7 +1943,7 @@ class TestProjectAccountOperations(cloudstackTestCase):
             "vlan must not be null for persistent network")
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_project_operations(self):
         # steps
         # 1. create account and create persistent network in it
@@ -2177,7 +2177,7 @@ class TestRestartPersistentNetwork(cloudstackTestCase):
         return
 
     @data("true", "false")
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_cleanup_persistent_network(self, value):
         # steps
         # 1. Create account and create persistent network in it
@@ -2310,7 +2310,7 @@ class TestRestartPersistentNetwork(cloudstackTestCase):
         return
 
     @data("true", "false")
-    @attr(tags=["advanced", "advancedns"])
+    @attr(tags=["advanced", "advancedns", "networks"])
     def test_cleanup_persistent_network_lb_netscaler(self, value):
         # steps
         # 1. Create account and create persistent network in
@@ -2634,7 +2634,7 @@ class TestVPCNetworkOperations(cloudstackTestCase):
         return
 
     @data("delete", "restart")
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_vpc_network_life_cycle(self, value):
         # steps
         # 1. Create account and create VPC network in the account
@@ -2788,7 +2788,7 @@ class TestVPCNetworkOperations(cloudstackTestCase):
                 ipaddresses)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_vpc_force_delete_domain(self):
         # steps
         # 1. Create account and create VPC network in the account
@@ -2922,7 +2922,7 @@ class TestVPCNetworkOperations(cloudstackTestCase):
         self.VerifyNetworkCleanup(persistent_network_2.id)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_vpc_delete_account(self):
         # steps
         # 1. Create account and create VPC network in the account
@@ -3142,7 +3142,7 @@ class TestVPCNetworkOperations(cloudstackTestCase):
         return
 
     @unittest.skip("WIP")
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "networks"])
     def test_vpc_private_gateway_static_route(self):
         # steps
         # 1. Create account and create VPC network in the account

--- a/test/integration/component/test_portable_ip.py
+++ b/test/integration/component/test_portable_ip.py
@@ -90,7 +90,7 @@ class TestCreatePortablePublicIpRanges(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_create_portable_ip_range(self):
         """Test create new portable ip range
         """
@@ -109,7 +109,7 @@ class TestCreatePortablePublicIpRanges(cloudstackTestCase):
             self.fail("Failed to create portable IP range: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_create_portable_ip_range_non_root_admin(self):
         """Test create new portable ip range with non admin root account
         """
@@ -141,7 +141,7 @@ class TestCreatePortablePublicIpRanges(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_create_portable_ip_range_invalid_region(self):
         """Test create portable ip range with invalid region id"""
 
@@ -213,7 +213,7 @@ class TestDeletePortablePublicIpRanges(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_delete_portable_ip_range(self):
         """Test delete ip range
         """
@@ -223,7 +223,7 @@ class TestDeletePortablePublicIpRanges(cloudstackTestCase):
         self.portable_ip_range.delete(self.apiclient)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_delete_portable_ip_range_non_root_admin(self):
         """Test delete ip range - non admin root
         """
@@ -255,7 +255,7 @@ class TestDeletePortablePublicIpRanges(cloudstackTestCase):
             self.portable_ip_range.delete(self.apiclient)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_delete_portable_ip_range_in_use(self):
         """Test delete ip range
         """
@@ -375,7 +375,7 @@ class TestListPortablePublicIpRanges(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_list_portable_ip_range(self):
         """Test list portable ip ranges
         """
@@ -407,7 +407,7 @@ class TestListPortablePublicIpRanges(cloudstackTestCase):
                          "Listed netmask not matching with the netmask of created public ip range")
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_list_portable_ip_range_non_root_admin(self):
         """Test list portable ip ranges with non admin root account
         """
@@ -521,7 +521,7 @@ class TestAssociatePublicIp(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_associate_ip_address(self):
         """ Test assocoate public ip address
         """
@@ -570,7 +570,7 @@ class TestAssociatePublicIp(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_associate_ip_address_invalid_zone(self):
         """ Test Associate IP with invalid zone id
         """
@@ -592,7 +592,7 @@ class TestAssociatePublicIp(cloudstackTestCase):
             publicipaddress.delete(self.apiclient)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_associate_ip_address_services_enable_disable(self):
         """ Test enabling and disabling NAT, Firewall services on portable ip
         """
@@ -691,7 +691,7 @@ class TestAssociatePublicIp(cloudstackTestCase):
             portableip.delete(self.apiclient)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_associate_ip_address_no_free_ip(self):
         """ Test assocoate public ip address
         """
@@ -849,7 +849,7 @@ class TestDisassociatePublicIp(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_disassociate_ip_address_no_services(self):
         """ Test disassociating portable ip
         """
@@ -872,7 +872,7 @@ class TestDisassociatePublicIp(cloudstackTestCase):
             raise Exception("Exception occured: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_disassociate_ip_address_services_enabled(self):
         """ Test disassociating portable ip
         """
@@ -929,7 +929,7 @@ class TestDisassociatePublicIp(cloudstackTestCase):
             raise Exception("Exception while disassociating portable ip: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_disassociate_ip_address_other_account(self):
         """ Test disassociating portable IP with non-owner account
         """
@@ -1063,7 +1063,7 @@ class TestDeleteAccount(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_delete_account_services_disabled(self):
         """ test delete account with portable ip with no services enabled
         """
@@ -1085,7 +1085,7 @@ class TestDeleteAccount(cloudstackTestCase):
         self.assertEqual(list_publicips, None, "List of ip addresses should be empty")
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_delete_account_services_enabled(self):
         """ test delete account with portable ip with PF and firewall services enabled
         """
@@ -1288,7 +1288,7 @@ class TestPortableIpTransferAcrossNetworks(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "networks"], required_hardware="true")
     def test_list_portable_ip_range_non_root_admin(self):
         """Test list portable ip ranges with non admin root account
         """

--- a/test/integration/component/test_ps_domain_limits.py
+++ b/test/integration/component/test_ps_domain_limits.py
@@ -194,7 +194,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
             return [FAIL, e, None]
         return [PASS, None, users]
 
-    @attr(tags=["advanced", "selfservice"], required_hardware="false")
+    @attr(tags=["advanced", "selfservice", "storage"], required_hardware="false")
     def test_01_multiple_domains_primary_storage_limits(self):
         """Test primary storage limit of domain and its sub-domains
 
@@ -341,7 +341,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
         self.assertTrue(result[2], "Resource count does not match")
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_02_multiple_domains_primary_storage_limits(self):
         """Test primary storage counts in multiple child domains
         # Steps
@@ -423,7 +423,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
                 self.fail("Failure: %s" % e)
             return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_03_multiple_domains_multiple_volumes(self):
         """Test primary storage counts in multiple child domains
         # Steps
@@ -536,7 +536,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
                 self.fail("Failure: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_04_create_template_snapshot(self):
         """Test create snapshot and templates from volume
 
@@ -637,7 +637,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
                 self.fail("Failed with exception : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_05_assign_virtual_machine_different_domain(self):
         """Test assign virtual machine to account belonging to different domain
 
@@ -704,7 +704,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
             self.fail("Failed with exception: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_06_destroy_recover_vm(self):
         """Test primary storage counts while destroying and recovering VM
         # Steps

--- a/test/integration/component/test_ps_limits.py
+++ b/test/integration/component/test_ps_limits.py
@@ -156,7 +156,7 @@ class TestVolumeLimits(cloudstackTestCase):
         return [PASS, None]
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic"], required_hardware="false")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="false")
     def test_stop_start_vm(self, value):
         """Test Deploy VM with 5 GB volume & verify the usage
 
@@ -195,7 +195,7 @@ class TestVolumeLimits(cloudstackTestCase):
 
     @unittest.skip("skip")
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic"], required_hardware="false")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="false")
     def test_destroy_recover_vm(self, value):
         """Test delete and recover instance
 
@@ -233,7 +233,7 @@ class TestVolumeLimits(cloudstackTestCase):
         return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic"], required_hardware="false")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="false")
     def test_attach_detach_volume(self, value):
         """Stop attach and detach volume from VM
 
@@ -302,7 +302,7 @@ class TestVolumeLimits(cloudstackTestCase):
         return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic"], required_hardware="false")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="false")
     def test_create_multiple_volumes(self, value):
         """Test create multiple volumes
 
@@ -396,7 +396,7 @@ class TestVolumeLimits(cloudstackTestCase):
         return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic"], required_hardware="false")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="false")
     def test_deploy_multiple_vm(self, value):
         """Test Deploy multiple VMs with & verify the usage
         # Validate the following
@@ -452,7 +452,7 @@ class TestVolumeLimits(cloudstackTestCase):
 	return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic","selfservice"])
+    @attr(tags=["advanced","basic", "storage","selfservice"])
     def test_assign_vm_different_account(self, value):
         """Test assign Vm to different account
         # Validate the following
@@ -505,7 +505,7 @@ class TestVolumeLimits(cloudstackTestCase):
 	return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced","basic"], required_hardware="true")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="true")
     def test_create_template_snapshot(self, value):
         """Test create snapshot and templates from volume
 

--- a/test/integration/component/test_ps_max_limits.py
+++ b/test/integration/component/test_ps_max_limits.py
@@ -151,7 +151,7 @@ class TestMaxPrimaryStorageLimits(cloudstackTestCase):
             return [FAIL, e]
         return [PASS, None]
 
-    @attr(tags=["advanced","selfservice"])
+    @attr(tags=["advanced","selfservice", "storage"])
     def test_01_deploy_vm_domain_limit_reached(self):
         """Test Try to deploy VM with admin account where account has not used
             the resources but @ domain they are not available
@@ -201,7 +201,7 @@ class TestMaxPrimaryStorageLimits(cloudstackTestCase):
                                    diskofferingid=disk_offering.id)
         return
 
-    @attr(tags=["advanced","selfservice"])
+    @attr(tags=["advanced","selfservice", "storage"])
     def test_02_deploy_vm_account_limit_reached(self):
         """Test Try to deploy VM with admin account where account has used
             the resources but @ domain they are available"""
@@ -245,7 +245,7 @@ class TestMaxPrimaryStorageLimits(cloudstackTestCase):
                                    diskofferingid=disk_offering.id)
         return
 
-    @attr(tags=["advanced","selfservice"])
+    @attr(tags=["advanced","selfservice", "storage"])
     def test_03_deploy_vm_project_limit_reached(self):
         """Test TTry to deploy VM with admin account where account has not used
         the resources but @ project they are not available

--- a/test/integration/component/test_ps_project_limits.py
+++ b/test/integration/component/test_ps_project_limits.py
@@ -138,7 +138,7 @@ class TestProjectsVolumeLimits(cloudstackTestCase):
             return [FAIL, e]
         return [PASS, None]
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_01_VM_start_stop(self):
         """Test project primary storage count with VM stop/start operation
 
@@ -173,7 +173,7 @@ class TestProjectsVolumeLimits(cloudstackTestCase):
         self.assertEqual(response[0], PASS, response[1])
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_02_migrate_vm(self):
         """Test migrate VM in project
 
@@ -202,7 +202,7 @@ class TestProjectsVolumeLimits(cloudstackTestCase):
         self.assertEqual(response[0], PASS, response[1])
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "storage"], required_hardware="false")
     def test_03_delete_vm(self):
         """Test delete VM belonging to project
 

--- a/test/integration/component/test_ps_resize_volume.py
+++ b/test/integration/component/test_ps_resize_volume.py
@@ -183,7 +183,7 @@ class TestResizeVolume(cloudstackTestCase):
             return [FAIL, e]
         return [PASS, None]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_01_increase_volume_size_within_account_limit(self):
         """Test increasing volume size within the account limit and verify
            primary storage usage
@@ -254,7 +254,7 @@ class TestResizeVolume(cloudstackTestCase):
             self.fail("Failed with exception: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_02_increase_volume_size_above_account_limit(self):
         """Test increasing volume size above the account limit
 
@@ -318,7 +318,7 @@ class TestResizeVolume(cloudstackTestCase):
                 diskofferingid=self.disk_offering_20_GB.id)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_03_increase_volume_size_above_domain_limit(self):
         """Test increasing volume size above the domain limit
 

--- a/test/integration/component/test_ps_resource_limits_volume.py
+++ b/test/integration/component/test_ps_resource_limits_volume.py
@@ -117,7 +117,7 @@ class TestPrimaryResourceLimitsVolume(cloudstackTestCase):
         return [PASS, None]
 
     # @data(USER_ACCOUNT)
-    @attr(tags=["advanced","basic"], required_hardware="true")
+    @attr(tags=["advanced","basic", "storage"], required_hardware="true")
     def test_attach_volume_exceeding_primary_limits(self):
         """
         # do

--- a/test/integration/component/test_redundant_router_cleanups.py
+++ b/test/integration/component/test_redundant_router_cleanups.py
@@ -210,7 +210,7 @@ class TestRedundantRouterNetworkCleanups(cloudstackTestCase):
             #raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="false")
     def test_restart_ntwk_no_cleanup(self):
         """Test restarting RvR network without cleanup
         """
@@ -344,7 +344,7 @@ class TestRedundantRouterNetworkCleanups(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="false")
     def test_restart_ntwk_with_cleanup(self):
         """Test restart RvR network with cleanup
         """
@@ -478,7 +478,7 @@ class TestRedundantRouterNetworkCleanups(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="false")
     def test_network_gc(self):
         """Test network garbage collection with RVR
         """

--- a/test/integration/component/test_redundant_router_services.py
+++ b/test/integration/component/test_redundant_router_services.py
@@ -200,7 +200,7 @@ class TestEnableVPNOverRvR(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="false")
     def test_enableVPNOverRvR(self):
         """Test redundant router internals
         """

--- a/test/integration/component/test_redundant_router_upgrades.py
+++ b/test/integration/component/test_redundant_router_upgrades.py
@@ -208,7 +208,7 @@ class TestRvRUpgradeDowngrade(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="false")
     def test_upgradeVR_to_redundantVR(self):
         """Test upgrade virtual router to redundant virtual router
         """
@@ -353,7 +353,7 @@ class TestRvRUpgradeDowngrade(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="false")
     def test_downgradeRvR_to_VR(self):
         """Test downgrade redundant virtual router to virtual router
         """

--- a/test/integration/component/test_region_vpc.py
+++ b/test/integration/component/test_region_vpc.py
@@ -305,7 +305,7 @@ class TestRegionVpcOffering(cloudstackTestCase):
         self.debug("VPC network created successfully - %s" % network.name)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "routers", "networks"])
     def test_01_create_vpc_offering_with_regionlevelvpc_service_capability(self):
         """ Test create VPC offering
         """
@@ -325,7 +325,7 @@ class TestRegionVpcOffering(cloudstackTestCase):
         self.validate_vpc_offering(vpc_off)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "routers", "networks"])
     def test_02_create_vpc_from_offering_with_regionlevelvpc_service_capability(self):
         """ Test create VPC offering
         """
@@ -360,7 +360,7 @@ class TestRegionVpcOffering(cloudstackTestCase):
             self.fail("Failed to delete VPC network - %s" % e)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "routers", "networks"])
     def test_03_deploy_vms_in_vpc_with_regionlevelvpc(self):
         """Test deploy virtual machines in VPC networks"""
 

--- a/test/integration/component/test_routers.py
+++ b/test/integration/component/test_routers.py
@@ -125,7 +125,7 @@ class TestRouterServices(cloudstackTestCase):
         self.cleanup = []
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers"], required_hardware="false")
     def test_01_AdvancedZoneRouterServices(self):
         """Test advanced zone router services
         """
@@ -277,7 +277,7 @@ class TestRouterServices(cloudstackTestCase):
         return
 
     @attr(configuration="network.gc")
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers"], required_hardware="false")
     def test_02_NetworkGarbageCollection(self):
         """Test network garbage collection
         """
@@ -457,7 +457,7 @@ class TestRouterServices(cloudstackTestCase):
         self.cleanup.append(self.vm_2)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "routers"], required_hardware="false")
     def test_03_RouterStartOnVmDeploy(self):
         """Test router start on VM deploy
         """
@@ -736,7 +736,7 @@ class TestRouterStopCreatePF(cloudstackTestCase):
         self.cleanup = []
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "routers"], required_hardware="true")
     def test_01_RouterStopCreatePF(self):
         """Test router stop create port forwarding
         """
@@ -953,7 +953,7 @@ class TestRouterStopCreateLB(cloudstackTestCase):
         self.cleanup = []
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "routers"], required_hardware="true")
     def test_01_RouterStopCreateLB(self):
         """Test router stop create Load balancing
         """
@@ -1171,7 +1171,7 @@ class TestRouterStopCreateFW(cloudstackTestCase):
         self.cleanup = []
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "routers"], required_hardware="true")
     def test_01_RouterStopCreateFW(self):
         """Test router stop create Firewall rule
         """

--- a/test/integration/component/test_shared_networks.py
+++ b/test/integration/component/test_shared_networks.py
@@ -208,7 +208,7 @@ class TestSharedNetworks(cloudstackTestCase):
             return True
         return False
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_sharedNetworkOffering_01(self):
         """  Test shared network Offering 01 """
 
@@ -350,7 +350,7 @@ class TestSharedNetworks(cloudstackTestCase):
             "NetworkOffering created and enabled: %s" %
             self.shared_network_offering.id)
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_sharedNetworkOffering_02(self):
         """ Test Shared Network Offering 02 """
 
@@ -446,7 +446,7 @@ class TestSharedNetworks(cloudstackTestCase):
                  in advance mode and shared guest type. Exception: %s" %
                 e)
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_sharedNetworkOffering_03(self):
         """ Test Shared Network Offering 03 """
 
@@ -543,7 +543,7 @@ class TestSharedNetworks(cloudstackTestCase):
                  ranges as False in advance mode and with shared guest type.\
                  Exception : %s" % e)
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_createSharedNetwork_All(self):
         """ Test Shared Network ALL  """
 
@@ -842,7 +842,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Virtual machine ip should be from the ip range assigned to\
                 network created.")
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_createSharedNetwork_accountSpecific(self):
         """ Test Shared Network with scope account """
 
@@ -1115,7 +1115,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Virtual machine ip should be from the ip range assigned\
                  to network created.")
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_createSharedNetwork_domainSpecific(self):
         """ Test Shared Network with scope domain """
 
@@ -1492,7 +1492,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Virtual machine ip should be from the ip range assigne\
                  to network created.")
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_createSharedNetwork_projectSpecific(self):
         """ Test Shared Network with scope project  """
 
@@ -1788,7 +1788,7 @@ class TestSharedNetworks(cloudstackTestCase):
     @unittest.skip(
         "skipped - This is a redundant case and also this\
                 is causing issue for rest fo the cases ")
-    @attr(tags=["advanced", "advancedns", "NA"])
+    @attr(tags=["advanced", "advancedns", "NA", "networks"])
     def test_createSharedNetwork_usedVlan(self):
         """ Test Shared Network with used vlan 01 """
 
@@ -1945,7 +1945,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Network creation failed because the valn id being used by\
                  another network. Exception: %s" % e)
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_createSharedNetwork_usedVlan2(self):
         """ Test Shared Network with used vlan 02 """
 
@@ -2152,7 +2152,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Network creation failed because the valn id being used by\
                  another network. Exception: %s" % e)
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_deployVM_multipleSharedNetwork(self):
         """ Test Vm deployment with multiple shared networks """
 
@@ -2429,7 +2429,7 @@ class TestSharedNetworks(cloudstackTestCase):
             is not None,
             "ip should be assigned to running virtual machine")
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="true")
     def test_deployVM_isolatedAndShared(self):
         """ Test VM deployment in shared and isolated networks """
 
@@ -2798,7 +2798,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 (self.isolated_network_admin_account_virtual_machine.ipaddress,
                     e))
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_networkWithsubdomainaccessTrue(self):
         """ Test Shared Network with subdomainaccess=True """
 
@@ -2937,7 +2937,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Network creation failed because subdomainaccess parameter was\
                  passed when scope was account.")
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_networkWithsubdomainaccessFalse(self):
         """ Test shared Network with subdomainaccess=False """
 
@@ -3076,7 +3076,7 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Network creation failed because subdomainaccess parameter\
                         was passed when scope was account.")
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced", "networks"], required_hardware="false")
     def test_escalation_ES1621(self):
         """
         @summary: ES1621:Allow creating shared networks with overlapping
@@ -3271,7 +3271,7 @@ class TestSharedNetworks(cloudstackTestCase):
         return
 
     @data(True, False)
-    @attr(tags=["advanced", "advancedns", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "dvs", "networks"], required_hardware="false")
     def test_restart_network(self, cleanup):
         """ Test restart shared Network
 
@@ -3362,7 +3362,7 @@ class TestSharedNetworks(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "advancedns", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "dvs", "networks"], required_hardware="false")
     def test_reboot_router(self):
         """Test reboot router
 
@@ -3459,7 +3459,7 @@ class TestSharedNetworks(cloudstackTestCase):
                     or in stopped state")
         return
 
-    @attr(tags=["advanced", "advancedns", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "dvs", "networks"], required_hardware="false")
     def test_stop_start_router(self):
         """Test stop and start router
 
@@ -3556,7 +3556,7 @@ class TestSharedNetworks(cloudstackTestCase):
             self.fail(exceptionMessage)
         return
 
-    @attr(tags=["advanced", "advancedns", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "dvs", "networks"], required_hardware="false")
     def test_acquire_ip(self):
         """Test acquire IP in shared network
 
@@ -3675,7 +3675,7 @@ class TestSharedNetworks(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["dvs"], required_hardware="true")
+    @attr(tags=["dvs", "networks"], required_hardware="true")
     def test_guest_traffic_port_groups_shared_network(self):
         """ Verify vcenter port groups are created for shared network
 

--- a/test/integration/component/test_ss_domain_limits.py
+++ b/test/integration/component/test_ss_domain_limits.py
@@ -148,7 +148,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
             return [FAIL, e, None]
         return [PASS, None, users]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_01_multiple_domains_secondary_storage_limits(self):
         """Test secondary storage limit of domain and its sub-domains
 
@@ -261,7 +261,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
         self.assertTrue(result[2], "Resource count does not match")
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_02_multiple_domains_secondary_storage_counts(self):
         """Test secondary storage counts in multiple child domains
         # Steps
@@ -325,7 +325,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
                 self.fail("Failed to get zone list: %s" % e)
 	    return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_03_copy_template(self):
         """Test secondary storage counts in multiple child domains
         # Steps
@@ -485,7 +485,7 @@ class TestDeleteAccount(cloudstackTestCase):
             return [FAIL, e, None]
         return [PASS, None, users]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_04_create_template_delete_account(self):
         """Test secondary storage limit of domain and its sub-domains
 

--- a/test/integration/component/test_ss_limits.py
+++ b/test/integration/component/test_ss_limits.py
@@ -129,7 +129,7 @@ class TestSecondaryStorageLimits(cloudstackTestCase):
         return [PASS, None]
  
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags = ["advanced"], required_hardware="true")
+    @attr(tags = ["advanced", "storage"], required_hardware="true")
     def test_01_register_template(self, value):
         """Test register template
         # Validate the following:
@@ -195,7 +195,7 @@ class TestSecondaryStorageLimits(cloudstackTestCase):
         return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_02_create_template_snapshot(self, value):
         """Test create snapshot and templates from volume
 
@@ -262,7 +262,7 @@ class TestSecondaryStorageLimits(cloudstackTestCase):
         return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags = ["advanced"], required_hardware="true")
+    @attr(tags = ["advanced", "storage"], required_hardware="true")
     def test_03_register_iso(self, value):
         """Test register iso
         Steps and validations:
@@ -324,7 +324,7 @@ class TestSecondaryStorageLimits(cloudstackTestCase):
         return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags = ["advanced"], required_hardware="true")
+    @attr(tags = ["advanced", "storage"], required_hardware="true")
     def test_04_copy_template(self, value):
         """Test copy template between zones
 

--- a/test/integration/component/test_ss_max_limits.py
+++ b/test/integration/component/test_ss_max_limits.py
@@ -170,7 +170,7 @@ class TestMaxSecondaryStorageLimits(cloudstackTestCase):
             return [FAIL, e]
         return [PASS, None]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_01_deploy_vm_domain_limit_reached(self):
         """Test Try to deploy VM with admin account where account has not used
             the resources but @ domain they are not available
@@ -207,7 +207,7 @@ class TestMaxSecondaryStorageLimits(cloudstackTestCase):
             template.delete(self.userapiclient)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_02_deploy_vm_account_limit_reached(self):
         """Test Try to deploy VM with admin account where account has used
             the resources but @ domain they are available
@@ -244,7 +244,7 @@ class TestMaxSecondaryStorageLimits(cloudstackTestCase):
             template.delete(self.userapiclient)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_03_deploy_vm_project_limit_reached(self):
         """Test TTry to deploy VM with admin account where account has not used
         the resources but @ project they are not available

--- a/test/integration/component/test_ss_project_limits.py
+++ b/test/integration/component/test_ss_project_limits.py
@@ -129,7 +129,7 @@ class TestProjectsVolumeLimits(cloudstackTestCase):
             return [FAIL, e]
         return [PASS, None]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "storage"], required_hardware="true")
     def test_01_register_template_with_project(self):
         """Test register template
         # Validate the following:
@@ -194,7 +194,7 @@ class TestProjectsVolumeLimits(cloudstackTestCase):
         self.assertEqual(response[0], PASS, response[1])
         return
 
-    @attr(tags = ["advanced"], required_hardware="true")
+    @attr(tags = ["advanced", "storage"], required_hardware="true")
     def test_02_register_iso(self):
         """Test register iso
         Steps and validations:

--- a/test/integration/component/test_stopped_vm.py
+++ b/test/integration/component/test_stopped_vm.py
@@ -116,7 +116,7 @@ class TestDeployVM(cloudstackTestCase):
         except Exception as e:
             self.debug("Warning! Exception in tearDown: %s" % e)
 
-    @attr(tags=["advanced", "eip", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "eip", "advancedns", "deploy-vm"], required_hardware="false")
     def test_01_deploy_vm_no_startvm(self):
         """Test Deploy Virtual Machine with no startVM parameter
         """
@@ -150,7 +150,8 @@ class TestDeployVM(cloudstackTestCase):
               "eip",
               "advancedns",
               "basic",
-              "sg"],
+              "sg",
+              "deploy-vm"],
         required_hardware="false")
     def test_02_deploy_vm_startvm_true(self):
         """Test Deploy Virtual Machine with startVM=true parameter
@@ -186,7 +187,8 @@ class TestDeployVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_03_deploy_vm_startvm_false(self):
         """Test Deploy Virtual Machine with startVM=false parameter
@@ -237,7 +239,8 @@ class TestDeployVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_04_deploy_startvm_false_attach_volume(self):
         """Test Deploy Virtual Machine with startVM=false and attach volume
@@ -293,7 +296,8 @@ class TestDeployVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_05_deploy_startvm_false_change_so(self):
         """Test Deploy Virtual Machine with startVM=false and change service offering
@@ -358,7 +362,8 @@ class TestDeployVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_06_deploy_startvm_attach_detach(self):
         """Test Deploy Virtual Machine with startVM=false and
@@ -433,7 +438,8 @@ class TestDeployVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_07_deploy_startvm_attach_iso(self):
         """Test Deploy Virtual Machine with startVM=false and attach ISO
@@ -511,7 +517,8 @@ class TestDeployVM(cloudstackTestCase):
               "eip",
               "advancedns",
               "basic",
-              "sg"],
+              "sg",
+              "deploy-vm"],
         required_hardware="false")
     def test_08_deploy_attached_volume(self):
         """Test Deploy Virtual Machine with startVM=false and attach volume
@@ -630,7 +637,8 @@ class TestDeployVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_09_stop_vm_migrate_vol(self):
         """Test Stopped Virtual Machine's ROOT volume migration
@@ -835,7 +843,8 @@ class TestDeployHaEnabledVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_01_deploy_ha_vm_startvm_false(self):
         """Test Deploy HA enabled Virtual Machine with startvm=false
@@ -870,7 +879,8 @@ class TestDeployHaEnabledVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_02_deploy_ha_vm_from_iso(self):
         """Test Deploy HA enabled Virtual Machine from ISO
@@ -927,7 +937,8 @@ class TestDeployHaEnabledVM(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_03_deploy_ha_vm_iso_startvm_false(self):
         """Test Deploy HA enabled Virtual Machine from ISO with startvm=false
@@ -1038,7 +1049,7 @@ class TestRouterStateAfterDeploy(cloudstackTestCase):
         except Exception as e:
             self.debug("Warning! Exception in tearDown: %s" % e)
 
-    @attr(tags=["advanced", "eip", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "eip", "advancedns", "deploy-vm"], required_hardware="false")
     def test_01_deploy_vm_no_startvm(self):
         """Test Deploy Virtual Machine with no startVM parameter
         """
@@ -1308,7 +1319,8 @@ class TestDeployVMFromTemplate(cloudstackTestCase):
               "eip",
               "advancedns",
               "basic",
-              "sg"],
+              "sg",
+              "deploy-vm"],
         required_hardware="true")
     def test_deploy_vm_password_enabled(self):
         """Test Deploy Virtual Machine with startVM=false & enabledpassword in
@@ -1414,7 +1426,8 @@ class TestVMAccountLimit(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_vm_per_account(self):
         """Test VM limit per account
@@ -1547,7 +1560,8 @@ class TestUploadAttachVolume(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="false")
     def test_upload_attach_volume(self):
         """Test Upload volume and attach to VM in stopped state
@@ -1660,7 +1674,7 @@ class TestDeployOnSpecificHost(cloudstackTestCase):
         return
 
     @attr(tags=["advanced", "advancedns", "simulator",
-                "api", "basic", "eip", "sg"])
+                "api", "basic", "eip", "sg", "deploy-vm"])
     def test_deployVmOnGivenHost(self):
         """Test deploy VM on specific host
         """

--- a/test/integration/component/test_storage_motion.py
+++ b/test/integration/component/test_storage_motion.py
@@ -150,7 +150,7 @@ class TestStorageMotion(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced", "basic", "multicluster", "storagemotion", "xenserver"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "multicluster", "storagemotion", "xenserver", "storage"], required_hardware="true")
     def test_01_migrate_vm_with_volume(self):
         """Test migrate virtual machine with its volumes
         """
@@ -231,7 +231,7 @@ class TestStorageMotion(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "basic", "multipool", "storagemotion", "xenserver"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "multipool", "storagemotion", "xenserver", "storage"], required_hardware="false")
     def test_02_migrate_volume(self):
         """Test migrate volume of a running vm
         """

--- a/test/integration/component/test_templates.py
+++ b/test/integration/component/test_templates.py
@@ -175,7 +175,7 @@ class TestCreateTemplate(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "templates"], required_hardware="true")
     def test_01_create_template(self):
         """Test create public & private template
         """
@@ -410,7 +410,7 @@ class TestTemplates(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "templates"], required_hardware="false")
     def test_01_create_template_volume(self):
         """Test Create template from volume
         """
@@ -451,7 +451,7 @@ class TestTemplates(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "templates"], required_hardware="false")
     def test_03_delete_template(self):
         """Test Delete template
         """
@@ -506,7 +506,7 @@ class TestTemplates(cloudstackTestCase):
         return
 
     @attr(speed="slow")
-    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "templates"], required_hardware="true")
     def test_04_template_from_snapshot(self):
         """Create Template from snapshot
         """
@@ -648,7 +648,7 @@ class TestListTemplate(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
 
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_01_list_templates_with_templatefilter_all_normal_user(self):
         """
             Test list templates with templatefilter=all is not permitted for normal user
@@ -664,7 +664,7 @@ class TestListTemplate(cloudstackTestCase):
             self.debug("ListTemplates API with templatefilter='all' is not permitted for normal user")
 
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_02_list_templates_with_templatefilter_all_domain_admin(self):
         """
             Test list templates with templatefilter=all is not permitted for domain admin

--- a/test/integration/component/test_vm_passwdenabled.py
+++ b/test/integration/component/test_vm_passwdenabled.py
@@ -265,7 +265,8 @@ class TestVMPasswordEnabled(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_11_get_vm_password(self):
         """Test get VM password for password enabled template"""

--- a/test/integration/component/test_vpc.py
+++ b/test/integration/component/test_vpc.py
@@ -313,7 +313,7 @@ class TestVPC(cloudstackTestCase):
 
     # list_vpc_apis should be the first case otherwise the vpc counts would be
     # wrong
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_01_list_vpc_apis(self):
         """ Test list VPC APIs
         """
@@ -491,7 +491,7 @@ class TestVPC(cloudstackTestCase):
                 )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc"], required_hardware="false")
     def test_02_restart_vpc_no_networks(self):
         """ Test restart VPC having no networks
         """
@@ -522,7 +522,7 @@ class TestVPC(cloudstackTestCase):
         self.validate_vpc_network(vpc, state='Enabled')
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc"], required_hardware="false")
     def test_03_restart_vpc_with_networks(self):
         """ Test restart VPC having networks
         """
@@ -607,7 +607,7 @@ class TestVPC(cloudstackTestCase):
         self.validate_vpc_network(vpc, state='Enabled')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_04_delete_vpc_no_networks(self):
         """ Test delete VPC having no networks
         """
@@ -647,7 +647,7 @@ class TestVPC(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_05_delete_vpc_with_networks(self):
         """ Test delete VPC having networks
         """
@@ -779,7 +779,7 @@ class TestVPC(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_06_list_vpc_apis_admin(self):
         """ Test list VPC APIs for different user roles
         """
@@ -839,7 +839,7 @@ class TestVPC(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan", "multiple"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "multiple", "networks", "vpc"], required_hardware="true")
     def test_07_restart_network_vm_running(self):
         """ Test Restart VPC when there are multiple networks associated
         """
@@ -1189,7 +1189,7 @@ class TestVPC(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_08_delete_vpc(self):
         """ Test vpc deletion after account deletion
         """
@@ -1557,7 +1557,7 @@ class TestVPC(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_09_vpc_create(self):
         """ Test to create vpc and verify VPC state, VR and SourceNatIP
         """
@@ -1618,7 +1618,7 @@ class TestVPC(cloudstackTestCase):
                          "Source Nat IP address was not allocated to VR"
                          )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_10_nonoverlaping_cidrs(self):
         """ Test creation of multiple VPCs with non-overlapping CIDRs
         """
@@ -1670,7 +1670,7 @@ class TestVPC(cloudstackTestCase):
             assert("VPC created with overlapping CIDR")
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_11_deploy_vm_wo_network_netdomain(self):
         """ Test deployment of vm in a VPC without network domain
         """
@@ -1828,7 +1828,7 @@ class TestVPC(cloudstackTestCase):
             (vm_domain, expected_netdomain)
         )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_12_deploy_vm_with_netdomain(self):
         """ Test deployment of vm in a VPC with network domain
         """
@@ -1883,7 +1883,7 @@ class TestVPC(cloudstackTestCase):
                 networkdomain='test.netdomain'
             )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_13_deploy_vm_with_vpc_netdomain(self):
         """ Test deployment of vm in a VPC with network domain
         """
@@ -1948,7 +1948,7 @@ class TestVPC(cloudstackTestCase):
 
         self.validate_vm_netdomain(virtual_machine, vpc, network, netdomain)
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_14_deploy_vm_1(self):
         """ Test vm deploy in network by a user where VPC was created
             without account/domain ID
@@ -2024,7 +2024,7 @@ class TestVPC(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_15_deploy_vm_2(self):
         """ Test deployment of vm in a network in a domain admin
         account where VPC is created without account/domain ID
@@ -2101,7 +2101,7 @@ class TestVPC(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_16_deploy_vm_for_user_by_admin(self):
         """ Test deployment of vm in a network by root admin for user.
         """
@@ -2180,7 +2180,7 @@ class TestVPC(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_17_deploy_vm_for_user_by_domain_admin(self):
         """ Test deployment of vm in a network by domain admin for user.
         """
@@ -2230,7 +2230,7 @@ class TestVPC(cloudstackTestCase):
                 zoneid=self.zone.id,
             )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_18_create_net_for_user_diff_domain_by_doadmin(self):
         """ Test creation of network by domain admin for user from different domain
         """
@@ -2304,7 +2304,7 @@ class TestVPC(cloudstackTestCase):
                 vpcid=vpc.id
             )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_19_create_vpc_wo_params(self):
         """ Test creation of VPC without mandatory parameters
         """
@@ -2364,7 +2364,7 @@ class TestVPC(cloudstackTestCase):
                 domainid=self.account.domainid
             )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_20_update_vpc_name_display_text(self):
         """ Test to verify updation of vpc name and display text
         """
@@ -2442,7 +2442,7 @@ class TestVPC(cloudstackTestCase):
                          new_display_text,
                          "Updation of VPC display text failed.")
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_21_deploy_vm_with_gateway_ip(self):
         self.services["vpc"]["cidr"] = "192.168.1.0/24"
         self.debug("creating a VPC network in the account: %s" %
@@ -2500,7 +2500,7 @@ class TestVPC(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_22_vpn_customer_gw_with_hostname(self):
         """
             Test to create vpn customer gateway with hostname

--- a/test/integration/component/test_vpc_distributed_routing_offering.py
+++ b/test/integration/component/test_vpc_distributed_routing_offering.py
@@ -298,7 +298,7 @@ class TestVPCDistributedRouterOffering(cloudstackTestCase):
         self.debug("VPC network created successfully - %s" % network.name)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "service-offerings", "networks", "vpc"])
     def test_01_create_vpc_offering_with_distributedrouter_service_capability(self):
         """ Test create VPC offering
         """
@@ -318,7 +318,7 @@ class TestVPCDistributedRouterOffering(cloudstackTestCase):
         self.validate_vpc_offering(vpc_off)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "service-offerings", "networks", "vpc"])
     def test_02_create_vpc_from_offering_with_distributedrouter_service_capability(self):
         """ Test create VPC offering
         """
@@ -352,7 +352,7 @@ class TestVPCDistributedRouterOffering(cloudstackTestCase):
             self.fail("Failed to delete VPC network - %s" % e)
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "service-offerings", "networks", "vpc"])
     def test_03_deploy_vms_in_vpc_with_distributedrouter(self):
         """Test deploy virtual machines in VPC networks"""
 

--- a/test/integration/component/test_vpc_network.py
+++ b/test/integration/component/test_vpc_network.py
@@ -366,7 +366,7 @@ class TestVPCNetwork(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_01_create_network(self, value):
         """ Test create network in VPC
         """
@@ -463,7 +463,7 @@ class TestVPCNetwork(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_02_create_network_fail(self, value):
         """ Test create network in VPC mismatched services (Should fail)
         """
@@ -539,7 +539,7 @@ class TestVPCNetwork(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_04_create_multiple_networks_with_lb(self, value):
         """ Test create multiple networks with LB service (Should fail)
         """
@@ -649,7 +649,7 @@ class TestVPCNetwork(cloudstackTestCase):
                     already exists")
         return
 
-    @attr(tags=["intervlan"])
+    @attr(tags=["intervlan", "networks", "vpc"])
     def test_05_create_network_ext_LB(self):
         """ Test create network with external LB devices
         """
@@ -707,7 +707,7 @@ class TestVPCNetwork(cloudstackTestCase):
         return
 
     @unittest.skip("skipped - RvR didn't support VPC currently ")
-    @attr(tags=["advanced", "intervlan", "NA"])
+    @attr(tags=["advanced", "intervlan", "NA", "networks", "vpc"])
     def test_06_create_network_with_rvr(self):
         """ Test create network with redundant router capability
         """
@@ -781,7 +781,7 @@ class TestVPCNetwork(cloudstackTestCase):
         self.debug("Network creation failed")
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_07_create_network_unsupported_services(self):
         """ Test create network services not supported by VPC (Should fail)
         """
@@ -849,7 +849,7 @@ class TestVPCNetwork(cloudstackTestCase):
         self.debug("Network creation failed as VPC doesn't have LB service")
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_08_create_network_without_sourceNAT(self):
         """ Test create network without sourceNAT service in VPC (should fail)
         """
@@ -917,7 +917,7 @@ class TestVPCNetwork(cloudstackTestCase):
         return
 
     @data("network_off_shared", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_09_create_network_shared_nwoff(self, value):
         """ Test create network with shared network offering
         """
@@ -991,7 +991,7 @@ class TestVPCNetwork(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_10_create_network_with_conserve_mode(self, value):
         """ Test create network with conserve mode ON
         """
@@ -1142,7 +1142,7 @@ class TestVPCNetworkRanges(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_01_create_network_outside_range(self, value):
         """ Test create network outside cidr range of VPC
         """
@@ -1211,7 +1211,7 @@ class TestVPCNetworkRanges(cloudstackTestCase):
             "Network creation failed as network cidr range is outside of vpc")
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_02_create_network_outside_range(self):
         """ Test create network outside cidr range of VPC
         """
@@ -1276,7 +1276,7 @@ class TestVPCNetworkRanges(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_03_create_network_inside_range(self, value):
         """ Test create network inside cidr range of VPC
         """
@@ -1350,7 +1350,7 @@ class TestVPCNetworkRanges(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_04_create_network_overlapping_range(self, value):
         """ Test create network overlapping cidr range of VPC
         """
@@ -1482,7 +1482,7 @@ class TestVPCNetworkRanges(cloudstackTestCase):
         return
 
     @data("network_offering", "network_offering_vpcns")
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"])
     def test_05_create_network_diff_account(self, value):
         """ Test create network from different account in VPC
         """
@@ -1675,7 +1675,7 @@ class TestVPCNetworkUpgrade(cloudstackTestCase):
         self.debug("VPC network validated - %s" % network.name)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_01_network_services_upgrade(self):
         """ Test update Network that is part of a VPC to a network
             offering that has more services
@@ -2045,7 +2045,7 @@ class TestVPCNetworkUpgrade(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_02_network_vpcvr2vr_upgrade(self):
         """ Test update Network that is NOT part of a VPC to a nw offering
             that has services that are provided by VPCVR and vice versa
@@ -2380,7 +2380,7 @@ class TestVPCNetworkGc(cloudstackTestCase):
         self.debug("VPC network validated - %s" % network.name)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_01_wait_network_gc(self):
         """ Test network gc after shutdown of vms in the network
         """
@@ -2411,7 +2411,7 @@ class TestVPCNetworkGc(cloudstackTestCase):
             "LBrules were not cleared after network GC thread is run")
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_02_start_vm_network_gc(self):
         """ Test network rules after starting a VpcVr that
             was shutdown after network.gc
@@ -2486,7 +2486,7 @@ class TestVPCNetworkGc(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc"], required_hardware="true")
     def test_03_restart_vpcvr(self):
         """ Test Stop all the Vms that are part of the a Network
             (Wait for network GC).Restart VPCVR.
@@ -2683,7 +2683,7 @@ class TestRouterOperations(cloudstackTestCase):
     def tearDown(self):
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_stop_start_vpc_router(self):
         """ Test stop and start VPC router
 

--- a/test/integration/component/test_vpc_network_internal_lbrules.py
+++ b/test/integration/component/test_vpc_network_internal_lbrules.py
@@ -364,7 +364,7 @@ class TestVPCNetworkInternalLBRules(cloudstackTestCase):
         cmd = "rm -r test.html"
         self.execute_cmd(ssh_client, cmd)
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_01_internallb_rules(self):
         """Test VPC Network Internal LB functionality with different combinations of Internal LB rules
         """
@@ -577,7 +577,7 @@ class TestVPCNetworkInternalLBRules(cloudstackTestCase):
             self.create_Internal_LB_Rule(internal_tier, vm_array=[public_vm])
         self.debug("Internal LB Rule creation failed as the VM belongs to a different network")
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_02_internallb_rules_traffic(self):
         """Test VPC Network Internal LB functionality by performing (wget) traffic tests within a VPC
         """
@@ -749,7 +749,7 @@ class TestVPCNetworkInternalLBRules(cloudstackTestCase):
                               http_rule["publicport"]
                               )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_03_internallb_rules_vpc_network_restarts_traffic(self):
         """Test VPC Network Internal LB functionality with restarts of VPC network components by performing (wget)
         traffic tests within a VPC
@@ -1005,7 +1005,7 @@ class TestVPCNetworkInternalLBRules(cloudstackTestCase):
                               self.test_data["http_rule"]["publicport"]
                               )
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_04_internallb_appliance_operations_traffic(self):
         """Test VPC Network Internal LB functionality with InternalLbVm appliance operations by performing (wget)
         traffic tests within a VPC

--- a/test/integration/component/test_vpc_network_lbrules.py
+++ b/test/integration/component/test_vpc_network_lbrules.py
@@ -506,7 +506,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
 
         return nwacl_internet_1
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_01_VPC_LBRulesListing(self):
         """ Test case no 210 and 227: List Load Balancing Rules belonging to a VPC
         """
@@ -554,7 +554,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_02_VPC_CreateLBRuleInMultipleNetworks(self):
         """ Test Create LB rules for 1 network which is part of a two/multiple virtual networks of a
             VPC using a new Public IP Address available with the VPC when the Virtual Router is in Running State
@@ -579,7 +579,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_03_VPC_CreateLBRuleInMultipleNetworksVRStoppedState(self):
         """ Test case no 222 : Create LB rules for a two/multiple virtual networks of a 
             VPC using a new Public IP Address available with the VPC when the Virtual Router is in Stopped State
@@ -615,7 +615,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=False)
         return    
 
-    @attr(tags=["advanced","advancedns", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced","advancedns", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_04_VPC_CreateLBRuleInMultipleNetworksVRStoppedState(self):
         """ Test case no 222 : Create LB rules for a two/multiple virtual networks of a
             VPC using a new Public IP Address available with the VPC when the Virtual Router is in Stopped State
@@ -645,7 +645,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_05_VPC_CreateAndDeleteLBRule(self):
         """ Test case no 214 : Delete few(not all) LB rules for a single virtual network of a
             VPC belonging to a single Public IP Address when the Virtual Router is in Running State
@@ -676,7 +676,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_1, public_ip_1, testnegative=True)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_06_VPC_CreateAndDeleteLBRuleVRStopppedState(self):
         """ Test Delete few(not all) LB rules for a single virtual network of
             a VPC belonging to a single Public IP Address when the Virtual Router is in Stopped State
@@ -713,7 +713,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_1, public_ip_1, testnegative=True)
         return    
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_07_VPC_CreateAndDeleteAllLBRule(self):
         """ Test Delete all LB rules for a single virtual network of a
             VPC belonging to a single Public IP Address when the Virtual Router is in Running State
@@ -746,7 +746,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=True)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_08_VPC_CreateAndDeleteAllLBRuleVRStoppedState(self):
         """ Test Delete all LB rules for a single virtual network of a
             VPC belonging to a single Public IP Address when the Virtual Router is in Stopped State
@@ -779,7 +779,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=True)
         return
     
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_09_VPC_LBRuleCreateFailMultipleVPC(self):
         """ Test User should not be allowed to create a LB rule for a VM that belongs to a different VPC.
         """
@@ -817,7 +817,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
             self.debug('Failed to Create LB rule vm_3 and vm_4')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_10_VPC_FailedToCreateLBRuleNonVPCNetwork(self):
         """ Test User should not be allowed to create a LB rule for a VM that does not belong to any VPC.
         """
@@ -854,7 +854,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
             self.debug('Failed to Create LB rule vm_3 and vm_4 in network2')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_11_VPC_LBRuleCreateNotAllowed(self):
         """ Test case no 217 and 236: User should not be allowed to create a LB rule for a
             VM that does not belong to the same network but belongs to the same VPC.
@@ -892,7 +892,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
             self.debug('Failed to Create LB rule vm_3 and vm_1')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_12_VPC_LBRuleCreateFailForRouterIP(self):
         """ Test User should not be allowed to create a LB rule on an Ipaddress that Source Nat enabled.
         """
@@ -920,7 +920,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
             self.debug('Failed to Create LB rule vm_2 and vm_1')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_13_VPC_LBRuleCreateFailForPFSourceNATIP(self):
         """ Test User should not be allowed to create a LB rule on an Ipaddress that already has a PF rule.
         """
@@ -950,7 +950,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
             self.debug('Failed to Create LB rule vm_2 and vm_1')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_14_VPC_LBRuleCreateFailForStaticNatRule(self):
         """ Test User should not be allowed to create a LB rule on an Ipaddress that already has a Static Nat rule.
         """
@@ -979,7 +979,7 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
             self.debug('Failed to Create LB rule vm_2 and vm_1')
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_15_VPC_ReleaseIPForLBRuleCreated(self):
         """ Test release Ip address that has a LB rule assigned to it.
         """

--- a/test/integration/component/test_vpc_network_pfrules.py
+++ b/test/integration/component/test_vpc_network_pfrules.py
@@ -520,7 +520,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         return nwacl_internet_1
 
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_01_network_services_VPC_StopCreatePF(self):
         """ Test : Create VPC PF rules on acquired public ip when VpcVirtualRouter is stopped
         """
@@ -551,7 +551,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_1, public_ip_1, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_02_network_services_VPC_CreatePF(self):
         """ Test Create VPC PF rules on acquired public ip when VpcVirtualRouter is Running
         """
@@ -571,7 +571,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_1, public_ip_1, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_03_network_services_VPC_StopCreateMultiplePF(self):
         """ Test Create multiple VPC PF rules on acquired public ip in diff't networks when VpcVirtualRouter is stopped
         """
@@ -607,7 +607,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_2, public_ip_2, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_04_network_services_VPC_CreateMultiplePF(self):
         """ Test Create multiple VPC PF rules on acquired public ip in diff't networks when VpcVirtualRouter is running
         """
@@ -635,7 +635,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_2, public_ip_2, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_05_network_services_VPC_StopDeletePF(self):
         """ Test delete a PF rule in VPC when VpcVirtualRouter is Stopped
         """
@@ -666,7 +666,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=True)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_06_network_services_VPC_DeletePF(self):
         """ Test delete a PF rule in VPC when VpcVirtualRouter is Running
         """
@@ -693,7 +693,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=True)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_07_network_services_VPC_StopDeleteAllPF(self):
         """ Test delete all PF rules in VPC when VpcVirtualRouter is Stopped
         """
@@ -728,7 +728,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
                 isVmAccessible=False, network=network_1)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_08_network_services_VPC_DeleteAllPF(self):
         """ Test delete all PF rules in VPC when VpcVirtualRouter is Running
         """
@@ -759,7 +759,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
                 isVmAccessible=False, network=network_1)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_09_network_services_VPC_StopDeleteAllMultiplePF(self):
         """ Test delete all PF rules in VPC across multiple networks when VpcVirtualRouter is Stopped
         """
@@ -830,7 +830,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
                 isVmAccessible=False, network=network_2)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_10_network_services_VPC_DeleteAllMultiplePF(self):
         """ Test delete all PF rules in VPC across multiple networks when VpcVirtualRouter is Running
         """

--- a/test/integration/component/test_vpc_network_staticnatrule.py
+++ b/test/integration/component/test_vpc_network_staticnatrule.py
@@ -494,7 +494,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         return nwacl_nat
 
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_01_VPC_StaticNatRuleCreateStoppedState(self):
         """ Test case no extra : 
         """
@@ -522,7 +522,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_02_VPC_CreateStaticNatRule(self):
         """ Test case no 229 : Create Static NAT Rule for a single virtual network of 
             a VPC using a new Public IP Address available with the VPC when the Virtual Router is in Running State
@@ -545,7 +545,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_1, public_ip_1, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_03_VPC_StopCreateMultipleStaticNatRuleStopppedState(self):
         """ Test case no extra : Create Static Nat Rule rules for a two/multiple virtual networks of a VPC using
                 a new Public IP Address available with the VPC when Virtual Router is in Stopped State
@@ -585,7 +585,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_2, public_ip_2, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_04_VPC_CreateMultipleStaticNatRule(self):
         """ Test case no 230 : Create Static NAT Rules for a two/multiple virtual networks of 
             a VPC using a new Public IP Address available with the VPC when the Virtual Router is in Running State
@@ -618,7 +618,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_ssh_into_vm(vm_2, public_ip_2, testnegative=False)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_05_network_services_VPC_DeleteAllPF(self):
         """ Test case no 232: Delete all Static NAT Rules for a single virtual network of 
             a VPC belonging to a single Public IP Address when the Virtual Router is in Running State
@@ -650,7 +650,7 @@ class TestVPCNetworkPFRules(cloudstackTestCase):
         self.check_wget_from_vm(vm_1, public_ip_1, testnegative=True)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_06_network_services_VPC_DeleteAllMultiplePF(self):
         """ Test case no 233: Delete all Static NAT rules for two/multiple virtual networks of a VPC. 
             Observe the status of the Public IP Addresses of the rules when the Virtual Router is in Running State.

--- a/test/integration/component/test_vpc_offerings.py
+++ b/test/integration/component/test_vpc_offerings.py
@@ -269,7 +269,7 @@ class TestVPCOffering(cloudstackTestCase):
         self.logger.debug("VPC network created successfully - %s" % network.name)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_01_create_vpc_offering(self):
         """ Test create VPC offering
         """
@@ -289,7 +289,7 @@ class TestVPCOffering(cloudstackTestCase):
         self.validate_vpc_offering(vpc_off)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="true")
     def test_02_deploy_vms_in_vpc_nw(self):
         """Test deploy virtual machines in VPC networks"""
 
@@ -491,7 +491,7 @@ class TestVPCOffering(cloudstackTestCase):
         # TODO: Remote Access VPN is not yet supported in VPC
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_03_vpc_off_without_lb(self):
         """Test VPC offering without load balancing service"""
 
@@ -616,7 +616,7 @@ class TestVPCOffering(cloudstackTestCase):
                                 )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_04_vpc_off_without_static_nat(self):
         """Test VPC offering without static NAT service"""
 
@@ -738,7 +738,7 @@ class TestVPCOffering(cloudstackTestCase):
                               )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_05_vpc_off_without_pf(self):
         """Test VPC offering without port forwarding service"""
 
@@ -860,7 +860,7 @@ class TestVPCOffering(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_06_vpc_off_invalid_services(self):
         """Test VPC offering with invalid services"""
 
@@ -892,7 +892,7 @@ class TestVPCOffering(cloudstackTestCase):
             self.fail("Failed to create the VPC offering - %s" % e)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_07_update_vpc_off(self):
         """Test update VPC offering"""
 
@@ -981,7 +981,7 @@ class TestVPCOffering(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "service-offerings", "vpc"], required_hardware="false")
     def test_08_list_vpc_off(self):
         """Test list VPC offering"""
 
@@ -1150,7 +1150,7 @@ class TestVPCOffering(cloudstackTestCase):
                  )
         return
 
-    @attr(tags=["advanced", "redundancy"], required_hardware="false")
+    @attr(tags=["advanced", "redundancy", "service-offerings", "vpc"], required_hardware="false")
     def test_09_create_redundant_vpc_offering(self):
 
         self.logger.debug("Creating Redundant VPC offering")

--- a/test/integration/component/test_vpc_routers.py
+++ b/test/integration/component/test_vpc_routers.py
@@ -372,7 +372,7 @@ class TestVPCRoutersBasic(cloudstackTestCase):
             (host.id, router.hostid))
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "vpc"], required_hardware="false")
     def test_01_stop_start_router_after_creating_vpc(self):
         """ Test to stop and start router after creation of VPC
         """
@@ -450,7 +450,7 @@ class TestVPCRoutersBasic(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "vpc"], required_hardware="false")
     def test_02_reboot_router_after_creating_vpc(self):
         """ Test to reboot the router after creating a VPC
         """
@@ -498,7 +498,7 @@ class TestVPCRoutersBasic(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "routers", "vpc"], required_hardware="true")
     def test_03_migrate_router_after_creating_vpc(self):
         """ Test migration of router to another host after creating VPC """
         self.hypervisor = self.testClient.getHypervisorInfo()
@@ -524,7 +524,7 @@ class TestVPCRoutersBasic(cloudstackTestCase):
         self.migrate_router(routers[0])
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "vpc"], required_hardware="false")
     def test_04_change_service_offerring_vpc(self):
         """ Tests to change service offering of the Router after
             creating a vpc
@@ -586,7 +586,7 @@ class TestVPCRoutersBasic(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "vpc"], required_hardware="false")
     def test_05_destroy_router_after_creating_vpc(self):
         """ Test to destroy the router after creating a VPC
             """
@@ -1024,7 +1024,7 @@ class TestVPCRouterOneNetwork(cloudstackTestCase):
             (host.id, router.hostid))
         return
 
-    @attr(tags=["advanced", "intervlan", "provisioining"])
+    @attr(tags=["advanced", "intervlan", "provisioining", "routers", "networks", "vpc"])
     def test_01_start_stop_router_after_addition_of_one_guest_network(self):
         """ Test start/stop of router after addition of one guest network
             """
@@ -1120,7 +1120,7 @@ class TestVPCRouterOneNetwork(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "networks", "vpc"], required_hardware="false")
     def test_02_reboot_router_after_addition_of_one_guest_network(self):
         """ Test reboot of router after addition of one guest network
             """
@@ -1188,7 +1188,7 @@ class TestVPCRouterOneNetwork(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "routers", "networks", "vpc"], required_hardware="true")
     def test_03_migrate_router_after_addition_of_one_guest_network(self):
         """ Test migrate of router after addition of one guest network
             """
@@ -1237,7 +1237,7 @@ class TestVPCRouterOneNetwork(cloudstackTestCase):
         self.migrate_router(routers[0])
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "networks", "vpc"], required_hardware="false")
     def test_04_chg_srv_off_router_after_addition_of_one_guest_network(self):
         """ Test to change service offering of router after addition of one guest network
             """
@@ -1316,7 +1316,7 @@ class TestVPCRouterOneNetwork(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "routers", "networks", "vpc"], required_hardware="false")
     def test_05_destroy_router_after_addition_of_one_guest_network(self):
         """ Test destroy of router after addition of one guest network
         """

--- a/test/integration/component/test_vpc_vm_life_cycle.py
+++ b/test/integration/component/test_vpc_vm_life_cycle.py
@@ -492,7 +492,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"])
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"])
     def test_01_deploy_instance_in_network(self):
         """ Test deploy an instance in VPC networks
         """
@@ -525,7 +525,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"])
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"])
     def test_02_stop_instance_in_network(self):
         """ Test stop an instance in VPC networks
         """
@@ -567,7 +567,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_03_start_instance_in_network(self):
         """ Test start an instance in VPC networks
         """
@@ -592,7 +592,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_04_reboot_instance_in_network(self):
         """ Test reboot an instance in VPC networks
         """
@@ -621,7 +621,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_05_destroy_instance_in_network(self):
         """ Test destroy an instance in VPC networks
         """
@@ -788,7 +788,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
         return
 
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_07_migrate_instance_in_network(self):
         """ Test migrate an instance in VPC networks
         """
@@ -824,7 +824,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_08_user_data(self):
         """ Test user data in virtual machines
         """
@@ -868,7 +868,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_09_meta_data(self):
         """ Test meta data in virtual machines
         """
@@ -910,7 +910,7 @@ class TestVMLifeCycleVPC(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_10_expunge_instance_in_network(self):
         """ Test expunge an instance in VPC networks
         """
@@ -1291,7 +1291,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
                                     (self.public_ip_1.ipaddress.ipaddress, e))
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_01_deploy_instance_in_network(self):
         """ Test deploy an instance in VPC networks
         """
@@ -1326,7 +1326,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_02_stop_instance_in_network(self):
         """ Test stop an instance in VPC networks
         """
@@ -1349,7 +1349,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_03_start_instance_in_network(self):
         """ Test start an instance in VPC networks
         """
@@ -1390,7 +1390,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_04_reboot_instance_in_network(self):
         """ Test reboot an instance in VPC networks
         """
@@ -1433,7 +1433,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_05_destroy_instance_in_network(self):
         """ Test destroy an instance in VPC networks
         """
@@ -1468,7 +1468,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_06_recover_instance_in_network(self):
         """ Test recover an instance in VPC networks
         """
@@ -1542,7 +1542,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_07_migrate_instance_in_network(self):
         """ Test migrate an instance in VPC networks
         """
@@ -1578,7 +1578,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_08_user_data(self):
         """ Test user data in virtual machines
         """
@@ -1622,7 +1622,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_09_meta_data(self):
         """ Test meta data in virtual machines
         """
@@ -1664,7 +1664,7 @@ class TestVMLifeCycleSharedNwVPC(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_10_expunge_instance_in_network(self):
         """ Test expunge an instance in VPC networks
         """
@@ -1946,7 +1946,7 @@ class TestVMLifeCycleBothIsolated(cloudstackTestCase):
                                     (self.public_ip_1.ipaddress.ipaddress, e))
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"])
     def test_01_deploy_vm_two_isolated_nw(self):
         """ Test deploy virtual machine in two isolated networks"""
 
@@ -1977,7 +1977,7 @@ class TestVMLifeCycleBothIsolated(cloudstackTestCase):
         self.debug("Deploy VM in 2 isolated networks failed")
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"])
     def test_02_deploy_vm_vpcvr_stopped(self):
         """ Test deploy virtual machine when VPC VR in stopped state"""
 
@@ -2064,7 +2064,7 @@ class TestVMLifeCycleBothIsolated(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["dvs"], required_hardware="true")
+    @attr(tags=["dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_guest_traffic_port_groups_vpc_network(self):
         """ Verify port groups are created for guest traffic
         used by vpc network """
@@ -2391,7 +2391,7 @@ class TestVMLifeCycleStoppedVPCVR(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"])
     def test_01_deploy_instance_in_network(self):
         """ Test deploy an instance in VPC networks
         """
@@ -2424,7 +2424,7 @@ class TestVMLifeCycleStoppedVPCVR(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"])
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"])
     def test_02_stop_instance_in_network(self):
         """ Test stop an instance in VPC networks
         """
@@ -2466,7 +2466,7 @@ class TestVMLifeCycleStoppedVPCVR(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_03_start_instance_in_network(self):
         """ Test start an instance in VPC networks
         """
@@ -2489,7 +2489,7 @@ class TestVMLifeCycleStoppedVPCVR(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_04_reboot_instance_in_network(self):
         """ Test reboot an instance in VPC networks
         """
@@ -2516,7 +2516,7 @@ class TestVMLifeCycleStoppedVPCVR(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced","multihost", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_05_destroy_instance_in_network(self):
         """ Test destroy an instance in VPC networks
         """
@@ -3077,7 +3077,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_01_deploy_instance_in_network(self):
         """ Test deploy an instance in VPC networks
         """
@@ -3111,7 +3111,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_02_stop_instance_in_network(self):
         """ Test stop an instance in VPC networks
         """
@@ -3153,7 +3153,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_03_start_instance_in_network(self):
         """ Test start an instance in VPC networks
         """
@@ -3204,7 +3204,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_04_reboot_instance_in_network(self):
         """ Test reboot an instance in VPC networks
         """
@@ -3231,7 +3231,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_05_destroy_instance_in_network(self):
         """ Test destroy an instance in VPC networks
         """
@@ -3394,7 +3394,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_06_migrate_instance_in_network(self):
         """ Test migrate an instance in VPC networks
         """
@@ -3430,7 +3430,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
         self.validate_network_rules()
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_07_user_data(self):
         """ Test user data in virtual machines
         """
@@ -3479,7 +3479,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_08_meta_data(self):
         """ Test meta data in virtual machines
         """
@@ -3526,7 +3526,7 @@ class TestVMLifeCycleDiffHosts(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced","multihost", "intervlan", "dvs"], required_hardware="true")
+    @attr(tags=["advanced","multihost", "intervlan", "dvs", "networks", "vpc", "deploy-vm"], required_hardware="true")
     def test_09_expunge_instance_in_network(self):
         """ Test expunge an instance in VPC networks
         """

--- a/test/integration/component/test_vpc_vms_deployment.py
+++ b/test/integration/component/test_vpc_vms_deployment.py
@@ -356,7 +356,7 @@ class TestVMDeployVPC(cloudstackTestCase):
         nat_rule.delete(self.apiclient)
         return vm
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_01_deploy_vms_in_network(self):
         """ Test deploy VMs in VPC networks
         """
@@ -570,7 +570,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_02_deploy_vms_delete_network(self):
         """ Test deploy VMs in VPC networks and delete one of the network
         """
@@ -822,7 +822,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_03_deploy_vms_delete_add_network(self):
         """ Test deploy VMs, delete one of the network and add another one
         """
@@ -1091,7 +1091,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_04_deploy_vms_delete_add_network_noLb(self):
         """ Test deploy VMs, delete one network without LB and add another one
         """
@@ -1385,7 +1385,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_05_create_network_max_limit(self):
         """ Test create networks in VPC upto maximum limit for hypervisor
         """
@@ -1556,7 +1556,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="false")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="false")
     def test_06_delete_network_vm_running(self):
         """ Test delete network having running instances in VPC
         """
@@ -1798,7 +1798,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                              )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_07_delete_network_with_rules(self):
         """ Test delete network that has PF/staticNat/LB rules/Network Acl
         """
@@ -2352,7 +2352,7 @@ class TestVMDeployVPC(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "networks", "vpc"], required_hardware="true")
     def test_08_ip_reallocation_CS5986(self):
         """
         @Desc: Test to verify dnsmasq dhcp conflict issue due to /ect/hosts not getting udpated

--- a/test/integration/component/test_vpn_service.py
+++ b/test/integration/component/test_vpn_service.py
@@ -193,7 +193,7 @@ class TestVPNService(cloudstackTestCase):
             self.fail("Failed to create remote VPN access: %s" % e)
 
 
-    @attr(tags=["advanced", "advancedns"])
+    @attr(tags=["advanced", "advancedns", "networks"])
     def test_01_VPN_service(self):
         """Tests if VPN service is running"""
 

--- a/test/integration/component/test_vpn_users.py
+++ b/test/integration/component/test_vpn_users.py
@@ -224,7 +224,7 @@ class TestVPNUsers(cloudstackTestCase):
         except Exception as e:
             self.fail("Failed to create remote VPN users: %s" % e)
 
-    @attr(tags=["advanced", "advancedns"])
+    @attr(tags=["advanced", "advancedns", "networks"])
     @attr(configuration='remote.access.vpn.user.limit')
     def test_01_VPN_user_limit(self):
         """VPN remote access user limit tests"""
@@ -261,7 +261,7 @@ class TestVPNUsers(cloudstackTestCase):
         self.debug("Limit exceeded exception raised!")
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_02_use_vpn_port(self):
         """Test create VPN when L2TP port in use"""
 
@@ -292,7 +292,7 @@ class TestVPNUsers(cloudstackTestCase):
         self.debug("Create VPN connection failed! Test successful!")
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_03_enable_vpn_use_port(self):
         """Test create NAT rule when VPN when L2TP enabled"""
 
@@ -318,7 +318,7 @@ class TestVPNUsers(cloudstackTestCase):
         self.debug("Create NAT rule failed! Test successful!")
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_04_add_new_users(self):
         """Test add new users to existing VPN"""
 
@@ -346,7 +346,7 @@ class TestVPNUsers(cloudstackTestCase):
             self.fail("Failed to create new VPN user: %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_05_add_duplicate_user(self):
         """Test add duplicate user to existing VPN"""
 
@@ -369,7 +369,7 @@ class TestVPNUsers(cloudstackTestCase):
             self.create_VPN_Users(rand_name=False)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_06_add_VPN_user_global_admin(self):
         """Test as global admin, add a new VPN user to an existing VPN entry
             that was created by another account."""
@@ -412,7 +412,7 @@ class TestVPNUsers(cloudstackTestCase):
                                                                             e)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_07_add_VPN_user_domain_admin(self):
         """Test as domain admin, add a new VPN user to an existing VPN entry
             that was created by another account."""
@@ -454,7 +454,7 @@ class TestVPNUsers(cloudstackTestCase):
                                                                             e)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "networks"], required_hardware="false")
     def test_08_add_TCP_PF_Rule_In_VPN(self):
         """
         Test to add TCP Port Forwarding rule for specific ports(500,1701 and 4500) in VPN

--- a/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
+++ b/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
@@ -171,7 +171,7 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             )
 		
 
-    @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
+    @attr(tags=['advanced', 'basic', 'vgpu', 'deploy-vm'], required_hardware="true")
     def test_deploy_vgpu_enabled_vm(self):
         """Test Deploy Virtual Machine
 
@@ -265,7 +265,7 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             self.debug("Warning! Exception in tearDown: %s" % e)
         return
 
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", 'deploy-vm'])
     def test_3d_gpu_support(self):
         """Test 3D GPU support
 

--- a/test/integration/smoke/test_deploy_virtio_scsi_vm.py
+++ b/test/integration/smoke/test_deploy_virtio_scsi_vm.py
@@ -270,7 +270,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
         self.logger.debug("xml is: \n\n%s\n\n" % (stdout))
         return stdout
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", 'deploy-vm'], required_hardware="true")
     def test_01_verify_libvirt(self):
         """Test that libvirt properly created domain with scsi controller
         """
@@ -281,7 +281,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
 
         self.verifyVirshState(2)
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", 'deploy-vm'], required_hardware="true")
     def test_02_verify_libvirt_after_restart(self):
         """ Verify that libvirt settings are as expected after a VM stop / start
         """
@@ -293,7 +293,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
         self.virtual_machine.start(self.apiclient)
         self.verifyVirshState(2)
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", 'deploy-vm'], required_hardware="true")
     def test_03_verify_libvirt_attach_disk(self):
         """ Verify that libvirt settings are expected after a disk add
         """
@@ -316,7 +316,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
 
         self.verifyVirshState(3)
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", 'deploy-vm'], required_hardware="true")
     def test_04_verify_guest_lspci(self):
         """ Verify that guest sees scsi controller and disks
         """
@@ -326,7 +326,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
 
         self.verifyGuestState(3)
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", 'deploy-vm'], required_hardware="true")
     def test_05_change_vm_ostype_restart(self):
         """ Update os type to Ubuntu, change vm details rootdiskController
             explicitly to scsi.
@@ -354,7 +354,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
 
         self.verifyVirshState(3)
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", 'deploy-vm'], required_hardware="true")
     def test_06_verify_guest_lspci_again(self):
         """ Verify that guest sees scsi controller and disks after switching ostype and rdc
         """

--- a/test/integration/smoke/test_deploy_vm_iso.py
+++ b/test/integration/smoke/test_deploy_vm_iso.py
@@ -33,7 +33,6 @@ from marvin.codes import PASS
 
 
 class TestDeployVMFromISO(cloudstackTestCase):
-
     @classmethod
     def setUpClass(cls):
 
@@ -106,7 +105,8 @@ class TestDeployVMFromISO(cloudstackTestCase):
             "eip",
             "advancedns",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_deploy_vm_from_iso(self):
         """Test Deploy Virtual Machine from ISO

--- a/test/integration/smoke/test_deploy_vm_root_resize.py
+++ b/test/integration/smoke/test_deploy_vm_root_resize.py
@@ -204,7 +204,7 @@ class TestDeployVmRootSize(cloudstackTestCase):
         except Exception:
             return False
 
-    @attr(tags = ['advanced', 'basic', 'sg'], required_hardware="false")
+    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="false")
     def test_00_deploy_vm_root_resize(self):
         """Test deploy virtual machine with root resize
 
@@ -321,7 +321,7 @@ class TestDeployVmRootSize(cloudstackTestCase):
 
             self.assertEqual(success, True, "Check if unsupported hypervisor %s fails appropriately" % self.hypervisor)
 
-    @attr(tags = ['advanced', 'basic', 'sg'], required_hardware="false")
+    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="false")
     def test_01_deploy_vm_root_resize(self):
         """Test proper failure to deploy virtual machine with rootdisksize of 0
         """
@@ -361,7 +361,7 @@ class TestDeployVmRootSize(cloudstackTestCase):
         else:
             self.debug("test 01 does not support hypervisor type " + self.hypervisor)
 
-    @attr(tags = ['advanced', 'basic', 'sg'], required_hardware="false", BugId="CLOUDSTACK-6984")
+    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="false", BugId="CLOUDSTACK-6984")
     def test_02_deploy_vm_root_resize(self):
         """Test proper failure to deploy virtual machine with rootdisksize less than template size
         """

--- a/test/integration/smoke/test_deploy_vm_root_resize.py
+++ b/test/integration/smoke/test_deploy_vm_root_resize.py
@@ -204,7 +204,7 @@ class TestDeployVmRootSize(cloudstackTestCase):
         except Exception:
             return False
 
-    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="false")
+    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="true")
     def test_00_deploy_vm_root_resize(self):
         """Test deploy virtual machine with root resize
 
@@ -321,7 +321,7 @@ class TestDeployVmRootSize(cloudstackTestCase):
 
             self.assertEqual(success, True, "Check if unsupported hypervisor %s fails appropriately" % self.hypervisor)
 
-    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="false")
+    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="true")
     def test_01_deploy_vm_root_resize(self):
         """Test proper failure to deploy virtual machine with rootdisksize of 0
         """
@@ -361,7 +361,7 @@ class TestDeployVmRootSize(cloudstackTestCase):
         else:
             self.debug("test 01 does not support hypervisor type " + self.hypervisor)
 
-    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="false", BugId="CLOUDSTACK-6984")
+    @attr(tags = ['advanced', 'basic', 'sg', 'deploy-vm'], required_hardware="true", BugId="CLOUDSTACK-6984")
     def test_02_deploy_vm_root_resize(self):
         """Test proper failure to deploy virtual machine with rootdisksize less than template size
         """

--- a/test/integration/smoke/test_deploy_vm_with_userdata.py
+++ b/test/integration/smoke/test_deploy_vm_with_userdata.py
@@ -71,7 +71,7 @@ class TestDeployVmWithUserData(cloudstackTestCase):
     def setup(self):
         self.hypervisor = self.testClient.getHypervisorInfo()
 
-    @attr(tags=["devcloud", "basic", "advanced", "post"], required_hardware="true")
+    @attr(tags=["devcloud", "basic", "advanced", "post", "deploy-vm"], required_hardware="true")
     def test_deployvm_userdata_post(self):
         """Test userdata as POST, size > 2k
         """
@@ -96,7 +96,7 @@ class TestDeployVmWithUserData(cloudstackTestCase):
         self.assert_(vm.id == str(deployVmResponse.id), "Vm deployed is different from the test")
         self.assert_(vm.state == "Running", "VM is not in Running state")
 
-    @attr(tags=["devcloud", "basic", "advanced"], required_hardware="true")
+    @attr(tags=["devcloud", "basic", "advanced", "deploy-vm"], required_hardware="true")
     def test_deployvm_userdata(self):
         """Test userdata as GET, size > 2k
         """

--- a/test/integration/smoke/test_deploy_vms_with_varied_deploymentplanners.py
+++ b/test/integration/smoke/test_deploy_vms_with_varied_deploymentplanners.py
@@ -61,7 +61,7 @@ class TestDeployVmWithVariedPlanners(cloudstackTestCase):
             cls.account
         ]
 
-    @attr(tags=["advanced", "basic", "sg"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_deployvm_firstfit(self):
         """Test to deploy vm with a first fit offering
         """
@@ -105,7 +105,7 @@ class TestDeployVmWithVariedPlanners(cloudstackTestCase):
             msg="VM is not in Running state"
         )
 
-    @attr(tags=["advanced", "basic", "sg"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_deployvm_userdispersing(self):
         """Test deploy VMs using user dispersion planner
         """
@@ -164,7 +164,7 @@ class TestDeployVmWithVariedPlanners(cloudstackTestCase):
             self.debug("VMs (%s, %s) meant to be dispersed are deployed in the same cluster %s" % (
             vm1.id, vm2.id, vm1clusterid))
 
-    @attr(tags=["advanced", "basic", "sg"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_deployvm_userconcentrated(self):
         """Test deploy VMs using user concentrated planner
         """

--- a/test/integration/smoke/test_disk_offerings.py
+++ b/test/integration/smoke/test_disk_offerings.py
@@ -46,7 +46,7 @@ class TestCreateDiskOffering(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke", "service-offerings"], required_hardware="false")
     def test_01_create_disk_offering(self):
         """Test to create disk offering
 
@@ -91,7 +91,7 @@ class TestCreateDiskOffering(cloudstackTestCase):
         return
 
     @attr(hypervisor="kvm")
-    @attr(tags = ["advanced", "basic", "eip", "sg", "advancedns", "simulator", "smoke"])
+    @attr(tags = ["advanced", "basic", "eip", "sg", "advancedns", "simulator", "smoke", "service-offerings"])
     def test_02_create_sparse_type_disk_offering(self):
         """Test to create  a sparse type disk offering"""
 
@@ -132,7 +132,7 @@ class TestCreateDiskOffering(cloudstackTestCase):
 
 
     @attr(hypervisor="kvm")
-    @attr(tags = ["advanced", "basic", "eip", "sg", "advancedns", "simulator", "smoke"])
+    @attr(tags = ["advanced", "basic", "eip", "sg", "advancedns", "simulator", "smoke", "service-offerings"])
     def test_04_create_fat_type_disk_offering(self):
         """Test to create  a sparse type disk offering"""
 
@@ -338,7 +338,7 @@ class TestDiskOfferings(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns",  "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns",  "smoke", "service-offerings"], required_hardware="false")
     def test_02_edit_disk_offering(self):
         """Test to update existing disk offering
 
@@ -390,7 +390,7 @@ class TestDiskOfferings(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke", "service-offerings"], required_hardware="false")
     def test_03_delete_disk_offering(self):
         """Test to delete disk offering
 

--- a/test/integration/smoke/test_dynamicroles.py
+++ b/test/integration/smoke/test_dynamicroles.py
@@ -173,7 +173,7 @@ class TestDynamicRoles(cloudstackTestCase):
             )
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "quick-test", "roles"], required_hardware=False)
     def test_role_lifecycle_create(self):
         """
             Tests normal lifecycle operations for roles
@@ -295,7 +295,7 @@ class TestDynamicRoles(cloudstackTestCase):
 
         self.validate_permissions_dict(self.testdata["importrole"]["rules"], role_imported.id)
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_role_lifecycle_update(self):
         """
             Tests role update
@@ -321,7 +321,7 @@ class TestDynamicRoles(cloudstackTestCase):
             msg="Role description does not match updated role description"
             )
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_role_lifecycle_update_role_inuse(self):
         """
             Tests role update when role is in use by an account
@@ -341,7 +341,7 @@ class TestDynamicRoles(cloudstackTestCase):
         )
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "quick-test", "roles"], required_hardware=False)
     def test_role_lifecycle_delete(self):
         """
             Tests role update
@@ -356,7 +356,7 @@ class TestDynamicRoles(cloudstackTestCase):
         )
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_role_inuse_deletion(self):
         """
             Test to ensure role in use cannot be deleted
@@ -367,7 +367,7 @@ class TestDynamicRoles(cloudstackTestCase):
         except CloudstackAPIException: pass
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_default_role_deletion(self):
         """
             Test to ensure 4 default roles cannot be deleted
@@ -381,7 +381,7 @@ class TestDynamicRoles(cloudstackTestCase):
             except CloudstackAPIException: pass
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "quick-test", "roles"], required_hardware=False)
     def test_rolepermission_lifecycle_list(self):
         """
             Tests listing of default role's permission
@@ -399,7 +399,7 @@ class TestDynamicRoles(cloudstackTestCase):
             )
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "quick-test", "roles"], required_hardware=False)
     def test_rolepermission_lifecycle_create(self):
         """
             Tests creation of role permission
@@ -436,7 +436,7 @@ class TestDynamicRoles(cloudstackTestCase):
         )
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_rolepermission_lifecycle_update(self):
         """
             Tests order updation of role permission
@@ -512,7 +512,7 @@ class TestDynamicRoles(cloudstackTestCase):
         else:
             self.fail("Negative test: Setting permission to 'some_other_value' should not be successful, failing")
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_rolepermission_lifecycle_concurrent_updates(self):
         """
             Tests concurrent order updation of role permission
@@ -546,7 +546,7 @@ class TestDynamicRoles(cloudstackTestCase):
         except CloudstackAPIException: pass
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_rolepermission_lifecycle_delete(self):
         """
             Tests deletion of role permission
@@ -606,7 +606,7 @@ class TestDynamicRoles(cloudstackTestCase):
 
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_role_account_acls(self):
         """
             Test to check role, role permissions and account life cycles
@@ -632,7 +632,7 @@ class TestDynamicRoles(cloudstackTestCase):
         self.checkApiCall(apiConfig, userApiClient)
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_role_account_acls_multiple_mgmt_servers(self):
         """
             Test for role-rule enforcement in case of multiple mgmt servers

--- a/test/integration/smoke/test_global_settings.py
+++ b/test/integration/smoke/test_global_settings.py
@@ -32,7 +32,7 @@ class TestUpdateConfigWithScope(cloudstackTestCase):
     def setUp(self):
         self.apiClient = self.testClient.getApiClient()
 
-    @attr(tags=["devcloud", "basic", "advanced"], required_hardware="false")
+    @attr(tags=["devcloud", "basic", "advanced", "quick-test"], required_hardware="false")
     def test_UpdateConfigParamWithScope(self):
         """
         test update configuration setting at zone level scope

--- a/test/integration/smoke/test_guest_vlan_range.py
+++ b/test/integration/smoke/test_guest_vlan_range.py
@@ -78,7 +78,7 @@ class TestDedicateGuestVlanRange(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "guestvlanrange", "dedicate", "release"], required_hardware="false")
+    @attr(tags=["advanced", "guestvlanrange", "dedicate", "release", "quick-test", "networks"], required_hardware="false")
     def test_dedicateGuestVlanRange(self):
         """Test guest vlan range dedication
         """

--- a/test/integration/smoke/test_internal_lb.py
+++ b/test/integration/smoke/test_internal_lb.py
@@ -544,7 +544,7 @@ class TestInternalLb(cloudstackTestCase):
                         "Response distribution count: %d difference to mean: %d within standard deviation: %d" % (value, mean, stddev))
                 return True
 
-    @attr(tags=["smoke", "advanced"], required_hardware="true")
+    @attr(tags=["smoke", "advanced", "routers", "networks"], required_hardware="true")
     def test_01_internallb_roundrobin_1VPC_3VM_HTTP_port80(self):
         """
            Test create, assign, remove of an Internal LB with roundrobin http traffic to 3 vm's in a Single VPC
@@ -562,7 +562,7 @@ class TestInternalLb(cloudstackTestCase):
         self.cleanup.insert(0, vpc_offering)
         self.execute_internallb_roundrobin_tests(vpc_offering)
 
-    @attr(tags=["smoke", "advanced"], required_hardware="true")
+    @attr(tags=["smoke", "advanced", "routers", "networks"], required_hardware="true")
     def test_02_internallb_roundrobin_1RVPC_3VM_HTTP_port80(self):
         """
            Test create, assign, remove of an Internal LB with roundrobin http traffic to 3 vm's in a Redundant VPC
@@ -709,7 +709,7 @@ class TestInternalLb(cloudstackTestCase):
         else:
             return False
 
-    @attr(tags=["smoke", "advanced"], required_hardware="true")
+    @attr(tags=["smoke", "advanced", "routers", "networks"], required_hardware="true")
     def test_03_vpc_internallb_haproxy_stats_on_all_interfaces(self):
         """ Test to verify access to loadbalancer haproxy admin stats page
             when global setting network.loadbalancer.haproxy.stats.visibility is set to 'all'
@@ -730,7 +730,7 @@ class TestInternalLb(cloudstackTestCase):
 
         self.execute_internallb_haproxy_tests(vpc_offering)
 
-    @attr(tags=["smoke", "advanced"], required_hardware="true")
+    @attr(tags=["smoke", "advanced", "routers", "networks"], required_hardware="true")
     def test_04_rvpc_internallb_haproxy_stats_on_all_interfaces(self):
         """ Test to verify access to loadbalancer haproxy admin stats page
             when global setting network.loadbalancer.haproxy.stats.visibility is set to 'all'

--- a/test/integration/smoke/test_iso.py
+++ b/test/integration/smoke/test_iso.py
@@ -90,7 +90,8 @@ class TestCreateIso(cloudstackTestCase):
             "basic",
             "eip",
             "sg",
-            "advancedns"],
+            "advancedns",
+            "templates"],
         required_hardware="true")
     def test_01_create_iso(self):
         """Test create public & private ISO
@@ -273,7 +274,8 @@ class TestISO(cloudstackTestCase):
             "eip",
             "sg",
             "advancedns",
-            "smoke"],
+            "smoke",
+            "templates"],
         required_hardware="true")
     def test_02_edit_iso(self):
         """Test Edit ISO
@@ -348,7 +350,8 @@ class TestISO(cloudstackTestCase):
             "basic",
             "eip",
             "sg",
-            "advancedns"],
+            "advancedns",
+            "templates"],
         required_hardware="true")
     def test_03_delete_iso(self):
         """Test delete ISO
@@ -383,7 +386,8 @@ class TestISO(cloudstackTestCase):
             "basic",
             "eip",
             "sg",
-            "advancedns"],
+            "advancedns",
+            "templates"],
         required_hardware="true")
     def test_04_extract_Iso(self):
         "Test for extract ISO"
@@ -443,7 +447,8 @@ class TestISO(cloudstackTestCase):
             "sg",
             "advancedns",
             "smoke",
-            "selfservice"])
+            "selfservice",
+            "templates"])
     def test_05_iso_permissions(self):
         """Update & Test for ISO permissions"""
 
@@ -504,7 +509,8 @@ class TestISO(cloudstackTestCase):
             "advancedns",
             "smoke",
             "multizone",
-            "provisioning"])
+            "provisioning",
+            "templates"])
     def test_06_copy_iso(self):
         """Test for copy ISO from one zone to another"""
 
@@ -603,7 +609,8 @@ class TestISO(cloudstackTestCase):
             "basic",
             "eip",
             "sg",
-            "advancedns"],
+            "advancedns",
+            "templates"],
         required_hardware="false")
     def test_07_list_default_iso(self):
         """Test delete ISO

--- a/test/integration/smoke/test_list_ids_parameter.py
+++ b/test/integration/smoke/test_list_ids_parameter.py
@@ -209,7 +209,7 @@ class TestListIdsParams(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "deploy-vm"], required_hardware="false")
     def test_01_list_volumes(self):
         """Test listing Volumes using 'ids' parameter
         """
@@ -230,7 +230,7 @@ class TestListIdsParams(cloudstackTestCase):
             "ListVolumes response expected 3 Volumes, received %s" % len(list_volume_response)
         )
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "deploy-vm"], required_hardware="false")
     def test_02_list_templates(self):
         """Test listing Templates using 'ids' parameter
         """
@@ -253,7 +253,7 @@ class TestListIdsParams(cloudstackTestCase):
             "ListTemplates response expected 3 Templates, received %s" % len(list_template_response)
         )
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "deploy-vm"], required_hardware="false")
     def test_03_list_snapshots(self):
         """Test listing Snapshots using 'ids' parameter
         """

--- a/test/integration/smoke/test_loadbalance.py
+++ b/test/integration/smoke/test_loadbalance.py
@@ -145,7 +145,7 @@ class TestLoadBalance(cloudstackTestCase):
                                     (e, ip_addr))
         time.sleep(5)
 
-    @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "routers", "networks"], required_hardware="true")
     def test_01_create_lb_rule_src_nat(self):
         """Test to create Load balancing rule with source NAT"""
 
@@ -305,7 +305,7 @@ class TestLoadBalance(cloudstackTestCase):
             self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "routers", "networks"], required_hardware="true")
     def test_02_create_lb_rule_non_nat(self):
         """Test to create Load balancing rule with non source NAT"""
 
@@ -423,7 +423,7 @@ class TestLoadBalance(cloudstackTestCase):
             self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "routers", "networks"], required_hardware="true")
     def test_assign_and_removal_lb(self):
         """Test for assign & removing load balancing rule"""
 

--- a/test/integration/smoke/test_login.py
+++ b/test/integration/smoke/test_login.py
@@ -77,7 +77,7 @@ class TestLogin(cloudstackTestCase):
 
 
     @attr(tags = ["devcloud", "advanced", "advancedns", "advancedsg", "smoke",
-                  "basic", "sg"], required_hardware="false")
+                  "basic", "sg", "quick-test"], required_hardware="false")
     def login_test_saml_user(self):
         """
             Tests that SAML users are not allowed CloudStack local log in

--- a/test/integration/smoke/test_metrics_api.py
+++ b/test/integration/smoke/test_metrics_api.py
@@ -67,7 +67,7 @@ class TestMetrics(cloudstackTestCase):
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "quick-test"], required_hardware="false")
     def test_list_hosts_metrics(self):
 
         cmd = listHostsMetrics.listHostsMetricsCmd()
@@ -94,7 +94,7 @@ class TestMetrics(cloudstackTestCase):
         self.assertTrue(hasattr(cluster_metric, 'memoryused'))
         self.assertTrue(hasattr(cluster_metric, 'memorymaxdeviation'))
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "quick-test"], required_hardware="false")
     def test_list_zones_metrics(self):
         cmd = listZonesMetrics.listZonesMetricsCmd()
         cmd.id = self.zone.id
@@ -138,7 +138,7 @@ class TestMetrics(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "storage"], required_hardware="false")
     def test_list_pstorage_metrics(self):
         #list StoragePools
         sp = self.apiclient.listStoragePools(listStoragePools.listStoragePoolsCmd())[0]

--- a/test/integration/smoke/test_multipleips_per_nic.py
+++ b/test/integration/smoke/test_multipleips_per_nic.py
@@ -123,7 +123,7 @@ class TestDeployVM(cloudstackTestCase):
             msg="VM is not in Running state"
         )
 
-    @attr(tags = ['advanced',  'basic'], required_hardware="false")
+    @attr(tags = ['advanced',  'basic', 'deploy-vm', "routers"], required_hardware="false")
     def test_nic_secondaryip_add_remove(self):
     #TODO: SIMENH: add verification
         list_vms = VirtualMachine.list(self.apiclient, id=self.virtual_machine.id)

--- a/test/integration/smoke/test_nested_virtualization.py
+++ b/test/integration/smoke/test_nested_virtualization.py
@@ -78,7 +78,7 @@ class TestNestedVirtualization(cloudstackTestCase):
 
         cls.cleanup = [cls.account]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm"], required_hardware="true")
     def test_nested_virtualization_vmware(self):
         """Test nested virtualization on Vmware hypervisor"""
         if self.hypervisor.lower() not in ["vmware"]:

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -182,7 +182,7 @@ class TestPublicIP(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "quick-test", "networks"], required_hardware="false")
     def test_public_ip_admin_account(self):
         """Test for Associate/Disassociate public IP address for admin account"""
 
@@ -236,7 +236,7 @@ class TestPublicIP(cloudstackTestCase):
             self.fail("list public ip response is not empty")
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "quick-test", "networks"], required_hardware="false")
     def test_public_ip_user_account(self):
         """Test for Associate/Disassociate public IP address for user account"""
 
@@ -352,7 +352,7 @@ class TestPortForwarding(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "networks"], required_hardware="true")
     def test_01_port_fwd_on_src_nat(self):
         """Test for port forwarding on source NAT"""
 
@@ -483,7 +483,7 @@ class TestPortForwarding(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "networks"], required_hardware="true")
     def test_02_port_fwd_on_non_src_nat(self):
         """Test for port forwarding on non source NAT"""
 
@@ -601,7 +601,7 @@ class TestPortForwarding(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["dvs"], required_hardware="true")
+    @attr(tags=["dvs", "networks"], required_hardware="true")
     def test_guest_traffic_port_groups_isolated_network(self):
         """ Verify port groups are created for guest traffic
         used by isolated network """
@@ -707,7 +707,7 @@ class TestRebootRouter(cloudstackTestCase):
                         ]
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "networks"], required_hardware="true")
     def test_reboot_router(self):
         """Test for reboot router"""
 
@@ -867,7 +867,7 @@ class TestReleaseIP(cloudstackTestCase):
     def tearDown(self):
         cleanup_resources(self.apiclient, self.cleanup)
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "networks"], required_hardware="false")
     def test_releaseIP(self):
         """Test for release public IP address"""
 
@@ -995,7 +995,7 @@ class TestDeleteAccount(cloudstackTestCase):
         self.cleanup = []
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "networks"], required_hardware="false")
     def test_delete_account(self):
         """Test for delete account"""
 

--- a/test/integration/smoke/test_network_acl.py
+++ b/test/integration/smoke/test_network_acl.py
@@ -55,7 +55,7 @@ class TestNetworkACL(cloudstackTestCase):
                           cls.account.id))
         cls.cleanup = [cls.account]
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "networks", "vpc"], required_hardware="true")
     def test_network_acl(self):
         #TODO: SIMENH: add actual verification Logic for rules.
         """Test network ACL lists and items in VPC"""

--- a/test/integration/smoke/test_nic.py
+++ b/test/integration/smoke/test_nic.py
@@ -154,7 +154,8 @@ class TestNic(cloudstackTestCase):
             "devcloud",
             "smoke",
             "advanced",
-            "advancedns"],
+            "advancedns",
+            "deploy-vm"],
         required_hardware="true")
     def test_01_nic(self):
         # TODO: SIMENH: add validation

--- a/test/integration/smoke/test_nic_adapter_type.py
+++ b/test/integration/smoke/test_nic_adapter_type.py
@@ -112,7 +112,7 @@ class TestAdapterTypeForNic(cloudstackTestCase):
         return
 
     @unittest.skip("VCenter API Integration Remaining")
-    @attr(tags=["advanced"])
+    @attr(tags=["advanced", "deploy-vm", "routers"])
     def test_vm_nic_adapter_vmxnet3(self):
         """
 

--- a/test/integration/smoke/test_non_contigiousvlan.py
+++ b/test/integration/smoke/test_non_contigiousvlan.py
@@ -38,7 +38,7 @@ class TestUpdatePhysicalNetwork(cloudstackTestCase):
             raise Exception("Failed to set non contiguous vlan ids to test. Free some ids from \
                         from existing physical networks at ends")
 
-    @attr(tags = ["advanced"], required_hardware="false")
+    @attr(tags = ["advanced", "quick-test", "networks"], required_hardware="false")
     def test_extendPhysicalNetworkVlan(self):
         """
         Test to update a physical network and extend its vlan

--- a/test/integration/smoke/test_outofbandmanagement.py
+++ b/test/integration/smoke/test_outofbandmanagement.py
@@ -217,7 +217,7 @@ class TestOutOfBandManagement(cloudstackTestCase):
             self.fail("Expected an exception to be thrown, failing")
 
 
-    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "quick-test"], required_hardware="false")
     def test_oobm_configure_default_driver(self):
         """
             Tests out-of-band management configuration with valid data
@@ -295,7 +295,7 @@ class TestOutOfBandManagement(cloudstackTestCase):
             self.fail("Expected an exception to be thrown, failing")
 
 
-    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "quick-test"], required_hardware="false")
     def test_oobm_enable_feature_valid(self):
         """
             Tests out-of-band management host enable feature with
@@ -308,7 +308,7 @@ class TestOutOfBandManagement(cloudstackTestCase):
         self.assertEqual(response.enabled, True)
 
 
-    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "quick-test"], required_hardware="false")
     def test_oobm_disable_feature_valid(self):
         """
             Tests out-of-band management host disable feature with
@@ -408,7 +408,7 @@ class TestOutOfBandManagement(cloudstackTestCase):
         self.assertEqual(response.powerstate, expected)
 
 
-    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "quick-test"], required_hardware="false")
     def test_oobm_issue_power_status(self):
         """
             Tests out-of-band management issue power action
@@ -444,7 +444,7 @@ class TestOutOfBandManagement(cloudstackTestCase):
         self.assertIssueCommandState('CYCLE', 'On')
 
 
-    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "quick-test"], required_hardware="false")
     def test_oobm_issue_power_reset(self):
         """
             Tests out-of-band management issue power reset action

--- a/test/integration/smoke/test_over_provisioning.py
+++ b/test/integration/smoke/test_over_provisioning.py
@@ -32,7 +32,7 @@ class TestUpdateOverProvision(cloudstackTestCase):
     def setUp(self):
         self.apiClient = self.testClient.getApiClient()
 
-    @attr(tags=["devcloud", "basic", "advanced"], required_hardware="false")
+    @attr(tags=["devcloud", "basic", "advanced", "quick-test", "storage"], required_hardware="false")
     def test_UpdateStorageOverProvisioningFactor(self):
         """
         test update configuration setting at storage scope

--- a/test/integration/smoke/test_password_server.py
+++ b/test/integration/smoke/test_password_server.py
@@ -236,7 +236,7 @@ class TestIsolatedNetworksPasswdServer(cloudstackTestCase):
 
         self.assertTrue(vm.nic[0].ipaddress in result, "Password file is empty or doesn't exist!")
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "deploy-vm"], required_hardware="true")
     def test_isolate_network_password_server(self):
         """Check the password file in the Router VM"""
 

--- a/test/integration/smoke/test_portable_publicip.py
+++ b/test/integration/smoke/test_portable_publicip.py
@@ -75,7 +75,7 @@ class TestPortablePublicIPRange(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["basic", "advanced",  "portablepublicip"], required_hardware="false")
+    @attr(tags = ["basic", "advanced",  "portablepublicip", "quick-test"], required_hardware="false")
     def test_createPortablePublicIPRange(self):
         """ Test to create a portable public ip range
         """
@@ -161,7 +161,7 @@ class TestPortablePublicIPAcquire(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced",  "portablepublicip"], required_hardware="false")
+    @attr(tags = ["advanced",  "portablepublicip", "quick-test"], required_hardware="false")
     def test_createPortablePublicIPAcquire(self):
         """ Test to acquire a provisioned public ip range
         """

--- a/test/integration/smoke/test_primary_storage.py
+++ b/test/integration/smoke/test_primary_storage.py
@@ -62,7 +62,7 @@ class TestPrimaryStorageServices(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "quick-test"], required_hardware="false")
     def test_01_primary_storage_nfs(self):
         """Test primary storage pools - XEN, KVM, VMWare. Not Supported for hyperv
         """
@@ -502,7 +502,7 @@ class TestStorageTags(cloudstackTestCase):
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm", "storage"], required_hardware="false")
     @skipTestIf("hypervisorNotSupported")
     def test_01_deploy_vms_storage_tags(self):
         """Test Deploy VMS using different Service Offerings with Storage Tags
@@ -590,7 +590,8 @@ class TestStorageTags(cloudstackTestCase):
         self.assertEquals(1, len(pool_tags), "Check storage tags size")
         self.assertEquals(tag, pool_tags[0].name, "Check storage tag on storage pool")
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+
+    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg", "quick-test", "storage"], required_hardware="false")
     @skipTestIf("hypervisorNotSupported")
     def test_02_edit_primary_storage_tags(self):
         """ Test Edit Storage Tags
@@ -626,7 +627,8 @@ class TestStorageTags(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    
+    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm", "storage"], required_hardware="false")
     @skipTestIf("hypervisorNotSupported")
     def test_03_migration_options_storage_tags(self):
         """ Test Volume migration options for Storage Pools with different Storage Tags

--- a/test/integration/smoke/test_privategw_acl.py
+++ b/test/integration/smoke/test_privategw_acl.py
@@ -226,7 +226,7 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.assertTrue(successResponse.success, "Failed to replace ACL list.")
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "networks", "vpc"], required_hardware="true")
     def test_01_vpc_privategw_acl(self):
         self.logger.debug("Creating a VPC offering..")
         vpc_off = VpcOffering.create(
@@ -266,7 +266,7 @@ class TestPrivateGwACL(cloudstackTestCase):
         privateGw = self.createPvtGw(vpc, "10.0.3.99", "10.0.3.100", acl.id, vlan_1)
         self.replacePvtGwACL(acl.id, privateGw.id)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "networks", "vpc"], required_hardware="true")
     def test_02_vpc_privategw_static_routes(self):
         self.logger.debug("Creating a VPC offering..")
         vpc_off = VpcOffering.create(
@@ -278,7 +278,7 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.performVPCTests(vpc_off)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "networks", "vpc"], required_hardware="true")
     def test_03_vpc_privategw_restart_vpc_cleanup(self):
         self.logger.debug("Creating a VPC offering..")
         vpc_off = VpcOffering.create(
@@ -290,7 +290,7 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.performVPCTests(vpc_off, restart_with_cleanup = True)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "networks", "vpc"], required_hardware="true")
     def test_04_rvpc_privategw_static_routes(self):
         self.logger.debug("Creating a Redundant VPC offering..")
         vpc_off = VpcOffering.create(
@@ -302,7 +302,7 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.performVPCTests(vpc_off)
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "networks", "vpc"], required_hardware="true")
     def _test_05_rvpc_privategw_check_interface(self):
         self.logger.debug("Creating a Redundant VPC offering..")
         vpc_off = VpcOffering.create(

--- a/test/integration/smoke/test_public_ip_range.py
+++ b/test/integration/smoke/test_public_ip_range.py
@@ -74,7 +74,7 @@ class TestDedicatePublicIPRange(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced", "publiciprange", "dedicate", "release"], required_hardware="false")
+    @attr(tags = ["advanced", "publiciprange", "dedicate", "release", "quick-test", "networks"], required_hardware="false")
     def test_dedicatePublicIpRange(self):
         """Test public IP range dedication
         """

--- a/test/integration/smoke/test_pvlan.py
+++ b/test/integration/smoke/test_pvlan.py
@@ -41,7 +41,7 @@ class TestPVLAN(cloudstackTestCase):
     def setUp(self):
         self.apiClient = self.testClient.getApiClient()
 
-    @attr(tags = ["advanced"], required_hardware="false")
+    @attr(tags = ["advanced", "quick-test", "networks"], required_hardware="false")
     def test_create_pvlan_network(self):
         self.debug("Test create pvlan network")
         createNetworkCmd = createNetwork.createNetworkCmd()

--- a/test/integration/smoke/test_regions.py
+++ b/test/integration/smoke/test_regions.py
@@ -64,7 +64,7 @@ class TestRegions(cloudstackTestCase):
             msg="Region creation failed"
         )
 
-    @attr(tags=["basic", "advanced"], required_hardware="false")
+    @attr(tags=["basic", "advanced", "quick-test"], required_hardware="false")
     def test_createRegion(self):
         """ Test for create region
         """

--- a/test/integration/smoke/test_reset_vm_on_reboot.py
+++ b/test/integration/smoke/test_reset_vm_on_reboot.py
@@ -97,7 +97,7 @@ class TestResetVmOnReboot(cloudstackTestCase):
         return
 
     @attr(hypervisor="xenserver")
-    @attr(tags=["advanced", "basic"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "deploy-vm"], required_hardware="false")
     def test_01_reset_vm_on_reboot(self):
     #TODO: SIMENH: add new test to check volume contents
         """Test reset virtual machine on reboot

--- a/test/integration/smoke/test_resource_detail.py
+++ b/test/integration/smoke/test_resource_detail.py
@@ -89,7 +89,7 @@ class TestResourceDetail(cloudstackTestCase):
         cleanup_resources(self.apiclient, self.cleanup)
         return
 
-    @attr(tags = ["advanced", "xenserver"], required_hardware="false")
+    @attr(tags = ["advanced", "xenserver", "quick-test"], required_hardware="false")
     def test_01_updatevolumedetail(self):
         """Test volume detail 
         """

--- a/test/integration/smoke/test_router_dhcphosts.py
+++ b/test/integration/smoke/test_router_dhcphosts.py
@@ -247,7 +247,7 @@ class TestRouterDHCPHosts(cloudstackTestCase):
             1,
             "DHCP hosts file contains duplicate IPs ==> %s!" % res)
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers"], required_hardware="true")
     def test_router_dhcphosts(self):
         """Check that the /etc/dhcphosts.txt doesn't contain duplicate IPs"""
 
@@ -599,7 +599,7 @@ class TestRouterDHCPOpts(cloudstackTestCase):
             0,
             "DHCP opts file does not contain exception for IP ==> %s!" % res)
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_router_dhcp_opts(self):
         """Check that the /etc/dhcpopts.txt has entries for the"""
 

--- a/test/integration/smoke/test_router_dns.py
+++ b/test/integration/smoke/test_router_dns.py
@@ -195,7 +195,7 @@ class TestRouterDns(cloudstackTestCase):
         return public_ips
 
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_router_dns_externalipquery(self):
         """Checks that non-guest network IPs cannot access VR DNS"""
 
@@ -213,7 +213,7 @@ class TestRouterDns(cloudstackTestCase):
             self.logger.debug("VR DNS query failed from non-guest network IP as expected")
 
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_router_dns_guestipquery(self):
         """Checks that guest VM can query VR DNS"""
 

--- a/test/integration/smoke/test_routers.py
+++ b/test/integration/smoke/test_routers.py
@@ -112,7 +112,7 @@ class TestRouterServices(cloudstackTestCase):
         self.hypervisor = self.testClient.getHypervisorInfo()
         return
 
-    @attr(tags=["advanced", "basic", "sg", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "sg", "smoke", "routers"], required_hardware="true")
     def test_01_router_internal_basic(self):
         """Test router internal basic zone
         """
@@ -199,7 +199,7 @@ class TestRouterServices(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "routers"], required_hardware="false")
     def test_02_router_internal_adv(self):
         """Test router internal advanced zone
         """
@@ -317,7 +317,9 @@ class TestRouterServices(cloudstackTestCase):
             "basic",
             "advancedns",
             "smoke",
-            "dvs"],
+            "dvs",
+            "quick-test",
+            "routers"],
         required_hardware="false")
     def test_03_restart_network_cleanup(self):
         """Test restart network
@@ -415,7 +417,7 @@ class TestRouterServices(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "routers"], required_hardware="true")
     def test_04_restart_network_wo_cleanup(self):
         """Test restart network without cleanup
         """
@@ -533,7 +535,7 @@ class TestRouterServices(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "routers"], required_hardware="false")
     def test_05_router_basic(self):
         """Test router basic setup
         """
@@ -599,7 +601,7 @@ class TestRouterServices(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "routers"], required_hardware="false")
     def test_06_router_advanced(self):
         """Test router advanced setup
         """
@@ -682,7 +684,7 @@ class TestRouterServices(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "routers"], required_hardware="false")
     def test_07_stop_router(self):
         """Test stop router
         """
@@ -725,7 +727,7 @@ class TestRouterServices(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "routers"], required_hardware="false")
     def test_08_start_router(self):
         """Test start router
         """
@@ -777,7 +779,7 @@ class TestRouterServices(cloudstackTestCase):
             return True
         return False
 
-    @attr(tags=["advanced", "advancedns", "smoke", "dvs"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "smoke", "dvs", "routers"], required_hardware="false")
     def test_09_reboot_router(self):
         """Test reboot router
         """

--- a/test/integration/smoke/test_routers_iptables_default_policy.py
+++ b/test/integration/smoke/test_routers_iptables_default_policy.py
@@ -286,7 +286,7 @@ class TestVPCIpTablesPolicies(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "routers", "networks"], required_hardware="true")
     def test_01_single_VPC_iptables_policies(self):
         """ Test iptables default INPUT/FORWARD policies on VPC router """
         self.logger.debug("Starting test_01_single_VPC_iptables_policies")
@@ -419,7 +419,7 @@ class TestRouterIpTablesPolicies(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "routers", "networks"], required_hardware="true")
     def test_02_routervm_iptables_policies(self):
         """ Test iptables default INPUT/FORWARD policy on RouterVM """
 

--- a/test/integration/smoke/test_routers_network_ops.py
+++ b/test/integration/smoke/test_routers_network_ops.py
@@ -154,7 +154,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_01_RVR_Network_FW_PF_SSH_default_routes_egress_true(self):
         """ Test redundant router internals """
         self.logger.debug("Starting test_01_RVR_Network_FW_PF_SSH_default_routes_egress_true...")
@@ -319,7 +319,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_02_RVR_Network_FW_PF_SSH_default_routes_egress_false(self):
         """ Test redundant router internals """
         self.logger.debug("Starting test_02_RVR_Network_FW_PF_SSH_default_routes_egress_false...")
@@ -492,7 +492,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_03_RVR_Network_check_router_state(self):
         """ Test redundant router internals """
         self.logger.debug("Starting test_03_RVR_Network_check_router_state...")
@@ -716,7 +716,7 @@ class TestIsolatedNetworks(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_01_isolate_network_FW_PF_default_routes_egress_true(self):
         """ Test redundant router internals """
         self.logger.debug("Starting test_01_isolate_network_FW_PF_default_routes_egress_true...")
@@ -872,7 +872,7 @@ class TestIsolatedNetworks(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "ssh"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "ssh", "routers", "networks"], required_hardware="true")
     def test_02_isolate_network_FW_PF_default_routes_egress_false(self):
         """ Test redundant router internals """
         self.logger.debug("Starting test_02_isolate_network_FW_PF_default_routes_egress_false...")

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -118,7 +118,7 @@ class TestScaleVm(cloudstackTestCase):
         return
 
     @attr(hypervisor="xenserver")
-    @attr(tags=["advanced", "basic"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "deploy-vm"], required_hardware="false")
     def test_01_scale_vm(self):
         """Test scale virtual machine
         """

--- a/test/integration/smoke/test_secondary_storage.py
+++ b/test/integration/smoke/test_secondary_storage.py
@@ -83,7 +83,7 @@ class TestSecStorageServices(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "eip", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "eip", "sg", "quick-test", "deploy-vm", "storage"], required_hardware="false")
     def test_01_sys_vm_start(self):
         """Test system VM start
         """
@@ -167,7 +167,7 @@ class TestSecStorageServices(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "eip", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "eip", "sg", "quick-test", "storage"], required_hardware="false")
     def test_02_sys_template_ready(self):
         """Test system templates are ready
         """

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -67,7 +67,9 @@ class TestCreateServiceOffering(cloudstackTestCase):
             "smoke",
             "basic",
             "eip",
-            "sg"],
+            "sg",
+            "quick-test",
+            "service-offerings"],
         required_hardware="false")
     def test_01_create_service_offering(self):
         """Test to create service offering"""
@@ -402,7 +404,8 @@ class TestServiceOfferings(cloudstackTestCase):
             "smoke",
             "basic",
             "eip",
-            "sg"],
+            "sg",
+            "service-offerings"],
         required_hardware="false")
     def test_02_edit_service_offering(self):
         """Test to update existing service offering"""
@@ -461,7 +464,8 @@ class TestServiceOfferings(cloudstackTestCase):
             "smoke",
             "basic",
             "eip",
-            "sg"],
+            "sg",
+            "service-offerings"],
         required_hardware="false")
     def test_03_delete_service_offering(self):
         """Test to delete service offering"""
@@ -488,7 +492,7 @@ class TestServiceOfferings(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm", "service-offerings"], required_hardware="true")
     def test_04_change_offering_small(self):
         """Test to change service to a small capacity
         """

--- a/test/integration/smoke/test_snapshots.py
+++ b/test/integration/smoke/test_snapshots.py
@@ -126,7 +126,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
         return
 
     @skipTestIf("hypervisorNotSupported")
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "quick-test"], required_hardware="true")
     def test_01_snapshot_root_disk(self):
         """Test Snapshot Root Disk
         """

--- a/test/integration/smoke/test_ssvm.py
+++ b/test/integration/smoke/test_ssvm.py
@@ -110,7 +110,9 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "quick-test",
+            "deploy-vm"],
         required_hardware="false")
     def test_01_list_sec_storage_vm(self):
         """Test List secondary storage VMs
@@ -251,7 +253,9 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "quick-test",
+            "deploy-vm"],
         required_hardware="false")
     def test_02_list_cpvm_vm(self):
         """Test List console proxy VMs
@@ -385,7 +389,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_03_ssvm_internals(self):
         """Test SSVM Internals"""
@@ -550,7 +555,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_04_cpvm_internals(self):
         """Test CPVM Internals"""
@@ -683,7 +689,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_05_stop_ssvm(self):
         """Test stop SSVM
@@ -746,7 +753,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_06_stop_cpvm(self):
         """Test stop CPVM
@@ -810,7 +818,9 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "quick-test",
+            "deploy-vm"],
         required_hardware="true")
     def test_07_reboot_ssvm(self):
         """Test reboot SSVM
@@ -885,7 +895,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_08_reboot_cpvm(self):
         """Test reboot CPVM
@@ -957,7 +968,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_09_destroy_ssvm(self):
         """Test destroy SSVM
@@ -1029,7 +1041,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_10_destroy_cpvm(self):
         """Test destroy CPVM
@@ -1100,7 +1113,8 @@ class TestSSVMs(cloudstackTestCase):
             "advancedns",
             "smoke",
             "basic",
-            "sg"],
+            "sg",
+            "deploy-vm"],
         required_hardware="true")
     def test_11_ss_nfs_version_on_ssvm(self):
         """Test NFS Version on Secondary Storage mounted properly on SSVM

--- a/test/integration/smoke/test_staticroles.py
+++ b/test/integration/smoke/test_staticroles.py
@@ -111,7 +111,7 @@ class TestStaticRoles(cloudstackTestCase):
         return -1
 
 
-    @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
+    @attr(tags=['advanced', 'simulator', 'basic', 'sg', "roles"], required_hardware=False)
     def test_static_role_account_acls(self):
         """
             Tests allowed APIs for common account types

--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -347,7 +347,7 @@ class TestCreateTemplate(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "templates"], required_hardware="false")
     def test_CreateTemplateWithDuplicateName(self):
         """Test when createTemplate is used to create templates having the same name all of them get
         different unique names so that the templates with same name does not get deleted during template sync"""
@@ -391,7 +391,7 @@ class TestCreateTemplate(cloudstackTestCase):
                             "unique names are different")
 
 
-    @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "quick-test", "templates"], required_hardware="false")
     def test_01_create_template(self):
         """Test create public & private template
         """
@@ -596,7 +596,7 @@ class TestTemplates(cloudstackTestCase):
 
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_02_edit_template(self):
         """Test Edit template
         """
@@ -680,7 +680,7 @@ class TestTemplates(cloudstackTestCase):
                         )
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_03_delete_template(self):
         """Test delete template
         """
@@ -709,7 +709,7 @@ class TestTemplates(cloudstackTestCase):
                          )
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="true")
     def test_04_extract_template(self):
         "Test for extract template"
 
@@ -758,7 +758,7 @@ class TestTemplates(cloudstackTestCase):
                          )
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_05_template_permissions(self):
         """Update & Test for template permissions"""
 
@@ -808,7 +808,7 @@ class TestTemplates(cloudstackTestCase):
                         )
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "multizone"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "multizone", "templates"], required_hardware="true")
     def test_06_copy_template(self):
         """Test for copy template from one zone to another"""
 
@@ -895,7 +895,7 @@ class TestTemplates(cloudstackTestCase):
         self.template_2.delete(self.apiclient, zoneid=self.services["destzoneid"])
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_07_list_public_templates(self):
         """Test only public templates are visible to normal user"""
 
@@ -927,7 +927,7 @@ class TestTemplates(cloudstackTestCase):
                         )
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "templates"], required_hardware="false")
     def test_08_list_system_templates(self):
         """Test System templates are not visible to normal user"""
 
@@ -1099,7 +1099,7 @@ class TestCopyAndDeleteTemplatesAcrossZones(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "templates"], required_hardware="false")
     def test_09_copy_delete_template(self):
         cmd = listZones.listZonesCmd()
         zones = self.apiclient.listZones(cmd)

--- a/test/integration/smoke/test_usage.py
+++ b/test/integration/smoke/test_usage.py
@@ -207,7 +207,8 @@ class TestVmUsage(cloudstackTestCase):
             "sg",
             "eip",
             "advancedns",
-            "simulator"],
+            "simulator",
+            "usage"],
         required_hardware="false")
     def test_01_vm_usage(self):
         """Test Create/Destroy VM and verify usage calculation
@@ -415,7 +416,8 @@ class TestPublicIPUsage(cloudstackTestCase):
             "advanced",
             "eip",
             "advancedns",
-            "simulator"],
+            "simulator",
+            "usage"],
         required_hardware="false")
     def test_01_public_ip_usage(self):
         """Test Assign new IP and verify usage calculation
@@ -585,7 +587,8 @@ class TestVolumeUsage(cloudstackTestCase):
             "basic",
             "sg",
             "eip",
-            "advancedns"],
+            "advancedns",
+            "usage"],
         required_hardware="true")
     def test_01_volume_usage(self):
         """Test Create/delete a volume and verify correct usage is recorded
@@ -899,7 +902,8 @@ class TestTemplateUsage(cloudstackTestCase):
             "basic",
             "sg",
             "eip",
-            "advancedns"],
+            "advancedns",
+            "usage"],
         required_hardware="false")
     def test_01_template_usage(self):
         """Test Upload/ delete a template and verify correct usage is generated
@@ -1057,7 +1061,8 @@ class TestISOUsage(cloudstackTestCase):
             "basic",
             "sg",
             "eip",
-            "advancedns"],
+            "advancedns",
+            "usage"],
         required_hardware="true")
     def test_01_ISO_usage(self):
         """Test Create/Delete a ISO and verify its usage is generated correctly
@@ -1222,7 +1227,8 @@ class TestLBRuleUsage(cloudstackTestCase):
             "advanced",
             "eip",
             "advancedns",
-            "simulator"],
+            "simulator",
+            "usage"],
         required_hardware="false")
     def test_01_lb_usage(self):
         """Test Create/Delete a LB rule and verify correct usage is recorded
@@ -1401,7 +1407,8 @@ class TestSnapshotUsage(cloudstackTestCase):
             "sg",
             "eip",
             "advancedns",
-            "simulator"],
+            "simulator",
+            "usage"],
         required_hardware="false")
     def test_01_snapshot_usage(self):
         """Test Create/Delete a manual snap shot and verify
@@ -1586,7 +1593,8 @@ class TestNatRuleUsage(cloudstackTestCase):
         tags=[
             "advanced",
             "advancedns",
-            "simulator"],
+            "simulator",
+            "usage"],
         required_hardware="false")
     def test_01_nat_usage(self):
         """Test Create/Delete a PF rule and verify correct usage is recorded
@@ -1756,7 +1764,7 @@ class TestVpnUsage(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "usage"], required_hardware="false")
     def test_01_vpn_usage(self):
         """Test Create/Delete a VPN and verify correct usage is recorded
         """

--- a/test/integration/smoke/test_usage_events.py
+++ b/test/integration/smoke/test_usage_events.py
@@ -87,7 +87,7 @@ class TestUsageEvents(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced, basic"], required_hardware="true")
+    @attr(tags=["advanced, basic", "deploy-vm", "usage"], required_hardware="true")
     def test_01_positive_tests_usage(self):
         """ Check events in usage_events table when VM creation fails
 

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -136,7 +136,7 @@ class TestDeployVM(cloudstackTestCase):
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_deploy_vm(self):
         """Test Deploy Virtual Machine
         """
@@ -181,7 +181,7 @@ class TestDeployVM(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags = ["advanced", "deploy-vm"], required_hardware="false")
     def test_advZoneVirtualRouter(self):
         # TODO: SIMENH: duplicate test, remove it
         """
@@ -203,7 +203,7 @@ class TestDeployVM(cloudstackTestCase):
         self.assertIsNotNone(router.publicip, msg="Router has no public ip")
         self.assertIsNotNone(router.guestipaddress, msg="Router has no guest ip")
 
-    @attr(mode=["basic"], required_hardware="false")
+    @attr(mode = ["basic", "deploy-vm"], required_hardware="false")
     def test_basicZoneVirtualRouter(self):
         # TODO: SIMENH: duplicate test, remove it
         """
@@ -219,7 +219,7 @@ class TestDeployVM(cloudstackTestCase):
         self.assertEqual(router.state, 'Running', msg="Router is not in running state")
         self.assertEqual(router.account, self.account.name, msg="Router does not belong to the account")
 
-    @attr(tags=['advanced', 'basic', 'sg'], required_hardware="false")
+    @attr(tags = ['advanced','basic','sg', "deploy-vm"], required_hardware="false")
     def test_deploy_vm_multiple(self):
         """Test Multiple Deploy Virtual Machine
 
@@ -378,7 +378,7 @@ class TestVMLifeCycle(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_01_stop_vm(self):
         """Test Stop Virtual Machine
         """
@@ -393,7 +393,7 @@ class TestVMLifeCycle(cloudstackTestCase):
             self.fail("Failed to stop VM: %s" % e)
         return
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_01_stop_vm_forced(self):
         """Test Force Stop Virtual Machine
         """
@@ -425,7 +425,7 @@ class TestVMLifeCycle(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_02_start_vm(self):
         """Test Start Virtual Machine
         """
@@ -463,7 +463,7 @@ class TestVMLifeCycle(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_03_reboot_vm(self):
         """Test Reboot Virtual Machine
         """
@@ -499,7 +499,7 @@ class TestVMLifeCycle(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "quick-test", "deploy-vm"], required_hardware="false")
     def test_06_destroy_vm(self):
         """Test destroy Virtual Machine
         """
@@ -535,7 +535,7 @@ class TestVMLifeCycle(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_07_restore_vm(self):
         # TODO: SIMENH: add another test the data on the restored VM.
         """Test recover Virtual Machine
@@ -576,7 +576,7 @@ class TestVMLifeCycle(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg", "multihost"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "multihost", "quick-test", "deploy-vm"], required_hardware="false")
     def test_08_migrate_vm(self):
         """Test migrate VM
         """
@@ -652,9 +652,9 @@ class TestVMLifeCycle(cloudstackTestCase):
             retries_cnt = retries_cnt - 1
         return
 
-    @attr(configuration="expunge.interval")
-    @attr(configuration="expunge.delay")
-    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    @attr(configuration = "expunge.interval")
+    @attr(configuration = "expunge.delay")
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="false")
     def test_09_expunge_vm(self):
         """Test destroy(expunge) Virtual Machine
         """
@@ -699,7 +699,7 @@ class TestVMLifeCycle(cloudstackTestCase):
         self.assertEqual(list_vm_response, None, "Check Expunged virtual machine is in listVirtualMachines response")
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "sg", "deploy-vm"], required_hardware="true")
     def test_10_attachAndDetach_iso(self):
         """Test for attach and detach ISO to virtual machine"""
 

--- a/test/integration/smoke/test_vm_snapshots.py
+++ b/test/integration/smoke/test_vm_snapshots.py
@@ -113,7 +113,7 @@ class TestVmSnapshot(cloudstackTestCase):
     def tearDown(self):
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "quick-test", "deploy-vm"], required_hardware="true")
     def test_01_create_vm_snapshots(self):
         """Test to create VM snapshots
         """
@@ -164,7 +164,7 @@ class TestVmSnapshot(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_02_revert_vm_snapshots(self):
         """Test to revert VM snapshots
         """
@@ -251,7 +251,7 @@ class TestVmSnapshot(cloudstackTestCase):
             "Check the random data is equal with the ramdom file!"
         )
 
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "deploy-vm"], required_hardware="true")
     def test_03_delete_vm_snapshots(self):
         """Test to delete vm snapshots
         """
@@ -420,7 +420,7 @@ class TestChangeServiceOfferingForVmWithSnapshots(cloudstackTestCase):
             "Check Memory(kb) for service offering"
         )
 
-    @attr(tags=["advanced", "smoke"], required_hardware="true")
+    @attr(tags=["advanced", "smoke", "deploy-vm"], required_hardware="true")
     def test_change_service_offering_for_vm_with_snapshots(self):
         """Test to change service offering for instances with vm snapshots
         """

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -392,7 +392,7 @@ class TestVolumes(cloudstackTestCase):
         cleanup_resources(self.apiClient, self.cleanup)
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "quick-test", "deploy-vm"], required_hardware="true")
     def test_02_attach_volume(self):
         """Attach a created Volume to a Running VM
         """
@@ -438,7 +438,7 @@ class TestVolumes(cloudstackTestCase):
                       (self.virtual_machine.ipaddress, e))
         return
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "deploy-vm"], required_hardware="false")
     def test_03_download_attached_volume(self):
         """Download a Volume attached to a VM
         """
@@ -460,7 +460,7 @@ class TestVolumes(cloudstackTestCase):
         with self.assertRaises(Exception):
             self.apiClient.extractVolume(cmd)
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "quick-test", "deploy-vm"], required_hardware="false")
     def test_04_delete_attached_volume(self):
         """Delete a Volume attached to a VM
         """
@@ -481,7 +481,7 @@ class TestVolumes(cloudstackTestCase):
         with self.assertRaises(Exception):
             self.apiClient.deleteVolume(cmd)
 
-    @attr(tags = ["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
+    @attr(tags = ["advanced", "advancedns", "smoke", "basic", "deploy-vm"], required_hardware="false")
     def test_05_detach_volume(self):
         """Detach a Volume attached to a VM
         """

--- a/test/integration/smoke/test_vpc_redundant.py
+++ b/test/integration/smoke/test_vpc_redundant.py
@@ -532,7 +532,7 @@ class TestVPCRedundancy(cloudstackTestCase):
             else:
                 self.fail("Failed to SSH into VM - %s" % (public_ip.ipaddress.ipaddress))
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_01_create_redundant_VPC_2tiers_4VMs_4IPs_4PF_ACL(self):
         """ Create a redundant VPC with two networks with two VMs in each network """
         self.logger.debug("Starting test_01_create_redundant_VPC_2tiers_4VMs_4IPs_4PF_ACL")
@@ -557,7 +557,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.check_routers_state()
         self.do_vpc_test(False)
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_02_redundant_VPC_default_routes(self):
         """ Create a redundant VPC with two networks with two VMs in each network and check default routes"""
         self.logger.debug("Starting test_02_redundant_VPC_default_routes")
@@ -568,7 +568,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.add_nat_rules()
         self.do_default_routes_test()
     
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_03_create_redundant_VPC_1tier_2VMs_2IPs_2PF_ACL_reboot_routers(self):
         """ Create a redundant VPC with two networks with two VMs in each network """
         self.logger.debug("Starting test_01_create_redundant_VPC_2tiers_4VMs_4IPs_4PF_ACL")
@@ -586,7 +586,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.check_routers_state()
         self.do_vpc_test(False)
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_04_rvpc_network_garbage_collector_nics(self):
         """ Create a redundant VPC with 1 Tier, 1 VM, 1 ACL, 1 PF and test Network GC Nics"""
         self.logger.debug("Starting test_04_rvpc_network_garbage_collector_nics")
@@ -617,7 +617,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.start_vm()
         self.check_routers_state(status_to_check="MASTER")
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_05_rvpc_multi_tiers(self):
         """ Create a redundant VPC with multiple tiers"""
         self.logger.debug("Starting test_05_rvpc_multi_tiers")

--- a/test/integration/smoke/test_vpc_router_nics.py
+++ b/test/integration/smoke/test_vpc_router_nics.py
@@ -375,7 +375,7 @@ class TestVPCNics(cloudstackTestCase):
         self.logger.debug('nwacl_nat=%s' % nwacl_nat.__dict__)
         return nat_rule
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_01_VPC_nics_after_destroy(self):
         """ Create a VPC with two networks with one VM in each network and test nics after destroy"""
         self.logger.debug("Starting test_01_VPC_nics_after_destroy")
@@ -399,7 +399,7 @@ class TestVPCNics(cloudstackTestCase):
         self.add_nat_rules()
         self.check_ssh_into_vm()
 
-    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    @attr(tags=["advanced", "intervlan", "vpc"], required_hardware="true")
     def test_02_VPC_default_routes(self):
         """ Create a VPC with two networks with one VM in each network and test default routes"""
         self.logger.debug("Starting test_02_VPC_default_routes")

--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -256,7 +256,7 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
         cls.cleanup = [cls.account, cls.compute_offering]
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "vpc"], required_hardware="true")
     def test_01_vpc_remote_access_vpn(self):
         """Test Remote Access VPN in VPC"""
 
@@ -516,7 +516,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
 
         return vpc_off
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "vpc"], required_hardware="true")
     def test_01_vpc_site2site_vpn(self):
         """Test Site 2 Site VPN Across VPCs"""
         self.logger.debug("Starting test: test_01_vpc_site2site_vpn")
@@ -885,7 +885,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         vm.public_port = int(public_port)
         return nat_rule
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced", "deploy-vm", "vpc"], required_hardware="true")
     def test_01_redundant_vpc_site2site_vpn(self):
         """Test Site 2 Site VPN Across redundant VPCs"""
         self.logger.debug("Starting test: test_02_redundant_vpc_site2site_vpn")

--- a/test/integration/testpaths/testpath_custom_disk_offering.py
+++ b/test/integration/testpaths/testpath_custom_disk_offering.py
@@ -70,7 +70,7 @@ class TestCustomDiskOfferingWithSize(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["basic", "advanced"], required_hardware="false")
+    @attr(tags=["basic", "advanced", "service-offerings"], required_hardware="false")
     def test_create_custom_disk_offering_with_size(self):
         """ Create custom disk offerign with size
             1.   Create custom disk offering with size.

--- a/test/integration/testpaths/testpath_storage_migration.py
+++ b/test/integration/testpaths/testpath_storage_migration.py
@@ -343,7 +343,7 @@ class TestStorageMigration(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_01_migrate_root_and_data_disk_nonlive(self):
         """ Test migrate Volume (root and data disk)
 
@@ -1092,7 +1092,7 @@ class TestStorageMigration(cloudstackTestCase):
                 ), None, "VM list should be empty")
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_02_migration_nonlive_xenserver_supported(self):
         """ Test migrate Volume (root and data disk) for Hypervisor Xenserver
 
@@ -1551,7 +1551,7 @@ class TestStorageMigration(cloudstackTestCase):
 
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_03_migrate_root_and_data_disk_nonlive_cwps_vmware(self):
         """ Test migrate Volume (root and data disk)
 
@@ -2016,7 +2016,7 @@ class TestStorageMigration(cloudstackTestCase):
                 ), None, "VM list should be empty")
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_04_migrate_root_and_data_disk_nonlive_zwps_vmware(self):
         """ Test migrate Volume (root and data disk)
 
@@ -2364,7 +2364,7 @@ class NegativeTestStorageMigration(cloudstackTestCase):
         except Exception as e:
             self.exceptionList.append(e)
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_01_migrate_data_disk_negative_test(self):
         """ Negative test cases
 
@@ -2724,7 +2724,7 @@ class TestLiveStorageMigration(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_01_migrate_live(self):
         """ Test migrate Volume (root and data disk)
 
@@ -2924,7 +2924,7 @@ class TestLiveStorageMigration(cloudstackTestCase):
     @unittest.skip(
         "Requires setup with 2 pods - Each pod having 2 clusters. \
             Yet to be tested")
-    @attr(tags=["advanced", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "basic", "storage"], required_hardware="true")
     def test_02_migration_live_different_pods(self):
         """ Test migrate Volume (root and data disk)
 
@@ -3755,7 +3755,8 @@ class TestStorageLiveMigrationVmware(cloudstackTestCase):
             "advanced",
             "basic",
             "vmware",
-            "vmfs"],
+            "vmfs",
+            "storage"],
         required_hardware="True")
     def test_01_migrate_root_and_data_disk_live(self):
         """


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adding 'quick-test' attribute to list of smoketests and adding 'vpc', 'templates', 'deploy-vm', 'roles', 'service-offerings', 'storage', 'routers', 'networks', 'usage', 'accounts' tags

quick-test label aims to provide quick feedback of recent changes to the developer, instead of waiting for the whole smoketest to execute(24h+). This execution lasts about 1.5h at Trillian environments.

The categories aim to offer more efficient way to slice through tests in both smoke and component tests. Let's say as a developer you've made a change in the accounts. You can simply trigger marvin tests with tag=accounts pointing all the tests for example:

```
nosetests --with-marvin --marvin-config=[config] --hypervisor=xenserver -a tags=accounts /tests/integration/*/*.*
```

http://cwiki.apache.org/confluence/display/CLOUDSTACK/Test+Categories+and+Quick-test+in+Marvin

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
