### PR TITLE
[UI] secondary storage - Display text and change the badge color of the Read-only column

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -3306,6 +3306,8 @@
 "state.expunging": "Expunging",
 "state.migrating": "Migrating",
 "state.pending": "Pending",
+"state.readonly": "Read-Only",
+"state.readwrite": "Read-Write",
 "state.running": "Running",
 "state.starting": "Starting",
 "state.stopped": "Stopped",

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -231,7 +231,7 @@
       <span v-else>{{ text }}</span>
     </span>
     <a slot="readonly" slot-scope="text, record">
-      <status :text="record.readonly ? 'ReadOnly' : 'ReadWrite'" />
+      <status :text="record.readonly ? 'ReadOnly' : 'ReadWrite'" displayText />
     </a>
     <span slot="created" slot-scope="text">
       {{ $toLocaleDate(text) }}

--- a/ui/src/components/widgets/Status.vue
+++ b/ui/src/components/widgets/Status.vue
@@ -72,6 +72,12 @@ export default {
           case 'Error':
             state = this.$t('state.error')
             break
+          case 'ReadOnly':
+            state = this.$t('state.readonly')
+            break
+          case 'ReadWrite':
+            state = this.$t('state.readwrite')
+            break
         }
         return state.charAt(0).toUpperCase() + state.slice(1)
       }
@@ -106,7 +112,6 @@ export default {
         case 'Error':
         case 'False':
         case 'Stopped':
-        case 'ReadOnly':
           status = 'error'
           break
         case 'Migrating':
@@ -126,6 +131,7 @@ export default {
         case 'Created':
         case 'Maintenance':
         case 'Pending':
+        case 'ReadOnly':
           status = 'warning'
           break
       }

--- a/ui/src/config/section/infra/secondaryStorages.js
+++ b/ui/src/config/section/infra/secondaryStorages.js
@@ -25,7 +25,10 @@ export default {
   columns: () => {
     var fields = ['name', 'url', 'protocol', 'scope', 'zonename']
     if (store.getters.apis.listImageStores.params.filter(x => x.name === 'readonly').length > 0) {
-      fields.push('readonly')
+      fields.push({
+        field: 'readonly',
+        customTitle: 'access'
+      })
     }
     return fields
   },

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -583,13 +583,21 @@ export default {
 
       const customRender = {}
       for (var columnKey of this.columnKeys) {
-        var key = columnKey
+        let key = columnKey
+        let title = columnKey
         if (typeof columnKey === 'object') {
-          key = Object.keys(columnKey)[0]
-          customRender[key] = columnKey[key]
+          if ('customTitle' in columnKey && 'field' in columnKey) {
+            key = columnKey.field
+            title = columnKey.customTitle
+            customRender[key] = columnKey[key]
+          } else {
+            key = Object.keys(columnKey)[0]
+            title = Object.keys(columnKey)[0]
+            customRender[key] = columnKey[key]
+          }
         }
         this.columns.push({
-          title: this.$t('label.' + String(key).toLowerCase()),
+          title: this.$t('label.' + String(title).toLowerCase()),
           dataIndex: key,
           scopedSlots: { customRender: key },
           sorter: function (a, b) { return genericCompare(a[this.dataIndex] || '', b[this.dataIndex] || '') }


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/5169
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13766648/124207706-4d6ed180-db10-11eb-98fc-8f59ae3a5c23.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
