### PR TITLE
marvin: make deployDataCenter.py script compatible with python 2 and 3

### DIFF
--- a/tools/marvin/marvin/deployDataCenter.py
+++ b/tools/marvin/marvin/deployDataCenter.py
@@ -71,9 +71,9 @@ class DeployDataCenters(object):
                 ts = strftime("%b_%d_%Y_%H_%M_%S", localtime())
                 dc_file_path = "dc_entries_" + str(ts) + ".obj"
 
-            file_to_write = open(dc_file_path, 'w')
+            file_to_write = open(dc_file_path, 'wb')
             if file_to_write:
-                pickle.dump(self.__cleanUp, file_to_write)
+                pickle.dump(self.__cleanUp, file_to_write, protocol=0)
                 print("\n=== Data Center Settings are dumped to %s===" % dc_file_path)
                 self.__tcRunLogger.debug("\n=== Data Center Settings are dumped to %s===" % dc_file_path)
         except Exception as e:


### PR DESCRIPTION
### Description

This PR fixes a compatibility issue noticed with deployDataCenter.py script when run with python3 - the script reports the following exception:
```
Exception Occurred  while persisting DC Settings: ['Traceback (most recent call last):\n', '  File "tools/marvin/marvin/deployDataCenter.py", line 76, in __persistDcConfig\n    pickle.dump(self.__cleanUp, file_to_write)\n', 'TypeError: write() argument must be str, not bytes\n']
```
And hence doesn't create the dc_entries.obj file

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### How Has This Been Tested?
Ran the deployDataCenter script using python2 and python3 - it runs successfully and generates the dc_entries.obj file in human readable format (which is controlled by the protocol number passed)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
