### PR TITLE
Added ability to create schemas only when using cloudstack-setup-data…

### DIFF
--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -188,9 +188,6 @@ for full help
         sys.exit(1)
 
     def setupDBSchema(self):
-        if self.options.schemaonly and self.rootuser != None:
-                    self.info("--schema-only and --deploy-as cannot be passed together\n", None)
-                    return
         if not self.options.schemaonly and not self.rootuser:
             self.info("No mysql root user specified, will not create Cloud DB schema\n", None)
             return
@@ -521,6 +518,8 @@ for example:
             self.info("Mysql server port:%s"%self.port, True)
 
         def validateParameters():
+            if self.options.schemaonly and self.rootuser != None:
+                self.errorAndExit("--schema-only and --deploy-as cannot be passed together\n")
             if self.encryptiontype != 'file' and self.encryptiontype != 'web':
                 self.errorAndExit('Wrong encryption type %s, --encrypt-type can only be "file" or "web'%self.encryptiontype)
 

--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -567,8 +567,9 @@ for example:
                           help="Colon-separated user name and password of a MySQL user with administrative privileges")
         self.parser.add_option("-s", "--schema-only", action="store_true", dest="schemaonly", default=False,
                           help="Creates the db schema without having to pass root credentials - " \
-                               "Please note: The databases (cloud, cloud_usage) and user (cloud) has to be configured manually" \
-                               "prior to running this script when using this flag.")
+                               "Please note: The databases (cloud, cloud_usage) and user (cloud) has to be configured " \
+                               "manually prior to running this script when using this flag.")
+
         self.parser.add_option("-a", "--auto", action="store", type="string", dest="serversetup", default="",
                           help="Path to an XML file describing an automated unattended cloud setup")
         self.parser.add_option("-e", "--encrypt-type", action="store", type="string", dest="encryptiontype", default="file",

--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -188,7 +188,7 @@ for full help
         sys.exit(1)
 
     def setupDBSchema(self):
-        if not self.options.createschema and not self.rootuser:
+        if not self.options.schemaonly and not self.rootuser:
             self.info("No mysql root user specified, will not create Cloud DB schema\n", None)
             return
 
@@ -220,7 +220,7 @@ for full help
             )
 
         scriptsToRun = ["create-database","create-schema", "create-database-premium","create-schema-premium"]
-        if self.options.createschema:
+        if self.options.schemaonly:
             scriptsToRun = ["create-schema", "create-schema-premium"]
 
         for f in scriptsToRun:
@@ -580,7 +580,7 @@ for example:
         self.parser.add_option("-j", "--encryption-jar-path", action="store", dest="encryptionJarPath", help="The path to the jasypt library to be used to encrypt the values in db.properties")
         self.parser.add_option("-n", "--encryption-key-file", action="store", dest="encryptionKeyFile", help="The name of the file in which encryption key to be generated")
         self.parser.add_option("-b", "--mysql-bin-path", action="store", dest="mysqlbinpath", help="The mysql installed bin path")
-        self.parser.add_option("-s", "--create-schema-only", action="store_true", dest="createschema", default=False,
+        self.parser.add_option("-s", "--schema-only", action="store_true", dest="schemaonly", default=False,
                           help="Creates the db schema without having to pass root credentials - "\
                                "Please note: The databases and user has to be configured manually prior to running this script when using this flag. "\
                                "If a management server has already upgraded the database and you intend to reinitialise the database, "\

--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -188,7 +188,7 @@ for full help
         sys.exit(1)
 
     def setupDBSchema(self):
-        if not self.rootuser:
+        if not self.options.createschema and not self.rootuser:
             self.info("No mysql root user specified, will not create Cloud DB schema\n", None)
             return
 
@@ -219,13 +219,17 @@ for full help
                     ""),
             )
 
-        for f in ["create-database","create-schema", "create-database-premium","create-schema-premium"]:
+        scriptsToRun = ["create-database","create-schema", "create-database-premium","create-schema-premium"]
+        if self.options.createschema:
+            scriptsToRun = ["create-schema", "create-schema-premium"]
+
+        for f in scriptsToRun:
             p = os.path.join(self.dbFilesPath,"%s.sql"%f)
             if not os.path.exists(p): continue
             text = open(p).read()
             for t, r in replacements: text = text.replace(t,r)
             self.info("Applying %s"%p)
-            self.runMysql(text, p, True)
+            self.runMysql(text, p, self.rootuser != None)
             self.info(None, True)
 
         if self.serversetup:
@@ -248,21 +252,21 @@ for full help
             p = os.path.join(self.dbFilesPath, 'server-setup.sql')
             text = open(p).read()
             self.info("Applying %s"%p)
-            self.runMysql(text, p, True)
+            self.runMysql(text, p, self.rootuser != None)
             self.info(None, True)
 
         for f in ["templates"]:
             p = os.path.join(self.dbFilesPath,"%s.sql"%f)
             text = open(p).read()
             self.info("Applying %s"%p)
