### PR TITLE
Enhance docs for changeServiceForVM & scaleVirtualMachine

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ScaleVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ScaleVMCmdByAdmin.java
@@ -25,6 +25,6 @@ import org.apache.cloudstack.api.response.SuccessResponse;
 import com.cloud.vm.VirtualMachine;
 
 
-@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering.", responseObject = SuccessResponse.class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
+@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering. This command also takes into account the Volume and it may resize the root disk size according to the service offering.", responseObject = SuccessResponse.class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleVMCmdByAdmin extends ScaleVMCmd implements AdminCmd {}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpgradeVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpgradeVMCmdByAdmin.java
@@ -26,6 +26,7 @@ import com.cloud.vm.VirtualMachine;
 
 @APICommand(name = "changeServiceForVirtualMachine", responseObject=UserVmResponse.class, description="Changes the service offering for a virtual machine. " +
                                             "The virtual machine must be in a \"Stopped\" state for " +
-        "this command to take effect.", responseView = ResponseView.Full, entityType = {VirtualMachine.class},
+        "this command to take effect. Note that it only changes the VM's compute offering and it does not update the root volume offering. "
+        + "If the Service Offering has a root disk size the volume will be resized only if using API command 'scaleVirtualMachine'.", responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class UpgradeVMCmdByAdmin extends UpgradeVMCmd implements AdminCmd {}


### PR DESCRIPTION
### Description

Over the past years, I have seen some confusion regarding which command to use when changing a VM's offering. Users tend to choose always the API command [changeServiceForVirtualMachine](https://cloudstack.apache.org/api/apidocs-4.15/apis/changeServiceForVirtualMachine.html) and are not aware of [scaleVirtualMachine](https://cloudstack.apache.org/api/apidocs-4.15/apis/scaleVirtualMachine.html). On the best case, the user knows that both commands exist but is not sure about which one to choose.

This PR proposes some enhancements on the documentation of API commands `changeServiceForVirtualMachine` and `scaleVirtualMachine`. One of the major differences of both is that `scaleVirtualMachine` takes into account disk offerings, and also resizes the volume if necessary while `changeServiceForVirtualMachine` focuses only on updating the "compute" offering. 

This leads to issues and inconsistencies where a client expects the root volume to have its disk offering updated matching the new Service offering; however, it is not changed and it gets to a point where VM has an offering and the volume another.

For instance, if one uses changeServiceForVM to change from a "Previous Offering" to "New Offering" this is what it happens:

```
(localcloud) 🐱 > list virtualmachines id=<VM-ID>  filter=name,serviceofferingname,
{
  "count": 1,
  "virtualmachine": [
    {
      "name": "VM-1234",
      "serviceofferingname": "New Offering"
    }
  ]
}
(localcloud) 🐱 > list volumes virtualmachineid=<VM-ID> filter=serviceofferingname, listall=true 
{
  "count": 1,
  "volume": [
    {
      "serviceofferingname": "Previous Offering"
    }
  ]
}
```

### Proposed changes on API descriptions:
#### 1. changeServiceForVirtualMachine
From:
~~~
Changes the service offering for a virtual machine.
The virtual machine must be in a "Stopped" state for this command to take effect.
~~~

To:
~~~
Changes the service offering for a virtual machine.
The virtual machine must be in a "Stopped" state for this command to take effect.
Note that it only changes the VM's compute offering and it does not update the root volume offering.
If the Service Offering has a root disk size the volume will be resized only if using API command 'scaleVirtualMachine'.
~~~



#### 2. Scale Virtual Machine documentation
From:
~~~
Scales the virtual machine to a new service offering.
~~~

To:
~~~
Scales the virtual machine to a new service offering.
This command also takes into account the Volume and it may resize the root disk size according to the service offering.
~~~

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
N/A

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
N/A

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
