### PR TITLE
ui: Fix error when no ipv6 address

### DIFF
--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -50,7 +50,7 @@
         </div>
       </div>
     </a-list-item>
-    <a-list-item slot="renderItem" slot-scope="item" v-else-if="item === 'ip6address' && ipV6Address.length > 0">
+    <a-list-item slot="renderItem" slot-scope="item" v-else-if="item === 'ip6address' && ipV6Address && ipV6Address.length > 0">
       <div>
         <strong>{{ $t('label.' + String(item).toLowerCase()) }}</strong>
         <br/>


### PR DESCRIPTION
### Description

Adds a check if ipV6Address is empty (usually before the details are fetched)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):

![Screenshot from 2021-06-07 14-39-38](https://user-images.githubusercontent.com/8244774/120992177-f8a19a80-c79f-11eb-9307-06dface9e470.png)
