### PR TITLE
ui: fix update vm details wrt backend changes

### DIFF
--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -176,6 +176,13 @@ export default {
       })
       this.disableSettings = (this.$route.meta.name === 'vm' && this.resource.state !== 'Stopped')
     },
+    filterOrReadOnlyDetails () {
+      for (var i = 0; i < this.details.length; i++) {
+        if (!this.allowEditOfDetail(this.details[i].name)) {
+          this.details.splice(i, 1)
+        }
+      }
+    },
     allowEditOfDetail (name) {
       if (this.resource.readonlyuidetails) {
         if (this.resource.readonlyuidetails.split(',').map(item => item.trim()).includes(name)) {
@@ -257,13 +264,16 @@ export default {
       }
       this.error = false
       this.details.push({ name: this.newKey, value: this.newValue })
+      this.filterOrReadOnlyDetails()
       this.runApi()
     },
     updateDetail (index) {
+      this.filterOrReadOnlyDetails()
       this.runApi()
     },
     deleteDetail (index) {
       this.details.splice(index, 1)
+      this.filterOrReadOnlyDetails()
       this.runApi()
     },
     onShowAddDetail () {


### PR DESCRIPTION
### Description

PR #4629 made changes in updateVirtualMachine behaviour wrt readonly details.
This change updates UI wrt new behaviour.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

- Deployed a VM as user.
- As admin added a new detail to the VM. Made the detail read-only by putting it in global config - `user.vm.readonly.ui.details`
- As user, tried add, edit and delete details operation on the VM.

![Screenshot from 2021-03-01 16-35-10](https://user-images.githubusercontent.com/153340/109489445-e4694580-7aac-11eb-8887-5bf68730f988.png)
![readonly](https://user-images.githubusercontent.com/153340/109489460-ea5f2680-7aac-11eb-9aac-4d0980f8d3b1.gif)


