### PR TITLE
vmware cks: Guard k8s cluster root disk resize if no root disk size passed

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -328,7 +328,9 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
         for (int i = offset + 1; i <= nodeCount; i++) {
             UserVm vm = createKubernetesNode(publicIpAddress, i);
             addKubernetesClusterVm(kubernetesCluster.getId(), vm.getId());
-            resizeNodeVolume(vm);
+            if (kubernetesCluster.getNodeRootDiskSize() > 0) {
+                resizeNodeVolume(vm);
+            }
             startKubernetesVM(vm);
             vm = userVmDao.findById(vm.getId());
             if (vm == null) {

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterStartWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterStartWorker.java
@@ -277,7 +277,9 @@ public class KubernetesClusterStartWorker extends KubernetesClusterResourceModif
         UserVm k8sMasterVM = null;
         k8sMasterVM = createKubernetesMaster(network, publicIpAddress);
         addKubernetesClusterVm(kubernetesCluster.getId(), k8sMasterVM.getId());
-        resizeNodeVolume(k8sMasterVM);
+        if (kubernetesCluster.getNodeRootDiskSize() > 0) {
+            resizeNodeVolume(k8sMasterVM);
+        }
         startKubernetesVM(k8sMasterVM);
         k8sMasterVM = userVmDao.findById(k8sMasterVM.getId());
         if (k8sMasterVM == null) {
@@ -297,7 +299,9 @@ public class KubernetesClusterStartWorker extends KubernetesClusterResourceModif
                 UserVm vm = null;
                 vm = createKubernetesAdditionalMaster(publicIpAddress, i);
                 addKubernetesClusterVm(kubernetesCluster.getId(), vm.getId());
-                resizeNodeVolume(vm);
+                if (kubernetesCluster.getNodeRootDiskSize() > 0) {
+                    resizeNodeVolume(vm);
+                }
                 startKubernetesVM(vm);
                 vm = userVmDao.findById(vm.getId());
                 if (vm == null) {

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -58,7 +58,7 @@ class TestScaleVm(cloudstackTestCase):
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.services['mode'] = cls.zone.networktype
 
-        if cls.hypervisor.lower() == 'simulator':
+        if cls.hypervisor.lower() in ['simulator', 'vmware']:
             cls.template = get_template(
                 cls.apiclient,
                 cls.zone.id,


### PR DESCRIPTION
### Description

This PR prevents k8s cluster nodes' root disks from being resized on VMware if root disk size isn't provided and addresses a test regression on scale vm. 
```
2021-04-27 06:26:28,971 ERROR [c.c.k.c.a.KubernetesClusterActionWorker] (API-Job-Executor-8:ctx-8126598d job-803 ctx-9a6a3ae2) (logid:f9bfd370) Provisioning the master VM failed in the Kubernetes cluster : k8s
com.cloud.exception.InvalidParameterValueException: Going from existing size of 4756340736 to size of 0 would shrink the volume.Need to sign off by supplying the shrinkok parameter with value of true.
	at com.cloud.storage.VolumeApiServiceImpl.resizeVolume(VolumeApiServiceImpl.java:1077)
	at com.cloud.storage.VolumeApiServiceImpl.resizeVolume(VolumeApiServiceImpl.java:192)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Deployed a Kubernetes cluster without passing any root disk size - and it deployed successfully 

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
