### PR TITLE
server: fix network access for addNicToVirtualMachine API

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -81,7 +81,6 @@ import org.apache.cloudstack.api.command.user.vm.UpgradeVMCmd;
 import org.apache.cloudstack.api.command.user.vmgroup.CreateVMGroupCmd;
 import org.apache.cloudstack.api.command.user.vmgroup.DeleteVMGroupCmd;
 import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
-import com.cloud.agent.api.to.deployasis.OVFNetworkTO;
 import org.apache.cloudstack.backup.Backup;
 import org.apache.cloudstack.backup.BackupManager;
 import org.apache.cloudstack.backup.dao.BackupDao;
@@ -145,6 +144,7 @@ import com.cloud.agent.api.VolumeStatsEntry;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.agent.api.to.deployasis.OVFNetworkTO;
 import com.cloud.agent.api.to.deployasis.OVFPropertyTO;
 import com.cloud.agent.manager.Commands;
 import com.cloud.alert.AlertManager;
@@ -1310,12 +1310,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("unable to find a network with id " + networkId);
         }
 
-        if (caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
-            if (!(network.getGuestType() == Network.GuestType.Shared && network.getAclType() == ACLType.Domain)
-                    && !(network.getAclType() == ACLType.Account && network.getAccountId() == vmInstance.getAccountId())) {
-                throw new InvalidParameterValueException("only shared network or isolated network with the same account_id can be added to vmId: " + vmId);
-            }
-        }
+        Account vmOwner = _accountMgr.getAccount(vmInstance.getAccountId());
+        _networkModel.checkNetworkPermissions(vmOwner, network);
 
         List<NicVO> allNics = _nicDao.listByVmId(vmInstance.getId());
         for (NicVO nic : allNics) {


### PR DESCRIPTION
### Description

New NICs shouldn't be added to VM with Shared and Isolated networks from admin account, same as deployment.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested:
- Admin trying to add a network from its own account to a VM from a user account.
- Admin trying to deploy VM in a user account with a network from its own account.
- Admin trying to attach a volume from its own account to a VM from a user account.

Networks
```
(local) 🐧 > list networks filter=id,name,domain,account listall=true 
{
  "count": 3,
  "network": [
    {
      "account": "admin",
      "domain": "ROOT",
      "id": "06fbdecb-e75d-4015-9ec1-8a08a217ad2d",
      "name": "l2nw"
    },
    {
      "account": "admin",
      "domain": "ROOT",
      "id": "a99496df-aade-42d7-b315-33f69719cdd6",
      "name": "isonw"
    },
    {
      "account": "user1",
      "domain": "ROOT",
      "id": "2b56b153-9b56-4cf0-b23a-ef3817f9b806",
      "name": "nw"
    }
  ]
}
```

Current behaviour for NIC/networks (works for all networks):
```
(local) 🕷 > list virtualmachines id=08a416c6-86c6-4e41-9263-8d1f386d85b2 filter=id,name,domain,account,nic
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "user1",
      "domain": "ROOT",
      "id": "08a416c6-86c6-4e41-9263-8d1f386d85b2",
      "name": "QA-08a416c6-86c6-4e41-9263-8d1f386d85b2",
      "nic": [
        {
          "broadcasturi": "vlan://144",
          "extradhcpoption": [],
          "gateway": "10.1.1.1",
          "id": "61dbd058-04f8-4a3c-b2c9-1ad91ef2b15f",
          "ipaddress": "10.1.1.38",
          "isdefault": true,
          "isolationuri": "vlan://144",
          "macaddress": "02:00:68:3a:00:09",
          "netmask": "255.255.255.0",
          "networkid": "2b56b153-9b56-4cf0-b23a-ef3817f9b806",
          "networkname": "nw",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "Isolated"
        }
      ]
    }
  ]
}
(local) 🐄 > add nictovirtualmachine virtualmachineid=08a416c6-86c6-4e41-9263-8d1f386d85b2 networkid=a99496df-aade-42d7-b315-33f69719cdd6 
{
  "virtualmachine": {
    "account": "user1",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "created": "2021-07-06T13:33:29+0530",
    "details": {},
    "displayname": "QA-08a416c6-86c6-4e41-9263-8d1f386d85b2",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "8d26be19-de24-11eb-9f57-645d8651f45a",
    "guestosid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "haenable": false,
    "hostid": "4ee25548-beba-4919-b3dc-fa17ccda787f",
    "hostname": "SimulatedAgent.822e30ca-1fcf-4907-b01c-fd4df43c8b78",
    "hypervisor": "Simulator",
    "id": "08a416c6-86c6-4e41-9263-8d1f386d85b2",
    "instancename": "i-5-12-QA",
    "isdynamicallyscalable": false,
    "name": "QA-08a416c6-86c6-4e41-9263-8d1f386d85b2",
    "nic": [
      {
        "broadcasturi": "vlan://144",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "61dbd058-04f8-4a3c-b2c9-1ad91ef2b15f",
        "ipaddress": "10.1.1.38",
        "isdefault": true,
        "isolationuri": "vlan://144",
        "macaddress": "02:00:68:3a:00:09",
        "netmask": "255.255.255.0",
        "networkid": "2b56b153-9b56-4cf0-b23a-ef3817f9b806",
        "networkname": "nw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      },
      {
        "broadcasturi": "vlan://165",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "809818df-f27d-4093-bce8-d5090f71be09",
        "ipaddress": "10.1.1.21",
        "isdefault": false,
        "isolationuri": "vlan://165",
        "macaddress": "02:00:6f:43:00:03",
        "netmask": "255.255.255.0",
        "networkid": "a99496df-aade-42d7-b315-33f69719cdd6",
        "networkname": "isonw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "pooltype": "NetworkFilesystem",
    "securitygroup": [],
    "state": "Running",
    "tags": [],
    "userid": "373a6269-44f3-4853-8462-1f84cd3261db",
    "username": "user1",
    "zoneid": "f058985d-64b4-4cb9-8185-12ccb3e36e6b",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🙉 > add nictovirtualmachine virtualmachineid=08a416c6-86c6-4e41-9263-8d1f386d85b2 networkid=06fbdecb-e75d-4015-9ec1-8a08a217ad2d 
{
  "virtualmachine": {
    "account": "user1",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "created": "2021-07-06T13:33:29+0530",
    "details": {},
    "displayname": "QA-08a416c6-86c6-4e41-9263-8d1f386d85b2",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "8d26be19-de24-11eb-9f57-645d8651f45a",
    "guestosid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "haenable": false,
    "hostid": "4ee25548-beba-4919-b3dc-fa17ccda787f",
    "hostname": "SimulatedAgent.822e30ca-1fcf-4907-b01c-fd4df43c8b78",
    "hypervisor": "Simulator",
    "id": "08a416c6-86c6-4e41-9263-8d1f386d85b2",
    "instancename": "i-5-12-QA",
    "isdynamicallyscalable": false,
    "name": "QA-08a416c6-86c6-4e41-9263-8d1f386d85b2",
    "nic": [
      {
        "broadcasturi": "vlan://146",
        "extradhcpoption": [],
        "id": "207f8554-5f76-42a2-908b-8a2d9a91b3b7",
        "isdefault": false,
        "isolationuri": "vlan://146",
        "macaddress": "02:00:19:f9:00:02",
        "networkid": "06fbdecb-e75d-4015-9ec1-8a08a217ad2d",
        "networkname": "l2nw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      },
      {
        "broadcasturi": "vlan://144",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "61dbd058-04f8-4a3c-b2c9-1ad91ef2b15f",
        "ipaddress": "10.1.1.38",
        "isdefault": true,
        "isolationuri": "vlan://144",
        "macaddress": "02:00:68:3a:00:09",
        "netmask": "255.255.255.0",
        "networkid": "2b56b153-9b56-4cf0-b23a-ef3817f9b806",
        "networkname": "nw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      },
      {
        "broadcasturi": "vlan://165",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "809818df-f27d-4093-bce8-d5090f71be09",
        "ipaddress": "10.1.1.21",
        "isdefault": false,
        "isolationuri": "vlan://165",
        "macaddress": "02:00:6f:43:00:03",
        "netmask": "255.255.255.0",
        "networkid": "a99496df-aade-42d7-b315-33f69719cdd6",
        "networkname": "isonw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "pooltype": "NetworkFilesystem",
    "securitygroup": [],
    "state": "Running",
    "tags": [],
    "userid": "373a6269-44f3-4853-8462-1f84cd3261db",
    "username": "user1",
    "zoneid": "f058985d-64b4-4cb9-8185-12ccb3e36e6b",
    "zonename": "Sandbox-simulator"
  }
}
```

Current deployment behaviour (works for L2 network, fails for Isolated and Shared networks)
```
(local) 🐼 > deploy virtualmachine zoneid=f058985d-64b4-4cb9-8185-12ccb3e36e6b templateid=92b2849b-de25-11eb-9f57-645d8651f45a serviceofferingid=2da9fd13-5eb3-44a2-8912-656ab3facb9d domainid=8d26be19-de24-11eb-9f57-645d8651f45a account=user1 networkids=06fbdecb-e75d-4015-9ec1-8a08a217ad2d 
{
  "virtualmachine": {
    "account": "user1",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-07-06T13:53:52+0530",
    "details": {},
    "displayname": "QA-ed28c0f9-7e90-4199-8deb-8689c34f0cb2",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "8d26be19-de24-11eb-9f57-645d8651f45a",
    "guestosid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "haenable": false,
    "hostid": "192509ea-0b6c-4267-902e-9be337061f13",
    "hostname": "SimulatedAgent.77b0247e-3448-41ce-9c07-5054cbc3a90c",
    "hypervisor": "Simulator",
    "id": "ed28c0f9-7e90-4199-8deb-8689c34f0cb2",
    "instancename": "i-5-17-QA",
    "isdynamicallyscalable": false,
    "jobid": "a859c500-40d5-44ee-94b6-4a3046f280e3",
    "jobstatus": 0,
    "memory": 512,
    "name": "QA-ed28c0f9-7e90-4199-8deb-8689c34f0cb2",
    "nic": [
      {
        "broadcasturi": "vlan://146",
        "extradhcpoption": [],
        "id": "f7c77fb7-6c80-4aec-9a6f-1a761dc9b136",
        "isdefault": true,
        "isolationuri": "vlan://146",
        "macaddress": "02:00:59:31:00:04",
        "networkid": "06fbdecb-e75d-4015-9ec1-8a08a217ad2d",
        "networkname": "l2nw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "serviceofferingid": "2da9fd13-5eb3-44a2-8912-656ab3facb9d",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "templateid": "92b2849b-de25-11eb-9f57-645d8651f45a",
    "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "userid": "373a6269-44f3-4853-8462-1f84cd3261db",
    "username": "user1",
    "zoneid": "f058985d-64b4-4cb9-8185-12ccb3e36e6b",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🦑 > deploy virtualmachine zoneid=f058985d-64b4-4cb9-8185-12ccb3e36e6b templateid=92b2849b-de25-11eb-9f57-645d8651f45a serviceofferingid=2da9fd13-5eb3-44a2-8912-656ab3facb9d domainid=8d26be19-de24-11eb-9f57-645d8651f45a account=user1 networkids=a99496df-aade-42d7-b315-33f69719cdd6 
🙈 Error: (HTTP 531, error code 4365) Unable to use network with id= a99496df-aade-42d7-b315-33f69719cdd6, permission denied
```

Current attach data disk behaviour (fails)
```
(local) 🐯 > create volume zoneid=f058985d-64b4-4cb9-8185-12ccb3e36e6b diskofferingid=355c7a9b-9605-4ada-9122-3b0511a46220 name=newdd
{
  "volume": {
    "account": "admin",
    "created": "2021-07-06T14:00:37+0530",
    "destroyed": false,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "355c7a9b-9605-4ada-9122-3b0511a46220",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "8d26be19-de24-11eb-9f57-645d8651f45a",
    "hypervisor": "None",
    "id": "355ca00d-3857-46e4-a3ff-e4e935a09ffa",
    "isextractable": true,
    "jobid": "adcb8af3-adcb-41b9-8c2d-14d8c8c5fcde",
    "jobstatus": 0,
    "name": "newdd",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Allocated",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "zoneid": "f058985d-64b4-4cb9-8185-12ccb3e36e6b",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🦏 > attach volume id=355ca00d-3857-46e4-a3ff-e4e935a09ffa virtualmachineid=08a416c6-86c6-4e41-9263-8d1f386d85b2 
{
  "accountid": "8d26fee1-de24-11eb-9f57-645d8651f45a",
  "cmd": "org.apache.cloudstack.api.command.admin.volume.AttachVolumeCmdByAdmin",
  "completed": "2021-07-06T14:01:16+0530",
  "created": "2021-07-06T14:01:16+0530",
  "jobid": "7bf73ed7-c890-41e7-bd63-9422e5370db1",
  "jobinstanceid": "355ca00d-3857-46e4-a3ff-e4e935a09ffa",
  "jobinstancetype": "Volume",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "Entity VM instance {\"id\": \"12\", \"name\": \"i-5-12-QA\", \"uuid\": \"08a416c6-86c6-4e41-9263-8d1f386d85b2\", \"type\"=\"User\"} and entity org.apache.cloudstack.storage.volume.VolumeObject@2d7250bf belong to different accounts"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "8d276e01-de24-11eb-9f57-645d8651f45a"
}
🙈 Error: async API failed for job 7bf73ed7-c890-41e7-bd63-9422e5370db1
```

After changes add NIC/network behaviour (fails for Isolated and shared networks but works for L2 networks)
```
(local) 🐺 > list virtualmachines id=0bd71bc7-80b4-4214-8967-3b925382ef63 filter=id,name,domain,account,nic
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "user1",
      "domain": "ROOT",
      "id": "0bd71bc7-80b4-4214-8967-3b925382ef63",
      "name": "QA-0bd71bc7-80b4-4214-8967-3b925382ef63",
      "nic": [
        {
          "broadcasturi": "vlan://144",
          "extradhcpoption": [],
          "gateway": "10.1.1.1",
          "id": "f56ba6d1-1516-43c9-9a4c-1535a9d449e4",
          "ipaddress": "10.1.1.219",
          "isdefault": true,
          "isolationuri": "vlan://144",
          "macaddress": "02:00:01:ed:00:0a",
          "netmask": "255.255.255.0",
          "networkid": "2b56b153-9b56-4cf0-b23a-ef3817f9b806",
          "networkname": "nw",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "Isolated"
        }
      ]
    }
  ]
}
(local) 🐕 > add nictovirtualmachine virtualmachineid=0bd71bc7-80b4-4214-8967-3b925382ef63 networkid=a99496df-aade-42d7-b315-33f69719cdd6 
{
  "accountid": "8d26fee1-de24-11eb-9f57-645d8651f45a",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.AddNicToVMCmdByAdmin",
  "completed": "2021-07-06T13:52:24+0530",
  "created": "2021-07-06T13:52:24+0530",
  "jobid": "dc801e6b-f3df-474a-b173-fac91c869202",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "Unable to use network with id= a99496df-aade-42d7-b315-33f69719cdd6, permission denied"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "8d276e01-de24-11eb-9f57-645d8651f45a"
}
🙈 Error: async API failed for job dc801e6b-f3df-474a-b173-fac91c869202
(local) 🦉 > add nictovirtualmachine virtualmachineid=0bd71bc7-80b4-4214-8967-3b925382ef63 networkid=06fbdecb-e75d-4015-9ec1-8a08a217ad2d 
{
  "virtualmachine": {
    "account": "user1",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "created": "2021-07-06T13:33:31+0530",
    "details": {},
    "displayname": "QA-0bd71bc7-80b4-4214-8967-3b925382ef63",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "8d26be19-de24-11eb-9f57-645d8651f45a",
    "guestosid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "haenable": false,
    "hostid": "192509ea-0b6c-4267-902e-9be337061f13",
    "hostname": "SimulatedAgent.77b0247e-3448-41ce-9c07-5054cbc3a90c",
    "hypervisor": "Simulator",
    "id": "0bd71bc7-80b4-4214-8967-3b925382ef63",
    "instancename": "i-5-13-QA",
    "isdynamicallyscalable": false,
    "name": "QA-0bd71bc7-80b4-4214-8967-3b925382ef63",
    "nic": [
      {
        "broadcasturi": "vlan://146",
        "extradhcpoption": [],
        "id": "280e89c8-4c38-4750-a5a2-e9c80860d99b",
        "isdefault": false,
        "isolationuri": "vlan://146",
        "macaddress": "02:00:10:8f:00:03",
        "networkid": "06fbdecb-e75d-4015-9ec1-8a08a217ad2d",
        "networkname": "l2nw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      },
      {
        "broadcasturi": "vlan://144",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "f56ba6d1-1516-43c9-9a4c-1535a9d449e4",
        "ipaddress": "10.1.1.219",
        "isdefault": true,
        "isolationuri": "vlan://144",
        "macaddress": "02:00:01:ed:00:0a",
        "netmask": "255.255.255.0",
        "networkid": "2b56b153-9b56-4cf0-b23a-ef3817f9b806",
        "networkname": "nw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "8d148fc5-de24-11eb-9f57-645d8651f45a",
    "pooltype": "NetworkFilesystem",
    "securitygroup": [],
    "state": "Running",
    "tags": [],
    "userid": "373a6269-44f3-4853-8462-1f84cd3261db",
    "username": "user1",
    "zoneid": "f058985d-64b4-4cb9-8185-12ccb3e36e6b",
    "zonename": "Sandbox-simulator"
  }
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
