### PR TITLE
listphysicalnetworks: Honouring keyword parameter

### DIFF
--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -3068,6 +3068,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
             sc.addAnd("name", SearchCriteria.Op.LIKE, "%" + name + "%");
         }
 
+        if (keyword != null) {
+            sc.addAnd("name", SearchCriteria.Op.LIKE, "%" + keyword + "%");
+        }
+
         Pair<List<PhysicalNetworkVO>, Integer> result = _physicalNetworkDao.searchAndCount(sc, searchFilter);
         return new Pair<List<? extends PhysicalNetwork>, Integer>(result.first(), result.second());
     }


### PR DESCRIPTION
### Description

The listPhysicalNetworks API does not consider `keyword`. This PR fixes it
Required since the UI uses keyword for searches

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### How Has This Been Tested?

### Before :
```
(localhost) 🐱 > list physicalnetworks filter=name, keyword=net2
{
  "count": 2,
  "physicalnetwork": [
    {
      "name": "Sandbox-pnet"
    },
    {
      "name": "phynet2"
    }
  ]
}

```

### After :
```
(localhost) 🐱 > list physicalnetworks filter=name, keyword=net2
{
  "count": 1,
  "physicalnetwork": [
    {
      "name": "phynet2"
    }
  ]
}

```