### PR TITLE
Externalize config to set min memory/cpu with division by overprovisi…

### DIFF
--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -34,6 +34,8 @@ import com.cloud.agent.api.to.DiskTO;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.gpu.GPU;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
 import com.cloud.network.Networks.BroadcastDomainType;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkDetailVO;
@@ -49,7 +51,6 @@ import com.cloud.service.dao.ServiceOfferingDetailsDao;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.Volume;
 import com.cloud.utils.Pair;
-import com.cloud.utils.StringUtils;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.NicVO;
@@ -61,8 +62,11 @@ import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.NicSecondaryIpDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
+import org.apache.commons.lang3.StringUtils;
 
-public abstract class HypervisorGuruBase extends AdapterBase implements HypervisorGuru {
+public abstract class HypervisorGuruBase extends AdapterBase implements HypervisorGuru, Configurable {
     public static final Logger s_logger = Logger.getLogger(HypervisorGuruBase.class);
 
     @Inject
@@ -85,6 +89,14 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
     private ServiceOfferingDao _serviceOfferingDao;
     @Inject
     private NetworkDetailsDao networkDetailsDao;
+    @Inject
+    private HostDao hostDao;
+
+    static final ConfigKey<Boolean> VmMinMemoryEqualsMemoryDividedByMemOverprovisioningFactor = new ConfigKey<Boolean>("Advanced", Boolean.class, "vm.min.memory.equals.memory.divided.by.mem.overprovisioning.factor", "true",
+            "If we set this to 'true', a minimum memory (memory/ mem.overprovisioning.factor) will be setted to the VM, independent of using a scalable service offering or not.", true, ConfigKey.Scope.Cluster);
+
+    static final ConfigKey<Boolean> VmMinCpuSpeedEqualsCpuSpeedDividedByCpuOverprovisioningFactor = new ConfigKey<Boolean>("Advanced", Boolean.class, "vm.min.cpu.speed.equals.cpu.speed.divided.by.cpu.overprovisioning.factor", "true",
+            "If we set this to 'true', a minimum cpu speed (cpu speed/ cpu.overprovisioning.factor) will be setted to the VM, independent of using a scalable service offering or not.", true, ConfigKey.Scope.Cluster);
 
     @Override
     public NicTO toNicTO(NicProfile profile) {
@@ -167,8 +179,13 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
     protected VirtualMachineTO toVirtualMachineTO(VirtualMachineProfile vmProfile) {
         ServiceOffering offering = _serviceOfferingDao.findById(vmProfile.getId(), vmProfile.getServiceOfferingId());
         VirtualMachine vm = vmProfile.getVirtualMachine();
-        Long minMemory = (long)(offering.getRamSize() / vmProfile.getMemoryOvercommitRatio());
-        int minspeed = (int)(offering.getSpeed() / vmProfile.getCpuOvercommitRatio());
+        HostVO host = hostDao.findById(vm.getHostId());
+
+        boolean divideMemoryByOverprovisioning = VmMinMemoryEqualsMemoryDividedByMemOverprovisioningFactor.valueIn(host.getClusterId());
+        boolean divideCpuByOverprovisioning = VmMinCpuSpeedEqualsCpuSpeedDividedByCpuOverprovisioningFactor.valueIn(host.getClusterId());
+
+        Long minMemory = (long)(offering.getRamSize() / (divideMemoryByOverprovisioning ? vmProfile.getMemoryOvercommitRatio() : 1));
+        int minspeed = (int)(offering.getSpeed() / (divideCpuByOverprovisioning ? vmProfile.getCpuOvercommitRatio() : 1));
         int maxspeed = (offering.getSpeed());
         VirtualMachineTO to = new VirtualMachineTO(vm.getId(), vm.getInstanceName(), vm.getType(), offering.getCpu(), minspeed, maxspeed, minMemory * 1024l * 1024l,
                 offering.getRamSize() * 1024l * 1024l, null, null, vm.isHaEnabled(), vm.limitCpuUse(), vm.getVncPassword());
@@ -301,4 +318,15 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
     public List<Command> finalizeMigrate(VirtualMachine vm, Map<Volume, StoragePool> volumeToPool) {
         return null;
     }
+
+     @Override
+    public String getConfigComponentName() {
+        return HypervisorGuruBase.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {VmMinMemoryEqualsMemoryDividedByMemOverprovisioningFactor, VmMinCpuSpeedEqualsCpuSpeedDividedByCpuOverprovisioningFactor };
+    }
+
 }


### PR DESCRIPTION
### Description
When ACS is deploying a VM, it defines a minimum memory|CPU to the VM based on a calculation through the overprovisioning (defined mem|cpu speed / overprovisioning factor); Therefore, it will define a range of memory|CPU, even if it does not use scalable (dynamic) service offerings. 

This PR intends to externalize 2 cluster's configurations to allow operators to decide if they want the minimum memory|CPU to be different from the allocated value when the overprovisioning's configurations are different than `1`. 

When we set the overprovisioning factor, it means that we (as operators) are willing to allocate more virtual resources than the physical ones. This is interesting when the hypervisor has optimization techniques such as the KVM ones for optimizing the allocation of common blocks among running virtual machines (Kernel Samepage Merging - KSM). Therefore, we do not need to reduce the minimum amount of memory that the VM must receive when the overprovisioning is higher than one. This is important for public cloud environments, where such definition can be perceived by final users.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?
It has been tested locally in a test lab.

1. I had created VM and observed the `dumpxml`.

2. When I was using the configuration as `true`, it kept the same behavior (allocated memory <> currentMemory).
![image](https://user-images.githubusercontent.com/38945620/108745447-d8640d80-7519-11eb-989b-3ee27887c2b5.png)

3. When I was using the configuration as `false`, it took the current memory equals the allocated memory.
![image](https://user-images.githubusercontent.com/38945620/108745526-f598dc00-7519-11eb-83b6-cb29c0699aab.png)

