### PR TITLE
Restricting http access on VR to internal network

### DIFF
--- a/systemvm/debian/etc/iptables/iptables-dhcpsrvr
+++ b/systemvm/debian/etc/iptables/iptables-dhcpsrvr
@@ -37,7 +37,6 @@ COMMIT
 -A INPUT -i eth0 -p udp -m udp --dport 53 -j ACCEPT
 -A INPUT -i eth0 -p tcp -m tcp --dport 53 -j ACCEPT
 -A INPUT -i eth1 -p tcp -m tcp -m state --state NEW,ESTABLISHED --dport 3922 -j ACCEPT
--A INPUT -i eth0 -p tcp -m tcp -m state --state NEW --dport 80 -j ACCEPT
 -A FORWARD -i eth0 -o eth1 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -i eth2 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -i eth0 -o eth0 -m state --state NEW -j ACCEPT

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -367,6 +367,8 @@ class CsIP:
         if self.config.is_vpc():
             return
 
+        self.fw.append(["", "front","-A INPUT -i %s -s %s/24 -p tcp -m tcp -m state --state NEW --dport 443 -j ACCEPT" % (self.dev, self.address['public_ip'])])
+
         self.fw.append(["mangle", "front", "-A PREROUTING " +
                         "-m state --state RELATED,ESTABLISHED " +
                         "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -367,8 +367,6 @@ class CsIP:
         if self.config.is_vpc():
             return
 
-        self.fw.append(["", "front","-A INPUT -i %s -s %s/24 -p tcp -m tcp -m state --state NEW --dport 443 -j ACCEPT" % (self.dev, self.address['public_ip'])])
-
         self.fw.append(["mangle", "front", "-A PREROUTING " +
                         "-m state --state RELATED,ESTABLISHED " +
                         "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
@@ -421,6 +419,8 @@ class CsIP:
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 80 -s %s -m state --state NEW -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(
+                ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 443 -s %s -m state --state NEW -j ACCEPT" % (self.dev, guestNetworkCidr)])
+            self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 8080 -s %s -m state --state NEW -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(
                 ["filter", "", "-A FORWARD -i %s -o eth1 -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.dev])
@@ -469,9 +469,10 @@ class CsIP:
                 ["filter", "", "-A INPUT -i %s -p udp -m udp --dport 53 -s %s -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 53 -s %s -j ACCEPT" % (self.dev, guestNetworkCidr)])
-
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 80 -s %s -m state --state NEW -j ACCEPT" % (self.dev, guestNetworkCidr)])
+            self.fw.append(
+                ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 443 -s %s -m state --state NEW -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 8080 -s %s -m state --state NEW -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(["mangle", "",

--- a/systemvm/debian/opt/cloud/bin/cs/CsApp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsApp.py
@@ -61,12 +61,12 @@ class CsApache(CsApp):
 
         self.fw.append([
             "", "front",
-            "-A INPUT -i %s -d %s/32 -p tcp -m tcp -m state --state NEW --dport 80 -j ACCEPT" % (self.dev, self.ip)
+            "-A INPUT -i %s -s %s/32 -p tcp -m tcp -m state --state NEW --dport 80 -j ACCEPT" % (self.dev, self.ip)
         ])
 
         self.fw.append([
             "", "front",
-            "-A INPUT -i %s -d %s/32 -p tcp -m tcp -m state --state NEW --dport 443 -j ACCEPT" % (self.dev, self.ip)
+            "-A INPUT -i %s -s %s/32 -p tcp -m tcp -m state --state NEW --dport 443 -j ACCEPT" % (self.dev, self.ip)
         ])
 
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsApp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsApp.py
@@ -59,16 +59,6 @@ class CsApache(CsApp):
             file.commit()
             CsHelper.execute2("systemctl restart apache2", False)
 
-        self.fw.append([
-            "", "front",
-            "-A INPUT -i %s -s %s/32 -p tcp -m tcp -m state --state NEW --dport 80 -j ACCEPT" % (self.dev, self.ip)
-        ])
-
-        self.fw.append([
-            "", "front",
-            "-A INPUT -i %s -s %s/32 -p tcp -m tcp -m state --state NEW --dport 443 -j ACCEPT" % (self.dev, self.ip)
-        ])
-
 
 class CsPasswdSvc():
     """


### PR DESCRIPTION
### Description

There is a potential security issue with having http access to the VR from anywhere.
This PR restricts http access to the VR to the internal network only.

<!--- Describe your changes in DETAIL - And how has behavior functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This was tested by creating a shared network and checking if port 80 and 443 is open on the VR based on the network you are connecting from.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
