### PR TITLE
CLOUDSTACK-10436:remind users to use correct permission for tmp dir and fixed an NPE

### DIFF
--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -189,7 +189,11 @@ public class JavaStorageLayer implements StorageLayer {
             File dir = new File(dirName);
             if (dir.exists()) {
                 if (isWorldReadable(dir)) {
-                    s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
+                    if (dir.getAbsolutePath().equals("/tmp")) {
+                        s_logger.warn("The temp dir is /tmp");
+                    }else {
+                        s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
+                    }
                 }
                 String uniqDirName = dir.getAbsolutePath() + File.separator + UUID.randomUUID().toString();
                 if (mkdir(uniqDirName)) {

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -183,7 +183,7 @@ public class JavaStorageLayer implements StorageLayer {
     }
 
     @Override
-    public File createUniqDir() {
+    public File createUniqDir() throws IOException {
         String dirName = System.getProperty("java.io.tmpdir");
         if (dirName != null) {
             File dir = new File(dirName);
@@ -197,7 +197,7 @@ public class JavaStorageLayer implements StorageLayer {
                 }
             }
         }
-        return null;
+        throw new IOException("the tmp dir " + dirName + " does not exist");
     }
 
     @Override
@@ -225,14 +225,11 @@ public class JavaStorageLayer implements StorageLayer {
         }
     }
 
-    public boolean isWorldReadable(File file) {
+    public boolean isWorldReadable(File file) throws IOException {
         Set<PosixFilePermission> permissions;
-        try {
-            permissions = Files.getPosixFilePermissions(
-                Paths.get(file.getAbsolutePath()));
-        } catch (IOException e) {
-            return false;
-        }
+        permissions = Files.getPosixFilePermissions(
+            Paths.get(file.getAbsolutePath()));
+
         for (PosixFilePermission permission:permissions) {
             if (permission.equals(PosixFilePermission.OTHERS_READ)) {
                 return true;

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import javax.naming.ConfigurationException;
-
 import org.apache.log4j.Logger;
 
 public class JavaStorageLayer implements StorageLayer {
@@ -226,7 +225,7 @@ public class JavaStorageLayer implements StorageLayer {
         }
     }
 
-    public static boolean isWorldReadable(File file) {
+    public boolean isWorldReadable(File file) {
         Set<PosixFilePermission> permissions;
         try {
             permissions = Files.getPosixFilePermissions(

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -189,7 +189,11 @@ public class JavaStorageLayer implements StorageLayer {
             File dir = new File(dirName);
             if (dir.exists()) {
                 if (isWorldReadable(dir)) {
-                    s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
+                    if (dir.getAbsolutePath().equals("/tmp")) {
+                        s_logger.warn("The temp dir is /tmp");
+                    } else {
+                        s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
+		    }
                 }
                 String uniqDirName = dir.getAbsolutePath() + File.separator + UUID.randomUUID().toString();
                 if (mkdir(uniqDirName)) {

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -233,13 +233,7 @@ public class JavaStorageLayer implements StorageLayer {
         Set<PosixFilePermission> permissions;
         permissions = Files.getPosixFilePermissions(
             Paths.get(file.getAbsolutePath()));
-
-        for (PosixFilePermission permission:permissions) {
-            if (permission.equals(PosixFilePermission.OTHERS_READ)) {
-                return true;
-            }
-        }
-        return false;
+        return permissions.contains(PosixFilePermission.OTHERS_READ);
     }
 
     private List<String> listDirPaths(String path) {

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -189,11 +189,7 @@ public class JavaStorageLayer implements StorageLayer {
             File dir = new File(dirName);
             if (dir.exists()) {
                 if (isWorldReadable(dir)) {
-                    if (dir.getAbsolutePath().equals("/tmp")) {
-                        s_logger.warn("The temp dir is /tmp");
-                    }else {
-                        s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
-                    }
+                    s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
                 }
                 String uniqDirName = dir.getAbsolutePath() + File.separator + UUID.randomUUID().toString();
                 if (mkdir(uniqDirName)) {

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -35,7 +35,7 @@ import org.apache.log4j.Logger;
 
 public class JavaStorageLayer implements StorageLayer {
     private static final Logger s_logger = Logger.getLogger(JavaStorageLayer.class);
-    private static final String STDTMP = "/tmp";
+    private static final String STD_TMP_DIR_PATH = "/tmp";
     String _name;
     boolean _makeWorldWriteable = true;
 
@@ -190,8 +190,8 @@ public class JavaStorageLayer implements StorageLayer {
             File dir = new File(dirName);
             if (dir.exists()) {
                 if (isWorldReadable(dir)) {
-                    if (STDTMP.equals(dir.getAbsolutePath())) {
-                        s_logger.warn(String.format("The temp dir is %s", STDTMP));
+                    if (STD_TMP_DIR_PATH.equals(dir.getAbsolutePath())) {
+                        s_logger.warn(String.format("The temp dir is %s", STD_TMP_DIR_PATH));
                     } else {
                         s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
                     }

--- a/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/JavaStorageLayer.java
@@ -35,6 +35,7 @@ import org.apache.log4j.Logger;
 
 public class JavaStorageLayer implements StorageLayer {
     private static final Logger s_logger = Logger.getLogger(JavaStorageLayer.class);
+    private static final String STDTMP = "/tmp";
     String _name;
     boolean _makeWorldWriteable = true;
 
@@ -189,11 +190,11 @@ public class JavaStorageLayer implements StorageLayer {
             File dir = new File(dirName);
             if (dir.exists()) {
                 if (isWorldReadable(dir)) {
-                    if (dir.getAbsolutePath().equals("/tmp")) {
-                        s_logger.warn("The temp dir is /tmp");
+                    if (STDTMP.equals(dir.getAbsolutePath())) {
+                        s_logger.warn(String.format("The temp dir is %s", STDTMP));
                     } else {
                         s_logger.warn("The temp dir " + dir.getAbsolutePath() + " is World Readable");
-		    }
+                    }
                 }
                 String uniqDirName = dir.getAbsolutePath() + File.separator + UUID.randomUUID().toString();
                 if (mkdir(uniqDirName)) {

--- a/core/src/main/java/com/cloud/storage/StorageLayer.java
+++ b/core/src/main/java/com/cloud/storage/StorageLayer.java
@@ -42,7 +42,7 @@ public interface StorageLayer extends Manager {
      */
     long getSize(String path);
 
-    File createUniqDir();
+    File createUniqDir() throws IOException;
 
     /**
      * Is this path a directory?


### PR DESCRIPTION
### Description


I think there is a potential securiry issuse in createUniqDir#JavaStorageLayer

 

    public File createUniqDir() {
        String dirName = System.getProperty("java.io.tmpdir");
        if (dirName != null) {
            File dir = new File(dirName);
            if (dir.exists()) {
                String uniqDirName = dir.getAbsolutePath() + File.separator + UUID.randomUUID().toString();
                if (mkdir(uniqDirName)) {
                    return new File(uniqDirName);
                }
            }
        }
        return null;
    }
So if a user do not specify the "java.io.tmpdir",  we will use the default tmp dir "/tmp" whose mode is 777. Even users specify the "java.io.tmpdir", they may also forget to set the file mode as 700, hence the tmp dir is still worldreadable.  Our code then create create UniqDir  in tmp dir, and it is also worldreadable.

 

createUniqDir will be called by swiftUploadMetadataFile and registerTemplateOnSwift in NfsSecondaryStorageResource. Hence the MetadataFile will be written in tmp dir and is also worldreadable. 

 

Hum, assums that cloudstack runs on  a server as root, and there are also some regualr users on this  server. These regualr users (they even do not belong to cloudstack group) can read these medadatafile, which is undesirable.

 

I think this is similar to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908 . 

This PR will remind users to use correct permission for tmp dir.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
