### PR TITLE
adapt condition to use the correct letter for pvlan types

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -615,10 +615,11 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                         !networkBroadcastUri.equals(String.format("vlan://%d", nic.getVlan())))) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("VLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) vlan://%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan()));
         }
+        char pvLanType = nic.getPvlanType() == null ? '\0' : nic.getPvlanType().toLowerCase().charAt(0);
         if (nic.getVlan() != null && nic.getVlan() != 0 && nic.getPvlan() != null && nic.getPvlan() != 0 &&
                 (Strings.isNullOrEmpty(network.getBroadcastUri().toString()) ||
-                        !networkBroadcastUri.equals(String.format("pvlan://%d-%s%d", nic.getVlan(), nic.getPvlanType().charAt(0), nic.getPvlan())))) {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("PVLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) pvlan://%d-%s%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan(), nic.getPvlanType().charAt(0), nic.getPvlan()));
+                        !networkBroadcastUri.equals(String.format("pvlan://%d-%s%d", nic.getVlan(), pvLanType, nic.getPvlan())))) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("PVLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) pvlan://%d-%s%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan(), pvLanType, nic.getPvlan()));
         }
     }
 

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -615,7 +615,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                         !networkBroadcastUri.equals(String.format("vlan://%d", nic.getVlan())))) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("VLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) vlan://%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan()));
         }
-        String pvLanType = nic.getPvlanType() == null ? "" : new String(nic.getPvlanType().toLowerCase().charAt(0));
+        String pvLanType = nic.getPvlanType() == null ? "" : nic.getPvlanType().toLowerCase().substring(0, 1);
         if (nic.getVlan() != null && nic.getVlan() != 0 && nic.getPvlan() != null && nic.getPvlan() != 0 &&
                 (Strings.isNullOrEmpty(network.getBroadcastUri().toString()) ||
                         !networkBroadcastUri.equals(String.format("pvlan://%d-%s%d", nic.getVlan(), pvLanType, nic.getPvlan())))) {

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -617,8 +617,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }
         if (nic.getVlan() != null && nic.getVlan() != 0 && nic.getPvlan() != null && nic.getPvlan() != 0 &&
                 (Strings.isNullOrEmpty(network.getBroadcastUri().toString()) ||
-                        !networkBroadcastUri.equals(String.format("pvlan://%d-i%d", nic.getVlan(), nic.getPvlan())))) {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("PVLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) pvlan://%d-i%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan(), nic.getPvlan()));
+                        !networkBroadcastUri.equals(String.format("pvlan://%d-%s%d", nic.getVlan(), nic.getPvlanType().charAt(0), nic.getPvlan())))) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("PVLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) pvlan://%d-%s%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan(), nic.getPvlanType().charAt(0), nic.getPvlan()));
         }
     }
 

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -615,7 +615,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                         !networkBroadcastUri.equals(String.format("vlan://%d", nic.getVlan())))) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("VLAN of network(ID: %s) %s is found different from the VLAN of nic(ID: %s) vlan://%d during VM import", network.getUuid(), networkBroadcastUri, nic.getNicId(), nic.getVlan()));
         }
