### PR TITLE
api: Add 'created' field to API response

### DIFF
--- a/api/src/main/java/com/cloud/network/Network.java
+++ b/api/src/main/java/com/cloud/network/Network.java
@@ -19,6 +19,7 @@ package com.cloud.network;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import com.cloud.exception.InvalidParameterValueException;
@@ -456,4 +457,6 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
     String getRouterIp();
 
     String getRouterIpv6();
+
+    Date getCreated();
 }

--- a/api/src/main/java/com/cloud/network/NetworkProfile.java
+++ b/api/src/main/java/com/cloud/network/NetworkProfile.java
@@ -17,6 +17,7 @@
 package com.cloud.network;
 
 import java.net.URI;
+import java.util.Date;
 
 import com.cloud.network.Networks.BroadcastDomainType;
 import com.cloud.network.Networks.Mode;
@@ -326,6 +327,12 @@ public class NetworkProfile implements Network {
 
     @Override
     public String getRouterIpv6() {
+        return null;
+    }
+
+    @Override
+    public Date getCreated() {
+        // TODO Auto-generated method stub
         return null;
     }
 

--- a/api/src/main/java/com/cloud/network/NetworkProfile.java
+++ b/api/src/main/java/com/cloud/network/NetworkProfile.java
@@ -332,7 +332,6 @@ public class NetworkProfile implements Network {
 
     @Override
     public Date getCreated() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/api/src/main/java/com/cloud/network/vpc/Vpc.java
+++ b/api/src/main/java/com/cloud/network/vpc/Vpc.java
@@ -20,6 +20,8 @@ import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
 
+import java.util.Date;
+
 public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
 
     public enum State {
@@ -91,4 +93,6 @@ public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
     boolean isRollingRestart();
 
     void setRollingRestart(boolean rollingRestart);
+
+    Date getCreated();
 }

--- a/api/src/main/java/com/cloud/offering/NetworkOffering.java
+++ b/api/src/main/java/com/cloud/offering/NetworkOffering.java
@@ -23,6 +23,8 @@ import org.apache.cloudstack.api.InternalIdentity;
 import com.cloud.network.Network.GuestType;
 import com.cloud.network.Networks.TrafficType;
 
+import java.util.Date;
+
 /**
  * Describes network offering
  *
@@ -141,4 +143,6 @@ public interface NetworkOffering extends InfrastructureEntity, InternalIdentity,
     boolean isSupportingPublicAccess();
 
     String getServicePackage();
+
+    Date getCreated();
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -248,7 +248,7 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
     private Boolean redundantRouter;
 
     @SerializedName(ApiConstants.CREATED)
-    @Param(description = "the date this network was created")
+    @Param(description = "the date this network was created", since = "4.16.0")
     private Date created;
 
     public Boolean getDisplayNetwork() {

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -245,6 +246,10 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
     @SerializedName(ApiConstants.REDUNDANT_ROUTER)
     @Param(description = "If the network has redundant routers enabled", since = "4.11.1")
     private Boolean redundantRouter;
+
+    @SerializedName(ApiConstants.CREATED)
+    @Param(description = "the date this network was created")
+    private Date created;
 
     public Boolean getDisplayNetwork() {
         return displayNetwork;
@@ -481,5 +486,13 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
 
     public void setVpcName(String vpcName) {
         this.vpcName = vpcName;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.api.response;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -206,6 +207,10 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
     @SerializedName("vmrunning")
     @Param(description = "the total number of virtual machines running for this project", since = "4.2.0")
     private Integer vmRunning;
+
+    @SerializedName(ApiConstants.CREATED)
+    @Param(description = "the date this project was created")
+    private Date created;
 
     public void setId(String id) {
         this.id = id;
@@ -420,5 +425,13 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
 
     public void setOwners(List<Map<String, String>> owners) {
         this.owners = owners;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
@@ -209,7 +209,7 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
     private Integer vmRunning;
 
     @SerializedName(ApiConstants.CREATED)
-    @Param(description = "the date this project was created")
+    @Param(description = "the date this project was created", since = "4.16.0")
     private Date created;
 
     public void setId(String id) {

--- a/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
@@ -242,6 +242,11 @@ public class VpcVO implements Vpc {
     }
 
     @Override
+    public Date getCreated() {
+        return created;
+    }
+
+    @Override
     public Class<?> getEntityType() {
         return Vpc.class;
     }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2354,6 +2354,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         }
         response.setExternalId(network.getExternalId());
         response.setRedundantRouter(network.isRedundant());
+        response.setCreated(network.getCreated());
         response.setObjectName("network");
         return response;
     }
@@ -2963,6 +2964,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setId(vpc.getUuid());
         response.setName(vpc.getName());
         response.setDisplayText(vpc.getDisplayText());
+        response.setCreated(vpc.getCreated());
         response.setState(vpc.getState().name());
         VpcOffering voff = ApiDBUtils.findVpcOfferingById(vpc.getVpcOfferingId());
         if (voff != null) {

--- a/server/src/main/java/com/cloud/api/query/dao/NetworkOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/NetworkOfferingJoinDaoImpl.java
@@ -88,6 +88,7 @@ public class NetworkOfferingJoinDaoImpl extends GenericDaoBase<NetworkOfferingJo
         networkOfferingResponse.setConcurrentConnections(offering.getConcurrentConnections());
         networkOfferingResponse.setSupportsStrechedL2Subnet(offering.isSupportingStrechedL2());
         networkOfferingResponse.setSupportsPublicAccess(offering.isSupportingPublicAccess());
+        networkOfferingResponse.setCreated(offering.getCreated());
         if (offering.getGuestType() != null) {
             networkOfferingResponse.setGuestIpType(offering.getGuestType().toString());
         }

--- a/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
@@ -110,6 +110,7 @@ public class ProjectJoinDaoImpl extends GenericDaoBase<ProjectJoinVO, Long> impl
             ownersList.add(ownerDetails);
         }
         response.setOwners(ownersList);
+        response.setCreated(proj.getCreated());
 
         // update tag information
         List<ResourceTagJoinVO> tags = ApiDBUtils.listResourceTagViewByResourceUUID(proj.getUuid(), ResourceObjectType.Project);


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/5209
This PR adds 'created' field to the response of listing Networks, VPCs, Projects, NetworkOffering
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
![image](https://user-images.githubusercontent.com/10495417/125804774-599329ff-cece-44af-b9fd-dc8545ee7ba5.png)




<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
