### PR TITLE
Check for VLAN or VXLAN in NetworkDaoImpl.listByPhysicalNetworkPvlan

### DIFF
--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
@@ -18,9 +18,12 @@ package com.cloud.network.dao;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -106,6 +109,9 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
 
     Random _rand = new Random(System.currentTimeMillis());
     long _prefix = 0x2;
+
+    private static final Set<String> VLAN_OR_VXLAN = new HashSet<>(Arrays.asList(BroadcastDomainType.Vlan.toString().toLowerCase(),
+                                                                BroadcastDomainType.Vxlan.toString().toLowerCase()));
 
     public NetworkDaoImpl() {
     }
@@ -780,8 +786,9 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
     @Override
     public List<NetworkVO> listByPhysicalNetworkPvlan(long physicalNetworkId, String broadcastUri) {
         final URI searchUri = BroadcastDomainType.fromString(broadcastUri);
-        if (!searchUri.getScheme().equalsIgnoreCase("vlan")) {
-            throw new CloudRuntimeException("VLAN requested but URI is not in the expected format: " + searchUri.toString());
+        if (!VLAN_OR_VXLAN.contains(searchUri.getScheme().toLowerCase())) {
+            throw new CloudRuntimeException(
+                    String.format("Requested URI '%s' is not in the expected format. Expected URI Scheme as 'vlan://VID' or 'vxlan://VID'.", searchUri.toString()));
         }
         final String searchRange = BroadcastDomainType.getValue(searchUri);
         final List<Integer> searchVlans = UriUtils.expandVlanUri(searchRange);


### PR DESCRIPTION
### Description

<!--- Describe your changes in DETAIL - And how has behavior functionally changed. -->
This PR fixes #5071; where it was reported an issue when creating a network with VXLAN.

Exception raised:
```
2021-06-03 11:09:55,724 ERROR [c.c.a.ApiServer] (qtp1665620686-39719:ctx-bf7efb52 ctx-c73431d6 ctx-c4105005) (logid:2252fead) unhandled exception executing api command: [Ljava.lang.String;@6b3403ea
com.cloud.utils.exception.CloudRuntimeException: VLAN requested but URI is not in the expected format: vxlan://525
        at com.cloud.network.dao.NetworkDaoImpl.listByPhysicalNetworkPvlan(NetworkDaoImpl.java:784)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
N/A

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

##### 1. Before fix:
Tested deploying a Zone with VXLAN and it failed: the same exception reported on issue #5071:
```
2021-06-03 21:24:49,358 ERROR [c.c.a.ApiServer] (qtp2109798150-18:ctx-03f9860b ctx-6124ca66) (logid:2f1fa8b3) unhandled exception executing api command: [Ljava.lang.String;@56cdd438 
com.cloud.utils.exception.CloudRuntimeException: VLAN requested but URI is not in the expected format: vxlan://0 
       at com.cloud.network.dao.NetworkDaoImpl.listByPhysicalNetworkPvlan(NetworkDaoImpl.java:784) 
       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 
       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) 
       at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 
       at java.base/java.lang.reflect.Method.invoke(Method.java:566) 
       at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344) 
       at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
```

##### 2. With the proposed fix at this PR:
I was able to deploy a network with VXLAN.

Tested with the commit on top of 4.15.1.0 RC1.

This issue happened in two cases:
1) deploying a new zone, where the step of creating network fails; 
2) creating a new network, the same workflow

Tested on both cases and it works.