### PR TITLE
server: fix finding pools for volume migration

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/StoragePoolAllocator.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/StoragePoolAllocator.java
@@ -29,6 +29,12 @@ import com.cloud.vm.VirtualMachineProfile;
  */
 public interface StoragePoolAllocator extends Adapter {
     /**
+     * Overloaded method calls allocateToPool with bypassStorageTypeCheck = false
+     * and returns a list of pools suitable.
+     **/
+    List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo);
+
+    /**
      * Determines which storage pools are suitable for the guest virtual machine
      * and returns a list of pools suitable.
      *
@@ -45,10 +51,12 @@ public interface StoragePoolAllocator extends Adapter {
      * @param ExcludeList
      *            avoid
      * @param int returnUpTo (use -1 to return all possible pools)
+     * @param boolean bypassStorageTypeCheck
      * @return List<StoragePool> List of storage pools that are suitable for the
      *         VM
      **/
-    List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo);
+    List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck);
+
 
     static int RETURN_UPTO_ALL = -1;
 

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/StoragePoolAllocator.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/StoragePoolAllocator.java
@@ -51,7 +51,7 @@ public interface StoragePoolAllocator extends Adapter {
      * @param ExcludeList
      *            avoid
      * @param int returnUpTo (use -1 to return all possible pools)
-     * @param boolean bypassStorageTypeCheck
+     * @param boolean bypassStorageTypeCheck allows bypassing useLocalStorage check for provided DiskProfile when true
      * @return List<StoragePool> List of storage pools that are suitable for the
      *         VM
      **/

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
@@ -122,6 +122,8 @@ public interface PrimaryDataStoreDao extends GenericDao<StoragePoolVO, Long> {
 
     List<StoragePoolVO> listLocalStoragePoolByPath(long datacenterId, String path);
 
+    List<StoragePoolVO> findPoolsInClusters(List<Long> clusterIds);
+
     void deletePoolTags(long poolId);
 
     List<StoragePoolVO> listChildStoragePoolsInDatastoreCluster(long poolId);

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
@@ -56,6 +56,7 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
     private final SearchBuilder<StoragePoolVO> DeleteLvmSearch;
     private final SearchBuilder<StoragePoolVO> DcLocalStorageSearch;
     private final GenericSearchBuilder<StoragePoolVO, Long> StatusCountSearch;
+    private final SearchBuilder<StoragePoolVO> ClustersSearch;
 
     @Inject
     private StoragePoolDetailsDao _detailsDao;
@@ -132,6 +133,10 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
         DcLocalStorageSearch.and("path", DcLocalStorageSearch.entity().getPath(), SearchCriteria.Op.EQ);
         DcLocalStorageSearch.and("scope", DcLocalStorageSearch.entity().getScope(), SearchCriteria.Op.EQ);
         DcLocalStorageSearch.done();
+
+        ClustersSearch = createSearchBuilder();
+        ClustersSearch.and("clusterIds", ClustersSearch.entity().getClusterId(), Op.IN);
+        ClustersSearch.and("status", ClustersSearch.entity().getStatus(), Op.EQ);
 
     }
 
@@ -567,5 +572,13 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
         sc.addAnd("parent", SearchCriteria.Op.EQ, 0);
         sc.addAnd("removed", SearchCriteria.Op.NULL);
         return getCount(sc);
+    }
+
+    @Override
+    public List<StoragePoolVO> findPoolsInClusters(List<Long> clusterIds) {
+        SearchCriteria<StoragePoolVO> sc = ClustersSearch.create();
+        sc.setParameters("clusterIds", clusterIds.toArray());
+        sc.setParameters("status", StoragePoolStatus.Up);
+        return listBy(sc);
     }
 }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -26,15 +26,12 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.exception.StorageUnavailableException;
-import com.cloud.storage.StoragePoolStatus;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.log4j.Logger;
 
 import com.cloud.capacity.Capacity;
 import com.cloud.capacity.dao.CapacityDao;
