### PR TITLE
UI: only display host information, if they are relevant

### DIFF
--- a/ui/src/views/infra/HostInfo.vue
+++ b/ui/src/views/infra/HostInfo.vue
@@ -43,7 +43,7 @@
           </div>
         </div>
       </a-list-item>
-      <a-list-item>
+      <a-list-item v-if="host.hosttags">
         <div>
           <strong>{{ $t('label.hosttags') }}</strong>
           <div>
@@ -51,7 +51,7 @@
           </div>
         </div>
       </a-list-item>
-      <a-list-item>
+      <a-list-item v-if="host.oscategoryid">
         <div>
           <strong>{{ $t('label.oscategoryid') }}</strong>
           <div>
@@ -83,7 +83,7 @@
           </div>
         </div>
       </a-list-item>
-      <a-list-item v-if="host.hostha">
+      <a-list-item v-if="host.hostha && host.hostha.haenable">
         <div>
           <strong>{{ $t('label.hastate') }}</strong>
           <div>
@@ -91,7 +91,7 @@
           </div>
         </div>
       </a-list-item>
-      <a-list-item v-if="host.hostha">
+      <a-list-item v-if="host.hostha && host.hostha.haenable">
         <div>
           <strong>{{ $t('label.haprovider') }}</strong>
           <div>


### PR DESCRIPTION
### Description

This PR improves the HostView, so that only relevant information is shown.
This also fixes a small bug, when no `hosttags` or `oscategoryid` exists, that wrong (_maybe cached?_) values were shown, instead of no values.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
