### PR TITLE
Root disk size should be listed in GB at listServiceOffering

### DIFF
--- a/server/src/main/java/com/cloud/api/query/dao/ServiceOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ServiceOfferingJoinDaoImpl.java
@@ -45,6 +45,13 @@ public class ServiceOfferingJoinDaoImpl extends GenericDaoBase<ServiceOfferingJo
 
     private SearchBuilder<ServiceOfferingJoinVO> sofIdSearch;
 
+    /**
+     * Constant used to convert GB into Bytes (or the other way around).
+     * GB   *  MB  *  KB  = Bytes //
+     * 1024 * 1024 * 1024 = 1073741824
+     */
+    private static final long GB_TO_BYTES = 1073741824;
+
     protected ServiceOfferingJoinDaoImpl() {
 
         sofIdSearch = createSearchBuilder();
@@ -123,7 +130,8 @@ public class ServiceOfferingJoinDaoImpl extends GenericDaoBase<ServiceOfferingJo
             }
         }
 
-        offeringResponse.setRootDiskSize(offering.getRootDiskSize());
+        long rootDiskSizeInGb = (long) offering.getRootDiskSize() / GB_TO_BYTES;
+        offeringResponse.setRootDiskSize(rootDiskSizeInGb);
 
         return offeringResponse;
     }

--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -35,7 +35,7 @@
         </div>
         <div v-else-if="$route.meta.name === 'computeoffering' && item === 'rootdisksize'">
           <div>
-            {{ parseFloat( resource.rootdisksize / (1024.0 * 1024.0 * 1024.0)).toFixed(1) }} GB
+            {{ resource.rootdisksize }} GB
           </div>
         </div>
         <div v-else-if="['name', 'type'].includes(item)">


### PR DESCRIPTION
### Description

When listing service offerings it is expected to list their Root disk size in GB (see documentation [[1]](http://cloudstack.apache.org/api/apidocs-4.15/apis/listServiceOfferings.html)); however, it is returned in Bytes.
Additionally, during deployment of a VM or creation of a Service Offering the root disk size is always passed as a value in GB [[2]](https://cloudstack.apache.org/api/apidocs-4.15/apis/deployVirtualMachine.html).

This PR aims to fix this by converting the root disk size at the ServiceOffering response from Bytes to GB.

[1] http://cloudstack.apache.org/api/apidocs-4.15/apis/listServiceOfferings.html
[2] https://cloudstack.apache.org/api/apidocs-4.15/apis/deployVirtualMachine.html

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):
N/A

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
List Service offerings via CloudMonkey (or any other way of calling API). Example: `list serviceofferings filter=rootdisksize`.

#### 1. Currently
~~~
list serviceofferings filter=rootdisksize
rootdisksize
3.221225472e+10
3.221225472e+10
3.221225472e+10
3.221225472e+10
1.073741824e+11
~~~

#### 2. With the fix
~~~
list serviceofferings filter=rootdisksize
rootdisksize
30
30
30
30
100
~~~
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
