### PR TITLE
ui: Display root disk size in Compute offering details

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1809,6 +1809,7 @@
 "label.rolename": "Role",
 "label.roles": "Roles",
 "label.roletype": "Role Type",
+"label.rootdisksize": "Root disk size (GB)",
 "label.root.certificate": "Root certificate",
 "label.root.disk.offering": "Root Disk Offering",
 "label.root.disk.size": "Root disk size (GB)",

--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -33,6 +33,11 @@
             <router-link :to="{ path: '/volume/' + volume.uuid }">{{ volume.type }} - {{ volume.path }}</router-link> ({{ parseFloat(volume.size / (1024.0 * 1024.0 * 1024.0)).toFixed(1) }} GB)
           </div>
         </div>
+        <div v-else-if="$route.meta.name === 'computeoffering' && item === 'rootdisksize'">
+          <div>
+            {{ parseFloat( resource.rootdisksize / (1024.0 * 1024.0 * 1024.0)).toFixed(1) }} GB
+          </div>
+        </div>
         <div v-else-if="['name', 'type'].includes(item)">
           <span v-if="['USER.LOGIN', 'USER.LOGOUT', 'ROUTER.HEALTH.CHECKS', 'FIREWALL.CLOSE', 'ALERT.SERVICE.DOMAINROUTER'].includes(resource[item])">{{ $t(resource[item].toLowerCase()) }}</span>
           <span v-else>{{ resource[item] }}</span>

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -36,6 +36,10 @@ export default {
           store.getters.apis.createServiceOffering.params.filter(x => x.name === 'storagepolicy').length > 0) {
           fields.splice(6, 0, 'vspherestoragepolicy')
         }
+        if (store.getters.apis.createServiceOffering &&
+          store.getters.apis.createServiceOffering.params.filter(x => x.name === 'rootdisksize').length > 0) {
+          fields.splice(12, 0, 'rootdisksize')
+        }
         return fields
       },
       related: [{


### PR DESCRIPTION
### Description

This PR displays the Root disk size as part of compute offering details if the offering was created with it specified.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### How Has This Been Tested?
Prior to this fix: When a compute offering is created with root disk size specified, there is not indication of this attribute in the corresponding Compute offering's details.

Post fix:
![image](https://user-images.githubusercontent.com/10495417/112145707-b3d68080-8c00-11eb-997f-8d4d06e331c2.png)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
