### PR TITLE
allow big contents from error output in marvin tests

### DIFF
--- a/tools/travis/xunit-reader.py
+++ b/tools/travis/xunit-reader.py
@@ -78,7 +78,7 @@ def parse_reports(file_path_list):
     exit_code = 0
 
     for file_path in file_path_list:
-        data = lxml.etree.iterparse(file_path, tag='testcase')
+        data = lxml.etree.iterparse(file_path, tag='testcase', huge_tree=True)
         for event, elem in data:
             name = ''
             status = 'Success'


### PR DESCRIPTION
### Description

This PR fixes error output for marvin tests not being generated if CDATA contains too much text.

the tests `test_multiple_subnets_in_isolated_network_rvr.py` and `test_multiple_subnets_in_vpc_rvr.py` from the component tests would crash `tools/xunit-reader.py` without it.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

generating cli output in a component test log dir with only the failing output (of successfull tests:

without the fix:
```
# python3 /marvin/tools/xunit-reader.py MarvinLogs_err/

Test | Result | Time (s) | Test File
--- | --- | --- | ---
Traceback (most recent call last):
  File "/marvin/tools/xunit-reader.py", line 111, in <module>
    main()
  File "/marvin/tools/xunit-reader.py", line 40, in main
    exit(parse_reports(file_path_list))
  File "/marvin/tools/xunit-reader.py", line 84, in parse_reports
    for event, elem in data:
  File "src/lxml/iterparse.pxi", line 209, in lxml.etree.iterparse.__next__
  File "src/lxml/iterparse.pxi", line 194, in lxml.etree.iterparse.__next__
  File "src/lxml/iterparse.pxi", line 229, in lxml.etree.iterparse._read_more_events
  File "src/lxml/parser.pxi", line 1384, in lxml.etree._FeedParser.feed
  File "src/lxml/parser.pxi", line 606, in lxml.etree._ParserContext._handleParseResult
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
  File "MarvinLogs_err/test_multiple_subnets_in_isolated_network_rvr.py.xml", line 6
lxml.etree.XMLSyntaxError: internal error: Huge input lookup, line 6, column 98
```
and in python2
```
# python2 /marvin/tools/xunit-reader.py MarvinLogs_err/

Test | Result | Time (s) | Test File
--- | --- | --- | ---
Traceback (most recent call last):
  File "/marvin/tools/xunit-reader.py", line 111, in <module>
    main()
  File "/marvin/tools/xunit-reader.py", line 40, in main
    exit(parse_reports(file_path_list))
  File "/marvin/tools/xunit-reader.py", line 84, in parse_reports
    for event, elem in data:
  File "src/lxml/iterparse.pxi", line 209, in lxml.etree.iterparse.__next__
  File "MarvinLogs_err/test_multiple_subnets_in_isolated_network_rvr.py.xml", line 6
lxml.etree.XMLSyntaxError: internal error: Huge input lookup, line 6, column 98
```
with the fix :
```
# python3 /marvin/tools/xunit-reader.py MarvinLogs_err/

Test | Result | Time (s) | Test File
--- | --- | --- | ---

```
or
```
# python2 /marvin/tools/xunit-reader.py MarvinLogs_err/

Test | Result | Time (s) | Test File
--- | --- | --- | ---
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
