### PR TITLE
Adding memoryallocatedpercentage & memoryallocatedbytes to HostsResponse & HostsForMigrationResponse

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
@@ -128,9 +128,18 @@ public class HostForMigrationResponse extends BaseResponse {
     @Param(description = "the outgoing network traffic on the host")
     private Long networkKbsWrite;
 
+    @Deprecated
     @SerializedName("memoryallocated")
     @Param(description = "the amount of the host's memory currently allocated")
     private String memoryAllocated;
+
+    @SerializedName("memoryallocatedpercentage")
+    @Param(description = "the amount of the host's memory currently allocated in percentage")
+    private String memoryAllocatedPercentage;
+
+    @SerializedName("memoryallocatedbytes")
+    @Param(description = "the amount of the host's memory currently allocated in bytes")
+    private Long memoryAllocatedBytes;
 
     @SerializedName("memoryused")
     @Param(description = "the amount of the host's memory currently used")
@@ -312,6 +321,14 @@ public class HostForMigrationResponse extends BaseResponse {
 
     public void setMemoryAllocated(String memoryAllocated) {
         this.memoryAllocated = memoryAllocated;
+    }
+
+    public void setMemoryAllocatedPercentage(String memoryAllocatedPercentage) {
+        this.memoryAllocatedPercentage = memoryAllocatedPercentage;
+    }
+
+    public void setMemoryAllocatedBytes(Long memoryAllocatedBytes) {
+        this.memoryAllocatedBytes = memoryAllocatedBytes;
     }
 
     public void setMemoryUsed(Long memoryUsed) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -136,9 +136,18 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the amount of the host's memory after applying the mem.overprovisioning.factor")
     private String memWithOverprovisioning;
 
+    @Deprecated
     @SerializedName("memoryallocated")
     @Param(description = "the amount of the host's memory currently allocated")
     private long memoryAllocated;
+
+    @SerializedName("memoryallocatedpercentage")
+    @Param(description = "the amount of the host's memory currently allocated in percentage")
+    private String memoryAllocatedPercentage;
+
+    @SerializedName("memoryallocatedbytes")
+    @Param(description = "the amount of the host's memory currently allocated in bytes")
+    private Long memoryAllocatedBytes;
 
     @SerializedName("memoryused")
     @Param(description = "the amount of the host's memory currently used")
@@ -607,6 +616,14 @@ public class HostResponse extends BaseResponse {
 
     public long getMemoryAllocated() {
         return memoryAllocated;
+    }
+
+    public void setMemoryAllocatedPercentage(String memoryAllocatedPercentage) {
+        this.memoryAllocatedPercentage = memoryAllocatedPercentage;
+    }
+
+    public void setMemoryAllocatedBytes(Long memoryAllocatedBytes) {
+        this.memoryAllocatedBytes = memoryAllocatedBytes;
     }
 
     public Long getMemoryUsed() {

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -170,9 +170,12 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 Long cpu = host.getCpuReservedCapacity() + host.getCpuUsedCapacity();
 
                 hostResponse.setMemoryTotal(host.getTotalMemory());
-                Float totalMemorywithOverprovisioning = host.getTotalMemory() * ApiDBUtils.getMemOverprovisioningFactor(host.getClusterId());
-                hostResponse.setMemWithOverprovisioning(decimalFormat.format(totalMemorywithOverprovisioning));
+                Float memWithOverprovisioning = host.getTotalMemory() * ApiDBUtils.getMemOverprovisioningFactor(host.getClusterId());
+                hostResponse.setMemWithOverprovisioning(decimalFormat.format(memWithOverprovisioning));
                 hostResponse.setMemoryAllocated(mem);
+                hostResponse.setMemoryAllocatedBytes(mem);
+                String memoryAllocatedPercentage = decimalFormat.format((float) mem / memWithOverprovisioning * 100.0f) +"%";
+                hostResponse.setMemoryAllocatedPercentage(memoryAllocatedPercentage);
 
                 String hostTags = host.getTag();
                 hostResponse.setHostTags(host.getTag());
@@ -321,7 +324,10 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 hostResponse.setMemoryTotal(host.getTotalMemory());
                 Float memWithOverprovisioning = host.getTotalMemory() * ApiDBUtils.getMemOverprovisioningFactor(host.getClusterId());
                 hostResponse.setMemWithOverprovisioning(decimalFormat.format(memWithOverprovisioning));
-                hostResponse.setMemoryAllocated(decimalFormat.format((float) mem / memWithOverprovisioning * 100.0f) +"%");
+                String memoryAllocatedPercentage = decimalFormat.format((float) mem / memWithOverprovisioning * 100.0f) +"%";
+                hostResponse.setMemoryAllocated(memoryAllocatedPercentage);
+                hostResponse.setMemoryAllocatedPercentage(memoryAllocatedPercentage);
+                hostResponse.setMemoryAllocatedBytes(mem);
 
                 String hostTags = host.getTag();
                 hostResponse.setHostTags(host.getTag());


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/4460

Adds `memoryallocatedpercentage` & `memoryallocatedbytes` to HostsResponse as well as HostsForMigrationResponse and deprecates `memoryallocated`

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### How Has This Been Tested?
```
(localhost) 🐱 > list hosts filter=cpuallocated,memoryallocated,memoryallocatedbytes,memoryallocatedpercentage, type=Routing
{
  "count": 2,
  "host": [
    {
      "cpuallocated": "6.25%",
      "memoryallocated": 2415919104,
      "memoryallocatedbytes": 2415919104,
      "memoryallocatedpercentage": "28.12%"
    },
    {
      "cpuallocated": "1.56%",
      "memoryallocated": 536870912,
      "memoryallocatedbytes": 536870912,
      "memoryallocatedpercentage": "6.25%"
    }
  ]
}
(localhost) 🐱 > find hostsformigration virtualmachineid=e3c2c89a-26b3-427e-bc4a-34caeedf466a filter=cpuallocated,memoryallocated,memoryallocatedbytes,memoryallocatedpercentage, type=Routing
{
  "count": 2,
  "host": [
    {
      "cpuallocated": "1.56%",
      "memoryallocated": "6.25%",
      "memoryallocatedbytes": 536870912,
      "memoryallocatedpercentage": "6.25%"
    }
  ]
}

```