### PR TITLE
ui: Show diskoffering for create volume from ROOT volume snaps

### DIFF
--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -284,7 +284,13 @@ export default {
           label: 'label.action.create.volume',
           dataView: true,
           show: (record) => { return record.state === 'BackedUp' },
-          args: ['snapshotid', 'name'],
+          args: (record, store) => {
+            var fields = ['snapshotid', 'name']
+            if (record.volumetype === 'ROOT') {
+              fields.push('diskofferingid')
+            }
+            return fields
+          },
           mapping: {
             snapshotid: {
               value: (record) => { return record.id }


### PR DESCRIPTION
### Description

Fixes the issue of not being able to select the diskofferingid while creating volumes from snapshots of ROOT volumes

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![Screenshot from 2021-04-12 16-44-30](https://user-images.githubusercontent.com/8244774/114386192-88670600-9bae-11eb-9adb-8a847e3aa0a4.png)
