### PR TITLE
Fix VMware OVF properties copy from template

### DIFF
--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -61,7 +61,6 @@ from operator import itemgetter
 
 _multiprocess_shared_ = True
 
-
 class TestDeployVM(cloudstackTestCase):
 
     @classmethod
@@ -1745,9 +1744,6 @@ class TestVAppsVM(cloudstackTestCase):
                 cls.l2_network_offering
             ]
 
-            # Uncomment when tests are finished, to cleanup the test templates
-            for template in cls.templates:
-                cls._cleanup.append(template)
 
     @classmethod
     def tearDownClass(cls):
@@ -1769,21 +1765,21 @@ class TestVAppsVM(cloudstackTestCase):
     def get_ova_parsed_information_from_template(self, template):
         if not template:
             return None
-        details = template.details.__dict__
+        details = template['deployasisdetails'].__dict__
         configurations = []
         disks = []
         isos = []
         networks = []
         for propKey in details:
-            if propKey.startswith('ACS-configuration'):
+            if propKey.startswith('configuration'):
                 configurations.append(json.loads(details[propKey]))
-            elif propKey.startswith('ACS-disk'):
+            elif propKey.startswith('disk'):
                 detail = json.loads(details[propKey])
                 if detail['isIso'] == True:
                     isos.append(detail)
                 else:
                     disks.append(detail)
-            elif propKey.startswith('ACS-network'):
+            elif propKey.startswith('network'):
                 networks.append(json.loads(details[propKey]))
 
         return configurations, disks, isos, networks
@@ -1939,8 +1935,6 @@ class TestVAppsVM(cloudstackTestCase):
 
             # Verify nics
             self.verify_nics(nicnetworklist, vm.id)
-            # Verify disks
-            self.verify_disks(disks, vm.id)
             # Verify properties
             original_properties = vm_service['properties']
             vm_properties = get_vm_vapp_configs(self.apiclient, self.config, self.zone, vm.instancename)

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1809,32 +1809,6 @@ class TestVAppsVM(cloudstackTestCase):
                 msg="VM NIC(InstanceID: {}) network mismatch, expected = {}, result = {}".format(nic_network["nic"], nic_network["network"], nic.networkid)
             )
 
-    def verify_disks(self, template_disks, vm_id):
-        cmd = listVolumes.listVolumesCmd()
-        cmd.virtualmachineid = vm_id
-        cmd.listall = True
-        vm_volumes =  self.apiclient.listVolumes(cmd)
-        self.assertEqual(
-            isinstance(vm_volumes, list),
-            True,
-            "Check listVolumes response returns a valid list"
-        )
-        self.assertEqual(
-            len(template_disks),
-            len(vm_volumes),
-            msg="VM volumes count is different, expected = {}, result = {}".format(len(template_disks), len(vm_volumes))
-        )
-        template_disks.sort(key=itemgetter('diskNumber'))
-        vm_volumes.sort(key=itemgetter('deviceid'))
-        for j in range(len(vm_volumes)):
-            volume = vm_volumes[j]
-            disk = template_disks[j]
-            self.assertEqual(
-                volume.size,
-                disk["virtualSize"],
-                msg="VM Volume(diskNumber: {}) network mismatch, expected = {}, result = {}".format(disk["diskNumber"], disk["virtualSize"], volume.size)
-            )
-
     @attr(tags=["advanced", "advancedns", "smoke", "sg", "dev"], required_hardware="false")
     @skipTestIf("hypervisorNotSupported")
     def test_01_vapps_vm_cycle(self):
@@ -1864,7 +1838,7 @@ class TestVAppsVM(cloudstackTestCase):
 
             nicnetworklist = []
             networks = []
-            vm_service = self.services["virtual_machine_vapps"][template.name]
+            vm_service = self.services["virtual_machine_vapps"][template['name']]
             network_mappings = vm_service["nicnetworklist"]
             for network_mapping in network_mappings:
                 network_service = self.services["isolated_network"]
@@ -1888,7 +1862,7 @@ class TestVAppsVM(cloudstackTestCase):
                 vm_service,
                 accountid=self.account.name,
                 domainid=self.account.domainid,
