### PR TITLE
test: reduce vr traceroute hops

### DIFF
--- a/test/integration/smoke/test_diagnostics.py
+++ b/test/integration/smoke/test_diagnostics.py
@@ -429,11 +429,11 @@ class TestRemoteDiagnostics(cloudstackTestCase):
     @attr(tags=["advanced", "advancedns", "ssh", "smoke"], required_hardware="true")
     def test_10_traceroute_in_vr(self):
         '''
-        Test Arping command execution in VR
+        Test traceroute command execution in VR
         '''
 
         # Validate the following:
-        # 1. Arping command is executed remotely on VR
+        # 1. Traceroute command is executed remotely on VR
 
         list_router_response = list_routers(
             self.apiclient,
@@ -452,13 +452,13 @@ class TestRemoteDiagnostics(cloudstackTestCase):
         cmd.targetid = router.id
         cmd.ipaddress = '8.8.4.4'
         cmd.type = 'traceroute'
-        cmd.params = "-m 10"
+        cmd.params = "-m 5"
         cmd_response = self.apiclient.runDiagnostics(cmd)
 
         self.assertEqual(
             '0',
             cmd_response.exitcode,
-            'Failed to run remote Arping in VR')
+            'Failed to run remote Traceroute in VR')
 
     @attr(tags=["advanced", "advancedns", "ssh", "smoke"], required_hardware="true")
     def test_11_traceroute_in_ssvm(self):
@@ -488,7 +488,7 @@ class TestRemoteDiagnostics(cloudstackTestCase):
         cmd.targetid = ssvm.id
         cmd.ipaddress = '8.8.4.4'
         cmd.type = 'traceroute'
-        cmd.params = '-m 10'
+        cmd.params = '-m 5'
         cmd_response = self.apiclient.runDiagnostics(cmd)
 
         self.assertEqual(
@@ -525,7 +525,7 @@ class TestRemoteDiagnostics(cloudstackTestCase):
         cmd.targetid = cpvm.id
         cmd.ipaddress = '8.8.4.4'
         cmd.type = 'traceroute'
-        cmd.params = '-m 10'
+        cmd.params = '-m 5'
         cmd_response = self.apiclient.runDiagnostics(cmd)
 
         self.assertEqual(


### PR DESCRIPTION
### Description

Intermittent failures were seen with Trillian for `test_10_traceroute_in_vr` from `test_diagnostics.py`
Exception due to timeout,
```
2021-04-10 10:45:48,164 - DEBUG - Response : {jobprocstatus : 0, created : u'2021-04-10T10:44:47+0000', completed : u'2021-04-10T10:45:47+0000', cmd : u'org.apache.cloudstack.api.command.admin.diagnostics.RunDiagnosticsCmd', userid : u'accb47d3-99e0-11eb-ab0f-1e00f6000333', jobstatus : 1, jobid : u'663465e7-1ec4-4783-80d0-a54197ee729a', jobresultcode : 0, jobresulttype : u'object', jobresult : {stdout : u'', stderr : u'Command failed due to Exception: com.cloud.utils.ssh.SshException\nMessage: Timed out in waiting for SSH execution exit status\n', exitcode : u'-1'}, accountid : u'acca0117-99e0-11eb-ab0f-1e00f6000333'}
```
Change is to reduce the maximum number of hops for traceroute to 5 to prevent a timeout.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
```
[root@pr4710-t412-vmware-67u3-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr4710-t412-vmware-67u3-advanced-cfg -s -a tags=advanced --hypervisor=VMware tests/smoke/test_diagnostics.py 
/usr/lib/python2.7/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Apr_12_2021_12_17_54_MXI93T. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_01_ping_in_vr_success | Status : SUCCESS ===

=== TestName: test_02_ping_in_vr_failure | Status : SUCCESS ===

=== TestName: test_03_ping_in_ssvm_success | Status : SUCCESS ===

=== TestName: test_04_ping_in_ssvm_failure | Status : SUCCESS ===

=== TestName: test_05_ping_in_cpvm_success | Status : SUCCESS ===

=== TestName: test_06_ping_in_cpvm_failure | Status : SUCCESS ===

=== TestName: test_07_arping_in_vr | Status : SUCCESS ===

=== TestName: test_08_arping_in_ssvm | Status : SUCCESS ===

=== TestName: test_09_arping_in_cpvm | Status : SUCCESS ===

=== TestName: test_10_traceroute_in_vr | Status : SUCCESS ===

=== TestName: test_11_traceroute_in_ssvm | Status : SUCCESS ===

=== TestName: test_12_traceroute_in_cpvm | Status : SUCCESS ===

=== TestName: test_13_retrieve_vr_default_files | Status : SUCCESS ===

=== TestName: test_14_retrieve_vr_one_file | Status : SUCCESS ===

=== TestName: test_15_retrieve_ssvm_default_files | Status : SUCCESS ===

=== TestName: test_16_retrieve_ssvm_single_file | Status : SUCCESS ===

=== TestName: test_17_retrieve_cpvm_default_files | Status : SUCCESS ===

=== TestName: test_18_retrieve_cpvm_single_file | Status : SUCCESS ===

===final results are now copied to: /marvin//MarvinLogs/test_diagnostics_52X55O===
```