### PR TITLE
kvm: remove unnecessary new String

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -4264,8 +4264,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         QemuImg qemu = new QemuImg(timeout);
         try{
             Map<String, String> info = qemu.info(file);
-            String backingFilePath = info.get("backing_file");
-            String backingFileFormat = info.get("backing_file_format");
+            String backingFilePath = info.get(QemuImg.BACKING_FILE);
+            String backingFileFormat = info.get(QemuImg.BACKING_FILE_FORMAT);
             if (org.apache.commons.lang.StringUtils.isNotBlank(backingFilePath)
                     && org.apache.commons.lang.StringUtils.isBlank(backingFileFormat)) {
                 // VMs which are created in CloudStack 4.14 and before cannot be started or migrated
@@ -4274,7 +4274,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 s_logger.info("Setting backing file format of " + volPath);
                 QemuImgFile backingFile = new QemuImgFile(backingFilePath);
                 Map<String, String> backingFileinfo = qemu.info(backingFile);
-                String backingFileFmt = backingFileinfo.get("file_format");
+                String backingFileFmt = backingFileinfo.get(QemuImg.FILE_FORMAT);
                 qemu.rebase(file, backingFile, backingFileFmt, false);
             }
         } catch (QemuImgException e) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -4264,8 +4264,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         QemuImg qemu = new QemuImg(timeout);
         try{
             Map<String, String> info = qemu.info(file);
-            String backingFilePath = info.get(new String("backing_file"));
-            String backingFileFormat = info.get(new String("backing_file_format"));
+            String backingFilePath = info.get("backing_file");
+            String backingFileFormat = info.get("backing_file_format");
             if (org.apache.commons.lang.StringUtils.isNotBlank(backingFilePath)
                     && org.apache.commons.lang.StringUtils.isBlank(backingFileFormat)) {
                 // VMs which are created in CloudStack 4.14 and before cannot be started or migrated
@@ -4274,7 +4274,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 s_logger.info("Setting backing file format of " + volPath);
                 QemuImgFile backingFile = new QemuImgFile(backingFilePath);
                 Map<String, String> backingFileinfo = qemu.info(backingFile);
-                String backingFileFmt = backingFileinfo.get(new String("file_format"));
+                String backingFileFmt = backingFileinfo.get("file_format");
                 qemu.rebase(file, backingFile, backingFileFmt, false);
             }
         } catch (QemuImgException e) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -809,7 +809,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         try{
             qemu.create(destFile, options);
             Map<String, String> info = qemu.info(destFile);
-            virtualSize = Long.parseLong(info.get("virtual_size"));
+            virtualSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
             actualSize = new File(destFile.getFileName()).length();
         } catch (QemuImgException e) {
             s_logger.error("Failed to create " + volPath +
@@ -1287,7 +1287,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                 srcFile = new QemuImgFile(sourcePath, sourceFormat);
                 try {
                     Map<String, String> info = qemu.info(srcFile);
-                    String backingFile = info.get("backing_file");
+                    String backingFile = info.get(QemuImg.BACKING_FILE);
                     // qcow2 templates can just be copied into place
                     if (sourceFormat.equals(destFormat) && backingFile == null && sourcePath.endsWith(".qcow2")) {
                         String result = Script.runSimpleBashScript("cp -f " + sourcePath + " " + destPath, timeout);
@@ -1299,7 +1299,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                         try {
                             qemu.convert(srcFile, destFile);
                             Map<String, String> destInfo = qemu.info(destFile);
-                            Long virtualSize = Long.parseLong(destInfo.get("virtual_size"));
+                            Long virtualSize = Long.parseLong(destInfo.get(QemuImg.VIRTUAL_SIZE));
                             newDisk.setVirtualSize(virtualSize);
                             newDisk.setSize(virtualSize);
                         } catch (QemuImgException e) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -809,7 +809,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         try{
             qemu.create(destFile, options);
             Map<String, String> info = qemu.info(destFile);
-            virtualSize = Long.parseLong(info.get(new String("virtual_size")));
+            virtualSize = Long.parseLong(info.get("virtual_size"));
             actualSize = new File(destFile.getFileName()).length();
         } catch (QemuImgException e) {
             s_logger.error("Failed to create " + volPath +
@@ -1287,7 +1287,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                 srcFile = new QemuImgFile(sourcePath, sourceFormat);
                 try {
                     Map<String, String> info = qemu.info(srcFile);
-                    String backingFile = info.get(new String("backing_file"));
+                    String backingFile = info.get("backing_file");
                     // qcow2 templates can just be copied into place
                     if (sourceFormat.equals(destFormat) && backingFile == null && sourcePath.endsWith(".qcow2")) {
                         String result = Script.runSimpleBashScript("cp -f " + sourcePath + " " + destPath, timeout);
@@ -1299,7 +1299,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                         try {
                             qemu.convert(srcFile, destFile);
                             Map<String, String> destInfo = qemu.info(destFile);
-                            Long virtualSize = Long.parseLong(destInfo.get(new String("virtual_size")));
+                            Long virtualSize = Long.parseLong(destInfo.get("virtual_size"));
                             newDisk.setVirtualSize(virtualSize);
                             newDisk.setSize(virtualSize);
                         } catch (QemuImgException e) {

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -28,6 +28,12 @@ import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.Script;
 
 public class QemuImg {
+    public final static String BACKING_FILE = "backing_file";
+    public final static String BACKING_FILE_FORMAT = "backing_file_format";
+    public final static String CLUSTER_SIZE = "cluster_size";
+    public final static String FILE_FORMAT = "file_format";
+    public final static String IMAGE = "image";
+    public final static String VIRTUAL_SIZE = "virtual_size";
 
     /* The qemu-img binary. We expect this to be in $PATH */
     public String _qemuImgPath = "qemu-img";

--- a/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/qemu/QemuImgTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/qemu/QemuImgTest.java
@@ -51,10 +51,10 @@ public class QemuImgTest {
             fail("We didn't get any information back from qemu-img");
         }
 
-        Long infoSize = Long.parseLong(info.get(new String("virtual_size")));
+        Long infoSize = Long.parseLong(info.get("virtual_size"));
         assertEquals(Long.valueOf(size), Long.valueOf(infoSize));
 
-        String infoPath = info.get(new String("image"));
+        String infoPath = info.get("image");
         assertEquals(filename, infoPath);
 
         File f = new File(filename);
@@ -78,13 +78,13 @@ public class QemuImgTest {
         qemu.create(file, options);
         Map<String, String> info = qemu.info(file);
 
-        Long infoSize = Long.parseLong(info.get(new String("virtual_size")));
+        Long infoSize = Long.parseLong(info.get("virtual_size"));
         assertEquals(Long.valueOf(size), Long.valueOf(infoSize));
 
-        String infoPath = info.get(new String("image"));
+        String infoPath = info.get("image");
         assertEquals(filename, infoPath);
 
-        String infoClusterSize = info.get(new String("cluster_size"));
+        String infoClusterSize = info.get("cluster_size");
         assertEquals(clusterSize, infoClusterSize);
 
         File f = new File(filename);
@@ -135,7 +135,7 @@ public class QemuImgTest {
                 fail("We didn't get any information back from qemu-img");
             }
 
-            Long infoSize = Long.parseLong(info.get(new String("virtual_size")));
+            Long infoSize = Long.parseLong(info.get("virtual_size"));
             assertEquals(Long.valueOf(endSize), Long.valueOf(infoSize));
         } catch (QemuImgException e) {
             fail(e.getMessage());
@@ -164,7 +164,7 @@ public class QemuImgTest {
                 fail("We didn't get any information back from qemu-img");
             }
 
-            Long infoSize = Long.parseLong(info.get(new String("virtual_size")));
+            Long infoSize = Long.parseLong(info.get("virtual_size"));
             assertEquals(Long.valueOf(startSize + increment), Long.valueOf(infoSize));
         } catch (QemuImgException e) {
             fail(e.getMessage());
@@ -192,7 +192,7 @@ public class QemuImgTest {
                 fail("We didn't get any information back from qemu-img");
             }
 
-            Long infoSize = Long.parseLong(info.get(new String("virtual_size")));
+            Long infoSize = Long.parseLong(info.get("virtual_size"));
             assertEquals(Long.valueOf(startSize + increment), Long.valueOf(infoSize));
         } catch (QemuImgException e) {
             fail(e.getMessage());
@@ -255,7 +255,7 @@ public class QemuImgTest {
             fail("We didn't get any information back from qemu-img");
         }
 
-        String backingFile = info.get(new String("backing_file"));
+        String backingFile = info.get("backing_file");
         if (backingFile == null) {
             fail("The second file does not have a property backing_file! Create failed?");
         }
@@ -303,10 +303,10 @@ public class QemuImgTest {
 
         Map<String, String> info = qemu.info(destFile);
 
-        PhysicalDiskFormat infoFormat = PhysicalDiskFormat.valueOf(info.get(new String("format")).toUpperCase());
+        PhysicalDiskFormat infoFormat = PhysicalDiskFormat.valueOf(info.get("format").toUpperCase());
         assertEquals(destFormat, infoFormat);
 
-        Long infoSize = Long.parseLong(info.get(new String("virtual_size")));
+        Long infoSize = Long.parseLong(info.get("virtual_size"));
         assertEquals(Long.valueOf(srcSize), Long.valueOf(infoSize));
 
         File sf = new File(srcFileName);

--- a/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/qemu/QemuImgTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/qemu/QemuImgTest.java
@@ -51,10 +51,10 @@ public class QemuImgTest {
             fail("We didn't get any information back from qemu-img");
         }
 
-        Long infoSize = Long.parseLong(info.get("virtual_size"));
+        Long infoSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
         assertEquals(Long.valueOf(size), Long.valueOf(infoSize));
 
-        String infoPath = info.get("image");
+        String infoPath = info.get(QemuImg.IMAGE);
         assertEquals(filename, infoPath);
 
         File f = new File(filename);
@@ -78,13 +78,13 @@ public class QemuImgTest {
         qemu.create(file, options);
         Map<String, String> info = qemu.info(file);
 
-        Long infoSize = Long.parseLong(info.get("virtual_size"));
+        Long infoSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
         assertEquals(Long.valueOf(size), Long.valueOf(infoSize));
 
-        String infoPath = info.get("image");
+        String infoPath = info.get(QemuImg.IMAGE);
         assertEquals(filename, infoPath);
 
-        String infoClusterSize = info.get("cluster_size");
+        String infoClusterSize = info.get(QemuImg.CLUSTER_SIZE);
         assertEquals(clusterSize, infoClusterSize);
 
         File f = new File(filename);
@@ -135,7 +135,7 @@ public class QemuImgTest {
                 fail("We didn't get any information back from qemu-img");
             }
 
-            Long infoSize = Long.parseLong(info.get("virtual_size"));
+            Long infoSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
             assertEquals(Long.valueOf(endSize), Long.valueOf(infoSize));
         } catch (QemuImgException e) {
             fail(e.getMessage());
@@ -164,7 +164,7 @@ public class QemuImgTest {
                 fail("We didn't get any information back from qemu-img");
             }
 
-            Long infoSize = Long.parseLong(info.get("virtual_size"));
+            Long infoSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
             assertEquals(Long.valueOf(startSize + increment), Long.valueOf(infoSize));
         } catch (QemuImgException e) {
             fail(e.getMessage());
@@ -192,7 +192,7 @@ public class QemuImgTest {
                 fail("We didn't get any information back from qemu-img");
             }
 
-            Long infoSize = Long.parseLong(info.get("virtual_size"));
+            Long infoSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
             assertEquals(Long.valueOf(startSize + increment), Long.valueOf(infoSize));
         } catch (QemuImgException e) {
             fail(e.getMessage());
@@ -255,7 +255,7 @@ public class QemuImgTest {
             fail("We didn't get any information back from qemu-img");
         }
 
-        String backingFile = info.get("backing_file");
+        String backingFile = info.get(QemuImg.BACKING_FILE);
         if (backingFile == null) {
             fail("The second file does not have a property backing_file! Create failed?");
         }
@@ -303,10 +303,10 @@ public class QemuImgTest {
 
         Map<String, String> info = qemu.info(destFile);
 
-        PhysicalDiskFormat infoFormat = PhysicalDiskFormat.valueOf(info.get("format").toUpperCase());
+        PhysicalDiskFormat infoFormat = PhysicalDiskFormat.valueOf(info.get(QemuImg.FILE_FORMAT).toUpperCase());
         assertEquals(destFormat, infoFormat);
 
-        Long infoSize = Long.parseLong(info.get("virtual_size"));
+        Long infoSize = Long.parseLong(info.get(QemuImg.VIRTUAL_SIZE));
         assertEquals(Long.valueOf(srcSize), Long.valueOf(infoSize));
 
         File sf = new File(srcFileName);


### PR DESCRIPTION
### Description

Thanks @rubieHess  to point it out. 
see https://github.com/apache/cloudstack/pull/4800#discussion_r598318705
```
I detect that this code is problematic. According to the Performance (PERFORMANCE), Dm: Method invokes inefficient new String(String) constructor (DM_STRING_CTOR).
Using the java.lang.String(String) constructor wastes memory because the object so constructed will be functionally indistinguishable from the String passed as a parameter.  Just use the argument String directly.
```


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
