### PR TITLE
kvm: Fix double-escape issue while creating rbd disk options

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
@@ -29,7 +29,7 @@ public class KVMPhysicalDisk {
         rbdOpts = "rbd:" + image;
         rbdOpts += ":mon_host=" + monHost;
         if (monPort > 0) {
-            rbdOpts += "\\\\:" + monPort;
+            rbdOpts += "\\:" + monPort;
         }
 
         if (authUserName == null) {

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java
@@ -25,7 +25,7 @@ public class KVMPhysicalDiskTest extends TestCase {
 
     public void testRBDStringBuilder() {
         assertEquals(KVMPhysicalDisk.RBDStringBuilder("ceph-monitor", 8000, "admin", "supersecret", "volume1"),
-                     "rbd:volume1:mon_host=ceph-monitor\\\\:8000:auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30");
+                     "rbd:volume1:mon_host=ceph-monitor\\:8000:auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30");
     }
 
     public void testAttributes() {


### PR DESCRIPTION
This fixes issue introduced in c3554ec31dafbdfaa0ed646afb17a6f3378571f5
which enable block of code that will double escape rados host/monitor
port.

Seen in logs:
```
2021-01-04 14:21:35,412 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-4:null) (logid:c5187751) Creating volume 125a9ebb-de4c-49cf-b9a7-9249c4af53b9 from template d9eb3660-23e5-4b37-85ec-b6ad4978bf22 in pool 509bd564-b7e3-3d5f-b84b-b799055b11ca (RBD) with size (5.00 GB) 5368709120
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)