### PR TITLE
extract volume: Fix NPE when Volume exists on secondary store but doesn't have a download URL

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2881,8 +2881,12 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         } else if (volumeStoreRef != null) {
             s_logger.debug("volume " + volumeId + " is already installed on secondary storage, install path is " +
                     volumeStoreRef.getInstallPath());
+            VolumeInfo destVol = volFactory.getVolume(volumeId, DataStoreRole.Image);
+            if (destVol == null) {
+                throw new CloudRuntimeException("Failed to find the volume on a secondary store");
+            }
             ImageStoreEntity secStore = (ImageStoreEntity) dataStoreMgr.getDataStore(volumeStoreRef.getDataStoreId(), DataStoreRole.Image);
-            String extractUrl = secStore.createEntityExtractUrl(volumeStoreRef.getInstallPath(), volume.getFormat(), null);
+            String extractUrl = secStore.createEntityExtractUrl(volumeStoreRef.getInstallPath(), volume.getFormat(), destVol);
             volumeStoreRef = _volumeStoreDao.findByVolume(volumeId);
             volumeStoreRef.setExtractUrl(extractUrl);
             volumeStoreRef.setExtractUrlCreated(DateUtil.now());


### PR DESCRIPTION
### Description

This PR fixes an NPE that's noticed when we perform the following:
1. Download a volume - such that we have the download_url set in the volume_store_ref table against the respective volume
2. Perform an operation that causes the download_url to be cleared, say, destroy the SSVM
3. Post re-creation of the SSVM , re-initiate download of the same volume, it fails with an NPE

```
2020-12-10 08:56:03,164 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-2:ctx-ef7f5a39 job-652) (logid:169bd39d) Unexpected exception while executing org.apache.cloudstack.api.command.user.volume.ExtractVolumeCmd
java.lang.NullPointerException
	at com.cloud.hypervisor.guru.VMwareGuru.getCommandHostDelegation(VMwareGuru.java:274)
	at com.cloud.hypervisor.HypervisorGuruManagerImpl.getGuruProcessedCommandTargetHost(HypervisorGuruManagerImpl.java:76)
	at org.apache.cloudstack.storage.RemoteHostEndPoint.sendMessage(RemoteHostEndPoint.java:120)
	at org.apache.cloudstack.storage.datastore.driver.CloudStackImageStoreDriverImpl.createEntityExtractUrl(CloudStackImageStoreDriverImpl.java:83)
	at org.apache.cloudstack.storage.image.store.ImageStoreImpl.createEntityExtractUrl(ImageStoreImpl.java:212)
	at com.cloud.storage.VolumeApiServiceImpl.setExtractVolumeSearchCriteria(VolumeApiServiceImpl.java:2887)
	at com.cloud.storage.VolumeApiServiceImpl.extractVolume(VolumeApiServiceImpl.java:2800)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.apache.cloudstack.network.contrail.management.EventUtils$EventInterceptor.invoke(EventUtils.java:107)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at com.cloud.event.ActionEventInterceptor.invoke(ActionEventInterceptor.java:51)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:95)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212)
	at com.sun.proxy.$Proxy215.extractVolume(Unknown Source)
	at org.apache.cloudstack.api.command.user.volume.ExtractVolumeCmd.execute(ExtractVolumeCmd.java:137)
	at com.cloud.api.ApiDispatcher.dispatch(ApiDispatcher.java:156)
	at com.cloud.api.ApiAsyncJobDispatcher.runJob(ApiAsyncJobDispatcher.java:108)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.runInContext(AsyncJobManagerImpl.java:620)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.run(AsyncJobManagerImpl.java:568)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [X] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### How Has This Been Tested?
Perform the above mentioned steps and the download url is created.