### PR TITLE
apiserver : Ensure required parameters are not empty

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/BaseRolePermissionCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/BaseRolePermissionCmd.java
@@ -19,7 +19,6 @@ package org.apache.cloudstack.api.command.admin.acl;
 
 import org.apache.cloudstack.acl.RolePermissionEntity.Permission;
 import org.apache.cloudstack.acl.Rule;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
@@ -32,8 +31,7 @@ public abstract class BaseRolePermissionCmd extends BaseCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
 
-    @Parameter(name = ApiConstants.RULE, type = CommandType.STRING, required = true, description = "The API name or wildcard rule such as list*",
-            validations = {ApiArgValidator.NotNullOrEmpty})
+    @Parameter(name = ApiConstants.RULE, type = CommandType.STRING, required = true, description = "The API name or wildcard rule such as list*")
     private String rule;
 
     @Parameter(name = ApiConstants.PERMISSION, type = CommandType.STRING, required = true, description = "The rule permission, allow or deny. Default: deny.")

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/CreateRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/CreateRoleCmd.java
@@ -26,7 +26,6 @@ import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.response.RoleResponse;
 import org.apache.cloudstack.context.CallContext;
 
@@ -42,7 +41,7 @@ public class CreateRoleCmd extends RoleCmd {
     /////////////////////////////////////////////////////
 
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true,
-            description = "Creates a role with this unique name", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "Creates a role with this unique name")
     private String roleName;
 
     @Parameter(name = ApiConstants.ROLE_ID, type = CommandType.UUID, entityType = RoleResponse.class,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/ImportRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/ImportRoleCmd.java
@@ -30,7 +30,6 @@ import org.apache.cloudstack.acl.Role;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.Rule;
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.ApiServerService;
@@ -56,7 +55,7 @@ public class ImportRoleCmd extends RoleCmd {
     /////////////////////////////////////////////////////
 
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true,
-            description = "Creates a role with this unique name", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "Creates a role with this unique name")
     private String roleName;
 
     @Parameter(name = ApiConstants.RULES, type = CommandType.MAP, required = true,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/CreateProjectRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/CreateProjectRoleCmd.java
@@ -20,7 +20,6 @@ package org.apache.cloudstack.api.command.admin.acl.project;
 import org.apache.cloudstack.acl.ProjectRole;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
@@ -42,7 +41,7 @@ public class CreateProjectRoleCmd extends ProjectRoleCmd {
     /////////////////////////////////////////////////////
 
     @Parameter(name = ApiConstants.NAME, type = BaseCmd.CommandType.STRING, required = true,
-            description = "creates a project role with this unique name", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "creates a project role with this unique name")
     private String projectRoleName;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/CreateProjectRolePermissionCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/CreateProjectRolePermissionCmd.java
@@ -47,7 +47,7 @@ public class CreateProjectRolePermissionCmd extends BaseRolePermissionCmd {
     private Long projectRoleId;
 
     @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, required = true, entityType = ProjectResponse.class,
-            description = "ID of project where project role permission is to be created", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "ID of project where project role permission is to be created")
     private Long projectId;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/ProjectRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/ProjectRoleCmd.java
@@ -18,7 +18,6 @@
 package org.apache.cloudstack.api.command.admin.acl.project;
 
 import org.apache.cloudstack.acl.ProjectRole;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
@@ -31,7 +30,7 @@ public abstract class ProjectRoleCmd extends BaseCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
     @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, required = true, entityType = ProjectResponse.class,
-            description = "ID of project where role is being created", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "ID of project where role is being created")
     private Long projectId;
 
     @Parameter(name = ApiConstants.DESCRIPTION, type = BaseCmd.CommandType.STRING, description = "The description of the Project role")

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/UpdateProjectRolePermissionCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/UpdateProjectRolePermissionCmd.java
@@ -53,7 +53,7 @@ public class UpdateProjectRolePermissionCmd extends BaseCmd {
     private Long projectRoleId;
 
     @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, required = true, entityType = ProjectResponse.class,
-            description = "ID of project where project role permission is to be updated", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "ID of project where project role permission is to be updated")
     private Long projectId;
 
     @Parameter(name = ApiConstants.RULE_ORDER, type = CommandType.LIST, collectionType = CommandType.UUID, entityType = ProjectRolePermissionResponse.class,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/diagnostics/RunDiagnosticsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/diagnostics/RunDiagnosticsCmd.java
@@ -70,12 +70,10 @@ public class RunDiagnosticsCmd extends BaseAsyncCmd {
     private Long id;
 
     @Parameter(name = ApiConstants.IP_ADDRESS, type = CommandType.STRING, required = true,
-            validations = {ApiArgValidator.NotNullOrEmpty},
             description = "The IP/Domain address to test connection to")
     private String address;
 
     @Parameter(name = ApiConstants.TYPE, type = CommandType.STRING, required = true,
-            validations = {ApiArgValidator.NotNullOrEmpty},
             description = "The system VM diagnostics type  valid options are: ping, traceroute, arping")
     private String type;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/ConfigureHAForHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/ConfigureHAForHostCmd.java
@@ -61,7 +61,7 @@ public final class ConfigureHAForHostCmd extends BaseAsyncCmd {
     private Long hostId;
 
     @Parameter(name = ApiConstants.PROVIDER, type = CommandType.STRING,
-            description = "HA provider", required = true, validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "HA provider", required = true)
     private String haProvider;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/ListHostHAProvidersCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/ListHostHAProvidersCmd.java
@@ -26,7 +26,6 @@ import com.cloud.user.Account;
 import com.google.common.base.Enums;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
@@ -57,7 +56,7 @@ public final class ListHostHAProvidersCmd extends BaseCmd {
     /////////////////////////////////////////////////////
 
     @Parameter(name = ApiConstants.HYPERVISOR, type = CommandType.STRING, required = true,
-            description = "Hypervisor type of the resource", validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "Hypervisor type of the resource")
     private String hypervisorType;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/network/CreateManagementNetworkIpRangeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/network/CreateManagementNetworkIpRangeCmd.java
@@ -62,22 +62,19 @@ public class CreateManagementNetworkIpRangeCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.GATEWAY,
             type = CommandType.STRING,
             required = true,
-            description = "The gateway for the management network.",
-            validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "The gateway for the management network.")
     private String gateway;
 
     @Parameter(name = ApiConstants.NETMASK,
             type = CommandType.STRING,
             required = true,
-            description = "The netmask for the management network.",
-            validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "The netmask for the management network.")
     private String netmask;
 
     @Parameter(name = ApiConstants.START_IP,
             type = CommandType.STRING,
             required = true,
-            description = "The starting IP address.",
-            validations = {ApiArgValidator.NotNullOrEmpty})
+            description = "The starting IP address.")
     private String startIp;
 
     @Parameter(name = ApiConstants.END_IP,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/network/CreateNetworkOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/network/CreateNetworkOfferingCmd.java
@@ -94,7 +94,6 @@ public class CreateNetworkOfferingCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.SUPPORTED_SERVICES,
             type = CommandType.LIST,
-            required = true,
             collectionType = CommandType.STRING,
             description = "services supported by the network offering")
     private List<String> supportedServices;
@@ -205,7 +204,7 @@ public class CreateNetworkOfferingCmd extends BaseCmd {
     }
 
     public List<String> getSupportedServices() {
-        return supportedServices;
+        return supportedServices == null ? new ArrayList<String>() : supportedServices;
     }
 
     public String getGuestIpType() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/network/DeleteManagementNetworkIpRangeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/network/DeleteManagementNetworkIpRangeCmd.java
@@ -61,15 +61,13 @@ public class DeleteManagementNetworkIpRangeCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.START_IP,
             type = CommandType.STRING,
             required = true,
-            description = "The starting IP address.",
-            validations = ApiArgValidator.NotNullOrEmpty)
+            description = "The starting IP address.")
     private String startIp;
 
     @Parameter(name = ApiConstants.END_IP,
             type = CommandType.STRING,
             required = true,
-            description = "The ending IP address.",
-            validations = ApiArgValidator.NotNullOrEmpty)
+            description = "The ending IP address.")
     private String endIp;
 
     @Parameter(name = ApiConstants.VLAN,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/outofbandmanagement/IssueOutOfBandManagementPowerActionCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/outofbandmanagement/IssueOutOfBandManagementPowerActionCmd.java
@@ -62,7 +62,7 @@ public class IssueOutOfBandManagementPowerActionCmd extends BaseAsyncCmd {
     private Long actionTimeout;
 
     @Parameter(name = ApiConstants.ACTION, type = CommandType.STRING, required = true,
-            validations = {ApiArgValidator.NotNullOrEmpty}, description = "out-of-band management power actions, valid actions are: ON, OFF, CYCLE, RESET, SOFT, STATUS")
+            description = "out-of-band management power actions, valid actions are: ON, OFF, CYCLE, RESET, SOFT, STATUS")
     private String powerAction;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/project/CreateProjectCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/project/CreateProjectCmd.java
@@ -17,7 +17,6 @@
 package org.apache.cloudstack.api.command.user.project;
 
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCreateCmd;
@@ -60,7 +59,7 @@ public class CreateProjectCmd extends BaseAsyncCreateCmd {
     @Parameter(name = ApiConstants.ACCOUNT_ID, type = CommandType.UUID, entityType = AccountResponse.class, description = "ID of the account owning a project")
     private Long accountId;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, validations = ApiArgValidator.NotNullOrEmpty, description = "name of the project")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "name of the project")
     private String name;
 
     @Parameter(name = ApiConstants.DISPLAY_TEXT, type = CommandType.STRING, required = true, description = "display text of the project")

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/resource/ListDetailOptionsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/resource/ListDetailOptionsCmd.java
@@ -18,7 +18,6 @@ package org.apache.cloudstack.api.command.user.resource;
 
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
@@ -43,9 +42,7 @@ public class ListDetailOptionsCmd extends BaseCmd {
     /////////////////////////////////////////////////////
 
     @Parameter(name = ApiConstants.RESOURCE_TYPE, type = CommandType.STRING, required = true,
-            description = "the resource type such as UserVm, Template etc.",
-            validations = {ApiArgValidator.NotNullOrEmpty}
-    )
+            description = "the resource type such as UserVm, Template etc.")
     private String resourceType;
 
     @Parameter(name = ApiConstants.RESOURCE_ID, type = CommandType.STRING,

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -159,6 +159,9 @@ public class ParamProcessWorker implements DispatchWorker {
                 }
                 continue;
             }
+            if (parameterAnnotation.required()){
+                validateNonEmptyString(paramObj, parameterAnnotation.name());
+            }
 
             // marshall the parameter into the correct type and set the field value
             try {


### PR DESCRIPTION
### Description

Addon to https://github.com/apache/cloudstack/pull/5135
Ensures that any required parameter is not empty / null

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

```
(localhost) 🐱 > create domain 
💩 Missing required parameters:  name
(localhost) 🐱 > create domain name= 
🙈 Error: (HTTP 431, error code 4350) Empty or null value provided for API arg: name
```
