### PR TITLE
vmware: create 'fcd' directory when it does not exist on datastore

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageLayoutHelper.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageLayoutHelper.java
@@ -174,6 +174,11 @@ public class VmwareStorageLayoutHelper implements Configurable {
             ds.makeDirectory(String.format("[%s] %s", ds.getName(), vmName), dcMo.getMor());
         }
 
+        if (!ds.folderExists(String.format("[%s]", ds.getName()), HypervisorHostHelper.VSPHERE_DATASTORE_BASE_FOLDER)) {
+            s_logger.info(HypervisorHostHelper.VSPHERE_DATASTORE_BASE_FOLDER + " folder does not exist on target datastore, we will create one. vm: " + vmName + ", datastore: " + ds.getName());
+            ds.makeDirectory(String.format("[%s] %s", ds.getName(), HypervisorHostHelper.VSPHERE_DATASTORE_BASE_FOLDER), dcMo.getMor());
+        }
+
         String[] vmdkLinkedCloneModeLegacyPair = getVmdkFilePairDatastorePath(ds, vmName, vmdkName, VmwareStorageLayoutType.CLOUDSTACK_LEGACY, true);
         String[] vmdkFullCloneModeLegacyPair = getVmdkFilePairDatastorePath(ds, vmName, vmdkName, VmwareStorageLayoutType.CLOUDSTACK_LEGACY, false);
 


### PR DESCRIPTION
This fixes local storage issue for VMware when fcd directory is missing
the VM and volume (root+data disks) deployments fail on VMware with
local storage.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial