### PR TITLE
Update chain info of the volumes after migrate operations

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2307,6 +2307,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             VolumeVO volume = _volsDao.findById(result.getId());
             volume.setPath(result.getPath());
             volume.setPoolId(destPool.getId());
+            if (result.getChainInfo() != null) {
+                volume.setChainInfo(result.getChainInfo());
+            }
             _volsDao.update(volume.getId(), volume);
         }
     }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -4429,7 +4429,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 } else {
                     s_logger.debug("Successfully consolidated disks of VM " + vmMo.getVmName() + ".");
                 }
-                return createAnswerForCmd(vmMo, poolUuid, cmd, volumeDeviceKey);
+                DatastoreMO dsMo = new DatastoreMO(getServiceContext(), morDs);
+                return createAnswerForCmd(vmMo, dsMo, cmd, volumeDeviceKey);
             } else {
                 return new Answer(cmd, false, "failed to changes data store for VM" + vmMo.getVmName());
             }
@@ -4440,7 +4441,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         }
     }
 
-    Answer createAnswerForCmd(VirtualMachineMO vmMo, String poolUuid, Command cmd, Map<Integer, Long> volumeDeviceKey) throws Exception {
+    Answer createAnswerForCmd(VirtualMachineMO vmMo, DatastoreMO dsMo, Command cmd, Map<Integer, Long> volumeDeviceKey) throws Exception {
         List<VolumeObjectTO> volumeToList = new ArrayList<>();
         VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();
         VirtualDisk[] disks = vmMo.getAllDiskDevice();
@@ -4458,7 +4459,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             for (VirtualDisk disk : disks) {
                 VolumeObjectTO newVol = new VolumeObjectTO();
                 String newPath = vmMo.getVmdkFileBaseName(disk);
-                VirtualMachineDiskInfo diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(newPath, poolUuid);
+                VirtualMachineDiskInfo diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(newPath, dsMo.getName());
                 newVol.setId(volumeDeviceKey.get(disk.getKey()));
                 newVol.setPath(newPath);
                 newVol.setChainInfo(_gson.toJson(diskInfo));
@@ -4804,8 +4805,9 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     if (volumeDeviceKey.get(volumeId) == disk.getKey()) {
                         VolumeObjectTO newVol = new VolumeObjectTO();
                         String newPath = vmMo.getVmdkFileBaseName(disk);
-                        String poolName = entry.second().getUuid().replace("-", "");
-                        VirtualMachineDiskInfo diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(newPath, poolName);
+                        ManagedObjectReference morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(tgtHyperHost, entry.second().getUuid());
+                        DatastoreMO dsMo = new DatastoreMO(getServiceContext(), morDs);
+                        VirtualMachineDiskInfo diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(newPath, dsMo.getName());
                         newVol.setId(volumeId);
                         newVol.setPath(newPath);
                         newVol.setChainInfo(_gson.toJson(diskInfo));
@@ -5100,7 +5102,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     }
             }
             VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();
-            String chainInfo = _gson.toJson(diskInfoBuilder.getDiskInfoByBackingFileBaseName(volumePath, poolTo.getUuid().replace("-", "")));
+            String chainInfo = _gson.toJson(diskInfoBuilder.getDiskInfoByBackingFileBaseName(volumePath, targetDsMo.getName()));
             MigrateVolumeAnswer answer = new MigrateVolumeAnswer(cmd, true, null, volumePath);
             answer.setVolumeChainInfo(chainInfo);
             return answer;

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -1745,7 +1745,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 } else {
                     // This is to find datastores which are removed from datastore cluster.
                     // The final set childDatastoreUUIDs contains the UUIDs of child datastores which needs to be removed from datastore cluster
-                    childDatastoreUUIDs.remove(childStoragePoolInfo.getUuid());
+                    childDatastoreUUIDs.remove(dataStoreVO.getUuid());
                 }
             } else {
                 dataStoreVO = createChildDatastoreVO(datastoreClusterPool, childDataStoreAnswer);


### PR DESCRIPTION

### Description
This PR fixes the problem of not updating the chain info or setting chain info to null after volume migrations.

Problem: While fetching the volume chain info, management server assumes datastore name to be a UUID (this is true only for NFS storages added by CloudStack) but datastore name can be with any name.
Solution: To fetch the volume chain info, use datastore name instead of UUID.

The fix is made in the flow of following API operations
1. migrateVirtualMachine
2. migrateVirtualMachineWithVolume
3. migrateVolume 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Created one NFS, one datastore cluster (with two child storages with names "child1", "child2") primary storages
1. Migrated a volume from NFS to datastore cluster. 'chain_info' in "volumes" table is updated
Before migration
![image](https://user-images.githubusercontent.com/3348673/121502618-f6d51280-c9fd-11eb-93ab-aabfb95b9b9c.png)
After migration
![image](https://user-images.githubusercontent.com/3348673/121502753-166c3b00-c9fe-11eb-9617-91e79fc136ce.png)
2. Migrated volume from datastore cluster to NFS storage. 'chain_info' in "volumes" table is updated
3. called APIs migrateVirtualMachine and migrateVirtualMachineWithVolumes to migrate volumes from NFS to datastore cluster and datastore cluster to NFS, all succeeded and updated the chain_info accordingly.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
