### PR TITLE
api: add templatename in kubernetesclusterresponse

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.kubernetes.cluster;
 
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -156,8 +158,6 @@ import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.google.common.base.Strings;
-
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 public class KubernetesClusterManagerImpl extends ManagerBase implements KubernetesClusterService {
 
@@ -587,6 +587,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         response.setClusterSize(kubernetesCluster.getNodeCount());
         VMTemplateVO template = ApiDBUtils.findTemplateById(kubernetesCluster.getTemplateId());
         response.setTemplateId(template.getUuid());
+        response.setTemplateName(template.getName());
         ServiceOfferingVO offering = serviceOfferingDao.findById(kubernetesCluster.getServiceOfferingId());
         response.setServiceOfferingId(offering.getUuid());
         response.setServiceOfferingName(offering.getName());

--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
@@ -61,6 +61,10 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
     @Param(description = "the ID of the template of the Kubernetes cluster")
     private String templateId;
 
+    @SerializedName(ApiConstants.TEMPLATE_NAME)
+    @Param(description = "the name of the template of the Kubernetes cluster", since = "4.15.1")
+    private String templateName;
+
     @SerializedName(ApiConstants.NETWORK_ID)
     @Param(description = "the ID of the network of the Kubernetes cluster")
     private String networkId;
@@ -190,6 +194,14 @@ public class KubernetesClusterResponse extends BaseResponse implements Controlle
 
     public void setTemplateId(String templateId) {
         this.templateId = templateId;
+    }
+
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public void setTemplateName(String templateName) {
+        this.templateName = templateName;
     }
 
     public String getNetworkId() {


### PR DESCRIPTION
### Description

Adds `templatename` in `kubernetesclusterresponse`.
Improves UX to some extent as UI previously showed UUID of the template in the k8s cluster info.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
**Before**

![Screenshot from 2021-04-28 10-53-18](https://user-images.githubusercontent.com/153340/116373388-e93b4300-a82a-11eb-9ae6-0594efe5e5a2.png)

**After**

![Screenshot from 2021-04-28 14-00-29](https://user-images.githubusercontent.com/153340/116373463-fbb57c80-a82a-11eb-9909-fb40a333ca4e.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
