### PR TITLE
Externalize tls version and security protocols configuration on mail sending

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/alert/AlertManager.java
+++ b/engine/components-api/src/main/java/com/cloud/alert/AlertManager.java
@@ -35,6 +35,12 @@ public interface AlertManager extends Manager, AlertService {
         "Alert", "0.75", "Percentage (as a value between 0 and 1) of allocated storage utilization above which alerts will be sent about low storage available.", true,
         ConfigKey.Scope.Cluster, null);
 
+    public static final ConfigKey<Boolean> AlertSmtpUseStartTLS = new ConfigKey<Boolean>("Advanced", Boolean.class, "alert.smtp.useStartTLS", "false",
+            "If set to true and if we enable security via alert.smtp.useAuth, this will enable StartTLS to secure the conection.", true);
+
+    public static final ConfigKey<String> AlertSmtpEnabledSecurityProtocols = new ConfigKey<String>("Advanced", String.class, "alert.smtp.enabledSecurityProtocols", "",
+            "White-space separated security protocols; ex: \"TLSv1 TLSv1.1\". Supported protocols: SSLv2Hello, SSLv3, TLSv1, TLSv1.1 and TLSv1.2", true);
+
     void clearAlert(AlertType alertType, long dataCenterId, long podId);
 
     void recalculateCapacity();

--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -754,7 +754,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {CPUCapacityThreshold, MemoryCapacityThreshold, StorageAllocatedCapacityThreshold, StorageCapacityThreshold};
+        return new ConfigKey<?>[] {CPUCapacityThreshold, MemoryCapacityThreshold, StorageAllocatedCapacityThreshold, StorageCapacityThreshold, AlertSmtpEnabledSecurityProtocols,
+            AlertSmtpUseStartTLS};
     }
 
     @Override

--- a/server/src/main/java/com/cloud/projects/ProjectManager.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManager.java
@@ -19,8 +19,15 @@ package com.cloud.projects;
 import java.util.List;
 
 import com.cloud.user.Account;
+import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface ProjectManager extends ProjectService {
+    public static final ConfigKey<Boolean> ProjectSmtpUseStartTLS = new ConfigKey<Boolean>("Advanced", Boolean.class, "project.smtp.useStartTLS", "false",
+            "If set to true and if we enable security via project.smtp.useAuth, this will enable StartTLS to secure the conection.", true);
+
+    public static final ConfigKey<String> ProjectSmtpEnabledSecurityProtocols = new ConfigKey<String>("Advanced", String.class, "project.smtp.enabledSecurityProtocols", "",
+            "White-space separated security protocols; ex: \"TLSv1 TLSv1.1\". Supported protocols: SSLv2Hello, SSLv3, TLSv1, TLSv1.1 and TLSv1.2", true);
+
     boolean canAccessProjectAccount(Account caller, long accountId);
 
     boolean canModifyProjectAccount(Account caller, long accountId);

--- a/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
@@ -82,13 +82,15 @@ import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.utils.mailing.MailAddress;
 import org.apache.cloudstack.utils.mailing.SMTPMailProperties;
 import org.apache.cloudstack.utils.mailing.SMTPMailSender;
 import org.apache.commons.lang3.BooleanUtils;
 
 @Component
-public class ProjectManagerImpl extends ManagerBase implements ProjectManager {
+public class ProjectManagerImpl extends ManagerBase implements ProjectManager, Configurable {
     public static final Logger s_logger = Logger.getLogger(ProjectManagerImpl.class);
 
     @Inject
@@ -1366,4 +1368,13 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager {
         return _allowUserToCreateProject;
     }
 
+    @Override
+    public String getConfigComponentName() {
+        return ProjectManager.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {ProjectSmtpEnabledSecurityProtocols, ProjectSmtpUseStartTLS};
+    }
 }


### PR DESCRIPTION
### Description

- Some servers (such as [Microsoft](https://docs.microsoft.com/en-us/microsoft-365/compliance/prepare-tls-1.2-in-office-365?view=o365-worldwide) exchange) are deprecating TLSv1 and TLSv1.1. On alert's and project's mailing settings, ACS uses the protocol TLSv1; therefore, operators do not have options to choose which version they want to use.

- ACS has configurations (`\*.smtp.useAuth`) to inform if it will use secure SMTP authentication when sending emails; However, this configuration only refers to the use of SSL. Operators have no means to choose if they want to use StartTLS option.

This PR intends to externalize the protocol's and StartTLS settings on alert's and project's mail sending. Alert and project (also quota) send email through the class `SMTPMailSender`, inserted in PR [4954](https://github.com/apache/cloudstack/pull/4954), which will handle these configurations.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?
It was tested in a test lab.

I set SMTP global settings to project and alert and enabled StartTLS (global setting); Then I allowed `Less secure app access` on my Google account and set the following settings:
```
server address: smtp.gmail.com
username: <gmail address>
password: <gmail password>
port (TLS): 587
```
- To alert, I started mgmt;
- To project, I enabled global setting `project.invite.required` and added a user via email;

In Gmail, we have an option to `show original` message, which provides the TLS version and the cipher. So I changed the configuration a few times and sent some alerts and invitations to verify if both versions, in configuration and Gmail, were the same.