### PR TITLE
Enable update compute offering tags fields

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateServiceOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateServiceOfferingCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.admin.offering;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -70,6 +71,12 @@ public class UpdateServiceOfferingCmd extends BaseCmd {
             description = "the ID of the containing zone(s) as comma separated string, all for all zones offerings",
             since = "4.13")
     private String zoneIds;
+
+    @Parameter(name = ApiConstants.TAGS, type = CommandType.STRING, description = "comma-separated list of tags for this service offering.", authorized = {RoleType.Admin}, since = "4.15")
+    private String tags;
+
+    @Parameter(name = ApiConstants.HOST_TAG, type = CommandType.STRING, description = "the host tag for this service offering.", authorized = {RoleType.Admin}, since = "4.15")
+    private String hostTag;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -149,6 +156,14 @@ public class UpdateServiceOfferingCmd extends BaseCmd {
             validZoneIds.addAll(_configService.getServiceOfferingZones(id));
         }
         return validZoneIds;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public String getHostTag() {
+        return hostTag;
     }
 
     /////////////////////////////////////////////////////


### PR DESCRIPTION
### Description

This PR enables editing of tags and host tag in a compute service offering.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### How Has This Been Tested?
It has been tested locally in a test lab. Also, I added unit tests to execute the code sanity of the affected methods.

1. I created a new Compute Service Offering, with tags and host tag.
2. I updated the tags and host tag using cloudmonkey.
3. I checked if the changes are correctly made, both in UI and DB.