### PR TITLE
Fix NPE on template garbage collection on primary storage

### DIFF
--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateDataFactoryImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateDataFactoryImpl.java
@@ -68,7 +68,11 @@ public class TemplateDataFactoryImpl implements TemplateDataFactory {
 
     @Override
     public TemplateInfo getTemplateOnPrimaryStorage(long templateId, DataStore store, String configuration) {
-        VMTemplateVO templ = imageDataDao.findById(templateId);
+        VMTemplateVO templ = imageDataDao.findByIdIncludingRemoved(templateId);
+        if (templ == null) {
+            s_logger.error("Could not find a template with id " + templateId);
+            return null;
+        }
         if (store.getRole() == DataStoreRole.Primary) {
             VMTemplateStoragePoolVO templatePoolVO = templatePoolDao.findByPoolTemplate(store.getId(), templateId, configuration);
             if (templatePoolVO != null) {


### PR DESCRIPTION
### Description

This PR fixes an NPE obtained when CloudStack cleans up templates from primary storage.

Tested:
- Set 'storage.cleanup.interval' to a suitable low value
- Create template
- Deploy VM
- Destroy VM
- Remove template
- Wait for 'storage.cleanup.interval' to be executed

As a result the template is cleanup up from primary storage, and the entry from 'template_spool_ref' is removed. However, the process throws an NPE:

```
2021-04-22 17:33:43,442 DEBUG [c.c.s.StorageManagerImpl] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Storage pool garbage collector found 0 templates to clean up in storage pool: ref-trl-779-v-M7-nicolas-vazquez-esxi-pri1
2021-04-22 17:33:43,445 DEBUG [c.c.s.StorageManagerImpl] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Storage pool garbage collector found 1 templates to clean up in storage pool: ref-trl-779-v-M7-nicolas-vazquez-esxi-pri2
2021-04-22 17:33:43,451 DEBUG [c.c.t.TemplateManagerImpl] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Evicting TmplPool[5-211-2-aeac61109f7a38898016398f2ecb9ad7]
2021-04-22 17:33:43,451 DEBUG [c.c.h.o.r.Ovm3HypervisorGuru] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) getCommandHostDelegation: class com.cloud.agent.api.storage.DestroyCommand
2021-04-22 17:33:43,451 DEBUG [c.c.h.XenServerGuru] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) We are returning the default host to execute commands because the command is not of Copy type.
2021-04-22 17:33:43,454 DEBUG [c.c.a.t.Request] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Seq 1-2119506574631239704: Sending  { Cmd , MgmtId: 32987429208583, via: 1(10.0.32.247), Ver: v1, Flags: 100111, [{"com.cloud.agent.api.storage.DestroyCommand":{"volume":{"id":"5","mountPoint":"/acs/primary/ref-trl-779-v-M7-nicolas-vazquez/ref-trl-779-v-M7-nicolas-vazquez-esxi-pri2","path":"aeac61109f7a38898016398f2ecb9ad7","size":"(50.00 MB) 52428800","storagePoolType":"NetworkFilesystem","storagePoolUuid":"05a8a39b-48fe-3ba0-acd2-1d3d73d45cc6","deviceId":"0"},"wait":"0"}}] }
2021-04-22 17:33:43,454 DEBUG [c.c.a.t.Request] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Seq 1-2119506574631239704: Executing:  { Cmd , MgmtId: 32987429208583, via: 1(10.0.32.247), Ver: v1, Flags: 100111, [{"com.cloud.agent.api.storage.DestroyCommand":{"volume":{"id":"5","mountPoint":"/acs/primary/ref-trl-779-v-M7-nicolas-vazquez/ref-trl-779-v-M7-nicolas-vazquez-esxi-pri2","path":"aeac61109f7a38898016398f2ecb9ad7","size":"(50.00 MB) 52428800","storagePoolType":"NetworkFilesystem","storagePoolUuid":"05a8a39b-48fe-3ba0-acd2-1d3d73d45cc6","deviceId":"0"},"wait":"0"}}] }
2021-04-22 17:33:43,454 DEBUG [c.c.a.m.DirectAgentAttache] (DirectAgent-25:ctx-46d4dcd5) (logid:e46d1aba) Seq 1-2119506574631239704: Executing request
2021-04-22 17:33:43,455 INFO  [c.c.h.v.r.VmwareResource] (DirectAgent-25:ctx-46d4dcd5 10.0.32.247, cmd: DestroyCommand) (logid:093e5adc) Executing resource DestroyCommand to evict template from storage pool: {"volume":{"id":"5","mountPoint":"/acs/primary/ref-trl-779-v-M7-nicolas-vazquez/ref-trl-779-v-M7-nicolas-vazquez-esxi-pri2","path":"aeac61109f7a38898016398f2ecb9ad7","size":"(50.00 MB) 52428800","storagePoolType":"NetworkFilesystem","storagePoolUuid":"05a8a39b-48fe-3ba0-acd2-1d3d73d45cc6","deviceId":"0"},"wait":"0"}
2021-04-22 17:33:43,503 INFO  [c.c.h.v.r.VmwareResource] (DirectAgent-25:ctx-46d4dcd5 10.0.32.247, cmd: DestroyCommand) (logid:093e5adc) Destroy template volume aeac61109f7a38898016398f2ecb9ad7
2021-04-22 17:33:44,652 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-11:null) (logid:) SeqA 4-95484: Processing Seq 4-95484:  { Cmd , MgmtId: -1, via: 4, Ver: v1, Flags: 11, [{"com.cloud.agent.api.ConsoleProxyLoadReportCommand":{"_proxyVmId":"2","_loadInfo":"{
  "connections": []
}","wait":"0"}}] }
2021-04-22 17:33:44,655 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-11:null) (logid:) SeqA 4-95484: Sending Seq 4-95484:  { Ans: , MgmtId: 32987429208583, via: 4, Ver: v1, Flags: 100010, [{"com.cloud.agent.api.AgentControlAnswer":{"result":"true","wait":"0"}}] }
2021-04-22 17:33:44,787 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-d937178d) (logid:af79b2c0) Found 0 routers to update status. 
2021-04-22 17:33:44,787 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-d937178d) (logid:af79b2c0) Found 0 VPC's to update Redundant State. 
2021-04-22 17:33:44,788 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-d937178d) (logid:af79b2c0) Found 0 networks to update RvR status. 
2021-04-22 17:33:44,977 DEBUG [c.c.a.m.DirectAgentAttache] (DirectAgent-25:ctx-46d4dcd5) (logid:093e5adc) Seq 1-2119506574631239704: Response Received: 
2021-04-22 17:33:44,978 DEBUG [c.c.a.t.Request] (DirectAgent-25:ctx-46d4dcd5) (logid:093e5adc) Seq 1-2119506574631239704: Processing:  { Ans: , MgmtId: 32987429208583, via: 1(10.0.32.247), Ver: v1, Flags: 110, [{"com.cloud.agent.api.Answer":{"result":"true","details":"Success","wait":"0"}}] }
2021-04-22 17:33:44,978 DEBUG [c.c.a.m.AgentAttache] (DirectAgent-25:ctx-46d4dcd5) (logid:093e5adc) Seq 1-2119506574631239704: No more commands found
2021-04-22 17:33:44,978 DEBUG [c.c.a.t.Request] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Seq 1-2119506574631239704: Received:  { Ans: , MgmtId: 32987429208583, via: 1(10.0.32.247), Ver: v1, Flags: 110, { Answer } }
2021-04-22 17:33:44,984 WARN  [c.c.s.StorageManagerImpl] (StorageManager-Scavenger-1:ctx-56d8209b) (logid:093e5adc) Problem cleaning up primary storage pool Pool[2|NetworkFilesystem]
java.lang.NullPointerException
	at org.apache.cloudstack.storage.image.store.TemplateObject.getName(TemplateObject.java:411)
	at com.cloud.template.TemplateManagerImpl.evictTemplateFromStoragePool(TemplateManagerImpl.java:1060)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy193.evictTemplateFromStoragePool(Unknown Source)
	at com.cloud.storage.StorageManagerImpl.cleanupStorage(StorageManagerImpl.java:1194)
	at com.cloud.storage.StorageManagerImpl$StorageGarbageCollector.runInContext(StorageManagerImpl.java:1646)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Set 'storage.cleanup.interval' to a suitable low value
- Create template
- Deploy VM
- Destroy VM
- Remove template
- Wait for 'storage.cleanup.interval' to be executed