### PR TITLE
ui - Project Role Permission: Change default permission type to 'Deny'

### DIFF
--- a/ui/src/views/project/iam/ProjectRolePermissionTab.vue
+++ b/ui/src/views/project/iam/ProjectRolePermissionTab.vue
@@ -133,7 +133,7 @@ export default {
       updateTable: false,
       rules: null,
       newRule: '',
-      newRulePermission: 'allow',
+      newRulePermission: 'deny',
       newRuleDescription: '',
       newRuleSelectError: false,
       drag: false,
@@ -159,7 +159,7 @@ export default {
     },
     resetNewFields () {
       this.newRule = ''
-      this.newRulePermission = 'allow'
+      this.newRulePermission = 'deny'
       this.newRuleDescription = ''
       this.newRuleSelectError = false
     },


### PR DESCRIPTION
### Description

This PR changes the default project role permission type to 'deny' as project role permissions are basically restrictive in nature, i.e., they are used to deny users/accounts in a project from performing certain actions that they would be allowed at the account-level, hence making sense to have the default permission to be Deny.


<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10495417/111416586-3d221a80-870a-11eb-8d9c-33f250614fb6.png)

### How Has This Been Tested?
As shown in the screenshot above, the default permission is Deny while adding project role permissions

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
