### PR TITLE
vr: remove old ips with same mac address in dhcpentry databag

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs_dhcp.py
@@ -28,7 +28,7 @@ def merge(dbag, data):
     else:
         remove_keys = set()
         for key, entry in dbag.iteritems():
-            if key != 'id' and entry['mac_address'] == data['mac_address'] and data['remove']:
+            if key != 'id' and entry['mac_address'] == data['mac_address']:
                 remove_keys.add(key)
                 break
 


### PR DESCRIPTION
### Description

This PR fixes #5058

when start a vm, the old entries in databag for the vm (with same mac addresses) should be removed then set again, to avoid duplicated records in dhcpentry databag and also /etc/dhcphosts.txt 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

isolated networks
(1) stop vm, change vm ip address, start vm
vm info is updated in /etc/dhcphosts.txt and /etc/cloudstack/dhcpentry.json
(2) stop vm, expunge vm.
vm is removed from /etc/dhcphosts.txt and /var/lib/misc/dnsmasq.leases

vpc
(1) create vm in 2 vpc tiers
vm has 2 entries in /etc/dhcphosts.txt, and /etc/cloudstack/dhcpentry.json
(2) stop vm, change ip addresses, change nics order, start vm
entries are updated in /etc/dhcphosts.txt and /etc/cloudstack/dhcpentry.json
(3) remove a nic from vm (hot unplug)
vm nic is removed from /etc/dhcphosts.txt and /var/lib/misc/dnsmasq.leases
entry in /etc/cloudstack/dhcpentry.json is updated.





<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
