### PR TITLE
Fix VMware vSAN storage support on vSphere6.0

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
@@ -148,7 +148,7 @@ public class DatastoreMO extends BaseMO {
         }
     }
 
-    String getDatastoreRootPath() throws Exception {
+    public String getDatastoreRootPath() throws Exception {
         return String.format("[%s]", getName());
     }
 

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -447,6 +447,16 @@ public class VirtualMachineMO extends BaseMO {
         return false;
     }
 
+    public DatastoreFile getVmdkFileName(VirtualDisk disk) throws Exception {
+        DatastoreFile dsBackingFile = null;
+        VirtualDeviceBackingInfo backingInfo = disk.getBacking();
+        if (backingInfo instanceof VirtualDiskFlatVer2BackingInfo) {
+            VirtualDiskFlatVer2BackingInfo diskBackingInfo = (VirtualDiskFlatVer2BackingInfo)backingInfo;
+            dsBackingFile = new DatastoreFile(diskBackingInfo.getFileName());
+        }
+        return dsBackingFile;
+    }
+
     public boolean changeHost(VirtualMachineRelocateSpec relocateSpec) throws Exception {
         ManagedObjectReference morTask = _context.getService().relocateVMTask(_mor, relocateSpec, VirtualMachineMovePriority.DEFAULT_PRIORITY);
         boolean result = _context.getVimClient().waitForTask(morTask);


### PR DESCRIPTION
Use moveVirtualDisk method which handled symlinks also instead of moving each disk format files specific to a volume

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)