### PR TITLE
Add support to StartTLS on Quota's mailing

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
@@ -54,6 +54,9 @@ public interface QuotaConfig {
     public static final ConfigKey<String> QuotaSmtpEnabledSecurityProtocols = new ConfigKey<String>("Advanced", String.class, "quota.usage.smtp.enabledSecurityProtocols", "",
             "White-space separated security protocols; ex: \"TLSv1 TLSv1.1\". Supported protocols: SSLv2Hello, SSLv3, TLSv1, TLSv1.1 and TLSv1.2", true);
 
+    public static final ConfigKey<String> QuotaSmtpUseStartTLS = new ConfigKey<String>("Advanced", String.class, "quota.usage.smtp.useStartTLS", "false",
+            "If set to true and if we enable security via quota.usage.smtp.useAuth, this will enable StartTLS to secure the conection.", true);
+
     enum QuotaEmailTemplateTypes {
         QUOTA_LOW, QUOTA_EMPTY, QUOTA_UNLOCK_ACCOUNT, QUOTA_STATEMENT
     }

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/quota/QuotaServiceImpl.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/quota/QuotaServiceImpl.java
@@ -137,7 +137,7 @@ public class QuotaServiceImpl extends ManagerBase implements QuotaService, Confi
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {QuotaPluginEnabled, QuotaEnableEnforcement, QuotaCurrencySymbol, QuotaStatementPeriod, QuotaSmtpHost, QuotaSmtpPort, QuotaSmtpTimeout,
-                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender, QuotaSmtpEnabledSecurityProtocols};
+                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender, QuotaSmtpEnabledSecurityProtocols, QuotaSmtpUseStartTLS};
     }
 
     @Override


### PR DESCRIPTION
### Description
On Quota's mailing settings, ACS has a configuration (`quota.usage.smtp.useAuth`) to inform if it will use secure SMTP authentication when sending emails.
However, this configuration only refers to use SSL or not. Operators haves no option to choose if they want to use StartTLS.

This PR intends to add support to StartTLS on Quota's mailing settings.

It is interesting to highlight that this enhancement would be able to solve issue #2625 (if it was applied in that setting as well); however, to reduce the scope of change, this one focuses only on Quota's mailing configuration.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [x] Major
- [ ] Minor

### How Has This Been Tested?

It has been tested locally on a test lab.

1. I had Enabled Quota's plugin on the management server and configured it to use Gmail's SMTP server.
```
server address: smtp.gmail.com
username: gmail address
password: gmail password
port (TLS): 587
```

2. On `Quota - All Accounts`, I added 10 credits to my user and set 20 as min balance.

3. I had added an gmail address to Accounts > \<account\> > Users - Email.

4. I allowed `Less secure app access` on my Google account.

5. I had restarted management server.

6. And I called `quota update` API via Cloudmonkey. Without the new option being introduced here, I would see an error in the management server. After setting it, everything is fine, and the alert email is sent.