### PR TITLE
ui: Display Zone Name instead of Zone UUID in list view

### DIFF
--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -174,7 +174,7 @@ export default {
       icon: 'cloud-upload',
       docHelp: 'adminguide/virtual_machines.html#backup-offerings',
       permission: ['listBackupOfferings', 'listInfrastructure'],
-      columns: ['name', 'description', 'zoneid'],
+      columns: ['name', 'description', 'zonename'],
       details: ['name', 'id', 'description', 'externalid', 'zone', 'created'],
       actions: [{
         api: 'importBackupOffering',


### PR DESCRIPTION
### Description

This PR displays zone name instead of zone uuid in backup offering list view

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Screenshots (if appropriate):


### How Has This Been Tested?
Before Fix:
![image](https://user-images.githubusercontent.com/10495417/117644769-78d7de80-b1a7-11eb-8620-2f06a4c91ad1.png)


After Fix:
![image](https://user-images.githubusercontent.com/10495417/117644800-82f9dd00-b1a7-11eb-977e-1282c34d841e.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
