### PR TITLE
server: filter null details during volume to template creation

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -28,11 +28,11 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.agent.api.to.DatadiskTO;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseListTemplateOrIsoPermissionsCmd;
@@ -109,6 +109,7 @@ import com.cloud.agent.api.Command;
 import com.cloud.agent.api.ComputeChecksumCommand;
 import com.cloud.agent.api.storage.DestroyCommand;
 import com.cloud.agent.api.to.DataTO;
+import com.cloud.agent.api.to.DatadiskTO;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.api.ApiDBUtils;
@@ -1936,7 +1937,12 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
                     UserVmVO userVm = _userVmDao.findById(vmId);
                     if (userVm != null) {
                         _userVmDao.loadDetails(userVm);
-                        details.putAll(userVm.getDetails());
+                        Map<String, String> vmDetails = userVm.getDetails();
+                        vmDetails = vmDetails.entrySet()
+                                .stream()
+                                .filter(map -> map.getValue() != null)
+                                .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
+                        details.putAll(vmDetails);
                     }
                 }
             }


### PR DESCRIPTION
### Description

Fixes #4628

```
mysql> describe user_vm_details;
+---------+-----------------+------+-----+---------+----------------+
| Field   | Type            | Null | Key | Default | Extra          |
+---------+-----------------+------+-----+---------+----------------+
| id      | bigint unsigned | NO   | PRI | NULL    | auto_increment |
| vm_id   | bigint unsigned | NO   | MUL | NULL    |                |
| name    | varchar(255)    | NO   |     | NULL    |                |
| value   | varchar(5120)   | YES  |     | NULL    |                |
| display | tinyint(1)      | NO   |     | 1       |                |
+---------+-----------------+------+-----+---------+----------------+
5 rows in set (0.00 sec)

mysql> describe vm_template_details;
+-------------+-----------------+------+-----+---------+----------------+
| Field       | Type            | Null | Key | Default | Extra          |
+-------------+-----------------+------+-----+---------+----------------+
| id          | bigint unsigned | NO   | PRI | NULL    | auto_increment |
| template_id | bigint unsigned | NO   | MUL | NULL    |                |
| name        | varchar(255)    | NO   |     | NULL    |                |
| value       | varchar(1024)   | NO   |     | NULL    |                |
| display     | tinyint(1)      | NO   |     | 1       |                |
+-------------+-----------------+------+-----+---------+----------------+
5 rows in set (0.00 sec)
```

While cloud.user_vm_details allows null values to be added for a detail, cloud.vm_template_details doesn't allow null values.
This change filters VM details with null values while creating template from a volume.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

Tested on a KVM env,

VM details (Details such as `kvm.vnc.address` can have NULL value in some scenarios):
```
MariaDB [cloud]> select * from user_vm_details where vm_id=9\G
*************************** 1. row ***************************
     id: 55
  vm_id: 9
   name: cpuOvercommitRatio
  value: 2.0
display: 1
*************************** 2. row ***************************
     id: 56
  vm_id: 9
   name: customdetail
  value: NULL
display: 1
*************************** 3. row ***************************
     id: 53
  vm_id: 9
   name: memoryOvercommitRatio
  value: 1.0
display: 1
*************************** 4. row ***************************
     id: 54
  vm_id: 9
   name: Message.ReservedCapacityFreed.Flag
  value: false
display: 1
*************************** 5. row ***************************
     id: 57
  vm_id: 9
   name: rootDiskController
  value: osdefault
display: 1
5 rows in set (0.00 sec)
```
Details with NULL value not shown in the API response
```
(localcloud) SBCM5> > list virtualmachines id=5c765ef4-3fd5-4da6-833b-1864da28a9c4 
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "admin",
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 500,
      "cpuused": "0%",
      "created": "2021-03-11T09:34:38+0000",
      "details": {
        "Message.ReservedCapacityFreed.Flag": "false",
        "cpuOvercommitRatio": "2.0",
        "memoryOvercommitRatio": "1.0",
        "rootDiskController": "osdefault"
      },
      "diskioread": 0,
      "diskiowrite": 0,
      "diskkbsread": 0,
      "diskkbswrite": 0,
      "displayname": "abc",
      "displayvm": true,
      "domain": "ROOT",
      "domainid": "d9a7f35c-7be5-11eb-87d3-1e00b1013ad6",
      "guestosid": "e87691ad-7be5-11eb-87d3-1e00b1013ad6",
      "haenable": false,
      "hypervisor": "KVM",
      "id": "5c765ef4-3fd5-4da6-833b-1864da28a9c4",
      "instancename": "i-2-9-VM",
      "isdynamicallyscalable": false,
      "memory": 512,
      "memoryintfreekbs": 26800,
      "memorykbs": 524288,
      "memorytargetkbs": 524288,
      "name": "abc",
      "networkkbsread": 0,
      "networkkbswrite": 0,
      "nic": [
        {
          "extradhcpoption": [],
          "gateway": "10.1.1.1",
          "id": "cfa414a0-4d1a-47e2-aabb-c484b33009c1",
          "ipaddress": "10.1.1.251",
          "isdefault": true,
          "macaddress": "02:00:51:7e:00:04",
          "netmask": "255.255.255.0",
          "networkid": "5c43ca1e-e39b-494b-adbd-c8f09b9501e6",
          "networkname": "t2-network",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "Isolated"
        }
      ],
      "osdisplayname": "CoreOS",
      "ostypeid": "e87691ad-7be5-11eb-87d3-1e00b1013ad6",
      "passwordenabled": false,
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "serviceofferingid": "8211efcb-aab3-40fd-99d0-f1d462431e3d",
      "serviceofferingname": "Small Instance",
      "state": "Stopped",
      "tags": [],
      "templatedisplaytext": "coresos-kvm",
      "templateid": "d18f6e11-1e3f-4701-8d04-2bacb2c3f1b7",
      "templatename": "coresos-kvm",
      "userid": "f128bc5c-7be5-11eb-87d3-1e00b1013ad6",
      "username": "admin",
      "zoneid": "3f4d015c-7d6b-4b5e-86b0-79552910f77b",
      "zonename": "pr4710-t3640-kvm-centos7"
    }
  ]
}
```

Template creation from VM ROOT volume:
**Before changes - error:**

```
2021-03-11 09:40:53,404 ERROR [c.c.a.ApiServer] (qtp1233705144-17:ctx-823aead3 ctx-ffd0c119) (logid:454f7d0e) unhandled exception executing api command: [Ljava.lang.String;@264f2ef
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: com.mysql.cj.jdbc.ClientPreparedStatement: INSERT INTO vm_template_details (vm_template_details.template_id, vm_template_details.name, vm_template_details.value, vm_template_details.display) VALUES (204, _binary'customdetail', null, 1)
	at com.cloud.utils.db.GenericDaoBase.persist(GenericDaoBase.java:1450)
	at org.apache.cloudstack.resourcedetail.ResourceDetailsDaoBase.saveDetails(ResourceDetailsDaoBase.java:147)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at com.cloud.utils.db.TransactionContextInterceptor.invoke(TransactionContextInterceptor.java:34)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy85.saveDetails(Unknown Source)
	at com.cloud.storage.dao.VMTemplateDaoImpl.saveDetails(VMTemplateDaoImpl.java:460)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at com.cloud.utils.db.TransactionContextInterceptor.invoke(TransactionContextInterceptor.java:34)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy104.saveDetails(Unknown Source)
	at com.cloud.template.TemplateManagerImpl.createPrivateTemplateRecord(TemplateManagerImpl.java:1949)
	at com.cloud.template.TemplateManagerImpl.createPrivateTemplateRecord(TemplateManagerImpl.java:208)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.apache.cloudstack.network.contrail.management.EventUtils$EventInterceptor.invoke(EventUtils.java:107)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at com.cloud.event.ActionEventInterceptor.invoke(ActionEventInterceptor.java:51)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy202.createPrivateTemplateRecord(Unknown Source)
	at org.apache.cloudstack.api.command.user.template.CreateTemplateCmd.create(CreateTemplateCmd.java:291)
	at com.cloud.api.dispatch.CommandCreationWorker.handle(CommandCreationWorker.java:47)
	at com.cloud.api.dispatch.DispatchChain.dispatch(DispatchChain.java:37)
	at com.cloud.api.ApiDispatcher.dispatchCreateCmd(ApiDispatcher.java:88)
	at com.cloud.api.ApiServer.queueCommand(ApiServer.java:688)
	at com.cloud.api.ApiServer.handleRequest(ApiServer.java:588)
	at com.cloud.api.ApiServlet.processRequestInContext(ApiServlet.java:321)
	at com.cloud.api.ApiServlet$1.run(ApiServlet.java:134)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at com.cloud.api.ApiServlet.processRequest(ApiServlet.java:131)
	at com.cloud.api.ApiServlet.doGet(ApiServlet.java:93)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:645)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
	at org.eclipse.jetty.servlet.ServletHolder$NotAsync.service(ServletHolder.java:1443)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:791)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:602)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1435)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1350)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:766)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:773)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:905)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.sql.SQLIntegrityConstraintViolationException: Column 'value' cannot be null
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:117)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	... 103 more
2021-03-11 09:40:53,424 DEBUG [c.c.a.ApiServlet] (qtp1233705144-17:ctx-823aead3 ctx-ffd0c119) (logid:454f7d0e) ===END===  10.1.0.3 -- GET  name=voltempbefore&displaytext=voltempbefore&ostypeid=e87691ad-7be5-11eb-87d3-1e00b1013ad6&ispublic=true&isfeatured=true&volumeid=44dccf77-750c-4d40-a1dd-fb800635dce2&command=createTemplate&response=json
````

**After changes - no error**
```
(localcloud) SBCM5> > create template name=voltempafter displaytext=voltempafter volumeid=44dccf77-750c-4d40-a1dd-fb800635dce2 ispublic=true isfeatured=true ostypeid=e87691ad-7be5-11eb-87d3-1e00b1013ad6
{
  "template": {
    "account": "admin",
    "bits": 0,
    "created": "2021-03-11T09:57:38+0000",
    "crossZones": false,
    "deployasis": false,
    "details": {
      "Message.ReservedCapacityFreed.Flag": "false",
      "cpuOvercommitRatio": "2.0",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "osdefault"
    },
    "directdownload": false,
    "displaytext": "voltempafter",
    "domain": "ROOT",
    "domainid": "d9a7f35c-7be5-11eb-87d3-1e00b1013ad6",
    "downloaddetails": [
      {
        "datastore": "NFS://10.10.0.16/acs/secondary/pr4710-t3640-kvm-centos7/pr4710-t3640-kvm-centos7-sec1",
        "downloadPercent": "100",
        "downloadState": "DOWNLOADED"
      }
    ],
    "format": "QCOW2",
    "hypervisor": "KVM",
    "id": "44824c83-218a-4643-95c4-c6747b206dc3",
    "isdynamicallyscalable": false,
    "isextractable": false,
    "isfeatured": true,
    "ispublic": true,
    "isready": true,
    "name": "voltempafter",
    "ostypeid": "e87691ad-7be5-11eb-87d3-1e00b1013ad6",
    "ostypename": "CoreOS",
    "passwordenabled": false,
    "physicalsize": 1067581440,
    "requireshvm": true,
    "size": 4756340736,
    "sourcetemplateid": "d18f6e11-1e3f-4701-8d04-2bacb2c3f1b7",
    "sshkeyenabled": false,
    "status": "Download Complete",
    "tags": [],
    "templatetype": "USER",
    "zoneid": "3f4d015c-7d6b-4b5e-86b0-79552910f77b",
    "zonename": "pr4710-t3640-kvm-centos7"
  }
}
```