### PR TITLE
Display lb rule name instead of uuid

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/network/ssl/CertServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/network/ssl/CertServiceImpl.java
@@ -169,14 +169,14 @@ public class CertServiceImpl implements CertService {
         final List<LoadBalancerCertMapVO> lbCertRule = _lbCertDao.listByCertId(certId);
 
         if (lbCertRule != null && !lbCertRule.isEmpty()) {
-            String lbUuids = "";
+            StringBuilder lbNames = new StringBuilder();
 
             for (final LoadBalancerCertMapVO rule : lbCertRule) {
                 final LoadBalancerVO lb = _entityMgr.findById(LoadBalancerVO.class, rule.getLbId());
-                lbUuids += " " + lb.getUuid();
+                lbNames.append(lb.getName()).append(" ");
             }
 
-            throw new CloudRuntimeException("Certificate in use by a loadbalancer(s)" + lbUuids);
+            throw new CloudRuntimeException("Certificate in use by a loadbalancer(s) " + lbNames.toString());
         }
 
         _sslCertDao.remove(certId);
@@ -311,9 +311,8 @@ public class CertServiceImpl implements CertService {
             {
                 response.setProjectId(project.getUuid());
                 response.setProjectName(project.getName());
-            } else {
-                response.setAccountName(account.getAccountName());
             }
+            response.setAccountName(account.getAccountName());
         } else {
             response.setAccountName(account.getAccountName());
         }


### PR DESCRIPTION
### Description
Display proper error message while deleting ssl cert which is
associated with a load balancer rule

Also display account name to which lb belongs to

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):
Before fix

![Screenshot 2020-12-07 at 12 21 30](https://user-images.githubusercontent.com/10645273/101496378-fd5cd180-3969-11eb-919e-132592467b69.png)


After fix

![Screenshot 2020-12-07 at 13 29 25](https://user-images.githubusercontent.com/10645273/101496401-03eb4900-396a-11eb-882a-14a2a417e275.png)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
