### PR TITLE
ui: Notify vm password on reinstall of VM (for password enabled templates)

### DIFF
--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -144,6 +144,18 @@ export default {
             virtualmachineid: {
               value: (record) => { return record.id }
             }
+          },
+          successMethod: (obj, result) => {
+            console.log('here')
+            const vm = result.jobresult.virtualmachine || {}
+            if (result.jobstatus === 1 && vm.password) {
+              const name = vm.displayname || vm.name || vm.id
+              obj.$notification.success({
+                message: `${obj.$t('label.reinstall.vm')}: ` + name,
+                description: `${obj.$t('label.password.reset.confirm')}: ` + vm.password,
+                duration: 0
+              })
+            }
           }
         },
         {

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -870,6 +870,16 @@ export default {
                 duration: 0
               })
             }
+          } else if (result.jobstatus === 1 && action.api === 'restoreVirtualMachine') {
+            const vm = result.jobresult.virtualmachine
+            const name = vm.displayname || vm.name || vm.id
+            if (vm.password) {
+              this.$notification.success({
+                message: `${this.$t('label.reinstall.vm')}: ` + name,
+                description: `${this.$t('label.password.reset.confirm')}: ` + vm.password,
+                duration: 0
+              })
+            }
           }
         },
         errorMethod: () => this.fetchData(),

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -870,16 +870,9 @@ export default {
                 duration: 0
               })
             }
-          } else if (result.jobstatus === 1 && action.api === 'restoreVirtualMachine') {
-            const vm = result.jobresult.virtualmachine
-            const name = vm.displayname || vm.name || vm.id
-            if (vm.password) {
-              this.$notification.success({
-                message: `${this.$t('label.reinstall.vm')}: ` + name,
-                description: `${this.$t('label.password.reset.confirm')}: ` + vm.password,
-                duration: 0
-              })
-            }
+          }
+          if ('successMethod' in action) {
+            action.successMethod(this, result)
           }
         },
         errorMethod: () => this.fetchData(),


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/5127
This PR notifies the users of the changed password on VM reinstall if template is password enabled

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
![image](https://user-images.githubusercontent.com/10495417/122515357-f5719e80-d02a-11eb-8797-e5473b434488.png)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
