### PR TITLE
Fix hypervisor type cast to string

### DIFF
--- a/engine/storage/integration-test/src/test/java/org/apache/cloudstack/storage/test/VolumeServiceTest.java
+++ b/engine/storage/integration-test/src/test/java/org/apache/cloudstack/storage/test/VolumeServiceTest.java
@@ -276,6 +276,7 @@ public class VolumeServiceTest extends CloudStackTestNGBase {
         params.put("path", uri.getPath());
         params.put("protocol", StoragePoolType.NetworkFilesystem);
         params.put("dcId", dcId.toString());
+        params.put("hypervisorType", HypervisorType.None);
         params.put("clusterId", clusterId.toString());
         params.put("name", this.primaryName);
         params.put("port", "1");
@@ -318,6 +319,7 @@ public class VolumeServiceTest extends CloudStackTestNGBase {
             params.put("path", uri.getPath());
             params.put("protocol", Storage.StoragePoolType.NetworkFilesystem);
             params.put("dcId", dcId.toString());
+            params.put("hypervisorType", HypervisorType.None);
             params.put("clusterId", clusterId.toString());
             params.put("name", this.primaryName);
             params.put("port", "1");

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
@@ -249,7 +249,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
             parameters.setPath(hostPath.replaceFirst("/", ""));
             parameters.setUserInfo(userInfo);
         } else if (scheme.equalsIgnoreCase("PreSetup")) {
-            if (hypervisorType.equals(HypervisorType.VMware)) {
+            if (HypervisorType.VMware.equals(hypervisorType)) {
                 validateVcenterDetails(zoneId, podId, clusterId,storageHost);
             }
             parameters.setType(StoragePoolType.PreSetup);

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
@@ -337,7 +337,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
             uuid = (String)existingUuid;
         } else if (scheme.equalsIgnoreCase("sharedmountpoint") || scheme.equalsIgnoreCase("clvm")) {
             uuid = UUID.randomUUID().toString();
-        } else if (scheme.equalsIgnoreCase("PreSetup") && !hypervisorType.equals(HypervisorType.VMware)) {
+        } else if ("PreSetup".equalsIgnoreCase(scheme) && !HypervisorType.VMware.equals(hypervisorType)) {
             uuid = hostPath.replace("/", "");
         } else {
             uuid = UUID.nameUUIDFromBytes((storageHost + hostPath).getBytes()).toString();

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
@@ -257,7 +257,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
             parameters.setPort(0);
             parameters.setPath(hostPath);
         } else if (scheme.equalsIgnoreCase("DatastoreCluster")) {
-            if (hypervisorType.equals(HypervisorType.VMware)) {
+            if (HypervisorType.VMware.equals(hypervisorType)) {
                 validateVcenterDetails(zoneId, podId, clusterId,storageHost);
             }
             parameters.setType(StoragePoolType.DatastoreCluster);

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/CloudStackPrimaryDataStoreLifeCycleImpl.java
@@ -64,7 +64,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.volume.datastore.PrimaryDataStoreHelper;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import javax.inject.Inject;
@@ -132,7 +131,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
         Long zoneId = (Long)dsInfos.get("zoneId");
         String url = (String)dsInfos.get("url");
         String providerName = (String)dsInfos.get("providerName");
-        String hypervisorType = (String)dsInfos.get("hypervisorType");
+        HypervisorType hypervisorType = (HypervisorType)dsInfos.get("hypervisorType");
         if (clusterId != null && podId == null) {
             throw new InvalidParameterValueException("Cluster id requires pod id");
         }
@@ -250,7 +249,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
             parameters.setPath(hostPath.replaceFirst("/", ""));
             parameters.setUserInfo(userInfo);
         } else if (scheme.equalsIgnoreCase("PreSetup")) {
-            if (StringUtils.isNotBlank(hypervisorType) && HypervisorType.getType(hypervisorType).equals(HypervisorType.VMware)) {
+            if (hypervisorType.equals(HypervisorType.VMware)) {
                 validateVcenterDetails(zoneId, podId, clusterId,storageHost);
             }
             parameters.setType(StoragePoolType.PreSetup);
@@ -258,7 +257,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
             parameters.setPort(0);
             parameters.setPath(hostPath);
         } else if (scheme.equalsIgnoreCase("DatastoreCluster")) {
-            if (StringUtils.isNotBlank(hypervisorType) && HypervisorType.getType(hypervisorType).equals(HypervisorType.VMware)) {
+            if (hypervisorType.equals(HypervisorType.VMware)) {
                 validateVcenterDetails(zoneId, podId, clusterId,storageHost);
             }
             parameters.setType(StoragePoolType.DatastoreCluster);
@@ -338,7 +337,7 @@ public class CloudStackPrimaryDataStoreLifeCycleImpl implements PrimaryDataStore
             uuid = (String)existingUuid;
         } else if (scheme.equalsIgnoreCase("sharedmountpoint") || scheme.equalsIgnoreCase("clvm")) {
             uuid = UUID.randomUUID().toString();
-        } else if (scheme.equalsIgnoreCase("PreSetup") && !(StringUtils.isNotBlank(hypervisorType) && HypervisorType.getType(hypervisorType).equals(HypervisorType.VMware))) {
+        } else if (scheme.equalsIgnoreCase("PreSetup") && !hypervisorType.equals(HypervisorType.VMware)) {
             uuid = hostPath.replace("/", "");
         } else {
             uuid = UUID.nameUUIDFromBytes((storageHost + hostPath).getBytes()).toString();

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -722,7 +722,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         params.put("zoneId", zone.getId());
         params.put("clusterId", clusterId);
         params.put("podId", podId);
-        params.put("hypervisorType", hypervisorType.toString());
+        params.put("hypervisorType", hypervisorType);
         params.put("url", cmd.getUrl());
         params.put("tags", cmd.getTags());
         params.put("name", cmd.getStoragePoolName());


### PR DESCRIPTION
### Description

This PR addresses an error that appears when you try to add a new host. I don't even understand why there was a cast to String in the first place. I will assume some classes send HypervisorType and some send a string (empty or otherwise). Shouldn't this be addressed to use the same type everywhere? With this fix adding a new xenserver host works fine.

Here is the stack trace:

> WARN  [c.c.s.StorageManagerImpl] (AgentTaskPool-6:ctx-90ed1f24) (logid:77e97d5e) Unable to setup the local storage pool for Host[-4-Routing]
java.lang.ClassCastException: class com.cloud.hypervisor.Hypervisor$HypervisorType cannot be cast to class java.lang.String (com.cloud.hypervisor.Hypervisor$HypervisorType is in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @3f69b166; java.lang.String is 
in module java.base of loader 'bootstrap')
        at org.apache.cloudstack.storage.datastore.lifecycle.CloudStackPrimaryDataStoreLifeCycleImpl.initialize(CloudStackPrimaryDataStoreLifeCycleImpl.java:135)
        at com.cloud.storage.StorageManagerImpl.createLocalStorage(StorageManagerImpl.java:627)
        ...
INFO  [c.c.u.e.CSExceptionErrorCode] (AgentTaskPool-6:ctx-90ed1f24) (logid:77e97d5e) Could not find exception: com.cloud.exception.ConnectionException in error code list for exceptions
WARN  [c.c.a.m.AgentManagerImpl] (AgentTaskPool-6:ctx-90ed1f24) (logid:77e97d5e) Monitor LocalStoragePoolListener says there is an error in the connect process for 4 due to Unable to setup the local storage pool for Host[-4-Routing]
INFO  [c.c.a.m.AgentManagerImpl] (AgentTaskPool-6:ctx-90ed1f24) (logid:77e97d5e) Host 4 is disconnecting with event AgentDisconnected
WARN  [c.c.r.ResourceManagerImpl] (AgentTaskPool-6:ctx-90ed1f24) (logid:77e97d5e) Unable to connect due to
com.cloud.exception.ConnectionException: Unable to setup the local storage pool for Host[-4-Routing]
        at com.cloud.storage.StorageManagerImpl.createLocalStorage(StorageManagerImpl.java:640)
        ...
Caused by: java.lang.ClassCastException: class com.cloud.hypervisor.Hypervisor$HypervisorType cannot be cast to class java.lang.String (com.cloud.hypervisor.Hypervisor$HypervisorType is in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @3f69b166; java.lang.String is in module java.base of loader 'bootstrap')
        at org.apache.cloudstack.storage.datastore.lifecycle.CloudStackPrimaryDataStoreLifeCycleImpl.initialize(CloudStackPrimaryDataStoreLifeCycleImpl.java:135)
        at com.cloud.storage.StorageManagerImpl.createLocalStorage(StorageManagerImpl.java:627)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        ... 35 more

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
Create a basic cloudstack development build (more or less following the installation guide, no oss), try to add a new host with **local storage** (I assume any virtualization type, but the code itself is fishy. I imagine it worked fine for whoever added this bit when he tested with VMware otherwise he would have not sent the patch) and you get this error. I tested with xenserver.