### PR TITLE
SystemVM: Set agent state to disconnected on Stopping the systemVM

### DIFF
--- a/api/src/main/java/com/cloud/host/Status.java
+++ b/api/src/main/java/com/cloud/host/Status.java
@@ -131,6 +131,7 @@ public enum Status {
         s_fsm.addTransition(Status.Up, Event.PingTimeout, Status.Alert);
         s_fsm.addTransition(Status.Up, Event.AgentDisconnected, Status.Alert);
         s_fsm.addTransition(Status.Up, Event.ShutdownRequested, Status.Disconnected);
+        s_fsm.addTransition(Status.Disconnected, Event.ShutdownRequested, Status.Disconnected);
         s_fsm.addTransition(Status.Up, Event.HostDown, Status.Down);
         s_fsm.addTransition(Status.Up, Event.Ping, Status.Up);
         s_fsm.addTransition(Status.Up, Event.AgentConnected, Status.Connecting);

--- a/api/src/main/java/com/cloud/host/Status.java
+++ b/api/src/main/java/com/cloud/host/Status.java
@@ -132,6 +132,8 @@ public enum Status {
         s_fsm.addTransition(Status.Up, Event.AgentDisconnected, Status.Alert);
         s_fsm.addTransition(Status.Up, Event.ShutdownRequested, Status.Disconnected);
         s_fsm.addTransition(Status.Disconnected, Event.ShutdownRequested, Status.Disconnected);
+        s_fsm.addTransition(Status.Down, Event.ShutdownRequested, Status.Disconnected);
+        s_fsm.addTransition(Status.Rebalancing, Event.ShutdownRequested, Status.Disconnected);
         s_fsm.addTransition(Status.Up, Event.HostDown, Status.Down);
         s_fsm.addTransition(Status.Up, Event.Ping, Status.Up);
         s_fsm.addTransition(Status.Up, Event.AgentConnected, Status.Connecting);

--- a/api/src/main/java/com/cloud/vm/VirtualMachine.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachine.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.api.Displayable;
@@ -186,6 +188,7 @@ public interface VirtualMachine extends RunningOn, ControlledEntity, Partition, 
         }
     }
 
+    static final Set<Type> systemVMs = new HashSet<>(Arrays.asList(VirtualMachine.Type.ConsoleProxy, VirtualMachine.Type.SecondaryStorageVm));
     static final String IsDynamicScalingEnabled = "enable.dynamic.scaling";
 
     public enum Event {

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1978,10 +1978,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     vmGuru.finalizeStop(profile, answer);
                 }
             } else {
-                if (VirtualMachine.Type.ConsoleProxy == vm.getType() || VirtualMachine.Type.SecondaryStorageVm == vm.getType()) {
+                if (VirtualMachine.systemVMs.contains(vm.getType())) {
                     HostVO systemVmHost = ApiDBUtils.findHostByTypeNameAndZoneId(vm.getDataCenterId(), vm.getHostName(),
                             VirtualMachine.Type.SecondaryStorageVm.equals(vm.getType()) ? Host.Type.SecondaryStorageVM : Host.Type.ConsoleProxy);
-                    _agentMgr.agentStatusTransitTo(systemVmHost, Status.Event.ShutdownRequested, _nodeId);
+                    if (systemVmHost != null) {
+                        _agentMgr.agentStatusTransitTo(systemVmHost, Status.Event.ShutdownRequested, _nodeId);
+                    }
                 }
             }
         }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.api.ApiDBUtils;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.command.admin.vm.MigrateVMCmd;
@@ -1975,6 +1976,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 } else {
                     s_logger.warn("Unable to actually stop " + vm + " but continue with release because it's a force stop");
                     vmGuru.finalizeStop(profile, answer);
+                }
+            } else {
+                if (Arrays.asList(new VirtualMachine.Type[]{VirtualMachine.Type.ConsoleProxy, VirtualMachine.Type.SecondaryStorageVm}).contains(vm.getType())) {
+                    HostVO systemVmHost = ApiDBUtils.findHostByTypeNameAndZoneId(vm.getDataCenterId(), vm.getHostName(),
+                            VirtualMachine.Type.SecondaryStorageVm.equals(vm.getType()) ? Host.Type.SecondaryStorageVM : Host.Type.ConsoleProxy);
+                    _agentMgr.agentStatusTransitTo(systemVmHost, Status.Event.ShutdownRequested, _nodeId);
                 }
             }
         }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1978,7 +1978,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     vmGuru.finalizeStop(profile, answer);
                 }
             } else {
-                if (Arrays.asList(new VirtualMachine.Type[]{VirtualMachine.Type.ConsoleProxy, VirtualMachine.Type.SecondaryStorageVm}).contains(vm.getType())) {
+                if (VirtualMachine.Type.ConsoleProxy == vm.getType() || VirtualMachine.Type.SecondaryStorageVm == vm.getType()) {
                     HostVO systemVmHost = ApiDBUtils.findHostByTypeNameAndZoneId(vm.getDataCenterId(), vm.getHostName(),
                             VirtualMachine.Type.SecondaryStorageVm.equals(vm.getType()) ? Host.Type.SecondaryStorageVM : Host.Type.ConsoleProxy);
                     _agentMgr.agentStatusTransitTo(systemVmHost, Status.Event.ShutdownRequested, _nodeId);

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1450,7 +1450,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 }
             }
 
-            if (vm.getType() == Type.SecondaryStorageVm || vm.getType() == Type.ConsoleProxy) {
+            if (VirtualMachine.systemVMs.contains(vm.getType())) {
                 Host systemVmHost = ApiDBUtils.findHostByTypeNameAndZoneId(vm.getDataCenterId(), vm.getHostName(),
                         Type.SecondaryStorageVm.equals(vm.getType()) ? Host.Type.SecondaryStorageVM : Host.Type.ConsoleProxy);
                 if (systemVmHost != null) {


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/4972
This PR sets systevms' agent state to disconnected when it is stopped. Currently, when a systemVM (Console Proxy VM / Secondary storage VM) is stopped, the agent state still appears to be 'Up'

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
#### Prior to Fix:
When the VM is stopped (with / without force): 
When the systemVM is 'Stopped' or 'Starting' the agent state appears to be 'Up'

![image](https://user-images.githubusercontent.com/10495417/117666879-f01a6c00-b1c1-11eb-8d45-849934f9c6ec.png)

![image](https://user-images.githubusercontent.com/10495417/117666903-f6a8e380-b1c1-11eb-9ae2-9bc2717804bf.png)


#### Post Fix:

![image](https://user-images.githubusercontent.com/10495417/117667342-6dde7780-b1c2-11eb-8089-7f40d7c081e9.png)

![image](https://user-images.githubusercontent.com/10495417/117667428-7e8eed80-b1c2-11eb-8d82-aa4bf6f7ca32.png)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
