### PR TITLE
VPC VR: fix Conflicting device id on private gw nic when restart vpc with cleanup

### DIFF
--- a/api/src/main/java/com/cloud/vm/NicProfile.java
+++ b/api/src/main/java/com/cloud/vm/NicProfile.java
@@ -173,6 +173,10 @@ public class NicProfile implements InternalIdentity, Serializable {
         this.deviceId = deviceId;
     }
 
+    public void setDeviceId(Integer deviceId) {
+        this.deviceId = deviceId;
+    }
+
     public String getName() {
         return name;
     }

--- a/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
@@ -85,6 +85,7 @@ public class NicProfileHelperImpl implements NicProfileHelper {
                     new NicProfile(privateNic, privateNetwork, privateNic.getBroadcastUri(), privateNic.getIsolationUri(), _networkModel.getNetworkRate(
                             privateNetwork.getId(), router.getId()), _networkModel.isSecurityGroupSupportedInNetwork(privateNetwork), _networkModel.getNetworkTag(
                                     router.getHypervisorType(), privateNetwork));
+            privateNicProfile.setDeviceId(null);
 
             if (router.getIsRedundantRouter()) {
               String newMacAddress = NetUtils.long2Mac(NetUtils.createSequenceBasedMacAddress(ipVO.getMacAddress(), NetworkModel.MACIdentifier.value()));

--- a/test/integration/component/test_multiple_subnets_in_isolated_network.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network.py
@@ -429,7 +429,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 6. create new public ip range 1
         self.services["publiciprange"]["zoneid"] = self.zone.id
         self.services["publiciprange"]["forvirtualnetwork"] = "true"
-        random_subnet_number = random.randrange(10,20)
+        random_subnet_number = random.randrange(10,50)
         self.services["publiciprange"]["vlan"] = get_free_vlan(
             self.apiclient,
             self.zone.id)[1]

--- a/test/integration/component/test_multiple_subnets_in_isolated_network.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network.py
@@ -753,7 +753,8 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 20. reboot router
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
         #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
-        for router in routers:
+        if len(routers) > 0:
+            router = routers[0]
             cmd = rebootRouter.rebootRouterCmd()
             cmd.id = router.id
             self.apiclient.rebootRouter(cmd)

--- a/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
@@ -429,7 +429,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 6. create new public ip range 1
         self.services["publiciprange"]["zoneid"] = self.zone.id
         self.services["publiciprange"]["forvirtualnetwork"] = "true"
-        random_subnet_number = random.randrange(10,20)
+        random_subnet_number = random.randrange(10,50)
         self.services["publiciprange"]["vlan"] = get_free_vlan(
             self.apiclient,
             self.zone.id)[1]

--- a/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
@@ -753,7 +753,8 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 20. reboot router
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,"
         #   verify the IPs in VR. eth0 -> guest nic, eth2 -> source nat IP, eth3 -> new ip 6
-        for router in routers:
+        if len(routers) > 0:
+            router = routers[0]
             cmd = rebootRouter.rebootRouterCmd()
             cmd.id = router.id
             self.apiclient.rebootRouter(cmd)

--- a/test/integration/component/test_multiple_subnets_in_vpc.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc.py
@@ -902,7 +902,8 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         routers = self.get_vpc_routers(self.vpc1.id)
-        for router in routers:
+        if len(routers) > 0:
+            router = routers[0]
             cmd = rebootRouter.rebootRouterCmd()
             cmd.id = router.id
             self.apiclient.rebootRouter(cmd)

--- a/test/integration/component/test_multiple_subnets_in_vpc.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc.py
@@ -328,13 +328,13 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6, eth3-> private gateway
         # 24. reboot router
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         # 25. restart VPC with cleanup
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         # 26. restart VPC with cleanup, makeredundant=true
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         """
 
         # Create new domain1
@@ -479,7 +479,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 6. create new public ip range 1
         self.services["publiciprange"]["zoneid"] = self.zone.id
         self.services["publiciprange"]["forvirtualnetwork"] = "true"
-        random_subnet_number = random.randrange(10,20)
+        random_subnet_number = random.randrange(10,50)
         self.services["publiciprange"]["vlan"] = get_free_vlan(
             self.apiclient,
             self.zone.id)[1]
@@ -900,7 +900,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
 
         # 24. reboot router
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         routers = self.get_vpc_routers(self.vpc1.id)
         if len(routers) > 0:
             router = routers[0]
@@ -914,14 +914,14 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth2", True)
-            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth3", True)
-            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth4", True)
+            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth3", True)
+            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth4", True)
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
-            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
+            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth3")
 
         # 25. restart VPC with cleanup
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
@@ -931,14 +931,14 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth2", True)
-            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth3", True)
-            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth4", True)
+            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth3", True)
+            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth4", True)
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
-            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
+            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth3")
 
         # 26. restart VPC with cleanup, makeredundant=true
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True, makeredundant=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
@@ -948,7 +948,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth2", True)
-            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth3", True)
-            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth4", True)
+            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth3", True)
+            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth4", True)
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
-            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
+            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth3")

--- a/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
@@ -902,7 +902,8 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
         routers = self.get_vpc_routers(self.vpc1.id)
-        for router in routers:
+        if len(routers) > 0:
+            router = routers[0]
             cmd = rebootRouter.rebootRouterCmd()
             cmd.id = router.id
             self.apiclient.rebootRouter(cmd)

--- a/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
@@ -328,13 +328,13 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> tier 1, eth4 -> tier 2, eth5 -> new ip 6, eth3-> private gateway
         # 24. reboot router
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         # 25. restart VPC with cleanup
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         # 26. restart VPC with cleanup, makeredundant=true
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         """
 
         # Create new domain1
@@ -479,7 +479,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
         # 6. create new public ip range 1
         self.services["publiciprange"]["zoneid"] = self.zone.id
         self.services["publiciprange"]["forvirtualnetwork"] = "true"
-        random_subnet_number = random.randrange(10,20)
+        random_subnet_number = random.randrange(10,50)
         self.services["publiciprange"]["vlan"] = get_free_vlan(
             self.apiclient,
             self.zone.id)[1]
@@ -900,7 +900,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
 
         # 24. reboot router
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         routers = self.get_vpc_routers(self.vpc1.id)
         if len(routers) > 0:
             router = routers[0]
@@ -914,14 +914,14 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth2", True)
-            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth3", True)
-            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth4", True)
+            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth3", True)
+            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth4", True)
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
-            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
+            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth3")
 
         # 25. restart VPC with cleanup
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
@@ -931,14 +931,14 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth2", True)
-            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth3", True)
-            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth4", True)
+            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth3", True)
+            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth4", True)
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
-            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
+            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth3")
 
         # 26. restart VPC with cleanup, makeredundant=true
         #   verify the available nics in VR should be "eth0,eth1,eth2,eth3,eth4,eth5,"
-        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> tier 1, eth4 -> private gateway, eth5 -> tier 2
+        #   verify the IPs in VR. eth1 -> source nat IP, eth2 -> new ip 6, eth3 -> private gateway, eth4 -> tier 1, eth5 -> tier 2
         self.vpc1.restart(self.apiclient, cleanup=True, makeredundant=True)
         routers = self.get_vpc_routers(self.vpc1.id)
         for router in routers:
@@ -948,7 +948,7 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.verify_ip_address_in_router(router, host, controlIp, "eth0", True)
             self.verify_ip_address_in_router(router, host, sourcenatIp, "eth1", True)
             self.verify_ip_address_in_router(router, host, ipaddress_6.ipaddress.ipaddress, "eth2", True)
-            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth3", True)
-            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth4", True)
+            self.verify_ip_address_in_router(router, host, private_gateway_ip, "eth3", True)
+            self.verify_ip_address_in_router(router, host, tier1_Ip, "eth4", True)
             self.verify_ip_address_in_router(router, host, tier2_Ip, "eth5", True)
-            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth4")
+            self.verify_router_publicnic_state(router, host, "eth1|eth2|eth3")

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -1054,6 +1054,11 @@ def get_free_vlan(apiclient, zoneid):
         usedVlanIds = [int(nw.vlan)
                        for nw in networks if (nw.vlan and str(nw.vlan).lower() != "untagged")]
 
+    ipranges = list_vlan_ipranges(apiclient, zoneid=zoneid)
+    if isinstance(ipranges, list) and len(ipranges) > 0:
+        usedVlanIds += [int(iprange.vlan.split("/")[-1])
+                        for iprange in ipranges if (iprange.vlan and iprange.vlan.split("/")[-1].lower() != "untagged")]
+
     if not hasattr(physical_network, "vlan"):
         while True:
             shared_ntwk_vlan = random.randrange(1, 4095)


### PR DESCRIPTION
### Description

Some issues with vpc vr have been fixed in #4484
This PR fixes the last two issues we found in our testing.

We run the the integration tests in test/integration/component/test_multiple_subnets*.py many times (>20) , all are SUCCESSFUL.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity


#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
