### PR TITLE
systemvmtemplate: reduce template by using cloud kernel

### DIFF
--- a/tools/appliance/systemvmtemplate/http/preseed.cfg
+++ b/tools/appliance/systemvmtemplate/http/preseed.cfg
@@ -60,13 +60,13 @@ d-i partman-auto/disk string /dev/vda
 d-i partman-auto/method string regular
 d-i partman-auto/expert_recipe string                         \
       boot-root ::                                            \
-              100 60 100 ext2                                 \
+              400 60 400 ext2                                 \
                       $primary{ } $bootable{ }                \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext2 }    \
                       mountpoint{ /boot }                     \
               .                                               \
-              4500 40 5000 ext4                               \
+              4000 40 5000 ext4                               \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ / }                         \
@@ -98,7 +98,7 @@ d-i passwd/user-default-groups string audio cdrom video admin
 
 ### Package selection
 tasksel tasksel/first multiselect ssh-server
-d-i pkgsel/include string linux-image-cloud-amd64 openssh-server ntp acpid sudo bzip2 openssl
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 openssl
 # Allowed values: none, safe-upgrade, full-upgrade
 d-i pkgsel/upgrade select full-upgrade
 d-i pkgsel/update-policy select none

--- a/tools/appliance/systemvmtemplate/http/preseed.cfg
+++ b/tools/appliance/systemvmtemplate/http/preseed.cfg
@@ -41,10 +41,14 @@ d-i mirror/http/proxy string
 ### Apt setup
 d-i apt-setup/cdrom/set-first false
 d-i apt-setup/security-updates boolean true
-d-i apt-setup/services-select multiselect security, updates
+d-i apt-setup/services-select multiselect backports, security, updates
 d-i apt-setup/security_host string security.debian.org
 d-i apt-setup/local0/source boolean false
 d-i apt-setup/multiarch string i386
+d-i apt-setup/backports boolean true
+d-i apt-setup/contrib   boolean true
+d-i apt-setup/multiverse        boolean true
+d-i apt-setup/universe  boolean true
 
 ### Clock and time zone setup
 d-i clock-setup/utc boolean true
@@ -62,7 +66,7 @@ d-i partman-auto/expert_recipe string                         \
                       use_filesystem{ } filesystem{ ext2 }    \
                       mountpoint{ /boot }                     \
               .                                               \
-              2240 40 2500 ext4                               \
+              4500 40 5000 ext4                               \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ / }                         \
@@ -94,7 +98,7 @@ d-i passwd/user-default-groups string audio cdrom video admin
 
 ### Package selection
 tasksel tasksel/first multiselect ssh-server
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 openssl
+d-i pkgsel/include string linux-image-cloud-amd64 openssh-server ntp acpid sudo bzip2 openssl
 # Allowed values: none, safe-upgrade, full-upgrade
 d-i pkgsel/upgrade select full-upgrade
 d-i pkgsel/update-policy select none

--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -55,14 +55,15 @@ function apt_upgrade() {
   apt-get -q -y update
 
   # Remove unused non-default kernel
-  apt-get remove -y --purge linux-image-amd64 linux-image-4.19.0-16-amd64 || true
   apt-get -q -y upgrade
   apt-get -q -y dist-upgrade
   apt-get -q -y upgrade -t buster-backports
+  apt-get -q -y dist-upgrade -t buster-backports
 
   apt-get -y autoremove --purge
   apt-get autoclean
   apt-get clean
+  reboot
 }
 
 return 2>/dev/null || apt_upgrade

