### PR TITLE
Fix NPE when no recipients configured for sending alerts

### DIFF
--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -712,16 +712,16 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
             return;
         }
 
+        if (recipients == null) {
+            s_logger.warn(String.format("No recipients set in 'alert.email.addresses', skipping sending alert with subject: %s and content: %s", subject, content));
+            return;
+        }
+
         SMTPMailProperties mailProps = new SMTPMailProperties();
         mailProps.setSender(new MailAddress(senderAddress));
         mailProps.setSubject(subject);
         mailProps.setContent(content);
         mailProps.setContentType("text/plain");
-
-        if (recipients == null) {
-            s_logger.info("No recipients set in 'alert.email.addresses', skipping sending an alert");
-            return;
-        }
 
         Set<MailAddress> addresses = new HashSet<>();
         for (String recipient : recipients) {

--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -718,6 +718,10 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
         mailProps.setContent(content);
         mailProps.setContentType("text/plain");
 
+        if (recipients == null) {
+            return;
+        }
+
         Set<MailAddress> addresses = new HashSet<>();
         for (String recipient : recipients) {
             addresses.add(new MailAddress(recipient));

--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -719,6 +719,7 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
         mailProps.setContentType("text/plain");
 
         if (recipients == null) {
+            s_logger.info("No recipients set in 'alert.email.addresses', skipping sending an alert");
             return;
         }
 


### PR DESCRIPTION
### Description

This PR fixes the NPE that's encountered when `alert.email.addresses` isn't configured i.e.,no recipient.

```
2021-06-23 04:08:46,798 ERROR [c.c.a.AlertManagerImpl] (RedundantRouterStatusMonitor-3:ctx-b0621cdd) (logid:3ad3ae67) Problem sending email alert
java.lang.NullPointerException
	at com.cloud.alert.AlertManagerImpl.sendAlert(AlertManagerImpl.java:722)
	at com.cloud.alert.AlertManagerImpl.sendAlert(AlertManagerImpl.java:243)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy121.sendAlert(Unknown Source)
	at com.cloud.network.router.VirtualNetworkApplianceManagerImpl.updateRoutersRedundantState(VirtualNetworkApplianceManagerImpl.java:939)
	at com.cloud.network.router.VirtualNetworkApplianceManagerImpl$RvRStatusUpdateTask.runInContext(VirtualNetworkApplianceManagerImpl.java:1083)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
