### PR TITLE
kvm: set cpu topology only if cpucore per socket is set

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -4239,10 +4239,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 numCoresPerSocket = 6;
             } else if (vcpus % 4 == 0) {
                 numCoresPerSocket = 4;
-            } else {
-                numCoresPerSocket = 1;
             }
         }
-        cmd.setTopology(numCoresPerSocket, vcpus / numCoresPerSocket);
+        if (numCoresPerSocket > 0) {
+            cmd.setTopology(numCoresPerSocket, vcpus / numCoresPerSocket);
+        }
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a regression issue in #4497 

In cloudstack 4.14 or before, the cpu topology is set only when cpucore per socket is set (to 4 or 6).
in other conditions, there is no cpu topology in vm xml definition.

with #4497, vm will have cpu topology in its xml definition, if cpucore per socket is not set.
```
    <topology sockets='<vm cpu cores>' cores='1' threads='1'/>
```
Not sure if it causes any issue. I think it would be better not to add this part in vm xml definition if cpucore per socket is not set.

fyi, in https://libvirt.org/formatdomain.html#cpu-model-and-topology, it says
```
topology
The topology element specifies requested topology of virtual CPU provided to the guest. Four attributes, sockets, dies, cores, and threads, accept non-zero positive integer values. They refer to the number of CPU sockets per NUMA node, number of dies per socket, number of cores per die, and number of threads per core, respectively. The dies attribute is optional and will default to 1 if omitted, while the other attributes are all mandatory. Hypervisors may require that the maximum number of vCPUs specified by the cpus element equals to the number of vcpus resulting from the topology.
```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
