### PR TITLE
VMware Datastore Cluster primary storage pool synchronisation

### DIFF
--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -374,6 +374,7 @@ public class EventTypes {
     // Primary storage pool
     public static final String EVENT_ENABLE_PRIMARY_STORAGE = "ENABLE.PS";
     public static final String EVENT_DISABLE_PRIMARY_STORAGE = "DISABLE.PS";
+    public static final String EVENT_SYNC_STORAGE_POOL = "SYNC.STORAGE.POOL";
 
     // VPN
     public static final String EVENT_REMOTE_ACCESS_VPN_CREATE = "VPN.REMOTE.ACCESS.CREATE";

--- a/api/src/main/java/com/cloud/storage/StorageService.java
+++ b/api/src/main/java/com/cloud/storage/StorageService.java
@@ -27,6 +27,7 @@ import org.apache.cloudstack.api.command.admin.storage.DeleteImageStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.DeletePoolCmd;
 import org.apache.cloudstack.api.command.admin.storage.DeleteSecondaryStagingStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateStoragePoolCmd;
+import org.apache.cloudstack.api.command.admin.storage.SyncStoragePoolCmd;
 
 import com.cloud.exception.DiscoveryException;
 import com.cloud.exception.InsufficientCapacityException;
@@ -103,5 +104,7 @@ public interface StorageService {
     ImageStore migrateToObjectStore(String name, String url, String providerName, Map<String, String> details) throws DiscoveryException;
 
     ImageStore updateImageStoreStatus(Long id, Boolean readonly);
+
+    StoragePool syncStoragePool(SyncStoragePoolCmd cmd);
 
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/SyncStoragePoolCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/SyncStoragePoolCmd.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.storage;
+
+import com.cloud.event.EventTypes;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.storage.StoragePool;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseAsyncCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.StoragePoolResponse;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.context.CallContext;
+
+import java.util.logging.Logger;
+
+@APICommand(name = SyncStoragePoolCmd.APINAME,
+        description = "Sync storage pool with management server",
+        responseObject = StoragePoolResponse.class,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = false,
+        since = "4.15.1",
+        authorized = {RoleType.Admin}
+        )
+public class SyncStoragePoolCmd extends BaseAsyncCmd {
+
+    public static final String APINAME = "syncStoragePool";
+    public static final Logger LOGGER = Logger.getLogger(SyncStoragePoolCmd.class.getName());
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = StoragePoolResponse.class, required = true, description = "Storage pool id")
+    private Long poolId;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getPoolId() {
+        return poolId;
+    }
+
+    @Override
+    public String getEventType() {
+        return EventTypes.EVENT_SYNC_STORAGE_POOL;
+    }
+
+    @Override
+    public String getEventDescription() {
+        return "Attempting to synchronise storage pool with management server";
+    }
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        StoragePool result = _storageService.syncStoragePool(this);
+        if (result != null) {
+            StoragePoolResponse response = _responseGenerator.createStoragePoolResponse(result);
+            response.setResponseName("storagepool");
+            this.setResponseObject(response);
+        } else {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to synchronise storage pool");
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + BaseAsyncCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return CallContext.current().getCallingAccountId();
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/SyncStoragePoolCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/SyncStoragePoolCmd.java
@@ -36,7 +36,7 @@ import org.apache.cloudstack.context.CallContext;
 import java.util.logging.Logger;
 
 @APICommand(name = SyncStoragePoolCmd.APINAME,
-        description = "Sync storage pool with management server",
+        description = "Sync storage pool with management server (currently supported for Datastore Cluster in VMware and syncs the datastores in it)",
         responseObject = StoragePoolResponse.class,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false,

--- a/core/src/main/java/com/cloud/storage/resource/StorageProcessor.java
+++ b/core/src/main/java/com/cloud/storage/resource/StorageProcessor.java
@@ -82,7 +82,7 @@ public interface StorageProcessor {
 
     Answer copyVolumeFromPrimaryToPrimary(CopyCommand cmd);
 
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd);
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd);
 
-    public Answer SyncVolumePath(SyncVolumePathCommand cmd);
+    public Answer syncVolumePath(SyncVolumePathCommand cmd);
 }

--- a/core/src/main/java/com/cloud/storage/resource/StorageProcessor.java
+++ b/core/src/main/java/com/cloud/storage/resource/StorageProcessor.java
@@ -30,6 +30,7 @@ import org.apache.cloudstack.storage.command.ForgetObjectCmd;
 import org.apache.cloudstack.storage.command.IntroduceObjectCmd;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 
 import com.cloud.agent.api.Answer;
 
@@ -82,4 +83,6 @@ public interface StorageProcessor {
     Answer copyVolumeFromPrimaryToPrimary(CopyCommand cmd);
 
     public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd);
+
+    public Answer SyncVolumePath(SyncVolumePathCommand cmd);
 }

--- a/core/src/main/java/com/cloud/storage/resource/StorageSubsystemCommandHandlerBase.java
+++ b/core/src/main/java/com/cloud/storage/resource/StorageSubsystemCommandHandlerBase.java
@@ -74,9 +74,9 @@ public class StorageSubsystemCommandHandlerBase implements StorageSubsystemComma
         } else if (command instanceof DirectDownloadCommand) {
             return processor.handleDownloadTemplateToPrimaryStorage((DirectDownloadCommand) command);
         } else if (command instanceof CheckDataStoreStoragePolicyComplainceCommand) {
-            return processor.CheckDataStoreStoragePolicyComplaince((CheckDataStoreStoragePolicyComplainceCommand) command);
+            return processor.checkDataStoreStoragePolicyCompliance((CheckDataStoreStoragePolicyComplainceCommand) command);
         } else if (command instanceof SyncVolumePathCommand) {
-            return processor.SyncVolumePath((SyncVolumePathCommand) command);
+            return processor.syncVolumePath((SyncVolumePathCommand) command);
         }
 
         return new Answer((Command)command, false, "not implemented yet");

--- a/core/src/main/java/com/cloud/storage/resource/StorageSubsystemCommandHandlerBase.java
+++ b/core/src/main/java/com/cloud/storage/resource/StorageSubsystemCommandHandlerBase.java
@@ -34,6 +34,7 @@ import org.apache.cloudstack.storage.command.IntroduceObjectCmd;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
@@ -74,6 +75,8 @@ public class StorageSubsystemCommandHandlerBase implements StorageSubsystemComma
             return processor.handleDownloadTemplateToPrimaryStorage((DirectDownloadCommand) command);
         } else if (command instanceof CheckDataStoreStoragePolicyComplainceCommand) {
             return processor.CheckDataStoreStoragePolicyComplaince((CheckDataStoreStoragePolicyComplainceCommand) command);
+        } else if (command instanceof SyncVolumePathCommand) {
+            return processor.SyncVolumePath((SyncVolumePathCommand) command);
         }
 
         return new Answer((Command)command, false, "not implemented yet");

