### PR TITLE
xenserver: check and eject patch vbd for systemvms

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1502,6 +1502,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                         if (!vbd.getEmpty(conn)) {
                             vbd.eject(conn);
                         }
+                        vbd.unplug(conn);
                         vbd.destroy(conn);
                         break;
                     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1063,33 +1063,43 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         }
     }
 
+    public SR findPatchIsoSR(final Connection conn) throws XmlRpcException, XenAPIException {
+        Set<SR> srs = SR.getByNameLabel(conn, "XenServer Tools");
+        if (srs.size() != 1) {
+            s_logger.debug("Failed to find SR by name 'XenServer Tools', will try to find 'XCP-ng Tools' SR");
+            srs = SR.getByNameLabel(conn, "XCP-ng Tools");
+        }
+        if (srs.size() != 1) {
+            s_logger.debug("Failed to find SR by name 'XenServer Tools' or 'XCP-ng Tools', will try to find 'Citrix Hypervisor' SR");
+            srs = SR.getByNameLabel(conn, "Citrix Hypervisor Tools");
+        }
+        if (srs.size() != 1) {
+            throw new CloudRuntimeException("There are " + srs.size() + " SRs with name XenServer Tools or XCP-ng Tools or Citrix Hypervisor Tools");
+        }
+        final SR sr = srs.iterator().next();
+        sr.scan(conn);
+        return sr;
+    }
+
+    public VDI findPatchIsoVDI(final Connection conn, final SR sr) throws XmlRpcException, XenAPIException {
+        final SR.Record srr = sr.getRecord(conn);
+        for (final VDI vdi : srr.VDIs) {
+            final VDI.Record vdir = vdi.getRecord(conn);
+            if (vdir.nameLabel.contains("systemvm.iso")) {
+                return vdi;
+            }
+        }
+        return null;
+    }
+
     public VBD createPatchVbd(final Connection conn, final String vmName, final VM vm) throws XmlRpcException, XenAPIException {
 
         if (_host.getSystemvmisouuid() == null) {
-            Set<SR> srs = SR.getByNameLabel(conn, "XenServer Tools");
-            if (srs.size() != 1) {
-                s_logger.debug("Failed to find SR by name 'XenServer Tools', will try to find 'XCP-ng Tools' SR");
-                srs = SR.getByNameLabel(conn, "XCP-ng Tools");
-            }
-            if (srs.size() != 1) {
-                s_logger.debug("Failed to find SR by name 'XenServer Tools' or 'XCP-ng Tools', will try to find 'Citrix Hypervisor' SR");
-                srs = SR.getByNameLabel(conn, "Citrix Hypervisor Tools");
-            }
-            if (srs.size() != 1) {
-                throw new CloudRuntimeException("There are " + srs.size() + " SRs with name XenServer Tools or XCP-ng Tools or Citrix Hypervisor Tools");
-            }
-            final SR sr = srs.iterator().next();
-            sr.scan(conn);
-
-            final SR.Record srr = sr.getRecord(conn);
-
+            final SR sr = findPatchIsoSR(conn);
             if (_host.getSystemvmisouuid() == null) {
-                for (final VDI vdi : srr.VDIs) {
-                    final VDI.Record vdir = vdi.getRecord(conn);
-                    if (vdir.nameLabel.contains("systemvm.iso")) {
-                        _host.setSystemvmisouuid(vdir.uuid);
-                        break;
-                    }
+                final VDI vdi = findPatchIsoVDI(conn, sr);
+                if (vdi != null) {
+                    _host.setSystemvmisouuid(vdi.getRecord(conn).uuid);
                 }
             }
             if (_host.getSystemvmisouuid() == null) {
@@ -1489,31 +1499,31 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         return result;
     }
 
-    public void ejectPatchVbd(final Connection conn, final Host host) {
-        try {
-            final Set<VM> vms = host.getResidentVMs(conn);
-            for (final VM vm : vms) {
-                destroyPatchVbd(conn, vm);
-            }
-        } catch (XenAPIException | XmlRpcException ignored) {}
-    }
-
-    public void destroyPatchVbd(final Connection conn, final VM vm) throws XmlRpcException, XenAPIException {
-        final String vmName = vm.getNameLabel(conn);
-        try {
-            if (!vmName.startsWith("r-") && !vmName.startsWith("s-") && !vmName.startsWith("v-")) {
-                return;
-            }
-            final Set<VBD> vbds = vm.getVBDs(conn);
-            for (final VBD vbd : vbds) {
-                if (Types.VbdType.CD.equals(vbd.getType(conn))) {
-                    vbd.eject(conn);
-                    vbd.destroy(conn);
-                    break;
+    public void destroyPatchVbd(final Connection conn, final Set<VM> vms) throws XmlRpcException, XenAPIException {
+        final SR sr = findPatchIsoSR(conn);
+        final VDI patchVDI = findPatchIsoVDI(conn, sr);
+        for (final VM vm : vms) {
+            final String vmName = vm.getNameLabel(conn);
+            try {
+                if (!vmName.startsWith("r-") && !vmName.startsWith("s-") && !vmName.startsWith("v-")) {
+                    return;
                 }
+                final Set<VBD> vbds = vm.getVBDs(conn);
+                for (final VBD vbd : vbds) {
+                    if (Types.VbdType.CD.equals(vbd.getType(conn))) {
+                        if (!vbd.getEmpty(conn)) {
+                            vbd.eject(conn);
+                        }
+                        // Workaround for any file descriptor caching issue
+                        vbd.insert(conn, patchVDI);
+                        vbd.eject(conn);
+                        vbd.destroy(conn);
+                        break;
+                    }
+                }
+            } catch (final Exception e) {
+                s_logger.debug("Cannot destroy CD-ROM device for VM " + vmName + " due to " + e.toString(), e);
             }
-        } catch (final Exception e) {
-            s_logger.debug("Cannot destroy CD-ROM device for VM " + vmName + " due to " + e.toString(), e);
         }
     }
 
@@ -4848,9 +4858,6 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                     }
                 }
             }
-
-            // Remove old systemvm.iso from any systemvms
-            ejectPatchVbd(conn, host);
 
             final com.trilead.ssh2.Connection sshConnection = new com.trilead.ssh2.Connection(hr.address, 22);
             try {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1082,6 +1082,9 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     }
 
     public VDI findPatchIsoVDI(final Connection conn, final SR sr) throws XmlRpcException, XenAPIException {
+        if (sr == null) {
+            return null;
+        }
         final SR.Record srr = sr.getRecord(conn);
         for (final VDI vdi : srr.VDIs) {
             final VDI.Record vdir = vdi.getRecord(conn);
@@ -1515,8 +1518,10 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                             vbd.eject(conn);
                         }
                         // Workaround for any file descriptor caching issue
-                        vbd.insert(conn, patchVDI);
-                        vbd.eject(conn);
+                        if (patchVDI != null) {
+                            vbd.insert(conn, patchVDI);
+                            vbd.eject(conn);
+                        }
                         vbd.destroy(conn);
                         break;
                     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1499,7 +1499,9 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                 final Set<VBD> vbds = vm.getVBDs(conn);
                 for (final VBD vbd : vbds) {
                     if (vbd.getType(conn) == Types.VbdType.CD) {
-                        vbd.eject(conn);
+                        if (!vbd.getEmpty(conn)) {
+                            vbd.eject(conn);
+                        }
                         vbd.destroy(conn);
                         break;
                     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixReadyCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixReadyCommandWrapper.java
@@ -55,7 +55,7 @@ public final class CitrixReadyCommandWrapper extends CommandWrapper<ReadyCommand
             final Host host = Host.getByUuid(conn, citrixResourceBase.getHost().getUuid());
             final Set<VM> vms = host.getResidentVMs(conn);
             for (final VM vm : vms) {
-                citrixResourceBase.destroyPatchVbd(conn, vm.getNameLabel(conn));
+                citrixResourceBase.destroyPatchVbd(conn, vm);
             }
         } catch (final Exception e) {
         }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixReadyCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixReadyCommandWrapper.java
@@ -54,9 +54,7 @@ public final class CitrixReadyCommandWrapper extends CommandWrapper<ReadyCommand
         try {
             final Host host = Host.getByUuid(conn, citrixResourceBase.getHost().getUuid());
             final Set<VM> vms = host.getResidentVMs(conn);
-            for (final VM vm : vms) {
-                citrixResourceBase.destroyPatchVbd(conn, vm);
-            }
+            citrixResourceBase.destroyPatchVbd(conn, vms);
         } catch (final Exception e) {
         }
         try {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixSetupCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixSetupCommandWrapper.java
@@ -77,7 +77,6 @@ public final class CitrixSetupCommandWrapper extends CommandWrapper<SetupCommand
 
             }
 
-
             final boolean r = citrixResourceBase.launchHeartBeat(conn);
             if (!r) {
                 return null;


### PR DESCRIPTION
This failed to destroy systemvms patch VBDs that attaches systemvm.iso
on host setup (ready). This will ensure for upgrades old systemvm.iso
files are not cached/used.

XenServer has an file descriptor/tapdisk iso-caching issue where new systemvm.iso are not recognised and inside the VR/ssvm/cpvm file IO error is seen. This was only reproducible with XS7.1, the fix was to check and eject the systemvm.iso (old/stale/cached), then insert the new systemvm.iso and then eject it :facepalm: 

![Screenshot from 2020-12-09 12-25-22](https://user-images.githubusercontent.com/95203/101625663-bc37f080-3a41-11eb-8c82-30e697c0e4ba.png)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial