### PR TITLE
server: return domain path in login exception error message

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -1130,7 +1130,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
 
             return createLoginResponse(session);
         }
-        throw new CloudAuthenticationException("Failed to authenticate user " + username + " in domain " + domainId + "; please provide valid credentials");
+        throw new CloudAuthenticationException("Failed to authenticate user " + username + " in domain " + userDomain.getPath() + "; please provide valid credentials");
     }
 
     @Override


### PR DESCRIPTION
### Description

Minor fix to not show domain's DB ID in the error message that gets displayed in the UI.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):
Before
![Screenshot from 2021-03-24 15-06-07](https://user-images.githubusercontent.com/153340/112291609-4422cd00-8cb6-11eb-9e0c-31fe786ebf11.png)

After
![Screenshot from 2021-03-24 15-31-55](https://user-images.githubusercontent.com/153340/112291628-4ab14480-8cb6-11eb-8e99-71a96c71d04e.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
