### PR TITLE
Fix volume state on migrate with migrateVirtualMachineWithVolume API call

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/DataMotionServiceImpl.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/DataMotionServiceImpl.java
@@ -32,6 +32,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.StorageStrategyFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine.Event;
 import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -110,6 +111,7 @@ public class DataMotionServiceImpl implements DataMotionService {
             List<String> volumeIds = new LinkedList<String>();
             for (final VolumeInfo volumeInfo : volumeMap.keySet()) {
                 volumeIds.add(volumeInfo.getUuid());
+                volumeInfo.processEvent(Event.OperationFailed);
             }
 
             throw new CloudRuntimeException("Can't find strategy to move data. " + "Source Host: " + srcHost.getName() + ", Destination Host: " + destHost.getName() +

--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/DataMotionServiceImpl.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/DataMotionServiceImpl.java
@@ -32,8 +32,8 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.StorageStrategyFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
-import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine.Event;
 import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
+import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +43,6 @@ import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.utils.StringUtils;
-import com.cloud.utils.exception.CloudRuntimeException;
 
 
 @Component
@@ -58,7 +57,9 @@ public class DataMotionServiceImpl implements DataMotionService {
     @Override
     public void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         if (srcData.getDataStore() == null || destData.getDataStore() == null) {
-            throw new CloudRuntimeException("can't find data store");
+            String errMsg = "can't find data store";
+            invokeCallback(errMsg, callback);
+            return;
         }
 
         if (srcData.getDataStore().getDriver().canCopy(srcData, destData)) {
@@ -74,8 +75,10 @@ public class DataMotionServiceImpl implements DataMotionService {
             // OfflineVmware volume migration
             // Cleanup volumes from target and reset the state of volume at source
             cleanUpVolumesForFailedMigrations(srcData, destData);
-            throw new CloudRuntimeException("Can't find strategy to move data. " + "Source: " + srcData.getType().name() + " '" + srcData.getUuid() + ", Destination: " +
-                    destData.getType().name() + " '" + destData.getUuid() + "'");
+            String errMsg = "Can't find strategy to move data. " + "Source: " + srcData.getType().name() + " '" + srcData.getUuid() + ", Destination: " +
+                    destData.getType().name() + " '" + destData.getUuid() + "'";
+            invokeCallback(errMsg, callback);
+            return;
         }
 
         strategy.copyAsync(srcData, destData, destHost, callback);
@@ -111,13 +114,24 @@ public class DataMotionServiceImpl implements DataMotionService {
             List<String> volumeIds = new LinkedList<String>();
             for (final VolumeInfo volumeInfo : volumeMap.keySet()) {
                 volumeIds.add(volumeInfo.getUuid());
-                volumeInfo.processEvent(Event.OperationFailed);
             }
 
-            throw new CloudRuntimeException("Can't find strategy to move data. " + "Source Host: " + srcHost.getName() + ", Destination Host: " + destHost.getName() +
-                    ", Volume UUIDs: " + StringUtils.join(volumeIds, ","));
+            String errMsg = "Can't find strategy to move data. " + "Source Host: " + srcHost.getName() + ", Destination Host: " + destHost.getName() +
+                    ", Volume UUIDs: " + StringUtils.join(volumeIds, ",");
+            invokeCallback(errMsg, callback);
+            return;
         }
 
         strategy.copyAsync(volumeMap, vmTo, srcHost, destHost, callback);
+    }
+
+    private void invokeCallback(String errMsg, AsyncCompletionCallback<CopyCommandResult> callback) {
+        CopyCmdAnswer copyCmdAnswer = new CopyCmdAnswer(errMsg);
+
+        CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+        result.setResult(errMsg);
+
+        callback.complete(result);
     }
 }


### PR DESCRIPTION
### Description

When invoking `migrateVirtualMachineWithVolume` API call and a strategy isn't found the volumes are left in `Migrating` state

This PR puts back the volumes to `Ready` state 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?
OS - CentOS 7
Hypervisors - KVM
CS version - 4.15.1.0

manual tests with cloudmonkey and 2 couples of primary storage, which don't have DataMotionStrategy for this functionality.
Tried to migrate the VM with its volumes:
1 - between 2 Ceph primary storages
2 - between 2 StorPool primary storages
