### PR TITLE
xenserver: retrieve correct name-label for presetup store

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.storage.Storage;
 import com.xensource.xenapi.Host;
 
@@ -47,11 +46,13 @@ public class CitrixHelper {
         return "";
     }
 
-    public static String getSRNameLabel(final StorageFilerTO primaryStore) {
-        if (Storage.StoragePoolType.PreSetup.equals(primaryStore.getType()) &&
-                !primaryStore.getPath().contains(primaryStore.getUuid())) {
-            return  primaryStore.getPath().replace("/", "");
+    public static String getSRNameLabel(final String poolUuid,
+                                        final Storage.StoragePoolType poolType,
+                                        final String poolPath) {
+        if (Storage.StoragePoolType.PreSetup.equals(poolType) &&
+                !poolPath.contains(poolUuid)) {
+            return  poolPath.replaceFirst("/", "");
         }
-        return primaryStore.getUuid();
+        return poolUuid;
     }
 }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
+import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.storage.Storage;
 import com.xensource.xenapi.Host;
 
 /**
@@ -43,5 +45,13 @@ public class CitrixHelper {
             }
         }
         return "";
+    }
+
+    public static String getSRNameLabel(final StorageFilerTO primaryStore) {
+        if (Storage.StoragePoolType.PreSetup.equals(primaryStore.getType()) &&
+                !primaryStore.getPath().contains(primaryStore.getUuid())) {
+            return  primaryStore.getPath().replace("/", "");
+        }
+        return primaryStore.getUuid();
     }
 }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -16,8 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -18,8 +18,6 @@
  */
 package com.cloud.hypervisor.xenserver.resource;
 
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
-
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
@@ -327,7 +325,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
 
                     destSr = hypervisorResource.prepareManagedSr(conn, details);
                 } else {
-                    final String srName = getSRNameLabel(destStore);
+                    final String srName = CitrixHelper.getSRNameLabel(destStore.getUuid(), destStore.getPoolType(), destStore.getPath());
                     final Set<SR> srs = SR.getByNameLabel(conn, srName);
 
                     if (srs.size() != 1) {
@@ -493,7 +491,8 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
         final DataTO destData = cmd.getDestTO();
         final int wait = cmd.getWait();
         final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)srcData.getDataStore();
-        final String primaryStorageNameLabel = getSRNameLabel(primaryStore);
+        final String primaryStorageNameLabel = CitrixHelper.getSRNameLabel(primaryStore.getUuid(),
+                primaryStore.getPoolType(), primaryStore.getPath());
         String secondaryStorageUrl = null;
         NfsTO cacheStore = null;
         String destPath = null;
@@ -994,7 +993,8 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             final SR srcSr = createFileSr(conn, uri.getHost() + ":" + uri.getPath(), volumeDirectory);
             Task task = null;
             try {
-                final SR primaryStoragePool = hypervisorResource.getStorageRepository(conn, getSRNameLabel(primaryStore));
+                final SR primaryStoragePool = hypervisorResource.getStorageRepository(conn,
+                        CitrixHelper.getSRNameLabel(primaryStore.getUuid(), primaryStore.getPoolType(), primaryStore.getPath()));
                 final VDI srcVdi = VDI.getByUuid(conn, volumeUuid);
                 task = srcVdi.copyAsync(conn, primaryStoragePool, null, null);
                 // poll every 1 seconds ,

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -18,6 +18,8 @@
  */
 package com.cloud.hypervisor.xenserver.resource;
 
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
@@ -325,7 +327,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
 
                     destSr = hypervisorResource.prepareManagedSr(conn, details);
                 } else {
-                    final String srName = destStore.getUuid();
+                    final String srName = getSRNameLabel(destStore);
                     final Set<SR> srs = SR.getByNameLabel(conn, srName);
 
                     if (srs.size() != 1) {
@@ -491,7 +493,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
         final DataTO destData = cmd.getDestTO();
         final int wait = cmd.getWait();
         final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)srcData.getDataStore();
-        final String primaryStorageNameLabel = primaryStore.getUuid();
+        final String primaryStorageNameLabel = getSRNameLabel(primaryStore);
         String secondaryStorageUrl = null;
         NfsTO cacheStore = null;
         String destPath = null;
@@ -992,7 +994,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             final SR srcSr = createFileSr(conn, uri.getHost() + ":" + uri.getPath(), volumeDirectory);
             Task task = null;
             try {
-                final SR primaryStoragePool = hypervisorResource.getStorageRepository(conn, primaryStore.getUuid());
+                final SR primaryStoragePool = hypervisorResource.getStorageRepository(conn, getSRNameLabel(primaryStore));
                 final VDI srcVdi = VDI.getByUuid(conn, volumeUuid);
                 task = srcVdi.copyAsync(conn, primaryStoragePool, null, null);
                 // poll every 1 seconds ,

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateVolumeCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateVolumeCommandWrapper.java
@@ -28,6 +28,7 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.storage.MigrateVolumeAnswer;
 import com.cloud.agent.api.storage.MigrateVolumeCommand;
 import com.cloud.agent.api.to.DiskTO;
+import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.XenServer610Resource;
 import com.cloud.resource.CommandWrapper;
@@ -62,7 +63,8 @@ public final class XenServer610MigrateVolumeCommandWrapper extends CommandWrappe
                         chapInitiatorUsername, chapInitiatorSecret, false);
             }
             else {
-                destPool = xenServer610Resource.getStorageRepository(connection, CitrixHelper.getSRNameLabel(command.getPool()));
+                final StorageFilerTO pool = command.getPool();
+                destPool = xenServer610Resource.getStorageRepository(connection, CitrixHelper.getSRNameLabel(pool.getUuid(), pool.getType(), pool.getPath()));
             }
 
             Map<String, String> other = new HashMap<>();

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateVolumeCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateVolumeCommandWrapper.java
@@ -28,7 +28,7 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.storage.MigrateVolumeAnswer;
 import com.cloud.agent.api.storage.MigrateVolumeCommand;
 import com.cloud.agent.api.to.DiskTO;
-import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.XenServer610Resource;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -62,10 +62,7 @@ public final class XenServer610MigrateVolumeCommandWrapper extends CommandWrappe
                         chapInitiatorUsername, chapInitiatorSecret, false);
             }
             else {
-                StorageFilerTO destPoolTO = command.getPool();
-                String destPoolUuid = destPoolTO.getUuid();
-
-                destPool = xenServer610Resource.getStorageRepository(connection, destPoolUuid);
+                destPool = xenServer610Resource.getStorageRepository(connection, CitrixHelper.getSRNameLabel(command.getPool()));
             }
 
             Map<String, String> other = new HashMap<>();

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageCommandWrapper.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.cloud.utils.Pair;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.log4j.Logger;
 
