### PR TITLE
cks: fix token TTL, set it to never expire

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/resources/conf/k8s-master.yml
+++ b/plugins/integrations/kubernetes-service/src/main/resources/conf/k8s-master.yml
@@ -204,7 +204,7 @@ write-files:
         fi
         retval=0
         set +e
-        kubeadm init --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.initargs }}
+        kubeadm init --token {{ k8s_master.cluster.token }} --token-ttl 0 {{ k8s_master.cluster.initargs }}
         retval=$?
         set -e
         if [ $retval -eq 0 ]; then


### PR DESCRIPTION
### Description

Fixes #4742 

kubeadm init is called with `--token-ttl 0`
This will allow the token to remain valid forever.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Checked token details after k8s cluster deployment;
```
Container Linux by CoreOS stable (2303.3.0)
Update Strategy: No Reboots
core@t2-master ~ $ sudo kubadm token list
sudo: kubadm: command not found
core@t2-master ~ $ sudo kubeadm token list
TOKEN                     TTL         EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
00dec2.178dc8478dbecfc5   <forever>   <never>                authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
ul9g7i.jl1ehlghm8apx634   1h          2021-03-03T12:03:15Z   <none>                   Proxy for managing TTL for the kubeadm-certs secret        <none>

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
