### PR TITLE
UI Storage Pool Tags: unable to delete last tag

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -957,8 +957,8 @@ export default {
             if (param.name !== key) {
               continue
             }
-            if (input === undefined || input === null || (input === '' &&
-              !['updateStoragePool', 'updateHost'].includes(action.api))) {
+            if (!input === undefined || input === null ||
+              (input === '' && !['updateStoragePool', 'updateHost', 'updatePhysicalNetwork'].includes(action.api))) {
               if (param.type === 'boolean') {
                 params[key] = false
               }

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -957,7 +957,8 @@ export default {
             if (param.name !== key) {
               continue
             }
-            if (input === undefined || input === null || input === '') {
+            if (input === undefined || input === null || (input === '' &&
+              !['updateStoragePool', 'updateHost'].includes(action.api))) {
               if (param.type === 'boolean') {
                 params[key] = false
               }


### PR DESCRIPTION
### Description

This PR attempts to fix https://github.com/apache/cloudstack/issues/4610 - wherein the last tag added to a host/storage pool doesn't get deleted

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

