### PR TITLE
travis: fix component test failure - persistent networks

### DIFF
--- a/test/integration/component/test_persistent_networks.py
+++ b/test/integration/component/test_persistent_networks.py
@@ -2780,7 +2780,8 @@ class TestVPCNetworkOperations(cloudstackTestCase):
             # Check if source nat IP address is released
             ipaddresses = PublicIPAddress.list(
                 self.apiclient,
-                id=publicipaddresses[0].id)
+                id=publicipaddresses[0].id,
+                state="Allocated")
             self.assertEqual(
                 validateList(ipaddresses)[0],
                 FAIL,


### PR DESCRIPTION
### Description

This PR fixes the travis failure noticed when deleting a vpc network - https://travis-ci.com/github/apache/cloudstack/jobs/495923832


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Ran the component test on a simulator based env:

```
nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=setup/dev/advanced.cfg -s -a tags=xx --hypervisor=Simulator test/integration/component/test_persistent_networks.py

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/Apr_05_2021_13_28_31_GNGM15. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_vpc_network_life_cycle_1_delete | Status : SUCCESS ===

=== TestName: test_vpc_network_life_cycle_2_restart | Status : SUCCESS ===


```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
