### PR TITLE
ui: pass requireshvm param for register/upload template API

### DIFF
--- a/ui/src/views/image/RegisterOrUploadTemplate.vue
+++ b/ui/src/views/image/RegisterOrUploadTemplate.vue
@@ -837,6 +837,9 @@ export default {
             }
           }
         }
+        if (!('requireshvm' in params)) { // handled as default true by API
+          params.requireshvm = false
+        }
         if (this.currentForm === 'Create') {
           this.loading = true
           api('registerTemplate', params).then(json => {


### PR DESCRIPTION
### Description

HVM is set to true if `requireshvm` param of `registerTemplate` and `getUploadParamsForTemplate` APIs if not passed (null value).
This change explicitly passes `requireshvm=false` when the checkbox is unselected in the UI form.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Using UI
Without change (`requireshvm` is not passed):
![Screenshot from 2021-05-29 02-26-52](https://user-images.githubusercontent.com/153340/120041484-f1eb8880-c025-11eb-86a7-ebfc53b536ea.png)
In DB
```
MariaDB [cloud]> select id,name,uuid,hvm from vm_template where uuid='af94adf5-36c8-434d-a87f-5e8c6fdfd89a'\G
*************************** 1. row ***************************
  id: 212
name: t31
uuid: af94adf5-36c8-434d-a87f-5e8c6fdfd89a
 hvm: 1
```

With change:
![Screenshot from 2021-05-29 02-27-03](https://user-images.githubusercontent.com/153340/120041510-ff087780-c025-11eb-8e05-10ab66ff842f.png)
In DB
```
MariaDB [cloud]> select id,name,uuid,hvm from vm_template where uuid='43b34bd5-d52a-47a5-928b-dc698bc4965c'\G
*************************** 1. row ***************************
  id: 213
name: t41
uuid: 43b34bd5-d52a-47a5-928b-dc698bc4965c
 hvm: 0
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