--- a/core/src/main/java/org/apache/cloudstack/storage/command/SyncVolumePathAnswer.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/SyncVolumePathAnswer.java
@@ -1,0 +1,49 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package org.apache.cloudstack.storage.command;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.to.DiskTO;
+
+public class SyncVolumePathAnswer extends Answer {
+    private DiskTO disk;
+
+    public SyncVolumePathAnswer() {
+        super(null);
+    }
+
+    public SyncVolumePathAnswer(DiskTO disk) {
+        super(null);
+        setDisk(disk);
+    }
+
+    public SyncVolumePathAnswer(String errMsg) {
+        super(null, false, errMsg);
+    }
+
+    public DiskTO getDisk() {
+        return disk;
+    }
+
+    public void setDisk(DiskTO disk) {
+        this.disk = disk;
+    }
+
+}

--- a/core/src/main/java/org/apache/cloudstack/storage/command/SyncVolumePathCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/SyncVolumePathCommand.java
@@ -1,0 +1,59 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package org.apache.cloudstack.storage.command;
+
+import com.cloud.agent.api.to.DiskTO;
+
+public class SyncVolumePathCommand extends StorageSubSystemCommand{
+
+    private DiskTO disk;
+    private String vmName;
+
+    public SyncVolumePathCommand(final DiskTO disk, final String vmName) {
+        super();
+        this.disk = disk;
+        this.vmName = vmName;
+    }
+
+    public DiskTO getDisk() {
+        return disk;
+    }
+
+    public void setDisk(final DiskTO disk) {
+        this.disk = disk;
+    }
+
+    public String getVmName() {
+        return vmName;
+    }
+
+    public void setVmName(final String vmName) {
+        this.vmName = vmName;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return false;
+    }
+
+    @Override
+    public void setExecuteInSequence(boolean inSeq) {
+
+    }
+}

--- a/core/src/main/java/org/apache/cloudstack/storage/command/SyncVolumePathCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/SyncVolumePathCommand.java
@@ -20,15 +20,13 @@ package org.apache.cloudstack.storage.command;
 
 import com.cloud.agent.api.to.DiskTO;
 
