### PR TITLE
api: Add validation for empty vm group name

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3081,6 +3081,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Unable to create vm group, a group with name " + groupName + " already exists for account " + accountId);
         }
 
+        if (StringUtils.isEmpty(groupName)) {
+            throw new InvalidParameterValueException("Instance group name is empty");
+        }
         return createVmGroup(groupName, accountId);
     }
 


### PR DESCRIPTION
### Description

This PR prevents creation of an instance group with an empty name

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Prior Fix:
```
(localcloud) 🐱 > create instancegroup name=
{
  "instancegroup": {
    "account": "admin",
    "created": "2021-06-21T21:52:37+0530",
    "domain": "ROOT",
    "domainid": "6b71db05-cf22-11eb-9edd-50eb7122da94",
    "id": "fad68789-78a0-4fb9-b33d-071f7c6d6f69",
    "name": ""
  }
}

```

Post Fix:
```
(localcloud) 🐱 > create instancegroup name=
🙈 Error: (HTTP 431, error code 4350) Instance group name is empty

```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
