### PR TITLE
ui: Show vm name along with password

### DIFF
--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -317,7 +317,7 @@ export default {
           message: 'message.action.instance.reset.password',
           dataView: true,
           show: (record) => { return ['Running', 'Stopped'].includes(record.state) && record.passwordenabled },
-          response: (result) => { return result.virtualmachine && result.virtualmachine.password ? `Password of the VM is ${result.virtualmachine.password}` : null }
+          response: (result) => { return result.virtualmachine && result.virtualmachine.password ? `The password of VM <b>${result.virtualmachine.displayname}</b> is <b>${result.virtualmachine.password}</b>` : null }
         },
         {
           api: 'resetSSHKeyForVirtualMachine',

--- a/ui/src/views/compute/StartVirtualMachine.vue
+++ b/ui/src/views/compute/StartVirtualMachine.vue
@@ -255,7 +255,7 @@ export default {
             successMethod: () => {
               this.parentFetchData()
             },
-            response: (result) => { return result.virtualmachine && result.virtualmachine.password ? `Password of the VM is ${result.virtualmachine.password}` : null }
+            response: (result) => { return result.virtualmachine && result.virtualmachine.password ? `The password of VM <b>${result.virtualmachine.displayname}</b> is <b>${result.virtualmachine.password}</b>` : null }
           })
           this.closeAction()
         }).catch(error => {


### PR DESCRIPTION
### Description

Adds the VM name along with the newly reset password. Useful when resetting the password of multiple VMs

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

#### Before

![Screenshot from 2021-03-16 11-05-43](https://user-images.githubusercontent.com/8244774/111261146-fc61cd00-8647-11eb-93e7-38bce6744cfa.png)

#### After

![Screenshot from 2021-03-16 11-04-41](https://user-images.githubusercontent.com/8244774/111261141-fa980980-8647-11eb-8ac5-f11a5f363bc5.png)