-public class SyncVolumePathCommand extends StorageSubSystemCommand{
+public class SyncVolumePathCommand extends StorageSubSystemCommand {
 
     private DiskTO disk;
-    private String vmName;
 
-    public SyncVolumePathCommand(final DiskTO disk, final String vmName) {
+    public SyncVolumePathCommand(final DiskTO disk) {
         super();
         this.disk = disk;
-        this.vmName = vmName;
     }
 
     public DiskTO getDisk() {
@@ -37,14 +35,6 @@ public class SyncVolumePathCommand extends StorageSubSystemCommand{
 
     public void setDisk(final DiskTO disk) {
         this.disk = disk;
-    }
-
-    public String getVmName() {
-        return vmName;
-    }
-
-    public void setVmName(final String vmName) {
-        this.vmName = vmName;
     }
 
     @Override

--- a/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
+++ b/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
@@ -19,6 +19,7 @@ package com.cloud.storage;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.cloud.agent.api.ModifyStoragePoolAnswer;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.HypervisorHostListener;
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -239,5 +240,7 @@ public interface StorageManager extends StorageService {
     DiskTO getDiskWithThrottling(DataTO volTO, Volume.Type volumeType, long deviceId, String path, long offeringId, long diskOfferingId);
 
     boolean isStoragePoolDatastoreClusterParent(StoragePool pool);
+
+    void syncDatastoreClusterStoragePool(long datastoreClusterPoolId, List<ModifyStoragePoolAnswer> childDatastoreAnswerList, long hostId);
 
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/StoragePoolHostDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/StoragePoolHostDao.java
@@ -32,6 +32,8 @@ public interface StoragePoolHostDao extends GenericDao<StoragePoolHostVO, Long> 
 
     List<StoragePoolHostVO> listByHostStatus(long poolId, Status hostStatus);
 
+    List<Long> findHostsConnectedToPools(List<Long> poolIds);
+
     List<Pair<Long, Integer>> getDatacenterStoragePoolHostInfo(long dcId, boolean sharedOnly);
 
     public void deletePrimaryRecordsForHost(long hostId);

--- a/engine/schema/src/main/java/com/cloud/storage/dao/StoragePoolHostDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/StoragePoolHostDaoImpl.java
@@ -141,10 +141,10 @@ public class StoragePoolHostDaoImpl extends GenericDaoBase<StoragePoolHostVO, Lo
                     hosts.add(hostId);
                 }
             } catch (SQLException e) {
-                s_logger.warn("findHostsConnectedToPools:Exception: ", e);
+                s_logger.warn(String.format("Unable to retrieve hosts from pools [%s] due to [%s].", poolIdsInStr, e.getMessage()));
             }
         } catch (Exception e) {
-            s_logger.warn("findHostsConnectedToPools:Exception: ", e);
+            s_logger.warn(String.format("Unable to retrieve hosts from pools [%s] due to [%s].", poolIdsInStr, e.getMessage()));
         }
 
         return hosts;

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
@@ -130,4 +130,6 @@ public interface PrimaryDataStoreDao extends GenericDao<StoragePoolVO, Long> {
 
     Integer countAll();
 
+    List<StoragePoolVO> findPoolsByStorageType(String storageType);
+
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
@@ -93,6 +93,7 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
         AllFieldSearch.and("podId", AllFieldSearch.entity().getPodId(), Op.EQ);
         AllFieldSearch.and("clusterId", AllFieldSearch.entity().getClusterId(), Op.EQ);
         AllFieldSearch.and("storage_provider_name", AllFieldSearch.entity().getStorageProviderName(), Op.EQ);
+        AllFieldSearch.and("poolType", AllFieldSearch.entity().getPoolType(), Op.EQ);
         AllFieldSearch.done();
 
         DcPodSearch = createSearchBuilder();
@@ -579,6 +580,13 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
         SearchCriteria<StoragePoolVO> sc = ClustersSearch.create();
         sc.setParameters("clusterIds", clusterIds.toArray());
         sc.setParameters("status", StoragePoolStatus.Up);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<StoragePoolVO> findPoolsByStorageType(String storageType) {
+        SearchCriteria<StoragePoolVO> sc = AllFieldSearch.create();
+        sc.setParameters("poolType", storageType);
         return listBy(sc);
     }
 }

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
@@ -24,20 +24,15 @@ import com.cloud.agent.api.ModifyStoragePoolAnswer;
 import com.cloud.agent.api.ModifyStoragePoolCommand;
 import com.cloud.alert.AlertManager;
 import com.cloud.exception.StorageConflictException;
-import com.cloud.host.dao.HostDao;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.StoragePoolHostVO;
 import com.cloud.storage.dao.StoragePoolHostDao;
-import com.cloud.storage.dao.StoragePoolTagsDao;
-import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.StorageManager;
 import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.vm.dao.VMInstanceDao;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.HypervisorHostListener;
-import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailVO;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
@@ -62,16 +57,6 @@ public class DefaultHostListener implements HypervisorHostListener {
     PrimaryDataStoreDao primaryStoreDao;
     @Inject
     StoragePoolDetailsDao storagePoolDetailsDao;
-    @Inject
-    StoragePoolTagsDao storagePoolTagsDao;
-    @Inject
-    VolumeDao volumeDao;
-    @Inject
-    VMInstanceDao vmInstanceDao;
-    @Inject
-    HostDao hostDao;
-    @Inject
-    private VolumeDataFactory volFactory;
     @Inject
     StorageManager storageManager;
 

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
@@ -22,19 +22,22 @@ import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.ModifyStoragePoolAnswer;
 import com.cloud.agent.api.ModifyStoragePoolCommand;
-import com.cloud.agent.api.StoragePoolInfo;
 import com.cloud.alert.AlertManager;
 import com.cloud.exception.StorageConflictException;
+import com.cloud.host.dao.HostDao;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.StoragePoolHostVO;
-import com.cloud.storage.StoragePoolStatus;
 import com.cloud.storage.dao.StoragePoolHostDao;
 import com.cloud.storage.dao.StoragePoolTagsDao;
+import com.cloud.storage.dao.VolumeDao;
+import com.cloud.storage.StorageManager;
 import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.dao.VMInstanceDao;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.HypervisorHostListener;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailVO;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
@@ -43,9 +46,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import javax.inject.Inject;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class DefaultHostListener implements HypervisorHostListener {
     private static final Logger s_logger = Logger.getLogger(DefaultHostListener.class);
@@ -63,6 +64,16 @@ public class DefaultHostListener implements HypervisorHostListener {
     StoragePoolDetailsDao storagePoolDetailsDao;
     @Inject
     StoragePoolTagsDao storagePoolTagsDao;
+    @Inject
+    VolumeDao volumeDao;
+    @Inject
+    VMInstanceDao vmInstanceDao;
+    @Inject
+    HostDao hostDao;
+    @Inject
+    private VolumeDataFactory volFactory;
+    @Inject
+    StorageManager storageManager;
 
     @Override
     public boolean hostAdded(long hostId) {
@@ -104,43 +115,7 @@ public class DefaultHostListener implements HypervisorHostListener {
         updateStoragePoolHostVOAndDetails(poolVO, hostId, mspAnswer);
 
         if (pool.getPoolType() == Storage.StoragePoolType.DatastoreCluster) {
-            for (ModifyStoragePoolAnswer childDataStoreAnswer : ((ModifyStoragePoolAnswer) answer).getDatastoreClusterChildren()) {
-                StoragePoolInfo childStoragePoolInfo = childDataStoreAnswer.getPoolInfo();
-                StoragePoolVO dataStoreVO = primaryStoreDao.findPoolByUUID(childStoragePoolInfo.getUuid());
-                if (dataStoreVO != null) {
-                    continue;
-                }
-                dataStoreVO = new StoragePoolVO();
-                dataStoreVO.setStorageProviderName(poolVO.getStorageProviderName());
-                dataStoreVO.setHostAddress(childStoragePoolInfo.getHost());
-                dataStoreVO.setPoolType(Storage.StoragePoolType.PreSetup);
-                dataStoreVO.setPath(childStoragePoolInfo.getHostPath());
-                dataStoreVO.setPort(poolVO.getPort());
-                dataStoreVO.setName(childStoragePoolInfo.getName());
-                dataStoreVO.setUuid(childStoragePoolInfo.getUuid());
-                dataStoreVO.setDataCenterId(poolVO.getDataCenterId());
-                dataStoreVO.setPodId(poolVO.getPodId());
-                dataStoreVO.setClusterId(poolVO.getClusterId());
-                dataStoreVO.setStatus(StoragePoolStatus.Up);
-                dataStoreVO.setUserInfo(poolVO.getUserInfo());
-                dataStoreVO.setManaged(poolVO.isManaged());
-                dataStoreVO.setCapacityIops(poolVO.getCapacityIops());
-                dataStoreVO.setCapacityBytes(childDataStoreAnswer.getPoolInfo().getCapacityBytes());
-                dataStoreVO.setUsedBytes(childDataStoreAnswer.getPoolInfo().getCapacityBytes() - childDataStoreAnswer.getPoolInfo().getAvailableBytes());
-                dataStoreVO.setHypervisor(poolVO.getHypervisor());
-                dataStoreVO.setScope(poolVO.getScope());
-                dataStoreVO.setParent(poolVO.getId());
-
-                Map<String, String> details = new HashMap<>();
-                if(StringUtils.isNotEmpty(childDataStoreAnswer.getPoolType())) {
-                    details.put("pool_type", childDataStoreAnswer.getPoolType());
-                }
-
-                List<String> storageTags = storagePoolTagsDao.getStoragePoolTags(poolId);
-                primaryStoreDao.persist(dataStoreVO, details, storageTags);
-
-                updateStoragePoolHostVOAndDetails(dataStoreVO, hostId, childDataStoreAnswer);
-            }
+            storageManager.syncDatastoreClusterStoragePool(poolId, ((ModifyStoragePoolAnswer) answer).getDatastoreClusterChildren(), hostId);
         }
 
         s_logger.info("Connection established between storage pool " + pool + " and host " + hostId);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1839,14 +1839,14 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         s_logger.info("'CheckDataStoreStoragePolicyComplainceCommand' not currently applicable for KVMStorageProcessor");
         return new Answer(cmd,false,"Not currently applicable for KVMStorageProcessor");
     }
 
     @Override
-    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+    public Answer syncVolumePath(SyncVolumePathCommand cmd) {
         s_logger.info("SyncVolumePathCommand not currently applicable for KVMStorageProcessor");
-        return new Answer(cmd,false,"Not currently applicable for KVMStorageProcessor");
+        return new Answer(cmd, false, "Not currently applicable for KVMStorageProcessor");
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -60,6 +60,7 @@ import org.apache.cloudstack.storage.command.ResignatureAnswer;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyAnswer;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
@@ -1840,6 +1841,12 @@ public class KVMStorageProcessor implements StorageProcessor {
     @Override
     public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         s_logger.info("'CheckDataStoreStoragePolicyComplainceCommand' not currently applicable for KVMStorageProcessor");
+        return new Answer(cmd,false,"Not currently applicable for KVMStorageProcessor");
+    }
+
+    @Override
+    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+        s_logger.info("SyncVolumePathCommand not currently applicable for KVMStorageProcessor");
         return new Answer(cmd,false,"Not currently applicable for KVMStorageProcessor");
     }
 }

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3StorageProcessor.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3StorageProcessor.java
@@ -829,15 +829,15 @@ public class Ovm3StorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         LOGGER.info("'CheckDataStoreStoragePolicyComplainceCommand' not applicable used for Ovm3StorageProcessor");
         return new Answer(cmd,false,"Not applicable used for Ovm3StorageProcessor");
     }
 
     @Override
-    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+    public Answer syncVolumePath(SyncVolumePathCommand cmd) {
         LOGGER.info("SyncVolumePathCommand not currently applicable for Ovm3StorageProcessor");
-        return new Answer(cmd,false,"Not currently applicable for Ovm3StorageProcessor");
+        return new Answer(cmd, false, "Not currently applicable for Ovm3StorageProcessor");
     }
 
     @Override

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3StorageProcessor.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3StorageProcessor.java
@@ -35,8 +35,9 @@ import org.apache.cloudstack.storage.command.ForgetObjectCmd;
 import org.apache.cloudstack.storage.command.IntroduceObjectCmd;
 import org.apache.cloudstack.storage.command.ResignatureAnswer;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
-import org.apache.cloudstack.storage.command.SnapshotAndCopyAnswer;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
+import org.apache.cloudstack.storage.command.SnapshotAndCopyAnswer;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
@@ -831,6 +832,12 @@ public class Ovm3StorageProcessor implements StorageProcessor {
     public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         LOGGER.info("'CheckDataStoreStoragePolicyComplainceCommand' not applicable used for Ovm3StorageProcessor");
         return new Answer(cmd,false,"Not applicable used for Ovm3StorageProcessor");
+    }
+
+    @Override
+    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+        LOGGER.info("SyncVolumePathCommand not currently applicable for Ovm3StorageProcessor");
+        return new Answer(cmd,false,"Not currently applicable for Ovm3StorageProcessor");
     }
 
     @Override

--- a/plugins/hypervisors/simulator/src/main/java/com/cloud/resource/SimulatorStorageProcessor.java
+++ b/plugins/hypervisors/simulator/src/main/java/com/cloud/resource/SimulatorStorageProcessor.java
@@ -41,6 +41,7 @@ import org.apache.cloudstack.storage.command.ResignatureAnswer;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyAnswer;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
@@ -272,7 +273,12 @@ public class SimulatorStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+        return new Answer(cmd, true, null);
+    }
+
+    @Override
+    public Answer syncVolumePath(SyncVolumePathCommand cmd) {
         return new Answer(cmd, true, null);
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5272,10 +5272,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     String datacenterName = datastoreClusterPath.substring(0, pathstartPosition+1);
                     String childPath = datacenterName + summary.getName();
                     poolInfo.setHostPath(childPath);
-                    String uuid = UUID.nameUUIDFromBytes(((pool.getHost() + childPath)).getBytes()).toString();
+                    String uuid = childDsMo.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
+                    if (uuid == null) {
+                        uuid = UUID.nameUUIDFromBytes(((pool.getHost() + childPath)).getBytes()).toString();
+                    }
                     poolInfo.setUuid(uuid);
                     poolInfo.setLocalPath(cmd.LOCAL_PATH_PREFIX + File.separator + uuid);
-
                     answer.setPoolInfo(poolInfo);
                     answer.setPoolType(summary.getType());
                     answer.setLocalDatastoreName(morDatastore.getValue());

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -50,6 +50,8 @@ import org.apache.cloudstack.storage.command.ResignatureAnswer;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyAnswer;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathAnswer;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
@@ -3960,6 +3962,83 @@ public class VmwareStorageProcessor implements StorageProcessor {
             String msg = "Error cloning VM from template in primary storage: %s" + e.getMessage();
             s_logger.error(msg, e);
             throw new CloudRuntimeException(msg, e);
+        }
+    }
+
+    @Override
+    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+        DiskTO disk = cmd.getDisk();
+        VolumeObjectTO volumeTO = (VolumeObjectTO)disk.getData();
+        DataStoreTO primaryStore = volumeTO.getDataStore();
+        String volumePath = volumeTO.getPath();
+        String vmName = cmd.getVmName();
+
+        boolean datastoreChangeObserved = false;
+        boolean volumePathChangeObserved = false;
+        String chainInfo = null;
+        try {
+            VmwareContext context = hostService.getServiceContext(null);
+            VmwareHypervisorHost hyperHost = hostService.getHyperHost(context, null);
+            VirtualMachineMO vmMo = hyperHost.findVmOnHyperHost(vmName);
+            if (vmMo == null) {
+                vmMo = hyperHost.findVmOnPeerHyperHost(vmName);
+                if (vmMo == null) {
+                    String msg = "Unable to find the VM to execute SyncVolumePathCommand, vmName: " + vmName;
+                    s_logger.error(msg);
+                    throw new Exception(msg);
+                }
+            }
+
+            String datastoreUUID = primaryStore.getUuid();
+            if (disk.getDetails().get(DiskTO.PROTOCOL_TYPE) != null && disk.getDetails().get(DiskTO.PROTOCOL_TYPE).equalsIgnoreCase("DatastoreCluster")) {
+                VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(hyperHost, context, vmMo, disk);
+                VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();
+                if (diskInfoBuilder != null && matchingExistingDisk != null) {
+                    String[] diskChain = matchingExistingDisk.getDiskChain();
+                    assert (diskChain.length > 0);
+                    DatastoreFile file = new DatastoreFile(diskChain[0]);
+                    if (!file.getFileBaseName().equalsIgnoreCase(volumePath)) {
+                        if (s_logger.isInfoEnabled())
+                            s_logger.info("Detected disk-chain top file change on volume: " + volumeTO.getId() + " " + volumePath + " -> " + file.getFileBaseName());
+                        volumePathChangeObserved = true;
+                        volumePath = file.getFileBaseName();
+                        volumeTO.setPath(volumePath);
+                        chainInfo = _gson.toJson(matchingExistingDisk);
+                    }
+
+                    DatastoreMO diskDatastoreMofromVM = getDiskDatastoreMofromVM(hyperHost, context, vmMo, disk, diskInfoBuilder);
+                    if (diskDatastoreMofromVM != null) {
+                        String actualPoolUuid = diskDatastoreMofromVM.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
+                        if (!actualPoolUuid.equalsIgnoreCase(primaryStore.getUuid())) {
+                            s_logger.warn(String.format("Volume %s found to be in a different storage pool %s", volumePath, actualPoolUuid));
+                            datastoreChangeObserved = true;
+                            datastoreUUID = actualPoolUuid;
+                            chainInfo = _gson.toJson(matchingExistingDisk);
+                        }
+                    }
+                }
+            }
+
+            SyncVolumePathAnswer answer = new SyncVolumePathAnswer(disk);
+            if (datastoreChangeObserved) {
+                answer.setContextParam("datastoreName", datastoreUUID);
+            }
+            if (volumePathChangeObserved) {
+                answer.setContextParam("volumePath", volumePath);
+            }
+            if (chainInfo != null && !chainInfo.isEmpty()) {
+                answer.setContextParam("chainInfo", chainInfo);
+            }
+
+            return answer;
+        }  catch (Throwable e) {
+            if (e instanceof RemoteException) {
+                s_logger.warn("Encounter remote exception to vCenter, invalidate VMware session context");
+
+                hostService.invalidateServiceContext(null);
+            }
+
+            return new SyncVolumePathAnswer("Failed to process SyncVolumePathCommand due to " + e.getMessage());
         }
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -3894,7 +3894,7 @@ public class VmwareStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         String primaryStorageNameLabel = cmd.getStoragePool().getUuid();
         String storagePolicyId = cmd.getStoragePolicyId();
         VmwareContext context = hostService.getServiceContext(cmd);
@@ -3966,12 +3966,12 @@ public class VmwareStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+    public Answer syncVolumePath(SyncVolumePathCommand cmd) {
         DiskTO disk = cmd.getDisk();
         VolumeObjectTO volumeTO = (VolumeObjectTO)disk.getData();
         DataStoreTO primaryStore = volumeTO.getDataStore();
         String volumePath = volumeTO.getPath();
-        String vmName = cmd.getVmName();
+        String vmName = volumeTO.getVmName();
 
         boolean datastoreChangeObserved = false;
         boolean volumePathChangeObserved = false;

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -218,15 +218,15 @@ public class XenServerStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         s_logger.info("'CheckDataStoreStoragePolicyComplainceCommand' not applicable used for XenServerStorageProcessor");
         return new Answer(cmd,false,"Not applicable used for XenServerStorageProcessor");
     }
 
     @Override
-    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+    public Answer syncVolumePath(SyncVolumePathCommand cmd) {
         s_logger.info("SyncVolumePathCommand not currently applicable for XenServerStorageProcessor");
-        return new Answer(cmd,false,"Not currently applicable for XenServerStorageProcessor");
+        return new Answer(cmd, false, "Not currently applicable for XenServerStorageProcessor");
     }
 
     @Override

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -50,6 +50,7 @@ import org.apache.cloudstack.storage.command.ResignatureAnswer;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyAnswer;
 import org.apache.cloudstack.storage.command.SnapshotAndCopyCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
@@ -220,6 +221,12 @@ public class XenServerStorageProcessor implements StorageProcessor {
     public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         s_logger.info("'CheckDataStoreStoragePolicyComplainceCommand' not applicable used for XenServerStorageProcessor");
         return new Answer(cmd,false,"Not applicable used for XenServerStorageProcessor");
+    }
+
+    @Override
+    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+        s_logger.info("SyncVolumePathCommand not currently applicable for XenServerStorageProcessor");
+        return new Answer(cmd,false,"Not currently applicable for XenServerStorageProcessor");
     }
 
     @Override

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import org.apache.cloudstack.storage.command.CheckDataStoreStoragePolicyComplainceCommand;
 import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.cloudstack.storage.command.CopyCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
@@ -918,6 +919,12 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
     public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         s_logger.info("'CheckDataStoreStoragePolicyComplainceCommand' not applicable used for XenServerStorageProcessor");
         return new Answer(cmd,false,"Not applicable used for XenServerStorageProcessor");
+    }
+
+    @Override
+    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+        s_logger.info("SyncVolumePathCommand not currently applicable for XenServerStorageProcessor");
+        return new Answer(cmd,false,"Not currently applicable for XenServerStorageProcessor");
     }
 
     @Override

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -916,15 +916,15 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
     }
 
     @Override
