### PR TITLE
Recover VM not able to attach the data disks which were attached before destroy

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -38,6 +38,7 @@ import com.cloud.storage.dao.VMTemplateDetailsDao;
 import com.cloud.utils.StringUtils;
 import com.cloud.vm.SecondaryStorageVmVO;
 import com.cloud.vm.UserVmDetailVO;
+import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.SecondaryStorageVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
@@ -220,6 +221,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
     UserVmDetailsDao userVmDetailsDao;
     @Inject
     private SecondaryStorageVmDao secondaryStorageVmDao;
+    @Inject
+    VolumeApiService _volumeApiService;
 
     private final StateMachine2<Volume.State, Volume.Event, Volume> _volStateMachine;
     protected List<StoragePoolAllocator> _storagePoolAllocators;
@@ -1037,6 +1040,10 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
                     } else {
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("Detaching " + vol);
+                        }
+                        VMInstanceVO vm = _userVmDao.findById(vmId);
+                        if (vm.getHypervisorType().equals(HypervisorType.VMware)) {
+                            _volumeApiService.detachVolumeViaDestroyVM(vmId, vol.getId());
                         }
                         _volsDao.detachVolume(vol.getId());
                     }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2946,13 +2946,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         stopVirtualMachine(vmId, VmDestroyForcestop.value());
 
-        if (vm.getHypervisorType() == HypervisorType.VMware) {
-            List<VolumeVO> allVolumes = _volsDao.findByInstance(vm.getId());
-            allVolumes.removeIf(vol -> vol.getVolumeType() == Volume.Type.ROOT);
-            detachVolumesFromVm(allVolumes);
-        } else {
-            detachVolumesFromVm(volumesToBeDeleted);
-        }
+        detachVolumesFromVm(volumesToBeDeleted);
 
         UserVm destroyedVm = destroyVm(vmId, expunge);
         if (expunge) {


### PR DESCRIPTION
### Description

This PR  fixes: #4462

Problem Statement: 
In case of VMware, when a VM having multiple data disk is destroyed (without expunge) and tried to recover the VM then the previous data disks are not attached to the VM like before destroy. Only root disk is attached to the VM.

Root cause:
All data disks were removed as part of VM destroy. Only the volumes which are selected to delete (while destroying VM) are supposed to be detached and destroyed.

Solution:
During VM destroy, detach and destroy only volumes which are selected during VM destroy. Detach the other volumes during expunge of VM.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Test cases covered:
1. VM destroy and recover VM
       - created VM with two data disks
       - destroyed VM (without expunge) along with one data disk
       - recovered VM, VM successfully came up with other data disk which is not selected to delete
2.  VM destroy with expunge
       - created VM with two data disks
       - destroyed VM with expunge
       - VM expunged successfully and two data disks were detached and ready to use for other VMs
3. VM destroy with expunge and leave a data disk not to delete
       - created VM with two data disks
       - destroy VM with expunge and select only data disk to delete
       - VM expunged successfully and one data disk is deleted and other data disk was detached and ready to use for other VMs
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