--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -53,11 +53,18 @@ function apt_upgrade() {
 
   rm -fv /root/*.iso
   apt-get -q -y update
+
+  # Remove unused non-default kernel
+  apt-get remove -y --purge linux-image-amd64 linux-image-4.19.0-16-amd64 || true
   apt-get -q -y upgrade
   apt-get -q -y dist-upgrade
+  apt-get -q -y upgrade -t buster-backports
+  apt-get -q -y dist-upgrade -t buster-backports
+
   apt-get -y autoremove --purge
   apt-get autoclean
   apt-get clean
+  reboot
 }
 
 return 2>/dev/null || apt_upgrade

--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -59,12 +59,10 @@ function apt_upgrade() {
   apt-get -q -y upgrade
   apt-get -q -y dist-upgrade
   apt-get -q -y upgrade -t buster-backports
-  apt-get -q -y dist-upgrade -t buster-backports
 
   apt-get -y autoremove --purge
   apt-get autoclean
   apt-get clean
-  reboot
 }
 
 return 2>/dev/null || apt_upgrade

--- a/tools/appliance/systemvmtemplate/scripts/configure_grub.sh
+++ b/tools/appliance/systemvmtemplate/scripts/configure_grub.sh
@@ -20,6 +20,8 @@ set -e
 set -x
 
 function configure_grub() {
+  # Remove old kernel
+  apt-get remove -y --purge linux-image-4.19.0-16-cloud-amd64 || true
   echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
   rmmod floppy || true
   update-initramfs -u

--- a/tools/appliance/systemvmtemplate/scripts/configure_grub.sh
+++ b/tools/appliance/systemvmtemplate/scripts/configure_grub.sh
@@ -21,7 +21,6 @@ set -x
 
 function configure_grub() {
   # Remove old kernel
-  apt-get remove -y --purge linux-image-4.19.0-16-cloud-amd64 || true
   echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
   rmmod floppy || true
   update-initramfs -u

--- a/tools/appliance/systemvmtemplate/scripts/configure_grub.sh
+++ b/tools/appliance/systemvmtemplate/scripts/configure_grub.sh
@@ -21,6 +21,7 @@ set -x
 
 function configure_grub() {
   # Remove old kernel
+  apt-get remove -y --purge linux-image-amd64 linux-image-4.19.0-16-amd64 || true
   echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
   rmmod floppy || true
   update-initramfs -u

--- a/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
+++ b/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
@@ -72,6 +72,7 @@ function install_packages() {
     strongswan libcharon-extra-plugins libstrongswan-extra-plugins strongswan-charon strongswan-starter \
     virt-what open-vm-tools qemu-guest-agent hyperv-daemons
 
+  apt-get -y upgrade -t buster-backports
   apt-get -y autoremove --purge
   apt-get clean
   apt-get autoclean

--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -6,7 +6,14 @@
       "type": "shell",
       "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
       "scripts": [
-        "scripts/apt_upgrade.sh",
+        "scripts/apt_upgrade.sh"
+      ],
+      "expect_disconnect": true
+    },
+    {
+      "type": "shell",
+      "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
+      "scripts": [
         "scripts/configure_grub.sh",
         "scripts/configure_locale.sh",
         "scripts/configure_networking.sh",

--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -6,14 +6,7 @@
       "type": "shell",
       "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
       "scripts": [
-        "scripts/apt_upgrade.sh"
-      ],
-      "expect_disconnect": true
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
-      "scripts": [
+        "scripts/apt_upgrade.sh",
         "scripts/configure_grub.sh",
         "scripts/configure_locale.sh",
         "scripts/configure_networking.sh",

--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -6,7 +6,14 @@
       "type": "shell",
       "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
       "scripts": [
-        "scripts/apt_upgrade.sh",
+        "scripts/apt_upgrade.sh"
+      ],
+      "expect_disconnect": true
+    },
+    {
+      "type": "shell",
+      "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
+      "scripts": [
         "scripts/configure_grub.sh",
         "scripts/configure_locale.sh",
         "scripts/configure_networking.sh",
@@ -33,11 +40,11 @@
         [ "-smp", "1" ]
       ],
       "format": "qcow2",
-      "disk_size": 2500,
+      "disk_size": 5000,
       "disk_interface": "virtio",
       "net_device": "virtio-net",
-      "iso_url": "https://cdimage.debian.org/debian-cd/10.8.0/amd64/iso-cd/debian-10.8.0-amd64-netinst.iso",
-      "iso_checksum": "934336d266535c91fcd12cd122c81f8261721efa117fdcb9a31615caa96c5c5ce3454ed5f28f1b25a7b1b5f44631fdfa78a93adb6445e2e2caaf6455ab344cf8",
+      "iso_url": "https://cdimage.debian.org/debian-cd/10.9.0/amd64/iso-cd/debian-10.9.0-amd64-netinst.iso",
+      "iso_checksum": "47d35187b4903e803209959434fb8b65ead3ad2a8f007eef1c3d3284f356ab9955aa7e15e24cb7af6a3859aa66837f5fa2e7441f936496ea447904f7dddfdc20",
       "iso_checksum_type": "sha512",
       "output_directory": "../dist",
       "http_directory": "http",


### PR DESCRIPTION
This switches the systemvmtemplate to use the default linux-image-cloud
kernel from Debian backports (v5.10), we don't really need many of the
kernel modules such as sound drivers etc in the systemvm. This reduces
the space consumed from a whooping 270+MB to just ~70MB by the kernel.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)