-    public Answer CheckDataStoreStoragePolicyComplaince(CheckDataStoreStoragePolicyComplainceCommand cmd) {
+    public Answer checkDataStoreStoragePolicyCompliance(CheckDataStoreStoragePolicyComplainceCommand cmd) {
         s_logger.info("'CheckDataStoreStoragePolicyComplainceCommand' not applicable used for XenServerStorageProcessor");
         return new Answer(cmd,false,"Not applicable used for XenServerStorageProcessor");
     }
 
     @Override
-    public Answer SyncVolumePath(SyncVolumePathCommand cmd) {
+    public Answer syncVolumePath(SyncVolumePathCommand cmd) {
         s_logger.info("SyncVolumePathCommand not currently applicable for XenServerStorageProcessor");
-        return new Answer(cmd,false,"Not currently applicable for XenServerStorageProcessor");
+        return new Answer(cmd, false, "Not currently applicable for XenServerStorageProcessor");
     }
 
     @Override

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -204,6 +204,7 @@ import org.apache.cloudstack.api.command.admin.storage.PreparePrimaryStorageForM
 import org.apache.cloudstack.api.command.admin.storage.UpdateCloudToUseObjectStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateImageStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateStoragePoolCmd;
+import org.apache.cloudstack.api.command.admin.storage.SyncStoragePoolCmd;
 import org.apache.cloudstack.api.command.admin.swift.AddSwiftCmd;
 import org.apache.cloudstack.api.command.admin.swift.ListSwiftsCmd;
 import org.apache.cloudstack.api.command.admin.systemvm.DestroySystemVmCmd;
@@ -3015,6 +3016,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(FindStoragePoolsForMigrationCmd.class);
         cmdList.add(PreparePrimaryStorageForMaintenanceCmd.class);
         cmdList.add(UpdateStoragePoolCmd.class);
+        cmdList.add(SyncStoragePoolCmd.class);
         cmdList.add(UpdateImageStoreCmd.class);
         cmdList.add(DestroySystemVmCmd.class);
         cmdList.add(ListSystemVMsCmd.class);

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -52,6 +53,7 @@ import org.apache.cloudstack.api.command.admin.storage.DeleteImageStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.DeletePoolCmd;
 import org.apache.cloudstack.api.command.admin.storage.DeleteSecondaryStagingStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateStoragePoolCmd;
+import org.apache.cloudstack.api.command.admin.storage.SyncStoragePoolCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.ClusterScope;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -90,6 +92,8 @@ import org.apache.cloudstack.management.ManagementServerHost;
 import org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDao;
 import org.apache.cloudstack.storage.command.CheckDataStoreStoragePolicyComplainceCommand;
 import org.apache.cloudstack.storage.command.DettachCommand;
+import org.apache.cloudstack.storage.command.SyncVolumePathAnswer;
+import org.apache.cloudstack.storage.command.SyncVolumePathCommand;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
@@ -104,6 +108,7 @@ import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreVO;
 import org.apache.cloudstack.storage.image.datastore.ImageStoreEntity;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -114,6 +119,8 @@ import com.cloud.agent.api.DeleteStoragePoolCommand;
 import com.cloud.agent.api.StoragePoolInfo;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.DiskTO;
+import com.cloud.agent.api.ModifyStoragePoolCommand;
+import com.cloud.agent.api.ModifyStoragePoolAnswer;
 import com.cloud.agent.manager.Commands;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.TemplateJoinDao;
@@ -1631,6 +1638,223 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         lifeCycle.cancelMaintain(store);
 
         return (PrimaryDataStoreInfo)_dataStoreMgr.getDataStore(primaryStorage.getId(), DataStoreRole.Primary);
+    }
+
+    @Override
+    @ActionEvent(eventType = EventTypes.EVENT_SYNC_STORAGE_POOL, eventDescription = "synchronising storage pool with management server", async = true)
+    public StoragePool syncStoragePool(SyncStoragePoolCmd cmd) {
+        Long poolId = cmd.getPoolId();
+        StoragePoolVO pool = _storagePoolDao.findById(poolId);
+
+        if (pool == null) {
+            String msg = "Unable to obtain lock on the storage pool record while syncing storage pool with management server";
+            s_logger.error(msg);
+            throw new InvalidParameterValueException(msg);
+        }
+
+        if (!pool.getPoolType().equals(StoragePoolType.DatastoreCluster)) {
+            throw new InvalidParameterValueException(String.format("SyncStoragePool API is currently supported only for storage type of datastore cluster"));
+        }
+
+        if (!pool.getStatus().equals(StoragePoolStatus.Up)) {
+            throw new InvalidParameterValueException(String.format("Primary storage with id %s is not ready for syncing, as the status is %s", pool.getUuid(), pool.getStatus().toString()));
+        }
+
+        // find the host
+        List<Long> poolIds = new ArrayList<>();
+        poolIds.add(poolId);
+        List<Long> hosts = _storagePoolHostDao.findHostsConnectedToPools(poolIds);
+        if (hosts.size() > 0) {
+            Long hostId = hosts.get(0);
+            ModifyStoragePoolCommand modifyStoragePoolCommand = new ModifyStoragePoolCommand(true, pool);
+            final Answer answer = _agentMgr.easySend(hostId, modifyStoragePoolCommand);
+
+            if (answer == null) {
+                throw new CloudRuntimeException("Unable to get an answer to the modify storage pool command" + pool.getId());
+            }
+
+            if (!answer.getResult()) {
+                String msg = "Unable to process ModifyStoragePoolCommand for " + poolId + " to the host" + hostId;
+                throw new CloudRuntimeException("Unable establish connection from storage head to storage pool " + pool.getId() + " due to " + answer.getDetails() +
+                        pool.getId());
+            }
+
+            assert (answer instanceof ModifyStoragePoolAnswer) : "Well, now why won't you actually return the ModifyStoragePoolAnswer when it's ModifyStoragePoolCommand? Pool=" +
+                    pool.getId() + "Host=" + hostId;
+            ModifyStoragePoolAnswer mspAnswer = (ModifyStoragePoolAnswer) answer;
+            StoragePoolVO poolVO = _storagePoolDao.findById(poolId);
+            updateStoragePoolHostVOAndBytes(poolVO, hostId, mspAnswer);
+            syncDatastoreClusterStoragePool(poolId, mspAnswer.getDatastoreClusterChildren(), hostId);
+            for (ModifyStoragePoolAnswer childDataStoreAnswer : mspAnswer.getDatastoreClusterChildren()) {
+                StoragePoolInfo childStoragePoolInfo = childDataStoreAnswer.getPoolInfo();
+                StoragePoolVO dataStoreVO = _storagePoolDao.findPoolByUUID(childStoragePoolInfo.getUuid());
+                for (Long host : hosts) {
+                    updateStoragePoolHostVOAndBytes(dataStoreVO, host, childDataStoreAnswer);
+                }
+            }
+
+        }
+        return (PrimaryDataStoreInfo) _dataStoreMgr.getDataStore(pool.getId(), DataStoreRole.Primary);
+    }
+
+    public void syncDatastoreClusterStoragePool(long datastoreClusterPoolId, List<ModifyStoragePoolAnswer> childDatastoreAnswerList, long hostId) {
+        StoragePoolVO datastoreClusterPool = _storagePoolDao.findById(datastoreClusterPoolId);
+        List<String> storageTags = _storagePoolTagsDao.getStoragePoolTags(datastoreClusterPoolId);
+        List<StoragePoolVO> childDatastores = _storagePoolDao.listChildStoragePoolsInDatastoreCluster(datastoreClusterPoolId);
+        Set<String> childDatastoreUUIDs = new HashSet<>();
+        for (StoragePoolVO childDatastore : childDatastores) {
+            childDatastoreUUIDs.add(childDatastore.getUuid());
+        }
+
+        for (ModifyStoragePoolAnswer childDataStoreAnswer : childDatastoreAnswerList) {
+            StoragePoolInfo childStoragePoolInfo = childDataStoreAnswer.getPoolInfo();
+            StoragePoolVO dataStoreVO = _storagePoolDao.findPoolByUUID(childStoragePoolInfo.getUuid());
+            if (dataStoreVO != null) {
+                if (dataStoreVO.getParent() != datastoreClusterPoolId) {
+                    s_logger.debug(String.format("Storage pool %s with uuid %s is found to be under datastore cluster %s at vCenter, " +
+                                    "so moving the storage pool to be a child storage pool under the datastore cluster in CloudStack management server",
+                            childStoragePoolInfo.getName(), childStoragePoolInfo.getUuid(), datastoreClusterPool.getName()));
+                    dataStoreVO.setParent(datastoreClusterPoolId);
+                    _storagePoolDao.update(dataStoreVO.getId(), dataStoreVO);
+                    if (CollectionUtils.isNotEmpty(storageTags)) {
+                        storageTags.addAll(_storagePoolTagsDao.getStoragePoolTags(dataStoreVO.getId()));
+                    } else {
+                        storageTags = _storagePoolTagsDao.getStoragePoolTags(dataStoreVO.getId());
+                    }
+                    if (CollectionUtils.isNotEmpty(storageTags)) {
+                        if (s_logger.isDebugEnabled()) {
+                            s_logger.debug("Updating Storage Pool Tags to :" + storageTags);
+                        }
+                        _storagePoolTagsDao.persist(dataStoreVO.getId(), storageTags);
+                    }
+                } else {
+                    // This is to find datastores which are removed from datastore cluster.
+                    // The final set childDatastoreUUIDs contains the UUIDs of child datastores which needs to be removed from datastore cluster
+                    childDatastoreUUIDs.remove(childStoragePoolInfo.getUuid());
+                }
+            } else {
+                dataStoreVO = createChildDatastoreVO(datastoreClusterPool, childDataStoreAnswer);
+            }
+            updateStoragePoolHostVOAndBytes(dataStoreVO, hostId, childDataStoreAnswer);
+        }
+
+        handleRemoveChildStoragePoolFromDatastoreCluster(childDatastoreUUIDs);
+    }
+
+    private StoragePoolVO createChildDatastoreVO(StoragePoolVO datastoreClusterPool, ModifyStoragePoolAnswer childDataStoreAnswer) {
+        StoragePoolInfo childStoragePoolInfo = childDataStoreAnswer.getPoolInfo();
+        List<String> storageTags = _storagePoolTagsDao.getStoragePoolTags(datastoreClusterPool.getId());
+
+        StoragePoolVO dataStoreVO = new StoragePoolVO();
+        dataStoreVO.setStorageProviderName(datastoreClusterPool.getStorageProviderName());
+        dataStoreVO.setHostAddress(childStoragePoolInfo.getHost());
+        dataStoreVO.setPoolType(Storage.StoragePoolType.PreSetup);
+        dataStoreVO.setPath(childStoragePoolInfo.getHostPath());
+        dataStoreVO.setPort(datastoreClusterPool.getPort());
+        dataStoreVO.setName(childStoragePoolInfo.getName());
+        dataStoreVO.setUuid(childStoragePoolInfo.getUuid());
+        dataStoreVO.setDataCenterId(datastoreClusterPool.getDataCenterId());
+        dataStoreVO.setPodId(datastoreClusterPool.getPodId());
+        dataStoreVO.setClusterId(datastoreClusterPool.getClusterId());
+        dataStoreVO.setStatus(StoragePoolStatus.Up);
+        dataStoreVO.setUserInfo(datastoreClusterPool.getUserInfo());
+        dataStoreVO.setManaged(datastoreClusterPool.isManaged());
+        dataStoreVO.setCapacityIops(datastoreClusterPool.getCapacityIops());
+        dataStoreVO.setCapacityBytes(childDataStoreAnswer.getPoolInfo().getCapacityBytes());
+        dataStoreVO.setUsedBytes(childDataStoreAnswer.getPoolInfo().getCapacityBytes() - childDataStoreAnswer.getPoolInfo().getAvailableBytes());
+        dataStoreVO.setHypervisor(datastoreClusterPool.getHypervisor());
+        dataStoreVO.setScope(datastoreClusterPool.getScope());
+        dataStoreVO.setParent(datastoreClusterPool.getId());
+
+        Map<String, String> details = new HashMap<>();
+        if(org.apache.commons.lang.StringUtils.isNotEmpty(childDataStoreAnswer.getPoolType())) {
+            details.put("pool_type", childDataStoreAnswer.getPoolType());
+        }
+        _storagePoolDao.persist(dataStoreVO, details, storageTags);
+        return dataStoreVO;
+    }
+
+    private void handleRemoveChildStoragePoolFromDatastoreCluster(Set<String> childDatastoreUUIDs) {
+
+        for (String childDatastoreUUID : childDatastoreUUIDs) {
+            StoragePoolVO dataStoreVO = _storagePoolDao.findPoolByUUID(childDatastoreUUID);
+            List<VolumeVO> allVolumes = _volumeDao.findByPoolId(dataStoreVO.getId());
+
+            for (VolumeVO volume : allVolumes) {
+                VMInstanceVO vmInstance = _vmInstanceDao.findById(volume.getInstanceId());
+                if (vmInstance == null) {
+                    continue;
+                }
+                long volumeId = volume.getId();
+                Long hostId = vmInstance.getHostId();
+                if (hostId == null) {
+                    hostId = vmInstance.getLastHostId();
+                }
+
+                // Prepare for the syncvolumepath command
+                DataTO volTO = volFactory.getVolume(volume.getId()).getTO();
+                DiskTO disk = new DiskTO(volTO, volume.getDeviceId(), volume.getPath(), volume.getVolumeType());
+                Map<String, String> details = new HashMap<String, String>();
+                details.put(DiskTO.PROTOCOL_TYPE, Storage.StoragePoolType.DatastoreCluster.toString());
+                disk.setDetails(details);
+
+                SyncVolumePathCommand cmd = new SyncVolumePathCommand(disk, vmInstance.getInstanceName());
+                final Answer answer = _agentMgr.easySend(hostId, cmd);
+                // validate answer
+                if (answer == null) {
+                    throw new CloudRuntimeException("Unable to get an answer to the SyncVolumePath command for volume " + volumeId);
+                }
+                if (!answer.getResult()) {
+                    String msg = "Unable to process SyncVolumePathCommand for the volume" + volumeId + " to the host" + hostId;
+                    throw new CloudRuntimeException("Unable to process SyncVolumePathCommand for the volume" + volumeId + " to the host " + hostId + " due to " + answer.getDetails());
+                }
+                assert (answer instanceof SyncVolumePathAnswer) : "Well, now why won't you actually return the SyncVolumePathAnswer when it's SyncVolumePathCommand? volume=" +
+                        volume.getUuid() + "Host=" + hostId;
+
+                // check for the changed details of volume and update database
+                VolumeVO volumeVO = _volumeDao.findById(volumeId);
+                String datastoreName = answer.getContextParam("datastoreName");
+                if (datastoreName != null) {
+                    StoragePoolVO storagePoolVO = _storagePoolDao.findByUuid(datastoreName);
+                    if (storagePoolVO != null) {
+                        volumeVO.setPoolId(storagePoolVO.getId());
+                    } else {
+                        s_logger.warn(String.format("Unable to find datastore %s while updating the new datastore of the volume %d", datastoreName, volumeId));
+                    }
+                }
+
+                String volumePath = answer.getContextParam("volumePath");
+                if (volumePath != null) {
+                    volumeVO.setPath(volumePath);
+                }
+
+                String chainInfo = answer.getContextParam("chainInfo");
+                if (chainInfo != null) {
+                    volumeVO.setChainInfo(chainInfo);
+                }
+
+                _volumeDao.update(volumeVO.getId(), volumeVO);
+            }
+            dataStoreVO.setParent(0L);
+            _storagePoolDao.update(dataStoreVO.getId(), dataStoreVO);
+        }
+
+    }
+
+    private void updateStoragePoolHostVOAndBytes(StoragePool pool, long hostId, ModifyStoragePoolAnswer mspAnswer) {
+        StoragePoolHostVO poolHost = _storagePoolHostDao.findByPoolHost(pool.getId(), hostId);
+        if (poolHost == null) {
+            poolHost = new StoragePoolHostVO(pool.getId(), hostId, mspAnswer.getPoolInfo().getLocalPath().replaceAll("//", "/"));
+            _storagePoolHostDao.persist(poolHost);
+        } else {
+            poolHost.setLocalPath(mspAnswer.getPoolInfo().getLocalPath().replaceAll("//", "/"));
+        }
+
+        StoragePoolVO poolVO = _storagePoolDao.findById(pool.getId());
+        poolVO.setUsedBytes(mspAnswer.getPoolInfo().getCapacityBytes() - mspAnswer.getPoolInfo().getAvailableBytes());
+        poolVO.setCapacityBytes(mspAnswer.getPoolInfo().getCapacityBytes());
+
+        _storagePoolDao.update(pool.getId(), poolVO);
     }
 
     protected class StorageGarbageCollector extends ManagedContextRunnable {

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -1791,6 +1791,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 if (hostId == null) {
                     hostId = vmInstance.getLastHostId();
                 }
+                HostVO hostVO = _hostDao.findById(hostId);
 
                 // Prepare for the syncvolumepath command
                 DataTO volTO = volFactory.getVolume(volume.getId()).getTO();
@@ -1799,6 +1800,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 details.put(DiskTO.PROTOCOL_TYPE, Storage.StoragePoolType.DatastoreCluster.toString());
                 disk.setDetails(details);
 
+                s_logger.debug(String.format("Attempting to process SyncVolumePathCommand for the volume %d on the host %d with state %s", volumeId, hostId, hostVO.getResourceState()));
                 SyncVolumePathCommand cmd = new SyncVolumePathCommand(disk);
                 final Answer answer = _agentMgr.easySend(hostId, cmd);
                 // validate answer
@@ -1806,7 +1808,6 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                     throw new CloudRuntimeException("Unable to get an answer to the SyncVolumePath command for volume " + volumeId);
                 }
                 if (!answer.getResult()) {
-                    String msg = "Unable to process SyncVolumePathCommand for the volume" + volumeId + " to the host" + hostId;
                     throw new CloudRuntimeException("Unable to process SyncVolumePathCommand for the volume" + volumeId + " to the host " + hostId + " due to " + answer.getDetails());
                 }
                 assert (answer instanceof SyncVolumePathAnswer) : "Well, now why won't you actually return the SyncVolumePathAnswer when it's SyncVolumePathCommand? volume=" +

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.LinkedHashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -1722,6 +1723,9 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                         storageTags = _storagePoolTagsDao.getStoragePoolTags(dataStoreVO.getId());
                     }
                     if (CollectionUtils.isNotEmpty(storageTags)) {
+                        Set<String> set = new LinkedHashSet<>(storageTags);
+                        storageTags.clear();
+                        storageTags.addAll(set);
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("Updating Storage Pool Tags to :" + storageTags);
                         }

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -1670,13 +1670,11 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             final Answer answer = _agentMgr.easySend(hostId, modifyStoragePoolCommand);
 
             if (answer == null) {
-                throw new CloudRuntimeException("Unable to get an answer to the modify storage pool command" + pool.getId());
+                throw new CloudRuntimeException(String.format("Unable to get an answer to the modify storage pool command %s", pool.getUuid()));
             }
 
             if (!answer.getResult()) {
-                String msg = "Unable to process ModifyStoragePoolCommand for " + poolId + " to the host" + hostId;
-                throw new CloudRuntimeException("Unable establish connection from storage head to storage pool " + pool.getId() + " due to " + answer.getDetails() +
-                        pool.getId());
+                throw new CloudRuntimeException(String.format("Unable to process ModifyStoragePoolCommand for pool %s on the host %s due to ", pool.getUuid(), hostId, answer.getDetails()));
             }
 
             assert (answer instanceof ModifyStoragePoolAnswer) : "Well, now why won't you actually return the ModifyStoragePoolAnswer when it's ModifyStoragePoolCommand? Pool=" +

