### PR TITLE
API discovery: Prevent overwrite of API parameters in cases where API names are same

### DIFF
--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,7 +68,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         if (s_apiNameDiscoveryResponseMap == null) {
             long startTime = System.nanoTime();
             s_apiNameDiscoveryResponseMap = new HashMap<String, ApiDiscoveryResponse>();
-            Set<Class<?>> cmdClasses = new HashSet<Class<?>>();
+            Set<Class<?>> cmdClasses = new LinkedHashSet<Class<?>>();
             for (PluggableService service : _services) {
                 s_logger.debug(String.format("getting api commands of service: %s", service.getClass().getName()));
                 cmdClasses.addAll(service.getCommands());


### PR DESCRIPTION
### Description

This PR addresses an issue that crops up during API discovery when we have the same API name pointing to 2 command classes, namely, xxxCmdByAdmin and xxxCmd. 
During api discovery we create a map of the apiNames and their corresponding parameters, however, in cases of api's like _createNetwork_ which point to both CreateNetworkCmd and CreateNetworkCmdByAdmin classes, though in [ManagementServerImpl](https://github.com/apache/cloudstack/blob/master/server/src/main/java/com/cloud/server/ManagementServerImpl.java#L2720) care has been taken to place the xxxCmdByAdmin classes after the regular xxxCmd classes, since we copy this list of command classes into a HashSet, is so happens, that sometimes the xxxCmdByAdmin Classes get discovered before their generic counterpart. Hence, parameters defined in the xxxCmdByAdmin class gets overwritten. This can be easily fixed by ensuring that the order of the API classes is maintained.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Cases when this can be seen:
This issue becomes predominant in the new UI as we use discovered API parameters to define the form fields:
![image](https://user-images.githubusercontent.com/10495417/105023276-c4d40b80-5a70-11eb-80d4-42baf031ce35.png)

Also,when logged in as admin via cmk and after doing a sync, listing params of createNetwork sometimes doesn't list the parameters defined in the CreateNetworkCmdByAdmin class - e.g., vlan, bypassoverlapcheck, etc
```
(localcloud) SBCM5> > create network -h
createNetwork: Creates a network
Required params: displaytext, name, networkofferingid, zoneid, 
API Params               Type     Description
==========               ====     ===========
account                  string   account that will own the network
aclid                    uuid     Network ACL ID associated for the network
                                  
acltype                  string   Access control type; supported values are
                                   account and domain. In 3.0 all shared n
                                  etworks should have aclType=Domain, and 
                                  all isolated networks - Account. Account
                                   means that only the account owner can u
                                  se the network, domain - all accounts in
                                   the domain can use the network
displaynetwork           boolean  an optional field, whether to the display
                                   the network to the end user or not.
displaytext              string   the display text of the network
domainid                 uuid     domain ID of the account owning a network
                                  
endip                    string   the ending IP address in the network IP r
                                  ange. If not specified, will be defaulte
                                  d to startIP
endipv6                  string   the ending IPv6 address in the IPv6 netwo
                                  rk range
externalid               string   ID of the network in an external system.
gateway                  string   the gateway of the network. Required for 
                                  shared networks and isolated networks wh
                                  en it belongs to VPC
ip6cidr                  string   the CIDR of IPv6 network, must be at leas
                                  t /64
ip6gateway               string   the gateway of the IPv6 network. Required
                                   for Shared networks
isolatedpvlan            string   the isolated private VLAN for this networ
                                  k
name                     string   the name of the network
netmask                  string   the netmask of the network. Required for 
                                  shared networks and isolated networks wh
                                  en it belongs to VPC
networkdomain            string   network domain
networkofferingid        uuid     the network offering ID
physicalnetworkid        uuid     the physical network ID the network belon
                                  gs to
projectid                uuid     an optional project for the SSH key
startip                  string   the beginning IP address in the network I
                                  P range
startipv6                string   the beginning IPv6 address in the IPv6 ne
                                  twork range
subdomainaccess          boolean  Defines whether to allow subdomains to us
                                  e networks dedicated to their parent dom
                                  ain(s). Should be used with aclType=Doma
                                  in, defaulted to allow.subdomain.network
                                  .access global config if not specified
vpcid                    uuid     the VPC network belongs to
zoneid                   uuid     the zone ID for the network

However, the listAPIs API enlists the parameters.
(localcloud) SBCM5> > list apis name=createNetwork
{
  "api": [
    {
      "description": "Creates a network",
      "isasync": true,
      "name": "createNetwork",
      "params": [
        {
          "description": "the physical network ID the network belongs to",
          "length": 255,
          "name": "physicalnetworkid",
          "related": "createPhysicalNetwork",
          "required": false,
          "type": "uuid"
        },
        {
...
        {
          "description": "The vlan of the network. This parameter is visible to ROOT admins only",
          "name": "vlan",
          "type": "string"
        }
      ]
    }
  ],
  "count": 1
}
```