-        char pvLanType = nic.getPvlanType() == null ? '\0' : nic.getPvlanType().toLowerCase().charAt(0);
+        String pvLanType = nic.getPvlanType() == null ? "" : new String(nic.getPvlanType().toLowerCase().charAt(0));
         if (nic.getVlan() != null && nic.getVlan() != 0 && nic.getPvlan() != null && nic.getPvlan() != 0 &&
                 (Strings.isNullOrEmpty(network.getBroadcastUri().toString()) ||
                         !networkBroadcastUri.equals(String.format("pvlan://%d-%s%d", nic.getVlan(), pvLanType, nic.getPvlan())))) {


### PR DESCRIPTION
### Description

In the past, the broadcast uri was changed to an "i" for isolated, as well as c for community. 

see https://github.com/apache/cloudstack/pull/4040

However, the ingest logic has not been adjusted, which means it's no longer possible to ingest a VM with a community 
network.

For this reason I've adapted the condition and add correct pvlan type. 

### **Important**
**All existing community network broadcast uri's in cloudstack before 4.15.1.0 must be updated manually or new created 
because all community networks contains the letter i in the broadcast uri.**

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested in own VMware env. 

```
import unmanagedinstance clusterid=b6dc2477-f3ec-43e2-a405-3605e29aaa42 name=ubuvtst6 displayname=ubuvtst6 projectid=fc61ebe1-6290-4100-98ca-18fb3d950af2 serviceofferingid=15b5681f-08c2-417a-a9ba-4480c229ec03 

{
  "accountid": "226c8611-ff24-11ea-9d07-005056827a97",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ImportUnmanagedInstanceCmd",
  "completed": "2021-07-15T09:42:19+0100",
  "created": "2021-07-15T09:42:05+0100",
  "jobid": "189390c5-6401-4e62-830f-7ba2b96c174f",
  "jobprocstatus": 0,
  "jobresult": {
    "virtualmachine": {
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 0,
      "created": "2021-07-15T09:42:19+0100",
      "details": {
        "cpuNumber": "1",
        "dataDiskController": "osdefault",
        "deployvm": "true",
        "memory": "1024",
        "nicAdapter": "Vmxnet3",
        "rootDiskController": "pvscsi"
      },
      "displayname": "ubuvtst6",
      "displayvm": true,
      "domain": "itelligence",
      "domainid": "05dfd7d7-5b11-4f3e-94e4-9569c95f75ee",
      "guestosid": "224af937-ff24-11ea-9d07-005056827a97",
      "haenable": false,
      "hostid": "73676017-b962-4942-bb4c-cf297634b212",
      "hostname": "iosvemt01.esx-tst.os.itelligence.de",
      "hypervisor": "VMware",
      "id": "c13c12de-aa87-413c-8fe3-895a7094af60",
      "instancename": "ubuvtst6",
      "isdynamicallyscalable": false,
      "memory": 1024,
      "name": "ubuvtst6",
      "nic": [
        {
          "broadcasturi": "vlan://289",
          "extradhcpoption": [],
          "id": "c5f110b3-cdc1-492d-be66-c313861942df",
          "isdefault": true,
          "isolationuri": "vlan://289",
          "macaddress": "00:50:56:92:12:41",
          "networkid": "c0816fba-bac0-46a7-b749-cc2c36e97f60",
          "networkname": "Frontend_289",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "L2"
        },
        {
          "broadcasturi": "pvlan://63-c289",
          "extradhcpoption": [],
          "id": "46820c91-c310-4b1e-9383-7a8036e97a8f",
          "isdefault": false,
          "isolationuri": "pvlan://63-c289",
          "macaddress": "02:00:39:f3:00:01",
          "networkid": "baad9713-c8a8-4f5f-8ea5-546190db4306",
          "networkname": "Backup_63-289",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "L2"
        }
      ],
      "osdisplayname": "Other Ubuntu (64-bit)",
      "ostypeid": "224af937-ff24-11ea-9d07-005056827a97",
      "passwordenabled": false,
      "project": "dev-01",
      "projectid": "fc61ebe1-6290-4100-98ca-18fb3d950af2",
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "serviceofferingid": "15b5681f-08c2-417a-a9ba-4480c229ec03",
      "serviceofferingname": "custom_std-ha-std_fat-fp-std",
      "state": "Running",
      "tags": [],
      "templatedisplaytext": "VM Import Default Template",
      "templateid": "59faead6-743e-442f-a964-ffb31da3e785",
      "templatename": "system-default-vm-import-dummy-template.iso",
      "userid": "22712228-ff24-11ea-9d07-005056827a97",
      "username": "admin",
      "zoneid": "de1c4b6f-a58b-46e6-9418-1fd55a9f022c",
      "zonename": "eu-de-vct5"
    }
  },
  "jobresultcode": 0,
  "jobresulttype": "object",
  "jobstatus": 1,
  "userid": "22712228-ff24-11ea-9d07-005056827a97"
}

```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
