### PR TITLE
test: fix listVolumes call for detach volume migration check

### DIFF
--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1305,7 +1305,7 @@ class TestMigrateVMwithVolume(cloudstackTestCase):
 
         Volume.migrate(self.apiclient, storageid=target_pool.id, volumeid=volume1.id)
 
-        vol = Volume.list(self.apiclient, volume=volume1.id)[0]
+        vol = Volume.list(self.apiclient, id=volume1.id)[0]
 
         self.assertEqual(vol.storageid, target_pool.id, "Storage pool was not the same as expected")
 


### PR DESCRIPTION
### Description

Fixes the wrong parameter while using listVolumes API after detached volume migration.
Current code uses an invalid `volume` parameter which leads to test failure in cases when there are other volumes in different pools.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
