### PR TITLE
Increase max length for VMInstanceVO.backupVolumes

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/VMInstanceVO.java
+++ b/engine/schema/src/main/java/com/cloud/vm/VMInstanceVO.java
@@ -200,7 +200,7 @@ public class VMInstanceVO implements VirtualMachine, FiniteStateObject<State, Vi
     @Column(name = "backup_external_id")
     protected String backupExternalId;
 
-    @Column(name = "backup_volumes")
+    @Column(name = "backup_volumes", length = 65535)
     protected String backupVolumes;
 
     public VMInstanceVO(long id, long serviceOfferingId, String name, String instanceName, Type type, Long vmTemplateId, HypervisorType hypervisorType, long guestOSId,


### PR DESCRIPTION
### Description

This PR adds an explicit length to `VMInstanceVO.backupVolumes`.

The default length is 255, which caused a truncation of data if the JSON object representing the backup volumes is too big.
It caused errors when backups were made on VMs with 3 volumes or more.

`vm_instance.backup_volumes` has the type TEXT, which has a maximal length of 65535 characters.

Fixes: #4965

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

N/A

### How Has This Been Tested?
I manually tested:
1. Build and package CloudStack with the fix
2. Reproduced the #4965 scenario (backup on a VM with 3 volumes, using Dummy B&R provider)
3. There was no issue, and the field in database is a valid JSON object.