@@ -42,10 +39,12 @@ import com.cloud.dc.ClusterVO;
 import com.cloud.dc.dao.ClusterDao;
 import com.cloud.deploy.DeploymentPlan;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.exception.StorageUnavailableException;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.storage.Storage;
 import com.cloud.storage.StorageManager;
 import com.cloud.storage.StoragePool;
+import com.cloud.storage.StoragePoolStatus;
 import com.cloud.storage.StorageUtil;
 import com.cloud.storage.Volume;
 import com.cloud.storage.dao.VolumeDao;
@@ -87,11 +86,16 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
         return false;
     }
 
-    protected abstract List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo);
+    protected abstract List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck);
 
     @Override
     public List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
-        List<StoragePool> pools = select(dskCh, vmProfile, plan, avoid, returnUpTo);
+        return allocateToPool(dskCh, vmProfile, plan, avoid, returnUpTo, false);
+    }
+
+    @Override
+    public List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
+        List<StoragePool> pools = select(dskCh, vmProfile, plan, avoid, returnUpTo, bypassStorageTypeCheck);
         return reorderPools(pools, vmProfile, plan);
     }
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ClusterScopeStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ClusterScopeStoragePoolAllocator.java
@@ -45,8 +45,12 @@ public class ClusterScopeStoragePoolAllocator extends AbstractStoragePoolAllocat
     DiskOfferingDao _diskOfferingDao;
 
     @Override
-    protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
+    protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
         s_logger.debug("ClusterScopeStoragePoolAllocator looking for storage pool");
+
+        if (!bypassStorageTypeCheck && dskCh.useLocalStorage()) {
+            return null;
+        }
 
         List<StoragePool> suitablePools = new ArrayList<StoragePool>();
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/GarbageCollectingStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/GarbageCollectingStoragePoolAllocator.java
@@ -47,7 +47,7 @@ public class GarbageCollectingStoragePoolAllocator extends AbstractStoragePoolAl
     boolean _storagePoolCleanupEnabled;
 
     @Override
