### PR TITLE
ui: Close Create network form from Zones -> Physical Network (Guest) -> Traffic Type view

### DIFF
--- a/ui/src/views/infra/network/IpRangesTabGuest.vue
+++ b/ui/src/views/infra/network/IpRangesTabGuest.vue
@@ -64,10 +64,10 @@
       :maskClosable="false"
       :footer="null"
       :cancelText="$t('label.cancel')"
-      @cancel="showCreateForm = false"
+      @cancel="closeAction"
       centered
       width="auto">
-      <CreateNetwork :resource="{ zoneid: resource.zoneid }"/>
+      <CreateNetwork :resource="{ zoneid: resource.zoneid }" @close-action="closeAction"/>
     </a-modal>
 
   </a-spin>
@@ -160,6 +160,9 @@ export default {
     },
     handleOpenShowCreateForm () {
       this.showCreateForm = true
+    },
+    closeAction () {
+      this.showCreateForm = false
     },
     changePage (page, pageSize) {
       this.page = page


### PR DESCRIPTION
### Description

From the Zones -> Physical Network (Guest) -> Traffic Types View, when we attempt to create a network, Cancel / Creation of network operation doesn't close the form. This PR fixes the issue.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Attempted creating a network from the Zones View and observed that the form closes on completion of action

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
