### PR TITLE
hostresponse: Setting memory allocated to percentage

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -138,7 +138,7 @@ public class HostResponse extends BaseResponse {
 
     @SerializedName("memoryallocated")
     @Param(description = "the amount of the host's memory currently allocated")
-    private long memoryAllocated;
+    private String memoryAllocated;
 
     @SerializedName("memoryused")
     @Param(description = "the amount of the host's memory currently used")
@@ -353,7 +353,7 @@ public class HostResponse extends BaseResponse {
         this.memWithOverprovisioning=memWithOverprovisioning;
     }
 
-    public void setMemoryAllocated(long memoryAllocated) {
+    public void setMemoryAllocated(String memoryAllocated) {
         this.memoryAllocated = memoryAllocated;
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -172,7 +172,7 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 hostResponse.setMemoryTotal(host.getTotalMemory());
                 Float totalMemorywithOverprovisioning = host.getTotalMemory() * ApiDBUtils.getMemOverprovisioningFactor(host.getClusterId());
                 hostResponse.setMemWithOverprovisioning(totalMemorywithOverprovisioning.toString());
-                hostResponse.setMemoryAllocated(mem);
+                hostResponse.setMemoryAllocated(decimalFormat.format((float) mem / totalMemorywithOverprovisioning * 100.0f) +"%");
 
                 String hostTags = host.getTag();
                 hostResponse.setHostTags(host.getTag());


### PR DESCRIPTION
### Description
Fixes https://github.com/apache/cloudstack/issues/4460

Sets `memoryAllocated` to a percentage considering overprovisioning

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


### How Has This Been Tested?
```
(localcloud) SBCM5> > list hosts filter=cpuallocated,memoryallocated type=Routing
{
  "count": 3,
  "host": [
    {
      "cpuallocated": "31.91%",
      "memoryallocated": "47.19%""
    },
    {
      "cpuallocated": "17.73%",
      "memoryallocated": "36.89%"
    },
    {
      "cpuallocated": "7.09%",
      "memoryallocated": "7.38%"
    }
  ]
}
(localcloud) SBCM5> > find hostsformigration virtualmachineid=5108c585-81eb-4f35-a2ce-730db1fedb42  filter=cpuallocated,memoryallocated
{
  "count": 2,
  "host": [
    {
      "cpuallocated": "7.09%",
      "memoryallocated": "7.38%"
    },
    {
      "cpuallocated": "17.73%",
      "memoryallocated": "36.89%"
    }
  ]
}
```