### PR TITLE
Fix no "data-server" DNS record for VPC router

### DIFF
--- a/systemvm/debian/etc/vpcdnsmasq.conf
+++ b/systemvm/debian/etc/vpcdnsmasq.conf
@@ -462,3 +462,4 @@ log-facility=/var/log/dnsmasq.log
 conf-dir=/etc/dnsmasq.d
 
 dhcp-optsfile=/etc/dhcpopts.txt
+localise-queries

--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -127,6 +127,9 @@ class CsDhcp(CsDataBag):
                 listen_address.append(gateway)
             else:
                 listen_address.append(ip)
+            # Add localized "data-server" records in /etc/hosts for VPC routers
+            if self.config.is_vpc():
+                self.add_host(gateway, "%s data-server" % CsHelper.get_hostname())
             idx += 1
 
         # Listen Address


### PR DESCRIPTION
### Description

This PR adds the capability to VPC VR to answer "data-server" DNS queries based on the source IP of the VM.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
1. Creates a new record for "data-server" translated to VR IP of newly create subnet in /etc/hosts file
2. Configure dnsmasq to send response of "data-server" query based on source IP of VM
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
##### STEPS TO REPRODUCE
<!--
For bugs, show exactly how to reproduce the problem, using a minimal test-case. Use Screenshots if accurate.

For new features, show how the feature would be used.
-->

<!-- Paste example playbooks or commands between quotes below -->
~~~
1. Create a VPC
2. Add an isolated network with UserData service with VirtualRouter as provider
3. Create a VM in this network
4. Run "nslookup data-server" command from inside of VM
5. Run "cat /etc/hosts" command from inside of VR
~~~

<!-- You can also paste gist.github.com links for larger files -->

##### EXPECTED RESULTS
<!-- What did you expect to happen when running the steps above? -->

~~~
Running "nslookup data-server" command returns IP address of router
Running "cat /etc/hosts" command from inside of VR shows "data-server" record and the VR NIC IP
~~~

##### ACTUAL RESULTS
<!-- What actually happened? -->

<!-- Paste verbatim command output between quotes below -->
~~~
Running "nslookup data-server" command returns "No answer"
The result of running "cat /etc/hosts" command from inside of VR, don't have any record about "data-server"
~~~


<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #4865 
<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/39186039/112468412-d7770380-8d85-11eb-83c6-2889a22b5905.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Apply the patch directly to VPC VR.
Add new subnet to VR, then add a new VM and check the record existance.
Restart VPC and check recreation of records.
Remove all VMs from the subnet and check the record is deleted.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
