### PR TITLE
marvin: fix test_scale_vm for xenserver/Xcp-ng

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -3110,7 +3110,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             s_logger.warn("No recommended value found for dynamic max, setting static max and dynamic max equal");
             return dynamicMaxRam;
         }
-        final long staticMax = Math.min(recommendedValue, 4l * dynamicMinRam); // XS
+        final long staticMax = Math.max(recommendedValue, 4L * dynamicMinRam); // XS
         // constraint
         // for
         // stability

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -3110,7 +3110,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             s_logger.warn("No recommended value found for dynamic max, setting static max and dynamic max equal");
             return dynamicMaxRam;
         }
-        final long staticMax = Math.max(recommendedValue, 4L * dynamicMinRam); // XS
+        final long staticMax = Math.min(recommendedValue, 4L * dynamicMinRam); // XS
         // constraint
         // for
         // stability

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1946,8 +1946,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     _itMgr.reConfigureVm(vmInstance.getUuid(), currentServiceOffering, newServiceOffering, customParameters, existingHostHasCapacity);
                     success = true;
                     return success;
-                } catch (Exception e) {
+                } catch (InsufficientCapacityException | ResourceUnavailableException | ConcurrentOperationException e) {
                     s_logger.warn("Received exception while scaling ", e);
+                } catch (Exception e) {
+                    s_logger.warn("Scaling failed with exception: ", e);
                 } finally {
                     if (!success) {
                         // Decrement CPU and Memory count accordingly.

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1946,12 +1946,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     _itMgr.reConfigureVm(vmInstance.getUuid(), currentServiceOffering, newServiceOffering, customParameters, existingHostHasCapacity);
                     success = true;
                     return success;
-                } catch (InsufficientCapacityException e) {
-                    s_logger.warn("Received exception while scaling ", e);
-                } catch (ResourceUnavailableException e) {
-                    s_logger.warn("Received exception while scaling ", e);
-                } catch (ConcurrentOperationException e) {
-                    s_logger.warn("Received exception while scaling ", e);
                 } catch (Exception e) {
                     s_logger.warn("Received exception while scaling ", e);
                 } finally {

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -119,15 +119,6 @@ class TestScaleVm(cloudstackTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.apiclient = super(
-            TestScaleVm,
-            cls).getClsTestClient().getApiClient()
-        Configurations.update(
-                    cls.apiclient,
-                    name="enable.dynamic.scale.vm",
-                    value="false"
-                )
-
         super(TestScaleVm,cls).tearDownClass()
         return
 
@@ -141,6 +132,11 @@ class TestScaleVm(cloudstackTestCase):
                     %s" % self.hypervisor)
 
     def tearDown(self):
+        Configurations.update(
+            self.apiclient,
+            name="enable.dynamic.scale.vm",
+            value="false"
+        )
         # Clean up, terminate the created ISOs
         super(TestScaleVm,self).tearDown()
         return


### PR DESCRIPTION
### Description

This PR fixes the scale VM failure noticed on XenServer/XCP-ng

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Ran test_scale_vm.py on a XenServer / XCP-ng env :

XCP-ng: 
```
nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=/marvin/ref-trl-780-x-M7-pearl-dsilva-advanced-cfg -s -a tags=advanced --hypervisor=xenserver /marvin/tests/smoke/test_scale_vm.py
/usr/lib/python2.7/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Apr_15_2021_07_50_46_XWEN9N. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_01_scale_vm | Status : SUCCESS ===

===final results are now copied to: /marvin//MarvinLogs/test_scale_vm_LPJEUB===
[root@ref-trl-780-x-M7-pearl-dsilva-marvin ~]# 
```

Xenserver:
```
[root@ref-trl-782-x-M7-pearl-dsilva-marvin ~]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=/marvin/ref-trl-782-x-M7-pearl-dsilva-advanced-cfg -s -a tags=advanced --hypervisor=Xenserver ./test_3.py 
/usr/lib/python2.7/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Apr_21_2021_07_19_49_C4IRNH. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
====Trying SSH Connection: Host:10.0.33.228 User:root                                   Port:22 RetryCnt:10===
===SSH to Host 10.0.33.228 port : 22 SUCCESSFUL===
===final results are now copied to: /marvin//MarvinLogs//Y51I1H===
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
