### PR TITLE
Fix of some UEFI related issues

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3449,15 +3449,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } else if (platformEmulator.startsWith("Other PV Virtio-SCSI")) {
             return DiskDef.DiskBus.SCSI;
         } else if (platformEmulator.contains("Ubuntu") ||
-                platformEmulator.startsWith("Fedora") ||
-                platformEmulator.startsWith("CentOS") ||
-                platformEmulator.startsWith("Red Hat Enterprise Linux") ||
-                platformEmulator.startsWith("Debian GNU/Linux") ||
-                platformEmulator.startsWith("FreeBSD") ||
-                platformEmulator.startsWith("Oracle") ||
-                platformEmulator.startsWith("Other PV")) {
+                org.apache.commons.lang3.StringUtils.startsWithAny(platformEmulator,
+                        "Fedora", "CentOS", "Red Hat Enterprise Linux", "Debian GNU/Linux", "FreeBSD", "Oracle", "Other PV")) {
             return DiskDef.DiskBus.VIRTIO;
-        } else if (isUefiEnabled && (platformEmulator.startsWith("Windows") || platformEmulator.startsWith("Other"))) {
+        } else if (isUefiEnabled && org.apache.commons.lang3.StringUtils.startsWithAny(platformEmulator, "Windows", "Other")) {
             return DiskDef.DiskBus.SATA;
         } else {
             return DiskDef.DiskBus.IDE;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3448,8 +3448,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             return DiskDef.DiskBus.IDE;
         } else if (platformEmulator.startsWith("Other PV Virtio-SCSI")) {
             return DiskDef.DiskBus.SCSI;
-        } else if (isUefiEnabled && platformEmulator.startsWith("Windows")) {
-            return DiskDef.DiskBus.SATA;
         } else if (platformEmulator.contains("Ubuntu") ||
                 platformEmulator.startsWith("Fedora") ||
                 platformEmulator.startsWith("CentOS") ||
@@ -3459,6 +3457,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 platformEmulator.startsWith("Oracle") ||
                 platformEmulator.startsWith("Other PV")) {
             return DiskDef.DiskBus.VIRTIO;
+        } else if (isUefiEnabled && (platformEmulator.startsWith("Windows") || platformEmulator.startsWith("Other"))) {
+            return DiskDef.DiskBus.SATA;
         } else {
             return DiskDef.DiskBus.IDE;
         }

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1302,10 +1302,10 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
 
         Command cmd = null;
         if (attach) {
-            cmd = new AttachCommand(disk, vmName);
+            cmd = new AttachCommand(disk, vmName, vmTO.getDetails());
             ((AttachCommand)cmd).setForced(forced);
         } else {
-            cmd = new DettachCommand(disk, vmName);
+            cmd = new DettachCommand(disk, vmName, vmTO.getDetails());
             ((DettachCommand)cmd).setForced(forced);
         }
         Answer a = _agentMgr.easySend(vm.getHostId(), cmd);


### PR DESCRIPTION
### Description

This PR fixes
1 - fix of attaching/detaching ISO of VM with UEFI boot type, which was introduced in #4773 
2 - if the OS type of an ISO is categorized as "Other", the bus type of the disk
will be set to "SATA" because we don't know what OS is behind "Other".


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X ] Minor
- [ ] Trivial


### How Has This Been Tested?
manual tests with CentOS8 and Windows 10 ISOs
