### PR TITLE
CentOS 8: Install libgcrypt v1.8.5 required by libvirt 6.0

### DIFF
--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -80,6 +80,7 @@ Requires: iptables-services
 Requires: qemu-img
 Requires: python3-pip
 Requires: python3-setuptools
+Requires: libgcrypt > 1.8.3
 Group:     System Environment/Libraries
 %description management
 The CloudStack management server is the central point of coordination,
@@ -109,6 +110,7 @@ Requires: perl
 Requires: python3-libvirt
 Requires: qemu-img
 Requires: qemu-kvm
+Requires: libgcrypt > 1.8.3
 Provides: cloud-agent
 Group: System Environment/Libraries
 %description agent


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/4969
This PR upgrades the version of libgcrypt that is required by libevirt 6.0


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Successfully deployed a CentOS 8 based ACS env 

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
