### PR TITLE
Fixed error when passing shell reserved characters to setup databases

### DIFF
--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -400,7 +400,7 @@ for example:
             return 'ENC(%s)'%value
 
         def encryptDBSecretKey():
-            self.putDbProperty('db.cloud.encrypt.secret', formatEncryptResult(encrypt(self.dbsecretkey)))
+            self.putDbProperty('db.cloud.encrypt.secret', formatEncryptResult(encrypt(shlex.quote(self.dbsecretkey))))
 
         def encryptDBPassword():
             dbPassword = self.getDbProperty('db.cloud.password')
@@ -444,7 +444,7 @@ for example:
 
             self.encryptiontype = self.options.encryptiontype
             self.mgmtsecretkey = self.options.mgmtsecretkey
-            self.dbsecretkey = shlex.quote(self.options.dbsecretkey)
+            self.dbsecretkey = self.options.dbsecretkey
             self.isDebug = self.options.debug
             if self.options.dbConfPath:
               self.dbConfPath = self.options.dbConfPath

--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -26,6 +26,7 @@ import string
 from optparse import OptionParser
 import subprocess
 import shutil
+import shlex
 import socket
 
 # squelch mysqldb spurious warnings
@@ -443,7 +444,7 @@ for example:
 
             self.encryptiontype = self.options.encryptiontype
             self.mgmtsecretkey = self.options.mgmtsecretkey
-            self.dbsecretkey = self.options.dbsecretkey
+            self.dbsecretkey = shlex.quote(self.options.dbsecretkey)
             self.isDebug = self.options.debug
             if self.options.dbConfPath:
               self.dbConfPath = self.options.dbConfPath


### PR DESCRIPTION
### Description

Duplicate PR of #4976 - Targeting 4.15

This PR will allow reserved Linux shell characters to be passed to the setup databases script for the database secret key.
Fixes #4925


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Manual tests have been performed.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
