### PR TITLE
Failed to scale between Service Offerings with the same root disk size

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1170,7 +1170,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
      * 1 - Root volume <br>
      * 2 - && Current Disk Offering enforces a root disk size (in this case one can resize only by changing the Service Offering)
      */
-    private boolean isNotPossibleToResize(VolumeVO volume, DiskOfferingVO diskOffering) {
+    protected boolean isNotPossibleToResize(VolumeVO volume, DiskOfferingVO diskOffering) {
         Long templateId = volume.getTemplateId();
         ImageFormat format = null;
         if (templateId != null) {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -924,14 +924,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         // if we are to use the existing disk offering
-        ImageFormat format = null;
         if (newDiskOffering == null) {
-            Long templateId = volume.getTemplateId();
-            if (templateId != null) {
-                VMTemplateVO template = _templateDao.findById(templateId);
-                format = template.getFormat();
-            }
-
             newSize = cmd.getSize();
             newHypervisorSnapshotReserve = volume.getHypervisorSnapshotReserve();
 
@@ -942,7 +935,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                             + "customizable or it must be a root volume (if providing a disk offering, make sure it is different from the current disk offering).");
                 }
 
-                if (isNotPossibleToResize(volume, format, diskOffering)) {
+                if (isNotPossibleToResize(volume, diskOffering)) {
                     throw new InvalidParameterValueException(
                             "Failed to resize Root volume. The service offering of this Volume has been configured with a root disk size; "
                                     + "on such case a Root Volume can only be resized when changing to another Service Offering with a Root disk size. "
@@ -1177,7 +1170,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
      * 1 - Root volume <br>
      * 2 - && Current Disk Offering enforces a root disk size (in this case one can resize only by changing the Service Offering) <br>
      */
-    private boolean isNotPossibleToResize(VolumeVO volume, ImageFormat format, DiskOfferingVO diskOffering) {
+    private boolean isNotPossibleToResize(VolumeVO volume, DiskOfferingVO diskOffering) {
         ServiceOfferingJoinVO serviceOfferingView = serviceOfferingJoinDao.findById(diskOffering.getId());
         return serviceOfferingView.getRootDiskSize() > 0 && volume.getVolumeType().equals(Volume.Type.ROOT);
     }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1174,7 +1174,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         Long templateId = volume.getTemplateId();
         ImageFormat format = null;
         if (templateId != null) {
-            VMTemplateVO template = _templateDao.findById(templateId);
+            VMTemplateVO template = _templateDao.findByIdIncludingRemoved(templateId);
             format = template.getFormat();
         }
         boolean isNotIso = format != null && format != ImageFormat.ISO;

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1181,7 +1181,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         boolean isRoot = Volume.Type.ROOT.equals(volume.getVolumeType());
 
         ServiceOfferingJoinVO serviceOfferingView = serviceOfferingJoinDao.findById(diskOffering.getId());
-        boolean isOfferingEnforcingRootDiskSize = serviceOfferingView.getRootDiskSize() > 0;
+        boolean isOfferingEnforcingRootDiskSize = serviceOfferingView != null && serviceOfferingView.getRootDiskSize() > 0;
 
         return isOfferingEnforcingRootDiskSize && isRoot && isNotIso;
     }

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -81,7 +81,6 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
-import com.cloud.hypervisor.dao.HypervisorCapabilitiesDao;
 import com.cloud.org.Grouping;
 import com.cloud.serializer.GsonHelper;
 import com.cloud.server.TaggedResourceService;
@@ -106,8 +105,6 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
-
-import javax.inject.Inject;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VolumeApiServiceImplTest {

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -1117,6 +1117,7 @@ public class VolumeApiServiceImplTest {
         VolumeVO volume = Mockito.mock(VolumeVO.class);
         when(volume.getVolumeType()).thenReturn(volumeType);
 
+        when(volume.getTemplateId()).thenReturn(1l);
         DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
 
         ServiceOfferingJoinVO serviceOfferingJoinVO = Mockito.mock(ServiceOfferingJoinVO.class);
@@ -1125,7 +1126,7 @@ public class VolumeApiServiceImplTest {
 
         VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
         when(template.getFormat()).thenReturn(imageFormat);
-        when(templateDao.findById(Mockito.anyLong())).thenReturn(template);
+        when(templateDao.findByIdIncludingRemoved(Mockito.anyLong())).thenReturn(template);
 
         boolean result = volumeApiServiceImpl.isNotPossibleToResize(volume, diskOffering);
         Assert.assertEquals(expectedIsNotPossibleToResize, result);

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -35,6 +35,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import com.cloud.api.query.dao.ServiceOfferingJoinDao;
+import com.cloud.api.query.vo.ServiceOfferingJoinVO;
+import com.cloud.storage.dao.VMTemplateDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.command.user.volume.CreateVolumeCmd;
@@ -104,6 +107,8 @@ import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 
+import javax.inject.Inject;
+
 @RunWith(MockitoJUnitRunner.class)
 public class VolumeApiServiceImplTest {
 
@@ -153,7 +158,9 @@ public class VolumeApiServiceImplTest {
     @Mock
     private StoragePoolTagsDao storagePoolTagsDao;
     @Mock
-    private HypervisorCapabilitiesDao hypervisorCapabilitiesDao;
+    private VMTemplateDao templateDao;
+    @Mock
+    private ServiceOfferingJoinDao serviceOfferingJoinDao;
 
     private DetachVolumeCmd detachCmd = new DetachVolumeCmd();
     private Class<?> _detachCmdClass = detachCmd.getClass();
@@ -1078,5 +1085,52 @@ public class VolumeApiServiceImplTest {
         boolean result = volumeApiServiceImpl.doesTargetStorageSupportDiskOffering(storagePoolMock, diskOfferingVoMock);
 
         Assert.assertTrue(result);
+    }
+
+    @Test
+    public void isNotPossibleToResizeTestAllFormats() {
+        Storage.ImageFormat[] imageFormat = Storage.ImageFormat.values();
+        for (int i = 0; i < imageFormat.length - 1; i++) {
+            if (imageFormat[i] != Storage.ImageFormat.ISO) {
+                prepareAndRunTestOfIsNotPossibleToResize(Type.ROOT, 10l, imageFormat[i], true);
+            } else {
+                prepareAndRunTestOfIsNotPossibleToResize(Type.ROOT, 10l, imageFormat[i], false);
+            }
+        }
+    }
+
+    @Test
+    public void isNotPossibleToResizeTestAllTypes() {
+        Type[] types = Type.values();
+        for (int i = 0; i < types.length - 1; i++) {
+            if (types[i] != Type.ROOT) {
+                prepareAndRunTestOfIsNotPossibleToResize(types[i], 10l, Storage.ImageFormat.QCOW2, false);
+            } else {
+                prepareAndRunTestOfIsNotPossibleToResize(types[i], 10l, Storage.ImageFormat.QCOW2, true);
+            }
+        }
+    }
+
+    @Test
+    public void isNotPossibleToResizeTestNoRootDiskSize() {
+        prepareAndRunTestOfIsNotPossibleToResize(Type.ROOT, 0l, Storage.ImageFormat.QCOW2, false);
+    }
+
+    private void prepareAndRunTestOfIsNotPossibleToResize(Type volumeType, Long rootDisk, Storage.ImageFormat imageFormat, boolean expectedIsNotPossibleToResize) {
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        when(volume.getVolumeType()).thenReturn(volumeType);
+
+        DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
+
+        ServiceOfferingJoinVO serviceOfferingJoinVO = Mockito.mock(ServiceOfferingJoinVO.class);
+        when(serviceOfferingJoinVO.getRootDiskSize()).thenReturn(rootDisk);
+        when(serviceOfferingJoinDao.findById(Mockito.anyLong())).thenReturn(serviceOfferingJoinVO);
+
+        VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
+        when(template.getFormat()).thenReturn(imageFormat);
+        when(templateDao.findById(Mockito.anyLong())).thenReturn(template);
+
+        boolean result = volumeApiServiceImpl.isNotPossibleToResize(volume, diskOffering);
+        Assert.assertEquals(expectedIsNotPossibleToResize, result);
     }
 }


### PR DESCRIPTION
### Description

When changing from a Service Offering with the root disk size enforced to another offering with the same root disk size enforced this will lead to the following error message.

![image](https://user-images.githubusercontent.com/5025148/121435280-fdf41600-c954-11eb-8627-731c902af85e.png)


On PR #4341 I covered manual tests **1, 2, & 3** as described on "**How Has This Been Tested?**"; however, none of these covered the issue discovered.

This PR addresses the test case **4** that is reported in "**How Has This Been Tested?**"

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):
N/A

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tests:
Created the following service offerings (via API and also via UI):

    0GB - default behavior with no Root Disk Size configured
    5GB - 5GB Root
    10GB - 10GB Root
    15GB - 15GB Root

Executed following tests

1. Test root volume resize.
Expected result: not allowed to resize
Steps:
a - deploy a VM with any of the root size configured offerings (e.g. 5GB)
b - Change root volume size
c - not allowed

2. Test resize via service offering.
Expected result: allow 5GB -> 10GB, and 10 GB -> 15, fail to "dowsize" from 10GB -> 5GB
Steps:
a - deploy VM with offering 5GB
b - Stop VM
c - Change Service offering to 10GB
d - Change offering back to 5GB, fails (as expected)
e - Change offering to 15GB

3. Test resize via offering to a Service offering with the default root size (0 GB) and then customize the volume
Expected result: allow 5GB -> 0GB, successfully change the root volume to a custom size
Steps:
a - deploy VM with offering 5GB
b - Stop VM
c - Change Service offering to 0GB
d - resize volume to custom size, e.g 50 GB

4. **Test resize via service offering from offerings with Root Disk of the same size.
Expected result: allow 10GB -> 10GB  successfully change the offering; note that they are two offerings where the compute resources are changed but root size stays the same**
Steps:
a - deploy VM with offering 10GB
b - Stop VM
c - Change Service offering to other offering 10GB