### PR TITLE
server: select root disk based on user input during vm import

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
@@ -500,6 +500,35 @@ public class VmImportManagerImpl implements VmImportService {
         return storagePool;
     }
 
+    private Pair<UnmanagedInstanceTO.Disk, List<UnmanagedInstanceTO.Disk>> getRootAndDataDisks(List<UnmanagedInstanceTO.Disk> disks, final Map<String, Long> dataDiskOfferingMap) {
+        UnmanagedInstanceTO.Disk rootDisk = null;
+        List<UnmanagedInstanceTO.Disk> dataDisks = new ArrayList<>();
+        if (disks.size() == 1) {
+            rootDisk = disks.get(0);
+            return new Pair<>(rootDisk, dataDisks);
+        }
+        Set<String> callerDiskIds = dataDiskOfferingMap.keySet();
+        if (callerDiskIds.size() != disks.size() - 1) {
+            String msg = String.format("VM has total %d disks for which %d disk offering mappings provided. %d disks need a disk offering for import", disks.size(), callerDiskIds.size(), disks.size()-1);
+            LOGGER.error(String.format("%s. %s parameter can be used to provide disk offerings for the disks", msg, ApiConstants.DATADISK_OFFERING_LIST));
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, msg);
+        }
+        List<String> diskIdsWithoutOffering = new ArrayList<>();
+        for (UnmanagedInstanceTO.Disk disk : disks) {
+            String diskId = disk.getDiskId();
+            if (!callerDiskIds.contains(diskId)) {
+                diskIdsWithoutOffering.add(diskId);
+                rootDisk = disk;
+            } else {
+                dataDisks.add(disk);
+            }
+        }
+        if (diskIdsWithoutOffering.size() > 1) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("VM has total %d disks, disk offering mapping not provided for %d disks. Disk IDs that may need a disk offering - %s", disks.size(), diskIdsWithoutOffering.size()-1, String.join(", ", diskIdsWithoutOffering)));
+        }
+        return new Pair<>(rootDisk, dataDisks);
+    }
+
     private void checkUnmanagedDiskAndOfferingForImport(UnmanagedInstanceTO.Disk disk, DiskOffering diskOffering, ServiceOffering serviceOffering, final Account owner, final DataCenter zone, final Cluster cluster, final boolean migrateAllowed)
             throws ServerApiException, PermissionDeniedException, ResourceAllocationException {
         if (serviceOffering == null && diskOffering == null) {
@@ -910,17 +939,16 @@ public class VmImportManagerImpl implements VmImportService {
         if (CollectionUtils.isEmpty(unmanagedInstanceDisks)) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("No attached disks found for the unmanaged VM: %s", instanceName));
         }
-        final UnmanagedInstanceTO.Disk rootDisk = unmanagedInstance.getDisks().get(0);
+        Pair<UnmanagedInstanceTO.Disk, List<UnmanagedInstanceTO.Disk>> rootAndDataDisksPair = getRootAndDataDisks(unmanagedInstanceDisks, dataDiskOfferingMap);
+        final UnmanagedInstanceTO.Disk rootDisk = rootAndDataDisksPair.first();
+        final List<UnmanagedInstanceTO.Disk> dataDisks = rootAndDataDisksPair.second();
         if (rootDisk == null || Strings.isNullOrEmpty(rootDisk.getController())) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("VM import failed. Unable to retrieve root disk details for VM: %s ", instanceName));
         }
         allDetails.put(VmDetailConstants.ROOT_DISK_CONTROLLER, rootDisk.getController());
