### PR TITLE
updated maven download link

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,10 +20,10 @@ Install tools and dependencies used for development:
 
 Set up Maven (3.6.0):
 
-    # wget http://www.us.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz
-    # tar -zxvf apache-maven-3.6.0-bin.tar.gz -C /usr/local
+    # wget http://www.us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+    # tar -zxvf apache-maven-3.6.3-bin.tar.gz -C /usr/local
     # cd /usr/local
-    # ln -s apache-maven-3.6.0 maven
+    # ln -s apache-maven-3.6.3 maven
     # echo export M2_HOME=/usr/local/maven >> ~/.bashrc # or .zshrc or .profile
     # echo export PATH=/usr/local/maven/bin:${PATH} >> ~/.bashrc # or .zshrc or .profile
     # source ~/.bashrc


### PR DESCRIPTION
`wget http://www.us.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz` gives `404`. updated new link
`http://www.us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz`