### PR TITLE
Added recursive fetch of child domains for listUsageRecords API call

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/usage/ListUsageRecordsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/usage/ListUsageRecordsCmd.java
@@ -85,6 +85,10 @@ public class ListUsageRecordsCmd extends BaseListCmd {
     @Parameter(name = ApiConstants.OLD_FORMAT, type = CommandType.BOOLEAN, description = "Flag to enable description rendered in old format which uses internal database IDs instead of UUIDs. False by default.")
     private Boolean oldFormat;
 
+    @Parameter(name = ApiConstants.IS_RECURSIVE, type = CommandType.BOOLEAN,
+            description = "Specify if usage records should be fetched recursively per domain.")
+    private Boolean recursive = false;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -151,6 +155,10 @@ public class ListUsageRecordsCmd extends BaseListCmd {
 
     public boolean getOldFormat() {
         return oldFormat != null && oldFormat;
+    }
+
+    public Boolean isRecursive() {
+        return recursive;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/usage/ListUsageRecordsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/usage/ListUsageRecordsCmd.java
@@ -86,7 +86,8 @@ public class ListUsageRecordsCmd extends BaseListCmd {
     private Boolean oldFormat;
 
     @Parameter(name = ApiConstants.IS_RECURSIVE, type = CommandType.BOOLEAN,
-            description = "Specify if usage records should be fetched recursively per domain.")
+            description = "Specify if usage records should be fetched recursively per domain.",
+            since = "4.15")
     private Boolean recursive = false;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/usage/ListUsageRecordsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/usage/ListUsageRecordsCmd.java
@@ -86,7 +86,7 @@ public class ListUsageRecordsCmd extends BaseListCmd {
     private Boolean oldFormat;
 
     @Parameter(name = ApiConstants.IS_RECURSIVE, type = CommandType.BOOLEAN,
-            description = "Specify if usage records should be fetched recursively per domain.",
+            description = "Specify if usage records should be fetched recursively per domain. If an account id is passed, records will be limited to that account.",
             since = "4.15")
     private Boolean recursive = false;
 

--- a/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
+++ b/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
@@ -228,26 +228,29 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
                 domainId = caller.getDomainId();
             }
 
-            // Check if a domain admin is allowed to access the requested account info.
-            Account account = _accountService.getAccount(accountId);
-            boolean matchFound = false;
+            if (cmd.getAccountId() != null) {
 
-            if (account.getDomainId() == domainId) {
-                matchFound = true;
-            } else {
+                // Check if a domain admin is allowed to access the requested account info.
+                Account account = _accountService.getAccount(accountId);
+                boolean matchFound = false;
 
-                // Check if the account is in a child domain of this domain admin.
-                List<DomainVO> childDomains = _domainDao.findAllChildren(_domainDao.findById(domainId).getPath(), domainId);
+                if (account.getDomainId() == domainId) {
+                    matchFound = true;
+                } else {
 
-                for (DomainVO domainVO : childDomains) {
-                    if (account.getDomainId() == domainVO.getId()) {
-                        matchFound = true;
-                        break;
+                    // Check if the account is in a child domain of this domain admin.
+                    List<DomainVO> childDomains = _domainDao.findAllChildren(_domainDao.findById(domainId).getPath(), domainId);
+
+                    for (DomainVO domainVO : childDomains) {
+                        if (account.getDomainId() == domainVO.getId()) {
+                            matchFound = true;
+                            break;
+                        }
                     }
                 }
-            }
-            if (!matchFound) {
+                if (!matchFound) {
                     throw new PermissionDeniedException("Domain admins may only retrieve usage records for accounts in their own domain and child domains.");
+                }
             }
         }
 

--- a/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
+++ b/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
@@ -286,8 +286,12 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
 
         SearchCriteria<UsageVO> sc = _usageDao.createSearchCriteria();
 
-        if (accountId != -1 && accountId != Account.ACCOUNT_ID_SYSTEM && !isAdmin && !cmd.isRecursive()) {
-            sc.addAnd("accountId", SearchCriteria.Op.EQ, accountId);
+        if (accountId != -1 && accountId != Account.ACCOUNT_ID_SYSTEM && !isAdmin) {
+            // account exists and either domain on user role
+            // If not recursive and the account belongs to the user/domain admin, or the account was passed in, filter
+            if ((accountId == caller.getId() && !cmd.isRecursive()) || cmd.getAccountId() != null){
+                sc.addAnd("accountId", SearchCriteria.Op.EQ, accountId);
+            }
         }
 
         if (domainId != null) {

--- a/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
+++ b/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
@@ -248,7 +248,17 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
             sc.addAnd("domainId", SearchCriteria.Op.IN, domainIds.toArray());
         }
 
-        if (domainId != null) {
+        if (cmd.isRecursive() && domainId != null){
+            SearchCriteria<DomainVO> sdc = _domainDao.createSearchCriteria();
+            sdc.addOr("path", SearchCriteria.Op.LIKE, _domainDao.findById(domainId).getPath() + "%");
+            List<DomainVO> domains = _domainDao.search(sdc, null);
+            List<Long> domainIds = new ArrayList<Long>();
+            for (DomainVO domain : domains)
+                domainIds.add(domain.getId());
+            sc.addAnd("domainId", SearchCriteria.Op.IN, domainIds.toArray());
+        }
+
+        if (!cmd.isRecursive() && domainId != null) {
             sc.addAnd("domainId", SearchCriteria.Op.EQ, domainId);
         }
 

--- a/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
+++ b/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
@@ -230,7 +230,6 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
 
             // Check if a domain admin is allowed to access the requested account info.
             Account account = _accountService.getAccount(accountId);
-            Domain domain = _domainDao.findById(caller.getDomainId());
             boolean matchFound = false;
 
             if (account.getDomainId() == domainId) {

--- a/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
+++ b/server/src/main/java/com/cloud/usage/UsageServiceImpl.java
@@ -286,7 +286,7 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
 
         SearchCriteria<UsageVO> sc = _usageDao.createSearchCriteria();
 
-        if (accountId != -1 && accountId != Account.ACCOUNT_ID_SYSTEM && !isAdmin) {
+        if (accountId != -1 && accountId != Account.ACCOUNT_ID_SYSTEM && !isAdmin && !cmd.isRecursive()) {
             sc.addAnd("accountId", SearchCriteria.Op.EQ, accountId);
         }
 


### PR DESCRIPTION
### Description

When calling the listUasageRecords API records per domain are fetched recursively. This is not the case if you specify a domain id.

This PR adds a new parameter to enable fetching records recursively (isRecursive) when passing the domain id.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This has been tested by calling the API with different parameters. With/without a domain id, with/without isRecursive and with/without an account id.
I have tested by calling the API logged in as a root admin, domain admin, and a user.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
