### PR TITLE
xenserver: attempt eject and destroying patch VBD separately

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1508,7 +1508,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         for (final VM vm : vms) {
             final String vmName = vm.getNameLabel(conn);
             if (!vmName.startsWith("r-") && !vmName.startsWith("s-") && !vmName.startsWith("v-")) {
-                return;
+                continue;
             }
             final Set<VBD> vbds = vm.getVBDs(conn);
             for (final VBD vbd : vbds) {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1507,13 +1507,13 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         final VDI patchVDI = findPatchIsoVDI(conn, sr);
         for (final VM vm : vms) {
             final String vmName = vm.getNameLabel(conn);
-            try {
-                if (!vmName.startsWith("r-") && !vmName.startsWith("s-") && !vmName.startsWith("v-")) {
-                    return;
-                }
-                final Set<VBD> vbds = vm.getVBDs(conn);
-                for (final VBD vbd : vbds) {
-                    if (Types.VbdType.CD.equals(vbd.getType(conn))) {
+            if (!vmName.startsWith("r-") && !vmName.startsWith("s-") && !vmName.startsWith("v-")) {
+                return;
+            }
+            final Set<VBD> vbds = vm.getVBDs(conn);
+            for (final VBD vbd : vbds) {
+                if (Types.VbdType.CD.equals(vbd.getType(conn))) {
+                    try {
                         if (!vbd.getEmpty(conn)) {
                             vbd.eject(conn);
                         }
@@ -1522,12 +1522,16 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                             vbd.insert(conn, patchVDI);
                             vbd.eject(conn);
                         }
-                        vbd.destroy(conn);
-                        break;
+                    } catch (Exception e) {
+                        s_logger.debug("Cannot eject CD-ROM device for VM " + vmName + " due to " + e.toString(), e);
                     }
+                    try {
+                        vbd.destroy(conn);
+                    } catch (Exception e) {
+                        s_logger.debug("Cannot destroy CD-ROM device for VM " + vmName + " due to " + e.toString(), e);
+                    }
+                    break;
                 }
-            } catch (final Exception e) {
-                s_logger.debug("Cannot destroy CD-ROM device for VM " + vmName + " due to " + e.toString(), e);
             }
         }
     }


### PR DESCRIPTION
This tries to separately eject and destroy cd-rom VBD for systemvms.

Doc fix also possible: https://github.com/apache/cloudstack-documentation/pull/216

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial
