### PR TITLE
api/server: cpu, memory values with overprovisioning in metrics response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -347,10 +347,6 @@ public class HostResponse extends BaseResponse {
         this.cpuSpeed = cpuSpeed;
     }
 
-    public String getCpuAllocated() {
-        return cpuAllocated;
-    }
-
     public void setCpuAllocated(String cpuAllocated) {
         this.cpuAllocated = cpuAllocated;
     }
@@ -620,6 +616,14 @@ public class HostResponse extends BaseResponse {
 
     public String getCpuUsed() {
         return cpuUsed;
+    }
+
+    public String getCpuAllocated() {
+        return cpuAllocated;
+    }
+
+    public String getCpuAllocatedWithOverprovisioning() {
+        return cpuAllocatedWithOverprovisioning;
     }
 
     public Double getAverageLoad() {

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -622,10 +622,6 @@ public class HostResponse extends BaseResponse {
         return cpuAllocated;
     }
 
-    public String getCpuAllocatedWithOverprovisioning() {
-        return cpuAllocatedWithOverprovisioning;
-    }
-
     public Double getAverageLoad() {
         return cpuloadaverage;
     }

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -285,7 +285,7 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             metricsResponse.setInstances(upInstances, totalInstances);
             metricsResponse.setCpuTotal(hostResponse.getCpuNumber(), hostResponse.getCpuSpeed(), cpuOvercommitRatio);
             metricsResponse.setCpuUsed(hostResponse.getCpuUsed(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
-            metricsResponse.setCpuAllocated(hostResponse.getCpuAllocated(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
+            metricsResponse.setCpuAllocated(hostResponse.getCpuAllocatedWithOverprovisioning(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
             metricsResponse.setLoadAverage(hostResponse.getAverageLoad());
             metricsResponse.setMemTotal(hostResponse.getMemoryTotal(), memoryOvercommitRatio);
             metricsResponse.setMemAllocated(hostResponse.getMemoryAllocated());

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -264,9 +264,6 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             final Double memoryThreshold = AlertManager.MemoryCapacityThreshold.valueIn(clusterId);
             final Float cpuDisableThreshold = DeploymentClusterPlanner.ClusterCPUCapacityDisableThreshold.valueIn(clusterId);
             final Float memoryDisableThreshold = DeploymentClusterPlanner.ClusterMemoryCapacityDisableThreshold.valueIn(clusterId);
-            // Over commit ratios
-            final Double cpuOvercommitRatio = findRatioValue(ApiDBUtils.findClusterDetails(clusterId, "cpuOvercommitRatio"));
-            final Double memoryOvercommitRatio = findRatioValue(ApiDBUtils.findClusterDetails(clusterId, "memoryOvercommitRatio"));
 
             Long upInstances = 0L;
             Long totalInstances = 0L;

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -283,11 +283,11 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             }
             metricsResponse.setPowerState(hostResponse.getOutOfBandManagementResponse().getPowerState());
             metricsResponse.setInstances(upInstances, totalInstances);
-            metricsResponse.setCpuTotal(hostResponse.getCpuNumber(), hostResponse.getCpuSpeed(), cpuOvercommitRatio);
+            metricsResponse.setCpuTotal(hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
             metricsResponse.setCpuUsed(hostResponse.getCpuUsed(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
-            metricsResponse.setCpuAllocated(hostResponse.getCpuAllocatedWithOverprovisioning(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
+            metricsResponse.setCpuAllocated(hostResponse.getCpuAllocated(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
             metricsResponse.setLoadAverage(hostResponse.getAverageLoad());
-            metricsResponse.setMemTotal(hostResponse.getMemoryTotal(), memoryOvercommitRatio);
+            metricsResponse.setMemTotal(hostResponse.getMemoryTotal());
             metricsResponse.setMemAllocated(hostResponse.getMemoryAllocated());
             metricsResponse.setMemUsed(hostResponse.getMemoryUsed());
             metricsResponse.setNetworkRead(hostResponse.getNetworkKbsRead());
@@ -295,13 +295,13 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             // CPU thresholds
             metricsResponse.setCpuUsageThreshold(hostResponse.getCpuUsed(), cpuThreshold);
             metricsResponse.setCpuUsageDisableThreshold(hostResponse.getCpuUsed(), cpuDisableThreshold);
-            metricsResponse.setCpuAllocatedThreshold(hostResponse.getCpuAllocated(), cpuOvercommitRatio, cpuThreshold);
-            metricsResponse.setCpuAllocatedDisableThreshold(hostResponse.getCpuAllocated(), cpuOvercommitRatio, cpuDisableThreshold);
+            metricsResponse.setCpuAllocatedThreshold(hostResponse.getCpuAllocated(), cpuThreshold);
+            metricsResponse.setCpuAllocatedDisableThreshold(hostResponse.getCpuAllocated(), cpuDisableThreshold);
             // Memory thresholds
             metricsResponse.setMemoryUsageThreshold(hostResponse.getMemoryUsed(), hostResponse.getMemoryTotal(), memoryThreshold);
             metricsResponse.setMemoryUsageDisableThreshold(hostResponse.getMemoryUsed(), hostResponse.getMemoryTotal(), memoryDisableThreshold);
-            metricsResponse.setMemoryAllocatedThreshold(hostResponse.getMemoryAllocated(), hostResponse.getMemoryTotal(), memoryOvercommitRatio, memoryThreshold);
-            metricsResponse.setMemoryAllocatedDisableThreshold(hostResponse.getMemoryAllocated(), hostResponse.getMemoryTotal(), memoryOvercommitRatio, memoryDisableThreshold);
+            metricsResponse.setMemoryAllocatedThreshold(hostResponse.getMemoryAllocated(), hostResponse.getMemoryTotal(), memoryThreshold);
+            metricsResponse.setMemoryAllocatedDisableThreshold(hostResponse.getMemoryAllocated(), hostResponse.getMemoryTotal(), memoryDisableThreshold);
             metricsResponses.add(metricsResponse);
         }
         return metricsResponses;

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
@@ -17,10 +17,11 @@
 
 package org.apache.cloudstack.response;
 
-import com.cloud.serializer.Param;
-import com.google.gson.annotations.SerializedName;
 import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.outofbandmanagement.OutOfBandManagement;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 public class HostMetricsResponse extends HostResponse {
     @SerializedName("powerstate")
@@ -109,9 +110,9 @@ public class HostMetricsResponse extends HostResponse {
         }
     }
 
-    public void setCpuTotal(final Integer cpuNumber, final Long cpuSpeed, final Double overcommitRatio) {
-        if (cpuNumber != null && cpuSpeed != null && overcommitRatio != null) {
-            this.cpuTotal = String.format("%.2f Ghz (x %.1f)", cpuNumber * cpuSpeed / 1000.0, overcommitRatio);
+    public void setCpuTotal(final Integer cpuNumber, final Long cpuSpeed) {
+        if (cpuNumber != null && cpuSpeed != null) {
+            this.cpuTotal = String.format("%.2f Ghz", cpuNumber * cpuSpeed / 1000.0);
         }
     }
 
@@ -133,9 +134,9 @@ public class HostMetricsResponse extends HostResponse {
         }
     }
 
-    public void setMemTotal(final Long memTotal, final Double overcommitRatio) {
-        if (memTotal != null && overcommitRatio != null) {
-            this.memTotal = String.format("%.2f GB (x %.1f)", memTotal / (1024.0 * 1024.0 * 1024.0), overcommitRatio);
+    public void setMemTotal(final Long memTotal) {
+        if (memTotal != null) {
+            this.memTotal = String.format("%.2f GB", memTotal / (1024.0 * 1024.0 * 1024.0));
         }
     }
 
@@ -175,15 +176,15 @@ public class HostMetricsResponse extends HostResponse {
         }
     }
 
-    public void setCpuAllocatedThreshold(final String cpuAllocated, final Double overCommitRatio, final Double threshold) {
-        if (cpuAllocated != null && overCommitRatio != null && threshold != null) {
-            this.cpuAllocatedThresholdExceeded = Double.valueOf(cpuAllocated.replace("%", "")) > (100.0 * threshold * overCommitRatio);
+    public void setCpuAllocatedThreshold(final String cpuAllocated, final Double threshold) {
+        if (cpuAllocated != null && threshold != null) {
+            this.cpuAllocatedThresholdExceeded = Double.valueOf(cpuAllocated.replace("%", "")) > (100.0 * threshold );
         }
     }
 
-    public void setCpuAllocatedDisableThreshold(final String cpuAllocated, final Double overCommitRatio, final Float threshold) {
-        if (cpuAllocated != null && overCommitRatio != null && threshold != null) {
-            this.cpuAllocatedDisableThresholdExceeded = Double.valueOf(cpuAllocated.replace("%", "")) > (100.0 * threshold * overCommitRatio);
+    public void setCpuAllocatedDisableThreshold(final String cpuAllocated, final Float threshold) {
+        if (cpuAllocated != null && threshold != null) {
+            this.cpuAllocatedDisableThresholdExceeded = Double.valueOf(cpuAllocated.replace("%", "")) > (100.0 * threshold);
         }
     }
 
@@ -199,15 +200,15 @@ public class HostMetricsResponse extends HostResponse {
         }
     }
 
-    public void setMemoryAllocatedThreshold(final Long memAllocated, final Long memTotal, final Double overCommitRatio, final Double threshold) {
-        if (memAllocated != null && memTotal != null && overCommitRatio != null && threshold != null) {
-            this.memoryAllocatedThresholdExceeded = memAllocated > (memTotal * threshold * overCommitRatio);
+    public void setMemoryAllocatedThreshold(final Long memAllocated, final Long memTotal, final Double threshold) {
+        if (memAllocated != null && memTotal != null && threshold != null) {
+            this.memoryAllocatedThresholdExceeded = memAllocated > (memTotal * threshold);
         }
     }
 
-    public void setMemoryAllocatedDisableThreshold(final Long memAllocated, final Long memTotal, final Double overCommitRatio, final Float threshold) {
-        if (memAllocated != null && memTotal != null && overCommitRatio != null && threshold != null) {
-            this.memoryAllocatedDisableThresholdExceeded = memAllocated > (memTotal * threshold * overCommitRatio);
+    public void setMemoryAllocatedDisableThreshold(final Long memAllocated, final Long memTotal, final Float threshold) {
+        if (memAllocated != null && memTotal != null && threshold != null) {
+            this.memoryAllocatedDisableThresholdExceeded = memAllocated > (memTotal * threshold);
         }
     }
 


### PR DESCRIPTION
### Description

Fixes #4778

Based on the discussion on https://lists.apache.org/thread.html/r9833add572ddd7303c2a523c833a8c863e8d272db268927a7ca9b525%40%3Cdev.cloudstack.apache.org%3E, metrics responses should return values with CPU/memory overprovisioning.
Changes in listHostsMetrics response, cpu and memory values with overprovisioning. Cluster and Zone metrics get correct values with host value changes.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

With cmk:

Without change:
```
(local) 🐱 > list zonesmetrics 
{
  "count": 1,
  "zone": [
    {
      "allocationstate": "Enabled",
      "clusters": "2 / 2",
      "cpuallocated": "0.52%",
      "cpuallocateddisablethreshold": false,
      "cpuallocatedthreshold": false,
      "cpudisablethreshold": false,
      "cputhreshold": false,
      "cputotal": "192.00 Ghz",
      "dhcpprovider": "VirtualRouter",
      "dns1": "10.147.28.6",
      "guestcidraddress": "10.1.1.0/24",
      "id": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "internaldns1": "10.147.28.6",
      "localstorageenabled": false,
      "memoryallocated": "3.13%",
      "memoryallocateddisablethreshold": false,
      "memoryallocatedthreshold": false,
      "memorydisablethreshold": false,
      "memorythreshold": false,
      "memorytotal": "48.00 GB",
      "name": "Sandbox-simulator",
      "networktype": "Advanced",
      "securitygroupsenabled": false,
      "state": "Enabled",
      "tags": [],
      "zonetoken": "20291feb-a0af-3dbf-8757-d5486debc1c3"
    }
  ]
}
(local) 🐱 > list clustersmetrics id=466e1831-8f69-4315-8477-3a16c3180038 
{
  "cluster": [
    {
      "allocationstate": "Enabled",
      "clustertype": "CloudManaged",
      "cpuallocated": "0.39%",
      "cpuallocateddisablethreshold": false,
      "cpuallocatedthreshold": false,
      "cpudisablethreshold": false,
      "cpuovercommitratio": "2.0",
      "cputhreshold": false,
      "cputotal": "128.00 Ghz",
      "hosts": "2 / 2",
      "hypervisortype": "Simulator",
      "id": "466e1831-8f69-4315-8477-3a16c3180038",
      "managedstate": "Managed",
      "memoryallocated": "1.56%",
      "memoryallocateddisablethreshold": false,
      "memoryallocatedthreshold": false,
      "memorydisablethreshold": false,
      "memoryovercommitratio": "2.0",
      "memorythreshold": false,
      "memorytotal": "32.00 GB",
      "name": "C1",
      "podid": "6163b5ba-fc97-422f-9b3c-cc11c70222f5",
      "podname": "POD0",
      "resourcedetails": {
        "cpuOvercommitRatio": "2.0",
        "memoryOvercommitRatio": "2.0"
      },
      "state": "Enabled",
      "zoneid": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "zonename": "Sandbox-simulator"
    }
  ],
  "count": 1
}
(local) 🐱 > list hosts id=17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7 
{
  "count": 1,
  "host": [
    {
      "capabilities": "hvm",
      "clusterid": "466e1831-8f69-4315-8477-3a16c3180038",
      "clustername": "C1",
      "clustertype": "CloudManaged",
      "cpuallocated": "1.56%",
      "cpuallocatedpercentage": "1.56%",
      "cpuallocatedvalue": 500,
      "cpuallocatedwithoverprovisioning": "0.78%",
      "cpuloadaverage": 0,
      "cpunumber": 4,
      "cpuspeed": 8000,
      "cpuused": "0%",
      "cpuwithoverprovisioning": "64000",
      "created": "2021-04-16T16:36:00+0530",
      "disconnected": "2021-04-20T13:57:10+0530",
      "events": "AgentDisconnected; AgentConnected; ManagementServerDown; PingTimeout; Ping; StartAgentRebalance; Remove; ShutdownRequested; HostDown",
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "hypervisor": "Simulator",
      "hypervisorversion": "4.15.1.0-SNAPSHOT",
      "id": "17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7",
      "ipaddress": "172.16.15.18",
      "islocalstorageactive": false,
      "lastpinged": "1970-01-19T12:40:44+0530",
      "managementserverid": "981bca31-c0b0-4c43-a0ec-92a93dc05580",
      "memoryallocated": 536870912,
      "memoryallocatedbytes": 536870912,
      "memoryallocatedpercentage": "3.12%",
      "memorytotal": 8589934592,
      "memoryused": 0,
      "memorywithoverprovisioning": "17179869184",
      "name": "SimulatedAgent.e2bbf03f-3f8a-491a-9998-50ba60ab9692",
      "networkkbsread": 32768,
      "networkkbswrite": 16384,
      "outofbandmanagement": {
        "enabled": false,
        "powerstate": "Disabled"
      },
      "podid": "6163b5ba-fc97-422f-9b3c-cc11c70222f5",
      "podname": "POD0",
      "resourcestate": "Enabled",
      "state": "Up",
      "type": "Routing",
      "version": "4.15.1.0-SNAPSHOT",
      "zoneid": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "zonename": "Sandbox-simulator"
    }
  ]
}
(local) 🐱 > list hostsmetrics id=17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7 
{
  "count": 1,
  "host": [
    {
      "capabilities": "hvm",
      "clusterid": "466e1831-8f69-4315-8477-3a16c3180038",
      "clustername": "C1",
      "clustertype": "CloudManaged",
      "cpuallocated": "1.56%",
      "cpuallocateddisablethreshold": false,
      "cpuallocatedghz": "0.50 Ghz",
      "cpuallocatedthreshold": false,
      "cpudisablethreshold": false,
      "cpuloadaverage": 0,
      "cpunumber": 4,
      "cpuspeed": 8000,
      "cputhreshold": false,
      "cputotalghz": "32.00 Ghz (x 2.0)",
      "cpuused": "0%",
      "cpuusedghz": "0.00 Ghz",
      "cpuwithoverprovisioning": "64000",
      "created": "2021-04-16T16:36:00+0530",
      "disconnected": "2021-04-20T13:57:10+0530",
      "events": "AgentDisconnected; AgentConnected; ManagementServerDown; PingTimeout; Ping; StartAgentRebalance; Remove; ShutdownRequested; HostDown",
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "hypervisor": "Simulator",
      "hypervisorversion": "4.15.1.0-SNAPSHOT",
      "id": "17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7",
      "instances": "0 / 0",
      "ipaddress": "172.16.15.18",
      "lastpinged": "1970-01-19T12:40:44+0530",
      "managementserverid": "981bca31-c0b0-4c43-a0ec-92a93dc05580",
      "memoryallocated": 536870912,
      "memoryallocateddisablethreshold": false,
      "memoryallocatedgb": "0.50 GB",
      "memoryallocatedthreshold": false,
      "memorydisablethreshold": false,
      "memorythreshold": false,
      "memorytotal": 8589934592,
      "memorytotalgb": "8.00 GB (x 2.0)",
      "memoryused": 0,
      "memoryusedgb": "0.00 GB",
      "name": "SimulatedAgent.e2bbf03f-3f8a-491a-9998-50ba60ab9692",
      "networkkbsread": 32768,
      "networkkbswrite": 16384,
      "networkread": "0.03 GB",
      "networkwrite": "0.02 GB",
      "outofbandmanagement": {
        "enabled": false,
        "powerstate": "Disabled"
      },
      "podid": "6163b5ba-fc97-422f-9b3c-cc11c70222f5",
      "podname": "POD0",
      "powerstate": "Disabled",
      "resourcestate": "Enabled",
      "state": "Up",
      "type": "Routing",
      "version": "4.15.1.0-SNAPSHOT",
      "zoneid": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```

With change (difference in host's reponses)
```
(local) 🐱 > list zonesmetrics 
{
  "count": 1,
  "zone": [
    {
      "allocationstate": "Enabled",
      "clusters": "2 / 2",
      "cpuallocated": "0.52%",
      "cpuallocateddisablethreshold": false,
      "cpuallocatedthreshold": false,
      "cpudisablethreshold": false,
      "cputhreshold": false,
      "cputotal": "192.00 Ghz",
      "dhcpprovider": "VirtualRouter",
      "dns1": "10.147.28.6",
      "guestcidraddress": "10.1.1.0/24",
      "id": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "internaldns1": "10.147.28.6",
      "localstorageenabled": false,
      "memoryallocated": "3.13%",
      "memoryallocateddisablethreshold": false,
      "memoryallocatedthreshold": false,
      "memorydisablethreshold": false,
      "memorythreshold": false,
      "memorytotal": "48.00 GB",
      "name": "Sandbox-simulator",
      "networktype": "Advanced",
      "securitygroupsenabled": false,
      "state": "Enabled",
      "tags": [],
      "zonetoken": "20291feb-a0af-3dbf-8757-d5486debc1c3"
    }
  ]
}
(local) 🐱 > list clustersmetrics id=466e1831-8f69-4315-8477-3a16c3180038 
{
  "cluster": [
    {
      "allocationstate": "Enabled",
      "clustertype": "CloudManaged",
      "cpuallocated": "0.39%",
      "cpuallocateddisablethreshold": false,
      "cpuallocatedthreshold": false,
      "cpudisablethreshold": false,
      "cpuovercommitratio": "2.0",
      "cputhreshold": false,
      "cputotal": "128.00 Ghz",
      "hosts": "2 / 2",
      "hypervisortype": "Simulator",
      "id": "466e1831-8f69-4315-8477-3a16c3180038",
      "managedstate": "Managed",
      "memoryallocated": "1.56%",
      "memoryallocateddisablethreshold": false,
      "memoryallocatedthreshold": false,
      "memorydisablethreshold": false,
      "memoryovercommitratio": "2.0",
      "memorythreshold": false,
      "memorytotal": "32.00 GB",
      "name": "C1",
      "podid": "6163b5ba-fc97-422f-9b3c-cc11c70222f5",
      "podname": "POD0",
      "resourcedetails": {
        "cpuOvercommitRatio": "2.0",
        "memoryOvercommitRatio": "2.0"
      },
      "state": "Enabled",
      "zoneid": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "zonename": "Sandbox-simulator"
    }
  ],
  "count": 1
}
(local) 🐱 > list hosts id=17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7 
{
  "count": 1,
  "host": [
    {
      "capabilities": "hvm",
      "clusterid": "466e1831-8f69-4315-8477-3a16c3180038",
      "clustername": "C1",
      "clustertype": "CloudManaged",
      "cpuallocated": "0.78%",
      "cpuallocatedpercentage": "0.78%",
      "cpuallocatedvalue": 500,
      "cpuallocatedwithoverprovisioning": "0.78%",
      "cpuloadaverage": 0,
      "cpunumber": 8,
      "cpuspeed": 8000,
      "cpuused": "0%",
      "cpuwithoverprovisioning": "64000",
      "created": "2021-04-16T16:36:00+0530",
      "disconnected": "2021-04-20T13:57:10+0530",
      "events": "AgentConnected; AgentDisconnected; Ping; ShutdownRequested; Remove; ManagementServerDown; PingTimeout; HostDown; StartAgentRebalance",
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "hypervisor": "Simulator",
      "hypervisorversion": "4.15.1.0-SNAPSHOT",
      "id": "17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7",
      "ipaddress": "172.16.15.18",
      "islocalstorageactive": false,
      "lastpinged": "1970-01-19T12:40:43+0530",
      "managementserverid": "981bca31-c0b0-4c43-a0ec-92a93dc05580",
      "memoryallocated": 536870912,
      "memoryallocatedbytes": 536870912,
      "memoryallocatedpercentage": "3.12%",
      "memorytotal": 17179869184,
      "memoryused": 0,
      "memorywithoverprovisioning": "17179869184",
      "name": "SimulatedAgent.e2bbf03f-3f8a-491a-9998-50ba60ab9692",
      "networkkbsread": 32768,
      "networkkbswrite": 16384,
      "outofbandmanagement": {
        "enabled": false,
        "powerstate": "Disabled"
      },
      "podid": "6163b5ba-fc97-422f-9b3c-cc11c70222f5",
      "podname": "POD0",
      "resourcestate": "Enabled",
      "state": "Up",
      "type": "Routing",
      "version": "4.15.1.0-SNAPSHOT",
      "zoneid": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "zonename": "Sandbox-simulator"
    }
  ]
}
(local) 🐱 > list hostsmetrics id=17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7 
{
  "count": 1,
  "host": [
    {
      "capabilities": "hvm",
      "clusterid": "466e1831-8f69-4315-8477-3a16c3180038",
      "clustername": "C1",
      "clustertype": "CloudManaged",
      "cpuallocated": "0.78%",
      "cpuallocateddisablethreshold": false,
      "cpuallocatedghz": "0.50 Ghz",
      "cpuallocatedthreshold": false,
      "cpuallocatedwithoverprovisioning": "0.78%",
      "cpudisablethreshold": false,
      "cpuloadaverage": 0,
      "cpunumber": 8,
      "cpuspeed": 8000,
      "cputhreshold": false,
      "cputotalghz": "64.00 Ghz",
      "cpuused": "0%",
      "cpuusedghz": "0.00 Ghz",
      "cpuwithoverprovisioning": "64000",
      "created": "2021-04-16T16:36:00+0530",
      "disconnected": "2021-04-20T13:57:10+0530",
      "events": "AgentConnected; AgentDisconnected; Ping; ShutdownRequested; Remove; ManagementServerDown; PingTimeout; HostDown; StartAgentRebalance",
      "hahost": false,
      "hostha": {
        "haenable": false,
        "hastate": "Disabled"
      },
      "hypervisor": "Simulator",
      "hypervisorversion": "4.15.1.0-SNAPSHOT",
      "id": "17d27b16-ae1e-43b0-89e8-e8ce8f0c54a7",
      "instances": "0 / 0",
      "ipaddress": "172.16.15.18",
      "lastpinged": "1970-01-19T12:40:43+0530",
      "managementserverid": "981bca31-c0b0-4c43-a0ec-92a93dc05580",
      "memoryallocated": 536870912,
      "memoryallocateddisablethreshold": false,
      "memoryallocatedgb": "0.50 GB",
      "memoryallocatedthreshold": false,
      "memorydisablethreshold": false,
      "memorythreshold": false,
      "memorytotal": 17179869184,
      "memorytotalgb": "16.00 GB",
      "memoryused": 0,
      "memoryusedgb": "0.00 GB",
      "name": "SimulatedAgent.e2bbf03f-3f8a-491a-9998-50ba60ab9692",
      "networkkbsread": 32768,
      "networkkbswrite": 16384,
      "networkread": "0.03 GB",
      "networkwrite": "0.02 GB",
      "outofbandmanagement": {
        "enabled": false,
        "powerstate": "Disabled"
      },
      "podid": "6163b5ba-fc97-422f-9b3c-cc11c70222f5",
      "podname": "POD0",
      "powerstate": "Disabled",
      "resourcestate": "Enabled",
      "state": "Up",
      "type": "Routing",
      "version": "4.15.1.0-SNAPSHOT",
      "zoneid": "e2b46eac-7f4b-4d87-a9d6-5a9957747cd5",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```