### PR TITLE
ui: Fix add primary store during Zone Deployment for PreSetup protocol

### DIFF
--- a/ui/src/views/infra/zone/ZoneWizardAddResources.vue
+++ b/ui/src/views/infra/zone/ZoneWizardAddResources.vue
@@ -351,7 +351,7 @@ export default {
           }
         },
         {
-          title: 'label.SR.name',
+          title: 'label.sr.name',
           key: 'primaryStorageSRLabel',
           placeHolder: 'message.error.sr.namelabel',
           required: true,

--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -1283,7 +1283,7 @@ export default {
         }
       }
 
-      const server = this.prefillContent.primaryStorageServer ? this.prefillContent.primaryStorageServer.value : null
+      var server = this.prefillContent.primaryStorageServer ? this.prefillContent.primaryStorageServer.value : null
       let url = ''
       const protocol = this.prefillContent.primaryStorageProtocol.value
 
@@ -1303,7 +1303,13 @@ export default {
         params['details[0].password'] = this.prefillContent.primaryStorageSMBPassword.value
         params['details[0].domain'] = this.prefillContent.primaryStorageSMBDomain.value
       } else if (protocol === 'PreSetup') {
-        let path = this.prefillContent.primaryStoragePath.value
+        let path = ''
+        if (this.stepData.clusterReturned.hypervisortype === 'XenServer') {
+          path = this.prefillContent.primaryStorageSRLabel.value
+          server = 'localhost'
+        } else {
+          path = this.prefillContent.primaryStoragePath.value
+        }
         if (path.substring(0, 1) !== '/') {
           path = '/' + path
         }


### PR DESCRIPTION
### Description

This PR fixes the issue that occurs while adding a primary store using PreSetup protocol during zone deployment for XenServer, where in, it fails to find the primary store path, as, for XenServer we provide the SR Label

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Prior fix:
![image](https://user-images.githubusercontent.com/10495417/111785827-1b2fc000-88e3-11eb-84d6-15ee48336aae.png)


Post Fix:
Successfully deploys the zone
![image](https://user-images.githubusercontent.com/10495417/111785521-b8d6bf80-88e2-11eb-94de-25d18ab4f0e2.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
