### PR TITLE
Migrate VR codebase from Python2 to Python3

### DIFF
--- a/python/bindir/cloud-grab-dependent-library-versions
+++ b/python/bindir/cloud-grab-dependent-library-versions
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -38,7 +38,7 @@ def getDependentLibraryInfo():
                 start = True
                 continue
             if not start: continue
-            
+
             (key, value) = l.split(':', 2)
             key = key.strip()
             value = value.strip()
@@ -70,7 +70,7 @@ def arrangeOutPut(libraryMap):
             entry = "%-40s:    %s"%(l, 'UNKNOWN')
         msg.append(entry)
     print('\n'.join(msg))
-        
+
 if __name__ == '__main__':
     pythonDepLibraries = ['python', 'python3']
     relver = runCmd(['rpm', '-q', 'centos-release'])

--- a/systemvm/debian/opt/cloud/bin/baremetal-vr.py
+++ b/systemvm/debian/opt/cloud/bin/baremetal-vr.py
@@ -16,7 +16,7 @@
 #under the License.
 
 import subprocess
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import hmac
 import hashlib
 import base64
@@ -131,10 +131,10 @@ class Server(object):
             "mac": mac
         }
 
-        request = zip(reqs.keys(), reqs.values())
+        request = list(zip(list(reqs.keys()), list(reqs.values())))
         request.sort(key=lambda x: str.lower(x[0]))
-        hashStr = "&".join(["=".join([str.lower(r[0]), str.lower(urllib.quote_plus(str(r[1]))).replace("+", "%20").replace('=', '%3d')]) for r in request])
-        sig = urllib.quote_plus(base64.encodestring(hmac.new(secretkey, hashStr, hashlib.sha1).digest()).strip())
+        hashStr = "&".join(["=".join([str.lower(r[0]), str.lower(urllib.parse.quote_plus(str(r[1]))).replace("+", "%20").replace('=', '%3d')]) for r in request])
+        sig = urllib.parse.quote_plus(base64.encodebytes(hmac.new(secretkey, hashStr, hashlib.sha1).digest()).strip())
         return sig
 
     def notify_provisioning_done(self, mac):

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -149,7 +149,9 @@ class CsInterface:
 
     def ip_in_subnet(self, ip):
         ipo = ip_address(ip)
-        net = ip_network("%s/%s" % (self.get_ip(), self.get_size()))
+        # we are using an ip as netaddress so strict must be False
+        net = ip_network("%s/%s" % (self.get_ip(), self.get_size()),
+                         strict=False)
         return ipo in net
 
     def get_gateway_cidr(self):

--- a/systemvm/debian/opt/cloud/bin/cs/CsApp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsApp.py
@@ -16,8 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-from CsFile import CsFile
-import CsHelper
+from .CsFile import CsFile
+from .CsProcess import CsProcess
+from . import CsHelper
 
 
 class CsApp:

--- a/systemvm/debian/opt/cloud/bin/cs/CsConfig.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsConfig.py
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from CsDatabag import CsCmdLine
-from CsAddress import CsAddress
+from .CsDatabag import CsCmdLine
+from .CsAddress import CsAddress
 import logging
 
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDatabag.py
@@ -33,7 +33,7 @@ class CsDataBag(object):
             self.config = config
 
     def dump(self):
-        print self.dbag
+        print(self.dbag)
 
     def get_bag(self):
         return self.dbag

--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import CsHelper
+from . import CsHelper
 import logging
 import os
-from netaddr import *
+from ipaddress import ip_address
 from random import randint
-from CsGuestNetwork import CsGuestNetwork
+from .CsGuestNetwork import CsGuestNetwork
 from cs.CsDatabag import CsDataBag
 from cs.CsFile import CsFile
 
@@ -207,7 +207,7 @@ class CsDhcp(CsDataBag):
                                                                             entry['ipv4_address'],
                                                                             entry['host_name']))
 
-        i = IPAddress(entry['ipv4_address'])
+        i = ip_address(entry['ipv4_address'])
         # Calculate the device
         for v in self.devinfo:
             if i > v['network'].network and i < v['network'].broadcast:

--- a/systemvm/debian/opt/cloud/bin/cs/CsFile.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsFile.py
@@ -70,7 +70,7 @@ class CsFile:
 
     def dump(self):
         for line in self.new_config:
