### PR TITLE
enable creation of vms with solidfire root volumes on vmware67

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -1390,10 +1390,12 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
                 verifyCopyCmdAnswer(copyCmdAnswer, templateInfo);
 
+                // Seems like vmware 6.5 and above does not automatically remount the datastore after rescanning the storage.
+                // Not sure if this is needed.
                 // If using VMware, have the host rescan its software HBA if dynamic discovery is in use.
-                if (HypervisorType.VMware.equals(templateInfo.getHypervisorType())) {
-                    disconnectHostFromVolume(hostVO, volumeInfo.getPoolId(), volumeInfo.get_iScsiName());
-                }
+                //if (HypervisorType.VMware.equals(templateInfo.getHypervisorType())) {
+                //    disconnectHostFromVolume(hostVO, volumeInfo.getPoolId(), volumeInfo.get_iScsiName());
+                //}
             }
             else {
                 VolumeObjectTO newVolume = new VolumeObjectTO();

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -280,7 +280,8 @@ public class VmwareStorageProcessor implements StorageProcessor {
                 }
             }
 
-            removeVmfsDatastore(cmd, hyperHost, datastoreName, storageHost, storagePortNumber, trimIqn(iScsiName), lstHosts);
+            //vmware 6.7 does not automatically mount datastores after rescanning once removed
+            //removeVmfsDatastore(cmd, hyperHost, datastoreName, storageHost, storagePortNumber, trimIqn(iScsiName), lstHosts);
 
             if (!foundExtent) {
                 throw new CloudRuntimeException("Unable to locate the applicable extent");

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
@@ -311,14 +311,15 @@ public class DatastoreMO extends BaseMO {
         DatastoreFile dirFile = new DatastoreFile(file.getDatastoreName(), file.getDir());
 
         HostDatastoreBrowserMO browserMo = getHostDatastoreBrowserMO();
-
-        s_logger.info("Search file " + file.getFileName() + " on " + dirFile.getPath());
-        HostDatastoreBrowserSearchResults results = browserMo.searchDatastore(dirFile.getPath(), file.getFileName(), true);
-        if (results != null) {
-            List<FileInfo> info = results.getFile();
-            if (info != null && info.size() > 0) {
-                s_logger.info("File " + fileFullPath + " exists on datastore");
-                return true;
+        if(folderExists(String.format("[%s]", file.getDatastoreName()), file.getDir())){
+            s_logger.info("Search file " + file.getFileName() + " on " + dirFile.getPath());
+            HostDatastoreBrowserSearchResults results = browserMo.searchDatastore(dirFile.getPath(), file.getFileName(), true);
+            if (results != null) {
+                List<FileInfo> info = results.getFile();
+                if (info != null && info.size() > 0) {
+                    s_logger.info("File " + fileFullPath + " exists on datastore");
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION

### Description

This PR is an attempt to fix the issue where vms cannot be created with solidfire root disks on vmware 6.5 and above https://github.com/apache/cloudstack/issues/3598

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

Previously the approximate steps would be:

1. Create snapshot of template volume
2. Resignature the resulting vmfs datastore
3. Expand the vmfs datastore if needed
4. Rename the vmfs datastore (iscsi name with / replaced by -)
5. Unmount the vmfs datastore
6. Remove iscsi target (remove volume from host)

Seems like previously vmware would rescan the storage and remount the datastore but newer versions do not seem to do this. When attempting to manually mount the datastore the following error occurs:

Operation failed, diagnostics report: Unable to find volume uuid[523486b0-32e55252-da6b-0cc47a30b11e] lvm [snap-4756ea21-52348590-76c4f8d5-a176-0cc47a30b11e] devices

Note: Newer versions of vmware in addition to updating the uuid also add a label snap-snapid-olduuid during the resignature process.


7. Start vm fails --> java.lang.RuntimeException: Datastore '-iqn.2010-01.com.solidfire:t5eb.root-150.150-0' is not accessible. No connected and accessible host is attached to this datastore.

This change modifies the steps as followings

1. Create snapshot of template volume
2. Resignature the resulting vmfs datastore (update the uuid since it would be identical to the template volume at creation)
3. Expand the vmfs datastore if needed
4. Rename the vmfs datastore (iscsi name with '/' replaced by '-')
5. SKIP the step that unmounts the vmfs datastore
6. SKIP the step that removes the iscsi target

Some checks expect a fcd folder to be present, ADD check to ensure folder exists before testing for existence of files inside it.

9. Start the vm --> this now works.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

Steps to reproduce:
Create a vm with solidfire root disks on vmware 6.5 and above.
Expected: Sucessful vm creation
Actual: fails with java.lang.RuntimeException: Datastore '-iqn.2010-01.com.solidfire:t5eb.root-150.150-0' is not accessible. No connected and accessible host is attached to this datastore.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Attempts to Fixe: #3598 

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested on vmware 6.7 using cloudstack 4.15 and solidfire 12

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
