### PR TITLE
Externalize secondary storage capacity threshold

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
@@ -87,7 +87,7 @@ public interface CapacityManager {
                     ConfigKey.Scope.ImageStore,
                     null);
 
-    static final ConfigKey<Double> secondaryStorageCapacityThreshold = new ConfigKey<Double>("Advanced", Double.class, "secondary.storage.capacity.threshold", "0.90",
+    static final ConfigKey<Float> SecondaryStorageCapacityThreshold = new ConfigKey<Float>("Advanced", Float.class, "secondary.storage.capacity.threshold", "0.90",
             "Secondary storage capacity threshold (1 = 100%).", true);
 
     public boolean releaseVmCapacity(VirtualMachine vm, boolean moveFromReserved, boolean moveToReservered, Long hostId);

--- a/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
@@ -87,6 +87,9 @@ public interface CapacityManager {
                     ConfigKey.Scope.ImageStore,
                     null);
 
+    static final ConfigKey<Double> secondaryStorageCapacityThreshold = new ConfigKey<Double>("Advanced", Double.class, "secondary.storage.capacity.threshold", "0.90",
+            "Secondary storage capacity threshold (1 = 100%).", true);
+
     public boolean releaseVmCapacity(VirtualMachine vm, boolean moveFromReserved, boolean moveToReservered, Long hostId);
 
     void allocateVmCapacity(VirtualMachine vm, boolean fromLastHost);

--- a/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
@@ -88,7 +88,7 @@ public interface CapacityManager {
                     null);
 
     static final ConfigKey<Float> SecondaryStorageCapacityThreshold = new ConfigKey<Float>("Advanced", Float.class, "secondary.storage.capacity.threshold", "0.90",
-            "Secondary storage capacity threshold (1 = 100%).", true);
+            "Percentage (as a value between 0 and 1) of secondary storage capacity threshold.", true);
 
     public boolean releaseVmCapacity(VirtualMachine vm, boolean moveFromReserved, boolean moveToReservered, Long hostId);
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -17,6 +17,7 @@
 
 package org.apache.cloudstack.engine.orchestration;
 
+import com.cloud.capacity.CapacityManager;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -101,7 +102,6 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
             true, ConfigKey.Scope.Global);
 
     Integer numConcurrentCopyTasksPerSSVM = 2;
-    private double imageStoreCapacityThreshold = 0.90;
 
     @Override
     public String getConfigComponentName() {
@@ -404,7 +404,7 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
     private boolean storageCapacityBelowThreshold(Map<Long, Pair<Long, Long>> storageCapacities, Long destStoreId) {
         Pair<Long, Long> imageStoreCapacity = storageCapacities.get(destStoreId);
         long usedCapacity = imageStoreCapacity.second() - imageStoreCapacity.first();
-        if (imageStoreCapacity != null && (usedCapacity / (imageStoreCapacity.second() * 1.0)) <= imageStoreCapacityThreshold) {
+        if (imageStoreCapacity != null && (usedCapacity / (imageStoreCapacity.second() * 1.0)) <= CapacityManager.SecondaryStorageCapacityThreshold.value()) {
             s_logger.debug("image store: " + destStoreId + " has sufficient capacity to proceed with migration of file");
             return true;
         }

--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -1233,6 +1233,6 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {CpuOverprovisioningFactor, MemOverprovisioningFactor, StorageCapacityDisableThreshold, StorageOverprovisioningFactor,
-            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull, ImageStoreNFSVersion};
+            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull, ImageStoreNFSVersion, secondaryStorageCapacityThreshold};
     }
 }

--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -1233,6 +1233,6 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {CpuOverprovisioningFactor, MemOverprovisioningFactor, StorageCapacityDisableThreshold, StorageOverprovisioningFactor,
-            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull, ImageStoreNFSVersion, secondaryStorageCapacityThreshold};
+            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull, ImageStoreNFSVersion, SecondaryStorageCapacityThreshold};
     }
 }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -494,6 +494,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         weightBasedParametersForValidation.add(DeploymentClusterPlanner.ClusterMemoryCapacityDisableThreshold.key());
         weightBasedParametersForValidation.add(Config.AgentLoadThreshold.key());
         weightBasedParametersForValidation.add(Config.VmUserDispersionWeight.key());