--- a/server/src/main/java/com/cloud/storage/StoragePoolAutomationImpl.java
+++ b/server/src/main/java/com/cloud/storage/StoragePoolAutomationImpl.java
@@ -166,7 +166,7 @@ public class StoragePoolAutomationImpl implements StoragePoolAutomation {
                         s_logger.debug("ModifyStoragePool false succeeded");
                     }
                     if (pool.getPoolType() == Storage.StoragePoolType.DatastoreCluster) {
-                        s_logger.debug(String.format("Started synchronising datastore cluster storage pool %s with vCenter", pool.getUuid());
+                        s_logger.debug(String.format("Started synchronising datastore cluster storage pool %s with vCenter", pool.getUuid()));
                         storageManager.syncDatastoreClusterStoragePool(pool.getId(), ((ModifyStoragePoolAnswer) answer).getDatastoreClusterChildren(), host.getId());
                     }
                 }
@@ -331,7 +331,7 @@ public class StoragePoolAutomationImpl implements StoragePoolAutomation {
                     s_logger.debug("ModifyStoragePool add succeeded");
                 }
                 if (pool.getPoolType() == Storage.StoragePoolType.DatastoreCluster) {
-                    s_logger.debug(String.format("Started synchronising datastore cluster storage pool %s with vCenter", pool.getUuid());
+                    s_logger.debug(String.format("Started synchronising datastore cluster storage pool %s with vCenter", pool.getUuid()));
                     storageManager.syncDatastoreClusterStoragePool(pool.getId(), ((ModifyStoragePoolAnswer) answer).getDatastoreClusterChildren(), host.getId());
                 }
             }

