### PR TITLE
get_bridge_physdev returns "device:" instead of "device"

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -149,7 +149,7 @@ def split_ips_by_family(ips):
 
 
 def get_bridge_physdev(brname):
-    physdev = execute("bridge -o link show | awk '/master %s / && !/^[0-9]+: vnet/ {print $2}' | head -1" % brname)
+    physdev = execute("bridge -o link show | awk '/master %s / && !/^[0-9]+: vnet/ {print $2}' | head -1 | cut -d ':' -f1" % brname)
     return physdev.strip()
 
 


### PR DESCRIPTION
### Description

When running [get_bridge_physdev(brname)](https://github.com/apache/cloudstack/blob/b2ffa3efa58a1569dbaa8a34f723756926e22820/scripts/vm/network/security_group.py#L152) from `security_group.py` it is returned the bridge device as `brname:` instead of the expected `brname`.

We experienced this issue on CloudStack 4.13.1.0 with _Security Groups_ enabled for _Advanced Networking_. Additionally, KVM nodes are running on Ubuntu 18.04.

PR #4303 (merged in 4.15) added support for Ubuntu 20.04 which turned out to fix `get_bridge_physdev(brname)`; however, we faced the very same issue with the previous CloudStack and Ubuntu versions.

Even though we might not get a `4.13.2`, and CloudStack `4.14.1.0` has just been released, this PR proposes merging the fix into branch `4.13` and then get it forwarded into `4.14`. Thus, allowing users to have this fix referenced and also opening the possibility of addressing this in case of a potential `4.14.2.0`.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

We had manually changed the `security_group.py` script on our KVM nodes. All is working fine after applying this change.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
