### PR TITLE
ui: fix add Vmware cluster

### DIFF
--- a/ui/src/views/infra/ClusterAdd.vue
+++ b/ui/src/views/infra/ClusterAdd.vue
@@ -216,11 +216,35 @@ export default {
 
       if (this.hypervisor === 'VMware') {
         this.clustertype = 'ExternalManaged'
+        if ((this.host === null || this.host.length === 0) &&
+          (this.dataCenter === null || this.dataCenter.length === 0)) {
+          api('listVmwareDcs', {
+            zoneid: this.zoneId
+          }).then(response => {
+            var vmwaredcs = response.listvmwaredcsresponse.VMwareDC
+            if (vmwaredcs !== null) {
+              this.host = vmwaredcs[0].vcenter
+              this.dataCenter = vmwaredcs[0].name
+            }
+            this.addCluster()
+          }).catch(error => {
+            this.$notification.error({
+              message: `${this.$t('label.error')} ${error.response.status}`,
+              description: error.response.data.listvmwaredcsresponse.errortext,
+              duration: 0
+            })
+          })
+          return
+        }
+      }
+      this.addCluster()
+    },
+    addCluster () {
+      if (this.hypervisor === 'VMware') {
         const clusternameVal = this.clustername
         this.url = `http://${this.host}/${this.dataCenter}/${clusternameVal}`
         this.clustername = `${this.host}/${this.dataCenter}/${clusternameVal}`
       }
-
       this.loading = true
       this.parentToggleLoading()
       api('addCluster', {}, 'POST', {


### PR DESCRIPTION
### Description

When adding a cluster from an existing host-datacenter UI should list and autofill host, DC name while making addCluster API call.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before fix:
![Screenshot from 2021-02-08 16-48-09](https://user-images.githubusercontent.com/153340/107213655-c9b42b80-6a2e-11eb-8b7d-4471ec12a35d.png)

After the fix, vCenter cluster successfully added

### How Has This Been Tested?
UI
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Deploy an env with VMware DC added in CloudStack zone with adv networking
2. Create a new cluster in vCenter
![Screenshot from 2021-02-24 16-41-22](https://user-images.githubusercontent.com/153340/108992884-d045d280-76bf-11eb-821a-05405fb370ee.png)

3. Try to add that cluster in CloudStack UI. This will return error as shown in the above screenshot. DC name and host are set to null without querying CloudStack
![vcenter-cluster](https://user-images.githubusercontent.com/153340/108992851-c623d400-76bf-11eb-9c82-8cf2c00bbdc5.gif)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