--- a/server/src/main/java/com/cloud/storage/StoragePoolAutomationImpl.java
+++ b/server/src/main/java/com/cloud/storage/StoragePoolAutomationImpl.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.ModifyStoragePoolCommand;
+import com.cloud.agent.api.ModifyStoragePoolAnswer;
 import com.cloud.alert.AlertManager;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
@@ -100,6 +101,8 @@ public class StoragePoolAutomationImpl implements StoragePoolAutomation {
     ManagementServer server;
     @Inject
     DataStoreProviderManager providerMgr;
+    @Inject
+    StorageManager storageManager;
 
     @Override
     public boolean maintain(DataStore store) {
@@ -161,6 +164,10 @@ public class StoragePoolAutomationImpl implements StoragePoolAutomation {
                 } else {
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("ModifyStoragePool false succeeded");
+                    }
+                    if (pool.getPoolType() == Storage.StoragePoolType.DatastoreCluster) {
+                        s_logger.debug(String.format("Started synchronising datastore cluster storage pool %s with vCenter", pool.getUuid());
+                        storageManager.syncDatastoreClusterStoragePool(pool.getId(), ((ModifyStoragePoolAnswer) answer).getDatastoreClusterChildren(), host.getId());
                     }
                 }
             }
@@ -322,6 +329,10 @@ public class StoragePoolAutomationImpl implements StoragePoolAutomation {
             } else {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("ModifyStoragePool add succeeded");
+                }
+                if (pool.getPoolType() == Storage.StoragePoolType.DatastoreCluster) {
+                    s_logger.debug(String.format("Started synchronising datastore cluster storage pool %s with vCenter", pool.getUuid());
+                    storageManager.syncDatastoreClusterStoragePool(pool.getId(), ((ModifyStoragePoolAnswer) answer).getDatastoreClusterChildren(), host.getId());
                 }
             }
         }

