### PR TITLE
[Vmware] Fix lsilogcsas controller for deploy-as-is

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
@@ -39,7 +39,8 @@ public enum DiskControllerType {
                 || diskController.equalsIgnoreCase("ide")) {
             return DiskControllerType.ide;
         } else if (diskController.equalsIgnoreCase("vim.vm.device.ParaVirtualSCSIController") || diskController.equalsIgnoreCase("ParaVirtualSCSIController")
-                || diskController.equalsIgnoreCase(ScsiDiskControllerType.VMWARE_PARAVIRTUAL)) {
+                || diskController.equalsIgnoreCase(ScsiDiskControllerType.VMWARE_PARAVIRTUAL)
+                || diskController.equalsIgnoreCase(ScsiDiskControllerType.VMWARE_VIRTUAL_SCSI)) {
             return DiskControllerType.pvscsi;
         } else if (diskController.equalsIgnoreCase("vim.vm.device.VirtualBusLogicController") || diskController.equalsIgnoreCase("VirtualBusLogicController")
                 || diskController.equalsIgnoreCase(ScsiDiskControllerType.BUSLOGIC)) {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
@@ -29,6 +29,7 @@ public enum DiskControllerType {
         if (diskController == null || diskController.equalsIgnoreCase("osdefault")) {
             return DiskControllerType.osdefault;
         } else if (diskController.equalsIgnoreCase("vim.vm.device.VirtualLsiLogicSASController") || diskController.equalsIgnoreCase("VirtualLsiLogicSASController")
+                || diskController.equalsIgnoreCase(ScsiDiskControllerType.LSILOGIC_SAS_1068)
                 || diskController.equalsIgnoreCase(ScsiDiskControllerType.LSILOGIC_SAS)) {
             return DiskControllerType.lsisas1068;
         } else if (diskController.equalsIgnoreCase("vim.vm.device.VirtualLsiLogicController") || diskController.equalsIgnoreCase("VirtualLsiLogicController")

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
@@ -40,7 +40,7 @@ public enum DiskControllerType {
             return DiskControllerType.ide;
         } else if (diskController.equalsIgnoreCase("vim.vm.device.ParaVirtualSCSIController") || diskController.equalsIgnoreCase("ParaVirtualSCSIController")
                 || diskController.equalsIgnoreCase(ScsiDiskControllerType.VMWARE_PARAVIRTUAL)
-                || diskController.equalsIgnoreCase(ScsiDiskControllerType.VMWARE_VIRTUAL_SCSI)) {
+                || diskController.equalsIgnoreCase(ScsiDiskControllerType.VIRTUAL_SCSI)) {
             return DiskControllerType.pvscsi;
         } else if (diskController.equalsIgnoreCase("vim.vm.device.VirtualBusLogicController") || diskController.equalsIgnoreCase("VirtualBusLogicController")
                 || diskController.equalsIgnoreCase(ScsiDiskControllerType.BUSLOGIC)) {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ScsiDiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ScsiDiskControllerType.java
@@ -22,4 +22,5 @@ public interface ScsiDiskControllerType {
     String LSILOGIC_SAS_1068 = "lsisas1068";
     String BUSLOGIC = "buslogic";
     String VMWARE_PARAVIRTUAL = "pvscsi";
+    String VMWARE_VIRTUAL_SCSI = "VirtualSCSI";
 }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ScsiDiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ScsiDiskControllerType.java
@@ -22,5 +22,5 @@ public interface ScsiDiskControllerType {
     String LSILOGIC_SAS_1068 = "lsisas1068";
     String BUSLOGIC = "buslogic";
     String VMWARE_PARAVIRTUAL = "pvscsi";
-    String VMWARE_VIRTUAL_SCSI = "VirtualSCSI";
+    String VIRTUAL_SCSI = "VirtualSCSI";
 }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ScsiDiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ScsiDiskControllerType.java
@@ -17,8 +17,9 @@
 package com.cloud.hypervisor.vmware.mo;
 
 public interface ScsiDiskControllerType {
-    public final static String LSILOGIC_PARALLEL = "lsilogic";
-    public final static String LSILOGIC_SAS = "lsisas1068";
-    public final static String BUSLOGIC = "buslogic";
-    public final static String VMWARE_PARAVIRTUAL = "pvscsi";
+    String LSILOGIC_PARALLEL = "lsilogic";
+    String LSILOGIC_SAS = "lsilogicsas";
+    String LSILOGIC_SAS_1068 = "lsisas1068";
+    String BUSLOGIC = "buslogic";
+    String VMWARE_PARAVIRTUAL = "pvscsi";
 }


### PR DESCRIPTION
### Description

This PR fixes deployment of VMs using controller `lsilogicsas` for Vmware deploy-as-is

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested using Windows 10 template containing the following information on its OVF file: 

````
<Item>
<rasd:Address>0</rasd:Address>
<rasd:Description>SCSI Controller</rasd:Description>
<rasd:ElementName>SCSI Controller 1</rasd:ElementName>
<rasd:InstanceID>3</rasd:InstanceID>
<rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
<rasd:ResourceType>6</rasd:ResourceType>
<vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
</Item>
````