### PR TITLE
Prevent KVM from performing volume migrations of running instances

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2173,6 +2173,12 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 if (capabilities != null) {
                     liveMigrateVolume = capabilities.isStorageMotionSupported();
                 }
+
+                if(liveMigrateVolume && HypervisorType.KVM.equals(host.getHypervisorType())) {
+                    throw new InvalidParameterValueException("KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. " +
+                            "Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. " +
+                            "Use 'migrateVirtualMachineWithVolumes' instead.");
+                }
             }
 
             // If vm is running, and hypervisor doesn't support live migration, then return error

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2174,7 +2174,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     liveMigrateVolume = capabilities.isStorageMotionSupported();
                 }
 
-                if(liveMigrateVolume && HypervisorType.KVM.equals(host.getHypervisorType())) {
+                if (liveMigrateVolume && HypervisorType.KVM.equals(host.getHypervisorType())) {
                     throw new InvalidParameterValueException("KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. " +
                             "Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. " +
                             "Use 'migrateVirtualMachineWithVolumes' instead.");


### PR DESCRIPTION
### Description
KVM has a limitation to modify instances definitions while they are on running state. Therefore, it is not possible to change volumes backend location easily.

There is a problem in the `migrateVolume` API. This API command ignores that limitation and causes an inconsistence on the database. ACS processes the migrate command, copies the volume to the destination storage, modifies the database and finishes the process with success. However, the running backend is still using the "old volume file".

This PR intends to prevent KVM to perform volumes migrations while KVM instances are in the running state and inform the user of an alternative API command that enables such operation on running instances.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity


#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
It has been tested locally.