--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -95,7 +95,7 @@ known_categories = {
     'StorageMaintenance': 'Storage Pool',
     'StoragePool': 'Storage Pool',
     'StorageProvider': 'Storage Pool',
-    'SyncStoragePool': 'Storage Pool',
+    'syncStoragePool': 'Storage Pool',
     'SecurityGroup': 'Security Group',
     'SSH': 'SSH',
     'register': 'Registration',

--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -95,6 +95,7 @@ known_categories = {
     'StorageMaintenance': 'Storage Pool',
     'StoragePool': 'Storage Pool',
     'StorageProvider': 'Storage Pool',
+    'SyncStoragePool': 'Storage Pool',
     'SecurityGroup': 'Security Group',
     'SSH': 'SSH',
     'register': 'Registration',


### PR DESCRIPTION

### Description

Datastore cluster as a primary storage support is already there. But if any changes at vCenter to datastore cluster like addition/removal of datastore is not synchronised with CloudStack directly. It needs removal of primary storage from CloudStack and add it again to CloudStack.

Here synchronisation of datastore cluster is fixed without need to remove or add the datastore cluster.
1. A new API is introduced syncStoragePool which takes datastore cluster storage pool UUID as the parameter. This API checks if there any changes in the datastore cluster and updates management server accordingly.
2. During synchronisation if a new child datastore is found in datastore cluster, then management server will create a new child storage pool in database under the datastore cluster. If the new child storage pool is already added as an individual storage pool then the existing storage pool entry will be converted to child storage pool (instead of creating a new storage pool entry)
3. During synchronisaton if the existing child datastore in CloudStack is found to be removed on vCenter then management server removes that child datastore from datastore cluster and makes it an individual storage pool.
The above behaviour is on par with the vCenter behaviour when adding and removing child datastore.<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Added datastore cluster with two child datastores as a primary storage pool into CloudStack
Case 1: Removal of child datastore from vCenter
1. Take out one child datastore from datastore cluster on vCenter   
2. Call syncStoragePool API on the datastore cluster
3. child datastore from CloudStack is removed from datastore cluster and made it as an individual storage pool

Case 2: Addition of new datastore into datastore cluster from vCenter
1. Add a new storage pool to the datastore cluster on vCenter
2. Call syncStoragePool API on the datastore cluster
3. A new child datastore is created under datastore cluster in CloudStack

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
