### PR TITLE
Prevent NPE if hypervisor's capabilities are null

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -6215,8 +6215,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             }
         }
 
-        if (!capabilities.isStorageMotionSupported()) {
-            throw new CloudRuntimeException("Migration with storage isn't supported on hypervisor " + srcHost.getHypervisorType() + " of version " + srcHost.getHypervisorVersion());
+        if (capabilities == null || !capabilities.isStorageMotionSupported()) {
+            throw new CloudRuntimeException(String.format("Migration with storage isn't supported on hypervisor %s of version %s", srcHost.getHypervisorType(), srcHost.getHypervisorVersion()));
         }
 
         // Check if destination host is up.

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -6208,7 +6208,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             List<HypervisorCapabilitiesVO> lstHypervisorCapabilities = _hypervisorCapabilitiesDao.listAllByHypervisorType(HypervisorType.KVM);
 
             capabilities = lstHypervisorCapabilities.stream().filter(hvCapabilities -> hvCapabilities.isStorageMotionSupported()).findAny()
-            .orElseThrow(() -> new CloudRuntimeException(String.format("Migration with storage isn't supported on hypervisor %s of version %s", srcHost.getHypervisorType(), srcHost.getHypervisorVersion())));
+            .orElseThrow(() -> new CloudRuntimeException(String.format("Cannot migrate VM with storage, as the capabilities are not found for the hypervisor %s with version %s", srcHost.getHypervisorType(), srcHost.getHypervisorVersion())));
         } else if (!capabilities.isStorageMotionSupported()) {
             throw new CloudRuntimeException(String.format("Migration with storage isn't supported on hypervisor %s of version %s", srcHost.getHypervisorType(), srcHost.getHypervisorVersion()));
         }


### PR DESCRIPTION
### Description

If the hypervisor's capabilities are null, CloudRuntimeException will be thrown;
Format the error message

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?
tested on CS 4.15.1.0 with KVM hypervisors
