### PR TITLE
test: fix checksums for test template

### DIFF
--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -77,7 +77,7 @@ class TestCreateTemplateWithChecksum(cloudstackTestCase):
         if "vmware" in self.hypervisor.lower():
             self.test_template = registerTemplate.registerTemplateCmd()
             self.test_template = registerTemplate.registerTemplateCmd()
-            self.test_template.checksum = "{SHA-1}" + "178639bd5ec089a27f6d39025be28c3de5d9393b"
+            self.test_template.checksum = "{SHA-1}" + "3c00872599c6e1e46a358aac51080db88266cf5c"
             self.test_template.hypervisor = self.hypervisor
             self.test_template.zoneid = self.zone.id
             self.test_template.name = 'test sha-2333'
@@ -85,8 +85,8 @@ class TestCreateTemplateWithChecksum(cloudstackTestCase):
             self.test_template.url = "http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.ova"
             self.test_template.format = "OVA"
             self.test_template.ostypeid = self.getOsType("Other Linux (64-bit)")
-            self.md5 = "3c23ac66bac7888dc7c972783646c644"
-            self.sha256 = "97aaa096d419522158c54f83eb61d9242d9f6bca9166fd4030d73683d647c7e7"
+            self.md5 = "27f3c56a8c7ec7b2f3ff2199f7078006"
+            self.sha256 = "a7b04c1eb507f3f5de844bda352df1ea5e20335b465409493ca6ae07dfd0a158"
 
         if "xen" in self.hypervisor.lower():
             self.test_template = registerTemplate.registerTemplateCmd()


### PR DESCRIPTION
### Description

macchinina-vmware.ova has changed at http://dl.openvm.eu/cloudstack/macchinina/x86_64/
sha1, sha256 and m5 checksum have been updated for template file in test_template.py

Fixes failing smoke tests on VMware

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
```
⇒  wget http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.ova
--2021-02-05 14:39:52--  http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.ova
Resolving dl.openvm.eu (dl.openvm.eu)... 217.19.15.108
Connecting to dl.openvm.eu (dl.openvm.eu)|217.19.15.108|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 23308288 (22M) [application/x-tar]
Saving to: ‘macchinina-vmware.ova’

macchinina-vmware.ova                              100%[===============================================================================================================>]  22.23M   405KB/s    in 78s     

2021-02-05 14:41:14 (290 KB/s) - ‘macchinina-vmware.ova’ saved [23308288/23308288]

shwstppr@shwstppr-ThinkPad:~/Downloads|
⇒  sha1sum macchinina-vmware.ova                                           
3c00872599c6e1e46a358aac51080db88266cf5c  macchinina-vmware.ova
shwstppr@shwstppr-ThinkPad:~/Downloads|
⇒  md5sum macchinina-vmware.ova                                            
27f3c56a8c7ec7b2f3ff2199f7078006  macchinina-vmware.ova
shwstppr@shwstppr-ThinkPad:~/Downloads|
⇒  sha256sum macchinina-vmware.ova                                            
a7b04c1eb507f3f5de844bda352df1ea5e20335b465409493ca6ae07dfd0a158  macchinina-vmware.ova
```
*Test run*
```
[root@pr4150-t3480-vmware-65u2-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr4150-t3480-vmware-65u2-advanced-cfg -s -a tags=advanced --hypervisor=VMware tests/smoke/test_templates.py 

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Feb_05_2021_09_00_15_QCAQ6B. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_01_create_template | Status : SUCCESS ===

=== TestName: test_CreateTemplateWithDuplicateName | Status : SUCCESS ===

Negative Test Passed - Exception Occurred Under template download ['Traceback (most recent call last):\n', '  File "/marvin/tests/smoke/test_templates.py", line 145, in test_02_1_create_template_with_checksum_sha1_negative\n    self.download(self.apiclient, template.id)\n', '  File "/marvin/tests/smoke/test_templates.py", line 220, in download\n    template.status)\n', 'Exception: Failed to download template: status - Failed post download script: checksum "{sha-1}3c00872599c6e1e46a358aac51080db88266cf5c" didn\'t match the given value, "{sha-1}someInvalidValue"\n']
=== TestName: test_02_1_create_template_with_checksum_sha1_negative | Status : SUCCESS ===

=== TestName: test_02_create_template_with_checksum_sha1 | Status : SUCCESS ===

Negative Test Passed - Exception Occurred Under template download ['Traceback (most recent call last):\n', '  File "/marvin/tests/smoke/test_templates.py", line 158, in test_03_1_create_template_with_checksum_sha256_negative\n    self.download(self.apiclient, template.id)\n', '  File "/marvin/tests/smoke/test_templates.py", line 220, in download\n    template.status)\n', 'Exception: Failed to download template: status - Failed post download script: checksum "{SHA-256}a7b04c1eb507f3f5de844bda352df1ea5e20335b465409493ca6ae07dfd0a158" didn\'t match the given value, "{SHA-256}someInvalidValue"\n']
=== TestName: test_03_1_create_template_with_checksum_sha256_negative | Status : SUCCESS ===

=== TestName: test_03_create_template_with_checksum_sha256 | Status : SUCCESS ===

Negative Test Passed - Exception Occurred Under template download ['Traceback (most recent call last):\n', '  File "/marvin/tests/smoke/test_templates.py", line 171, in test_04_1_create_template_with_checksum_md5_negative\n    self.download(self.apiclient, template.id)\n', '  File "/marvin/tests/smoke/test_templates.py", line 220, in download\n    template.status)\n', 'Exception: Failed to download template: status - Failed post download script: checksum "{md5}27f3c56a8c7ec7b2f3ff2199f7078006" didn\'t match the given value, "{md5}someInvalidValue"\n']
=== TestName: test_04_1_create_template_with_checksum_md5_negative | Status : SUCCESS ===

=== TestName: test_04_create_template_with_checksum_md5 | Status : SUCCESS ===

=== TestName: test_05_create_template_with_no_checksum | Status : SUCCESS ===

=== TestName: test_02_edit_template | Status : SUCCESS ===

=== TestName: test_03_delete_template | Status : SUCCESS ===

=== TestName: test_04_extract_template | Status : SUCCESS ===

=== TestName: test_05_template_permissions | Status : SUCCESS ===

=== TestName: test_07_list_public_templates | Status : SUCCESS ===

=== TestName: test_08_list_system_templates | Status : SUCCESS ===

===final results are now copied to: /marvin//MarvinLogs/test_templates_2A9OZW===

```