### PR TITLE
api: fix disk/service offering volume response keys

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.cloud.vm.NicVO;
-import com.cloud.vm.dao.NicDao;
 import org.apache.cloudstack.acl.Role;
 import org.apache.cloudstack.acl.RoleService;
 import org.apache.cloudstack.affinity.AffinityGroup;
@@ -318,6 +316,7 @@ import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.InstanceGroup;
 import com.cloud.vm.InstanceGroupVO;
 import com.cloud.vm.NicProfile;
+import com.cloud.vm.NicVO;
 import com.cloud.vm.UserVmDetailVO;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.UserVmVO;
@@ -327,6 +326,7 @@ import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.VmStats;
 import com.cloud.vm.dao.ConsoleProxyDao;
 import com.cloud.vm.dao.DomainRouterDao;
+import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.NicSecondaryIpDao;
 import com.cloud.vm.dao.NicSecondaryIpVO;
 import com.cloud.vm.dao.UserVmDao;
@@ -1115,6 +1115,10 @@ public class ApiDBUtils {
 
     public static ServiceOffering findServiceOfferingById(Long serviceOfferingId) {
         return s_serviceOfferingDao.findByIdIncludingRemoved(serviceOfferingId);
+    }
+
+    public static ServiceOffering findServiceOfferingByUuid(String serviceOfferingUuid) {
+        return s_serviceOfferingDao.findByUuidIncludingRemoved(serviceOfferingUuid);
     }
 
     public static ServiceOfferingDetailsVO findServiceOfferingDetail(long serviceOfferingId, String key) {

--- a/server/src/main/java/com/cloud/api/query/dao/VolumeJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/VolumeJoinDaoImpl.java
@@ -176,22 +176,8 @@ public class VolumeJoinDaoImpl extends GenericDaoBaseWithTagInformation<VolumeJo
         // populate owner.
         ApiResponseHelper.populateOwner(volResponse, volume);
 
-        // DiskOfferingVO diskOffering =
-        // ApiDBUtils.findDiskOfferingById(volume.getDiskOfferingId());
         if (volume.getDiskOfferingId() > 0) {
-            boolean isServiceOffering = false;
-            if (volume.getVolumeType().equals(Volume.Type.ROOT)) {
-                isServiceOffering = true;
-            } else {
-                // can't rely on the fact that the volume is the datadisk as it might have been created as a root, and
-                // then detached later
-                long offeringId = volume.getDiskOfferingId();
-                if (ApiDBUtils.findDiskOfferingById(offeringId) == null) {
-                    isServiceOffering = true;
-                }
-            }
-
-            if (isServiceOffering) {
+            if (ApiDBUtils.findServiceOfferingByUuid(volume.getDiskOfferingUuid()) != null) {
                 volResponse.setServiceOfferingId(volume.getDiskOfferingUuid());
                 volResponse.setServiceOfferingName(volume.getDiskOfferingName());
                 volResponse.setServiceOfferingDisplayText(volume.getDiskOfferingDisplayText());


### PR DESCRIPTION
### Description

Volume can either have an associated disk offering (for DATA disks & ROOT disks for VMs created from ISO) or a compute/service offering (for ROOT disks of VMs created from templates).
This fix simplifies and fixes check to return the appropriate response keys in these cases.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Using cmk and API,

```(localcloud) SBCM5> > list virtualmachines id=6d098d2c-04e1-48eb-ada7-0b997a630a4f filter=id,name,serviceofferingid,serviceofferingname,templateid,templatename,
{
  "count": 1,
  "virtualmachine": [
    {
      "id": "6d098d2c-04e1-48eb-ada7-0b997a630a4f",
      "name": "iso-vm1",
      "serviceofferingid": "b0eac06c-95bf-4abc-91dc-3e6fd278af53",
      "serviceofferingname": "Small Instance",
      "templateid": "13c613ec-1f2a-4e56-b4d0-fe3021c87c70",
      "templatename": "ma-iso"
    }
  ]
}

(localcloud) SBCM5> > list isos id=13c613ec-1f2a-4e56-b4d0-fe3021c87c70 
{
  "count": 1,
  "iso": [
    {
      "account": "admin",
      "bits": 64,
      "bootable": true,
      "checksum": "2541a4199e48686f4f6d250e04bfccad2e730ebfa4f17ab66fabe37f4bbc3d2808e4ce113fab5e23bba19088e8ec98bb0074d537f87ca093bf83f956ca7d73cb",
      "created": "2021-04-26T07:42:41+0000",
      "crossZones": true,
      "directdownload": false,
      "displaytext": "ma-iso",
      "domain": "ROOT",
      "domainid": "0588599d-9b59-11eb-9054-1e00f70001e1",
      "id": "13c613ec-1f2a-4e56-b4d0-fe3021c87c70",
      "isdynamicallyscalable": false,
      "isextractable": false,
      "isfeatured": true,
      "ispublic": true,
      "isready": true,
      "name": "ma-iso",
      "ostypeid": "05a034a7-9b59-11eb-9054-1e00f70001e1",
      "ostypename": "Other Linux (64-bit)",
      "passwordenabled": false,
      "size": 9369600,
      "status": "Successfully Installed",
      "tags": [],
      "url": "http://10.0.3.122/iso/macchinina-kvm.iso",
      "zoneid": "60800d62-6ec8-421f-99bb-f5e34afbde24",
      "zonename": "pr4710-t412-vmware-67u3"
    }
  ]
}
```

**Before change**
```
(localcloud) SBCM5> > list volumes virtualmachineid=6d098d2c-04e1-48eb-ada7-0b997a630a4f filter=id,name,serviceofferingid,serviceofferingname,serviceofferingdisplaytext,diskofferingid,diskofferingname,diskofferingdisplaytext,type,
{
  "count": 2,
  "volume": [
    {
      "diskofferingdisplaytext": "Small Disk, 5 GB",
      "diskofferingid": "0070ed71-879b-4bb0-b682-fc542d7c2cc1",
      "diskofferingname": "Small",
      "id": "f2e6543b-3624-4c0f-87fc-25506f387f20",
      "name": "DATA-265",
      "type": "DATADISK"
    },
    {
      "id": "65461b66-d2ce-4a2b-81ed-7eb1b542b126",
      "name": "ROOT-265",
      "serviceofferingdisplaytext": "Small Disk, 5 GB",
      "serviceofferingid": "0070ed71-879b-4bb0-b682-fc542d7c2cc1",
      "serviceofferingname": "Small",
      "type": "ROOT"
    }
  ]
}

(localcloud) SBCM5> > list serviceofferings id=0070ed71-879b-4bb0-b682-fc542d7c2cc1
🙈 Error: (HTTP 431, error code 9999) Unable to execute API command listserviceofferings due to invalid value. Invalid parameter id value=0070ed71-879b-4bb0-b682-fc542d7c2cc1 due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.

(localcloud) SBCM5> > list diskofferings id=0070ed71-879b-4bb0-b682-fc542d7c2cc1
{
  "count": 1,
  "diskoffering": [
    {
      "created": "2021-04-12T06:34:21+0000",
      "disksize": 5,
      "displayoffering": true,
      "displaytext": "Small Disk, 5 GB",
      "id": "0070ed71-879b-4bb0-b682-fc542d7c2cc1",
      "iscustomized": false,
      "name": "Small",
      "provisioningtype": "thin",
      "storagetype": "shared"
    }
  ]
}
```
**After changes:**
```
(localcloud) SBCM5> > list volumes virtualmachineid=6d098d2c-04e1-48eb-ada7-0b997a630a4f filter=id,name,serviceofferingid,serviceofferingname,serviceofferingdisplaytext,diskofferingid,diskofferingname,diskofferingdisplaytext,type,
{
  "count": 2,
  "volume": [
    {
      "diskofferingdisplaytext": "Small Disk, 5 GB",
      "diskofferingid": "0070ed71-879b-4bb0-b682-fc542d7c2cc1",
      "diskofferingname": "Small",
      "id": "f2e6543b-3624-4c0f-87fc-25506f387f20",
      "name": "DATA-265",
      "type": "DATADISK"
    },
    {
      "diskofferingdisplaytext": "Small Disk, 5 GB",
      "diskofferingid": "0070ed71-879b-4bb0-b682-fc542d7c2cc1",
      "diskofferingname": "Small",
      "id": "65461b66-d2ce-4a2b-81ed-7eb1b542b126",
      "name": "ROOT-265",
      "type": "ROOT"
    }
  ]
}
```

With correct response key, UI shows correct detail in info card,
![Screenshot from 2021-04-26 13-49-39](https://user-images.githubusercontent.com/153340/116051553-58336300-a696-11eb-8dfc-09f5d23d170b.png)




<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
