### PR TITLE
cks: fix CNI release url returning 404

### DIFF
--- a/scripts/util/create-kubernetes-binaries-iso.sh
+++ b/scripts/util/create-kubernetes-binaries-iso.sh
@@ -37,7 +37,10 @@ CNI_VERSION="v${3}"
 echo "Downloading CNI ${CNI_VERSION}..."
 cni_dir="${working_dir}/cni/"
 mkdir -p "${cni_dir}"
-curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" -o "${cni_dir}/cni-plugins-amd64.tgz"
+cni_status_code=$(curl -L  --write-out "%{http_code}\n" "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" -o "${cni_dir}/cni-plugins-amd64.tgz")
+if [[ ${cni_status_code} -eq 404 ]] ; then
+  curl -L  --write-out "%{http_code}\n" "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" -o "${cni_dir}/cni-plugins-amd64.tgz"
+fi
 
 CRICTL_VERSION="v${4}"
 echo "Downloading CRI tools ${CRICTL_VERSION}..."


### PR DESCRIPTION
### Description

CNI plugin release naming has changed, https://github.com/containernetworking/plugins/releases
Releases are named for host OS from 0.8.0 onwards.
This change adds check for 404 response code and attempts retry

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Creating ISO for k8s 1.16.3 and 1.19.7

For k8s 1.16.3 with CNI plugin 0.7.1
```
./create-kubernetes-binaries-iso.sh ~/Desktop 1.16.3 0.7.1 1.16.0 "https://cloud.weave.works/k8s/net?k8s-version=1.16.3" "https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-rc3/aio/deploy/recommended.yaml" setup-v1.16.3 
+ set -e
+ '[' 7 -lt 6 ']'
+ RELEASE=v1.16.3
+ output_dir=/home/shwstppr/Desktop
+ start_dir=/home/shwstppr/lab/shapeblue/cloudstack/scripts/util
+ iso_dir=/tmp/iso
+ working_dir=/tmp/iso/
+ mkdir -p /tmp/iso/
+ build_name=setup-v1.16.3.iso
+ '[' -z setup-v1.16.3.iso ']'
+ CNI_VERSION=v0.7.1
+ echo 'Downloading CNI v0.7.1...'
Downloading CNI v0.7.1...
+ cni_dir=/tmp/iso//cni/
+ mkdir -p /tmp/iso//cni/
++ curl -L --write-out '%{http_code}\n' https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-linux-amd64-v0.7.1.tgz -o /tmp/iso//cni//cni-plugins-amd64.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0     26      0 --:--:-- --:--:-- --:--:--    26
+ cni_status_code=404
+ [[ 404 -eq 404 ]]
+ curl -L --write-out '%{http_code}\n' https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-amd64-v0.7.1.tgz -o /tmp/iso//cni//cni-plugins-amd64.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   634  100   634    0     0   1699      0 --:--:-- --:--:-- --:--:--  1699
100 16.3M  100 16.3M    0     0  2055k      0  0:00:08  0:00:08 --:--:-- 2398k
200
...
...
```

For k8s 1.19.7 with CNI plugin 0.8.1
```
./create-kubernetes-binaries-iso.sh ~/Desktop/ 1.19.7 0.8.1 1.12.0 "https://cloud.weave.works/k8s/net?k8s-version=1.19.7" https://raw.githubusercontent.com/kubernetes/dashboard/v2.1.0/aio/deploy/recommended.yaml setup-1.19.7
+ set -e
+ '[' 7 -lt 6 ']'
+ RELEASE=v1.19.7
+ output_dir=/home/shwstppr/Desktop/
+ start_dir=/home/shwstppr/lab/shapeblue/cloudstack/scripts/util
+ iso_dir=/tmp/iso
+ working_dir=/tmp/iso/
+ mkdir -p /tmp/iso/
+ build_name=setup-1.19.7.iso
+ '[' -z setup-1.19.7.iso ']'
+ CNI_VERSION=v0.8.1
+ echo 'Downloading CNI v0.8.1...'
Downloading CNI v0.8.1...
+ cni_dir=/tmp/iso//cni/
+ mkdir -p /tmp/iso//cni/
++ curl -L --write-out '%{http_code}\n' https://github.com/containernetworking/plugins/releases/download/v0.8.1/cni-plugins-linux-amd64-v0.8.1.tgz -o /tmp/iso//cni//cni-plugins-amd64.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   640  100   640    0     0   3786      0 --:--:-- --:--:-- --:--:--  3764
100 34.9M  100 34.9M    0     0  5408k      0  0:00:06  0:00:06 --:--:-- 5475k
+ cni_status_code=200
+ [[ 200 -eq 404 ]]
...
...
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