+        weightBasedParametersForValidation.add(CapacityManager.SecondaryStorageCapacityThreshold.key());
 
     }
 

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1389,7 +1389,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             return true;
         }
 
-        s_logger.warn(String.format("Image storage [%s] has not enough capacity. Capacity: total=[%s], used=[%s], threshold=[%s%%].", imageStoreId,readableTotalCapacity, readableUsedCapacity, threshold * 100));
+        s_logger.warn(String.format("Image storage [%s] has not enough capacity. Capacity: total=[%s], used=[%s], threshold=[%s%%].", imageStoreId, readableTotalCapacity, readableUsedCapacity, threshold * 100));
         return false;
     }
 

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -146,6 +146,7 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * Provides real time stats for various agent resources up to x seconds
@@ -1625,16 +1626,27 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     }
 
     public double getImageStoreCapacityThreshold() {
-        double thresholdConfig = secondaryStorageCapacityThreshold.value();
+        double thresholdConfigValue = secondaryStorageCapacityThreshold.value();
+        double thresholdConfigDefaultValue = NumberUtils.toDouble(secondaryStorageCapacityThreshold.defaultValue());
+        String thresholdConfigKey = secondaryStorageCapacityThreshold.key();
 
-        if (thresholdConfig >= MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD && thresholdConfig <= MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD) {
-            return thresholdConfig;
+        if (thresholdConfigValue >= MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD && thresholdConfigValue <= MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD) {
+            return thresholdConfigValue;
         }
 
-        s_logger.warn(String.format("Invalid [%s] configuration: value set [%s] is [%s]. Assuming %s as secondary storage capacity threshold.",
-                                    secondaryStorageCapacityThreshold.key(),
-                                    thresholdConfig,
-                                    thresholdConfig < MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD ? String.format("lower than '%s'", MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD) : String.format("bigger than '%s'", MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD),
+        if (thresholdConfigValue < MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD) {
+            s_logger.warn(String.format("Invalid [%s] configuration: value set [%s] is lower than '%s'. Assuming '%s', default value, as secondary storage capacity threshold.",
+                                        thresholdConfigKey,
+                                        thresholdConfigValue,
+                                        MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD,
+                                        thresholdConfigDefaultValue));
+            return thresholdConfigDefaultValue;
+        }
+
+        s_logger.warn(String.format("Invalid [%s] configuration: value set [%s] is bigger than '%s'. Assuming '%s', top limit, as secondary storage capacity threshold.",
+                                    thresholdConfigKey,
+                                    thresholdConfigValue,
+                                    MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD,
                                     MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD));
         return MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD;
     }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -207,9 +207,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     private static final String INFLUXDB_HOST_MEASUREMENT = "host_stats";
     private static final String INFLUXDB_VM_MEASUREMENT = "vm_stats";
 
-    private static final double MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD = 0.00;
-    private static final double MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD = 1.00;
-
     private static final ConfigKey<Integer> vmDiskStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval", "0",
             "Interval (in seconds) to report vm disk statistics. Vm disk statistics will be disabled if this is set to 0 or less than 0.", false);
     private static final ConfigKey<Integer> vmDiskStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval.min", "300",
@@ -1625,28 +1622,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     }
 
     public double getImageStoreCapacityThreshold() {
-        double thresholdConfigValue = CapacityManager.secondaryStorageCapacityThreshold.value();
-        double thresholdConfigDefaultValue = NumberUtils.toDouble(CapacityManager.secondaryStorageCapacityThreshold.defaultValue());
-        String thresholdConfigKey = CapacityManager.secondaryStorageCapacityThreshold.key();
-
-        if (thresholdConfigValue >= MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD && thresholdConfigValue <= MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD) {
-            return thresholdConfigValue;
-        }
-
-        if (thresholdConfigValue < MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD) {
-            s_logger.warn(String.format("Invalid [%s] configuration: value set [%s] is lower than '%s'. Assuming '%s', default value, as secondary storage capacity threshold.",
-                                        thresholdConfigKey,
-                                        thresholdConfigValue,
-                                        MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD,
-                                        thresholdConfigDefaultValue));
-            return thresholdConfigDefaultValue;
-        }
-
-        s_logger.warn(String.format("Invalid [%s] configuration: value set [%s] is bigger than '%s'. Assuming '%s', top limit, as secondary storage capacity threshold.",
-                                    thresholdConfigKey,
-                                    thresholdConfigValue,
-                                    MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD,
-                                    MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD));
-        return MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD;
+        return CapacityManager.SecondaryStorageCapacityThreshold.value();
     }
 }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -147,7 +147,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * Provides real time stats for various agent resources up to x seconds

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -70,6 +70,7 @@ import com.cloud.agent.api.VmDiskStatsEntry;
 import com.cloud.agent.api.VmNetworkStatsEntry;
 import com.cloud.agent.api.VmStatsEntry;
 import com.cloud.agent.api.VolumeStatsEntry;
