### PR TITLE
marvin: fix test failures when changing service offering of a VM

### DIFF
--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -502,6 +502,23 @@ class TestServiceOfferings(cloudstackTestCase):
             self.skipTest("Skipping this test for {} due to bug CS-38153".format(self.hypervisor))
         try:
             self.medium_virtual_machine.stop(self.apiclient)
+            timeout = self.services["timeout"]
+            while True:
+                time.sleep(self.services["sleep"])
+                # Ensure that VM is in stopped state
+                list_vm_response = list_virtual_machines(
+                                            self.apiclient,
+                                            id=self.medium_virtual_machine.id
+                                            )
+                if isinstance(list_vm_response, list):
+                    vm = list_vm_response[0]
+                    if vm.state == 'Stopped':
+                        self.debug("VM state: %s" % vm.state)
+                        break
+                if timeout == 0:
+                    raise Exception(
+                        "Failed to stop VM (ID: %s) in change service offering" % vm.id)
+                timeout = timeout - 1
         except Exception as e:
             self.fail("Failed to stop VM: %s" % e)
 

--- a/test/integration/smoke/test_vm_snapshots.py
+++ b/test/integration/smoke/test_vm_snapshots.py
@@ -454,6 +454,30 @@ class TestChangeServiceOfferingForVmWithSnapshots(cloudstackTestCase):
         self.debug("Stopping VM - ID: %s" % virtual_machine.id)
         try:
             virtual_machine.stop(self.apiclient)
+            timeout = self.services["timeout"]
+
+            while True:
+                time.sleep(self.services["sleep"])
+
+                # Ensure that VM is in stopped state
+                list_vm_response = list_virtual_machines(
+                    self.apiclient,
+                    id=virtual_machine.id
+                )
+
+                if isinstance(list_vm_response, list):
+
+                    vm = list_vm_response[0]
+                    if vm.state == 'Stopped':
+                        self.debug("VM state: %s" % vm.state)
+                        break
+
+                if timeout == 0:
+                    raise Exception(
+                        "Failed to stop VM (ID: %s) in change service offering" % vm.id)
+
+                timeout = timeout - 1
+
         except Exception as e:
             self.fail("Failed to stop VM: %s" % e)
         


### PR DESCRIPTION
### Description

This PR fixes the test failures noticed on VMware test runs where in change of service offering for a VM fails with the following error:
```
2021-02-04 11:58:05,241 - CRITICAL - EXCEPTION: test_04_change_offering_small: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 369, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_service_offerings.py", line 511, in test_04_change_offering_small\n    self.apiclient.changeServiceForVirtualMachine(cmd)\n', '  File "/usr/lib/python2.7/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 1086, in changeServiceForVirtualMachine\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/lib/python2.7/site-packages/marvin/cloudstackConnection.py", line 379, in marvinRequest\n    raise e\n', 'CloudstackAPIException: Execute cmd: changeserviceforvirtualmachine failed, due to: errorCode: 431, errorText:VM current state is : PowerOn. But VM should be in PowerOff state.\n']

```
This seems to be a consequence of changing the enabling volumeresize with changeServiceForVirtualMachine introduced with : https://github.com/apache/cloudstack/pull/4491. The failure is seen in **test_service_offerings.py -> test_04_change_offering_small**  and **test_vm_snapshots.py -> test_change_service_offering_for_vm_with_snapshots**

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

