### PR TITLE
server: use network details from nic network

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -3922,7 +3922,6 @@ public class ApiResponseHelper implements ResponseGenerator {
         NicResponse response = new NicResponse();
         NetworkVO network = _entityMgr.findById(NetworkVO.class, result.getNetworkId());
         VMInstanceVO vm = _entityMgr.findById(VMInstanceVO.class, result.getInstanceId());
-        UserVmJoinVO userVm = _entityMgr.findById(UserVmJoinVO.class, result.getInstanceId());
         List<NicExtraDhcpOptionVO> nicExtraDhcpOptionVOs = _nicExtraDhcpOptionDao.listByNicId(result.getId());
 
         // The numbered comments are to keep track of the data returned from here and UserVmJoinDaoImpl.setUserVmResponse()
@@ -3936,15 +3935,13 @@ public class ApiResponseHelper implements ResponseGenerator {
             response.setVmId(vm.getUuid());
         }
 
-        if (userVm != null){
-            if (userVm.getTrafficType() != null) {
-                /*4: trafficType*/
-                response.setTrafficType(userVm.getTrafficType().toString());
-            }
-            if (userVm.getGuestType() != null) {
-                /*5: guestType*/
-                response.setType(userVm.getGuestType().toString());
-            }
+        if (network.getTrafficType() != null) {
+            /*4: trafficType*/
+            response.setTrafficType(network.getTrafficType().toString());
+        }
+        if (network.getGuestType() != null) {
+            /*5: guestType*/
+            response.setType(network.getGuestType().toString());
         }
         /*6: ipAddress*/
         response.setIpaddress(result.getIPv4Address());
@@ -3953,9 +3950,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         /*8: netmask*/
         response.setNetmask(result.getIPv4Netmask());
         /*9: networkName*/
-        if(userVm != null && userVm.getNetworkName() != null) {
-            response.setNetworkName(userVm.getNetworkName());
-        }
+        response.setNetworkName(network.getName());
         /*10: macAddress*/
         response.setMacAddress(result.getMacAddress());
         /*11: IPv6Address*/


### PR DESCRIPTION
### Description

Fixes #4770

Uses network details from nic's network instead of details from virtual machine.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

With a VMware env, zone with advanced networking.

Networks:
```
(localcloud) SBCM5> > list networks id=1e9022b5-173e-43ee-81ef-6c8ad6b7322a filter=id,name,traffictype,type
{
  "count": 1,
  "network": [
    {
      "id": "1e9022b5-173e-43ee-81ef-6c8ad6b7322a",
      "name": "testl2",
      "traffictype": "Guest",
      "type": "L2"
    }
  ]
}
```
Before changes - both nics show same network anem, traffic type and guest type:
```
(localcloud) SBCM5> > list nics virtualmachineid=cd54a0b9-36ab-41c0-a1e5-650a5ec9ccd1 
{
  "count": 2,
  "nic": [
    {
      "broadcasturi": "vlan://1343",
      "deviceid": "0",
      "extradhcpoption": [],
      "gateway": "10.1.1.1",
      "id": "0042bd3f-8b1d-48cf-8265-b7dadb8e8fb8",
      "ipaddress": "10.1.1.43",
      "isdefault": true,
      "isolationuri": "vlan://1343",
      "macaddress": "02:00:7c:87:00:18",
      "netmask": "255.255.255.0",
      "networkid": "5ae167c5-6d8f-439b-b2de-e9413637f129",
      "networkname": "testiso",
      "traffictype": "Guest",
      "type": "Isolated",
      "virtualmachineid": "cd54a0b9-36ab-41c0-a1e5-650a5ec9ccd1"
    },
    {
      "broadcasturi": "vlan://1354",
      "deviceid": "1",
      "extradhcpoption": [],
      "id": "a8615986-2b79-470c-bd89-8dbbfbd0db0b",
      "isdefault": false,
      "isolationuri": "vlan://1354",
      "macaddress": "02:00:56:67:00:03",
      "networkid": "1e9022b5-173e-43ee-81ef-6c8ad6b7322a",
      "networkname": "testiso",
      "traffictype": "Guest",
      "type": "Isolated",
      "virtualmachineid": "cd54a0b9-36ab-41c0-a1e5-650a5ec9ccd1"
    }
  ]
}
```
After changes - correct network details returned:
```
(localcloud) SBCM5> > list nics virtualmachineid=cd54a0b9-36ab-41c0-a1e5-650a5ec9ccd1 
{
  "count": 2,
  "nic": [
    {
      "broadcasturi": "vlan://1343",
      "deviceid": "0",
      "extradhcpoption": [],
      "gateway": "10.1.1.1",
      "id": "0042bd3f-8b1d-48cf-8265-b7dadb8e8fb8",
      "ipaddress": "10.1.1.43",
      "isdefault": true,
      "isolationuri": "vlan://1343",
      "macaddress": "02:00:7c:87:00:18",
      "netmask": "255.255.255.0",
      "networkid": "5ae167c5-6d8f-439b-b2de-e9413637f129",
      "networkname": "testiso",
      "traffictype": "Guest",
      "type": "Isolated",
      "virtualmachineid": "cd54a0b9-36ab-41c0-a1e5-650a5ec9ccd1"
    },
    {
      "broadcasturi": "vlan://1354",
      "deviceid": "1",
      "extradhcpoption": [],
      "id": "a8615986-2b79-470c-bd89-8dbbfbd0db0b",
      "isdefault": false,
      "isolationuri": "vlan://1354",
      "macaddress": "02:00:56:67:00:03",
      "networkid": "1e9022b5-173e-43ee-81ef-6c8ad6b7322a",
      "networkname": "testl2",
      "traffictype": "Guest",
      "type": "L2",
      "virtualmachineid": "cd54a0b9-36ab-41c0-a1e5-650a5ec9ccd1"
    }
  ]
}
```
