### PR TITLE
Allow host cert renewals even if client auth strictness is false

### DIFF
--- a/plugins/ca/root-ca/src/main/java/org/apache/cloudstack/ca/provider/RootCACustomTrustManager.java
+++ b/plugins/ca/root-ca/src/main/java/org/apache/cloudstack/ca/provider/RootCACustomTrustManager.java
@@ -79,13 +79,16 @@ public final class RootCACustomTrustManager implements X509TrustManager {
         if (LOG.isDebugEnabled()) {
             printCertificateChain(certificates, s);
         }
-        if (!authStrictness) {
+
+        final X509Certificate primaryClientCertificate = (certificates != null && certificates.length > 0 && certificates[0] != null) ? certificates[0] : null;
+        String exceptionMsg = "";
+
+        if (authStrictness && primaryClientCertificate == null) {
+            throw new CertificateException("In strict auth mode, certificate(s) are expected from client:" + clientAddress);
+        } else if (primaryClientCertificate == null) {
+            LOG.info("No certificate was received from client, but continuing since strict auth mode is disabled");
             return;
         }
-        if (certificates == null || certificates.length < 1 || certificates[0] == null) {
-            throw new CertificateException("In strict auth mode, certificate(s) are expected from client:" + clientAddress);
-        }
-        final X509Certificate primaryClientCertificate = certificates[0];
 
         // Revocation check
         final BigInteger serialNumber = primaryClientCertificate.getSerialNumber();
@@ -93,18 +96,19 @@ public final class RootCACustomTrustManager implements X509TrustManager {
             final String errorMsg = String.format("Client is using revoked certificate of serial=%x, subject=%s from address=%s",
                     primaryClientCertificate.getSerialNumber(), primaryClientCertificate.getSubjectDN(), clientAddress);
             LOG.error(errorMsg);
-            throw new CertificateException(errorMsg);
+            exceptionMsg = (Strings.isNullOrEmpty(exceptionMsg)) ? errorMsg : (exceptionMsg + ". " + errorMsg);
         }
 
         // Validity check
-        if (!allowExpiredCertificate) {
-            try {
-                primaryClientCertificate.checkValidity();
-            } catch (final CertificateExpiredException | CertificateNotYetValidException e) {
-                final String errorMsg = String.format("Client certificate has expired with serial=%x, subject=%s from address=%s",
-                        primaryClientCertificate.getSerialNumber(), primaryClientCertificate.getSubjectDN(), clientAddress);
-                LOG.error(errorMsg);
-                throw new CertificateException(errorMsg);                }
+        try {
+            primaryClientCertificate.checkValidity();
+        } catch (final CertificateExpiredException | CertificateNotYetValidException e) {
+            final String errorMsg = String.format("Client certificate has expired with serial=%x, subject=%s from address=%s",
+                    primaryClientCertificate.getSerialNumber(), primaryClientCertificate.getSubjectDN(), clientAddress);
+            LOG.error(errorMsg);
+            if (!allowExpiredCertificate) {
+                throw new CertificateException(errorMsg);
+            }
         }
 
         // Ownership check
@@ -122,13 +126,21 @@ public final class RootCACustomTrustManager implements X509TrustManager {
         if (!certMatchesOwnership) {
             final String errorMsg = "Certificate ownership verification failed for client: " + clientAddress;
             LOG.error(errorMsg);
-            throw new CertificateException(errorMsg);
+            exceptionMsg = (Strings.isNullOrEmpty(exceptionMsg)) ? errorMsg : (exceptionMsg + ". " + errorMsg);
         }
-        if (activeCertMap != null && !Strings.isNullOrEmpty(clientAddress)) {
-            activeCertMap.put(clientAddress, primaryClientCertificate);
+        if (authStrictness && !Strings.isNullOrEmpty(exceptionMsg)) {
+            throw new CertificateException(exceptionMsg);
         }
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Client/agent connection from ip=" + clientAddress + " has been validated and trusted.");
+            if (authStrictness) {
+                LOG.debug("Client/agent connection from ip=" + clientAddress + " has been validated and trusted.");
+            } else {
+                LOG.debug("Client/agent connection from ip=" + clientAddress + " accepted without certificate validation.");
+            }
+        }
+
+        if (primaryClientCertificate != null && activeCertMap != null && !Strings.isNullOrEmpty(clientAddress)) {
+            activeCertMap.put(clientAddress, primaryClientCertificate);
         }
     }
 
@@ -138,9 +150,6 @@ public final class RootCACustomTrustManager implements X509TrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
-        if (!authStrictness) {
-            return null;
-        }
         return new X509Certificate[]{caCertificate};
     }
 }

--- a/plugins/ca/root-ca/src/main/java/org/apache/cloudstack/ca/provider/RootCAProvider.java
+++ b/plugins/ca/root-ca/src/main/java/org/apache/cloudstack/ca/provider/RootCAProvider.java
@@ -267,9 +267,16 @@ public final class RootCAProvider extends AdapterBase implements CAProvider, Con
         final boolean allowExpiredCertificate = rootCAAllowExpiredCert.value();
 
         TrustManager[] tms = new TrustManager[]{new RootCACustomTrustManager(remoteAddress, authStrictness, allowExpiredCertificate, certMap, caCertificate, crlDao)};
+
         sslContext.init(kmf.getKeyManagers(), tms, new SecureRandom());
         final SSLEngine sslEngine = sslContext.createSSLEngine();
-        sslEngine.setNeedClientAuth(authStrictness);
+        // If authStrictness require SSL and validate client cert, otherwise prefer SSL but don't validate client cert
+        if (authStrictness) {
+            sslEngine.setNeedClientAuth(true);  // Require SSL and client cert validation
+        } else {
+            sslEngine.setWantClientAuth(true);  // Prefer SSL but don't validate client cert
+        }
+
         return sslEngine;
     }
 

