### PR TITLE
vxlan: Fix failure to delete vxlan

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -376,7 +376,9 @@ public class BridgeVifDriver extends VifDriverBase {
             command.add("-v", vNetId);
             command.add("-p", pName);
             command.add("-b", brName);
-            command.add("-d", String.valueOf(deleteBr));
+            if (cmdout != null && !cmdout.contains("vxlan")) {
+                command.add("-d", String.valueOf(deleteBr));
+            }
 
             final String result = command.execute();
             if (result != null) {


### PR DESCRIPTION
### Description

This PR fixes: https://github.com/apache/cloudstack/issues/5077
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
1. On a zone with VXLAN isolation type:
- Created an Isolated network
- Created a VM 
- Deleted the VM - successfully deletes the Vxlan
```
2021-06-07 09:03:11,042 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-4:null) (logid:6f469f8f) Executing: /usr/share/cloudstack-common/scripts/vm/network/vnet/modifyvxlan.sh -o delete -v 1850 -p vx -b brvx-1850
2021-06-07 09:03:11,043 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-4:null) (logid:6f469f8f) Executing while with timeout : 1800000
2021-06-07 09:03:11,094 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-4:null) (logid:6f469f8f) Execution is successful.
```

2. Verified with VLAN isolation type to ensure no regression:
```
2021-06-07 08:59:12,143 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-1:null) (logid:4bd5fcfd) Executing: /usr/share/cloudstack-common/scripts/vm/network/vnet/modifyvlan.sh -o delete -v 1409 -p eth1 -b breth1-1409 -d true
2021-06-07 08:59:12,144 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-1:null) (logid:4bd5fcfd) Executing while with timeout : 1800000
2021-06-07 08:59:12,184 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-1:null) (logid:4bd5fcfd) Execution is successful.
```




<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