@@ -35,12 +34,14 @@ import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.agent.api.to.VolumeTO;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.XenServer610Resource;
 import com.cloud.hypervisor.xenserver.resource.XsHost;
 import com.cloud.hypervisor.xenserver.resource.XsLocalNetwork;
 import com.cloud.network.Networks.TrafficType;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
+import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Host;
@@ -88,7 +89,8 @@ public final class XenServer610MigrateWithStorageCommandWrapper extends CommandW
             for (final Pair<VolumeTO, StorageFilerTO> entry : volumeToFiler) {
                 final StorageFilerTO storageFiler = entry.second();
                 final VolumeTO volume = entry.first();
-                vdiMap.put(xenServer610Resource.getVDIbyUuid(connection, volume.getPath()), xenServer610Resource.getStorageRepository(connection, storageFiler.getUuid()));
+                vdiMap.put(xenServer610Resource.getVDIbyUuid(connection, volume.getPath()),
+                        xenServer610Resource.getStorageRepository(connection, CitrixHelper.getSRNameLabel(storageFiler)));
             }
 
             // Get the vm to migrate.

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageCommandWrapper.java
@@ -90,7 +90,8 @@ public final class XenServer610MigrateWithStorageCommandWrapper extends CommandW
                 final StorageFilerTO storageFiler = entry.second();
                 final VolumeTO volume = entry.first();
                 vdiMap.put(xenServer610Resource.getVDIbyUuid(connection, volume.getPath()),
-                        xenServer610Resource.getStorageRepository(connection, CitrixHelper.getSRNameLabel(storageFiler)));
+                        xenServer610Resource.getStorageRepository(connection,
+                                CitrixHelper.getSRNameLabel(storageFiler.getUuid(), storageFiler.getType(), storageFiler.getPath())));
             }
 
             // Get the vm to migrate.

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateCommandWrapper.java
@@ -28,6 +28,7 @@ import com.cloud.agent.api.storage.CreateAnswer;
 import com.cloud.agent.api.storage.CreateCommand;
 import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.agent.api.to.VolumeTO;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.CitrixResourceBase;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -50,7 +51,7 @@ public final class CitrixCreateCommandWrapper extends CommandWrapper<CreateComma
 
         VDI vdi = null;
         try {
-            final SR poolSr = citrixResourceBase.getStorageRepository(conn, pool.getUuid());
+            final SR poolSr = citrixResourceBase.getStorageRepository(conn, CitrixHelper.getSRNameLabel(pool));
             if (command.getTemplateUrl() != null) {
                 VDI tmpltvdi = null;
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateCommandWrapper.java
@@ -51,7 +51,8 @@ public final class CitrixCreateCommandWrapper extends CommandWrapper<CreateComma
 
         VDI vdi = null;
         try {
-            final SR poolSr = citrixResourceBase.getStorageRepository(conn, CitrixHelper.getSRNameLabel(pool));
+            final SR poolSr = citrixResourceBase.getStorageRepository(conn,
+                    CitrixHelper.getSRNameLabel(pool.getUuid(), pool.getType(), pool.getPath()));
             if (command.getTemplateUrl() != null) {
                 VDI tmpltvdi = null;
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixDeleteStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixDeleteStoragePoolCommandWrapper.java
@@ -26,6 +26,7 @@ import org.apache.log4j.Logger;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.DeleteStoragePoolCommand;
 import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.CitrixResourceBase;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -46,16 +47,16 @@ public final class CitrixDeleteStoragePoolCommandWrapper extends CommandWrapper<
 
             // getRemoveDatastore being true indicates we are using managed storage and need to pull the SR name out of a Map
             // instead of pulling it out using getUuid of the StorageFilerTO instance.
+
+            String srNameLabel;
             if (command.getRemoveDatastore()) {
                 Map<String, String> details = command.getDetails();
-
-                String srNameLabel = details.get(DeleteStoragePoolCommand.DATASTORE_NAME);
-
-                sr = citrixResourceBase.getStorageRepository(conn, srNameLabel);
+                srNameLabel = details.get(DeleteStoragePoolCommand.DATASTORE_NAME);
             }
             else {
-                sr = citrixResourceBase.getStorageRepository(conn, poolTO.getUuid());
+                srNameLabel = CitrixHelper.getSRNameLabel(poolTO);
             }
+            sr = citrixResourceBase.getStorageRepository(conn, srNameLabel);
 
             citrixResourceBase.removeSR(conn, sr);
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixDeleteStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixDeleteStoragePoolCommandWrapper.java
@@ -54,7 +54,7 @@ public final class CitrixDeleteStoragePoolCommandWrapper extends CommandWrapper<
                 srNameLabel = details.get(DeleteStoragePoolCommand.DATASTORE_NAME);
             }
             else {
-                srNameLabel = CitrixHelper.getSRNameLabel(poolTO);
+                srNameLabel = CitrixHelper.getSRNameLabel(poolTO.getUuid(), poolTO.getType(), poolTO.getPath());
             }
             sr = citrixResourceBase.getStorageRepository(conn, srNameLabel);
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixModifyStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixModifyStoragePoolCommandWrapper.java
@@ -28,6 +28,7 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.ModifyStoragePoolAnswer;
 import com.cloud.agent.api.ModifyStoragePoolCommand;
 import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.CitrixResourceBase;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -49,7 +50,10 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
         final boolean add = command.getAdd();
         if (add) {
             try {
-                final String srName = command.getStoragePath() != null ? command.getStoragePath() : pool.getUuid();
+                String srName = command.getStoragePath();
+                if (srName == null) {
+                    srName = CitrixHelper.getSRNameLabel(pool);
+                }
                 final SR sr = citrixResourceBase.getStorageRepository(conn, srName);
                 citrixResourceBase.setupHeartbeatSr(conn, sr, false);
                 final long capacity = sr.getPhysicalSize(conn);
@@ -75,7 +79,7 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
             }
         } else {
             try {
-                final SR sr = citrixResourceBase.getStorageRepository(conn, pool.getUuid());
+                final SR sr = citrixResourceBase.getStorageRepository(conn, CitrixHelper.getSRNameLabel(pool));
                 final String srUuid = sr.getUuid(conn);
                 final String result = citrixResourceBase.callHostPluginPremium(conn, "setup_heartbeat_file", "host", citrixResourceBase.getHost().getUuid(), "sr", srUuid, "add",
                         "false");

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixModifyStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixModifyStoragePoolCommandWrapper.java
@@ -52,7 +52,7 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
             try {
                 String srName = command.getStoragePath();
                 if (srName == null) {
-                    srName = CitrixHelper.getSRNameLabel(pool);
+                    srName = CitrixHelper.getSRNameLabel(pool.getUuid(), pool.getType(), pool.getPath());
                 }
                 final SR sr = citrixResourceBase.getStorageRepository(conn, srName);
                 citrixResourceBase.setupHeartbeatSr(conn, sr, false);
@@ -79,7 +79,8 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
             }
         } else {
             try {
-                final SR sr = citrixResourceBase.getStorageRepository(conn, CitrixHelper.getSRNameLabel(pool));
+                final SR sr = citrixResourceBase.getStorageRepository(conn,
+                        CitrixHelper.getSRNameLabel(pool.getUuid(), pool.getType(), pool.getPath()));
                 final String srUuid = sr.getUuid(conn);
                 final String result = citrixResourceBase.callHostPluginPremium(conn, "setup_heartbeat_file", "host", citrixResourceBase.getHost().getUuid(), "sr", srUuid, "add",
                         "false");

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
@@ -331,7 +331,7 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
                     String srNameLabel = pool.getUuid();
                     if (Storage.StoragePoolType.PreSetup.equals(pool.getPoolType()) &&
                             !pool.getPath().contains(pool.getUuid())) {
-                        srNameLabel = pool.getPath().replace("/", "");
+                        srNameLabel = pool.getPath().replaceFirst("/", "");
                     }
                     volumeToStorageUuid.add(new Pair<>(volumeTo, srNameLabel));
                 }

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
@@ -58,18 +58,18 @@ import com.cloud.exception.AgentUnavailableException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.host.Host;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
-import com.cloud.storage.Storage;
-import com.cloud.storage.dao.SnapshotDao;
-import com.cloud.storage.StoragePool;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
-import com.cloud.storage.VolumeVO;
+import com.cloud.storage.StoragePool;
 import com.cloud.storage.VolumeDetailVO;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeDetailsDao;
-import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.Pair;
 import com.cloud.utils.StringUtils;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.dao.VMInstanceDao;
 
@@ -328,11 +328,7 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
                 }
                 else {
                     StoragePool pool = (StoragePool)entry.getValue();
-                    String srNameLabel = pool.getUuid();
-                    if (Storage.StoragePoolType.PreSetup.equals(pool.getPoolType()) &&
-                            !pool.getPath().contains(pool.getUuid())) {
-                        srNameLabel = pool.getPath().replaceFirst("/", "");
-                    }
+                    String srNameLabel = CitrixHelper.getSRNameLabel(pool.getUuid(), pool.getPoolType(), pool.getPath());
                     volumeToStorageUuid.add(new Pair<>(volumeTo, srNameLabel));
                 }
             }

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
@@ -58,6 +58,7 @@ import com.cloud.exception.AgentUnavailableException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.host.Host;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
+import com.cloud.storage.Storage;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.Snapshot;
@@ -326,7 +327,13 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
                     volumeToStorageUuid.add(new Pair<>(volumeTo, iqn));
                 }
                 else {
-                    volumeToStorageUuid.add(new Pair<>(volumeTo, ((StoragePool)entry.getValue()).getUuid()));
+                    StoragePool pool = (StoragePool)entry.getValue();
+                    String srNameLabel = pool.getUuid();
+                    if (Storage.StoragePoolType.PreSetup.equals(pool.getPoolType()) &&
+                            !pool.getPath().contains(pool.getUuid())) {
+                        srNameLabel = pool.getPath().replace("/", "");
+                    }
+                    volumeToStorageUuid.add(new Pair<>(volumeTo, srNameLabel));
                 }
             }
 


### PR DESCRIPTION
### Description

Fixes #4729

As reported in the issue ACP 4.7 used a normal UUID in db for a presetup primary store on Xenserver.
Later the value has been changed to store's path with '/' removed.
Current changes try to retrieve SR's name-lable from store's path if UUID doesn't match path field for a pre-setup store.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
