### PR TITLE
Fix k8s cluster upgrade in shared networks

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterUpgradeWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterUpgradeWorker.java
@@ -78,7 +78,7 @@ public class KubernetesClusterUpgradeWorker extends KubernetesClusterActionWorke
                 index == 0 ? "true" : "false",
                 KubernetesVersionManagerImpl.compareSemanticVersions(upgradeVersion.getSemanticVersion(), "1.15.0") < 0 ? "true" : "false",
                 Hypervisor.HypervisorType.VMware.equals(vm.getHypervisorType()));
-        return SshHelper.sshExecute(publicIpAddress, nodeSshPort, CLUSTER_NODE_VM_USER, sshKeyFile, null,
+        return SshHelper.sshExecute(nodeAddress, nodeSshPort, CLUSTER_NODE_VM_USER, sshKeyFile, null,
                 cmdStr,
                 10000, 10000, 10 * 60 * 1000);
     }


### PR DESCRIPTION
## Description
Upgrade of kubernetes cluster reports as successful on a shared network, when it doesn't successfully upgrade the nodes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Prior to the fix:
Deployed a 1.16.0 k8s cluster:
```
k8s-master ~ # kubectl get nodes
NAME         STATUS                     ROLES    AGE     VERSION
k8s-master   Ready,SchedulingDisabled   master   6m23s   v1.16.0
k8s-node-1   Ready                      <none>   5m51s   v1.16.0
```

Upgraded the cluster to 1.16.3, though the upgradeKubernetesCluster API returns a successful response, it doesn't upgrade the worker nodes:
```
k8s-master ~ # kubectl get nodes
NAME         STATUS   ROLES    AGE     VERSION
k8s-master   Ready    master   8m35s   v1.16.3
k8s-node-1   Ready    <none>   8m3s    v1.16.0
```

Post fix, once the upgrade completes i.e., when the upgradeKubernetesCluster API  returns a success response, `kubectl get nodes` shows all nodes to be at the upgraded version, here, 1.16.3
```
c2-master ~ # kubectl get nodes
NAME        STATUS   ROLES    AGE   VERSION
c2-master   Ready    master   18m   v1.16.0
c2-node-1   Ready    <none>   18m   v1.16.0
c2-master ~ # kubectl get nodes
NAME        STATUS                     ROLES    AGE   VERSION
c2-master   Ready,SchedulingDisabled   master   19m   v1.16.0
c2-node-1   Ready                      <none>   18m   v1.16.0

...
c2-master ~ # kubectl get nodes
NAME        STATUS     ROLES    AGE   VERSION
c2-master   Ready      master   25m   v1.16.3
c2-node-1   NotReady   <none>   25m   v1.16.3
```