### PR TITLE
Adjust tests to fix a problem with the container builders (https://github.com/khos2ow/cloudstack-deb-builder)

### DIFF
--- a/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -58,12 +58,6 @@ public class RootCAProviderTest {
         f.set(provider, o);
     }
 
-    private void overrideDefaultConfigValue(final ConfigKey configKey, final String name, final Object o) throws IllegalAccessException, NoSuchFieldException {
-        Field f = ConfigKey.class.getDeclaredField(name);
-        f.setAccessible(true);
-        f.set(configKey, o);
-    }
-
     @Before
     public void setUp() throws Exception {
         caKeyPair = CertUtils.generateRandomKeyPair(1024);

--- a/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -41,6 +41,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -133,17 +134,17 @@ public class RootCAProviderTest {
 
     @Test
     public void testCreateSSLEngineWithoutAuthStrictness() throws Exception {
-        overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "false");
+        provider.rootCAAuthStrictness = Mockito.mock(ConfigKey.class);
+        Mockito.when(provider.rootCAAuthStrictness.value()).thenReturn(Boolean.FALSE);
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
-        Assert.assertFalse(e.getUseClientMode());
         Assert.assertFalse(e.getNeedClientAuth());
     }
 
     @Test
     public void testCreateSSLEngineWithAuthStrictness() throws Exception {
-        overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "true");
+        provider.rootCAAuthStrictness = Mockito.mock(ConfigKey.class);
+        Mockito.when(provider.rootCAAuthStrictness.value()).thenReturn(Boolean.TRUE);
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
-        Assert.assertFalse(e.getUseClientMode());
         Assert.assertTrue(e.getNeedClientAuth());
     }
 


### PR DESCRIPTION
### Description
These tests were changing the value of an attribute in a protected static object at runtime instead of mocking the object. We discovered this problem when working with the docker build containers in https://github.com/khos2ow/cloudstack-deb-builder/pull/20. They were breaking the tests when building in the docker container. 

This PR intends to improve these tests to use actual mocks, instead of change the value at runtime with reflection, keeping the same behavior.


Obs: The [DEB Builder](https://github.com/khos2ow/cloudstack-deb-builder) uses version 4.13 to test the container's building for Java8 containers, and 4.15 for Java11 containers.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

#### Bug Severity
- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
The tests were been ran and the packages were built locally.