### PR TITLE
vr: fix python exception when configure VRs

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
@@ -35,7 +35,7 @@ STATE_COMMANDS = {"router": "ip addr show dev eth0 | grep inet | wc -l | xargs b
 
 def reconfigure_interfaces(router_config, interfaces):
     for interface in interfaces:
-        cmd = "ip link show %s | grep 'state DOWN'" % interface.get_device()
+        cmd = "ip link show %s | grep ' state '" % interface.get_device()
         for device in execute(cmd):
             if " DOWN " in device:
                 cmd = "ip link set %s up" % interface.get_device()


### PR DESCRIPTION
### Description

This PR fixes #4474

before
```
root@r-27-VM:/var/cache/cloud# /opt/cloud/bin/configure.py monitor_service.json
ERROR:root:Command 'ip link show eth0 | grep 'state DOWN'' returned non-zero exit status 1
```

with this change
```
root@r-27-VM:/var/cache/cloud# /opt/cloud/bin/configure.py monitor_service.json
root@r-27-VM:/var/cache/cloud#
```


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
