### PR TITLE
server: fix root disk size on vm reset

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1259,10 +1259,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
 
             _volsDao.update(volume.getId(), volume);
-            if (userVm != null && Volume.Type.ROOT.equals(volume.getVolumeType())) {
-                Long sizeInGB = newSize / (1024 * 1024 * 1024);
-                userVmDetailsDao.addDetail(userVm.getId(), VmDetailConstants.ROOT_DISK_SIZE, String.valueOf(sizeInGB), true);
-            }
 
             /* Update resource count for the account on primary storage resource */
             if (!shrinkOk) {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -175,6 +175,7 @@ import com.cloud.vm.VmWorkResizeVolume;
 import com.cloud.vm.VmWorkSerializer;
 import com.cloud.vm.VmWorkTakeVolumeSnapshot;
 import com.cloud.vm.dao.UserVmDao;
+import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
@@ -213,6 +214,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     private ServiceOfferingDetailsDao _serviceOfferingDetailsDao;
     @Inject
     private UserVmDao _userVmDao;
+    @Inject
+    private UserVmDetailsDao userVmDetailsDao;
     @Inject
     private UserVmService _userVmService;
     @Inject
@@ -901,9 +904,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         HypervisorType hypervisorType = _volsDao.getHypervisorType(volume.getId());
 
-        if (hypervisorType != HypervisorType.KVM && hypervisorType != HypervisorType.XenServer && hypervisorType != HypervisorType.VMware && hypervisorType != HypervisorType.Any
+        if (hypervisorType != HypervisorType.KVM && hypervisorType != HypervisorType.XenServer
+                && hypervisorType != HypervisorType.VMware && hypervisorType != HypervisorType.Any
                 && hypervisorType != HypervisorType.None) {
-            throw new InvalidParameterValueException("Hypervisor " + hypervisorType + " does not support  rootdisksize override");
+            throw new InvalidParameterValueException("Hypervisor " + hypervisorType + " does not support volume resize");
         }
 
         if (volume.getState() != Volume.State.Ready && volume.getState() != Volume.State.Allocated) {
@@ -1255,6 +1259,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
 
             _volsDao.update(volume.getId(), volume);
+            if (userVm != null && Volume.Type.ROOT.equals(volume.getVolumeType())) {
+                Long sizeInGB = newSize / (1024 * 1024 * 1024);
+                userVmDetailsDao.addDetail(userVm.getId(), VmDetailConstants.ROOT_DISK_SIZE, String.valueOf(sizeInGB), true);
+            }
 
             /* Update resource count for the account on primary storage resource */
             if (!shrinkOk) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -6678,6 +6678,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 newVol = volumeMgr.allocateDuplicateVolume(root, null);
             }
 
+            if (userVmDetailsDao.findDetail(vm.getId(), VmDetailConstants.ROOT_DISK_SIZE) == null && !newVol.getSize().equals(template.getSize())) {
+                VolumeVO resizedVolume = (VolumeVO) newVol;
+                resizedVolume.setSize(template.getSize());
+                _volsDao.update(resizedVolume.getId(), resizedVolume);
+            }
+
             // 1. Save usage event and update resource count for user vm volumes
             _resourceLimitMgr.incrementResourceCount(newVol.getAccountId(), ResourceType.volume, newVol.isDisplay());
             _resourceLimitMgr.incrementResourceCount(newVol.getAccountId(), ResourceType.primary_storage, newVol.isDisplay(), new Long(newVol.getSize()));


### PR DESCRIPTION
### Description

If VM details contain `rootdisksize`, volume entry in DB should reflect correct size when VM reset is performed.

Fixes #3957 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
