### PR TITLE
systemvm: increase apache2 default timeout to 10min from 5mins

### DIFF
--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -500,7 +500,7 @@ clean_ipalias_config() {
 }
 
 setup_apache2_common() {
-  sed -i 's/^Timeout.*/Timeout 900/g' /etc/apache2/apache2.conf
+  sed -i 's/^Timeout.*/Timeout 600/g' /etc/apache2/apache2.conf
   sed -i 's/^Include ports.conf.*/# CS: Done by Python CsApp config\n#Include ports.conf/g' /etc/apache2/apache2.conf
   # Disable listing of http://SSVM-IP/icons folder for security issue. see article http://www.i-lateral.com/tutorials/disabling-the-icons-folder-on-an-ubuntu-web-server/
   [ -f /etc/apache2/mods-available/alias.conf ] && sed -i s/"Options Indexes MultiViews"/"Options -Indexes MultiViews"/ /etc/apache2/mods-available/alias.conf

--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -500,6 +500,7 @@ clean_ipalias_config() {
 }
 
 setup_apache2_common() {
+  sed -i 's/^Timeout.*/Timeout 900/g' /etc/apache2/apache2.conf
   sed -i 's/^Include ports.conf.*/# CS: Done by Python CsApp config\n#Include ports.conf/g' /etc/apache2/apache2.conf
   # Disable listing of http://SSVM-IP/icons folder for security issue. see article http://www.i-lateral.com/tutorials/disabling-the-icons-folder-on-an-ubuntu-web-server/
   [ -f /etc/apache2/mods-available/alias.conf ] && sed -i s/"Options Indexes MultiViews"/"Options -Indexes MultiViews"/ /etc/apache2/mods-available/alias.conf


### PR DESCRIPTION
Increases `Timeout` of apache2 to 10mins. This will potentially may be a workaround/fix for template upload that fail due to flaky network or higher timeouts that may result in 504 (gateway timeout) issue.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)