--- a/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCACustomTrustManagerTest.java
+++ b/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCACustomTrustManagerTest.java
@@ -62,10 +62,43 @@ public class RootCACustomTrustManagerTest {
     }
 
     @Test
-    public void testAuthNotStrict() throws Exception {
+    public void testAuthNotStrictWithInvalidCert() throws Exception {
         final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
         trustManager.checkClientTrusted(null, null);
-        Assert.assertNull(trustManager.getAcceptedIssuers());
+    }
+
+    @Test
+    public void testAuthNotStrictWithRevokedCert() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(new CrlVO());
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{caCertificate}, "RSA");
+        Assert.assertTrue(certMap.containsKey(clientIp));
+        Assert.assertEquals(certMap.get(clientIp), caCertificate);
+    }
+
+    @Test
+    public void testAuthNotStrictWithInvalidCertOwnership() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(null);
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{caCertificate}, "RSA");
+        Assert.assertTrue(certMap.containsKey(clientIp));
+        Assert.assertEquals(certMap.get(clientIp), caCertificate);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void testAuthNotStrictWithDenyExpiredCertAndOwnership() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(null);
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, false, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{expiredClientCertificate}, "RSA");
+    }
+
+    @Test
+    public void testAuthNotStrictWithAllowExpiredCertAndOwnership() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(null);
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{expiredClientCertificate}, "RSA");
+        Assert.assertTrue(certMap.containsKey(clientIp));
+        Assert.assertEquals(certMap.get(clientIp), expiredClientCertificate);
     }
 
     @Test(expected = CertificateException.class)

--- a/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/src/test/java/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -133,6 +133,7 @@ public class RootCAProviderTest {
         provider.rootCAAuthStrictness = Mockito.mock(ConfigKey.class);
         Mockito.when(provider.rootCAAuthStrictness.value()).thenReturn(Boolean.FALSE);
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
+        Assert.assertTrue(e.getWantClientAuth());
         Assert.assertFalse(e.getNeedClientAuth());
     }
 


### PR DESCRIPTION
### Description

This PR allows the management servers to renew certificates issued to hosts, even if ca.plugin.root.auth.strictness is false.  There is already a global setting named ca.framework.cert.automatic.renewal that should be controlling the certificate renewals.  However, ca.plugin.root.auth.strictness currently circumvents that setting.

#### More Detail

The ca.plugin.root.auth.strictness setting is checked early in the client certificate checking method and exits the method without adding the certificate to the management server's in-memory certificate map if strictness is false.  The certificate renewal process (if enabled with ca.framework.cert.automatic.renewal) reads that in-memory certificate map to determine what certs it could renew.  Those two settings shouldn't be so closely related.


<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
We've deployed and tested this in our CloudStack environments.