### PR TITLE
host-allocator: check capacity for suitable hosts 

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
@@ -22,8 +22,10 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 
 import com.cloud.host.Host;
+import com.cloud.offering.ServiceOffering;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.storage.VMTemplateVO;
+import com.cloud.utils.Pair;
 import com.cloud.vm.VirtualMachine;
 
 /**
@@ -141,4 +143,6 @@ public interface CapacityManager {
     long getUsedBytes(StoragePoolVO pool);
 
     long getUsedIops(StoragePoolVO pool);
+
+    Pair<Boolean, Boolean> checkIfHostHasCpuCapabilityAndCapacity(Host host, ServiceOffering offering, boolean considerReservedCapacity);
 }

--- a/plugins/host-allocators/random/src/main/java/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
+++ b/plugins/host-allocators/random/src/main/java/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -56,44 +57,46 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
     @Inject
     private CapacityManager capacityManager;
 
-    @Override
-    public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type, ExcludeList avoid, int returnUpTo) {
-        return allocateTo(vmProfile, plan, type, avoid, returnUpTo, true);
-    }
-
-    @Override
-    public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type, ExcludeList avoid, List<? extends Host> hosts, int returnUpTo,
-        boolean considerReservedCapacity) {
+    private List<Host> findSuitableHosts(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type,
+                                         ExcludeList avoid, List<? extends Host> hosts, int returnUpTo,
+                                         boolean considerReservedCapacity) {
         long dcId = plan.getDataCenterId();
         Long podId = plan.getPodId();
         Long clusterId = plan.getClusterId();
         ServiceOffering offering = vmProfile.getServiceOffering();
+        List<? extends Host> hostsCopy = null;
         List<Host> suitableHosts = new ArrayList<Host>();
-        List<Host> hostsCopy = new ArrayList<Host>(hosts);
 
         if (type == Host.Type.Storage) {
             return suitableHosts;
         }
-
         String hostTag = offering.getHostTag();
         if (hostTag != null) {
             s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId + " having host tag:" + hostTag);
         } else {
             s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
         }
-
-        // list all computing hosts, regardless of whether they support routing...it's random after all
-        if (hostTag != null) {
-            hostsCopy.retainAll(_hostDao.listByHostTag(type, clusterId, podId, dcId, hostTag));
+        if (hosts != null) {
+            // retain all computing hosts, regardless of whether they support routing...it's random after all
+            hostsCopy = new ArrayList<Host>(hosts);
+            if (hostTag != null) {
+                hostsCopy.retainAll(_hostDao.listByHostTag(type, clusterId, podId, dcId, hostTag));
+            } else {
+                hostsCopy.retainAll(_resourceMgr.listAllUpAndEnabledHosts(type, clusterId, podId, dcId));
+            }
         } else {
-            hostsCopy.retainAll(_resourceMgr.listAllUpAndEnabledHosts(type, clusterId, podId, dcId));
+            // list all computing hosts, regardless of whether they support routing...it's random after all
+            hostsCopy = new ArrayList<HostVO>();
+            if (hostTag != null) {
+                hostsCopy = _hostDao.listByHostTag(type, clusterId, podId, dcId, hostTag);
+            } else {
+                hostsCopy = _resourceMgr.listAllUpAndEnabledHosts(type, clusterId, podId, dcId);
+            }
         }
-
         s_logger.debug("Random Allocator found " + hostsCopy.size() + "  hosts");
         if (hostsCopy.size() == 0) {
             return suitableHosts;
         }
-
         Collections.shuffle(hostsCopy);
         for (Host host : hostsCopy) {
             if (suitableHosts.size() == returnUpTo) {
@@ -117,76 +120,34 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             }
             suitableHosts.add(host);
         }
-
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");
         }
-
         return suitableHosts;
     }
 
     @Override
-    public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type, ExcludeList avoid, int returnUpTo, boolean considerReservedCapacity) {
+    public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type, ExcludeList avoid, int returnUpTo) {
+        return allocateTo(vmProfile, plan, type, avoid, returnUpTo, true);
+    }
 
-        long dcId = plan.getDataCenterId();
-        Long podId = plan.getPodId();
-        Long clusterId = plan.getClusterId();
-        ServiceOffering offering = vmProfile.getServiceOffering();
-
-        List<Host> suitableHosts = new ArrayList<Host>();
-
-        if (type == Host.Type.Storage) {
-            return suitableHosts;
-        }
-
-        String hostTag = offering.getHostTag();
-        if (hostTag != null) {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId + " having host tag:" + hostTag);
-        } else {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
-        }
-
-        // list all computing hosts, regardless of whether they support routing...it's random after all
-        List<? extends Host> hosts = new ArrayList<HostVO>();
-        if (hostTag != null) {
-            hosts = _hostDao.listByHostTag(type, clusterId, podId, dcId, hostTag);
-        } else {
-            hosts = _resourceMgr.listAllUpAndEnabledHosts(type, clusterId, podId, dcId);
-        }
-
-        s_logger.debug("Random Allocator found " + hosts.size() + "  hosts");
-
-        if (hosts.size() == 0) {
-            return suitableHosts;
-        }
-
-        Collections.shuffle(hosts);
-        for (Host host : hosts) {
-            if (suitableHosts.size() == returnUpTo) {
-                break;
-            }
-            if (avoid.shouldAvoid(host)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
-                }
-                continue;
-            }
-            Pair<Boolean, Boolean> cpuCapabilityAndCapacity = capacityManager.checkIfHostHasCpuCapabilityAndCapacity(host, offering, considerReservedCapacity);
-            if (!cpuCapabilityAndCapacity.first() || !cpuCapabilityAndCapacity.second()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Not using host " + host.getId() + "; host has cpu capability? " + cpuCapabilityAndCapacity.first() + ", host has capacity?" + cpuCapabilityAndCapacity.second());
-                }
-                continue;
-            }
+    @Override
+    public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type,
+                                 ExcludeList avoid, List<? extends Host> hosts, int returnUpTo,
+                                 boolean considerReservedCapacity) {
+        if (CollectionUtils.isEmpty(hosts)) {
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Found a suitable host, adding to list: " + host.getId());
+                s_logger.debug("Random Allocator found 0 hosts as given host list is empty");
             }
-            suitableHosts.add(host);
+            return new ArrayList<Host>();
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");
-        }
-        return suitableHosts;
+        return findSuitableHosts(vmProfile, plan, type, avoid, hosts, returnUpTo, considerReservedCapacity);
+    }
+
+    @Override
+    public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan,
+                                 Type type, ExcludeList avoid, int returnUpTo, boolean considerReservedCapacity) {
+        return findSuitableHosts(vmProfile, plan, type, avoid, null, returnUpTo, considerReservedCapacity);
     }
 
     @Override

--- a/plugins/host-allocators/random/src/main/java/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
+++ b/plugins/host-allocators/random/src/main/java/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
@@ -26,6 +26,10 @@ import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.manager.allocator.HostAllocator;
+import com.cloud.capacity.CapacityManager;
+import com.cloud.dc.ClusterDetailsDao;
+import com.cloud.dc.ClusterDetailsVO;
+import com.cloud.dc.dao.ClusterDao;
 import com.cloud.deploy.DeploymentPlan;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.host.Host;
@@ -33,6 +37,7 @@ import com.cloud.host.Host.Type;
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
 import com.cloud.offering.ServiceOffering;
+import com.cloud.org.Cluster;
 import com.cloud.resource.ResourceManager;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.vm.VirtualMachine;
@@ -45,6 +50,28 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
     private HostDao _hostDao;
     @Inject
     private ResourceManager _resourceMgr;
+    @Inject
+    private ClusterDao clusterDao;
+    @Inject
+    private ClusterDetailsDao clusterDetailsDao;
+    @Inject
+    private CapacityManager capacityManager;
+
+    private boolean checkHostCapacity(Host host, ServiceOffering offering, boolean considerReservedCapacity) {
+        int cpu_requested = offering.getCpu() * offering.getSpeed();
+        long ram_requested = offering.getRamSize() * 1024L * 1024L;
+        Cluster cluster = clusterDao.findById(host.getClusterId());
+        ClusterDetailsVO clusterDetailsCpuOvercommit = clusterDetailsDao.findDetail(cluster.getId(), "cpuOvercommitRatio");
+        ClusterDetailsVO clusterDetailsRamOvercommmt = clusterDetailsDao.findDetail(cluster.getId(), "memoryOvercommitRatio");
+        Float cpuOvercommitRatio = Float.parseFloat(clusterDetailsCpuOvercommit.getValue());
+        Float memoryOvercommitRatio = Float.parseFloat(clusterDetailsRamOvercommmt.getValue());
+
+        boolean hostHasCpuCapability = capacityManager.checkIfHostHasCpuCapability(host.getId(), offering.getCpu(), offering.getSpeed());
+        boolean hostHasCapacity = capacityManager.checkIfHostHasCapacity(host.getId(), cpu_requested, ram_requested, false, cpuOvercommitRatio, memoryOvercommitRatio,
+                considerReservedCapacity);
+
+        return hostHasCpuCapability && hostHasCapacity;
+    }
 
     @Override
     public List<Host> allocateTo(VirtualMachineProfile vmProfile, DeploymentPlan plan, Type type, ExcludeList avoid, int returnUpTo) {
@@ -89,14 +116,19 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             if (suitableHosts.size() == returnUpTo) {
                 break;
             }
-
-            if (!avoid.shouldAvoid(host)) {
-                suitableHosts.add(host);
-            } else {
+            if (avoid.shouldAvoid(host)) {
                 if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, " + "skipping this and trying other available hosts");
+                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
                 }
+                continue;
             }
+            if (!checkHostCapacity(host, offering, considerReservedCapacity)) {
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " does not have enough capacity, skipping this and trying other available hosts");
+                }
+                continue;
+            }
+            suitableHosts.add(host);
         }
 
         if (s_logger.isDebugEnabled()) {
@@ -146,14 +178,19 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             if (suitableHosts.size() == returnUpTo) {
                 break;
             }
-
-            if (!avoid.shouldAvoid(host)) {
-                suitableHosts.add(host);
-            } else {
+            if (avoid.shouldAvoid(host)) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
                 }
+                continue;
             }
+            if (!checkHostCapacity(host, offering, considerReservedCapacity)) {
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " does not have enough capacity, skipping this and trying other available hosts");
+                }
+                continue;
+            }
+            suitableHosts.add(host);
         }
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");

--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -60,6 +60,7 @@ import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.dao.HypervisorCapabilitiesDao;
 import com.cloud.offering.ServiceOffering;
+import com.cloud.org.Cluster;
 import com.cloud.resource.ResourceListener;
 import com.cloud.resource.ResourceManager;
 import com.cloud.resource.ResourceState;
@@ -1089,6 +1090,23 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
         return false;
 
+    }
+
+    @Override
+    public Pair<Boolean, Boolean> checkIfHostHasCpuCapabilityAndCapacity(Host host, ServiceOffering offering, boolean considerReservedCapacity) {
+        int cpu_requested = offering.getCpu() * offering.getSpeed();
+        long ram_requested = offering.getRamSize() * 1024L * 1024L;
+        Cluster cluster = _clusterDao.findById(host.getClusterId());
+        ClusterDetailsVO clusterDetailsCpuOvercommit = _clusterDetailsDao.findDetail(cluster.getId(), "cpuOvercommitRatio");
+        ClusterDetailsVO clusterDetailsRamOvercommmt = _clusterDetailsDao.findDetail(cluster.getId(), "memoryOvercommitRatio");
+        Float cpuOvercommitRatio = Float.parseFloat(clusterDetailsCpuOvercommit.getValue());
+        Float memoryOvercommitRatio = Float.parseFloat(clusterDetailsRamOvercommmt.getValue());
+
+        boolean hostHasCpuCapability = checkIfHostHasCpuCapability(host.getId(), offering.getCpu(), offering.getSpeed());
+        boolean hostHasCapacity = checkIfHostHasCapacity(host.getId(), cpu_requested, ram_requested, false, cpuOvercommitRatio, memoryOvercommitRatio,
+                considerReservedCapacity);
+
+        return new Pair<>(hostHasCpuCapability, hostHasCapacity);
     }
 
     @Override


### PR DESCRIPTION
### Description
Fixes #4517 

Adds capacity checks for RandomAllocator (host allocator)

Factors out host cpu capability and capacity check wrt serviceoffering code into CapacityManager.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. For an env with one cluster with two hosts load the first host to max
2. Remove **RandomAllocator** from `host.allocators.exclude` and set `host.allocators.order` to **RandomAllocator,FirstFitRouting**
3. During deployment RandomAllocator will return both hosts as suitable hosts. But since the first host is not having enough capacity deployment will fail.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
