### PR TITLE
ui: pass podid for basic zone createvlaniprange

### DIFF
--- a/ui/src/views/network/CreateVlanIpRange.vue
+++ b/ui/src/views/network/CreateVlanIpRange.vue
@@ -23,6 +23,17 @@
           :form="form"
           @submit="handleSubmit"
           layout="vertical">
+          <a-form-item :label="$t('label.podid')" v-if="pods && pods.length > 0">
+            <a-select
+              autoFocus
+              v-decorator="['podid', {
+                initialValue: this.pods && this.pods.length > 0 ? this.pods[0].id : '',
+                rules: [{ required: true, message: `${$t('label.required')}` }]
+              }]"
+            >
+              <a-select-option v-for="pod in pods" :key="pod.id" :value="pod.id">{{ pod.name }}</a-select-option>
+            </a-select>
+          </a-form-item>
           <a-form-item>
             <span slot="label">
               {{ $t('label.gateway') }}
@@ -195,6 +206,8 @@ export default {
   data () {
     return {
       loading: false,
+      zone: {},
+      pods: [],
       ipV4Regex: /^(25[0-5]|2[0-4]\d|[01]?\d\d?)\.(25[0-5]|2[0-4]\d|[01]?\d\d?)\.(25[0-5]|2[0-4]\d|[01]?\d\d?)\.(25[0-5]|2[0-4]\d|[01]?\d\d?)$/i,
       ipV6Regex: /^((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}:[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){5}:([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){4}:([0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){3}:([0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){2}:([0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(([0-9A-Fa-f]{1,4}:){0,5}:((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(::([0-9A-Fa-f]{1,4}:){0,5}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|([0-9A-Fa-f]{1,4}::([0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})|(::([0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){1,7}:))$/i
     }
@@ -206,8 +219,41 @@ export default {
     this.apiConfig.params.forEach(param => {
       this.apiParams[param.name] = param
     })
+    this.fetchData()
   },
   methods: {
+    async fetchData () {
+      await this.fetchZone()
+      if (this.zone.networktype === 'Basic') {
+        this.fetchPods()
+      }
+    },
+    fetchZone () {
+      return new Promise((resolve, reject) => {
+        this.loading = true
+        api('listZones', { id: this.resource.zoneid }).then(json => {
+          this.zone = json.listzonesresponse.zone[0] || {}
+          resolve(this.zone)
+        }).catch(error => {
+          this.$notifyError(error)
+          reject(error)
+        }).finally(() => {
+          this.loading = false
+        })
+      })
+    },
+    fetchPods () {
+      this.loading = true
+      api('listPods', {
+        zoneid: this.resource.zoneid
+      }).then(response => {
+        this.pods = response.listpodsresponse.pod ? response.listpodsresponse.pod : []
+      }).catch(error => {
+        this.$notifyError(error)
+      }).finally(() => {
+        this.loading = false
+      })
+    },
     handleSubmit (e) {
       e.preventDefault()
 
@@ -219,6 +265,9 @@ export default {
         const params = {}
         params.forVirtualNetwork = false
         params.networkid = this.resource.id
+        if (values.podid) {
+          params.podid = values.podid
+        }
         params.gateway = values.gateway
         params.netmask = values.netmask
         params.startip = values.startip


### PR DESCRIPTION
### Description

While add IP range for a basic zone, podid parameter must be passed with createVlanIpRange.

Fixes #5021 
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

In legacy UI:
![Screenshot from 2021-05-13 14-23-58](https://user-images.githubusercontent.com/153340/118102854-e9286f00-b3f6-11eb-863a-1e2e6243e155.png)

W/o change in UI:
![Screenshot from 2021-05-13 14-24-58](https://user-images.githubusercontent.com/153340/118102975-0b21f180-b3f7-11eb-88c8-c6f0235d21e0.png)


After change in UI:
![Screenshot from 2021-05-13 14-23-19](https://user-images.githubusercontent.com/153340/118102879-f180aa00-b3f6-11eb-9431-61fc5a398fda.png)


