### PR TITLE
Remove condition that are prevent resizing for root volumes (vmware)

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1159,10 +1159,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         UserVmVO userVm = _userVmDao.findById(volume.getInstanceId());
 
         if (userVm != null) {
-            if (volume.getVolumeType().equals(Volume.Type.ROOT) && userVm.getPowerState() != VirtualMachine.PowerState.PowerOff && hypervisorType == HypervisorType.VMware) {
-                s_logger.error(" For ROOT volume resize VM should be in Power Off state.");
-                throw new InvalidParameterValueException("VM current state is : " + userVm.getPowerState() + ". But VM should be in " + VirtualMachine.PowerState.PowerOff + " state.");
-            }
             // serialize VM operation
             AsyncJobExecutionContext jobContext = AsyncJobExecutionContext.getCurrentExecutionContext();
 

--- a/test/integration/component/test_rootvolume_resize.py
+++ b/test/integration/component/test_rootvolume_resize.py
@@ -228,16 +228,14 @@ class TestResizeVolume(cloudstackTestCase):
             listall='True'
         )
         rootvolume = list_volume_response[0]
-        if vm.state == "Running" and \
-                (vm.hypervisor.lower() == "xenserver" or \
-                             vm.hypervisor.lower() == "vmware"):
+        if vm.state == "Running" and vm.hypervisor.lower() == "xenserver":
             self.virtual_machine.stop(apiclient)
             time.sleep(self.services["sleep"])
-            if vm.hypervisor.lower() == "vmware":
-                rootdiskcontroller = self.getDiskController(vm)
-                if rootdiskcontroller!="scsi":
-                    raise Exception("root volume resize only supported on scsi disk ,"
-                                    "please check rootdiskcontroller type")
+        if vm.hypervisor.lower() == "vmware":
+            rootdiskcontroller = self.getDiskController(vm)
+            if rootdiskcontroller!="scsi":
+                raise Exception("root volume resize only supported on scsi disk ,"
+                                "please check rootdiskcontroller type")
 
         rootvolobj = Volume(rootvolume.__dict__)
         newsize = (rootvolume.size >> 30) + 2
@@ -245,8 +243,7 @@ class TestResizeVolume(cloudstackTestCase):
         if rootvolume is not None:
             try:
                 rootvolobj.resize(apiclient, size=newsize)
-                if vm.hypervisor.lower() == "xenserver" or \
-                                vm.hypervisor.lower() == "vmware":
+                if vm.hypervisor.lower() == "xenserver":
                     self.virtual_machine.start(apiclient)
                     time.sleep(self.services["sleep"])
                 ssh = SshClient(self.virtual_machine.ssh_ip, 22,
@@ -916,9 +913,7 @@ class TestResizeVolume(cloudstackTestCase):
             )
             res = validateList(list_volume_response)
             self.assertNotEqual(res[2], INVALID_INPUT, "listVolumes returned invalid object in response")
-            if vm.state == "Running" and (
-                            vm.hypervisor.lower() == "xenserver" or
-                            vm.hypervisor.lower() == "vmware"):
+            if vm.state == "Running" and vm.hypervisor.lower() == "xenserver":
                 self.virtual_machine.stop(self.apiclient)
                 time.sleep(self.services["sleep"])
 
@@ -998,9 +993,7 @@ class TestResizeVolume(cloudstackTestCase):
             )
             res = validateList(list_volume_response)
             self.assertNotEqual(res[2], INVALID_INPUT, "listVolumes returned invalid object in response")
-            if vm.state == "Running" and (
-                            vm.hypervisor.lower() == "xenserver" or
-                            vm.hypervisor.lower() == "vmware"):
+            if vm.state == "Running" and vm.hypervisor.lower() == "xenserver":
                 self.virtual_machine.stop(self.apiclient)
                 time.sleep(self.services["sleep"])
             rootvolume = list_volume_response[0]
@@ -1115,9 +1108,7 @@ class TestResizeVolume(cloudstackTestCase):
             )
             res = validateList(list_volume_response)
             self.assertNotEqual(res[2], INVALID_INPUT, "listVolumes returned invalid object in response")
-            if vm.state == "Running" and \
-                    (vm.hypervisor.lower() == "xenserver" or
-                             vm.hypervisor.lower() == "vmware"):
+            if vm.state == "Running" and vm.hypervisor.lower() == "xenserver":
                 self.virtual_machine.stop(self.apiclient)
                 time.sleep(self.services["sleep"])
             rootvolume = list_volume_response[0]

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -627,8 +627,8 @@ class TestVolumes(cloudstackTestCase):
 
         if hosts[0].hypervisor == "XenServer":
             self.virtual_machine.stop(self.apiClient)
-        elif hosts[0].hypervisor.lower() in ("vmware", "hyperv"):
-            self.skipTest("Resize Volume is unsupported on VmWare and Hyper-V")
+        elif hosts[0].hypervisor.lower() == "hyperv":
+            self.skipTest("Resize Volume is unsupported on Hyper-V")
 
         # Attempting to resize it should throw an exception, as we're using a non
         # customisable disk offering, therefore our size parameter should be ignored
@@ -659,8 +659,8 @@ class TestVolumes(cloudstackTestCase):
 
         if hosts[0].hypervisor == "XenServer":
             self.virtual_machine.stop(self.apiClient)
-        elif hosts[0].hypervisor.lower() in ("vmware", "hyperv"):
-            self.skipTest("Resize Volume is unsupported on VmWare and Hyper-V")
+        elif hosts[0].hypervisor.lower() == "hyperv":
+            self.skipTest("Resize Volume is unsupported on Hyper-V")
 
         # resize the data disk
         self.debug("Resize Volume ID: %s" % self.volume.id)


### PR DESCRIPTION
### Description

Remove condition that are prevent resizing for root volumes (vmware).

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested in own VMware Environment. Works without errors and root disk is correct resized 