### PR TITLE
[Vmware] Make deploy-as-is optional

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
@@ -162,6 +162,11 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
                 description = "true if template should bypass Secondary Storage and be downloaded to Primary Storage on deployment")
     private Boolean directDownload;
 
+    @Parameter(name=ApiConstants.DEPLOY_AS_IS,
+            type = CommandType.BOOLEAN,
+            description = "(Vmware only) true if VM deployments should preserve all the configurations defined for this template")
+    private Boolean deployAsIs;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -275,7 +280,8 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
     }
 
     public Boolean isDeployAsIs() {
-        return hypervisor != null && hypervisor.equalsIgnoreCase(Hypervisor.HypervisorType.VMware.toString());
+        return hypervisor != null && hypervisor.equalsIgnoreCase(Hypervisor.HypervisorType.VMware.toString())
+                && deployAsIs != null && deployAsIs;
     }
 
     /////////////////////////////////////////////////////
@@ -341,7 +347,7 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
                     "Parameter directdownload is only allowed for KVM templates");
         }
 
-        if (!getHypervisor().equalsIgnoreCase(Hypervisor.HypervisorType.VMware.toString()) && osTypeId == null) {
+        if (!isDeployAsIs() && osTypeId == null) {
             throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Please provide a guest OS type");
         }
     }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
@@ -72,7 +72,7 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
     private String format;
 
     @Parameter(name = ApiConstants.HYPERVISOR, type = CommandType.STRING, required = true, description = "the target hypervisor for the template")
-    private String hypervisor;
+    protected String hypervisor;
 
     @Parameter(name = ApiConstants.IS_FEATURED, type = CommandType.BOOLEAN, description = "true if this template is a featured template, false otherwise")
     private Boolean featured;
@@ -165,7 +165,7 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
     @Parameter(name=ApiConstants.DEPLOY_AS_IS,
             type = CommandType.BOOLEAN,
             description = "(VMware only) true if VM deployments should preserve all the configurations defined for this template", since = "4.15.1")
-    private Boolean deployAsIs;
+    protected Boolean deployAsIs;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -279,7 +279,7 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
         return directDownload == null ? false : directDownload;
     }
 
