### PR TITLE
Fix typo in error message on login page

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2766,7 +2766,7 @@
 "message.error.custom.disk.size": "Please enter custom disk size",
 "message.error.date": "Please select a date",
 "message.error.description": "Please enter description",
-"message.error.discovering.feature": "Exception caught while discoverying features",
+"message.error.discovering.feature": "Exception caught while discovering features",
 "message.error.display.text": "Please enter display text",
 "message.error.domain": "Enter your domain, leave empty for ROOT domain",
 "message.error.enable.saml": "Unable to find users IDs to enable SAML Single Sign On, kindly enable it manually.",


### PR DESCRIPTION
### Description

This PR fixes a typo on the login page :see_no_evil: 

![image](https://user-images.githubusercontent.com/10495417/122215314-b3c8e280-cec8-11eb-8b06-a9d07323dcfe.png)

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
With Fix:
![image](https://user-images.githubusercontent.com/10495417/122215430-d529ce80-cec8-11eb-99e0-297afbc503b1.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
