### PR TITLE
usage: return guest OS type UUID instead of internal DB ID

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -256,6 +256,7 @@ public class ApiConstants {
     public static final String OLD_FORMAT = "oldformat";
     public static final String OP = "op";
     public static final String OS_CATEGORY_ID = "oscategoryid";
+    public static final String OS_CATEGORY_NAME = "oscategoryname";
     public static final String OS_ID = "osid";
     public static final String OS_TYPE_ID = "ostypeid";
     public static final String OS_DISPLAY_NAME = "osdisplayname";

--- a/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
@@ -16,15 +16,14 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.google.gson.annotations.SerializedName;
-
-import org.apache.cloudstack.api.ApiConstants;
-
-import com.cloud.serializer.Param;
-import org.apache.cloudstack.api.BaseResponseWithTagInformation;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseResponseWithTagInformation;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 @SuppressWarnings("unused")
 public class UsageRecordResponse extends BaseResponseWithTagInformation implements ControlledEntityResponse {
@@ -89,8 +88,20 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
     private String templateId;
 
     @SerializedName(ApiConstants.OS_TYPE_ID)
-    @Param(description = "virtual machine os type id")
-    private Long osTypeId;
+    @Param(description = "virtual machine os type ID")
+    private String osTypeId;
+
+    @SerializedName(ApiConstants.OS_DISPLAY_NAME)
+    @Param(description = "virtual machine os display name")
+    private String osDisplayName;
+
+    @SerializedName(ApiConstants.OS_CATEGORY_ID)
+    @Param(description = "virtual machine guest os category ID")
+    private String osCategoryId;
+
+    @SerializedName(ApiConstants.OS_CATEGORY_NAME)
+    @Param(description = "virtual machine os category name")
+    private String osCategoryName;
 
     @SerializedName("usageid")
     @Param(description = "id of the resource")
@@ -206,8 +217,20 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
         this.templateId = templateId;
     }
 
-    public void setOsTypeId(Long osTypeId) {
+    public void setOsTypeId(String osTypeId) {
         this.osTypeId = osTypeId;
+    }
+
+    public void setOsDisplayName(String osDisplayName) {
+        this.osDisplayName = osDisplayName;
+    }
+
+    public void setOsCategoryId(String osCategoryId) {
+        this.osCategoryId = osCategoryId;
+    }
+
+    public void setOsCategoryName(String osCategoryName) {
+        this.osCategoryName = osCategoryName;
     }
 
     public void setUsageId(String usageId) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -306,6 +306,7 @@ import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.GuestOS;
 import com.cloud.storage.GuestOSCategoryVO;
 import com.cloud.storage.GuestOSHypervisor;
+import com.cloud.storage.GuestOsCategory;
 import com.cloud.storage.ImageStore;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
@@ -315,6 +316,8 @@ import com.cloud.storage.UploadVO;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.GuestOSCategoryDao;
+import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.snapshot.SnapshotPolicy;
 import com.cloud.storage.snapshot.SnapshotSchedule;
@@ -394,6 +397,10 @@ public class ApiResponseHelper implements ResponseGenerator {
     private VMSnapshotDao vmSnapshotDao;
     @Inject
     private BackupOfferingDao backupOfferingDao;
+    @Inject
+    private GuestOSCategoryDao _guestOsCategoryDao;
+    @Inject
+    private GuestOSDao _guestOsDao;
 
     @Override
     public UserResponse createUserResponse(User user) {
@@ -3395,7 +3402,16 @@ public class ApiResponseHelper implements ResponseGenerator {
                 resourceType = ResourceTag.ResourceObjectType.UserVm;
                 usageRecResponse.setUsageId(vm.getUuid());
                 resourceId = vm.getId();
-                usageRecResponse.setOsTypeId(vm.getGuestOSId());
+                final GuestOS guestOS = _guestOsDao.findById(vm.getGuestOSId());
+                if (guestOS != null) {
+                    usageRecResponse.setOsTypeId(guestOS.getUuid());
+                    usageRecResponse.setOsDisplayName(guestOS.getDisplayName());
+                    final GuestOsCategory guestOsCategory = _guestOsCategoryDao.findById(guestOS.getCategoryId());
+                    if (guestOsCategory != null) {
+                        usageRecResponse.setOsCategoryId(guestOsCategory.getUuid());
+                        usageRecResponse.setOsCategoryName(guestOsCategory.getName());
+                    }
+                }
             }
             //Hypervisor Type
             usageRecResponse.setType(usageRecord.getType());


### PR DESCRIPTION
This fixes the ostype ID returned in listUsageRecords API response to
be uuid instead of internal DB ID and also returns the os category ID
(uuid) and name.

Original change was recently introduced in 4.15 with https://github.com/apache/cloudstack/pull/4266

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial