### PR TITLE
KVM NFS disk IO driver supporting IO_URING

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2619,6 +2619,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                     disk.setDiscard(DiscardType.UNMAP);
                 }
 
+                setDiskIoDriver(disk);
+
                 if (pool.getType() == StoragePoolType.RBD) {
                     /*
                             For RBD pools we use the secret mechanism in libvirt.
@@ -2711,6 +2713,17 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                     }
                 }
             }
+        }
+    }
+
+    private void setDiskIoDriver(DiskDef disk) {
+        /*
+         * IO Driver works for
+         * - Qemu >= 5.0
+         * - Libvirt >= 6.3.0
+         */
+        if(_hypervisorLibvirtVersion >= 6030000 && _hypervisorQemuVersion >= 5000000) {
+            disk.setIoDriver(DiskDef.IoDriver.IOURING);
         }
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2731,12 +2731,13 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return storagePool.getPhysicalDisk(data.getPath());
     }
 
+    /**
+     * Set Disk IO Driver, if supported by the Libvirt/Qemu version.
+     * IO Driver works for:
+     * (i) Qemu >= 5.0;
+     * (ii) Libvirt >= 6.3.0
+     */
     protected void setDiskIoDriver(DiskDef disk) {
-        /*
-         * IO Driver works for
-         * - Qemu >= 5.0
-         * - Libvirt >= 6.3.0
-         */
         if (getHypervisorLibvirtVersion() >= HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IO_URING && getHypervisorQemuVersion() >= HYPERVISOR_QEMU_VERSION_SUPPORTS_IO_URING) {
             disk.setIoDriver(DiskDef.IoDriver.IOURING);
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -253,7 +253,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     protected static final String DEFAULT_OVS_VIF_DRIVER_CLASS_NAME = "com.cloud.hypervisor.kvm.resource.OvsVifDriver";
     protected static final String DEFAULT_BRIDGE_VIF_DRIVER_CLASS_NAME = "com.cloud.hypervisor.kvm.resource.BridgeVifDriver";
-    private final static long HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IO_URING = 6030000;
+    private final static long HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IO_URING = 6003000;
     private final static long HYPERVISOR_QEMU_VERSION_SUPPORTS_IO_URING = 5000000;
 
     protected HypervisorType _hypervisorType;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -651,6 +651,20 @@ public class LibvirtVMDef {
 
         }
 
+        public enum IoDriver {
+            IOURING("io_uring");
+            String ioDriver;
+
+            IoDriver(String driver) {
+                ioDriver = driver;
+            }
+
+            @Override
+            public String toString() {
+                return ioDriver;
+            }
+        }
+
         private DeviceType _deviceType; /* floppy, disk, cdrom */
         private DiskType _diskType;
         private DiskProtocol _diskProtocol;
@@ -681,6 +695,7 @@ public class LibvirtVMDef {
         private String _serial;
         private boolean qemuDriver = true;
         private DiscardType _discard = DiscardType.IGNORE;
+        private IoDriver ioDriver;
 
         public DiscardType getDiscard() {
             return _discard;
@@ -688,6 +703,10 @@ public class LibvirtVMDef {
 
         public void setDiscard(DiscardType discard) {
             this._discard = discard;
+        }
+
+        public void setIoDriver(IoDriver ioDriver) {
+            this.ioDriver = ioDriver;
         }
 
         public void setDeviceType(DeviceType deviceType) {
@@ -1001,6 +1020,11 @@ public class LibvirtVMDef {
                 if(_discard != null && _discard != DiscardType.IGNORE) {
                     diskBuilder.append("discard='" + _discard.toString() + "' ");
                 }
+
+                if(ioDriver != null) {
+                    diskBuilder.append("io='" + ioDriver.toString() + "'");
+                }
+
                 diskBuilder.append("/>\n");
             }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -656,14 +656,17 @@ public class LibvirtVMDef {
          * Qemu guests support "threads" and "native" options Since 0.8.8 ; "io_uring" is supported Since 6.3.0 (QEMU 5.0).
          */
         public enum IoDriver {
-            NATIVE("native"), THREADS("threads"), IOURING("io_uring");
+            NATIVE("native"),
+            THREADS("threads"),
+            IOURING("io_uring");
             String ioDriver;
 
             IoDriver(String driver) {
                 ioDriver = driver;
             }
 
-            @Override public String toString() {
+            @Override
+            public String toString() {
                 return ioDriver;
             }
         }
@@ -706,6 +709,10 @@ public class LibvirtVMDef {
 
         public void setDiscard(DiscardType discard) {
             this._discard = discard;
+        }
+
+        public DiskDef.IoDriver getIoDriver() {
+            return ioDriver;
         }
 
         public void setIoDriver(IoDriver ioDriver) {
@@ -1025,7 +1032,7 @@ public class LibvirtVMDef {
                 }
 
                 if(ioDriver != null) {
-                    diskBuilder.append("io='" + ioDriver.toString() + "'");
+                    diskBuilder.append("io='" + ioDriver + "'");
                 }
 
                 diskBuilder.append("/>\n");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1032,7 +1032,7 @@ public class LibvirtVMDef {
                 }
 
                 if(ioDriver != null) {
-                    diskBuilder.append("io='" + ioDriver + "'");
+                    diskBuilder.append(String.format("io='%s'", ioDriver));
                 }
 
                 diskBuilder.append("/>\n");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -651,16 +651,19 @@ public class LibvirtVMDef {
 
         }
 
+        /**
+         * This enum specifies IO Drivers, each option controls specific policies on I/O.
+         * Qemu guests support "threads" and "native" options Since 0.8.8 ; "io_uring" is supported Since 6.3.0 (QEMU 5.0).
+         */
         public enum IoDriver {
-            IOURING("io_uring");
+            NATIVE("native"), THREADS("threads"), IOURING("io_uring");
             String ioDriver;
 
             IoDriver(String driver) {
                 ioDriver = driver;
             }
 
-            @Override
-            public String toString() {
+            @Override public String toString() {
                 return ioDriver;
             }
         }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -202,6 +202,9 @@ public class LibvirtComputingResourceTest {
     @Mock
     LibvirtVMDef vmDef;
 
+    private final static long HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IOURING = 6030000;
+    private final static long HYPERVISOR_QEMU_VERSION_SUPPORTS_IOURING = 5000000;
+
     String hyperVisorType = "kvm";
     Random random = new Random();
     final String memInfo = "MemTotal:        5830236 kB\n" +
@@ -5208,5 +5211,38 @@ public class LibvirtComputingResourceTest {
         extraConfig.put("extraconfig-3", "value3");
         libvirtComputingResource.addExtraConfigComponent(extraConfig, vmDef);
         Mockito.verify(vmDef, times(1)).addComp(any());
+    }
+
+    @Test
+    public void setDiskIoDriverTestIoUring() {
+        DiskDef diskDef = configureAndTestSetDiskIoDriverTest(HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IOURING, HYPERVISOR_QEMU_VERSION_SUPPORTS_IOURING);
+        Assert.assertEquals(DiskDef.IoDriver.IOURING, diskDef.getIoDriver());
+    }
+
+    @Test
+    public void setDiskIoDriverTestLibvirtSupportsIoUring() {
+        DiskDef diskDef = configureAndTestSetDiskIoDriverTest(123l, HYPERVISOR_QEMU_VERSION_SUPPORTS_IOURING);
+        Assert.assertNotEquals(DiskDef.IoDriver.IOURING, diskDef.getIoDriver());
+    }
+
+    @Test
+    public void setDiskIoDriverTestQemuSupportsIoUring() {
+        DiskDef diskDef = configureAndTestSetDiskIoDriverTest(HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IOURING, 123l);
+        Assert.assertNotEquals(DiskDef.IoDriver.IOURING, diskDef.getIoDriver());
+    }
+
+    @Test
+    public void setDiskIoDriverTestNoSupportToIoUring() {
+        DiskDef diskDef = configureAndTestSetDiskIoDriverTest(123l, 123l);
+        Assert.assertNotEquals(DiskDef.IoDriver.IOURING, diskDef.getIoDriver());
+    }
+
+    private DiskDef configureAndTestSetDiskIoDriverTest(long hypervisorLibvirtVersion, long hypervisorQemuVersion) {
+        DiskDef diskDef = new DiskDef();
+        LibvirtComputingResource libvirtComputingResourceSpy = Mockito.spy(new LibvirtComputingResource());
+        Mockito.when(libvirtComputingResourceSpy.getHypervisorLibvirtVersion()).thenReturn(hypervisorLibvirtVersion);
+        Mockito.when(libvirtComputingResourceSpy.getHypervisorQemuVersion()).thenReturn(hypervisorQemuVersion);
+        libvirtComputingResourceSpy.setDiskIoDriver(diskDef);
+        return diskDef;
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -202,7 +202,7 @@ public class LibvirtComputingResourceTest {
     @Mock
     LibvirtVMDef vmDef;
 
-    private final static long HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IOURING = 6030000;
+    private final static long HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IOURING = 6003000;
     private final static long HYPERVISOR_QEMU_VERSION_SUPPORTS_IOURING = 5000000;
 
     String hyperVisorType = "kvm";


### PR DESCRIPTION
### Description

Currently there is no disk IO driver configuration for VMs running on KVM. That's OK for most the cases; however, recently there have been added some quite interesting optimizations with the IO driver `io_uring`.

Note that IO URING requires:
- `Qemu >= 5.0`, and
- `Libvirt >= 6.3.0`.

By using `io_uring` we can see a massive I/O performance improvement within Virtual Machines running from Local and/or NFS storage.

This implementation enhances the KVM disk configuration by adding workflow for setting the disk IO drivers. Additionally, if the    Qemu and Libvirt versions matches with the required for having `io_uring` we are going to set it on the VM. If there is no support for such driver we keep it as it is nowadays, without any IO driver configured.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #4883

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Locally debugging with breakpoints on remote debug and asserting the IO driver as well as qemu/libvirt versions.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
