### PR TITLE
networkorchestrator: Fix typo in exception message

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2352,7 +2352,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         // Validate network offering
         if (ntwkOff.getState() != NetworkOffering.State.Enabled) {
             // see NetworkOfferingVO
-            final InvalidParameterValueException ex = new InvalidParameterValueException("Can't use specified network offering id as its stat is not " + NetworkOffering.State.Enabled);
+            final InvalidParameterValueException ex = new InvalidParameterValueException("Can't use specified network offering id as its state is not " + NetworkOffering.State.Enabled);
             ex.addProxyObject(ntwkOff.getUuid(), "networkOfferingId");
             throw ex;
         }


### PR DESCRIPTION
### Description

Fixes a typo in the exception raised when trying to create a network from a disabled offering

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### How Has This Been Tested?
```
(qa) 🐱 > create network networkofferingid=a529b060-2407-4085-ab44-fc35f534d6c6 name=nothing displaytext=nothing zoneid=04ccc336-d730-42fe-8ff6-5ae36e141e81 
🙈 Error: (HTTP 431, error code 4350) Can't use specified network offering id as its state is not Enabled

```
