### PR TITLE
FIX Network with SG Disabled still has security group script adding rules on KVM

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3182,7 +3182,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
             final Answer rebootAnswer = cmds.getAnswer(RebootAnswer.class);
             if (rebootAnswer != null && rebootAnswer.getResult()) {
-                if (dc.isSecurityGroupEnabled() && vm.getType() == VirtualMachine.Type.User) {
+                boolean isVmSecurityGroupEnabled = _securityGroupManager.isVmSecurityGroupEnabled(vm.getId());
+                if (isVmSecurityGroupEnabled && vm.getType() == VirtualMachine.Type.User) {
                     List<Long> affectedVms = new ArrayList<Long>();
                     affectedVms.add(vm.getId());
                     _securityGroupManager.scheduleRulesetUpdateToHosts(affectedVms, true, null);


### PR DESCRIPTION

### Description
This PR fixes #5047 which can be reproduced on Zones with _(I) Advanced Networks, (II) Security Groups enabled for the Zone, (III)  network offering without Security Groups_; for instance, `DefaultSharedNetworkOffering` which does not list Security Group as supported service.

The issue is due to the following code inside the method `VirtualMachineManagerImpl.orchestrateReboot`:
[VirtualMachineManagerImpl.java#L3340](https://github.com/apache/cloudstack/blob/280c13a4bb103dd748ec304bfe0714a148c24602/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java#L3340).

```
  final Answer rebootAnswer = cmds.getAnswer(RebootAnswer.class);
  if (rebootAnswer != null && rebootAnswer.getResult()) {
      if (dc.isSecurityGroupEnabled() && vm.getType() == VirtualMachine.Type.User) {
          List<Long> affectedVms = new ArrayList<Long>();
          affectedVms.add(vm.getId());
          _securityGroupManager.scheduleRulesetUpdateToHosts(affectedVms, true, null);
      }
      return;
  }
```

As the Data Center was deployed enabling Security group, it is expected column `is_security_group_enabled = 1`; therefore,  `dc.isSecurityGroupEnabled()` is `true`; which combined with VM of type User schedules a Ruleset update to the KVM node where the VM is being rebooted at. This particular scenario is not wanted if the VM's network has no SG.

When testing SG for 4.15.0.0 RCs as well as testing/reviewing any PR within KVM/SG scope the tests looked good due to the fact that I was always using networks with SG.

The issue can be seen only on networks that have no SG enabled but the `dc.isSecurityGroupEnabled()` is `true`.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
N/A

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

:alert: Tests will be done soon. PR is a draft opened as soon as possible.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
