### PR TITLE
Fix string format error

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1169,7 +1169,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     private void checkIfVolumeIsRootAndVmIsRunning(Long newSize, VolumeVO volume, VMInstanceVO vmInstanceVO) {
         if (!volume.getSize().equals(newSize) && volume.getVolumeType().equals(Volume.Type.ROOT) && !State.Stopped.equals(vmInstanceVO.getState())) {
-            throw new InvalidParameterValueException(String.format("Cannot resize ROOT volume [%s] when VM is not on Stopped State. VM %s is in state %.", volume.getName(), vmInstanceVO
+            throw new InvalidParameterValueException(String.format("Cannot resize ROOT volume [%s] when VM is not on Stopped State. VM %s is in state %s", volume.getName(), vmInstanceVO
                     .getInstanceName(), vmInstanceVO.getState()));
         }
     }


### PR DESCRIPTION
### Description

Fixes 
```
ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-45:ctx-76ee0dfd job-787) (logid:c554bac0) Unexpected exception while executing org.apache.cloudstack.api.command.admin.volume.ResizeVolumeCmdByAdmin
java.util.UnknownFormatConversionException: Conversion = '.'
	at java.base/java.util.Formatter.checkText(Formatter.java:2732)
	at java.base/java.util.Formatter.parse(Formatter.java:2718)
	at java.base/java.util.Formatter.format(Formatter.java:2655)
	at java.base/java.util.Formatter.format(Formatter.java:2609)
	at java.base/java.lang.String.format(String.java:2897)
	at com.cloud.storage.VolumeApiServiceImpl.checkIfVolumeIsRootAndVmIsRunning(VolumeApiServiceImpl.java:1172)
	at com.cloud.storage.VolumeApiServiceImpl.resizeVolume(VolumeApiServiceImpl.java:1013)
	at com.cloud.storage.VolumeApiServiceImpl.resizeVolume(VolumeApiServiceImpl.java:192)
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

