### PR TITLE
vr: Ensuring dnsmasq.leases file is populated

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -28,6 +28,7 @@ DHCP_HOSTS = "/etc/dhcphosts.txt"
 DHCP_OPTS = "/etc/dhcpopts.txt"
 CLOUD_CONF = "/etc/dnsmasq.d/cloud.conf"
 
+
 class CsDhcp(CsDataBag):
     """ Manage dhcp entries """
 
@@ -189,9 +190,9 @@ class CsDhcp(CsDataBag):
                                             entry['ipv4_address'],
                                             entry['host_name'],
                                             lease))
-            self.dhcp_leases.search(entry['mac_address'], "0 %s %s %s *"  % (entry['mac_address'],
-                                                                             entry['ipv4_address'],
-                                                                             entry['host_name']))
+            self.dhcp_leases.search(entry['mac_address'], "0 %s %s %s *" % (entry['mac_address'],
+                                                                            entry['ipv4_address'],
+                                                                            entry['host_name']))
         else:
             tag = entry['ipv4_address'].replace(".", "_")
             self.cloud.add("%s,set:%s,%s,%s,%s" % (entry['mac_address'],
@@ -202,9 +203,9 @@ class CsDhcp(CsDataBag):
             self.dhcp_opts.add("%s,%s" % (tag, 3))
             self.dhcp_opts.add("%s,%s" % (tag, 6))
             self.dhcp_opts.add("%s,%s" % (tag, 15))
-            self.dhcp_leases.search(entry['mac_address'], "0 %s %s %s *"  % (entry['mac_address'],
-                                                                             entry['ipv4_address'],
-                                                                             entry['host_name']))
+            self.dhcp_leases.search(entry['mac_address'], "0 %s %s %s *" % (entry['mac_address'],
+                                                                            entry['ipv4_address'],
+                                                                            entry['host_name']))
 
         i = IPAddress(entry['ipv4_address'])
         # Calculate the device


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/3788

When a VR is deleted and a new one brought up it populates the dhcphosts.txt with all hosts in the network, but the dnsmasq.leases file is blank which can cause issues if VMs try to renew their lease.
This PR also adds an entry in the dnsmasq.leases file for each host when the dhcphosts.txt file is populated
An existing lease when a VM tries to acquire a new one doesn't seem to cause any issues

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### How Has This Been Tested?
1. Create a network with a couple of VMs on them
2. Restart the network with cleanup
3. Wait for the new router to come up
4. Cat /var/log/dnsmasq.log to verify that no DHCP request has been made
5. Check out /var/lib/misc/dnsmasq.leases

#### /var/log/dnsmasq.log - No DHCP requests received
```
root@r-8-VM:~# cat /var/log/dnsmasq.log
Dec 10 13:01:44 dnsmasq[928]: started, version 2.80 cachesize 150
Dec 10 13:01:44 dnsmasq[928]: compile time options: IPv6 GNU-getopt DBus i18n IDN DHCP DHCPv6 no-Lua TFTP conntrack ipset auth DNSSEC loop-detect inotify dumpfile
Dec 10 13:01:44 dnsmasq-dhcp[928]: DHCP, static leases only on 10.1.1.1, lease time 1h
Dec 10 13:01:44 dnsmasq-tftp[928]: TFTP root is /opt/tftpboot 
Dec 10 13:01:44 dnsmasq[928]: using local addresses only for domain cs2cloud.internal
Dec 10 13:01:44 dnsmasq[928]: reading /etc/dnsmasq-resolv.conf
Dec 10 13:01:44 dnsmasq[928]: using local addresses only for domain cs2cloud.internal
Dec 10 13:01:44 dnsmasq[928]: using nameserver 10.2.0.50#53
Dec 10 13:01:44 dnsmasq[928]: using nameserver 8.8.8.8#53
Dec 10 13:01:44 dnsmasq[928]: read /etc/hosts - 6 addresses
Dec 10 13:01:44 dnsmasq[928]: cannot read /etc/dhcphosts.txt: No such file or directory
Dec 10 13:01:44 dnsmasq-dhcp[928]: read /etc/dhcpopts.txt
Dec 10 13:01:44 dnsmasq[928]: read /etc/hosts - 6 addresses
Dec 10 13:01:44 dnsmasq[928]: cannot read /etc/dhcphosts.txt: No such file or directory
Dec 10 13:01:44 dnsmasq-dhcp[928]: read /etc/dhcpopts.txt
Dec 10 13:01:50 dnsmasq[928]: exiting on receipt of SIGTERM
Dec 10 13:01:50 dnsmasq[1841]: started, version 2.80 cachesize 150
Dec 10 13:01:50 dnsmasq[1841]: compile time options: IPv6 GNU-getopt DBus i18n IDN DHCP DHCPv6 no-Lua TFTP conntrack ipset auth DNSSEC loop-detect inotify dumpfile
Dec 10 13:01:50 dnsmasq-dhcp[1841]: DHCP, static leases only on 10.1.1.1, lease time 1h
Dec 10 13:01:50 dnsmasq-dhcp[1841]: DHCP, static leases only on 10.1.1.1, lease time 1h
Dec 10 13:01:50 dnsmasq-tftp[1841]: TFTP root is /opt/tftpboot 
Dec 10 13:01:50 dnsmasq[1841]: using local addresses only for domain cs2cloud.internal
Dec 10 13:01:50 dnsmasq[1841]: reading /etc/dnsmasq-resolv.conf
Dec 10 13:01:50 dnsmasq[1841]: using local addresses only for domain cs2cloud.internal
Dec 10 13:01:50 dnsmasq[1841]: using nameserver 10.2.0.50#53
Dec 10 13:01:50 dnsmasq[1841]: using nameserver 8.8.8.8#53
Dec 10 13:01:50 dnsmasq[1841]: read /etc/hosts - 8 addresses
Dec 10 13:01:50 dnsmasq-dhcp[1841]: read /etc/dhcphosts.txt
Dec 10 13:01:50 dnsmasq-dhcp[1841]: read /etc/dhcpopts.txt
Dec 10 13:01:56 dnsmasq[1841]: read /etc/hosts - 8 addresses
Dec 10 13:01:56 dnsmasq-dhcp[1841]: read /etc/dhcphosts.txt
Dec 10 13:01:56 dnsmasq-dhcp[1841]: read /etc/dhcpopts.txt
```

#### /var/lib/misc/dnsmasq.leases - They exist :sparkles: 
```
root@r-8-VM:~# cat /var/lib/misc/dnsmasq.leases 
0 02:00:62:58:00:04 10.1.1.52 vm-2 *
0 02:00:50:85:00:01 10.1.1.224 VM-1 *
```

### BEFORE :
#### Logs when rebooting a VM after network restart with cleanup
```
Dec 10 13:12:45 dnsmasq[2240]: read /etc/hosts - 9 addresses
Dec 10 13:12:45 dnsmasq-dhcp[2240]: read /etc/dhcphosts.txt
Dec 10 13:12:45 dnsmasq-dhcp[2240]: read /etc/dhcpopts.txt

Dec 10 13:13:48 dnsmasq-dhcp[2240]: DHCPDISCOVER(eth0) 10.1.1.24 02:00:24:5c:00:03 
Dec 10 13:13:48 dnsmasq-dhcp[2240]: DHCPOFFER(eth0) 10.1.1.24 02:00:24:5c:00:03 
Dec 10 13:13:48 dnsmasq-dhcp[2240]: DHCPREQUEST(eth0) 10.1.1.24 02:00:24:5c:00:03 
Dec 10 13:13:48 dnsmasq-dhcp[2240]: DHCPACK(eth0) 10.1.1.24 02:00:24:5c:00:03 VM-2

```

### AFTER :
#### Logs when rebooting a VM after network restart with cleanup
```
Dec 10 13:06:19 dnsmasq[1841]: read /etc/hosts - 8 addresses
Dec 10 13:06:19 dnsmasq-dhcp[1841]: read /etc/dhcphosts.txt
Dec 10 13:06:19 dnsmasq-dhcp[1841]: read /etc/dhcpopts.txt

Dec 10 13:07:03 dnsmasq-dhcp[1841]: DHCPREQUEST(eth0) 10.1.1.52 02:00:62:58:00:04 
Dec 10 13:07:03 dnsmasq-dhcp[1841]: DHCPACK(eth0) 10.1.1.52 02:00:62:58:00:04 vm-2
```