+import com.cloud.capacity.CapacityManager;
 import com.cloud.cluster.ManagementServerHostVO;
 import com.cloud.cluster.dao.ManagementServerHostDao;
 import com.cloud.dc.Vlan.VlanType;
@@ -224,8 +225,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     private static final ConfigKey<String> statsOutputUri = new ConfigKey<String>("Advanced", String.class, "stats.output.uri", "",
             "URI to send StatsCollector statistics to. The collector is defined on the URI scheme. Example: graphite://graphite-hostaddress:port or influxdb://influxdb-hostaddress/dbname. Note that the port is optional, if not added the default port for the respective collector (graphite or influxdb) will be used. Additionally, the database name '/dbname' is  also optional; default db name is 'cloudstack'. You must create and configure the database if using influxdb.",
             true);
-    private static final ConfigKey<Double> secondaryStorageCapacityThreshold = new ConfigKey<Double>("Advanced", Double.class, "secondary.storage.capacity.threshold", "0.90",
-            "Secondary storage capacity threshold (1 = 100%).", true);
 
     private static StatsCollector s_instance = null;
 
@@ -1622,13 +1621,13 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {vmDiskStatsInterval, vmDiskStatsIntervalMin, vmNetworkStatsInterval, vmNetworkStatsIntervalMin, StatsTimeout, statsOutputUri, secondaryStorageCapacityThreshold};
+        return new ConfigKey<?>[] {vmDiskStatsInterval, vmDiskStatsIntervalMin, vmNetworkStatsInterval, vmNetworkStatsIntervalMin, StatsTimeout, statsOutputUri};
     }
 
     public double getImageStoreCapacityThreshold() {
-        double thresholdConfigValue = secondaryStorageCapacityThreshold.value();
-        double thresholdConfigDefaultValue = NumberUtils.toDouble(secondaryStorageCapacityThreshold.defaultValue());
-        String thresholdConfigKey = secondaryStorageCapacityThreshold.key();
+        double thresholdConfigValue = CapacityManager.secondaryStorageCapacityThreshold.value();
+        double thresholdConfigDefaultValue = NumberUtils.toDouble(CapacityManager.secondaryStorageCapacityThreshold.defaultValue());
+        String thresholdConfigKey = CapacityManager.secondaryStorageCapacityThreshold.key();
 
         if (thresholdConfigValue >= MIN_STORAGE_SECONDARY_CAPACITY_THRESHOLD && thresholdConfigValue <= MAX_STORAGE_SECONDARY_CAPACITY_THRESHOLD) {
             return thresholdConfigValue;


### PR DESCRIPTION
### Description
On StatsCollector, it limits secondary storages capacity to 90%; therefore, operators do not have option to choose which threshold they want/need. 

This PR intends to externalize the secondary storage capacity threshold configuration on StatsCollector (`secondary.storage.capacity.threshold`), validating if it is between 0 and 100% (0.00 and 1.00).

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functioanlity)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [x] Major
- [ ] Minor

### How Has This Been Tested?
It has been tested locally on a test lab.
1. I enabled a zone;
2. I created a template and observed the log. It will log messages according to the configuration set.