### PR TITLE
server: fix wrong error message when create isolated network without SourceNat

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2412,8 +2412,11 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 && (ntwkOff.getGuestType() == GuestType.Shared || (ntwkOff.getGuestType() == GuestType.Isolated
                 && !_networkModel.areServicesSupportedByNetworkOffering(ntwkOff.getId(), Service.SourceNat)));
         if (cidr == null && ip6Cidr == null && cidrRequired) {
-            throw new InvalidParameterValueException("StartIp/endIp/gateway/netmask are required when create network of" + " type " + Network.GuestType.Shared
-                    + " and network of type " + GuestType.Isolated + " with service " + Service.SourceNat.getName() + " disabled");
+            if (ntwkOff.getGuestType() == GuestType.Shared) {
+                throw new InvalidParameterValueException("StartIp/endIp/gateway/netmask are required when create network of" + " type " + Network.GuestType.Shared);
+            } else {
+                throw new InvalidParameterValueException("gateway/netmask are required when create network of" + " type " + GuestType.Isolated + " with service " + Service.SourceNat.getName() + " disabled");
+            }
         }
 
         checkL2OfferingServices(ntwkOff);


### PR DESCRIPTION
### Description

This PR fixes wrong message when create isolated network without SourceNat

When I created network without sourcenat, I got message below
```
(localcloud) 🐱 > create network name=fully-isolated-noservices displaytext=fully-isolated-noservices networkofferingid=83f13c21-38fd-439f-a0fc-54d6d5233fec zoneid=70e90072-db05-42c0-a639-71d16d905406
🙈 Error: (HTTP 431, error code 4350) StartIp/endIp/gateway/netmask are required when create network of type Shared and network of type Isolated with service SourceNat disabled
```
However, when I passed StartIp/endIp/gateway/netmask, it also failed.
```
(localcloud) 🐱 > create network name=fully-isolated-noservices displaytext=fully-isolated-noservices networkofferingid=83f13c21-38fd-439f-a0fc-54d6d5233fec zoneid=70e90072-db05-42c0-a639-71d16d905406 startip=192.168.101.2 endip=192.168.101.20 gateway=192.168.101.1 netmask=255.255.255.0
🙈 Error: (HTTP 431, error code 4350) Network offering with specified id doesn't support adding multiple ip ranges
```

without startip/endip, the following worked.
```
create network name=fully-isolated-noservices displaytext=fully-isolated-noservices networkofferingid=83f13c21-38fd-439f-a0fc-54d6d5233fec zoneid=70e90072-db05-42c0-a639-71d16d905406 gateway=192.168.102.1 netmask=255.255.255.0
```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity


#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
