### PR TITLE
Externalize OOBM background task's interval

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementService.java
+++ b/api/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementService.java
@@ -33,6 +33,9 @@ public interface OutOfBandManagementService {
     ConfigKey<Integer> SyncThreadPoolSize = new ConfigKey<Integer>("Advanced", Integer.class, "outofbandmanagement.sync.poolsize", "50",
             "The out of band management background sync thread pool size", true, ConfigKey.Scope.Global);
 
+    ConfigKey<Integer> outOfBandManagementBackgroundTaskExecutionInterval = new ConfigKey<>("Advanced", Integer.class, "outofbandmanagement.background.task.execution.interval", "4",
+            "The interval in seconds for the out of band management (OOBM) background task.", true);
+
     long getId();
     boolean isOutOfBandManagementEnabled(Host host);
     void submitBackgroundPowerSyncTask(Host host);

--- a/api/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementService.java
+++ b/api/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementService.java
@@ -33,7 +33,7 @@ public interface OutOfBandManagementService {
     ConfigKey<Integer> SyncThreadPoolSize = new ConfigKey<Integer>("Advanced", Integer.class, "outofbandmanagement.sync.poolsize", "50",
             "The out of band management background sync thread pool size", true, ConfigKey.Scope.Global);
 
-    ConfigKey<Integer> outOfBandManagementBackgroundTaskExecutionInterval = new ConfigKey<>("Advanced", Integer.class, "outofbandmanagement.background.task.execution.interval", "4",
+    ConfigKey<Integer> OutOfBandManagementBackgroundTaskExecutionInterval = new ConfigKey<>("Advanced", Integer.class, "outofbandmanagement.background.task.execution.interval", "4",
             "The interval in seconds for the out of band management (OOBM) background task.", true);
 
     long getId();

--- a/server/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementServiceImpl.java
@@ -534,7 +534,7 @@ public class OutOfBandManagementServiceImpl extends ManagerBase implements OutOf
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ActionTimeout, SyncThreadPoolSize, outOfBandManagementBackgroundTaskExecutionInterval};
+        return new ConfigKey<?>[] {ActionTimeout, SyncThreadPoolSize, OutOfBandManagementBackgroundTaskExecutionInterval};
     }
 
     public List<OutOfBandManagementDriver> getOutOfBandManagementDrivers() {
@@ -578,7 +578,7 @@ public class OutOfBandManagementServiceImpl extends ManagerBase implements OutOf
 
         @Override
         public Long getDelay() {
-            return outOfBandManagementBackgroundTaskExecutionInterval.value() * 1000L;
+            return OutOfBandManagementBackgroundTaskExecutionInterval.value() * 1000L;
         }
 
     }

--- a/server/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/outofbandmanagement/OutOfBandManagementServiceImpl.java
@@ -534,7 +534,7 @@ public class OutOfBandManagementServiceImpl extends ManagerBase implements OutOf
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ActionTimeout, SyncThreadPoolSize};
+        return new ConfigKey<?>[] {ActionTimeout, SyncThreadPoolSize, outOfBandManagementBackgroundTaskExecutionInterval};
     }
 
     public List<OutOfBandManagementDriver> getOutOfBandManagementDrivers() {
@@ -578,7 +578,7 @@ public class OutOfBandManagementServiceImpl extends ManagerBase implements OutOf
 
         @Override
         public Long getDelay() {
-            return null;
+            return outOfBandManagementBackgroundTaskExecutionInterval.value() * 1000L;
         }
 
     }


### PR DESCRIPTION
### Description
On `BackgroundPollManagerImpl`, each submitted task needs to implement delay's configuration; otherwise it will assume the delay (which acts like the execution interval, not an actual delay) `4000ms` (hardcoded).

This PR intends to externalize the OOBM delay's configuration.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?

It has been tested locally on a test lab.
1. I enabled a zone;
2. i configured the OOBM in the host;
2. I observed the log. It will log in intervals according to the configuration set.