-        List<UnmanagedInstanceTO.Disk> dataDisks = new ArrayList<>();
         try {
             checkUnmanagedDiskAndOfferingForImport(rootDisk, null, validatedServiceOffering, owner, zone, cluster, migrateAllowed);
-            if (unmanagedInstanceDisks.size() > 1) { // Data disk(s) present
-                dataDisks.addAll(unmanagedInstanceDisks);
-                dataDisks.remove(0);
+            if (CollectionUtils.isNotEmpty(dataDisks)) { // Data disk(s) present
                 checkUnmanagedDiskAndOfferingForImport(dataDisks, dataDiskOfferingMap, owner, zone, cluster, migrateAllowed);
                 allDetails.put(VmDetailConstants.DATA_DISK_CONTROLLER, dataDisks.get(0).getController());
             }


### PR DESCRIPTION
### Description

Improves logic for selecting ROOT disk for VM to be imported when VM has multiple disks.
Based on user input of parameter - datadiskofferinglist, a check will be performed if user correctly provided disk offering mapping for n - 1 disks (one less than the total number of the disks). Remaining one disk will be considered as the ROOT disk.
This will allow correct ROOT disk being selected when first disk in the list of disks of listUnmanagedInstance API or list returned by vSphere SDK is not the ROOT disk.

Fixes #4547 

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
CMK

Unmanaged VM
```
> list unmanagedinstances clusterid=c4ae9767-cca3-46e3-a801-3218ea8b69d1
{
  "count": 1,
  "unmanagedinstance": [
    {
      "clusterid": "c4ae9767-cca3-46e3-a801-3218ea8b69d1",
      "cpucorepersocket": 1,
      "cpunumber": 1,
      "cpuspeed": 0,
      "disk": [
        {
          "capacity": 2147483648,
          "controller": "lsilogic",
          "controllerunit": 0,
          "datastorehost": "10.10.0.16",
          "datastorename": "3ae2b131a9e2303b9a5d4b779a3a3b14",
          "datastorepath": "/acs/primary/ref-trl-2240-v-M7-abhishek-kumar/ref-trl-2240-v-M7-abhishek-kumar-esxi-pri2",
          "datastoretype": "NFS",
          "id": "16-2000",
          "imagepath": "[3ae2b131a9e2303b9a5d4b779a3a3b14] import/import_7.vmdk",
          "label": "Hard disk 1",
          "position": 0
        },
        {
          "capacity": 5368709120,
          "controller": "lsilogic",
          "controllerunit": 0,
          "datastorehost": "10.10.0.16",
          "datastorename": "3ae2b131a9e2303b9a5d4b779a3a3b14",
          "datastorepath": "/acs/primary/ref-trl-2240-v-M7-abhishek-kumar/ref-trl-2240-v-M7-abhishek-kumar-esxi-pri2",
          "datastoretype": "NFS",
          "id": "16-2001",
          "imagepath": "[3ae2b131a9e2303b9a5d4b779a3a3b14] import/import_6.vmdk",
          "label": "Hard disk 2",
          "position": 1
        },
        {
          "capacity": 5368709120,
          "controller": "lsilogic",
          "controllerunit": 0,
          "datastorehost": "10.10.0.16",
          "datastorename": "3ae2b131a9e2303b9a5d4b779a3a3b14",
          "datastorepath": "/acs/primary/ref-trl-2240-v-M7-abhishek-kumar/ref-trl-2240-v-M7-abhishek-kumar-esxi-pri2",
          "datastoretype": "NFS",
          "id": "16-2002",
          "imagepath": "[3ae2b131a9e2303b9a5d4b779a3a3b14] import/import_8.vmdk",
          "label": "Hard disk 3",
          "position": 2
        },
        {
          "capacity": 2147483648,
          "controller": "lsilogic",
          "controllerunit": 0,
          "datastorehost": "10.10.0.16",
          "datastorename": "3ae2b131a9e2303b9a5d4b779a3a3b14",
          "datastorepath": "/acs/primary/ref-trl-2240-v-M7-abhishek-kumar/ref-trl-2240-v-M7-abhishek-kumar-esxi-pri2",
          "datastoretype": "NFS",
          "id": "16-2003",
          "imagepath": "[3ae2b131a9e2303b9a5d4b779a3a3b14] import/import_9.vmdk",
          "label": "Hard disk 4",
          "position": 3
        }
      ],
      "hostid": "0029b901-ddf9-4e18-9e3d-244bebc7bd5e",
      "memory": 512,
      "name": "import",
      "nic": [
        {
          "adaptertype": "E1000",
          "id": "Network adapter 1",
          "macaddress": "02:00:1f:66:00:04",
          "networkname": "cloud.guest.1539.200.1-vSwitch1",
          "vlanid": 1539
        }
      ],
      "osdisplayname": "CentOS 4/5 or later (64-bit)",
      "osid": "centos64Guest",
      "powerstate": "PowerOff"
    }
  ]
}

```
Import attempt without giving data disk mapping:
```
> import unmanagedinstance clusterid=c4ae9767-cca3-46e3-a801-3218ea8b69d1 name=import serviceofferingid=2564ca56-6ceb-4295-a72b-9c164185584b templateid=8a7a0fe1-5bc0-11eb-89cd-1e00770138e0
{
  "accountid": "a16abb02-5bc0-11eb-89cd-1e00770138e0",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ImportUnmanagedInstanceCmd",
  "completed": "2021-01-25T07:16:41+0000",
  "created": "2021-01-25T07:16:40+0000",
  "jobid": "559bd155-a641-41ce-a38e-80101cfb6741",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "VM has total 4 disks for which 0 disk offering mappings provided. 3 disks need a disk offering for import"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "a16be7b3-5bc0-11eb-89cd-1e00770138e0"
}
```

Import attempt without giving enough data disk mapping:
```
> import unmanagedinstance clusterid=c4ae9767-cca3-46e3-a801-3218ea8b69d1 name=import serviceofferingid=2564ca56-6ceb-4295-a72b-9c164185584b templateid=8a7a0fe1-5bc0-11eb-89cd-1e00770138e0 datadiskofferinglist[0].disk=16-2001 datadiskofferinglist[0].diskOffering=c73bbf09-9b34-4010-b735-2fb6a0a930e6
{
  "accountid": "a16abb02-5bc0-11eb-89cd-1e00770138e0",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ImportUnmanagedInstanceCmd",
  "completed": "2021-01-25T07:16:58+0000",
  "created": "2021-01-25T07:16:58+0000",
  "jobid": "1f15a269-ea02-4ce0-b1cf-0f47d38cb486",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "VM has total 4 disks for which 1 disk offering mappings provided. 3 disks need a disk offering for import"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "a16be7b3-5bc0-11eb-89cd-1e00770138e0"
}
```
Import attempt with wrong data disk ids in mapping but correct mapping count:
```
 import unmanagedinstance clusterid=c4ae9767-cca3-46e3-a801-3218ea8b69d1 name=import serviceofferingid=2564ca56-6ceb-4295-a72b-9c164185584b templateid=8a7a0fe1-5bc0-11eb-89cd-1e00770138e0 datadiskofferinglist[0].disk=16-2001 datadiskofferinglist[0].diskOffering=c73bbf09-9b34-4010-b735-2fb6a0a930e6 datadiskofferinglist[1].disk=16-2006 datadiskofferinglist[1].diskOffering=c73bbf09-9b34-4010-b735-2fb6a0a930e6 datadiskofferinglist[2].disk=16-2005 datadiskofferinglist[2].diskOffering=c73bbf09-9b34-4010-b735-2fb6a0a930e6
{
  "accountid": "a16abb02-5bc0-11eb-89cd-1e00770138e0",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ImportUnmanagedInstanceCmd",
  "completed": "2021-01-25T07:17:28+0000",
  "created": "2021-01-25T07:17:28+0000",
  "jobid": "d53495de-4768-4ac3-a9a8-63b1bc34f9d6",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "VM has total 4 disks, disk offering mapping not provided for 2 disks. Disk IDs that may need a disk offering - 16-2000, 16-2002, 16-2003"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "a16be7b3-5bc0-11eb-89cd-1e00770138e0"
}
```
Successful import with correct mapping:
```
> import unmanagedinstance clusterid=c4ae9767-cca3-46e3-a801-3218ea8b69d1 name=import serviceofferingid=2564ca56-6ceb-4295-a72b-9c164185584b templateid=8a7a0fe1-5bc0-11eb-89cd-1e00770138e0 datadiskofferinglist[0].disk=16-2001 datadiskofferinglist[0].diskOffering=c73bbf09-9b34-4010-b735-2fb6a0a930e6 datadiskofferinglist[1].disk=16-2002 datadiskofferinglist[1].diskOffering=c73bbf09-9b34-4010-b735-2fb6a0a930e6 datadiskofferinglist[2].disk=16-2003 datadiskofferinglist[2].diskOffering=12acfa5b-f4ce-4aca-ab82-dc832c7a9f3e nicnetworklist[0].nic='Network adapter 1' nicnetworklist[0].network=fc3c8122-0a7e-4dd2-ad15-86985fe117a6 nicipaddresslist[0].nic='Network adapter 1' nicipaddresslist[0].ip4Address=auto
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-01-25T07:28:48+0000",
    "details": {
      "dataDiskController": "lsilogic",
      "deployvm": "true",
      "nicAdapter": "E1000",
      "rootDiskController": "lsilogic"
    },
    "displayname": "import",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "8a73a1ac-5bc0-11eb-89cd-1e00770138e0",
    "guestosid": "8a8449f9-5bc0-11eb-89cd-1e00770138e0",
    "haenable": false,
    "hostid": "0029b901-ddf9-4e18-9e3d-244bebc7bd5e",
    "hostname": "10.10.2.159",
    "hypervisor": "VMware",
    "id": "2acdf6dc-a946-4e8a-90c5-c8bd499ff21b",
    "instancename": "import",
    "isdynamicallyscalable": false,
    "memory": 512,
    "name": "import",
    "nic": [
      {
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "f65143d5-0cd2-4f71-8bbf-16aea5a585c5",
        "ipaddress": "10.1.1.208",
        "isdefault": true,
        "macaddress": "02:00:1f:66:00:04",
        "netmask": "255.255.255.0",
        "networkid": "fc3c8122-0a7e-4dd2-ad15-86985fe117a6",
        "networkname": "test",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.3 (64-bit)",
    "ostypeid": "8a8449f9-5bc0-11eb-89cd-1e00770138e0",
    "passwordenabled": false,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "serviceofferingid": "2564ca56-6ceb-4295-a72b-9c164185584b",
    "serviceofferingname": "Small Instance",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "8a7a0fe1-5bc0-11eb-89cd-1e00770138e0",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "a16be7b3-5bc0-11eb-89cd-1e00770138e0",
    "username": "admin",
    "zoneid": "a3932dd2-618b-47de-8d8a-0df2c7e697b9",
    "zonename": "ref-trl-2240-v-M7-abhishek-kumar"
  }
}
```


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
