### PR TITLE
uservmjoindaoimpl: Set free memory to zero if greater than total memory

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -209,7 +209,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     private Long memoryKBs;
 
     @SerializedName("memoryintfreekbs")
-    @Param(description = "the internal memory thats free in vm or zero if it can not be calculated in the case of KVM")
+    @Param(description = "the internal memory thats free in vm or zero if it can not be calculated")
     private Long memoryIntFreeKBs;
 
     @SerializedName("memorytargetkbs")

--- a/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -209,7 +209,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     private Long memoryKBs;
 
     @SerializedName("memoryintfreekbs")
-    @Param(description = "the internal memory thats free in vm")
+    @Param(description = "the internal memory thats free in vm or zero if it can not be calculated in the case of KVM")
     private Long memoryIntFreeKBs;
 
     @SerializedName("memorytargetkbs")

--- a/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -209,7 +209,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     private Long memoryKBs;
 
     @SerializedName("memoryintfreekbs")
-    @Param(description = "the internal memory thats free in vm or zero if it can not be calculated")
+    @Param(description = "the internal memory that's free in vm or zero if it can not be calculated")
     private Long memoryIntFreeKBs;
 
     @SerializedName("memorytargetkbs")

--- a/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -222,8 +222,11 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
                 userVmResponse.setDiskKbsWrite((long)vmStats.getDiskWriteKBs());
                 userVmResponse.setDiskIORead((long)vmStats.getDiskReadIOs());
                 userVmResponse.setDiskIOWrite((long)vmStats.getDiskWriteIOs());
-                userVmResponse.setMemoryKBs((long)vmStats.getMemoryKBs());
-                userVmResponse.setMemoryIntFreeKBs((long)vmStats.getIntFreeMemoryKBs());
+                long totalMemory = (long)vmStats.getMemoryKBs();
+                long freeMemory = (long)vmStats.getIntFreeMemoryKBs();
+                long correctedFreeMemory = freeMemory > totalMemory ? 0 : freeMemory;
+                userVmResponse.setMemoryKBs(totalMemory);
+                userVmResponse.setMemoryIntFreeKBs(correctedFreeMemory);
                 userVmResponse.setMemoryTargetKBs((long)vmStats.getTargetMemoryKBs());
 
             }

--- a/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -224,7 +224,7 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
                 userVmResponse.setDiskIOWrite((long)vmStats.getDiskWriteIOs());
                 long totalMemory = (long)vmStats.getMemoryKBs();
                 long freeMemory = (long)vmStats.getIntFreeMemoryKBs();
-                long correctedFreeMemory = freeMemory > totalMemory ? 0 : freeMemory;
+                long correctedFreeMemory = freeMemory >= totalMemory ? 0 : freeMemory;
                 userVmResponse.setMemoryKBs(totalMemory);
                 userVmResponse.setMemoryIntFreeKBs(correctedFreeMemory);
                 userVmResponse.setMemoryTargetKBs((long)vmStats.getTargetMemoryKBs());


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/4566

Sets `memoryintfreekbs` to zero if it is greater than `memorykbs`. Caused by KVM returning the RSS memory of the process running the VM rather than the free memory inside the VM

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


### How Has This Been Tested?

#### Before
```
(localcloud) SBCM5> > list virtualmachines filter=memoryintfreekbs,memorykbs,
{
  "count": 2,
  "virtualmachine": [
    {
      "memoryintfreekbs": 2138672,
      "memorykbs": 2097152
    },
    {
      "memoryintfreekbs": 2143292,
      "memorykbs": 2097152
    }
  ]
}
```

#### After
```
(localcloud) SBCM5> > list virtualmachines filter=memoryintfreekbs,memorykbs,
{
  "count": 2,
  "virtualmachine": [
    {
      "memoryintfreekbs": 0,
      "memorykbs": 2097152
    },
    {
      "memoryintfreekbs": 0,
      "memorykbs": 2097152
    }
  ]
}
```