### PR TITLE
kvm: pre-add 32 PCI controller for hot-plug issue on ARM64/aarch64

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -530,6 +530,15 @@ public class LibvirtVMDef {
                     devicesBuilder.append(dev.toString());
                 }
             }
+
+            if (_emulator != null && _emulator.endsWith("aarch64")) {
+                devicesBuilder.append("<controller type='pci' model='pcie-root'/>\n");
+                for (int i = 0; i < 32; i++) {
+                  devicesBuilder.append("<controller type='pci' model='pcie-root-port'/>\n");
+                }
+                devicesBuilder.append("<controller type='pci' model='pcie-to-pci-bridge'/>\n");
+            }
+
             devicesBuilder.append("</devices>\n");
             return devicesBuilder.toString();
         }


### PR DESCRIPTION
On newer libvirt/qemu it seems PCI hot-plugging could be an issue as
seen in:

https://www.suse.com/support/kb/doc/?id=000019383
https://bugs.launchpad.net/nova/+bug/1836065

This was found to be true on ARM64/aarch64 platform (tested on
RaspberryPi4). As per the default machine doc, it advises to
pre-allocate PCI controllers on the machine and pcie-to-pci-bridge based
controller for legacy PCI models:
https://libvirt.org/pci-hotplug.html#x86_64-q35

This patch introduces the concept as a workaround until a proper fix is
done (ideally in the upstream libvirt/qemu projects). Until then client
code can add 32 PCI controllers and a pcie-to-pci-bridge controller for
aarch64 platforms.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

Tested on RaspberryPi4+Ubuntu 20.04 with: http://download.cloudstack.org/rpi4/4.15/
Old PR: https://github.com/apache/cloudstack/pull/4182