### PR TITLE
[Vmware] Fix worker VM invalid numeric value

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
@@ -2280,7 +2280,7 @@ public class HypervisorHostHelper {
             Integer host1Version = getHostHardwareVersion(host1);
             Integer host2Version = getHostHardwareVersion(host2);
             if (host1Version != null && host2Version != null && !host1Version.equals(host2Version)) {
-                hardwareVersion = String.valueOf(Math.min(host1Version, host2Version));
+                hardwareVersion = VirtualMachineMO.getVmxFormattedVirtualHardwareVersion(Math.min(host1Version, host2Version));
             }
         }
         return hardwareVersion;


### PR DESCRIPTION
### Description

This PR fixes an issue on VMware when creating worker VMs for volume migration from/to hosts with different ESXi versions. In this case, the minimum ESXi host version is chosen for the worker VM hardware version but it is set in a wrong format ("DD" instead of "vmx-DD")
 
### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Vmware mixed environment with 2 clusters of 2 hosts each. One cluster with 5.5 hosts and other cluster with 6.5 hosts