-    public Boolean isDeployAsIs() {
+    public boolean isDeployAsIs() {
         return Hypervisor.HypervisorType.VMware.toString().equalsIgnoreCase(hypervisor) &&
                 Boolean.TRUE.equals(deployAsIs);
     }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
@@ -280,8 +280,8 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
     }
 
     public Boolean isDeployAsIs() {
-        return hypervisor != null && hypervisor.equalsIgnoreCase(Hypervisor.HypervisorType.VMware.toString())
-                && deployAsIs != null && deployAsIs;
+        return Hypervisor.HypervisorType.VMware.toString().equalsIgnoreCase(hypervisor) &&
+                Boolean.TRUE.equals(deployAsIs);
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
@@ -164,7 +164,7 @@ public class RegisterTemplateCmd extends BaseCmd implements UserCmd {
 
     @Parameter(name=ApiConstants.DEPLOY_AS_IS,
             type = CommandType.BOOLEAN,
-            description = "(Vmware only) true if VM deployments should preserve all the configurations defined for this template")
+            description = "(VMware only) true if VM deployments should preserve all the configurations defined for this template", since = "4.15.1")
     private Boolean deployAsIs;
 
     /////////////////////////////////////////////////////

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmdTest.java
@@ -20,6 +20,7 @@
 package org.apache.cloudstack.api.command.user.template;
 
 import com.cloud.exception.ResourceAllocationException;
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.template.TemplateApiService;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.ServerApiException;
@@ -32,7 +33,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.ArrayList;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RegisterTemplateCmdTest{
+public class RegisterTemplateCmdTest {
 
     @InjectMocks
     private RegisterTemplateCmd registerTemplateCmd;
@@ -107,5 +108,35 @@ public class RegisterTemplateCmdTest{
             registerTemplateCmd.zoneIds = null;
             registerTemplateCmd.zoneId = 1L;
             Assert.assertEquals((Long)1L,registerTemplateCmd.getZoneIds().get(0));
+    }
+
+    private void testIsDeployAsIsBase(Hypervisor.HypervisorType hypervisorType, Boolean deployAsIsParameter, boolean expectedResult) {
+        registerTemplateCmd = new RegisterTemplateCmd();
+        registerTemplateCmd.hypervisor = hypervisorType.name();
+        registerTemplateCmd.deployAsIs = deployAsIsParameter;
+        boolean isDeployAsIs = registerTemplateCmd.isDeployAsIs();
+        Assert.assertEquals(expectedResult, isDeployAsIs);
+    }
+
+    @Test
+    public void testIsDeployAsIsVmwareNullAsIs() {
+        testIsDeployAsIsBase(Hypervisor.HypervisorType.VMware, null, false);
+    }
+
+    @Test
+    public void testIsDeployAsIsVmwareNotAsIs() {
+        testIsDeployAsIsBase(Hypervisor.HypervisorType.VMware, false, false);
+    }
+
+    @Test
+    public void testIsDeployAsIsVmwareAsIs() {
+        testIsDeployAsIsBase(Hypervisor.HypervisorType.VMware, true, true);
+    }
+
+    @Test
+    public void testIsDeployAsIsNonVmware() {
+        testIsDeployAsIsBase(Hypervisor.HypervisorType.KVM, true, false);
+        testIsDeployAsIsBase(Hypervisor.HypervisorType.XenServer, true, false);
+        testIsDeployAsIsBase(Hypervisor.HypervisorType.Any, true, false);
     }
 }

--- a/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -291,7 +291,7 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
         }
 
         Map details = cmd.getDetails();
-        if (hypervisorType == HypervisorType.VMware) {
+        if (cmd.isDeployAsIs()) {
             if (MapUtils.isNotEmpty(details)) {
                 if (details.containsKey(VmDetailConstants.ROOT_DISK_CONTROLLER)) {
                     s_logger.info("Ignoring the rootDiskController detail provided, as we honour what is defined in the template");

--- a/test/integration/smoke/test_kubernetes_clusters.py
+++ b/test/integration/smoke/test_kubernetes_clusters.py
@@ -260,8 +260,8 @@ class TestKubernetesCluster(cloudstackTestCase):
 
         if validateList(templates)[0] != PASS:
             details = None
-            if hypervisor in ["vmware"]:
-                details = [{"keyboard": "us"}]
+            if hypervisor in ["vmware"] and "details" in cks_template:
+                details = cks_template["details"]
             template = Template.register(cls.apiclient, cks_template, zoneid=cls.zone.id, hypervisor=hypervisor.lower(), randomize_name=False, details=details)
             template.download(cls.apiclient)
             return template, False

--- a/test/integration/smoke/test_storage_policy.py
+++ b/test/integration/smoke/test_storage_policy.py
@@ -59,6 +59,7 @@ class TestVMWareStoragePolicies(cloudstackTestCase):
             cls.apiclient,
             cls.zone.id,
             cls.hypervisor,
+            deploy_as_is=cls.hypervisor.lower() == "vmware"
         )
         cls._cleanup.append(cls.network_offering)
         return

--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -84,6 +84,7 @@ class TestCreateTemplateWithChecksum(cloudstackTestCase):
             self.test_template.displaytext = 'test sha-1'
             self.test_template.url = "http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.ova"
             self.test_template.format = "OVA"
+            self.test_template.ostypeid = self.getOsType("Other Linux (64-bit)")
             self.md5 = "27f3c56a8c7ec7b2f3ff2199f7078006"
             self.sha256 = "a7b04c1eb507f3f5de844bda352df1ea5e20335b465409493ca6ae07dfd0a158"
 

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -88,8 +88,7 @@ class TestCreateVolume(cloudstackTestCase):
             cls.apiclient,
             cls.zone.id,
             cls.services["ostype"],
-            cls.hypervisor,
-            deploy_as_is=cls.hypervisor.lower() == "vmware"
+            cls.hypervisor
         )
         if template == FAILED:
             assert False, "get_suitable_test_template() failed to return template with description %s" % cls.services["ostype"]

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -88,7 +88,8 @@ class TestCreateVolume(cloudstackTestCase):
             cls.apiclient,
             cls.zone.id,
             cls.services["ostype"],
-            cls.hypervisor
+            cls.hypervisor,
+            deploy_as_is=cls.hypervisor.lower() == "vmware"
         )
         if template == FAILED:
             assert False, "get_suitable_test_template() failed to return template with description %s" % cls.services["ostype"]
@@ -308,7 +309,8 @@ class TestVolumes(cloudstackTestCase):
             cls.apiclient,
             cls.zone.id,
             cls.services["ostype"],
-            cls.hypervisor
+            cls.hypervisor,
+            deploy_as_is=cls.hypervisor.lower() == "vmware"
         )
         if cls.template == FAILED:
             assert False, "get_suitable_test_template() failed to return template with description %s" % cls.services["ostype"]

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1403,24 +1403,22 @@ class Template:
         elif "hypervisor" in services:
             cmd.hypervisor = services["hypervisor"]
 
-        if cmd.hypervisor.lower() not in ["vmware"]:
-            # Since version 4.15 VMware templates honour the guest OS defined in the template
-            if "ostypeid" in services:
-                cmd.ostypeid = services["ostypeid"]
-            elif "ostype" in services:
-                # Find OSTypeId from Os type
-                sub_cmd = listOsTypes.listOsTypesCmd()
-                sub_cmd.description = services["ostype"]
-                ostypes = apiclient.listOsTypes(sub_cmd)
+        if "ostypeid" in services:
+            cmd.ostypeid = services["ostypeid"]
+        elif "ostype" in services:
+            # Find OSTypeId from Os type
+            sub_cmd = listOsTypes.listOsTypesCmd()
+            sub_cmd.description = services["ostype"]
+            ostypes = apiclient.listOsTypes(sub_cmd)
 
-                if not isinstance(ostypes, list):
-                    raise Exception(
-                        "Unable to find Ostype id with desc: %s" %
-                        services["ostype"])
-                cmd.ostypeid = ostypes[0].id
-            else:
+            if not isinstance(ostypes, list):
                 raise Exception(
-                    "Unable to find Ostype is required for registering template")
+                    "Unable to find Ostype id with desc: %s" %
+                    services["ostype"])
+            cmd.ostypeid = ostypes[0].id
+        else:
+            raise Exception(
+                "Unable to find Ostype is required for registering template")
 
         cmd.url = services["url"]
 
