### PR TITLE
Fix deploy-as-is not honoured on upload from local

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/GetUploadParamsForTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/GetUploadParamsForTemplateCmd.java
@@ -89,6 +89,11 @@ public class GetUploadParamsForTemplateCmd extends AbstractGetUploadParamsCmd {
     @Parameter(name = ApiConstants.TEMPLATE_TAG, type = CommandType.STRING, description = "the tag for this template.")
     private String templateTag;
 
+    @Parameter(name=ApiConstants.DEPLOY_AS_IS,
+            type = CommandType.BOOLEAN,
+            description = "(VMware only) true if VM deployments should preserve all the configurations defined for this template", since = "4.15.1")
+    private Boolean deployAsIs;
+
     public String getDisplayText() {
         return displayText;
     }
@@ -151,6 +156,11 @@ public class GetUploadParamsForTemplateCmd extends AbstractGetUploadParamsCmd {
 
     public String getTemplateTag() {
         return templateTag;
+    }
+
+    public boolean isDeployAsIs() {
+        return Hypervisor.HypervisorType.VMware.toString().equalsIgnoreCase(hypervisor) &&
+                Boolean.TRUE.equals(deployAsIs);
     }
 
     @Override

--- a/server/src/main/java/com/cloud/storage/upload/params/TemplateUploadParams.java
+++ b/server/src/main/java/com/cloud/storage/upload/params/TemplateUploadParams.java
@@ -29,10 +29,10 @@ public class TemplateUploadParams extends UploadParamsBase {
                                 Long zoneId, Hypervisor.HypervisorType hypervisorType, String chksum,
                                 String templateTag, long templateOwnerId,
                                 Map details, Boolean sshkeyEnabled,
-                                Boolean isDynamicallyScalable, Boolean isRoutingType) {
+                                Boolean isDynamicallyScalable, Boolean isRoutingType, boolean deployAsIs) {
         super(userId, name, displayText, bits, passwordEnabled, requiresHVM, isPublic, featured, isExtractable,
                 format, guestOSId, zoneId, hypervisorType, chksum, templateTag, templateOwnerId, details,
-                sshkeyEnabled, isDynamicallyScalable, isRoutingType);
+                sshkeyEnabled, isDynamicallyScalable, isRoutingType, deployAsIs);
         setBootable(true);
     }
 }

--- a/server/src/main/java/com/cloud/storage/upload/params/UploadParamsBase.java
+++ b/server/src/main/java/com/cloud/storage/upload/params/UploadParamsBase.java
@@ -44,6 +44,7 @@ public abstract class UploadParamsBase implements UploadParams {
     private boolean sshkeyEnabled;
     private boolean isDynamicallyScalable;
     private boolean isRoutingType;
+    private boolean deployAsIs;
 
     UploadParamsBase(long userId, String name, String displayText,
                                Integer bits, boolean passwordEnabled, boolean requiresHVM,
@@ -52,7 +53,7 @@ public abstract class UploadParamsBase implements UploadParams {
                                Long zoneId, Hypervisor.HypervisorType hypervisorType, String checksum,
                                String templateTag, long templateOwnerId,
                                Map details, boolean sshkeyEnabled,
-                               boolean isDynamicallyScalable, boolean isRoutingType) {
+                               boolean isDynamicallyScalable, boolean isRoutingType, boolean deployAsIs) {
         this.userId = userId;
         this.name = name;
         this.displayText = displayText;
@@ -73,6 +74,7 @@ public abstract class UploadParamsBase implements UploadParams {
         this.sshkeyEnabled = sshkeyEnabled;
         this.isDynamicallyScalable = isDynamicallyScalable;
         this.isRoutingType = isRoutingType;
+        this.deployAsIs = deployAsIs;
     }
 
     UploadParamsBase(long userId, String name, String displayText, boolean isPublic, boolean isFeatured,
@@ -216,7 +218,7 @@ public abstract class UploadParamsBase implements UploadParams {
 
     @Override
     public boolean isDeployAsIs() {
-        return false;
+        return deployAsIs;
     }
 
     void setIso(boolean iso) {

--- a/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -358,7 +358,7 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
                 BooleanUtils.toBoolean(cmd.isFeatured()), BooleanUtils.toBoolean(cmd.isExtractable()), cmd.getFormat(), osTypeId,
                 cmd.getZoneId(), HypervisorType.getType(cmd.getHypervisor()), cmd.getChecksum(),
                 cmd.getTemplateTag(), cmd.getEntityOwnerId(), cmd.getDetails(), BooleanUtils.toBoolean(cmd.isSshKeyEnabled()),
-                BooleanUtils.toBoolean(cmd.isDynamicallyScalable()), BooleanUtils.toBoolean(cmd.isRoutingType()));
+                BooleanUtils.toBoolean(cmd.isDynamicallyScalable()), BooleanUtils.toBoolean(cmd.isRoutingType()), cmd.isDeployAsIs());
         return prepareUploadParamsInternal(params);
     }
 

--- a/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -337,7 +337,7 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
                 params.isExtractable(), params.getFormat(), params.getGuestOSId(), zoneList,
                 params.getHypervisorType(), params.getChecksum(), params.isBootable(), params.getTemplateTag(), owner,
                 params.getDetails(), params.isSshKeyEnabled(), params.getImageStoreUuid(),
-                params.isDynamicallyScalable(), params.isRoutingType() ? TemplateType.ROUTING : TemplateType.USER, params.isDirectDownload(), false);
+                params.isDynamicallyScalable(), params.isRoutingType() ? TemplateType.ROUTING : TemplateType.USER, params.isDirectDownload(), params.isDeployAsIs());
     }
 
     private Long getDefaultDeployAsIsGuestOsId() {


### PR DESCRIPTION
### Description

This PR fixes the upload from local using 'Read VM setting from OVA' - was not honoured if it was selected

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Upload template from local selecting 'Read VM settings from OVA' and other template without selecting it 
- Check both uploaded templates 'Read VM settings from OVA' values