### PR TITLE
server: fixes NPE on empty vmware.root.disk.controller config

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4048,7 +4048,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                         vm.setDetail(VmDetailConstants.FIRMWARE, "efi");
                         s_logger.info("guestOS is OSX : overwrite root disk controller to scsi, use smc and efi");
                     } else {
-String controllerSetting = StringUtils.defaultIfEmpty(_configDao.getValue(Config.VmwareRootDiskControllerType.key()),
+                        String controllerSetting = StringUtils.defaultIfEmpty(_configDao.getValue(Config.VmwareRootDiskControllerType.key()),
                                 Config.VmwareRootDiskControllerType.getDefaultValue());
                         // Don't override if VM already has root/data disk controller detail
                         if (vm.getDetail(VmDetailConstants.ROOT_DISK_CONTROLLER) == null) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4048,10 +4048,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                         vm.setDetail(VmDetailConstants.FIRMWARE, "efi");
                         s_logger.info("guestOS is OSX : overwrite root disk controller to scsi, use smc and efi");
                     } else {
-                        String controllerSetting = _configDao.getValue(Config.VmwareRootDiskControllerType.key());
-                        if (StringUtils.isEmpty(controllerSetting)) {
-                            controllerSetting = Config.VmwareRootDiskControllerType.getDefaultValue();
-                        }
+String controllerSetting = StringUtils.defaultIfEmpty(_configDao.getValue(Config.VmwareRootDiskControllerType.key()),
+                                Config.VmwareRootDiskControllerType.getDefaultValue());
                         // Don't override if VM already has root/data disk controller detail
                         if (vm.getDetail(VmDetailConstants.ROOT_DISK_CONTROLLER) == null) {
                             vm.setDetail(VmDetailConstants.ROOT_DISK_CONTROLLER, controllerSetting);


### PR DESCRIPTION
### Description

When global config - vmware.root.disk.controller is set to empty and template is registered with deployasis, server will throw NPE while deploying a VM. This change fixes the problem by using default value of the config in this case.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

By deploying VM with a deployasis (read settings from OVA) template.
**Without change:**
```
2021-05-28 06:41:53,503 DEBUG [c.c.a.ApiServlet] (qtp1233705144-21:ctx-18f24cbd) (logid:a0001979) ===START===  172.16.250.9 -- GET  zoneid=251398d0-707d-4e5a-9298-2a97a1eff534&templateid=888f0a52-e34b-4193-8cfb-4b7d3ce42753&startvm=true&serviceofferingid=8b28cbe8-5d57-4c3d-85d9-d92b67af13a3&affinitygroupids=&iptonetworklist[0].networkid=f3185526-afce-462d-ba75-b2ac439b9de9&name=t202&displayname=t202&command=deployVirtualMachine&response=json
2021-05-28 06:41:53,511 DEBUG [c.c.a.ApiServer] (qtp1233705144-21:ctx-18f24cbd ctx-ed3119fc) (logid:a0001979) CIDRs from which account 'Acct[a0d53995-92b4-11eb-9b07-1e0053000169-admin]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-05-28 06:41:53,522 DEBUG [c.c.u.AccountManagerImpl] (qtp1233705144-21:ctx-18f24cbd ctx-ed3119fc) (logid:a0001979) Access granted to Acct[a0d53995-92b4-11eb-9b07-1e0053000169-admin] to org.apache.cloudstack.quota.vo.ServiceOfferingVO$$EnhancerByCGLIB$$633a68df@124467e8 by AffinityGroupAccessChecker
2021-05-28 06:41:53,522 DEBUG [c.c.u.AccountManagerImpl] (qtp1233705144-21:ctx-18f24cbd ctx-ed3119fc) (logid:a0001979) Access granted to Acct[a0d53995-92b4-11eb-9b07-1e0053000169-admin] to null by AffinityGroupAccessChecker
2021-05-28 06:41:53,530 DEBUG [c.c.n.NetworkModelImpl] (qtp1233705144-21:ctx-18f24cbd ctx-ed3119fc) (logid:a0001979) Service SecurityGroup is not supported in the network id=213
2021-05-28 06:41:53,537 DEBUG [c.c.u.d.T.Transaction] (qtp1233705144-21:ctx-18f24cbd ctx-ed3119fc) (logid:a0001979) Rolling back the transaction: Time = 2 Name =  qtp1233705144-21; called by -TransactionLegacy.rollback:888-TransactionLegacy.removeUpTo:831-TransactionLegacy.close:655-Transaction.execute:38-UserVmManagerImpl.commitUserVm:3993-UserVmManagerImpl.commitUserVm:4180-UserVmManagerImpl.createVirtualMachine:3888-UserVmManagerImpl.createAdvancedVirtualMachine:3414-UserVmManagerImpl.createVirtualMachine:5350-NativeMethodAccessorImpl.invoke0:-2-NativeMethodAccessorImpl.invoke:62-DelegatingMethodAccessorImpl.invoke:43
2021-05-28 06:41:53,538 ERROR [c.c.a.ApiServer] (qtp1233705144-21:ctx-18f24cbd ctx-ed3119fc) (logid:a0001979) unhandled exception executing api command: [Ljava.lang.String;@62805107
java.lang.NullPointerException
	at com.cloud.vm.UserVmManagerImpl$4.doInTransaction(UserVmManagerImpl.java:4057)
	at com.cloud.vm.UserVmManagerImpl$4.doInTransaction(UserVmManagerImpl.java:3993)
	at com.cloud.utils.db.Transaction.execute(Transaction.java:40)
	at com.cloud.vm.UserVmManagerImpl.commitUserVm(UserVmManagerImpl.java:3993)
	at com.cloud.vm.UserVmManagerImpl.commitUserVm(UserVmManagerImpl.java:4180)
	at com.cloud.vm.UserVmManagerImpl.createVirtualMachine(UserVmManagerImpl.java:3888)
	at com.cloud.vm.UserVmManagerImpl.createAdvancedVirtualMachine(UserVmManagerImpl.java:3414)
	at com.cloud.vm.UserVmManagerImpl.createVirtualMachine(UserVmManagerImpl.java:5350)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
```
**With change:**
```
2021-05-28 07:33:00,190 DEBUG [c.c.a.ApiServlet] (qtp1233705144-22:ctx-596f958a) (logid:036c2e85) ===START===  172.16.250.9 -- GET  zoneid=251398d0-707d-4e5a-9298-2a97a1eff534&templateid=888f0a52-e34b-4193-8cfb-4b7d3ce42753&startvm=true&serviceofferingid=8b28cbe8-5d57-4c3d-85d9-d92b67af13a3&affinitygroupids=&iptonetworklist[0].networkid=f3185526-afce-462d-ba75-b2ac439b9de9&name=t204&displayname=t204&command=deployVirtualMachine&response=json
2021-05-28 07:33:00,195 DEBUG [c.c.a.ApiServer] (qtp1233705144-22:ctx-596f958a ctx-70050728) (logid:036c2e85) CIDRs from which account 'Acct[a0d53995-92b4-11eb-9b07-1e0053000169-admin]' is allowed to perform API calls: 0.0.0.0/0,::/0
2021-05-28 07:33:00,203 DEBUG [c.c.u.AccountManagerImpl] (qtp1233705144-22:ctx-596f958a ctx-70050728) (logid:036c2e85) Access granted to Acct[a0d53995-92b4-11eb-9b07-1e0053000169-admin] to org.apache.cloudstack.quota.vo.ServiceOfferingVO$$EnhancerByCGLIB$$633a68df@19466499 by AffinityGroupAccessChecker
2021-05-28 07:33:00,204 DEBUG [c.c.u.AccountManagerImpl] (qtp1233705144-22:ctx-596f958a ctx-70050728) (logid:036c2e85) Access granted to Acct[a0d53995-92b4-11eb-9b07-1e0053000169-admin] to null by AffinityGroupAccessChecker
2021-05-28 07:33:00,210 DEBUG [c.c.n.NetworkModelImpl] (qtp1233705144-22:ctx-596f958a ctx-70050728) (logid:036c2e85) Service SecurityGroup is not supported in the network id=213
2021-05-28 07:33:00,224 DEBUG [c.c.v.UserVmManagerImpl] (qtp1233705144-22:ctx-596f958a ctx-70050728) (logid:036c2e85) Allocating in the DB for VM
...
2021-05-28 07:33:15,962 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (API-Job-Executor-3:ctx-b4f0832b job-440 ctx-84dfc40e) (logid:21a80315) Complete async job-440, jobStatus: SUCCEEDED, resultCode: 0, result: org.apache.cloudstack.api.response.UserVmResponse/virtualmachine/{"id":"43767842-2833-4d61-9487-1f5c4615af8a","name":"t204","displayname":"t204","account":"admin","userid":"a0d68685-92b4-11eb-9b07-1e0053000169","username":"admin","domainid":"89597c05-92b4-11eb-9b07-1e0053000169","domain":"ROOT","created":"2021-05-28T07:33:00+0000","state":"Running","haenable":"false","zoneid":"251398d0-707d-4e5a-9298-2a97a1eff534","zonename":"pr4758-t323-vmware-65u2","hostid":"4d627038-eb66-4a93-891a-b937572855d5","hostname":"10.0.33.186","templateid":"888f0a52-e34b-4193-8cfb-4b7d3ce42753","templatename":"mac","templatedisplaytext":"mac","passwordenabled":"false","serviceofferingid":"8b28cbe8-5d57-4c3d-85d9-d92b67af13a3","serviceofferingname":"Small Instance","cpunumber":"1","cpuspeed":"500","memory":"512","guestosid":"89703585-92b4-11eb-9b07-1e0053000169","rootdeviceid":"0","rootdevicetype":"ROOT","securitygroup":[],"nic":[{"id":"8d7dd20c-ca90-4021-912f-393064f2615a","networkid":"f3185526-afce-462d-ba75-b2ac439b9de9","networkname":"iso1","netmask":"255.255.255.0","gateway":"10.1.1.1","ipaddress":"10.1.1.32","isolationuri":"vlan://1489","broadcasturi":"vlan://1489","traffictype":"Guest","type":"Isolated","isdefault":"true","macaddress":"02:00:49:4f:00:04","secondaryip":[],"extradhcpoption":[]}],"hypervisor":"VMware","instancename":"i-2-45-VM","details":{"dataDiskController":"osdefault","memoryOvercommitRatio":"1.0","cpuOvercommitRatio":"2.0","rootDiskController":"lsilogic"},"affinitygroup":[],"displayvm":"true","isdynamicallyscalable":"false","ostypeid":"89703585-92b4-11eb-9b07-1e0053000169","osdisplayname":"Other Linux (64-bit)","tags":[],"jobid":"21a80315-8143-4c12-8fd3-9d7b109a27cb","jobstatus":"0"}

```