@@ -1438,6 +1436,7 @@ class Template:
         cmd.isdynamicallyscalable = services["isdynamicallyscalable"] if "isdynamicallyscalable" in services else False
         cmd.passwordenabled = services[
             "passwordenabled"] if "passwordenabled" in services else False
+        cmd.deployasis = services["deployasis"] if "deployasis" in services else False
 
         if account:
             cmd.account = account

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -527,7 +527,7 @@ def get_suitable_test_template(apiclient, zoneid, ostypeid, hypervisor, deploy_a
               template Information matching the inputs
     '''
     template = FAILED
-    if hypervisor.lower() in ["xenserver", "vmware"]:
+    if hypervisor.lower() in ["xenserver"] or (hypervisor.lower() in ["vmware"] and deploy_as_is):
         template = get_test_template(
             apiclient,
             zoneid,

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -348,7 +348,7 @@ def get_template(
     return list_templatesout[0]
 
 
-def get_test_template(apiclient, zone_id=None, hypervisor=None, test_templates=None):
+def get_test_template(apiclient, zone_id=None, hypervisor=None, test_templates=None, deploy_as_is=False):
     """
     @Name : get_test_template
     @Desc : Retrieves the test template used to running tests. When the template
@@ -373,6 +373,8 @@ def get_test_template(apiclient, zone_id=None, hypervisor=None, test_templates=N
         return FAILED
 
     test_template = test_templates[hypervisor]
+    if deploy_as_is:
+        test_template['deployasis'] = True
 
     cmd = listTemplates.listTemplatesCmd()
     cmd.name = test_template['name']
@@ -513,7 +515,7 @@ def get_windows_template(
 
     return FAILED
 
-def get_suitable_test_template(apiclient, zoneid, ostypeid, hypervisor):
+def get_suitable_test_template(apiclient, zoneid, ostypeid, hypervisor, deploy_as_is=False):
     '''
     @Name : get_suitable_test_template
     @Desc : Retrieves the test template information based upon inputs provided
@@ -525,11 +527,12 @@ def get_suitable_test_template(apiclient, zoneid, ostypeid, hypervisor):
               template Information matching the inputs
     '''
     template = FAILED
-    if hypervisor.lower() in ["xenserver"]:
+    if hypervisor.lower() in ["xenserver", "vmware"]:
         template = get_test_template(
             apiclient,
             zoneid,
-            hypervisor)
+            hypervisor,
+            deploy_as_is=deploy_as_is)
     if template == FAILED:
         template = get_template(
             apiclient,

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -715,7 +715,7 @@
 "label.demote.project.owner": "Demote account to Regular role",
 "label.demote.project.owner.user": "Demote user to Regular role",
 "label.deny": "Deny",
-"label.deployasis":"Deploy As-Is",
+"label.deployasis":"Read VM settings from OVA",
 "label.deploymentplanner": "Deployment planner",
 "label.description": "Description",
 "label.destcidr": "Destination CIDR",

--- a/ui/src/views/image/RegisterOrUploadTemplate.vue
+++ b/ui/src/views/image/RegisterOrUploadTemplate.vue
@@ -208,8 +208,18 @@
               :default-checked="xenServerProvider" />
           </a-form-item>
         </a-row>
+
+        <a-form-item :label="$t('label.deployasis')" v-if="hyperVMWShow">
+          <a-switch
+            v-decorator="['deployasis', {
+              initialValue: false,
+            }]"
+            :checked="deployasis"
+            @change="val => deployasis = val"/>
+        </a-form-item>
+
         <a-row :gutter="12" v-if="hyperKVMShow || hyperVMWShow">
-          <a-col :md="24" :lg="24" v-if="hyperKVMShow">
+          <a-col :md="24" :lg="24" v-if="hyperKVMShow || (hyperVMWShow && !deployasis)">
             <a-form-item :label="$t('label.rootdiskcontrollertype')">
               <a-select
                 v-decorator="['rootDiskControllerType', {
@@ -230,7 +240,7 @@
             </a-form-item>
           </a-col>
           <a-col :md="24" :lg="24">
-            <a-form-item v-if="hyperVMWShow" :label="$t('label.keyboardtype')">
+            <a-form-item v-if="hyperVMWShow && !deployasis" :label="$t('label.keyboardtype')">
               <a-select
                 v-decorator="['keyboardType', {
                   rules: [
@@ -248,7 +258,7 @@
             </a-form-item>
           </a-col>
         </a-row>
-        <a-row :gutter="12" v-if="!hyperVMWShow">
+        <a-row :gutter="12" v-if="!hyperVMWShow || (hyperVMWShow && !deployasis)">
           <a-col :md="24" :lg="24">
             <a-form-item :label="$t('label.ostypeid')">
               <a-select
@@ -378,6 +388,7 @@ export default {
       hyperKVMShow: false,
       hyperXenServerShow: false,
       hyperVMWShow: false,
+      deployasis: false,
       zoneError: '',
       zoneErrorMessage: '',
       loading: false,
@@ -763,6 +774,7 @@ export default {
       this.hyperXenServerShow = false
       this.hyperVMWShow = false
       this.hyperKVMShow = false
+      this.deployasis = false
       this.allowDirectDownload = false
 
       this.resetSelect()
@@ -800,6 +812,8 @@ export default {
             params[key] = input
           } else if (key === 'hypervisor') {
             params[key] = this.hyperVisor.opts[input].name
+          } else if (key === 'deployasis') {
+            params[key] = input
           } else if (key === 'groupenabled') {
             for (const index in input) {
               const name = input[index]

--- a/ui/src/views/image/RegisterOrUploadTemplate.vue
+++ b/ui/src/views/image/RegisterOrUploadTemplate.vue
@@ -806,14 +806,8 @@ export default {
               continue
             }
             params[key] = input.join()
-          } else if (key === 'zoneid') {
-            params[key] = input
-          } else if (key === 'ostypeid') {
-            params[key] = input
           } else if (key === 'hypervisor') {
             params[key] = this.hyperVisor.opts[input].name
-          } else if (key === 'deployasis') {
-            params[key] = input
           } else if (key === 'groupenabled') {
             for (const index in input) {
               const name = input[index]


### PR DESCRIPTION
### Description

This PR allows users and administrators whether to enable the feature to read settings from the OVA instead of providing them, or continue using the previous workflow.

Documentation PR: https://github.com/apache/cloudstack-documentation/pull/209

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Register template using deploy-as-is
Register template using the usual worflow
Deploy VMs
