### PR TITLE
fix: create template with Marvin

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1469,16 +1469,12 @@ class Template:
 
     @classmethod
     def create_from_volume(cls, apiclient, volume, services,
-                           random_name=True):
+                           random_name=True, projectid=None):
         """Create Template from volume"""
         # Create template from Volume ID
         cmd = createTemplate.createTemplateCmd()
 
-        Template._set_command(apiclient, cmd, services, random_name)
-
-        cmd.volumeid = volume.id
-
-        return Template(apiclient.createTemplate(cmd).__dict__)
+        return Template._set_command(apiclient, cmd, services, random_name, projectid = projectid, volume = volume)
 
     @classmethod
     def create_from_snapshot(cls, apiclient, snapshot, services, account=None,
@@ -1487,14 +1483,10 @@ class Template:
         # Create template from Snapshot ID
         cmd = createTemplate.createTemplateCmd()
 
-        Template._set_command(apiclient, cmd, services, random_name)
-
-        cmd.snapshotid = snapshot.id
-
-        return Template(apiclient.createTemplate(cmd).__dict__)
+        return Template._set_command(apiclient, cmd, services, random_name, snapshot = snapshot, projectid = projectid)
 
     @classmethod
-    def _set_command(cls, apiclient, cmd, services, random_name=True):
+    def _set_command(cls, apiclient, cmd, services, random_name=True, snapshot=None, volume=None, projectid=None):
         cmd.displaytext = services["displaytext"]
         cmd.name = "-".join([
             services["name"],
@@ -1521,12 +1513,12 @@ class Template:
             raise Exception(
                 "Unable to find Ostype is required for creating template")
 
-        cmd.snapshotid = snapshot.id
+        if volume:
+            cmd.volumeid = volume.id
 
-        if account:
-            cmd.account = account
-        if domainid:
-            cmd.domainid = domainid
+        if snapshot:
+            cmd.snapshotid = snapshot.id
+
         if projectid:
             cmd.projectid = projectid
 


### PR DESCRIPTION
Fixes problems with:
* undefined params
* if we define those params when invoking the functions create_from_volume/create_from_snapshot will be created two templates
* according to the API docs and some digging into the code createTemplate command does not accept account and domainid

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### How Has This Been Tested?
execute nose tests

