### PR TITLE
api/server: fix hahost value in listHosts

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostForMigrationResponse.java
@@ -18,8 +18,6 @@ package org.apache.cloudstack.api.response;
 
 import java.util.Date;
 
-import com.google.gson.annotations.SerializedName;
-
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.EntityReference;
@@ -28,6 +26,7 @@ import com.cloud.host.Host;
 import com.cloud.host.Status;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = Host.class)
 public class HostForMigrationResponse extends BaseResponse {
@@ -450,6 +449,10 @@ public class HostForMigrationResponse extends BaseResponse {
 
     public void setHypervisorVersion(String hypervisorVersion) {
         this.hypervisorVersion = hypervisorVersion;
+    }
+
+    public Boolean getHaHost() {
+        return haHost;
     }
 
     public void setHaHost(Boolean haHost) {

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -276,7 +276,7 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 response.setHostTags(tag);
             }
 
-            if (!Boolean.TRUE.equals(response.getHaHost())) {
+            if (Boolean.FALSE.equals(response.getHaHost())) {
                 String haTag = ApiDBUtils.getHaTag();
                 if (StringUtils.isNotEmpty(haTag) && haTag.equalsIgnoreCase(tag)) {
                     response.setHaHost(true);

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -418,7 +418,7 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 response.setHostTags(tag);
             }
 
-            if (!Boolean.TRUE.equals(response.getHaHost())) {
+            if (Boolean.FALSE.equals(response.getHaHost())) {
                 String haTag = ApiDBUtils.getHaTag();
                 if (StringUtils.isNotEmpty(haTag) && haTag.equalsIgnoreCase(tag)) {
                     response.setHaHost(true);

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -177,7 +177,7 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 hostResponse.setMemoryAllocatedPercentage(memoryAllocatedPercentage);
 
                 String hostTags = host.getTag();
-                hostResponse.setHostTags(host.getTag());
+                hostResponse.setHostTags(hostTags);
 
                 hostResponse.setHaHost(false);
                 String haTag = ApiDBUtils.getHaTag();
@@ -336,17 +336,13 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 hostResponse.setMemoryAllocatedBytes(mem);
 
                 String hostTags = host.getTag();
-                hostResponse.setHostTags(host.getTag());
+                hostResponse.setHostTags(hostTags);
 
+                hostResponse.setHaHost(false);
                 String haTag = ApiDBUtils.getHaTag();
-                if (haTag != null && !haTag.isEmpty() && hostTags != null && !hostTags.isEmpty()) {
-                    if (haTag.equalsIgnoreCase(hostTags)) {
-                        hostResponse.setHaHost(true);
-                    } else {
-                        hostResponse.setHaHost(false);
-                    }
-                } else {
-                    hostResponse.setHaHost(false);
+                if (StringUtils.isNotEmpty(haTag) && StringUtils.isNotEmpty(hostTags) &&
+                        haTag.equalsIgnoreCase(hostTags)) {
+                    hostResponse.setHaHost(true);
                 }
 
                 hostResponse.setHypervisorVersion(host.getHypervisorVersion());
@@ -420,6 +416,13 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 response.setHostTags(response.getHostTags() + "," + tag);
             } else {
                 response.setHostTags(tag);
+            }
+
+            if (!Boolean.TRUE.equals(response.getHaHost())) {
+                String haTag = ApiDBUtils.getHaTag();
+                if (StringUtils.isNotEmpty(haTag) && haTag.equalsIgnoreCase(tag)) {
+                    response.setHaHost(true);
+                }
             }
         }
         return response;

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -26,16 +26,18 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
 import org.apache.cloudstack.api.ApiConstants.HostDetails;
 import org.apache.cloudstack.api.response.GpuResponse;
 import org.apache.cloudstack.api.response.HostForMigrationResponse;
 import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.VgpuResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.ha.HAResource;
+import org.apache.cloudstack.ha.dao.HAConfigDao;
 import org.apache.cloudstack.outofbandmanagement.dao.OutOfBandManagementDao;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.vo.HostJoinVO;
@@ -51,9 +53,6 @@ import com.cloud.storage.StorageStats;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
-
-import org.apache.cloudstack.ha.HAResource;
-import org.apache.cloudstack.ha.dao.HAConfigDao;
 
 @Component
 public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements HostJoinDao {
@@ -180,15 +179,11 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 String hostTags = host.getTag();
                 hostResponse.setHostTags(host.getTag());
 
+                hostResponse.setHaHost(false);
                 String haTag = ApiDBUtils.getHaTag();
-                if (haTag != null && !haTag.isEmpty() && hostTags != null && !hostTags.isEmpty()) {
-                    if (haTag.equalsIgnoreCase(hostTags)) {
-                        hostResponse.setHaHost(true);
-                    } else {
-                        hostResponse.setHaHost(false);
-                    }
-                } else {
-                    hostResponse.setHaHost(false);
+                if (StringUtils.isNotEmpty(haTag) && StringUtils.isNotEmpty(hostTags) &&
+                        haTag.equalsIgnoreCase(hostTags)) {
+                    hostResponse.setHaHost(true);
                 }
 
                 hostResponse.setHypervisorVersion(host.getHypervisorVersion());
@@ -274,11 +269,18 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
     @Override
     public HostResponse setHostResponse(HostResponse response, HostJoinVO host) {
         String tag = host.getTag();
-        if (tag != null) {
-            if (response.getHostTags() != null && response.getHostTags().length() > 0) {
+        if (StringUtils.isNotEmpty(tag)) {
+            if (StringUtils.isNotEmpty(response.getHostTags())) {
                 response.setHostTags(response.getHostTags() + "," + tag);
             } else {
                 response.setHostTags(tag);
+            }
+
+            if (!Boolean.TRUE.equals(response.getHaHost())) {
+                String haTag = ApiDBUtils.getHaTag();
+                if (StringUtils.isNotEmpty(haTag) && haTag.equalsIgnoreCase(tag)) {
+                    response.setHaHost(true);
+                }
             }
         }
         return response;


### PR DESCRIPTION
### Description

Fixes #3717 

Hosts can have multiple tags assigned to them therefore changes have been made to check for all of the host tags if they match `ha.tag` configuration value.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
With a 2xKVM hosts env with advanced networking
Global config - ha.tag:
```
(localcloud) SBCM5> > list configurations name=ha.tag
{
  "configuration": [
    {
      "category": "Advanced",
      "description": "HA tag defining that the host marked with this tag can be used for HA purposes only",
      "isdynamic": false,
      "name": "ha.tag",
      "value": "ha"
    }
  ],
  "count": 1
}
```
Before changes:
```
(localcloud) SBCM5> > list hosts type='Routing' filter=id,name,hahost,hosttags,hostha
{
  "count": 2,
  "host": [
    {
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "id": "845ba3d4-3c28-497d-a4b5-f3918a3031b3",
      "name": "pr4710-t3640-kvm-centos7-kvm2"
    },
    {
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "hosttags": "test,ha",
      "id": "4937aa4f-6f27-4dc8-af70-2335279edf27",
      "name": "pr4710-t3640-kvm-centos7-kvm1"
    }
  ]
}
```
After changes:
```
(localcloud) SBCM5> > list hosts type='Routing' filter=id,name,hahost,hosttags,hostha
{
  "count": 2,
  "host": [
    {
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "id": "845ba3d4-3c28-497d-a4b5-f3918a3031b3",
      "name": "pr4710-t3640-kvm-centos7-kvm2"
    },
    {
      "hahost": true,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "hosttags": "test,ha",
      "id": "4937aa4f-6f27-4dc8-af70-2335279edf27",
      "name": "pr4710-t3640-kvm-centos7-kvm1"
    }
  ]
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
