### PR TITLE
server: create DB entry for storage pool capacity when create storage pool

### DIFF
--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/volume/datastore/PrimaryDataStoreHelper.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/volume/datastore/PrimaryDataStoreHelper.java
@@ -173,6 +173,7 @@ public class PrimaryDataStoreHelper {
 
     public DataStore attachZone(DataStore store) {
         StoragePoolVO pool = this.dataStoreDao.findById(store.getId());
+        storageMgr.createCapacityEntry(pool.getId());
         pool.setScope(ScopeType.ZONE);
         pool.setStatus(StoragePoolStatus.Up);
         this.dataStoreDao.update(pool.getId(), pool);
@@ -181,6 +182,7 @@ public class PrimaryDataStoreHelper {
 
     public DataStore attachZone(DataStore store, HypervisorType hypervisor) {
         StoragePoolVO pool = this.dataStoreDao.findById(store.getId());
+        storageMgr.createCapacityEntry(pool.getId());
         pool.setScope(ScopeType.ZONE);
         pool.setHypervisor(hypervisor);
         pool.setStatus(StoragePoolStatus.Up);

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -757,15 +757,6 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             throw new CloudRuntimeException("Failed to add data store: " + e.getMessage(), e);
         }
 
-        // create entry for storage pool capacity
-        StoragePoolVO pool = _storagePoolDao.findById(store.getId());
-        long disk = _capacityMgr.getAllocatedPoolCapacity(pool, null);
-        if (pool.isShared()) {
-            createCapacityEntry(pool, Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED, disk);
-        } else {
-            createCapacityEntry(pool, Capacity.CAPACITY_TYPE_LOCAL_STORAGE, disk);
-        }
-
         return (PrimaryDataStoreInfo)_dataStoreMgr.getDataStore(store.getId(), DataStoreRole.Primary);
     }
 

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -757,6 +757,15 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             throw new CloudRuntimeException("Failed to add data store: " + e.getMessage(), e);
         }
 
+        // create entry for storage pool capacity
+        StoragePoolVO pool = _storagePoolDao.findById(store.getId());
+        long disk = _capacityMgr.getAllocatedPoolCapacity(pool, null);
+        if (pool.isShared()) {
+            createCapacityEntry(pool, Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED, disk);
+        } else {
+            createCapacityEntry(pool, Capacity.CAPACITY_TYPE_LOCAL_STORAGE, disk);
+        }
+
         return (PrimaryDataStoreInfo)_dataStoreMgr.getDataStore(store.getId(), DataStoreRole.Primary);
     }
 


### PR DESCRIPTION
### Description
This PR fixes the issue that new storage pool can not be used in the first few minute after adding to cloudstack.

steps to reproduce the issue
(1) change global setting vm.allocation.algorithm to 'firstfitleastconsumed' (this allocator orders host/storage by capacity, maybe other algorithim has same issue).
(2) create a zone and enable it
(3) systemvm cannot be created, until Capacity Checker runs (it runs every 5 minutes).


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity


#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
