### PR TITLE
Adding zone name to physicalnetworkresponse

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/PhysicalNetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/PhysicalNetworkResponse.java
@@ -47,6 +47,10 @@ public class PhysicalNetworkResponse extends BaseResponse {
     @Param(description = "zone id of the physical network")
     private String zoneId;
 
+    @SerializedName(ApiConstants.ZONE_NAME)
+    @Param(description = "zone name of the physical network")
+    private String zoneName;
+
     @SerializedName(ApiConstants.STATE)
     @Param(description = "state of the physical network")
     private String state;
@@ -83,6 +87,10 @@ public class PhysicalNetworkResponse extends BaseResponse {
 
     public void setZoneId(String zoneId) {
         this.zoneId = zoneId;
+    }
+
+    public void setZoneName(String zoneName) {
+        this.zoneName = zoneName;
     }
 
     public void setState(String state) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2545,6 +2545,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         DataCenter zone = ApiDBUtils.findZoneById(result.getDataCenterId());
         if (zone != null) {
             response.setZoneId(zone.getUuid());
+            response.setZoneName(zone.getName());
         }
         response.setNetworkSpeed(result.getSpeed());
         response.setVlan(result.getVnetString());


### PR DESCRIPTION
### Description

Adding zone name to physicalnetworkresponse which looks better on the UI

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


### Screenshots (if appropriate):

### Before : 
![Screenshot from 2020-12-01 12-19-12](https://user-images.githubusercontent.com/8244774/100706700-72ab2e00-33cf-11eb-80e5-8e0f529a32b9.png)

### After :
![Screenshot from 2020-12-01 12-18-23](https://user-images.githubusercontent.com/8244774/100706625-5909e680-33cf-11eb-809c-4aa1bf30bbd6.png)


### How Has This Been Tested?
```
(localhost) 🐱 > list physicalnetworks 
{
  "count": 1,
  "physicalnetwork": [
    {
      "broadcastdomainrange": "ZONE",
      "id": "580b516c-f1fa-4fc4-949c-42381a394287",
      "isolationmethods": "VLAN",
      "name": "Sandbox-pnet",
      "state": "Enabled",
      "vlan": "100-200",
      "zoneid": "ee54cb21-c2e2-4757-bb4a-a2e16a4c2516",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```