### PR TITLE
ui: Refresh after async job completed only on current / parent page

### DIFF
--- a/ui/src/utils/plugins.js
+++ b/ui/src/utils/plugins.js
@@ -53,7 +53,8 @@ export const pollJobPlugin = {
         showLoading = true,
         catchMessage = i18n.t('label.error.caught'),
         catchMethod = () => {},
-        action = null
+        action = null,
+        originalPage = null
       } = options
 
       store.dispatch('AddHeaderNotice', {
@@ -63,6 +64,7 @@ export const pollJobPlugin = {
         status: 'progress'
       })
 
+      options.originalPage = options.originalPage ? options.originalPage : this.$router.currentRoute.path
       api('queryAsyncJobResult', { jobId }).then(json => {
         const result = json.queryasyncjobresultresponse
         if (result.jobstatus === 1) {
@@ -85,7 +87,11 @@ export const pollJobPlugin = {
             status: 'done',
             duration: 2
           })
-          if (!action || !('isFetchData' in action) || (action.isFetchData)) {
+
+          // Ensure we refresh on the same / parent page
+          const currentPage = this.$router.currentRoute.path
+          const samePage = originalPage === currentPage || originalPage.startsWith(currentPage + '/')
+          if (samePage && (!action || !('isFetchData' in action) || (action.isFetchData))) {
             eventBus.$emit('async-job-complete')
           }
           successMethod(result)


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/5172

Ensures that the page is refreshed after an async job only if it is the same / parent page being viewed

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial
