### PR TITLE
Usage: usage generated for destroyed VMs with assigned backup offering

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -158,4 +158,6 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
     boolean isPowerStateUpToDate(long instanceId);
 
     List<VMInstanceVO> listNonMigratingVmsByHostEqualsLastHost(long hostId);
+
+    List<VMInstanceVO> listDestroyedVmsWithBackupOfferingAssigned();
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -95,6 +95,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     protected SearchBuilder<VMInstanceVO> StartingWithNoHostSearch;
     protected SearchBuilder<VMInstanceVO> NotMigratingSearch;
     protected SearchBuilder<VMInstanceVO> BackupSearch;
+    protected SearchBuilder<VMInstanceVO> DestroyedVMBackupSearch;
     protected SearchBuilder<VMInstanceVO> LastHostAndStatesSearch;
 
     @Inject
@@ -300,6 +301,11 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         LastHostAndStatesSearch.and("lastHost", LastHostAndStatesSearch.entity().getLastHostId(), Op.EQ);
         LastHostAndStatesSearch.and("states", LastHostAndStatesSearch.entity().getState(), Op.IN);
         LastHostAndStatesSearch.done();
+
+        DestroyedVMBackupSearch = createSearchBuilder();
+        DestroyedVMBackupSearch.and("backup_offering_id", DestroyedVMBackupSearch.entity().getBackupOfferingId(), Op.NNULL);
+        DestroyedVMBackupSearch.and("removed", DestroyedVMBackupSearch.entity().getRemoved(), SearchCriteria.Op.NNULL);
+        DestroyedVMBackupSearch.done();
     }
 
     @Override
@@ -331,6 +337,12 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         sc.setParameters("lastHost", hostId);
         sc.setParameters("state", State.Migrating);
         return listBy(sc);
+    }
+
+    @Override
+    public List<VMInstanceVO> listDestroyedVmsWithBackupOfferingAssigned() {
+        SearchCriteria<VMInstanceVO> sc = DestroyedVMBackupSearch.create();
+        return listIncludingRemovedBy(sc);
     }
 
     @Override

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -88,6 +88,9 @@ import org.apache.cloudstack.api.command.user.vmgroup.CreateVMGroupCmd;
 import org.apache.cloudstack.api.command.user.vmgroup.DeleteVMGroupCmd;
 import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
 import com.cloud.agent.api.to.deployasis.OVFNetworkTO;
+import org.apache.cloudstack.backup.BackupManager;
+import org.apache.cloudstack.backup.BackupOfferingVO;
+import org.apache.cloudstack.backup.dao.BackupOfferingDao;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.cloud.entity.api.VirtualMachineEntity;
 import org.apache.cloudstack.engine.cloud.entity.api.db.dao.VMNetworkMapDao;
@@ -519,6 +522,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private StorageManager storageMgr;
     @Inject
     private ServiceOfferingJoinDao serviceOfferingJoinDao;
+    @Inject
+    private BackupOfferingDao backupOfferingDao;
+    @Inject
+    private BackupManager backupManager;
 
     private ScheduledExecutorService _executor = null;
     private ScheduledExecutorService _vmIpFetchExecutor = null;
@@ -2978,7 +2985,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         deleteVolumesFromVm(volumesToBeDeleted);
-
+        if (destroyedVm.getBackupOfferingId() != null) {
+            final BackupOfferingVO offering = backupOfferingDao.findById(destroyedVm.getBackupOfferingId());
+            if (offering != null) {
+                backupManager.removeVMFromBackupOffering(destroyedVm.getId(), true);
+            }
+        }
         return destroyedVm;
     }
 


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/4990
When a VM associated with a backup offering is destroyed/expunged, the backup offering isn't unassigned, hence leading to backup usage generation. This PR fixes/addresses the following:
- When a VM is destroyed, backup offering associated with the VM is removed
- A cleanup job to disassociate the backup offering from expunged VMs

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Created a VM and assigned a backup offering to it, destroyed the VM and verified no further usage events are generated and events corresponding to "BACKUP.OFFERING.REMOVE" is generated / added in the event table


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