-                templateid=template.id,
+                templateid=template['id'],
                 serviceofferingid=self.custom_offering.id,
                 zoneid=self.zone.id,
                 customcpunumber=cpu_number,

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1765,7 +1765,7 @@ class TestVAppsVM(cloudstackTestCase):
     def get_ova_parsed_information_from_template(self, template):
         if not template:
             return None
-        details = template['deployasisdetails'].__dict__
+        details = template.deployasisdetails.__dict__
         configurations = []
         disks = []
         isos = []
@@ -1838,7 +1838,7 @@ class TestVAppsVM(cloudstackTestCase):
 
             nicnetworklist = []
             networks = []
-            vm_service = self.services["virtual_machine_vapps"][template['name']]
+            vm_service = self.services["virtual_machine_vapps"][template.name]
             network_mappings = vm_service["nicnetworklist"]
             for network_mapping in network_mappings:
                 network_service = self.services["isolated_network"]
@@ -1862,7 +1862,7 @@ class TestVAppsVM(cloudstackTestCase):
                 vm_service,
                 accountid=self.account.name,
                 domainid=self.account.domainid,
-                templateid=template['id'],
+                templateid=template.id,
                 serviceofferingid=self.custom_offering.id,
                 zoneid=self.zone.id,
                 customcpunumber=cpu_number,

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -429,20 +429,20 @@ def get_test_ovf_templates(apiclient, zone_id=None, test_ovf_templates=None, hyp
             template = Template.register(apiclient, test_template, zoneid=zone_id, hypervisor=hypervisor.lower(), randomize_name=False)
             template.download(apiclient)
             retries = 3
-            while (not template.deployasisdetails or len(template.deployasisdetails.__dict__) == 0) and retries > 0:
+            while (not hasattr(template, 'deployasisdetails') or len(template.deployasisdetails.__dict__) == 0) and retries > 0:
                 time.sleep(10)
                 template_list = Template.list(apiclient, id=template.id, zoneid=zone_id, templatefilter='all')
                 if isinstance(template_list, list):
                     template = Template(template_list[0].__dict__)
                 retries = retries - 1
-            if not template.deployasisdetails or len(template.deployasisdetails.__dict__) == 0:
+            if not hasattr(template, 'deployasisdetails') or len(template.deployasisdetails.__dict__) == 0:
                 template.delete(apiclient)
             else:
                 result.append(template)
 
         if templates:
             for template in templates:
-                if template.isready and template.ispublic and template.deployasisdetails != None and len(template.deployasisdetails.__dict__) > 0:
+                if template.isready and template.ispublic and template.deployasisdetails and len(template.deployasisdetails.__dict__) > 0:
                     result.append(template)
 
     return result

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -429,21 +429,21 @@ def get_test_ovf_templates(apiclient, zone_id=None, test_ovf_templates=None, hyp
             template = Template.register(apiclient, test_template, zoneid=zone_id, hypervisor=hypervisor.lower(), randomize_name=False)
             template.download(apiclient)
             retries = 3
-            while (template.details == None or len(template.details.__dict__) == 0) and retries > 0:
+            while (not template.deployasisdetails or len(template.deployasisdetails.__dict__) == 0) and retries > 0:
                 time.sleep(10)
                 template_list = Template.list(apiclient, id=template.id, zoneid=zone_id, templatefilter='all')
                 if isinstance(template_list, list):
                     template = Template(template_list[0].__dict__)
                 retries = retries - 1
-            if template.details == None or len(template.details.__dict__) == 0:
+            if not template.deployasisdetails or len(template.deployasisdetails.__dict__) == 0:
                 template.delete(apiclient)
             else:
                 result.append(template)
 
         if templates:
             for template in templates:
-                if template.isready and template.ispublic and template.details != None and len(template.details.__dict__) > 0:
-                    result.append(template.__dict__)
+                if template.isready and template.ispublic and template.deployasisdetails != None and len(template.deployasisdetails.__dict__) > 0:
+                    result.append(template)
 
     return result
 


### PR DESCRIPTION
### Description

For backward compatibility, prior to Vmware 6.5 use EDIT operation instead of ADD when copying template vApp information 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
