### PR TITLE
Prevent starting a VM in destroyed state (or any state but Stopped)

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -881,8 +881,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             }
 
             if (state != State.Stopped) {
-                s_logger.debug("VM " + vm + " is not in a state to be started: " + state);
-                return null;
+                s_logger.warn("VM " + vm + " is not in a state to be started: " + state);
+                throw new CloudRuntimeException(String.format("Cannot start VM: %s in %s state", vm, state));
             }
         }
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -881,7 +881,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             }
 
             if (state != State.Stopped) {
-                String msg = String.format("Cannot start VM: %s in %s state", vm, state);
+                String msg = String.format("Cannot start %s in %s state", vm, state);
                 s_logger.warn(msg);
                 throw new CloudRuntimeException(msg);
             }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -881,8 +881,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             }
 
             if (state != State.Stopped) {
-                s_logger.warn("VM " + vm + " is not in a state to be started: " + state);
-                throw new CloudRuntimeException(String.format("Cannot start VM: %s in %s state", vm, state));
+                String msg = String.format("Cannot start VM: %s in %s state", vm, state);
+                s_logger.warn(msg);
+                throw new CloudRuntimeException(msg);
             }
         }
 


### PR DESCRIPTION
### Description

A destroyed VM when attempted to be started (using the bulk action support in the UI), results in a successful operation, however, the VM doesn't actually start. This PR fixes the false positive result shown in the above mentioned condition

![image](https://user-images.githubusercontent.com/10495417/123799807-352b6680-d906-11eb-96be-63bca470a5b2.png)

VM continues to remain in destroyed state - but a success response is returned

![image](https://user-images.githubusercontent.com/10495417/123799975-64da6e80-d906-11eb-97c1-5d3c04d97930.png)



<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tried starting an instance in destroyed state:
```
2021-06-29 12:57:51,609 WARN  [c.c.v.VirtualMachineManagerImpl] (Work-Job-Executor-5:ctx-da4601fa job-52/job-54 ctx-cc08e96e) (logid:08e57fcb) VM VM instance {"id": "3", "name": "i-2-3-VM", "uuid": "4213c3d9-72a8-4201-96c4-003e2c2f845b", "type"="User"} is not in a state to be started: Destroyed
2021-06-29 12:57:51,610 INFO  [c.c.v.VirtualMachineManagerImpl] (Work-Job-Executor-5:ctx-da4601fa job-52/job-54 ctx-cc08e96e) (logid:08e57fcb) Caught CloudRuntimeException, returning job failed com.cloud.utils.exception.CloudRuntimeException: Cannot start VM: VM instance {"id": "3", "name": "i-2-3-VM", "uuid": "4213c3d9-72a8-4201-96c4-003e2c2f845b", "type"="User"} in Destroyed state
2021-06-29 12:57:51,613 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-5:ctx-da4601fa job-52/job-54 ctx-cc08e96e) (logid:08e57fcb) Done executing VM work job: com.cloud.vm.VmWorkStart{"dcId":0,"rawParams":{"VmPassword":"rO0ABXQADnNhdmVkX3Bhc3N3b3Jk"},"userId":2,"accountId":2,"vmId":3,"handlerName":"VirtualMachineManagerImpl"}

```
![image](https://user-images.githubusercontent.com/10495417/123801573-09a97b80-d908-11eb-9749-f6dd13f9bf11.png)


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
