### PR TITLE
ui: Fix breadcrumb discrepancy

### DIFF
--- a/ui/src/components/widgets/Breadcrumb.vue
+++ b/ui/src/components/widgets/Breadcrumb.vue
@@ -26,12 +26,15 @@
         {{ $t(item.meta.title) }}
       </router-link>
       <span v-else-if="$route.params.id">
-        <label v-if="'name' in resource">
-          <span v-if="['USER.LOGIN', 'USER.LOGOUT', 'ROUTER.HEALTH.CHECKS', 'FIREWALL.CLOSE', 'ALERT.SERVICE.DOMAINROUTER'].includes(resource.name)">{{ $t(resource.name.toLowerCase()) }}</span>
-          <span v-else>{{ resource.name }}</span>
+        <label
+          v-if="'name' in resource &&
+            ['USER.LOGIN', 'USER.LOGOUT', 'ROUTER.HEALTH.CHECKS', 'FIREWALL.CLOSE', 'ALERT.SERVICE.DOMAINROUTER'].includes(resource.name)">
+          <span>
+            {{ $t(resource.name.toLowerCase()) }}
+          </span>
         </label>
         <label v-else>
-          {{ resource.name || resource.displayname || resource.displaytext || resource.hostname || resource.username || resource.ipaddress || $route.params.id }}
+          {{ resource.displayname || resource.displaytext || resource.name || resource.hostname || resource.username || resource.ipaddress || $route.params.id }}
         </label>
       </span>
       <span v-else>


### PR DESCRIPTION
### Description

This PR aligns the breadcrumb with the info card display name

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

#### Before :

![Screenshot from 2021-03-10 15-00-19](https://user-images.githubusercontent.com/8244774/110607605-5e868200-81b1-11eb-9788-26dde4776228.png)

#### After :

![Screenshot from 2021-03-10 15-00-46](https://user-images.githubusercontent.com/8244774/110607653-69d9ad80-81b1-11eb-8652-866a8e9a544a.png)

