### PR TITLE
Add UnavailableCommandException at ExceptionErrorCodeMap

### DIFF
--- a/utils/src/main/java/com/cloud/utils/exception/CSExceptionErrorCode.java
+++ b/utils/src/main/java/com/cloud/utils/exception/CSExceptionErrorCode.java
@@ -70,6 +70,7 @@ public class CSExceptionErrorCode {
             ExceptionErrorCodeMap.put("com.cloud.async.AsyncCommandQueued", 4540);
             ExceptionErrorCodeMap.put("com.cloud.exception.RequestLimitException", 4545);
             ExceptionErrorCodeMap.put("com.cloud.exception.StorageConflictException", 4550);
+            ExceptionErrorCodeMap.put("com.cloud.exception.UnavailableCommandException", 4555);
 
             // Have a special error code for ServerApiException when it is
             // thrown in a standalone manner when failing to detect any of the above


### PR DESCRIPTION
### Description

#### Proposal

This PR proposes adding Exception UnavailableCommandException at the ExceptionErrorCodeMap.

#### Why?

When an API command is "blocked" due to the User's role not allowing it, an UnavailableCommandException is thrown. However, this leads to multiple logs such as:

 `Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions`

This escalates to a level that it gets hard to understand what is going on, especially if there have been multiple API commands refused (e.g. logging on UI with an User that has lots of API restrictions, thus failing many commands such as `list*`)

```
...
...
2021-04-15 16:00:48,454 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,462 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,465 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,468 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,472 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,476 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,480 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,483 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,486 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,490 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,494 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,498 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,501 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,504 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,508 DEBUG [c.c.a.ApiServlet] (qtp477376212-15892:ctx-cb70c68d) (logid:5257d522) ===START===  <Just an IP> -- GET  listAll=true&details=min&page=1&pageSize=500&command=listAndSwitchSamlAccount&response=json
2021-04-15 16:00:48,509 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,509 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,515 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,520 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-29347:ctx-34fbeee5 ctx-ca7a23a4) (logid:f56ab770) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,521 INFO  [c.c.u.e.CSExceptionErrorCode] (qtp477376212-15892:ctx-cb70c68d ctx-3781f075) (logid:5257d522) Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions
2021-04-15 16:00:48,521 DEBUG [c.c.a.ApiServer] (qtp477376212-15892:ctx-cb70c68d ctx-3781f075) (logid:5257d522) The API listAndSwitchSamlAccount does not exist or is not available for this account.
...
...
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
1. Build
2. Upgrade test environment
3. Place breakpoints and tail logs to verify `CSExceptionErrorCode`
4. Assert that the INFO log is not printed:  `Could not find exception: com.cloud.exception.UnavailableCommandException in error code list for exceptions`

Lines which were validated to be working as expected via remote debug at [CSExceptionErrorCode.java#L89](https://github.com/PCextreme/cloudstack/blob/6e020172e28e818c7f9866fcff2fe59eee3d7763/utils/src/main/java/com/cloud/utils/exception/CSExceptionErrorCode.java#L89):
```
    public static int getCSErrCode(String exceptionName) {
        if (ExceptionErrorCodeMap.containsKey(exceptionName)) {
 ->         return ExceptionErrorCodeMap.get(exceptionName); //  when exception matches  `UnavailableCommandException` code is 4555
        } else {
            s_logger.info("Could not find exception: " + exceptionName + " in error code list for exceptions");
 ->          return -1; // no occurrences happened on tests, as expected
        }
    }
```

Additionally, checked the logs and no occurrences of the INFO lines were found. The only log is the relevant one of `The API listCapabilities does not exist or is not available for this account.`

Example of the log with the patch:
```

2021-04-16 00:29:17,289 DEBUG [c.c.a.ApiServlet] (qtp1484673893-23:ctx-7594877d) (logid:c3428299) ===START===  <Just an IP> -- GET  command=listLdapConfigurations&response=json
2021-04-16 00:29:17,294 DEBUG [c.c.a.ApiServer] (qtp1484673893-258:ctx-a36869f9 ctx-01283620) (logid:b6551dd5) CIDRs from which account 'Acct[ea60629a-776f-4863-aac8-fce6bbf5f3e7-User]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-04-16 00:29:17,297 DEBUG [c.c.a.ApiServer] (qtp1484673893-23:ctx-7594877d ctx-0a014a38) (logid:c3428299) CIDRs from which account 'Acct[ea60629a-776f-4863-aac8-fce6bbf5f3e7-User]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-04-16 00:29:17,302 DEBUG [c.c.a.ApiServer] (qtp1484673893-17:ctx-b8cfe0c1 ctx-ccea4d29) (logid:91ff3c5f) CIDRs from which account 'Acct[ea60629a-776f-4863-aac8-fce6bbf5f3e7-User]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-04-16 00:29:17,304 DEBUG [c.c.a.ApiServer] (qtp1484673893-18:ctx-eeead663 ctx-9649bad5) (logid:b4f1d06c) CIDRs from which account 'Acct[ea60629a-776f-4863-aac8-fce6bbf5f3e7-User]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-04-16 00:29:17,304 DEBUG [c.c.a.ApiServer] (qtp1484673893-21:ctx-cd195e4f ctx-3f152e22) (logid:ff3a62eb) CIDRs from which account 'Acct[ea60629a-776f-4863-aac8-fce6bbf5f3e7-User]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-04-16 00:29:17,311 DEBUG [c.c.a.ApiServer] (qtp1484673893-22:ctx-c9139e14 ctx-5bd0c148) (logid:b5088f9d) CIDRs from which account 'Acct[ea60629a-776f-4863-aac8-fce6bbf5f3e7-User]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-04-16 00:29:24,750 DEBUG [c.c.a.ApiServer] (qtp1484673893-17:ctx-b8cfe0c1 ctx-ccea4d29) (logid:91ff3c5f) The API listCapabilities does not exist or is not available for this account.
2021-04-16 00:29:32,038 DEBUG [c.c.a.ApiServlet] (qtp1484673893-17:ctx-b8cfe0c1 ctx-ccea4d29) (logid:91ff3c5f) ===END===  <Just an IP> -- GET  command=listCapabilities&response=json

```
