### PR TITLE
ui: Show memory allocated percentage when migrating vm

### DIFF
--- a/ui/src/views/compute/MigrateWizard.vue
+++ b/ui/src/views/compute/MigrateWizard.vue
@@ -47,6 +47,9 @@
       <div slot="memused" slot-scope="record">
         {{ record.memoryused | byteToGigabyte }} GB
       </div>
+      <div slot="memoryallocatedpercentage" slot-scope="record">
+        {{ record.memoryallocatedpercentage }}
+      </div>
       <template slot="select" slot-scope="record">
         <a-radio
           class="host-item__radio"
@@ -112,6 +115,10 @@ export default {
         {
           title: this.$t('label.cpuused'),
           dataIndex: 'cpuused'
+        },
+        {
+          title: this.$t('label.memoryallocated'),
+          scopedSlots: { customRender: 'memoryallocatedpercentage' }
         },
         {
           title: this.$t('label.memused'),


### PR DESCRIPTION
### Description

This PR  adds the memory allocated percentage to the migrate wizard form, since just seeing the used memory may not be enough

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):
![Screenshot from 2021-03-10 12-46-48](https://user-images.githubusercontent.com/8244774/110591255-d8614000-819e-11eb-8d3c-8efd4d62fde5.png)
