### PR TITLE
Removed sensitive info from UI when volume attach/detach fails

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -2248,15 +2248,16 @@ public class VmwareStorageProcessor implements StorageProcessor {
             String msg = "";
 
             if (isAttach) {
-                msg += "Failed to attach volume: " + e.getMessage();
+                msg += "Failed to attach volume";
             }
             else {
-                msg += "Failed to detach volume: " + e.getMessage();
+                msg += "Failed to detach volume";
             }
 
-            s_logger.error(msg, e);
+            s_logger.error(msg + e.getMessage(), e);
 
-            return new AttachAnswer(msg);
+            // Sending empty error message - too many duplicate errors in UI
+            return new AttachAnswer("");
         }
     }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -2248,10 +2248,10 @@ public class VmwareStorageProcessor implements StorageProcessor {
             String msg = "";
 
             if (isAttach) {
-                msg += "Failed to attach volume";
+                msg += "Failed to attach volume: ";
             }
             else {
-                msg += "Failed to detach volume";
+                msg += "Failed to detach volume: ";
             }
 
             s_logger.error(msg + e.getMessage(), e);


### PR DESCRIPTION
### Description

This PR sends the error message when attaching/detaching a volume fails only to logs and not the UI
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
Fixes: #4419 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This was tested by creating a volume, attaching it to a running instance, and detaching the volume.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