-            self.runMysql(text, p, True)
+            self.runMysql(text, p, self.rootuser != None)
             self.info(None, True)
 
         p = os.path.join(self.dbFilesPath,"schema-level.sql")
         if os.path.isfile(p):
             text = open(p).read()
             self.info("Applying %s"%p)
-            self.runMysql(text, p, True)
+            self.runMysql(text, p, self.rootuser != None)
             self.info(None, True)
 
     def prepareDBFiles(self):
@@ -576,7 +580,11 @@ for example:
         self.parser.add_option("-j", "--encryption-jar-path", action="store", dest="encryptionJarPath", help="The path to the jasypt library to be used to encrypt the values in db.properties")
         self.parser.add_option("-n", "--encryption-key-file", action="store", dest="encryptionKeyFile", help="The name of the file in which encryption key to be generated")
         self.parser.add_option("-b", "--mysql-bin-path", action="store", dest="mysqlbinpath", help="The mysql installed bin path")
-
+        self.parser.add_option("-s", "--create-schema-only", action="store_true", dest="createschema", default=False,
+                          help="Creates the db schema without having to pass root credentials - "\
+                               "Please note: The databases and user has to be configured manually prior to running this script when using this flag. "\
+                               "If a management server has already upgraded the database and you intend to reinitialise the database, "\
+                               "the cloud and cloud_usage databases will need to be recreated manually prior to running this script.")
         (self.options, self.args) = self.parser.parse_args()
         parseCasualCredit()
         parseOtherOptions()

--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -565,6 +565,10 @@ for example:
                           help="If enabled, print the commands it will run as they run")
         self.parser.add_option("-d", "--deploy-as", action="store", type="string", dest="rootcreds", default="",
                           help="Colon-separated user name and password of a MySQL user with administrative privileges")
+        self.parser.add_option("-s", "--schema-only", action="store_true", dest="schemaonly", default=False,
+                          help="Creates the db schema without having to pass root credentials - " \
+                               "Please note: The databases (cloud, cloud_usage) and user (cloud) has to be configured manually" \
+                               "prior to running this script when using this flag.")
         self.parser.add_option("-a", "--auto", action="store", type="string", dest="serversetup", default="",
                           help="Path to an XML file describing an automated unattended cloud setup")
         self.parser.add_option("-e", "--encrypt-type", action="store", type="string", dest="encryptiontype", default="file",
@@ -582,11 +586,6 @@ for example:
         self.parser.add_option("-j", "--encryption-jar-path", action="store", dest="encryptionJarPath", help="The path to the jasypt library to be used to encrypt the values in db.properties")
         self.parser.add_option("-n", "--encryption-key-file", action="store", dest="encryptionKeyFile", help="The name of the file in which encryption key to be generated")
         self.parser.add_option("-b", "--mysql-bin-path", action="store", dest="mysqlbinpath", help="The mysql installed bin path")
-        self.parser.add_option("-s", "--schema-only", action="store_true", dest="schemaonly", default=False,
-                          help="Creates the db schema without having to pass root credentials - "\
-                               "Please note: The databases and user has to be configured manually prior to running this script when using this flag. "\
-                               "If a management server has already upgraded the database and you intend to reinitialise the database, "\
-                               "the cloud and cloud_usage databases will need to be recreated manually prior to running this script.")
         (self.options, self.args) = self.parser.parse_args()
         parseCasualCredit()
         parseOtherOptions()

--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -188,6 +188,9 @@ for full help
         sys.exit(1)
 
     def setupDBSchema(self):
+        if self.options.schemaonly and self.rootuser != None:
+                    self.info("--schema-only and --deploy-as cannot be passed together\n", None)
+                    return
         if not self.options.schemaonly and not self.rootuser:
             self.info("No mysql root user specified, will not create Cloud DB schema\n", None)
             return


### PR DESCRIPTION
…bases

### Description

This PR adds the ability to run the cloudstack-setup-databases script without having to know the root user credentials.

The cloud and cloud_usage databases and cloud user can be manually configured by a different admin prior to running the script.

It will allow the script to be called like this:
./cloudstack-setup-databases user:password@host:port -s 
or
./cloudstack-setup-databases user:password@host:port --schema-only 

Using this flag will instruct to skip the SQL files responsible for creating the databases, user and granting permissions to the user. It will still run all other SQL scripts that need to be run before starting the management server for the first time. Initial databases and user creation will be the responsibility of the administrator.

Doc PR here: https://github.com/apache/cloudstack-documentation/pull/229  

<!--- Describe your changes in DETAIL - And how has behavior functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviors, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This has been tested by creating the cloud and cloud_usage databases and cloud user prior to executing the script, and then executing the script like this:

./cloudstack-setup-databases user:password@host:port -s 
or
./cloudstack-setup-databases user:password@host:port --schema-only 

An extra option is listed from:
./cloudstack-setup-databases -h
```
  -s, --schema-only     Creates the db schema without having to pass root
                        credentials - Please note: The databases (cloud,
                        cloud_usage) and user (cloud) has to be configured
                        manuallyprior to running this script when using this
                        flag.
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
