### PR TITLE
Packaging: new timestamp format and add output dir option

### DIFF
--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -163,6 +163,7 @@ dpkg-buildpackage -uc -us -b
 if [ -n "$OUTPUT_DIR" ];then
     mkdir -p "$OUTPUT_DIR"
     mv ../*${VERSION}* "$OUTPUT_DIR"
+    echo "====== CloudStack packages have been moved to $OUTPUT_DIR ======"
 fi
 
 if [ "$USE_TIMESTAMP" == "true" ]; then

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -43,6 +43,7 @@ note that you can override/provide "branding" string with "-b, --brand" flag as 
 Optional arguments:
    -b, --brand string                      Set branding to be used in package name (it will override any branding string in POM version)
    -T, --use-timestamp                     Use epoch timestamp instead of SNAPSHOT in the package name (if not provided, use "SNAPSHOT")
+   -o, --output-directory                  The output directory of packages
 
 Other arguments:
    -h, --help                              Display this help message and exit
@@ -84,6 +85,16 @@ while [ -n "$1" ]; do
             fi
             ;;
 
+        -o | --output-directory)
+            if [ -n "$OUTPUT_DIR" ]; then
+                echo "ERROR: you have already entered value for -o, --output-directory"
+                exit 1
+            else
+                OUTPUT_DIR=$2
+                shift 2
+            fi
+            ;;
+
         -*|*)
             echo "ERROR: no such option $1. -h or --help for help"
             exit 1
@@ -96,7 +107,7 @@ if [ -z "$(which dch)" ] ; then
     exit 1
 fi
 
-NOW="$(date +%s)"
+NOW="$(date +'%Y%m%dT%H%M%S')"
 PWD=$(cd $(dirname "$0") && pwd -P)
 cd $PWD/../
 
@@ -139,7 +150,7 @@ else
     fi
 fi
 
-/bin/cp debian/changelog /tmp/changelog.orig
+/bin/cp debian/changelog debian/changelog.$NOW
 
 dch -b -v "${VERSION}~${DISTCODE}" -u low -m "Apache CloudStack Release ${VERSION}"
 sed -i '0,/ UNRELEASED;/s// unstable;/g' debian/changelog
@@ -147,7 +158,12 @@ sed -i '0,/ UNRELEASED;/s// unstable;/g' debian/changelog
 dpkg-checkbuilddeps
 dpkg-buildpackage -uc -us -b
 
-/bin/mv /tmp/changelog.orig debian/changelog
+/bin/mv debian/changelog.$NOW debian/changelog
+
+if [ -n "$OUTPUT_DIR" ];then
+    mkdir -p "$OUTPUT_DIR"
+    mv ../*${VERSION}* "$OUTPUT_DIR"
+fi
 
 if [ "$USE_TIMESTAMP" == "true" ]; then
     (cd $PWD; git reset --hard)


### PR DESCRIPTION
### Description

This PR add an option "-o" to specify the output directory of packages.

Usage:
    cd packaging && ./build-deb.sh -T -o ~/packages/$BRANCH_NAME

This PR also changes the format of timestamp when create packages using "./build-deb.sh -T"

old output
```
# ls -l *16052*
-rw-r--r-- 1 jenkins jenkins     12509 Nov 12 22:31 cloudstack_4.14.1.0-1605219288~bionic_amd64.buildinfo
-rw-r--r-- 1 jenkins jenkins      3714 Nov 12 22:31 cloudstack_4.14.1.0-1605219288~bionic_amd64.changes
-rw-r--r-- 1 jenkins jenkins  62306764 Nov 12 22:30 cloudstack-agent_4.14.1.0-1605219288~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins  61913896 Nov 12 22:30 cloudstack-common_4.14.1.0-1605219288~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins     52964 Nov 12 22:30 cloudstack-docs_4.14.1.0-1605219288~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins    651156 Nov 12 22:30 cloudstack-integration-tests_4.14.1.0-1605219288~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins 107535424 Nov 12 22:31 cloudstack-management_4.14.1.0-1605219288~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins    508912 Nov 12 22:30 cloudstack-marvin_4.14.1.0-1605219288~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins  48869360 Nov 12 22:31 cloudstack-usage_4.14.1.0-1605219288~bionic_all.deb
```

new output
```
# ls -l 
total 277092
-rw-rw-r-- 1 jenkins jenkins     12619 Nov 12 09:25 cloudstack_4.14.1.0-20201112T085715~bionic_amd64.buildinfo
-rw-rw-r-- 1 jenkins jenkins      3849 Nov 12 09:25 cloudstack_4.14.1.0-20201112T085715~bionic_amd64.changes
-rw-r--r-- 1 jenkins jenkins  62132640 Nov 12 09:24 cloudstack-agent_4.14.1.0-20201112T085715~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins  62454532 Nov 12 09:24 cloudstack-common_4.14.1.0-20201112T085715~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins     52964 Nov 12 09:24 cloudstack-docs_4.14.1.0-20201112T085715~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins    662468 Nov 12 09:24 cloudstack-integration-tests_4.14.1.0-20201112T085715~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins 107355880 Nov 12 09:25 cloudstack-management_4.14.1.0-20201112T085715~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins    512556 Nov 12 09:24 cloudstack-marvin_4.14.1.0-20201112T085715~bionic_all.deb
-rw-r--r-- 1 jenkins jenkins  50534436 Nov 12 09:25 cloudstack-usage_4.14.1.0-20201112T085715~bionic_all.deb
```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
