### PR TITLE
Adding cpuallocated percentage and value to host and hostsformigrationresponse

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
@@ -95,9 +95,18 @@ public class HostForMigrationResponse extends BaseResponse {
     @Param(description = "the CPU speed of the host")
     private Long cpuSpeed;
 
+    @Deprecated
     @SerializedName("cpuallocated")
     @Param(description = "the amount of the host's CPU currently allocated")
     private String cpuAllocated;
+
+    @SerializedName("cpuallocatedvalue")
+    @Param(description = "the amount of the host's CPU currently allocated in MHz")
+    private Long cpuAllocatedValue;
+
+    @SerializedName("cpuallocatedpercentage")
+    @Param(description = "the amount of the host's CPU currently allocated in percentage")
+    private String cpuAllocatedPercentage;
 
     @SerializedName("cpuallocatedwithoverprovisioning")
     @Param(description = "the amount of the host's CPU currently allocated after applying the cpu.overprovisioning.factor")
@@ -305,6 +314,14 @@ public class HostForMigrationResponse extends BaseResponse {
 
     public void setCpuAllocated(String cpuAllocated) {
         this.cpuAllocated = cpuAllocated;
+    }
+
+    public void setCpuAllocatedValue(Long cpuAllocatedValue) {
+        this.cpuAllocatedValue = cpuAllocatedValue;
+    }
+
+    public void setCpuAllocatedPercentage(String cpuAllocatedPercentage) {
+        this.cpuAllocatedPercentage = cpuAllocatedPercentage;
     }
 
     public void setCpuAllocatedWithOverprovisioning(String cpuAllocatedWithOverprovisioning) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
@@ -99,6 +99,10 @@ public class HostForMigrationResponse extends BaseResponse {
     @Param(description = "the amount of the host's CPU currently allocated")
     private String cpuAllocated;
 
+    @SerializedName("cpuallocatedwithoverprovisioning")
+    @Param(description = "the amount of the host's CPU currently allocated after applying the cpu.overprovisioning.factor")
+    private String cpuAllocatedWithOverprovisioning;
+
     @SerializedName("cpuused")
     @Param(description = "the amount of the host's CPU currently used")
     private String cpuUsed;
@@ -301,6 +305,10 @@ public class HostForMigrationResponse extends BaseResponse {
 
     public void setCpuAllocated(String cpuAllocated) {
         this.cpuAllocated = cpuAllocated;
+    }
+
+    public void setCpuAllocatedWithOverprovisioning(String cpuAllocatedWithOverprovisioning) {
+        this.cpuAllocatedWithOverprovisioning = cpuAllocatedWithOverprovisioning;
     }
 
     public void setCpuUsed(String cpuUsed) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -103,9 +103,18 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the CPU speed of the host")
     private Long cpuSpeed;
 
+    @Deprecated
     @SerializedName("cpuallocated")
     @Param(description = "the amount of the host's CPU currently allocated")
     private String cpuAllocated;
+
+    @SerializedName("cpuallocatedvalue")
+    @Param(description = "the amount of the host's CPU currently allocated in MHz")
+    private Long cpuAllocatedValue;
+
+    @SerializedName("cpuallocatedpercentage")
+    @Param(description = "the amount of the host's CPU currently allocated in percentage")
+    private String cpuAllocatedPercentage;
 
     @SerializedName("cpuallocatedwithoverprovisioning")
     @Param(description = "the amount of the host's CPU currently allocated after applying the cpu.overprovisioning.factor")
@@ -344,6 +353,14 @@ public class HostResponse extends BaseResponse {
 
     public void setCpuAllocated(String cpuAllocated) {
         this.cpuAllocated = cpuAllocated;
+    }
+
+    public void setCpuAllocatedValue(Long cpuAllocatedValue) {
+        this.cpuAllocatedValue = cpuAllocatedValue;
+    }
+
+    public void setCpuAllocatedPercentage(String cpuAllocatedPercentage) {
+        this.cpuAllocatedPercentage = cpuAllocatedPercentage;
     }
 
     public void setCpuAllocatedWithOverprovisioning(String cpuAllocatedWithOverprovisioning) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -107,12 +107,16 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the amount of the host's CPU currently allocated")
     private String cpuAllocated;
 
+    @SerializedName("cpuallocatedwithoverprovisioning")
+    @Param(description = "the amount of the host's CPU currently allocated after applying the cpu.overprovisioning.factor")
+    private String cpuAllocatedWithOverprovisioning;
+
     @SerializedName("cpuused")
     @Param(description = "the amount of the host's CPU currently used")
     private String cpuUsed;
 
     @SerializedName("cpuwithoverprovisioning")
-    @Param(description = "the amount of the host's CPU after applying the cpu.overprovisioning.factor ")
+    @Param(description = "the amount of the host's CPU after applying the cpu.overprovisioning.factor")
     private String cpuWithOverprovisioning;
 
     @SerializedName(ApiConstants.CPU_LOAD_AVERAGE)
@@ -340,6 +344,10 @@ public class HostResponse extends BaseResponse {
 
     public void setCpuAllocated(String cpuAllocated) {
         this.cpuAllocated = cpuAllocated;
+    }
+
+    public void setCpuAllocatedWithOverprovisioning(String cpuAllocatedWithOverprovisioning) {
+        this.cpuAllocatedWithOverprovisioning = cpuAllocatedWithOverprovisioning;
     }
 
     public void setCpuUsed(String cpuUsed) {

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -193,8 +193,10 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
 
                 hostResponse.setHypervisorVersion(host.getHypervisorVersion());
 
+                hostResponse.setCpuAllocatedValue(cpu);
                 String cpuAlloc = decimalFormat.format(((float)cpu / (float)(host.getCpus() * host.getSpeed())) * 100f) + "%";
                 hostResponse.setCpuAllocated(cpuAlloc);
+                hostResponse.setCpuAllocatedPercentage(cpuAlloc);
                 float cpuWithOverprovisioning = host.getCpus() * host.getSpeed() * ApiDBUtils.getCpuOverprovisioningFactor(host.getClusterId());
                 hostResponse.setCpuAllocatedWithOverprovisioning(calculateResourceAllocatedPercentage(cpu, cpuWithOverprovisioning));
                 hostResponse.setCpuWithOverprovisioning(decimalFormat.format(cpuWithOverprovisioning));
@@ -347,8 +349,10 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
 
                 hostResponse.setHypervisorVersion(host.getHypervisorVersion());
 
+                hostResponse.setCpuAllocatedValue(cpu);
                 String cpuAlloc = decimalFormat.format(((float)cpu / (float)(host.getCpus() * host.getSpeed())) * 100f) + "%";
                 hostResponse.setCpuAllocated(cpuAlloc);
+                hostResponse.setCpuAllocatedPercentage(cpuAlloc);
                 float cpuWithOverprovisioning = host.getCpus() * host.getSpeed() * ApiDBUtils.getCpuOverprovisioningFactor(host.getClusterId());
                 hostResponse.setCpuAllocatedWithOverprovisioning(calculateResourceAllocatedPercentage(cpu, cpuWithOverprovisioning));
                 hostResponse.setCpuWithOverprovisioning(decimalFormat.format(cpuWithOverprovisioning));

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -193,8 +193,10 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
 
                 hostResponse.setHypervisorVersion(host.getHypervisorVersion());
 
+                String cpuAlloc = decimalFormat.format(((float)cpu / (float)(host.getCpus() * host.getSpeed())) * 100f) + "%";
+                hostResponse.setCpuAllocated(cpuAlloc);
                 float cpuWithOverprovisioning = host.getCpus() * host.getSpeed() * ApiDBUtils.getCpuOverprovisioningFactor(host.getClusterId());
-                hostResponse.setCpuAllocated(calculateResourceAllocatedPercentage(cpu, cpuWithOverprovisioning));
+                hostResponse.setCpuAllocatedWithOverprovisioning(calculateResourceAllocatedPercentage(cpu, cpuWithOverprovisioning));
                 hostResponse.setCpuWithOverprovisioning(decimalFormat.format(cpuWithOverprovisioning));
             }
 
@@ -345,8 +347,10 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
 
                 hostResponse.setHypervisorVersion(host.getHypervisorVersion());
 
+                String cpuAlloc = decimalFormat.format(((float)cpu / (float)(host.getCpus() * host.getSpeed())) * 100f) + "%";
+                hostResponse.setCpuAllocated(cpuAlloc);
                 float cpuWithOverprovisioning = host.getCpus() * host.getSpeed() * ApiDBUtils.getCpuOverprovisioningFactor(host.getClusterId());
-                hostResponse.setCpuAllocated(calculateResourceAllocatedPercentage(cpu, cpuWithOverprovisioning));
+                hostResponse.setCpuAllocatedWithOverprovisioning(calculateResourceAllocatedPercentage(cpu, cpuWithOverprovisioning));
                 hostResponse.setCpuWithOverprovisioning(decimalFormat.format(cpuWithOverprovisioning));
             }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/4488

Deprecates `cpuallocated` and adds a new field `cpuallocatedwithoverprovisoning` which considers overprovisioning.
Also adds `cpuallocatedpercentage` and `cpuallocatedvalue` to provide clearer metrics

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

```
(localhost) 🐱 > list hosts filter=cpuallocatedvalue,cpuallocatedpercentage,cpuallocatedwithoverprovisioning,cpuallocated, type=Routing clusterid=56d84816-7594-49ba-99fd-d5c647fb4890
{
  "count": 2,
  "host": [
    {
      "cpuallocated": "1.56%",
      "cpuallocatedpercentage": "1.56%",
      "cpuallocatedvalue": 500,
      "cpuallocatedwithoverprovisioning": "0.78%"
    },
    {
      "cpuallocated": "6.25%",
      "cpuallocatedpercentage": "6.25%",
      "cpuallocatedvalue": 2000,
      "cpuallocatedwithoverprovisioning": "3.12%"
    }
  ]
}


(localhost) 🐱 > find hostsformigration virtualmachineid=a4dfcf94-76b5-41fc-9ceb-424f0eff5427  filter=cpuallocatedvalue,cpuallocatedpercentage,cpuallocatedwithoverprovisioning,cpuallocated, type=Routing
{
  "count": 2,
  "host": [
    {
      "cpuallocated": "1.56%",
      "cpuallocatedpercentage": "1.56%",
      "cpuallocatedvalue": 500,
      "cpuallocatedwithoverprovisioning": "0.78%"
    }
  ]
}

```