### PR TITLE
ui: Fix Settings Tab view

### DIFF
--- a/ui/src/components/view/SettingsTab.vue
+++ b/ui/src/components/view/SettingsTab.vue
@@ -96,7 +96,7 @@ export default {
       filter: ''
     }
   },
-  beforeMount () {
+  created () {
     switch (this.$route.meta.name) {
       case 'account':
         this.scopeKey = 'accountid'
@@ -119,8 +119,6 @@ export default {
       default:
         this.scopeKey = ''
     }
-  },
-  created () {
     this.fetchData()
   },
   watch: {


### PR DESCRIPTION
### Description

This PR fixes the issue noticed when traversing to the Settings tab on account, domain, Zone, Cluster, Storagepool Sections. On navigating to the Settings tabs, it displays all the configuration as opposed to only displaying the configuration specific to that scope as the scope specific parameter isn't passed until refreshed.

![image](https://user-images.githubusercontent.com/10495417/116257429-ac6f3d80-a791-11eb-834d-5f83c4586b00.png)

Only after refresh are we able to see the correct configuration:

![image](https://user-images.githubusercontent.com/10495417/116257485-b98c2c80-a791-11eb-9bf3-e932a6fb83e7.png)

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested various views specified above


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
