### PR TITLE
Externalize TLS version on Quota's mailing

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaAlertManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaAlertManagerImpl.java
@@ -62,6 +62,7 @@ import com.google.common.base.Strings;
 import com.sun.mail.smtp.SMTPMessage;
 import com.sun.mail.smtp.SMTPSSLTransport;
 import com.sun.mail.smtp.SMTPTransport;
+import org.apache.commons.lang3.StringUtils;
 
 @Component
 public class QuotaAlertManagerImpl extends ManagerBase implements QuotaAlertManager {
@@ -114,8 +115,9 @@ public class QuotaAlertManagerImpl extends ManagerBase implements QuotaAlertMana
         String smtpUsername = configs.get(QuotaConfig.QuotaSmtpUser.key());
         String smtpPassword = configs.get(QuotaConfig.QuotaSmtpPassword.key());
         String emailSender = configs.get(QuotaConfig.QuotaSmtpSender.key());
+        String smtpEnabledSecurityProtocols = configs.get(QuotaConfig.QuotaSmtpEnabledSecurityProtocols.key());
         _lockAccountEnforcement = "true".equalsIgnoreCase(configs.get(QuotaConfig.QuotaEnableEnforcement.key()));
-        _emailQuotaAlert = new EmailQuotaAlert(smtpHost, smtpPort, useAuth, smtpUsername, smtpPassword, emailSender, _smtpDebug);
+        _emailQuotaAlert = new EmailQuotaAlert(smtpHost, smtpPort, useAuth, smtpUsername, smtpPassword, emailSender, smtpEnabledSecurityProtocols, _smtpDebug);
 
         return true;
     }
@@ -341,7 +343,7 @@ public class QuotaAlertManagerImpl extends ManagerBase implements QuotaAlertMana
         private final String _smtpPassword;
         private final String _emailSender;
 
-        public EmailQuotaAlert(String smtpHost, int smtpPort, boolean smtpUseAuth, final String smtpUsername, final String smtpPassword, String emailSender, boolean smtpDebug) {
+        public EmailQuotaAlert(String smtpHost, int smtpPort, boolean smtpUseAuth, final String smtpUsername, final String smtpPassword, String emailSender, String smtpEnabledSecurityProtocols, boolean smtpDebug) {
             _smtpHost = smtpHost;
             _smtpPort = smtpPort;
             _smtpUseAuth = smtpUseAuth;
@@ -363,6 +365,10 @@ public class QuotaAlertManagerImpl extends ManagerBase implements QuotaAlertMana
                 smtpProps.put("mail.smtps.auth", "" + smtpUseAuth);
                 if (!Strings.isNullOrEmpty(smtpUsername)) {
                     smtpProps.put("mail.smtps.user", smtpUsername);
+                }
+
+                if (StringUtils.isNotBlank(smtpEnabledSecurityProtocols)) {
+                    smtpProps.put("mail.smtp.ssl.protocols", smtpEnabledSecurityProtocols);
                 }
 
                 if (!Strings.isNullOrEmpty(smtpUsername) && !Strings.isNullOrEmpty(smtpPassword)) {

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
@@ -51,6 +51,9 @@ public interface QuotaConfig {
     public static final ConfigKey<String> QuotaSmtpSender = new ConfigKey<String>("Advanced", String.class, "quota.usage.smtp.sender", "",
             "Sender of quota alert email (will be in the From header of the email)", true);
 
+    public static final ConfigKey<String> QuotaSmtpEnabledSecurityProtocols = new ConfigKey<String>("Advanced", String.class, "quota.usage.smtp.enabledSecurityProtocols", "",
+            "White-space separated security protocols; ex: \"TLSv1 TLSv1.1\". Supported protocols: SSLv2Hello, SSLv3, TLSv1, TLSv1.1 and TLSv1.2", true);
+
     enum QuotaEmailTemplateTypes {
         QUOTA_LOW, QUOTA_EMPTY, QUOTA_UNLOCK_ACCOUNT, QUOTA_STATEMENT
     }

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/quota/QuotaServiceImpl.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/quota/QuotaServiceImpl.java
@@ -137,7 +137,7 @@ public class QuotaServiceImpl extends ManagerBase implements QuotaService, Confi
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {QuotaPluginEnabled, QuotaEnableEnforcement, QuotaCurrencySymbol, QuotaStatementPeriod, QuotaSmtpHost, QuotaSmtpPort, QuotaSmtpTimeout,
-                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender};
+                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender, QuotaSmtpEnabledSecurityProtocols};
     }
 
     @Override


### PR DESCRIPTION
### Description
Some servers (like [microsoft](https://docs.microsoft.com/en-us/microsoft-365/compliance/prepare-tls-1.2-in-office-365?view=o365-worldwide)) are deprecating TLSv1 and TLSv1.1. 

On Quota's mailing settings, ACS uses the protocol `TLSv1`; therefore, operators do not have options to choose which version they want to use. 

This PR intends to externalize the protocol setting on Quota's mailing.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [x] Major
- [ ] Minor

### How Has This Been Tested?
It has been tested locally on a test lab.

1. I had Enabled Quota's plugin on the management server and configured it to use Gmail's SMTP server.
```
server address: smtp.gmail.com
username: gmail address
password: gmail password
port (TLS): 587
```

2. On `Quota - All Accounts`, I added 10 credits to my user and set 20 as min balance.

3. I had added an gmail address to Accounts > \<account\> > Users - Email.

4. I allowed `Less secure app access` on my Google account.

5. I had restarted management server.

6. And I called `quota update` API via Cloudmonkey. 

7. In Gmail, we have an option to `show original` message, which provides the TLS version and the cipher. So I changed the configuration some times and sent some alerts to verify if both versions, in configuration and gmail, are the same.