### PR TITLE
ui: fix tags selection for add disk offering

### DIFF
--- a/ui/src/views/offering/AddDiskOffering.vue
+++ b/ui/src/views/offering/AddDiskOffering.vue
@@ -334,8 +334,8 @@
             :loading="storageTagLoading"
             :placeholder="this.$t('label.tags')"
             v-if="this.isAdmin()">
-            <a-select-option v-for="(opt) in this.storageTags" :key="opt.name">
-              {{ opt.name || opt.description }}
+            <a-select-option v-for="(opt) in this.storageTags" :key="opt">
+              {{ opt }}
             </a-select-option>
           </a-select>
         </a-form-item>
@@ -530,13 +530,10 @@ export default {
       params.listAll = true
       this.storageTagLoading = true
       api('listStorageTags', params).then(json => {
-        const tags = json.liststoragetagsresponse.storagetag
-        if (this.arrayHasItems(tags)) {
-          for (var i in tags) {
-            var tag = {}
-            tag.id = tags[i].name
-            tag.name = tags[i].name
-            this.storageTags.push(tag)
+        const tags = json.liststoragetagsresponse.storagetag || []
+        for (const tag of tags) {
+          if (!this.storageTags.includes(tag.name)) {
+            this.storageTags.push(tag.name)
           }
         }
       }).finally(() => {


### PR DESCRIPTION
### Description

Multiple entries were showing in tag selection dropdown of Add disk offering form.

![Screenshot from 2021-02-08 18-48-16](https://user-images.githubusercontent.com/153340/107225600-01c36a80-6a3f-11eb-98ca-4812094df2e5.png)


<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![Screenshot from 2021-02-08 18-48-26](https://user-images.githubusercontent.com/153340/107225582-fa9c5c80-6a3e-11eb-910f-95d1d54f9756.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
With UI

- Add same tag in different primary stores belonging to different clusters
- Try to create a new disk offering
- Tag selection dropdown will show same tag multiple times (same number as of primary stores to which the tag was added)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
