### PR TITLE
novnc: Hide fullscreen button when not connected

### DIFF
--- a/systemvm/agent/noVNC/app/styles/base.css
+++ b/systemvm/agent/noVNC/app/styles/base.css
@@ -672,6 +672,10 @@ select:active {
   max-width: 100%;
 }
 
+:root:not(.noVNC_connected) #noVNC_fullscreen_button {
+  display: none;
+}
+
 /* Settings */
 #noVNC_settings {
 }


### PR DESCRIPTION
### Description

Hides the fullscreen button in novnc until connected to the VM
This prevents the `UI.rfb is not initialized` error

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
#### Before
![Screenshot from 2021-03-10 12-30-17](https://user-images.githubusercontent.com/8244774/110589429-6982e780-819c-11eb-96ff-246626616453.png)
![Screenshot from 2021-03-10 12-30-22](https://user-images.githubusercontent.com/8244774/110589434-6ab41480-819c-11eb-9641-027a71d4df6e.png)

#### After
![Screenshot from 2021-03-10 12-29-34](https://user-images.githubusercontent.com/8244774/110589438-6c7dd800-819c-11eb-8b92-add824f43069.png)
