### PR TITLE
Fix of delete of Ceph's snapshots from secondary storage

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategy.java
@@ -64,10 +64,6 @@ public class CephSnapshotStrategy extends StorageSystemSnapshotStrategy {
             return StrategyPriority.HIGHEST;
         }
 
-        if (SnapshotOperation.DELETE.equals(op)) {
-            return StrategyPriority.HIGHEST;
-        }
-
         return StrategyPriority.CANT_HANDLE;
     }
 

--- a/engine/storage/snapshot/src/test/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategyTest.java
+++ b/engine/storage/snapshot/src/test/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategyTest.java
@@ -87,8 +87,6 @@ public class CephSnapshotStrategyTest {
             StrategyPriority strategyPriority = cephSnapshotStrategy.canHandle(snapshot, snapshotOps[i]);
             if (snapshotOps[i] == SnapshotOperation.REVERT && isSnapshotStoredOnRbdStoragePool) {
                 Assert.assertEquals(StrategyPriority.HIGHEST, strategyPriority);
-            } else if (snapshotOps[i] == SnapshotOperation.DELETE && isSnapshotStoredOnRbdStoragePool) {
-                Assert.assertEquals(StrategyPriority.HIGHEST, strategyPriority);
             } else {
                 Assert.assertEquals(StrategyPriority.CANT_HANDLE, strategyPriority);
             }


### PR DESCRIPTION
### Description

This PR fixes the deletion will be handled by DefaultSnapshotStrategy::deleteSnapshot #4797 


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
Manually tested: check if the snapshot is deleted from primary/secondary storage 