-    public List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
+    public List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
         s_logger.debug("GarbageCollectingStoragePoolAllocator looking for storage pool");
         if (!_storagePoolCleanupEnabled) {
             s_logger.debug("Storage pool cleanup is not enabled, so GarbageCollectingStoragePoolAllocator is being skipped.");
@@ -68,7 +68,7 @@ public class GarbageCollectingStoragePoolAllocator extends AbstractStoragePoolAl
         ExcludeList myAvoids =
             new ExcludeList(avoid.getDataCentersToAvoid(), avoid.getPodsToAvoid(), avoid.getClustersToAvoid(), avoid.getHostsToAvoid(), avoid.getPoolsToAvoid());
 
-        return allocator.allocateToPool(dskCh, vmProfile, plan, myAvoids, returnUpTo);
+        return allocator.allocateToPool(dskCh, vmProfile, plan, myAvoids, returnUpTo, bypassStorageTypeCheck);
     }
 
     @Override

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/LocalStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/LocalStoragePoolAllocator.java
@@ -60,10 +60,10 @@ public class LocalStoragePoolAllocator extends AbstractStoragePoolAllocator {
     ConfigurationDao _configDao;
 
     @Override
-    protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
+    protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
         s_logger.debug("LocalStoragePoolAllocator trying to find storage pool to fit the vm");
 
-        if (!dskCh.useLocalStorage()) {
+        if (!bypassStorageTypeCheck && !dskCh.useLocalStorage()) {
             return null;
         }
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/UseLocalForRootAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/UseLocalForRootAllocator.java
@@ -39,12 +39,17 @@ public class UseLocalForRootAllocator extends LocalStoragePoolAllocator implemen
 
     @Override
     public List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
+        return allocateToPool(dskCh, vmProfile, plan, avoid, returnUpTo, false);
+    }
+
+    @Override
+    public List<StoragePool> allocateToPool(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
         DataCenterVO dc = _dcDao.findById(plan.getDataCenterId());
         if (!dc.isLocalStorageEnabled()) {
             return null;
         }
 
-        return super.allocateToPool(dskCh, vmProfile, plan, avoid, returnUpTo);
+        return super.allocateToPool(dskCh, vmProfile, plan, avoid, returnUpTo, bypassStorageTypeCheck);
     }
 
     @Override

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ZoneWideStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ZoneWideStoragePoolAllocator.java
@@ -50,10 +50,10 @@ public class ZoneWideStoragePoolAllocator extends AbstractStoragePoolAllocator {
 
 
     @Override
-    protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
+    protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
         LOGGER.debug("ZoneWideStoragePoolAllocator to find storage pool");
 
-        if (dskCh.useLocalStorage()) {
+        if (!bypassStorageTypeCheck && dskCh.useLocalStorage()) {
             return null;
         }
 

--- a/plugins/storage-allocators/random/src/main/java/org/apache/cloudstack/storage/allocator/RandomStoragePoolAllocator.java
+++ b/plugins/storage-allocators/random/src/main/java/org/apache/cloudstack/storage/allocator/RandomStoragePoolAllocator.java
@@ -35,7 +35,7 @@ public class RandomStoragePoolAllocator extends AbstractStoragePoolAllocator {
     private static final Logger s_logger = Logger.getLogger(RandomStoragePoolAllocator.class);
 
     @Override
-    public List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
+    public List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo, boolean bypassStorageTypeCheck) {
 
         List<StoragePool> suitablePools = new ArrayList<StoragePool>();
 

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1586,12 +1586,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         HypervisorType type = getHypervisorType(vm, srcVolumePool, profile);
 
         DiskOfferingVO diskOffering = _diskOfferingDao.findById(volume.getDiskOfferingId());
-        //This is an override mechanism so we can list the possible local storage pools that a volume in a shared pool might be able to be migrated to
         DiskProfile diskProfile = new DiskProfile(volume, diskOffering, type);
-        diskProfile.setUseLocalStorage(true);
 
         for (StoragePoolAllocator allocator : _storagePoolAllocators) {
-            List<StoragePool> pools = allocator.allocateToPool(diskProfile, profile, plan, avoid, StoragePoolAllocator.RETURN_UPTO_ALL);
+            List<StoragePool> pools = allocator.allocateToPool(diskProfile, profile, plan, avoid, StoragePoolAllocator.RETURN_UPTO_ALL, true);
             if (CollectionUtils.isEmpty(pools)) {
                 continue;
             }

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1588,10 +1588,14 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         ExcludeList avoid = new ExcludeList();
         avoid.addPool(srcVolumePool.getId());
-
-        DataCenterDeployment plan = new DataCenterDeployment(volume.getDataCenterId(), srcVolumePool.getPodId(),
-                srcCluster != null ? srcCluster.getId() : null, srcCluster != null ? srcCluster.getPodId() : null,
-                null, null, null);
+        Long clusterId = null;
+        Long podId = null;
+        if (srcCluster != null) {
+            clusterId = srcCluster.getId();
+            podId = srcCluster.getPodId();
+        }
+        DataCenterDeployment plan = new DataCenterDeployment(volume.getDataCenterId(), podId, clusterId,
+                null, null, null, null);
         VirtualMachineProfile profile = new VirtualMachineProfileImpl(vm);
         // OfflineVmwareMigration: vm might be null here; deal!
         HypervisorType type = getHypervisorType(vm, srcVolumePool, profile);

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1488,7 +1488,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         StoragePool srcVolumePool = _poolDao.findById(volume.getPoolId());
-        Cluster srcCluster = getVolumeSourceStoragePoolVmCluster(srcVolumePool, vm);
+        Cluster srcCluster = null;
+        if (vm != null) {
+            srcCluster = getVolumeSourceStoragePoolVmCluster(srcVolumePool, vm);
+        }
         allPools = getAllStoragePoolCompatibleWithVolumeSourceStoragePool(srcVolumePool,
                 ApiDBUtils.getHypervisorTypeFromFormat(volume.getDataCenterId(), volume.getFormat()),
                 srcCluster != null ? srcCluster.getId() : null);


### PR DESCRIPTION
### Description

While finding pools for volume migration list following compatible storages:
- all zone-wide storages of the same hypervisor.
- when the volume is attached to a VM, then all storages from the same cluster as that of VM.
- for detached volume, all storages that belong to clusters of the same hypervisor. 

Fixes #4692 
Fixes #4400 

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
Using cmk and UI.
Tested with a multi-cluster VMware env.
Storage Pools,
```
(localcloud) SBCM5> > list storagepools filter=id,name,scope,clustername,tags,hypervisor
{
  "count": 8,
  "storagepool": [
    {
      "hypervisor": "VMware",
      "id": "53a4a81b-0271-3989-94d1-a00708fd9c32",
      "name": "ps8",
      "scope": "ZONE",
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "98a0e79c-f879-36e2-b9ce-230f66e88698",
      "name": "ps6",
      "scope": "CLUSTER",
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4",
      "name": "ps5",
      "scope": "CLUSTER"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "79f5ea41-e6dd-3f9d-acca-10267cf7b796",
      "name": "ps4",
      "scope": "CLUSTER",
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "0a74f7c2-63f6-374f-b5df-bc6304d0ff58",
      "name": "ps2",
      "scope": "CLUSTER"
    },
    {
      "clustername": "p1-c1",
      "id": "e777166e-7dbe-340d-977d-a51d5349b5f1",
      "name": "ps2",
      "scope": "CLUSTER",
      "tags": "tag1"
    },
    {
      "clustername": "p1-c1",
      "id": "b2888e3e-b1e2-36d9-9936-861bc6901d3f",
      "name": "ps1",
      "scope": "CLUSTER"
    }
  ]
}
```

Disk offerings used for data disks,
```
(localcloud) SBCM5> > list diskofferings id=bc71e51d-b1fc-4311-87d6-23b366274038 filter=id,name,tags
{
  "count": 1,
  "diskoffering": [
    {
      "id": "bc71e51d-b1fc-4311-87d6-23b366274038",
      "name": "Tagged",
      "tags": "tag1"
    }
  ]
}
(localcloud) SBCM5> > list diskofferings id=310f053a-1c13-47fe-8590-ef3dd1f74e87 filter=id,name,tags
{
  "count": 1,
  "diskoffering": [
    {
      "id": "310f053a-1c13-47fe-8590-ef3dd1f74e87",
      "name": "Small"
    }
  ]
}
```

Disks tested,

1. Detached volume with tagged offering on a zone-wide pool
2. Detached volume with untagged offering on cluster scope pool
3. Volume attached to a VM with tagged offering on a zone-wide pool
4. Volume attached to a VM with untagged offering on a cluster scope pool
5. Root volume of a VM with untagged compute offering on a cluster scope pool
6. Detached volume with tagged offering on a cluster scope pool

```
(localcloud) SBCM5> > list volumes ids=73d242e1-f8fb-4447-8c78-a1e10d106694,7af032e8-a2b3-49bf-b280-45884a0aed90,4f7e80f1-f3b7-4907-9437-0cc02a14d615,65f5248e-dd27-42c8-83e2-bc1e0b781d27,db7e952a-507f-45f8-b113-724f0f4cc9fc,e665c777-7339-4604-9535-2564c23abca8 filter=id,name,virtualmachineid,vmname,diskofferingid,diskofferingname,storageid,storage,hypervisor
{
  "count": 6,
  "volume": [
    {
      "diskofferingid": "bc71e51d-b1fc-4311-87d6-23b366274038",
      "diskofferingname": "Tagged",
      "hypervisor": "VMware",
      "id": "db7e952a-507f-45f8-b113-724f0f4cc9fc",
      "name": "DATA-5-3",
      "storage": "ps8",
      "storageid": "53a4a81b-0271-3989-94d1-a00708fd9c32"
    },
    {
      "diskofferingid": "310f053a-1c13-47fe-8590-ef3dd1f74e87",
      "diskofferingname": "Small",
      "hypervisor": "VMware",
      "id": "65f5248e-dd27-42c8-83e2-bc1e0b781d27",
      "name": "DATA-5-2",
      "storage": "ps5",
      "storageid": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4"
    },
    {
      "diskofferingid": "bc71e51d-b1fc-4311-87d6-23b366274038",
      "diskofferingname": "Tagged",
      "hypervisor": "VMware",
      "id": "4f7e80f1-f3b7-4907-9437-0cc02a14d615",
      "name": "DATA-5-1",
      "storage": "ps8",
      "storageid": "53a4a81b-0271-3989-94d1-a00708fd9c32",
      "virtualmachineid": "c893649d-cc11-43f6-81a2-a96a1c0cb9a8",
      "vmname": "t1"
    },
    {
      "diskofferingid": "310f053a-1c13-47fe-8590-ef3dd1f74e87",
      "diskofferingname": "Small",
      "hypervisor": "VMware",
      "id": "7af032e8-a2b3-49bf-b280-45884a0aed90",
      "name": "DATA-5",
      "storage": "ps5",
      "storageid": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4",
      "virtualmachineid": "c893649d-cc11-43f6-81a2-a96a1c0cb9a8",
      "vmname": "t1"
    },
    {
      "hypervisor": "VMware",
      "id": "73d242e1-f8fb-4447-8c78-a1e10d106694",
      "name": "ROOT-5",
      "storage": "ps5",
      "storageid": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4",
      "virtualmachineid": "c893649d-cc11-43f6-81a2-a96a1c0cb9a8",
      "vmname": "t1"
    },
    {
      "diskofferingid": "bc71e51d-b1fc-4311-87d6-23b366274038",
      "diskofferingname": "Tagged",
      "hypervisor": "VMware",
      "id": "e665c777-7339-4604-9535-2564c23abca8",
      "name": "DATA-5-4",
      "storage": "ps6",
      "storageid": "98a0e79c-f879-36e2-b9ce-230f66e88698"
    }
  ]
}
```

findStoragePoolForMigration results in above order:
```
(localcloud) SBCM5> > find storagepoolsformigration id=db7e952a-507f-45f8-b113-724f0f4cc9fc filter=id,name,scope,clustername,tags,hypervisor,suitableformigration
{
  "count": 7,
  "storagepool": [
    {
      "clustername": "p1-c1",
      "id": "e777166e-7dbe-340d-977d-a51d5349b5f1",
      "name": "ps2",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "79f5ea41-e6dd-3f9d-acca-10267cf7b796",
      "name": "ps4",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "98a0e79c-f879-36e2-b9ce-230f66e88698",
      "name": "ps6",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE",
      "suitableformigration": false
    },
    {
      "clustername": "p1-c1",
      "id": "b2888e3e-b1e2-36d9-9936-861bc6901d3f",
      "name": "ps1",
      "scope": "CLUSTER",
      "suitableformigration": false
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "0a74f7c2-63f6-374f-b5df-bc6304d0ff58",
      "name": "ps2",
      "scope": "CLUSTER",
      "suitableformigration": false
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4",
      "name": "ps5",
      "scope": "CLUSTER",
      "suitableformigration": false
    }
  ]
}

(localcloud) SBCM5> > find storagepoolsformigration id=65f5248e-dd27-42c8-83e2-bc1e0b781d27 filter=id,name,scope,clustername,tags,hypervisor,suitableformigration
{
  "count": 7,
  "storagepool": [
    {
      "clustername": "p1-c1",
      "id": "b2888e3e-b1e2-36d9-9936-861bc6901d3f",
      "name": "ps1",
      "scope": "CLUSTER",
      "suitableformigration": true
    },
    {
      "clustername": "p1-c1",
      "id": "e777166e-7dbe-340d-977d-a51d5349b5f1",
      "name": "ps2",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "0a74f7c2-63f6-374f-b5df-bc6304d0ff58",
      "name": "ps2",
      "scope": "CLUSTER",
      "suitableformigration": true
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "79f5ea41-e6dd-3f9d-acca-10267cf7b796",
      "name": "ps4",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "98a0e79c-f879-36e2-b9ce-230f66e88698",
      "name": "ps6",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE",
      "suitableformigration": true
    },
    {
      "hypervisor": "VMware",
      "id": "53a4a81b-0271-3989-94d1-a00708fd9c32",
      "name": "ps8",
      "scope": "ZONE",
      "suitableformigration": true,
      "tags": "tag1"
    }
  ]
}

(localcloud) SBCM5> > find storagepoolsformigration id=4f7e80f1-f3b7-4907-9437-0cc02a14d615 filter=id,name,scope,clustername,tags,hypervisor,suitableformigration
{
  "count": 3,
  "storagepool": [
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "98a0e79c-f879-36e2-b9ce-230f66e88698",
      "name": "ps6",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE",
      "suitableformigration": false
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4",
      "name": "ps5",
      "scope": "CLUSTER",
      "suitableformigration": false
    }
  ]
}

(localcloud) SBCM5> > find storagepoolsformigration id=7af032e8-a2b3-49bf-b280-45884a0aed90 filter=id,name,scope,clustername,tags,hypervisor,suitableformigration
{
  "count": 3,
  "storagepool": [
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "98a0e79c-f879-36e2-b9ce-230f66e88698",
      "name": "ps6",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE",
      "suitableformigration": true
    },
    {
      "hypervisor": "VMware",
      "id": "53a4a81b-0271-3989-94d1-a00708fd9c32",
      "name": "ps8",
      "scope": "ZONE",
      "suitableformigration": true,
      "tags": "tag1"
    }
  ]
}

(localcloud) SBCM5> > find storagepoolsformigration id=73d242e1-f8fb-4447-8c78-a1e10d106694 filter=id,name,scope,clustername,tags,hypervisor,suitableformigration
{
  "count": 3,
  "storagepool": [
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "98a0e79c-f879-36e2-b9ce-230f66e88698",
      "name": "ps6",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE",
      "suitableformigration": true
    },
    {
      "hypervisor": "VMware",
      "id": "53a4a81b-0271-3989-94d1-a00708fd9c32",
      "name": "ps8",
      "scope": "ZONE",
      "suitableformigration": true,
      "tags": "tag1"
    }
  ]
}

(localcloud) SBCM5> > find storagepoolsformigration id=e665c777-7339-4604-9535-2564c23abca8 filter=id,name,scope,clustername,tags,hypervisor,suitableformigration
{
  "count": 7,
  "storagepool": [
    {
      "clustername": "p1-c1",
      "id": "e777166e-7dbe-340d-977d-a51d5349b5f1",
      "name": "ps2",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "79f5ea41-e6dd-3f9d-acca-10267cf7b796",
      "name": "ps4",
      "scope": "CLUSTER",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "53a4a81b-0271-3989-94d1-a00708fd9c32",
      "name": "ps8",
      "scope": "ZONE",
      "suitableformigration": true,
      "tags": "tag1"
    },
    {
      "hypervisor": "VMware",
      "id": "17899b5b-1838-3e8d-b0fe-76cab34093b1",
      "name": "ps7",
      "scope": "ZONE",
      "suitableformigration": false
    },
    {
      "clustername": "p1-c1",
      "id": "b2888e3e-b1e2-36d9-9936-861bc6901d3f",
      "name": "ps1",
      "scope": "CLUSTER",
      "suitableformigration": false
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c2",
      "id": "0a74f7c2-63f6-374f-b5df-bc6304d0ff58",
      "name": "ps2",
      "scope": "CLUSTER",
      "suitableformigration": false
    },
    {
      "clustername": "10.10.3.184/Trillian/p1-c3",
      "id": "b9aa5fb3-ce0a-316c-a2bb-3dbf905082d4",
      "name": "ps5",
      "scope": "CLUSTER",
      "suitableformigration": false
    }
  ]
}
```
