### PR TITLE
change debug to warn for unknown exceptions

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -369,7 +369,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
             s_logger.warn("Unable to resolve the host name", e);
             return null;
         } catch (Exception e) {
-            s_logger.debug("other exceptions: " + e.toString(), e);
+            s_logger.warn("other exceptions: " + e.toString(), e);
             return null;
         }
         return resources;


### PR DESCRIPTION
This will make unknown errors more readily available in log, debug flag no longer being required in this case.

Fixes #4520 