### PR TITLE
Fix in Marvin - migrate_vm_with_volume

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -867,8 +867,8 @@ class VirtualMachine:
         if hostid:
             cmd.hostid = hostid
         if migrateto:
-            migrateto = []
-            for volume, pool in migrateto.items():
+            cmd.migrateto = []
+            for volume, pool in list(migrateto.items()):
                 cmd.migrateto.append({
                     'volume': volume,
                     'pool': pool


### PR DESCRIPTION
### Description
Cannot migrate VM to another storage, because 'migrateto' argument is overridden.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?
tested with Marvin nose tests
