### PR TITLE
VPC: fix some issues related to multiple public IP ranges and private gateway

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/to/IpAddressTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/IpAddressTO.java
@@ -35,6 +35,7 @@ public class IpAddressTO {
     private String networkName;
     private Integer nicDevId;
     private boolean newNic;
+    private boolean isPrivateGateway;
 
     public IpAddressTO(long accountId, String ipAddress, boolean add, boolean firstIP, boolean sourceNat, String broadcastUri, String vlanGateway, String vlanNetmask,
             String vifMacAddress, Integer networkRate, boolean isOneToOneNat) {
@@ -132,5 +133,13 @@ public class IpAddressTO {
 
     public void setNewNic(boolean newNic) {
         this.newNic = newNic;
+    }
+
+    public boolean isPrivateGateway() {
+        return isPrivateGateway;
+    }
+
+    public void setPrivateGateway(boolean isPrivateGateway) {
+        this.isPrivateGateway = isPrivateGateway;
     }
 }

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
@@ -42,6 +42,7 @@ public class IpAssociationConfigItem extends AbstractConfigItemFacade {
         for (final IpAddressTO ip : command.getIpAddresses()) {
             final IpAddress ipAddress = new IpAddress(ip.getPublicIp(), ip.isSourceNat(), ip.isAdd(), ip.isOneToOneNat(), ip.isFirstIP(), ip.getVlanGateway(), ip.getVlanNetmask(),
                     ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString());
+            ipAddress.setPrivateGateway(ip.isPrivateGateway());
             ips.add(ipAddress);
         }
 

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/model/IpAddress.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/model/IpAddress.java
@@ -32,6 +32,7 @@ public class IpAddress {
     private Integer nicDevId;
     private boolean newNic;
     private String nwType;
+    private boolean isPrivateGateway;
 
     public IpAddress() {
         // Empty constructor for (de)serialization
@@ -131,6 +132,14 @@ public class IpAddress {
 
     public void setNewNic(boolean newNic) {
         this.newNic = newNic;
+    }
+
+    public boolean isPrivateGateway() {
+        return isPrivateGateway;
+    }
+
+    public void setPrivateGateway(boolean isPrivateGateway) {
+        this.isPrivateGateway = isPrivateGateway;
     }
 
 }

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -104,9 +104,7 @@ import com.cloud.network.vpc.PrivateIpAddress;
 import com.cloud.network.vpc.StaticRouteProfile;
 import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpc.VpcGateway;
-import com.cloud.network.vpc.VpcGatewayVO;
 import com.cloud.network.vpc.dao.VpcDao;
-import com.cloud.network.vpc.dao.VpcGatewayDao;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
@@ -171,8 +169,6 @@ public class CommandSetupHelper {
     private Site2SiteVpnGatewayDao _s2sVpnGatewayDao;
     @Inject
     private VpcDao _vpcDao;
-    @Inject
-    private VpcGatewayDao _vpcGatewayDao;
     @Inject
     private VlanDao _vlanDao;
     @Inject
@@ -726,8 +722,7 @@ public class CommandSetupHelper {
                 final IpAddressTO ip = new IpAddressTO(ipAddr.getAccountId(), ipAddr.getAddress().addr(), add, firstIP, sourceNat, BroadcastDomainType.fromString(ipAddr.getVlanTag()).toString(), ipAddr.getGateway(),
                         ipAddr.getNetmask(), macAddress, networkRate, ipAddr.isOneToOneNat());
 
-                ip.setTrafficType(getNetworkTrafficType(network));
-                ip.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
+                setIpAddressNetworkParams(ip, network, router);
                 ipsToSend[i++] = ip;
                 if (ipAddr.isSourceNat()) {
                     sourceNatIpAdd = new Pair<IpAddressTO, Long>(ip, ipAddr.getNetworkId());
@@ -851,8 +846,7 @@ public class CommandSetupHelper {
                 final IpAddressTO ip = new IpAddressTO(ipAddr.getAccountId(), ipAddr.getAddress().addr(), add, firstIP, sourceNat, vlanId, vlanGateway, vlanNetmask,
                         vifMacAddress, networkRate, ipAddr.isOneToOneNat());
 
-                ip.setTrafficType(getNetworkTrafficType(network));
-                ip.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
+                setIpAddressNetworkParams(ip, network, router);
                 ipsToSend[i++] = ip;
                 /*
                  * send the firstIP = true for the first Add, this is to create
@@ -979,8 +973,7 @@ public class CommandSetupHelper {
                 final IpAddressTO ip = new IpAddressTO(Account.ACCOUNT_ID_SYSTEM, ipAddr.getIpAddress(), add, false, ipAddr.getSourceNat(), ipAddr.getBroadcastUri(),
                         ipAddr.getGateway(), ipAddr.getNetmask(), ipAddr.getMacAddress(), null, false);
 
-                ip.setTrafficType(getNetworkTrafficType(network));
-                ip.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
+                setIpAddressNetworkParams(ip, network, router);
                 ipsToSend[i++] = ip;
 
             }
@@ -1136,13 +1129,16 @@ public class CommandSetupHelper {
         return dhcpRange;
     }
 
-    private TrafficType getNetworkTrafficType(Network network) {
-        final VpcGatewayVO gateway = _vpcGatewayDao.getVpcGatewayByNetworkId(network.getId());
-        if (gateway != null) {
+    private void setIpAddressNetworkParams(IpAddressTO ipAddress, final Network network, final VirtualRouter router) {
+        if (_networkModel.isPrivateGateway(network.getId())) {
             s_logger.debug("network " + network.getId() + " (name: " + network.getName() + " ) is a vpc private gateway, set traffic type to Public");
-            return TrafficType.Public;
+            ipAddress.setTrafficType(TrafficType.Public);
+            ipAddress.setPrivateGateway(true);
         } else {
-            return network.getTrafficType();
+            ipAddress.setTrafficType(network.getTrafficType());
+            ipAddress.setPrivateGateway(false);
         }
+        ipAddress.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
     }
+
 }

--- a/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -77,7 +77,6 @@ import com.cloud.network.vpc.StaticRoute;
 import com.cloud.network.vpc.StaticRouteProfile;
 import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpc.VpcGateway;
-import com.cloud.network.vpc.VpcGatewayVO;
 import com.cloud.network.vpc.VpcManager;
 import com.cloud.network.vpc.VpcVO;
 import com.cloud.network.vpc.dao.PrivateIpDao;
@@ -276,15 +275,6 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 buf.append(" dns1=").append(defaultDns1);
                 if (defaultDns2 != null) {
                     buf.append(" dns2=").append(defaultDns2);
-                }
-
-                VpcGatewayVO privateGatewayForVpc = _vpcGatewayDao.getPrivateGatewayForVpc(domainRouterVO.getVpcId());
-                if (privateGatewayForVpc != null) {
-                    String ip4Address = privateGatewayForVpc.getIp4Address();
-                    buf.append(" privategateway=").append(ip4Address);
-                    s_logger.debug("Set privategateway field in cmd_line.json to " + ip4Address);
-                } else {
-                    buf.append(" privategateway=None");
                 }
             }
         }

--- a/server/src/main/java/com/cloud/network/rules/VirtualNetworkApplianceFactory.java
+++ b/server/src/main/java/com/cloud/network/rules/VirtualNetworkApplianceFactory.java
@@ -26,6 +26,7 @@ import com.cloud.dc.dao.HostPodDao;
 import com.cloud.dc.dao.VlanDao;
 import com.cloud.network.IpAddressManager;
 import com.cloud.network.NetworkModel;
+import com.cloud.network.dao.FirewallRulesDao;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.LoadBalancerDao;
 import com.cloud.network.dao.NetworkDao;
@@ -85,6 +86,8 @@ public class VirtualNetworkApplianceFactory {
     private IpAddressManager _ipAddrMgr;
     @Inject
     private NetworkACLManager _networkACLMgr;
+    @Inject
+    private FirewallRulesDao _rulesDao;
 
     @Autowired
     @Qualifier("networkHelper")
@@ -182,5 +185,9 @@ public class VirtualNetworkApplianceFactory {
 
     public NetworkTopologyContext getNetworkTopologyContext() {
         return _networkTopologyContext;
+    }
+
+    public FirewallRulesDao getFirewallRulesDao() {
+        return _rulesDao;
     }
 }

--- a/server/src/main/java/com/cloud/network/rules/VirtualNetworkApplianceFactory.java
+++ b/server/src/main/java/com/cloud/network/rules/VirtualNetworkApplianceFactory.java
@@ -43,6 +43,8 @@ import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.NicIpAliasDao;
 import com.cloud.vm.dao.UserVmDao;
 
+import org.apache.cloudstack.network.topology.NetworkTopologyContext;
+
 public class VirtualNetworkApplianceFactory {
 
     @Inject
@@ -90,6 +92,9 @@ public class VirtualNetworkApplianceFactory {
 
     @Inject
     private NicProfileHelper _nicProfileHelper;
+
+    @Inject
+    private NetworkTopologyContext _networkTopologyContext;
 
     public NetworkModel getNetworkModel() {
         return _networkModel;
@@ -173,5 +178,9 @@ public class VirtualNetworkApplianceFactory {
 
     public NicProfileHelper getNicProfileHelper() {
         return _nicProfileHelper;
+    }
+
+    public NetworkTopologyContext getNetworkTopologyContext() {
+        return _networkTopologyContext;
     }
 }

--- a/server/src/main/java/org/apache/cloudstack/network/topology/AdvancedNetworkTopology.java
+++ b/server/src/main/java/org/apache/cloudstack/network/topology/AdvancedNetworkTopology.java
@@ -214,7 +214,11 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
         final boolean result = applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(ipAssociationRules));
 
         if (result) {
-            _advancedVisitor.visit(nicPlugInOutRules);
+            if (router.getState() == State.Stopped || router.getState() == State.Stopping) {
+                s_logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending NicPlugInOutRules command to the backend");
+            } else {
+                _advancedVisitor.visit(nicPlugInOutRules);
+            }
         }
 
         return result;

--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -949,11 +949,11 @@ class CsForwardingRules(CsDataBag):
             raise Exception("Ip address %s has no device in the ips databag" % rule["public_ip"])
 
         self.fw.append(["mangle", "front",
-                        "-A PREROUTING -d %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
-                        rule["public_ip"]])
+                        "-A PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
+                        rule["internal_ip"]])
         self.fw.append(["mangle", "front",
-                        "-A PREROUTING -d %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
-                        (rule["public_ip"], hex(100 + int(device[len("eth"):])))])
+                        "-A PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
+                        (rule["internal_ip"], hex(100 + int(device[len("eth"):])))])
         self.fw.append(["nat", "front",
                         "-A PREROUTING -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])
         self.fw.append(["nat", "front",

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -492,6 +492,10 @@ class CsIP:
                 self.fw.append(["nat", "front",
                                 "-A POSTROUTING -o %s -j SNAT --to-source %s" %
                                 (self.dev, self.address['public_ip'])])
+            if self.get_gateway() == self.get_ip_address():
+                # Accept packet from private gateway if VPC VR is used as gateway
+                self.fw.append(["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" %
+                                (self.address['network'], self.address['network'])])
 
         if self.get_type() in ["public"]:
             self.fw.append(

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -488,6 +488,9 @@ class CsIP:
             self.fw.append(["mangle", "",
                             "-A PREROUTING -m state --state NEW -i %s -s %s ! -d %s/32 -j ACL_OUTBOUND_%s" %
                             (self.dev, self.address['network'], self.address['gateway'], self.dev)])
+            self.fw.append(["mangle", "front",
+                            "-A PREROUTING -s %s -d %s -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
+                            (self.cl.get_vpccidr(), self.address['network'], hex(100 + int(self.dev[3:])))])
             if self.address["source_nat"]:
                 self.fw.append(["nat", "front",
                                 "-A POSTROUTING -o %s -j SNAT --to-source %s" %

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -493,6 +493,15 @@ class CsIP:
                                 "-A POSTROUTING -o %s -j SNAT --to-source %s" %
                                 (self.dev, self.address['public_ip'])])
             if self.get_gateway() == self.get_ip_address():
+                for inf, addresses in self.config.address().dbag.iteritems():
+                    if not inf.startswith("eth"):
+                        continue
+                    for address in addresses:
+                        if "nw_type" in address and address["nw_type"] == "guest":
+                            self.fw.append(["filter", "front", "-A FORWARD -s %s -d %s -j ACL_INBOUND_%s" %
+                                            (address["network"], self.address["network"], self.dev)])
+                            self.fw.append(["filter", "front", "-A FORWARD -s %s -d %s -j ACL_INBOUND_%s" %
+                                            (self.address["network"], address["network"], address["device"])])
                 # Accept packet from private gateway if VPC VR is used as gateway
                 self.fw.append(["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" %
                                 (self.address['network'], self.address['network'])])

--- a/test/integration/component/test_multiple_subnets_in_isolated_network.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network.py
@@ -35,6 +35,7 @@ from marvin.lib.base import (Account,
                              NetworkOffering,
                              VPC,
                              VpcOffering,
+                             StaticNATRule,
                              NATRule,
                              PublicIPAddress,
                              PublicIpRange)
@@ -247,7 +248,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the IPs in VR. eth0 -> guest nic IP, eth2 -> source nat IP
 
         # 6. create new public ip range 1
-        # 7. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
+        # 7. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
         #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 1
         # 8. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
@@ -395,7 +396,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         )
         self.cleanup.append(self.public_ip_range1)
 
-        # 7. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
+        # 7. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm
         ip_address_1 = self.get_free_ipaddress(self.public_ip_range1.vlan.id)
         ipaddress_1 = PublicIPAddress.create(
             self.apiclient,
@@ -404,12 +405,11 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_1
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine1.id,
             ipaddressid=ipaddress_1.ipaddress.id,
-            openfirewall=True
+            networkid=self.network1.id
         )
 
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
@@ -544,12 +544,11 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_4
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine1.id,
             ipaddressid=ipaddress_4.ipaddress.id,
-            openfirewall=True
+            networkid=self.network1.id
         )
 
 

--- a/test/integration/component/test_multiple_subnets_in_isolated_network.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network.py
@@ -308,6 +308,21 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 17. release new ip 4
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,"
         #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 3, eth4 -> new ip 6
+        # 18. release new ip 3
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth4 -> new ip 6
+        # 19. restart network
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth4 -> new ip 6
+        # 20. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
+        # 21. restart network with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
+        # 22. restart network with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         """
 
         # Create new domain1
@@ -719,6 +734,8 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_router_publicnic_state(router, host, "eth2|eth4")
 
         # 19. restart network
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth4 -> new ip 6
         self.network1.restart(self.apiclient)
         routers = self.get_routers(self.network1.id)
         for router in routers:
@@ -733,7 +750,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
             self.verify_router_publicnic_state(router, host, "eth2|eth4")
 
-        # reboot router
+        # 20. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         for router in routers:
             cmd = rebootRouter.rebootRouterCmd()
             cmd.id = router.id
@@ -750,7 +769,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth3", True)
             self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
-        # 20. restart network with cleanup
+        # 21. restart network with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         self.network1.restart(self.apiclient, cleanup=True)
         routers = self.get_routers(self.network1.id)
         for router in routers:
@@ -764,7 +785,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth3", True)
 
-        # 21. restart network with cleanup, makeredundant=true
+        # 22. restart network with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         self.network1.restart(self.apiclient, cleanup=True, makeredundant=True)
         routers = self.get_routers(self.network1.id)
         for router in routers:

--- a/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
@@ -35,6 +35,7 @@ from marvin.lib.base import (Account,
                              NetworkOffering,
                              VPC,
                              VpcOffering,
+                             StaticNATRule,
                              NATRule,
                              PublicIPAddress,
                              PublicIpRange)
@@ -247,7 +248,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the IPs in VR. eth0 -> guest nic IP, eth2 -> source nat IP
 
         # 6. create new public ip range 1
-        # 7. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
+        # 7. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
         #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 1
         # 8. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
@@ -395,7 +396,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         )
         self.cleanup.append(self.public_ip_range1)
 
-        # 7. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
+        # 7. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm
         ip_address_1 = self.get_free_ipaddress(self.public_ip_range1.vlan.id)
         ipaddress_1 = PublicIPAddress.create(
             self.apiclient,
@@ -404,12 +405,11 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_1
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine1.id,
             ipaddressid=ipaddress_1.ipaddress.id,
-            openfirewall=True
+            networkid=self.network1.id
         )
 
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
@@ -544,12 +544,11 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_4
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine1.id,
             ipaddressid=ipaddress_4.ipaddress.id,
-            openfirewall=True
+            networkid=self.network1.id
         )
 
 

--- a/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
@@ -192,6 +192,35 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
                 sourcenatIp = nic.ipaddress
         return guestIp, controlIp, sourcenatIp
 
+    def verify_router_publicnic_state(self, router, host, publicNics):
+        command = '/opt/cloud/bin/checkrouter.sh | cut -d ":" -f2 |tr -d " "'
+        self.logger.debug("Executing command '%s'" % command)
+        result = get_process_status(
+            host.ipaddress,
+            host.port,
+            host.user,
+            host.password,
+            router.linklocalip,
+            command)
+        self.assertTrue(len(result) > 0, "Cannot get router %s redundant state" % router.name)
+        redundant_state = result[0]
+        self.logger.debug("router %s redudnant state is %s" % (router.name, redundant_state))
+        if redundant_state == "FAULT":
+            self.logger.debug("Skip as redundant_state is %s" % redundant_state)
+            return
+        elif redundant_state == "MASTER":
+            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state DOWN" |wc -l' % publicNics
+        elif redundant_state == "BACKUP":
+            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state UP" |wc -l' % publicNics
+        result = get_process_status(
+            host.ipaddress,
+            host.port,
+            host.user,
+            host.password,
+            router.linklocalip,
+            command)
+        self.assertTrue(len(result) > 0 and result[0] == "0", "Expected result is 0 but actual result is %s" % result[0])
+
     def verify_network_interfaces_in_router(self, router, host, expectedNics):
         command = 'ip link show |grep BROADCAST | cut -d ":" -f2 |tr -d " "|tr "\n" ","'
         self.logger.debug("Executing command '%s'" % command)
@@ -338,6 +367,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, guestIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, controlIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
+            self.verify_router_publicnic_state(router, host, "eth2")
 
         # 4. get a free public ip, assign to network, and create port forwarding rules (ssh) to the vm
         ipaddress = PublicIPAddress.create(
@@ -363,6 +393,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
             self.verify_ip_address_in_router(router, host, ipaddress.ipaddress.ipaddress, "eth2", True)
+            self.verify_router_publicnic_state(router, host, "eth2")
 
         # 5. release the new ip
         ipaddress.delete(self.apiclient)
@@ -378,6 +409,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
             self.verify_ip_address_in_router(router, host, ipaddress.ipaddress.ipaddress, "eth2", False)
+            self.verify_router_publicnic_state(router, host, "eth2")
 
         # 6. create new public ip range 1
         self.services["publiciprange"]["zoneid"] = self.zone.id
@@ -423,6 +455,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
             self.verify_ip_address_in_router(router, host, ipaddress_1.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
         # 8. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
@@ -452,6 +485,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
             self.verify_ip_address_in_router(router, host, ipaddress_1.ipaddress.ipaddress, "eth3", True)
             self.verify_ip_address_in_router(router, host, ipaddress_2.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
         # 9. get a free ip in new ip range, assign to network, and create port forwarding rules (ssh) to the vm
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
@@ -482,6 +516,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_1.ipaddress.ipaddress, "eth3", True)
             self.verify_ip_address_in_router(router, host, ipaddress_2.ipaddress.ipaddress, "eth3", True)
             self.verify_ip_address_in_router(router, host, ipaddress_3.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
         # 10. release new ip 2
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
@@ -499,6 +534,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_1.ipaddress.ipaddress, "eth3", True)
             self.verify_ip_address_in_router(router, host, ipaddress_2.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_3.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
         # 11. release new ip 1
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3"
@@ -515,6 +551,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_1.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_2.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_3.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
         # 12. create new public ip range 2
         self.services["publiciprange"]["zoneid"] = self.zone.id
@@ -562,6 +599,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
             self.verify_ip_address_in_router(router, host, ipaddress_3.ipaddress.ipaddress, "eth3", True)
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3|eth4")
 
         # 14. get a free ip 5 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,"
@@ -592,6 +630,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_3.ipaddress.ipaddress, "eth3", True)
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", True)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3|eth4")
 
         # 15. get a free ip 6 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,"
@@ -623,6 +662,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", True)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth4", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3|eth4")
 
         # 16. release new ip 5
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,"
@@ -641,6 +681,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", True)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3|eth4")
 
         # 17. release new ip 4
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,"
@@ -658,6 +699,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3|eth4")
 
         # 18. release new ip 3
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
@@ -674,6 +716,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth4")
 
         # 19. restart network
         self.network1.restart(self.apiclient)
@@ -688,6 +731,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth4", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth4")
 
         # reboot router
         for router in routers:
@@ -704,6 +748,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
         # 20. restart network with cleanup
         self.network1.restart(self.apiclient, cleanup=True)
@@ -718,3 +763,4 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth3", False)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")

--- a/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
@@ -308,6 +308,21 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 17. release new ip 4
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,"
         #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 3, eth4 -> new ip 6
+        # 18. release new ip 3
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth4 -> new ip 6
+        # 19. restart network
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth4 -> new ip 6
+        # 20. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
+        # 21. restart network with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
+        # 22. restart network with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         """
 
         # Create new domain1
@@ -719,6 +734,8 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_router_publicnic_state(router, host, "eth2|eth4")
 
         # 19. restart network
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth4 -> new ip 6
         self.network1.restart(self.apiclient)
         routers = self.get_routers(self.network1.id)
         for router in routers:
@@ -733,7 +750,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth4", True)
             self.verify_router_publicnic_state(router, host, "eth2|eth4")
 
-        # reboot router
+        # 20. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         for router in routers:
             cmd = rebootRouter.rebootRouterCmd()
             cmd.id = router.id
@@ -750,8 +769,27 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth3", True)
             self.verify_router_publicnic_state(router, host, "eth2|eth3")
 
-        # 20. restart network with cleanup
+        # 21. restart network with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
         self.network1.restart(self.apiclient, cleanup=True)
+        routers = self.get_routers(self.network1.id)
+        for router in routers:
+            host = self.get_router_host(router)
+            self.verify_network_interfaces_in_router(router, host, "eth0,eth1,eth2,eth3,")
+            guestIp, controlIp, sourcenatIp = self.get_router_ips(router)
+            self.verify_ip_address_in_router(router, host, guestIp, "eth0", True)
+            self.verify_ip_address_in_router(router, host, controlIp, "eth1", True)
+            self.verify_ip_address_in_router(router, host, sourcenatIp, "eth2", True)
+            self.verify_ip_address_in_router(router, host, ipaddress_4.ipaddress.ipaddress, "eth3", False)
+            self.verify_ip_address_in_router(router, host, ipaddress_5.ipaddress.ipaddress, "eth3", False)
+            self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth3", True)
+            self.verify_router_publicnic_state(router, host, "eth2|eth3")
+
+        # 22. restart network with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
+        #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
+        self.network1.restart(self.apiclient, cleanup=True, makeredundant=True)
         routers = self.get_routers(self.network1.id)
         for router in routers:
             host = self.get_router_host(router)

--- a/test/integration/component/test_multiple_subnets_in_vpc.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc.py
@@ -35,6 +35,7 @@ from marvin.lib.base import (Account,
                              NetworkOffering,
                              VPC,
                              VpcOffering,
+                             StaticNATRule,
                              NATRule,
                              PublicIPAddress,
                              PublicIpRange)
@@ -272,7 +273,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2
 
         # 13. create new public ip range 2
-        # 14. get a free ip 4 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
+        # 14. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm 2 in tier 2
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2, eth5 -> new ip 4
         # 15. get a free ip 5 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
@@ -451,10 +452,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_1
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine1.id,
             ipaddressid=ipaddress_1.ipaddress.id,
             networkid=vpc_tier_1.id
         )
@@ -581,7 +581,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         )
 
         try:
-            self.virtual_machine1 = VirtualMachine.create(
+            self.virtual_machine2 = VirtualMachine.create(
                 self.apiclient,
                 self.services["virtual_machine"],
                 accountid=self.account1.name,
@@ -621,7 +621,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         )
         self.cleanup.append(self.public_ip_range2)
 
-        # 14. get a free ip 4 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
+        # 14. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm 2 in tier 2
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2, eth5 -> new ip 4
         ip_address_4 = self.get_free_ipaddress(self.public_ip_range2.vlan.id)
@@ -632,10 +632,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_4
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine2.id,
             ipaddressid=ipaddress_4.ipaddress.id,
             networkid=vpc_tier_2.id
         )
@@ -665,7 +664,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
 
         nat_rule = NATRule.create(
             self.apiclient,
-            self.virtual_machine1,
+            self.virtual_machine2,
             self.services["natrule"],
             ipaddressid=ipaddress_5.ipaddress.id,
             networkid=vpc_tier_2.id
@@ -696,7 +695,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
 
         nat_rule = NATRule.create(
             self.apiclient,
-            self.virtual_machine1,
+            self.virtual_machine2,
             self.services["natrule"],
             ipaddressid=ipaddress_6.ipaddress.id,
             networkid=vpc_tier_2.id

--- a/test/integration/component/test_multiple_subnets_in_vpc.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc.py
@@ -318,6 +318,23 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 18. release new ip 4
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2, eth5 -> new ip 6
+        # 19. release new ip 3
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6
+        # 20. restart tier1
+        # 22. restart VPC
+        # 23. Add private gateway
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6, eth3-> private gateway
+        # 24. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        # 25. restart VPC with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        # 26. restart VPC with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         """
 
         # Create new domain1
@@ -796,7 +813,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_router_publicnic_state(router, host, "eth1|eth3|eth5")
 
         # 19. release new ip 3
-        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6
         ipaddress_3.delete(self.apiclient)
         routers = self.get_vpc_routers(self.vpc1.id)
@@ -855,7 +872,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth5")
 
-        # Add private gateway
+        # 23. Add private gateway
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6, eth3-> private gateway
         private_gateway_ip = "172.16." + str(random_subnet_number + 2) + ".1"
         private_gateway = PrivateGateway.create(
             self.apiclient,
@@ -879,7 +898,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth3|eth5")
 
-        # reboot router
+        # 24. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
             cmd = rebootRouter.rebootRouterCmd()
@@ -897,7 +918,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
 
-        # 23. restart VPC with cleanup
+        # 25. restart VPC with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
@@ -912,7 +935,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
 
-        # 24. restart VPC with cleanup, makeredundant=true
+        # 26. restart VPC with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True, makeredundant=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:

--- a/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
@@ -35,6 +35,7 @@ from marvin.lib.base import (Account,
                              NetworkOffering,
                              VPC,
                              VpcOffering,
+                             StaticNATRule,
                              NATRule,
                              PublicIPAddress,
                              PublicIpRange)
@@ -272,7 +273,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2
 
         # 13. create new public ip range 2
-        # 14. get a free ip 4 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
+        # 14. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm 2 in tier 2
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2, eth5 -> new ip 4
         # 15. get a free ip 5 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
@@ -451,10 +452,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_1
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine1.id,
             ipaddressid=ipaddress_1.ipaddress.id,
             networkid=vpc_tier_1.id
         )
@@ -581,7 +581,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         )
 
         try:
-            self.virtual_machine1 = VirtualMachine.create(
+            self.virtual_machine2 = VirtualMachine.create(
                 self.apiclient,
                 self.services["virtual_machine"],
                 accountid=self.account1.name,
@@ -621,7 +621,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         )
         self.cleanup.append(self.public_ip_range2)
 
-        # 14. get a free ip 4 in new ip range 2, assign to network, and create port forwarding rules (ssh) to the vm
+        # 14. get a free ip 4 in new ip range 2, assign to network, and enable static nat to vm 2 in tier 2
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2, eth5 -> new ip 4
         ip_address_4 = self.get_free_ipaddress(self.public_ip_range2.vlan.id)
@@ -632,10 +632,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             ipaddress=ip_address_4
         )
 
-        nat_rule = NATRule.create(
+        StaticNATRule.enable(
             self.apiclient,
-            self.virtual_machine1,
-            self.services["natrule"],
+            virtualmachineid=self.virtual_machine2.id,
             ipaddressid=ipaddress_4.ipaddress.id,
             networkid=vpc_tier_2.id
         )
@@ -665,7 +664,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
 
         nat_rule = NATRule.create(
             self.apiclient,
-            self.virtual_machine1,
+            self.virtual_machine2,
             self.services["natrule"],
             ipaddressid=ipaddress_5.ipaddress.id,
             networkid=vpc_tier_2.id
@@ -696,7 +695,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
 
         nat_rule = NATRule.create(
             self.apiclient,
-            self.virtual_machine1,
+            self.virtual_machine2,
             self.services["natrule"],
             ipaddressid=ipaddress_6.ipaddress.id,
             networkid=vpc_tier_2.id

--- a/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
@@ -318,6 +318,23 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 18. release new ip 4
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth3 -> new ip 3, eth4 -> tier 2, eth5 -> new ip 6
+        # 19. release new ip 3
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6
+        # 20. restart tier1
+        # 22. restart VPC
+        # 23. Add private gateway
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6, eth3-> private gateway
+        # 24. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        # 25. restart VPC with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        # 26. restart VPC with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         """
 
         # Create new domain1
@@ -796,7 +813,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_router_publicnic_state(router, host, "eth1|eth3|eth5")
 
         # 19. release new ip 3
-        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6
         ipaddress_3.delete(self.apiclient)
         routers = self.get_vpc_routers(self.vpc1.id)
@@ -855,7 +872,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth5")
 
-        # Add private gateway
+        # 23. Add private gateway
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6, eth3-> private gateway
         private_gateway_ip = "172.16." + str(random_subnet_number + 2) + ".1"
         private_gateway = PrivateGateway.create(
             self.apiclient,
@@ -879,7 +898,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth3|eth5")
 
-        # reboot router
+        # 24. reboot router
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
             cmd = rebootRouter.rebootRouterCmd()
@@ -897,7 +918,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
 
-        # 23. restart VPC with cleanup
+        # 25. restart VPC with cleanup
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
@@ -912,7 +935,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
             self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
 
-        # 24. restart VPC with cleanup, makeredundant=true
+        # 26. restart VPC with cleanup, makeredundant=true
+        #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True, makeredundant=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:


### PR DESCRIPTION
### Description

This PR contains 13 commits below

```
bugfix #1 vpc: fix ips on wrong interfaces after rebooting vpc vrs
bugfix #1 vr: Force a restart of keepalived if conntrackd is not running or configuration has changed
bugfix #2 vpc: Fix remove first public ip will remove all ips on the nic
bugfix #3 apply ip dessociation before unplugging a nic so ip is marked as add:false in ips.json
bugfix #2 vpc vr: fix issue if static nat is disabled but still other IP used by lb/pf
bugfix #4 vpc vr: Do NOT send Nic plug in/out command to Stopped/Stopping VR
Revert "Handle private gateways more reliably"
Revert "Add private gateway IP to router initialization config"
Revert "Fix Policy Based Routing for private gateway static routes (#3604)"
bugfix #6 vpc vr: Add iptables rules for ACL of private gateway
bugfix #7 vpc vr: allow servers in private gateway to reach internet via the VPC VR if it is gateway
bugfix #8 vpc: add rule for traffic between vm and private gateway
bugfix #9 vpc vr: Add PREROUTING rule for vm with static nat to multiple private gateways
```

Here are description of bugs
(1) ips on wrong interfaces after rebooting vpc vrs
When add new vpc tier, create private gateway, associated IP in new range to a VPC, nics will be plugged  to VPC VRs.
However, when reboot(or start) a VPC VR, the nics will be added by order: Public IP (source nat), other Public IP range, private gateway, VPC tiers. so the device_id of nics are different before stopping VR.

I have created a PR for this issue #4467 

(2) remove first public ip will remove all ips on the nic
When use more public IPs in new public IP range (not same as source nat), a nic will be plugged to VPC VR. All public IPs used by the VPC will be attached to the nic.
However, when we release the first public IP of the nic, it will remove the nic, all other IPs on the nic will be gone as well.

(3) public ip is not marked as "add: false" in /etc/cloudstack/ips.json when release it.
When use a public IP in new range to VPC VR, a nic will be plugged to VPC VR.
When remove the public from VPC, the nic will be unplugged. however, the ip is still marked as "add: true" in /etc/cloudstack/ips.json
so when we add a new nic to the VPC, the (old) public ip will be added back to the nic.

(4) When a VPC VR is stopped, we cannot add/remove new nic to VPC VR.

(5) Static NAT with multiple public interfaces uses wrong outgoing IP #4234
This is a regression of the fix for #3604 
we need to revert the commit "Fix Policy Based Routing for private gateway static routes (#3604)"

(6) There is no ACL rule for private gateway
This is a regression of the fix for #3402 
private gateway is changed to 'public' in commit "vpc: set traffic type of private gateway IP to Public to fix ke… (#3851)"
so we need to add ACL rules.

(7) servers in private gateway cannot reach internet via the VPC VR if it is gateway
When add private gateway and use VPC as gateway (private gateway IP = gateway IP), the servers in private gateway network cannot reach internet via VPC VR.
need to add rule to accept packet if VPC VR is used as gateway.

(8) INBOUND rules for traffic between vm and private gateway servers does not work.
Even rules are added to fix bug (6), the incoming traffic between vm and private gateway network is always accepted.
for example, if the ACL of vm disallow traffic from private gateway network, vm still accepts traffic from private gateway network.
need to add rules to check the INBOUND ACL rules.

(9) vm with static nat cannot connect to private gateway network.
As the fix is reverted to fix (5), the issue described in #3604 is back. 
this PR introduced another way to fix the issue.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity


#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