-            print line
+            print(line)
 
     def addeq(self, string):
         """ Update a line in a file of the form token=something
@@ -153,7 +153,7 @@ class CsFile:
         logging.debug("Searching for %s string " % search)
 
         for index, line in enumerate(self.new_config):
-            print ' line = ' + line
+            print(' line = ' + line)
             if line.lstrip().startswith(ignoreLinesStartWith):
                 continue
             if search in line:

--- a/systemvm/debian/opt/cloud/bin/cs/CsGuestNetwork.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsGuestNetwork.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from merge import DataBag
-import CsHelper
+from . import CsHelper
 
 
 class CsGuestNetwork:
@@ -27,7 +27,7 @@ class CsGuestNetwork:
         db.load()
         dbag = db.getDataBag()
         self.config = config
-        if device in dbag.keys() and len(dbag[device]) != 0:
+        if device in list(dbag.keys()) and len(dbag[device]) != 0:
             self.data = dbag[device][0]
         else:
             self.guest = False

--- a/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
@@ -25,7 +25,7 @@ import sys
 import os.path
 import re
 import shutil
-from netaddr import *
+from ipaddress import *
 
 PUBLIC_INTERFACES = {"router": "eth2", "vpcrouter": "eth1"}
 
@@ -86,7 +86,7 @@ def mkdir(name, mode, fatal):
         os.makedirs(name, mode)
     except OSError as e:
         if e.errno != 17:
-            print "failed to make directories " + name + " due to :" + e.strerror
+            print("failed to make directories " + name + " due to :" + e.strerror)
             if(fatal):
                 sys.exit(1)
 
@@ -119,7 +119,7 @@ def get_device_info():
             to = {}
             to['ip'] = vals[1]
             to['dev'] = vals[-1]
-            to['network'] = IPNetwork(to['ip'])
+            to['network'] = ip_network(to['ip'])
             to['dnsmasq'] = False
             list.append(to)
     return list

--- a/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
@@ -119,7 +119,7 @@ def get_device_info():
             to = {}
             to['ip'] = vals[1]
             to['dev'] = vals[-1]
-            to['network'] = ip_network(to['ip'])
+            to['network'] = ip_network(to['ip'], strict=False)
             to['dnsmasq'] = False
             list.append(to)
     return list

--- a/systemvm/debian/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -18,9 +18,9 @@ import logging
 import os.path
 import re
 from cs.CsDatabag import CsDataBag
-from CsProcess import CsProcess
-from CsFile import CsFile
-import CsHelper
+from .CsProcess import CsProcess
+from .CsFile import CsFile
+from . import CsHelper
 
 HAPROXY_CONF_T = "/etc/haproxy/haproxy.cfg.new"
 HAPROXY_CONF_P = "/etc/haproxy/haproxy.cfg"
@@ -30,9 +30,9 @@ class CsLoadBalancer(CsDataBag):
     """ Manage Load Balancer entries """
 
     def process(self):
-        if "config" not in self.dbag.keys():
+        if "config" not in list(self.dbag.keys()):
             return
-        if 'configuration' not in self.dbag['config'][0].keys():
+        if 'configuration' not in list(self.dbag['config'][0].keys()):
             return
         config = self.dbag['config'][0]['configuration']
         file1 = CsFile(HAPROXY_CONF_T)

--- a/systemvm/debian/opt/cloud/bin/cs/CsMonitor.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsMonitor.py
@@ -16,7 +16,7 @@
 # under the License.
 import logging
 from cs.CsDatabag import CsDataBag
-from CsFile import CsFile
+from .CsFile import CsFile
 import json
 
 MON_CONFIG = "/etc/monitor.conf"
@@ -48,13 +48,13 @@ class CsMonitor(CsDataBag):
         cron_rep_basic = self.get_basic_check_interval()
         cron_rep_advanced = self.get_advanced_check_interval()
         cron = CsFile("/etc/cron.d/process")
-        cron.deleteLine("root /usr/bin/python /root/monitorServices.py")
+        cron.deleteLine("root /usr/bin/python3 /root/monitorServices.py")
         cron.add("SHELL=/bin/bash", 0)
         cron.add("PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin", 1)
         if cron_rep_basic > 0:
-            cron.add("*/" + str(cron_rep_basic) + " * * * * root /usr/bin/python /root/monitorServices.py basic", -1)
+            cron.add("*/" + str(cron_rep_basic) + " * * * * root /usr/bin/python3 /root/monitorServices.py basic", -1)
         if cron_rep_advanced > 0:
-            cron.add("*/" + str(cron_rep_advanced) + " * * * * root /usr/bin/python /root/monitorServices.py advanced", -1)
+            cron.add("*/" + str(cron_rep_advanced) + " * * * * root /usr/bin/python3 /root/monitorServices.py advanced", -1)
         cron.commit()
 
     def setupHealthChecksConfigFile(self):

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -28,7 +28,7 @@ class CsChain(object):
         self.count = {}
 
     def add(self, table, chain):
-         if table not in list(self.chain.keys()):
+        if table not in list(self.chain.keys()):
             self.chain.setdefault(table, []).append(chain)
         else:
             self.chain[table].append(chain)

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -15,8 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import CsHelper
-from CsDatabag import CsCmdLine
+from . import CsHelper
+from .CsDatabag import CsCmdLine
 import logging
 
 
@@ -28,7 +28,7 @@ class CsChain(object):
         self.count = {}
 
     def add(self, table, chain):
-        if table not in self.chain.keys():
+         if table not in list(self.chain.keys()):
             self.chain.setdefault(table, []).append(chain)
         else:
             self.chain[table].append(chain)
@@ -40,7 +40,7 @@ class CsChain(object):
         self.count[chain] += 1
 
     def get(self, table):
-        if table not in self.chain.keys():
+        if table not in list(self.chain.keys()):
             return {}
         return self.chain[table]
 
@@ -51,7 +51,7 @@ class CsChain(object):
         return self.last_added
 
     def has_chain(self, table, chain):
-        if table not in self.chain.keys():
+        if table not in list(self.chain.keys()):
             return False
         if chain not in self.chain[table]:
             return False
@@ -242,7 +242,7 @@ class CsNetfilter(object):
         self.seen = True
 
     def __convert_to_dict(self, rule):
-        rule = unicode(rule.lstrip())
+        rule = str(rule.lstrip())
         rule = rule.replace('! -', '!_-')
         rule = rule.replace('-p all', '')
         rule = rule.replace('  ', ' ')
@@ -253,8 +253,8 @@ class CsNetfilter(object):
         rule = rule.replace('-m state', '-m2 state')
         rule = rule.replace('ESTABLISHED,RELATED', 'RELATED,ESTABLISHED')
         bits = rule.split(' ')
-        rule = dict(zip(bits[0::2], bits[1::2]))
-        if "-A" in rule.keys():
+        rule = dict(list(zip(bits[0::2], bits[1::2])))
+        if "-A" in list(rule.keys()):
             self.chain = rule["-A"]
         return rule
 
@@ -289,7 +289,7 @@ class CsNetfilter(object):
                  '--to-source', '--to-destination', '--mark']
         str = ''
         for k in order:
-            if k in self.rule.keys():
+            if k in list(self.rule.keys()):
                 printable = k.replace('-m2', '-m')
                 printable = printable.replace('!_-', '! -')
                 if delete:
@@ -306,7 +306,7 @@ class CsNetfilter(object):
             return False
         if rule.get_chain() != self.get_chain():
             return False
-        if len(rule.get_rule().items()) != len(self.get_rule().items()):
+        if len(list(rule.get_rule().items())) != len(list(self.get_rule().items())):
             return False
         common = set(rule.get_rule().items()) & set(self.get_rule().items())
         if len(common) != len(rule.get_rule()):

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -90,7 +90,7 @@ class CsNetfilters(object):
             if i.startswith(b'*'):  # Table
                 self.table.add(i[1:])
             if i.startswith(b':'):  # Chain
-                self.chain.add(self.table.last(), i[1:].split(' ')[0])
+                self.chain.add(self.table.last(), i[1:].split(b' ')[0])
             if i.startswith(b'-A'):  # Rule
                 self.chain.add_rule(i.split()[1])
                 rule = CsNetfilter()

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -87,11 +87,11 @@ class CsNetfilters(object):
 
     def get_all_rules(self):
         for i in CsHelper.execute("iptables-save"):
-            if i.startswith('*'):  # Table
+            if i.startswith(b'*'):  # Table
                 self.table.add(i[1:])
-            if i.startswith(':'):  # Chain
+            if i.startswith(b':'):  # Chain
                 self.chain.add(self.table.last(), i[1:].split(' ')[0])
-            if i.startswith('-A'):  # Rule
+            if i.startswith(b'-A'):  # Rule
                 self.chain.add_rule(i.split()[1])
                 rule = CsNetfilter()
                 rule.parse(i)

--- a/systemvm/debian/opt/cloud/bin/cs/CsProcess.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsProcess.py
@@ -17,7 +17,7 @@
 # under the License.
 import os
 import re
-import CsHelper
+from . import CsHelper
 import logging
 
 
@@ -42,12 +42,15 @@ class CsProcess(object):
         self.pid = []
         items = len(self.search)
         for i in CsHelper.execute("ps aux"):
-            proc = re.split(r"\s+", i)[10:]
+            items = len(self.search)
+            decodedItem = i.decode()
+            proc = re.split(r"\s+", decodedItem)[10:]
             matches = len([m for m in proc if m in self.search])
             if matches == items:
-                self.pid.append(re.split(r"\s+", i)[1])
+                self.pid.append(re.split(r"\s+", decodedItem)[1])
 
-        logging.debug("CsProcess:: Searching for process ==> %s and found PIDs ==> %s", self.search, self.pid)
+        log_str = "CsProcess:: Searching for process ==> %s and found PIDs ==> %s" % ("self.search", "self.pid")
+        logging.debug(log_str)
         return self.pid
 
     def find(self):

--- a/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
@@ -32,13 +32,13 @@
 # -------------------------------------------------------------------- #
 import os
 import logging
-import CsHelper
-from CsFile import CsFile
-from CsProcess import CsProcess
-from CsApp import CsPasswdSvc
-from CsAddress import CsDevice
-from CsRoute import CsRoute
-from CsStaticRoutes import CsStaticRoutes
+from . import CsHelper
+from .CsFile import CsFile
+from .CsProcess import CsProcess
+from .CsApp import CsPasswdSvc
+from .CsAddress import CsDevice
+from .CsRoute import CsRoute
+from .CsStaticRoutes import CsStaticRoutes
 import socket
 from time import sleep
 
@@ -111,9 +111,9 @@ class CsRedundant(object):
             CsHelper.service("keepalived", "stop")
             return
 
-        CsHelper.mkdir(self.CS_RAMDISK_DIR, 0755, False)
+        CsHelper.mkdir(self.CS_RAMDISK_DIR, 0o755, False)
         CsHelper.mount_tmpfs(self.CS_RAMDISK_DIR)
-        CsHelper.mkdir(self.CS_ROUTER_DIR, 0755, False)
+        CsHelper.mkdir(self.CS_ROUTER_DIR, 0o755, False)
         for s in self.CS_TEMPLATES:
             d = s
             if s.endswith(".templ"):
@@ -222,10 +222,10 @@ class CsRedundant(object):
                 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 s.bind('/tmp/master_lock')
                 return s
-            except socket.error, e:
+            except socket.error as e:
                 error_code = e.args[0]
                 error_string = e.args[1]
-                print "Process already running (%d:%s). Exiting" % (error_code, error_string)
+                print("Process already running (%d:%s). Exiting" % (error_code, error_string))
                 logging.info("Master is already running, waiting")
                 sleep(time_between)
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
@@ -225,7 +225,7 @@ class CsRedundant(object):
             except socket.error as e:
                 error_code = e.args[0]
                 error_string = e.args[1]
-                print("Process already running (%d:%s). Exiting" % (error_code, error_string))
+                print(f"Process already running ({error_code}:{error_string}). Exiting")
                 logging.info("Master is already running, waiting")
                 sleep(time_between)
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import CsHelper
+from . import CsHelper
 import logging
 
 
@@ -116,7 +116,7 @@ class CsRoute:
         route_found = CsHelper.execute("ip -4 route list 0/0")
 
         if len(route_found) > 0:
-            logging.info("Default route found: " + route_found[0])
+            logging.info("Default route found: " + route_found[0].decode())
             return True
         else:
             logging.warn("No default route found!")
@@ -124,6 +124,6 @@ class CsRoute:
 
     def findRule(self, rule):
         for i in CsHelper.execute("ip rule show"):
-            if rule in i.strip():
+            if rule in i.decode().strip():
                 return True
         return False

--- a/systemvm/debian/opt/cloud/bin/cs/CsRule.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRule.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import CsHelper
+from . import CsHelper
 import logging
 
 
@@ -57,6 +57,6 @@ class CsRule:
     def findMark(self):
         srch = "from all fwmark %s lookup %s" % (hex(self.tableNo), self.table)
         for i in CsHelper.execute("ip rule show"):
-            if srch in i.strip():
+            if srch in i.decode().strip():
                 return True
         return False

--- a/systemvm/debian/opt/cloud/bin/cs/CsStaticRoutes.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsStaticRoutes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -- coding: utf-8 --
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -18,8 +18,8 @@
 # under the License.
 
 import logging
-import CsHelper
-from CsDatabag import CsDataBag
+from . import CsHelper
+from .CsDatabag import CsDataBag
 
 
 class CsStaticRoutes(CsDataBag):

--- a/systemvm/debian/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs_dhcp.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import logging
-from netaddr import *
+from ipaddress import *
 
 
 def merge(dbag, data):
@@ -27,7 +27,7 @@ def merge(dbag, data):
             del(dbag[data['ipv4_address']])
     else:
         remove_keys = set()
-        for key, entry in dbag.iteritems():
+        for key, entry in list(dbag.items()):
             if key != 'id' and entry['mac_address'] == data['mac_address'] and data['remove']:
                 remove_keys.add(key)
                 break

--- a/systemvm/debian/opt/cloud/bin/cs_firewallrules.py
+++ b/systemvm/debian/opt/cloud/bin/cs_firewallrules.py
@@ -25,8 +25,8 @@ def merge(dbag, data):
     for rule in data['rules']:
         id = str(rule['id'])
         if rule['revoked']:
-            if id in dbagc.keys():
+            if id in list(dbagc.keys()):
                 del(dbagc[id])
-        elif id not in dbagc.keys():
+        elif id not in list(dbagc.keys()):
             dbagc[id] = rule
     return dbagc

--- a/systemvm/debian/opt/cloud/bin/cs_forwardingrules.py
+++ b/systemvm/debian/opt/cloud/bin/cs_forwardingrules.py
@@ -39,7 +39,7 @@ def merge(dbag, rules):
                 dbag[source_ip] = [newrule]
             elif rules["type"] == "forwardrules":
                 index = -1
-                if source_ip in dbag.keys():
+                if source_ip in list(dbag.keys()):
                     for forward in dbag[source_ip]:
                         if ruleCompare(forward, newrule):
                             index = dbag[source_ip].index(forward)
@@ -51,15 +51,15 @@ def merge(dbag, rules):
                     dbag[source_ip] = [newrule]
         else:
             if rules["type"] == "staticnatrules":
-                if source_ip in dbag.keys():
+                if source_ip in list(dbag.keys()):
                     del dbag[source_ip]
             elif rules["type"] == "forwardrules":
-                if source_ip in dbag.keys():
+                if source_ip in list(dbag.keys()):
                     index = -1
                     for forward in dbag[source_ip]:
                         if ruleCompare(forward, newrule):
                             index = dbag[source_ip].index(forward)
-                            print "removing index %s" % str(index)
+                            print("removing index %s" % str(index))
                     if not index == -1:
                         del dbag[source_ip][index]
 

--- a/systemvm/debian/opt/cloud/bin/cs_guestnetwork.py
+++ b/systemvm/debian/opt/cloud/bin/cs_guestnetwork.py
@@ -28,8 +28,8 @@ def merge(dbag, gn):
             device_to_die = dbag[device][0]
             try:
                 dbag[device].remove(device_to_die)
-            except ValueError, e:
-                print "[WARN] cs_guestnetwork.py :: Error occurred removing item from databag. => %s" % device_to_die
+            except ValueError as e:
+                print("[WARN] cs_guestnetwork.py :: Error occurred removing item from databag. => %s" % device_to_die)
                 del(dbag[device])
         else:
             del(dbag[device])

--- a/systemvm/debian/opt/cloud/bin/cs_ip.py
+++ b/systemvm/debian/opt/cloud/bin/cs_ip.py
@@ -54,7 +54,7 @@ def merge(dbag, ip):
     ip['broadcast'] = str(ipo.broadcast_address)
     ip['cidr'] = str(ipo.network_address) + '/' + str(ipo.prefixlen)
     ip['size'] = str(ipo.prefixlen)
-    ip['network'] = str(ipo.ip_network)
+    ip['network'] = str(ipo.compressed)
     if 'nw_type' not in list(ip.keys()):
         ip['nw_type'] = 'public'
     else:

--- a/systemvm/debian/opt/cloud/bin/cs_ip.py
+++ b/systemvm/debian/opt/cloud/bin/cs_ip.py
@@ -17,7 +17,7 @@
 # under the License.
 
 import os
-from netaddr import *
+from ipaddress import *
 
 
 def macdevice_map():
@@ -42,7 +42,7 @@ def merge(dbag, ip):
                     nic_dev_id = address['nic_dev_id']
                 dbag[dev].remove(address)
 
-    ipo = IPNetwork(ip['public_ip'] + '/' + ip['netmask'])
+    ipo = ip_network(ip['public_ip'] + '/' + ip['netmask'])
     if 'nic_dev_id' in ip:
         nic_dev_id = ip['nic_dev_id']
     if 'vif_mac_address' in ip:
@@ -51,11 +51,11 @@ def merge(dbag, ip):
         if mac_address in device_map:
             nic_dev_id = device_map[mac_address]
     ip['device'] = 'eth' + str(nic_dev_id)
-    ip['broadcast'] = str(ipo.broadcast)
-    ip['cidr'] = str(ipo.ip) + '/' + str(ipo.prefixlen)
+    ip['broadcast'] = str(ipo.broadcast_address)
+    ip['cidr'] = str(ipo.network_address) + '/' + str(ipo.prefixlen)
     ip['size'] = str(ipo.prefixlen)
-    ip['network'] = str(ipo.network) + '/' + str(ipo.prefixlen)
-    if 'nw_type' not in ip.keys():
+    ip['network'] = str(ipo.ip_network)
+    if 'nw_type' not in list(ip.keys()):
         ip['nw_type'] = 'public'
     else:
         ip['nw_type'] = ip['nw_type'].lower()

--- a/systemvm/debian/opt/cloud/bin/cs_ip.py
+++ b/systemvm/debian/opt/cloud/bin/cs_ip.py
@@ -42,7 +42,9 @@ def merge(dbag, ip):
                     nic_dev_id = address['nic_dev_id']
                 dbag[dev].remove(address)
 
-    ipo = ip_network(ip['public_ip'] + '/' + ip['netmask'])
+    # we are passing and must allow for host bits so strict is False
+    ipo = ip_network(ip['public_ip'] + '/' + ip['netmask'],
+                     strict=False)
     if 'nic_dev_id' in ip:
         nic_dev_id = ip['nic_dev_id']
     if 'vif_mac_address' in ip:

--- a/systemvm/debian/opt/cloud/bin/cs_monitorservice.py
+++ b/systemvm/debian/opt/cloud/bin/cs_monitorservice.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from netaddr import *
+from ipaddress import *
 
 
 def merge(dbag, data):

--- a/systemvm/debian/opt/cloud/bin/cs_network_acl.py
+++ b/systemvm/debian/opt/cloud/bin/cs_network_acl.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from netaddr import *
+from ipaddress import *
 
 
 def merge(dbag, data):

--- a/systemvm/debian/opt/cloud/bin/cs_remoteaccessvpn.py
+++ b/systemvm/debian/opt/cloud/bin/cs_remoteaccessvpn.py
@@ -20,7 +20,7 @@
 def merge(dbag, vpn):
     key = vpn['vpn_server_ip']
     op = vpn['create']
-    if key in dbag.keys() and not op:
+    if key in list(dbag.keys()) and not op:
         del(dbag[key])
     else:
         dbag[key] = vpn

--- a/systemvm/debian/opt/cloud/bin/cs_site2sitevpn.py
+++ b/systemvm/debian/opt/cloud/bin/cs_site2sitevpn.py
@@ -20,7 +20,7 @@
 def merge(dbag, vpn):
     key = vpn['peer_gateway_ip']
     op = vpn['create']
-    if key in dbag.keys() and not op:
+    if key in list(dbag.keys()) and not op:
         del(dbag[key])
     else:
         dbag[key] = vpn

--- a/systemvm/debian/opt/cloud/bin/cs_vmp.py
+++ b/systemvm/debian/opt/cloud/bin/cs_vmp.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from netaddr import *
+from ipaddress import *
 
 
 def merge(dbag, data):

--- a/systemvm/debian/opt/cloud/bin/cs_vpnusers.py
+++ b/systemvm/debian/opt/cloud/bin/cs_vpnusers.py
@@ -22,13 +22,13 @@ import copy
 def merge(dbag, data):
     dbagc = copy.deepcopy(dbag)
 
-    print dbag
-    print data
+    print(dbag)
+    print(data)
     if "vpn_users" not in data:
         return dbagc
 
     # remove previously deleted user from the dict
-    for user in dbagc.keys():
+    for user in list(dbagc.keys()):
         if user == 'id':
             continue
         userrec = dbagc[user]
@@ -39,9 +39,9 @@ def merge(dbag, data):
     for user in data['vpn_users']:
         username = user['user']
         add = user['add']
-        if username not in dbagc.keys():
+        if username not in list(dbagc.keys()):
             dbagc[username] = user
-        elif username in dbagc.keys() and not add:
+        elif username in list(dbagc.keys()) and not add:
             dbagc[username] = user
 
     return dbagc

--- a/systemvm/debian/opt/cloud/bin/diagnostics.py
+++ b/systemvm/debian/opt/cloud/bin/diagnostics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/systemvm/debian/opt/cloud/bin/filesystem_writable_check.py
+++ b/systemvm/debian/opt/cloud/bin/filesystem_writable_check.py
@@ -28,17 +28,17 @@ def check_filesystem():
     readOnly1 = bool(stat1.f_flag & ST_RDONLY)
 
     if (readOnly1):
-        print "Read-only file system : monitor results (/root) file system is mounted as read-only"
+        print("Read-only file system : monitor results (/root) file system is mounted as read-only")
         exit(1)
 
     stat2 = os.statvfs('/var/cache/cloud')
     readOnly2 = bool(stat2.f_flag & ST_RDONLY)
 
     if (readOnly2):
-        print "Read-only file system : config info (/var/cache/cloud) file system is mounted as read-only"
+        print("Read-only file system : config info (/var/cache/cloud) file system is mounted as read-only")
         exit(1)
 
-    print "file system is writable"
+    print("file system is writable")
     exit(0)
 
 

--- a/systemvm/debian/opt/cloud/bin/get_diagnostics_files.py
+++ b/systemvm/debian/opt/cloud/bin/get_diagnostics_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -65,7 +65,7 @@ def zip_files(files):
         cleanup(files_from_shell_commands)
         generate_retrieved_files_txt(zf, files_found_list, files_not_found_list)
         zf.close()
-        print zf_name
+        print(zf_name)
 
 
 def get_cmd(script):

--- a/systemvm/debian/opt/cloud/bin/get_diagnostics_files.py
+++ b/systemvm/debian/opt/cloud/bin/get_diagnostics_files.py
@@ -129,9 +129,9 @@ def generate_retrieved_files_txt(zip_file, files_found, files_not_found):
     try:
         with open(output_file, 'wb', 0) as man:
             for i in files_found:
-                man.write(i + '\n')
+                man.write(i + b'\n')
             for j in files_not_found:
-                man.write(j + 'File Not Found!!\n')
+                man.write(j + b' File Not Found!!\n')
         zip_file.write(output_file, output_file)
     finally:
         cleanup_cmd = "rm -f %s" % output_file

--- a/systemvm/debian/opt/cloud/bin/merge.py
+++ b/systemvm/debian/opt/cloud/bin/merge.py
@@ -97,7 +97,7 @@ class updateDataBag:
             self.db.setKey("forwardingrules")
         else:
             self.db.setKey(self.qFile.type)
-        dbag = self.db.load()
+        self.db.load()
         logging.info("Command of type %s received", self.qFile.type)
 
         if self.qFile.type == 'ips':

--- a/systemvm/debian/opt/cloud/bin/merge.py
+++ b/systemvm/debian/opt/cloud/bin/merge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -155,7 +155,7 @@ class updateDataBag:
         dp['nw_type'] = 'guest'
         qf = QueueFile()
         qf.load({'ip_address': [dp], 'type': 'ips'})
-        if 'domain_name' not in d.keys() or d['domain_name'] == '':
+        if 'domain_name' not in list(d.keys()) or d['domain_name'] == '':
             d['domain_name'] = "cloudnine.internal"
         return cs_guestnetwork.merge(dbag, d)
 
@@ -246,7 +246,7 @@ class updateDataBag:
     def process_ipaliases(self, dbag):
         nic_dev = None
         # Should be a way to deal with this better
-        for intf, data in dbag.items():
+        for intf, data in list(dbag.items()):
             if intf == 'id':
                 continue
             elif any([net['nw_type'] == 'guest' for net in data]):

--- a/systemvm/debian/opt/cloud/bin/passwd_server_ip.py
+++ b/systemvm/debian/opt/cloud/bin/passwd_server_ip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -31,10 +31,10 @@ import os
 import sys
 import syslog
 import threading
-import urlparse
+from urllib.parse import *
 
-from BaseHTTPServer   import BaseHTTPRequestHandler, HTTPServer
-from SocketServer     import ThreadingMixIn #, ForkingMixIn
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn #, ForkingMixIn
 
 
 passMap = {}
@@ -64,7 +64,7 @@ def checkToken(token):
 
 def loadPasswordFile():
     try:
-        with file(getPasswordFile()) as f:
+        with open(getPasswordFile()) as f:
             for line in f:
                 if '=' not in line: continue
                 key, value = line.strip().split('=', 1)
@@ -75,11 +75,11 @@ def loadPasswordFile():
 def savePasswordFile():
     with lock:
         try:
-            with file(getPasswordFile(), 'w') as f:
+            with open(getPasswordFile(), 'w') as f:
                 for ip in passMap:
                     f.write('%s=%s\n' % (ip, passMap[ip]))
             f.close()
-        except IOError, e:
+        except IOError as e:
             syslog.syslog('serve_password: Unable to save to password file %s' % e)
 
 def getPassword(ip):
@@ -192,7 +192,7 @@ def serve(HandlerClass = PasswordRequestHandler,
     except KeyboardInterrupt:
         syslog.syslog('serve_password shutting down')
         passwordServer.socket.close()
-    except Exception, e:
+    except Exception as e:
         syslog.syslog('serve_password hit exception %s -- died' % e)
         passwordServer.socket.close()
 

--- a/systemvm/debian/opt/cloud/bin/update_config.py
+++ b/systemvm/debian/opt/cloud/bin/update_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -64,7 +64,7 @@ def is_guestnet_configured(guestnet_dict, keys):
     existing_keys = []
     new_eth_key = None
 
-    for k1, v1 in guestnet_dict.iteritems():
+    for k1, v1 in list(guestnet_dict.items()):
         if k1 in keys and len(v1) > 0:
             existing_keys.append(k1)
 

--- a/systemvm/debian/opt/cloud/bin/vmdata.py
+++ b/systemvm/debian/opt/cloud/bin/vmdata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -31,7 +31,7 @@ def main(argv):
     try:
         opts, args = getopt.getopt(argv, "f:d:")
     except getopt.GetoptError:
-        print 'params: -f <filename> -d <b64jsondata>'
+        print('params: -f <filename> -d <b64jsondata>')
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-f':
@@ -46,7 +46,7 @@ def main(argv):
     elif b64data != '':
         json_data = json.loads(base64.b64decode(b64data))
     else:
-        print '-f <filename> or -d <b64jsondata> required'
+        print('-f <filename> or -d <b64jsondata> required')
         sys.exit(2)
 
     for ip in json_data:
@@ -99,15 +99,15 @@ def createfile(ip, folder, file, data):
         fh.write("")
     unflock(fh)
     fh.close()
-    os.chmod(dest, 0644)
+    os.chmod(dest, 0o644)
 
     if folder == "metadata" or folder == "meta-data":
         try:
-            os.makedirs(metamanifestdir, 0755)
+            os.makedirs(metamanifestdir, 0o755)
         except OSError as e:
             # error 17 is already exists, we do it this way for concurrency
             if e.errno != 17:
-                print "failed to make directories " + metamanifestdir + " due to :" + e.strerror
+                print("failed to make directories " + metamanifestdir + " due to :" + e.strerror)
                 sys.exit(1)
         if os.path.exists(metamanifest):
             fh = open(metamanifest, "r+a")
@@ -124,7 +124,7 @@ def createfile(ip, folder, file, data):
             fh.close()
 
     if os.path.exists(metamanifest):
-        os.chmod(metamanifest, 0644)
+        os.chmod(metamanifest, 0o644)
 
 
 def htaccess(ip, folder, file):
@@ -133,11 +133,11 @@ def htaccess(ip, folder, file):
     htaccessFile = htaccessFolder+"/.htaccess"
 
     try:
-        os.makedirs(htaccessFolder, 0755)
+        os.makedirs(htaccessFolder, 0o755)
     except OSError as e:
         # error 17 is already exists, we do it this way for sake of concurrency
         if e.errno != 17:
-            print "failed to make directories " + htaccessFolder + " due to :" + e.strerror
+            print("failed to make directories " + htaccessFolder + " due to :" + e.strerror)
             sys.exit(1)
 
     fh = open(htaccessFile, "w")
@@ -151,7 +151,7 @@ def exflock(file):
     try:
         flock(file, LOCK_EX)
     except IOError as e:
-        print "failed to lock file" + file.name + " due to : " + e.strerror
+        print("failed to lock file" + file.name + " due to : " + e.strerror)
         sys.exit(1)
     return True
 
@@ -160,7 +160,7 @@ def unflock(file):
     try:
         flock(file, LOCK_UN)
     except IOError as e:
-        print "failed to unlock file" + file.name + " due to : " + e.strerror
+        print("failed to unlock file" + file.name + " due to : " + e.strerror)
         sys.exit(1)
     return True
 

--- a/systemvm/debian/root/health_checks/cpu_usage_check.py
+++ b/systemvm/debian/root/health_checks/cpu_usage_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,7 +18,7 @@
 
 from os import sys, path, statvfs
 from subprocess import *
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def main():
@@ -28,7 +28,7 @@ def main():
         data = entries[0]
 
     if "maxCpuUsage" not in data:
-        print "Missing maxCpuUsage in health_checks_data systemThresholds, skipping"
+        print("Missing maxCpuUsage in health_checks_data systemThresholds, skipping")
         exit(0)
 
     maxCpuUsage = float(data["maxCpuUsage"])
@@ -40,14 +40,14 @@ def main():
     if pout.wait() == 0:
         currentUsage = float(pout.communicate()[0].strip())
         if currentUsage > maxCpuUsage:
-            print "CPU Usage " + str(currentUsage) + \
-                  "% has crossed threshold of " + str(maxCpuUsage) + "%"
+            print("CPU Usage " + str(currentUsage) +
+                  "% has crossed threshold of " + str(maxCpuUsage) + "%")
             exit(1)
-        print "CPU Usage within limits with current at " \
-              + str(currentUsage) + "%"
+        print("CPU Usage within limits with current at "
+              + str(currentUsage) + "%")
         exit(0)
     else:
-        print "Failed to retrieve cpu usage using " + cmd
+        print("Failed to retrieve cpu usage using " + cmd)
         exit(1)
 
 

--- a/systemvm/debian/root/health_checks/dhcp_check.py
+++ b/systemvm/debian/root/health_checks/dhcp_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,14 +17,14 @@
 # under the License.
 
 from os import sys, path
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def main():
     vMs = getHealthChecksData("virtualMachines")
 
     if vMs is None or len(vMs) == 0:
-        print "No VMs running data available, skipping"
+        print("No VMs running data available, skipping")
         exit(0)
 
     with open('/etc/dhcphosts.txt', 'r') as hostsFile:
@@ -57,10 +57,10 @@ def main():
             failureMessage = failureMessage + entry + ", "
 
     if failedCheck:
-        print failureMessage[:-2]
+        print(failureMessage[:-2])
         exit(1)
     else:
-        print "All " + str(len(vMs)) + " VMs are present in dhcphosts.txt"
+        print("All " + str(len(vMs)) + " VMs are present in dhcphosts.txt")
         exit(0)
 
 

--- a/systemvm/debian/root/health_checks/disk_space_check.py
+++ b/systemvm/debian/root/health_checks/disk_space_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,7 +17,7 @@
 # under the License.
 
 from os import sys, path, statvfs
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def main():
@@ -27,7 +27,7 @@ def main():
         data = entries[0]
 
     if "minDiskNeeded" not in data:
-        print "Missing minDiskNeeded in health_checks_data systemThresholds, skipping"
+        print("Missing minDiskNeeded in health_checks_data systemThresholds, skipping")
         exit(0)
 
     minDiskNeeded = float(data["minDiskNeeded"]) * 1024
@@ -35,10 +35,10 @@ def main():
     freeSpace = (s.f_bavail * s.f_frsize) / 1024
 
     if (freeSpace < minDiskNeeded):
-        print "Insufficient free space is " + str(freeSpace/1024) + " MB"
+        print("Insufficient free space is " + str(freeSpace/1024) + " MB")
         exit(1)
     else:
-        print "Sufficient free space is " + str(freeSpace/1024) + " MB"
+        print("Sufficient free space is " + str(freeSpace/1024) + " MB")
         exit(0)
 
 

--- a/systemvm/debian/root/health_checks/dns_check.py
+++ b/systemvm/debian/root/health_checks/dns_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,14 +17,14 @@
 # under the License.
 
 from os import sys, path
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def main():
     vMs = getHealthChecksData("virtualMachines")
 
     if vMs is None or len(vMs) == 0:
-        print "No VMs running data available, skipping"
+        print("No VMs running data available, skipping")
         exit(0)
 
     with open('/etc/hosts', 'r') as hostsFile:
@@ -47,10 +47,10 @@ def main():
             failureMessage = failureMessage + vM["ip"] + " " + vM["vmName"] + ", "
 
     if failedCheck:
-        print failureMessage[:-2]
+        print(failureMessage[:-2])
         exit(1)
     else:
-        print "All " + str(len(vMs)) + " VMs are present in /etc/hosts"
+        print("All " + str(len(vMs)) + " VMs are present in /etc/hosts")
         exit(0)
 
 

--- a/systemvm/debian/root/health_checks/gateways_check.py
+++ b/systemvm/debian/root/health_checks/gateways_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,13 +18,13 @@
 
 from os import sys, path
 from subprocess import *
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def main():
     gws = getHealthChecksData("gateways")
     if gws is None and len(gws) == 0:
-        print "No gateways data available, skipping"
+        print("No gateways data available, skipping")
         exit(0)
 
     unreachableGateWays = []
@@ -44,11 +44,11 @@ def main():
             unreachableGateWays.append(gw)
 
     if len(unreachableGateWays) == 0:
-        print "All " + str(len(gws)) + " gateways are reachable via ping"
+        print("All " + str(len(gws)) + " gateways are reachable via ping")
         exit(0)
     else:
-        print "Unreachable gateways found-"
-        print unreachableGateWays
+        print("Unreachable gateways found-")
+        print(unreachableGateWays)
         exit(1)
 
 

--- a/systemvm/debian/root/health_checks/haproxy_check.py
+++ b/systemvm/debian/root/health_checks/haproxy_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,13 +17,13 @@
 # under the License.
 
 from os import sys, path
-from utility import getHealthChecksData, formatPort
+from .utility import getHealthChecksData, formatPort
 
 
 def checkMaxconn(haproxyData, haCfgSections):
     if "maxconn" in haproxyData and "maxconn" in haCfgSections["global"]:
         if haproxyData["maxconn"] != haCfgSections["global"]["maxconn"][0].strip():
-            print "global maxconn mismatch occured"
+            print("global maxconn mismatch occured")
             return False
 
     return True
@@ -38,26 +38,26 @@ def checkLoadBalance(haproxyData, haCfgSections):
         secName = "listen " + srcServer
 
         if secName not in haCfgSections:
-            print "Missing section for load balancing " + secName + "\n"
+            print("Missing section for load balancing " + secName + "\n")
             correct = False
         else:
             cfgSection = haCfgSections[secName]
             if "server" in cfgSection:
                 if lbSec["algorithm"] != cfgSection["balance"][0]:
-                    print "Incorrect balance method for " + secName + \
-                          "Expected : " + lbSec["algorithm"] + \
-                          " but found " + cfgSection["balance"][0] + "\n"
+                    print("Incorrect balance method for " + secName +
+                          "Expected : " + lbSec["algorithm"] +
+                          " but found " + cfgSection["balance"][0] + "\n")
                     correct = False
 
                 bindStr = lbSec["sourceIp"] + ":" + formatPort(lbSec["sourcePortStart"], lbSec["sourcePortEnd"])
                 if cfgSection["bind"][0] != bindStr:
-                    print "Incorrect bind string found. Expected " + bindStr + " but found " + cfgSection["bind"][0] + "."
+                    print("Incorrect bind string found. Expected " + bindStr + " but found " + cfgSection["bind"][0] + ".")
                     correct = False
 
                 if (lbSec["sourcePortStart"] == "80" and lbSec["sourcePortEnd"] == "80" and lbSec["keepAliveEnabled"] == "false") \
                         or (lbSec["stickiness"].find("AppCookie") != -1 or lbSec["stickiness"].find("LbCookie") != -1):
                     if not ("mode" in cfgSection and cfgSection["mode"][0] == "http"):
-                        print "Expected HTTP mode but not found"
+                        print("Expected HTTP mode but not found")
                         correct = False
 
                 expectedServerIps = lbSec["vmIps"].split(" ")
@@ -74,7 +74,7 @@ def checkLoadBalance(haproxyData, haCfgSections):
 
                     if not foundPattern:
                         correct = False
-                        print "Missing load balancing for " + pattern + ". "
+                        print("Missing load balancing for " + pattern + ". ")
 
     return correct
 
@@ -86,7 +86,7 @@ def main():
     '''
     haproxyData = getHealthChecksData("haproxyData")
     if haproxyData is None or len(haproxyData) == 0:
-        print "No data provided to check, skipping"
+        print("No data provided to check, skipping")
         exit(0)
 
     with open("/etc/haproxy/haproxy.cfg", 'r') as haCfgFile:
@@ -94,7 +94,7 @@ def main():
         haCfgFile.close()
 
     if len(haCfgLines) == 0:
-        print "Unable to read config file /etc/haproxy/haproxy.cfg"
+        print("Unable to read config file /etc/haproxy/haproxy.cfg")
         exit(1)
 
     haCfgSections = {}
@@ -123,7 +123,7 @@ def main():
     checkLbRules = checkLoadBalance(haproxyData, haCfgSections)
 
     if checkMaxConn and checkLbRules:
-        print "All checks pass"
+        print("All checks pass")
         exit(0)
     else:
         exit(1)

--- a/systemvm/debian/root/health_checks/iptables_check.py
+++ b/systemvm/debian/root/health_checks/iptables_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,13 +18,13 @@
 
 from os import sys, path
 from subprocess import *
-from utility import getHealthChecksData, formatPort
+from .utility import getHealthChecksData, formatPort
 
 
 def main():
     portForwards = getHealthChecksData("portForwarding")
     if portForwards is None or len(portForwards) == 0:
-        print "No portforwarding rules provided to check, skipping"
+        print("No port forwarding rules provided to check, skipping")
         exit(0)
 
     failedCheck = False
@@ -68,10 +68,10 @@ def main():
                 failureMessage = failureMessage + str(pfEntryListExpected) + "\n"
 
     if failedCheck:
-        print failureMessage
+        print(failureMessage)
         exit(1)
     else:
-        print "Found all entries (count " + str(len(portForwards)) + ") in iptables"
+        print("Found all entries (count " + str(len(portForwards)) + ") in iptables")
         exit(0)
 
 

--- a/systemvm/debian/root/health_checks/memory_usage_check.py
+++ b/systemvm/debian/root/health_checks/memory_usage_check.py
@@ -28,7 +28,7 @@ def main():
         data = entries[0]
 
     if "maxMemoryUsage" not in data:
-        print("Missing maxMemoryUsage in health_checks_data " + \
+        print("Missing maxMemoryUsage in health_checks_data " +
               "systemThresholds, skipping")
         exit(0)
 
@@ -39,10 +39,10 @@ def main():
     if pout.wait() == 0:
         currentUsage = float(pout.communicate()[0].strip())
         if currentUsage > maxMemoryUsage:
-            print("Memory Usage " + str(currentUsage) + \
+            print("Memory Usage " + str(currentUsage) +
                   "% has crossed threshold of " + str(maxMemoryUsage) + "%")
             exit(1)
-        print("Memory Usage within limits with current at " + \
+        print("Memory Usage within limits with current at " +
               str(currentUsage) + "%")
         exit(0)
     else:

--- a/systemvm/debian/root/health_checks/memory_usage_check.py
+++ b/systemvm/debian/root/health_checks/memory_usage_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,7 +18,7 @@
 
 from os import sys, path, statvfs
 from subprocess import *
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def main():
@@ -28,8 +28,8 @@ def main():
         data = entries[0]
 
     if "maxMemoryUsage" not in data:
-        print "Missing maxMemoryUsage in health_checks_data " + \
-              "systemThresholds, skipping"
+        print("Missing maxMemoryUsage in health_checks_data " + \
+              "systemThresholds, skipping")
         exit(0)
 
     maxMemoryUsage = float(data["maxMemoryUsage"])
@@ -39,14 +39,14 @@ def main():
     if pout.wait() == 0:
         currentUsage = float(pout.communicate()[0].strip())
         if currentUsage > maxMemoryUsage:
-            print "Memory Usage " + str(currentUsage) + \
-                  "% has crossed threshold of " + str(maxMemoryUsage) + "%"
+            print("Memory Usage " + str(currentUsage) + \
+                  "% has crossed threshold of " + str(maxMemoryUsage) + "%")
             exit(1)
-        print "Memory Usage within limits with current at " + \
-              str(currentUsage) + "%"
+        print("Memory Usage within limits with current at " + \
+              str(currentUsage) + "%")
         exit(0)
     else:
-        print "Failed to retrieve memory usage using " + cmd
+        print("Failed to retrieve memory usage using " + cmd)
         exit(1)
 
 

--- a/systemvm/debian/root/health_checks/router_version_check.py
+++ b/systemvm/debian/root/health_checks/router_version_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,7 +17,7 @@
 # under the License.
 
 from os import sys, path, statvfs
-from utility import getHealthChecksData
+from .utility import getHealthChecksData
 
 
 def getFirstLine(file=None):
@@ -41,7 +41,8 @@ def main():
         data = entries[0]
 
     if len(data) == 0:
-        print "Missing routerVersion in health_checks_data, skipping"
+        print("Missing routerVersion in health_checks_data, skipping")
+
         exit(0)
 
     templateVersionMatches = True
@@ -52,11 +53,11 @@ def main():
         releaseFile = "/etc/cloudstack-release"
         found = getFirstLine(releaseFile)
         if found is None:
-            print "Release version not yet setup at " + releaseFile +\
-                  ", skipping."
+            print("Release version not yet setup at " + releaseFile +\
+                  ", skipping.")
         elif expected != found:
-            print "Template Version mismatch. Expected: " + \
-                  expected + ", found: " + found
+            print("Template Version mismatch. Expected: " + \
+                  expected + ", found: " + found)
             templateVersionMatches = False
 
     if "scriptsVersion" in data:
@@ -64,15 +65,15 @@ def main():
         sigFile = "/var/cache/cloud/cloud-scripts-signature"
         found = getFirstLine(sigFile)
         if found is None:
-            print "Scripts signature is not yet setup at " + sigFile +\
-                  ", skipping"
+            print("Scripts signature is not yet setup at " + sigFile +\
+                  ", skipping")
         if expected != found:
-            print "Scripts Version mismatch. Expected: " + \
-                  expected + ", found: " + found
+            print("Scripts Version mismatch. Expected: " + \
+                  expected + ", found: " + found)
             scriptVersionMatches = False
 
     if templateVersionMatches and scriptVersionMatches:
-        print "Template and scripts version match successful"
+        print("Template and scripts version match successful")
         exit(0)
     else:
         exit(1)

--- a/systemvm/debian/root/health_checks/router_version_check.py
+++ b/systemvm/debian/root/health_checks/router_version_check.py
@@ -53,10 +53,10 @@ def main():
         releaseFile = "/etc/cloudstack-release"
         found = getFirstLine(releaseFile)
         if found is None:
-            print("Release version not yet setup at " + releaseFile +\
+            print("Release version not yet setup at " + releaseFile +
                   ", skipping.")
         elif expected != found:
-            print("Template Version mismatch. Expected: " + \
+            print("Template Version mismatch. Expected: " +
                   expected + ", found: " + found)
             templateVersionMatches = False
 
@@ -65,11 +65,11 @@ def main():
         sigFile = "/var/cache/cloud/cloud-scripts-signature"
         found = getFirstLine(sigFile)
         if found is None:
-            print("Scripts signature is not yet setup at " + sigFile +\
+            print("Scripts signature is not yet setup at " + sigFile +
                   ", skipping")
         if expected != found:
-            print("Scripts Version mismatch. Expected: " + \
-                  expected + ", found: " + found)
+            print("Scripts Version mismatch. Expected: " + expected +
+                  ", found: " + found)
             scriptVersionMatches = False
 
     if templateVersionMatches and scriptVersionMatches:

--- a/systemvm/debian/root/health_checks/router_version_check.py
+++ b/systemvm/debian/root/health_checks/router_version_check.py
@@ -68,8 +68,8 @@ def main():
             print("Scripts signature is not yet setup at " + sigFile +
                   ", skipping")
         if expected != found:
-            print("Scripts Version mismatch. Expected: " + expected +
-                  ", found: " + found)
+            print("Scripts Version mismatch. Expected: " +
+                  expected + ", found: " + found)
             scriptVersionMatches = False
 
     if templateVersionMatches and scriptVersionMatches:

--- a/systemvm/debian/root/health_checks/utility/__init__.py
+++ b/systemvm/debian/root/health_checks/utility/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +16,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sharedFunctions import getHealthChecksData, formatPort
+from .sharedFunctions import getHealthChecksData, formatPort

--- a/systemvm/debian/root/monitorServices.py
+++ b/systemvm/debian/root/monitorServices.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 from subprocess import *
 from datetime import datetime
 import time
@@ -81,7 +81,7 @@ def printd (msg):
     f.seek(0, 2)
     f.write(str(msg)+"\n")
     f.close()
-    print str(msg)
+    print(str(msg))
 
 def raisealert(severity, msg, process_name=None):
     """ Writes the alert message"""
@@ -96,7 +96,7 @@ def raisealert(severity, msg, process_name=None):
     logging.info(log)
     msg = 'logger -t monit '+ log
     pout = Popen(msg, shell=True, stdout=PIPE)
-    print "[Alert] " + msg
+    print("[Alert] " + msg)
 
 
 def isPidMatchPidFile(pidfile, pids):
@@ -258,12 +258,12 @@ def monitProcess( processes_info ):
         printd("No config items provided - means a redundant VR or a VPC Router")
         return service_status, failing_services
 
-    print "[Process Info] " + json.dumps(processes_info)
+    print("[Process Info] " + json.dumps(processes_info))
 
     #time for noting process down time
     csec = repr(time.time()).split('.')[0]
 
-    for process,properties in processes_info.items():
+    for process,properties in list(processes_info.items()):
         printd ("---------------------------\nchecking the service %s\n---------------------------- " %process)
         serviceName = process + ".service"
         processStatus, wasRestarted = checkProcessStatus(properties)

--- a/systemvm/test/TestCsDhcp.py
+++ b/systemvm/test/TestCsDhcp.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import unittest
-import mock
+from unittest import mock
 from cs.CsDhcp import CsDhcp
 from cs import CsHelper
 import merge

--- a/systemvm/test/TestCsHelper.py
+++ b/systemvm/test/TestCsHelper.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import unittest
-import mock
+from unittest import mock
 from cs import CsHelper
 import merge
 

--- a/systemvm/test/runtests.sh
+++ b/systemvm/test/runtests.sh
@@ -31,8 +31,15 @@ then
 fi
 
 echo "Running pylint to check systemvm/python code for errors"
+
 pylint --disable=R,C,W *.py
 pylint --disable=R,C,W `find ../debian -name \*.py`
+
+python --version
+pyenv versions
+pylint3 --disable=R,C,W *.py
+pylint3 --disable=R,C,W `find ../debian -name \*.py`
+
 if [ $? -gt 0 ]
 then
     echo "pylint failed, please check your code"

--- a/systemvm/test/runtests.sh
+++ b/systemvm/test/runtests.sh
@@ -22,8 +22,8 @@ export PYTHONPATH="../debian/opt/cloud/bin/"
 export PYTHONDONTWRITEBYTECODE=False
 
 echo "Running pycodestyle to check systemvm/python code for errors"
-pycodestyle --max-line-length=179 *py
-pycodestyle --max-line-length=179 --exclude=monitorServices.py,baremetal-vr.py,passwd_server_ip.py `find ../debian -name \*.py`
+python3 -m pycodestyle --max-line-length=179 *py
+python3 -m pycodestyle --max-line-length=179 --exclude=monitorServices.py,baremetal-vr.py,passwd_server_ip.py `find ../debian -name \*.py`
 if [ $? -gt 0 ]
 then
     echo "pycodestyle failed, please check your code"

--- a/systemvm/test/runtests.sh
+++ b/systemvm/test/runtests.sh
@@ -40,10 +40,6 @@ pyenv versions
 pylint3 --disable=R,C,W *.py
 pylint3 --disable=R,C,W `find ../debian -name \*.py`
 
-
-pylint3 --disable=R,C,W *.py
-pylint3 --disable=R,C,W `find ../debian -name \*.py`
-
 if [ $? -gt 0 ]
 then
     echo "pylint failed, please check your code"

--- a/systemvm/test/runtests.sh
+++ b/systemvm/test/runtests.sh
@@ -40,6 +40,10 @@ pyenv versions
 pylint3 --disable=R,C,W *.py
 pylint3 --disable=R,C,W `find ../debian -name \*.py`
 
+
+pylint3 --disable=R,C,W *.py
+pylint3 --disable=R,C,W `find ../debian -name \*.py`
+
 if [ $? -gt 0 ]
 then
     echo "pylint failed, please check your code"

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -81,7 +81,7 @@ if [[ $? -ne 0 ]]; then
   echo -e "\napt-get packages failed to install"
 fi
 
-sudo apt-get -q -y -V install freeipmi-common libfreeipmi16 libgcrypt20 libgpg-error-dev libgpg-error0 libopenipmi0 ipmitool libpython-dev libssl-dev libffi-dev python-openssl build-essential --no-install-recommends > /dev/null
+sudo apt-get -q -y -V install freeipmi-common libfreeipmi16 libgcrypt20 libgpg-error-dev libgpg-error0 libopenipmi0 ipmitool libpython-dev libssl-dev libffi-dev pylint3 python-openssl build-essential --no-install-recommends > /dev/null
 
 echo -e "\nIPMI version"
 ipmitool -V

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -107,7 +107,7 @@ echo -e "\nInstalling some python packages: "
 
 for ((i=0;i<$RETRY_COUNT;i++))
 do
-  pip install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl pycrypto mock flask netaddr pylint pycodestyle six astroid > /tmp/piplog
+  pip3 install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl pycrypto mock flask netaddr pylint pycodestyle six astroid > /tmp/piplog
   if [[ $? -eq 0 ]]; then
     echo -e "\npython packages installed successfully"
     break;


### PR DESCRIPTION
### Description

Considering the Python2 end of life we must migrate the VR's codebase to Python3.

This PR covers partially issue #3195. Additionally, this PR is a joint of the work done in #3730 and #4727.

