### PR TITLE
server: fix failed to remove template/iso if upload from local fails

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -456,6 +456,10 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
             throw new InvalidParameterValueException("Please specify a valid template.");
         }
 
+        if (template.getState() == VirtualMachineTemplate.State.NotUploaded || template.getState() == VirtualMachineTemplate.State.UploadInProgress) {
+            throw new InvalidParameterValueException("The template is either getting uploaded or it may be initiated shortly, please wait for it to be completed");
+        }
+
         return new TemplateProfile(userId, template, zoneId);
     }
 
@@ -493,6 +497,10 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
 
         if (template.getFormat() != ImageFormat.ISO) {
             throw new InvalidParameterValueException("Please specify a valid iso.");
+        }
+
+        if (template.getState() == VirtualMachineTemplate.State.NotUploaded || template.getState() == VirtualMachineTemplate.State.UploadInProgress) {
+            throw new InvalidParameterValueException("The iso is either getting uploaded or it may be initiated shortly, please wait for it to be completed");
         }
 
         return new TemplateProfile(userId, template, zoneId);

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -2253,6 +2253,9 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             File tmpltParent = null;
             if (tmpltPath.exists() && tmpltPath.isDirectory()) {
                 tmpltParent = tmpltPath;
+            } else if (absoluteTemplatePath.endsWith(File.separator + obj.getId())) {
+                // the path ends with <account id>/<template id>, if upload fails
+                tmpltParent = tmpltPath;
             } else {
                 tmpltParent = tmpltPath.getParentFile();
             }
@@ -2356,6 +2359,9 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             File tmpltParent = null;
             if (volPath.exists() && volPath.isDirectory()) {
                 // for vmware, absoluteVolumePath represents a directory where volume files are located.
+                tmpltParent = volPath;
+            } else if (absoluteVolumePath.endsWith(File.separator + obj.getId())) {
+                // the path ends with <account id>/<volume id>, if upload fails
                 tmpltParent = volPath;
             } else {
                 // for other hypervisors, the volume .vhd or .qcow2 file path is passed


### PR DESCRIPTION
### Description

This PR fixes the issue that failed to remove template/iso if upload from local fails

When upload template/iso/volume from local fails, the install_path will not be a full path of file so removing it will fail.

```
mysql> select install_path from template_store_ref;
+--------------------------------------------------------------------+
| install_path                                                       |
+--------------------------------------------------------------------+
| template/tmpl/1/3/805f4763-248e-40ec-b79a-b868cc480d0a.qcow2       |
| template/tmpl/1/4/c7e32c9e-5e72-3726-85cf-aa5ccd84118d.qcow2       |
| template/tmpl/2/201/bc4f4f08-138a-31b8-af1a-d4450eff7982.qcow2     |
| template/tmpl/2/202                                                |
| template/tmpl/2/203/203-2-d47f8cde-a2a8-31e7-a826-2628ad98a6c8.iso |
| template/tmpl/2/204                                                |
| template/tmpl/5/205                                                |
| template/tmpl/2/206                                                |
| template/tmpl/2/207                                                |
| template/tmpl/2/208                                                |
| template/tmpl/2/209                                                |
| template/tmpl/2/210                                                |
+--------------------------------------------------------------------+
12 rows in set (0.00 sec)

mysql> select install_path from volume_store_ref;
+---------------------------------------------------------+
| install_path                                            |
+---------------------------------------------------------+
| volumes/2/22                                            |
| volumes/2/19/f93face9-6521-4184-b89a-cb07f86bbae8.qcow2 |
| volumes/2/23                                            |
| volumes/2/24                                            |
+---------------------------------------------------------+
4 rows in set (0.00 sec)
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
