### PR TITLE
api: remove account from listProjects API response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
@@ -51,10 +51,6 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
     @Param(description = "the domain name where the project belongs to")
     private String domain;
 
-    @SerializedName(ApiConstants.ACCOUNT)
-    @Param(description = "the account name of the project's owner")
-    private String ownerName;
-
     @SerializedName(ApiConstants.OWNER)
     @Param(description = "the account name of the project's owners")
     private List<Map<String, String>> owners;
@@ -229,10 +225,6 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
 
     public void setDomain(String domain) {
         this.domain = domain;
-    }
-
-    public void setOwner(String owner) {
-        ownerName = owner;
     }
 
     public void setProjectAccountName(String projectAccountName) {


### PR DESCRIPTION
The `account` is no longer set in the listProjects API response that is
still mentioned in the API docs. API consumers should now use the
`owner` key from the listProjects API response which returns a list of
owners (accounts and users).

To generate the API docs with 4.15.1: http://cloudstack.apache.org/api/apidocs-4.15/

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial