### PR TITLE
server: delete template on storage over capacity threshold

### DIFF
--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -159,7 +159,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
     }
 
     private void checkZoneImageStores(final List<Long> zoneIdList) {
-        if (zoneIdList != null && CollectionUtils.isEmpty(storeMgr.getImageStoresByScopeExcludingReadOnly(new ZoneScope(zoneIdList.get(0))))) {
+        if (zoneIdList != null && CollectionUtils.isEmpty(storeMgr.getImageStoresByScope(new ZoneScope(zoneIdList.get(0))))) {
             throw new InvalidParameterValueException("Failed to find a writable secondary storage in the specified zone.");
         }
     }

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -160,7 +160,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
 
     private void checkZoneImageStores(final List<Long> zoneIdList) {
         if (zoneIdList != null && CollectionUtils.isEmpty(storeMgr.getImageStoresByScope(new ZoneScope(zoneIdList.get(0))))) {
-            throw new InvalidParameterValueException("Failed to find a writable secondary storage in the specified zone.");
+            throw new InvalidParameterValueException("Failed to find a secondary storage in the specified zone.");
         }
     }
 


### PR DESCRIPTION
### Description

While deleting a template for a specific zone, the check should be done only for secondary storages and not for storages with the available capacity threshold.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
