### PR TITLE
Stat collector solidfire capacity fix

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1030,7 +1030,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                     s_logger.warn("Not setting capacity bytes, received " + ((StorageStats)answer).getCapacityBytes()  + " capacity for pool ID " + poolId);
                                 }
                             }
-                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY) && !pool.isManaged()) {
+                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY)) {
                                 pool.setUsedBytes(((StorageStats) answer).getByteUsed());
                                 poolNeedsUpdating = true;
                             }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1027,7 +1027,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                     pool.setCapacityBytes(((StorageStats)answer).getCapacityBytes());
                                     poolNeedsUpdating = true;
                                 } else {
-                                    s_logger.warn("Received 0 capacity for pool ID " + poolId);
+                                    s_logger.warn("Not setting capacity bytes, received " + ((StorageStats)answer).getCapacityBytes()  + " capacity for pool ID " + poolId);
                                 }
                             }
                             if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY) && !pool.isManaged()) {

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1026,7 +1026,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                 pool.setCapacityBytes(((StorageStats)answer).getCapacityBytes());
                                 poolNeedsUpdating = true;
                             }
-                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY)) {
+                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY) && ((StorageStats)answer).getByteUsed() > 0) {
                                 pool.setUsedBytes(((StorageStats) answer).getByteUsed());
                                 poolNeedsUpdating = true;
                             }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1023,10 +1023,14 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                             boolean poolNeedsUpdating = false;
                             // Seems like we have dynamically updated the pool size since the prev. size and the current do not match
                             if (_storagePoolStats.get(poolId) != null && _storagePoolStats.get(poolId).getCapacityBytes() != ((StorageStats)answer).getCapacityBytes()) {
-                                pool.setCapacityBytes(((StorageStats)answer).getCapacityBytes());
-                                poolNeedsUpdating = true;
+                                if (((StorageStats)answer).getCapacityBytes() > 0) {
+                                    pool.setCapacityBytes(((StorageStats)answer).getCapacityBytes());
+                                    poolNeedsUpdating = true;
+                                } else {
+                                    s_logger.warn("Received 0 capacity for pool ID " + poolId);
+                                }
                             }
-                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY) && ((StorageStats)answer).getByteUsed() > 0) {
+                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY) && !pool.isManaged()) {
                                 pool.setUsedBytes(((StorageStats) answer).getByteUsed());
                                 poolNeedsUpdating = true;
                             }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1020,14 +1020,18 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         if (answer != null && answer.getResult()) {
                             storagePoolStats.put(pool.getId(), (StorageStats)answer);
 
+                            boolean poolNeedsUpdating = false;
                             // Seems like we have dynamically updated the pool size since the prev. size and the current do not match
-                            if (pool.getCapacityBytes() != ((StorageStats)answer).getCapacityBytes() ||
-                                    pool.getUsedBytes() != ((StorageStats)answer).getByteUsed()) {
+                            if (_storagePoolStats.get(poolId) != null && _storagePoolStats.get(poolId).getCapacityBytes() != ((StorageStats)answer).getCapacityBytes()) {
                                 pool.setCapacityBytes(((StorageStats)answer).getCapacityBytes());
-                                if (pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY)) {
-                                    pool.setUsedBytes(((StorageStats) answer).getByteUsed());
-                                    pool.setUpdateTime(new Date());
-                                }
+                                poolNeedsUpdating = true;
+                            }
+                            if (pool.getUsedBytes() != ((StorageStats)answer).getByteUsed() && pool.getStorageProviderName().equalsIgnoreCase(DataStoreProvider.DEFAULT_PRIMARY)) {
+                                pool.setUsedBytes(((StorageStats) answer).getByteUsed());
+                                poolNeedsUpdating = true;
+                            }
+                            if (poolNeedsUpdating) {
+                                pool.setUpdateTime(new Date());
                                 _storagePoolDao.update(pool.getId(), pool);
                             }
                         }


### PR DESCRIPTION
   
    Fixes regression introduced in 71c5dbcf492a023dbea5f8c34f8fd883c3ad653f
    which would cause capacity bytes of certain pools to be update which
    shouldn't get updated by StatsCollector such as solidfire.
    
Fixes #4911

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

Temporary repo builds here for testing purposes for community: http://download.cloudstack.org/testing/pr-4918/
(This will be removed after the PR is merged)