### PR TITLE
UI fix deployVm with rootdisk size wrongly converted

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1966,7 +1966,7 @@ export default {
         }
       }
       if (offering && offering.rootdisksize > 0) {
-        this.rootDiskSizeFixed = offering.rootdisksize / (1024 * 1024 * 1024.0).toFixed(2)
+        this.rootDiskSizeFixed = offering.rootdisksize
         this.showRootDiskSizeChanger = false
       }
     }


### PR DESCRIPTION
### Description

Failed to deploy VM on UI when the offering has root disk size. This issue is caused due to PR #5085.
It was updated the API listing to keep it aligned with specifications/documentation (list in GB); however, it did not address the root disk size in the UI `DeployVM.vue`.

Without this fix deploying a VM with such an offering fails.
![image](https://user-images.githubusercontent.com/5025148/123167310-c1441680-d44c-11eb-9e52-78a5d192f5b1.png)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Change UI and re-test VM deployment

Successfully deploy via UI a VM where the offering has root disk size.
