### PR TITLE
ui: Consider overprovisioning when displaying allocated progress

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -262,7 +262,8 @@
               <a-progress
                 class="progress-bar"
                 size="small"
-                :percent="Number(parseFloat(100.0 * parseFloat(resource.disksizeallocatedgb) / parseFloat(resource.disksizetotalgb)).toFixed(2))"
+                :percent="Number(parseFloat(100.0 * parseFloat(resource.disksizeallocatedgb) / (parseFloat(resource.disksizetotalgb) *
+                  (parseFloat(resource.overprovisionfactor) || 1.0))).toFixed(2))"
                 :format="(percent, successPercent) => parseFloat(percent).toFixed(2) + '% ' + $t('label.disksizeallocatedgb')" />
             </span>
           </div>


### PR DESCRIPTION
### Description

This PR fixes the UI info card by considering the overprovisioning factor while displaying the disk allocated progress bar

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):

#### Before: 

![Screenshot from 2021-03-20 10-26-53](https://user-images.githubusercontent.com/8244774/111859459-20365300-8967-11eb-8846-80eee5457f22.png)

#### After:

![Screenshot from 2021-03-20 10-26-37](https://user-images.githubusercontent.com/8244774/111859452-10b70a00-8967-11eb-80d9-4a1adec4d71d.png)
