### PR TITLE
Store Vm migration details in db

### DIFF
--- a/api/src/main/java/com/cloud/event/VmMigrationEvent.java
+++ b/api/src/main/java/com/cloud/event/VmMigrationEvent.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.event;
+
+import org.apache.cloudstack.api.InternalIdentity;
+
+import java.util.Date;
+
+public interface VmMigrationEvent extends InternalIdentity {
+    enum State {
+        Started, Completed, Failed;
+    }
+
+    enum VmType {
+        User, DomainRouter, SecondaryStorage, ConsoleProxy;
+    }
+
+    State getState();
+
+    String getDescription();
+
+    Date getCreateDate();
+
+    String getVmType();
+}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/MigrateVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/MigrateVMCmd.java
@@ -120,12 +120,21 @@ public class MigrateVMCmd extends BaseAsyncCmd {
     @Override
     public String getEventDescription() {
         String eventDescription;
+        Long sourceHostId = 0L;
+
+        UserVm userVm = _entityMgr.findById(UserVm.class, getVirtualMachineId());
+        if (userVm != null) {
+            sourceHostId = userVm.getHostId();
+        }
         if (getHostId() != null) {
             eventDescription = String.format("Attempting to migrate VM id: %s to host Id: %s", getVirtualMachineId(), getHostId());
         } else if (getStoragePoolId() != null) {
             eventDescription = String.format("Attempting to migrate VM id: %s to storage pool Id: %s", getVirtualMachineId(), getStoragePoolId());
         } else {
             eventDescription = String.format("Attempting to migrate VM id: %s", getVirtualMachineId());
+        }
+        if (sourceHostId != 0L) {
+            eventDescription = eventDescription + " from host id: " + sourceHostId;
         }
         return eventDescription;
     }

--- a/engine/schema/src/main/java/org/apache/cloudstack/vmmigration/VmMigrationVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/vmmigration/VmMigrationVO.java
@@ -1,0 +1,204 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.vmmigration;
+
+import com.cloud.event.VmMigrationEvent;
+import com.cloud.utils.db.GenericDao;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+@Entity
+@Table(name = "vm_migration")
+public class VmMigrationVO implements VmMigrationEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private long id;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "state")
+    private State state;
+
+    @Column(name = "instance_name")
+    private String instanceName;
+
+    @Column(name = "instance_id")
+    private Long instanceId;
+
+    @Column(name = "description", length = 1024)
+    private String description;
+
+    @Column(name = "vm_type")
+    private String vmType;
+
+    @Column(name = "source_host")
+    private String sourceHost;
+
+    @Column(name = "destination_host")
+    private String destinationHost;
+
+    @Column(name = GenericDao.CREATED_COLUMN)
+    private Date created;
+
+    @Column(name = "user_name")
+    private String userName;
+
+    @Column(name = "account_id")
+    private long accountId;
+
+    @Column(name = "domain_id")
+    private long domainId;
+
+    public VmMigrationVO() {}
+
+    public VmMigrationVO(VmMigrationEvent.State state, String instanceName, Long instanceId, String description,
+                         String vmType, String sourceHostName, String destinationHostName, Date created,
+                         String userName, long accountId, long domainId) {
+        this.state = state;
+        this.instanceId = instanceId;
+        this.description = description;
+        this.vmType = vmType;
+        this.sourceHost = sourceHostName;
+        this.destinationHost = destinationHostName;
+        this.created = created;
+        this.userName = userName;
+        this.accountId = accountId;
+        this.domainId = domainId;
+        this.instanceName = instanceName;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @Override
+    public State getState() {
+        return state;
+    }
+
+    public VmMigrationVO setState(State state) {
+        this.state = state;
+        return this;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    public VmMigrationVO setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getSourceHost() {
+        return sourceHost;
+    }
+
+    public VmMigrationVO setSourceHost(String sourceHost) {
+        this.sourceHost = sourceHost;
+        return this;
+    }
+
+    public String getDestinationHost() {
+        return destinationHost;
+    }
+
+    public VmMigrationVO setDestinationHost(String destinationHost) {
+        this.destinationHost = destinationHost;
+        return this;
+    }
+
+    @Override
+    public Date getCreateDate() {
+        return created;
+    }
+
+    public VmMigrationVO setCreated(Date createDate) {
+        this.created = createDate;
+        return this;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public VmMigrationVO setUserName(String userId) {
+        this.userName = userId;
+        return this;
+    }
+
+    public long getAccountId() {
+        return accountId;
+    }
+
+    public VmMigrationVO setAccountId(long accountId) {
+        this.accountId = accountId;
+        return this;
+    }
+
+    public long getDomainId() {
+        return domainId;
+    }
+
+    public VmMigrationVO setDomainId(long domainId) {
+        this.domainId = domainId;
+        return this;
+    }
+
+    @Override
+    public String getVmType() {
+        return vmType;
+    }
+
+    public VmMigrationVO setVmType(String vmtype) {
+        this.vmType = vmtype;
+        return this;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public VmMigrationVO setInstanceName(String vmName) {
+        this.instanceName = vmName;
+        return this;
+    }
+
+    public Long getInstanceId() {
+        return instanceId;
+    }
+
+    public VmMigrationVO setInstanceId(Long instanceId) {
+        this.instanceId = instanceId;
+        return this;
+    }
+}

--- a/engine/schema/src/main/java/org/apache/cloudstack/vmmigration/dao/VmMigrationDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/vmmigration/dao/VmMigrationDao.java
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.vmmigration.dao;
+
+import com.cloud.utils.db.GenericDao;
+import org.apache.cloudstack.vmmigration.VmMigrationVO;
+
+import java.util.List;
+
+public interface VmMigrationDao extends GenericDao<VmMigrationVO, Long> {
+    List<VmMigrationVO> searchCompletedMigrations();
+
+    List<VmMigrationVO> searchFailedMigrations();
+
+    List<VmMigrationVO> searchMigratedUserVms();
+
+    List<VmMigrationVO> searchMigratedDomainRouters();
+
+    List<VmMigrationVO> searchMigratedSystemVms();
+
+    List<VmMigrationVO> searchByInstanceId(Long instanceId);
+}

--- a/engine/schema/src/main/java/org/apache/cloudstack/vmmigration/dao/VmMigrationDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/vmmigration/dao/VmMigrationDaoImpl.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.vmmigration.dao;
+
+import com.cloud.event.VmMigrationEvent;
+import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchCriteria;
+import org.apache.cloudstack.vmmigration.VmMigrationVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class VmMigrationDaoImpl extends GenericDaoBase<VmMigrationVO, Long> implements VmMigrationDao {
+    public static final Logger s_logger = Logger.getLogger(VmMigrationDaoImpl.class);
+
+    @Override
+    public List<VmMigrationVO> searchCompletedMigrations() {
+        SearchCriteria<VmMigrationVO> sc = createSearchCriteria();
+        sc.setParameters("state", VmMigrationEvent.State.Completed);
+        return listIncludingRemovedBy(sc, null);
+    }
+
+    @Override
+    public List<VmMigrationVO> searchFailedMigrations() {
+        SearchCriteria<VmMigrationVO> sc = createSearchCriteria();
+        sc.setParameters("state", VmMigrationEvent.State.Failed);
+        return listIncludingRemovedBy(sc, null);
+    }
+
+    @Override
+    public List<VmMigrationVO> searchMigratedUserVms() {
+        SearchCriteria<VmMigrationVO> sc = createSearchCriteria();
+        sc.setParameters("state", VmMigrationEvent.State.Completed);
+        sc.setParameters("vm_type", VmMigrationEvent.VmType.User);
+        return listIncludingRemovedBy(sc, null);
+    }
+
+    @Override
+    public List<VmMigrationVO> searchMigratedDomainRouters() {
+        SearchCriteria<VmMigrationVO> sc = createSearchCriteria();
+        sc.setParameters("state", VmMigrationEvent.State.Completed);
+        sc.setParameters("vm_type", VmMigrationEvent.VmType.DomainRouter);
+        return listIncludingRemovedBy(sc, null);
+    }
+
+    @Override
+    public List<VmMigrationVO> searchMigratedSystemVms() {
+        SearchCriteria<VmMigrationVO> sc = createSearchCriteria();
+        sc.addOr("vm_type", SearchCriteria.Op.EQ, VmMigrationEvent.VmType.ConsoleProxy);
+        sc.addOr("vm_type", SearchCriteria.Op.EQ, VmMigrationEvent.VmType.SecondaryStorage);
+        return listIncludingRemovedBy(sc, null);
+    }
+
+    @Override
+    public List<VmMigrationVO> searchByInstanceId(Long instanceId) {
+        SearchCriteria<VmMigrationVO> sc = createSearchCriteria();
+        sc.setParameters("instance_id", instanceId);
+        return listIncludingRemovedBy(sc, null);
+    }
+}

--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -294,4 +294,5 @@
   <bean id="VsphereStoragePolicyDaoImpl" class="com.cloud.dc.dao.VsphereStoragePolicyDaoImpl" />
   <bean id="TemplateDeployAsIsDetailsDaoImpl" class="com.cloud.deployasis.dao.TemplateDeployAsIsDetailsDaoImpl" />
   <bean id="UserVmDeployAsIsDetailsDaoImpl" class="com.cloud.deployasis.dao.UserVmDeployAsIsDetailsDaoImpl" />
+  <bean id="VmMigrationDaoImpl" class="org.apache.cloudstack.vmmigration.dao.VmMigrationDaoImpl" />
 </beans>

--- a/engine/schema/src/main/resources/META-INF/db/schema-41510to41600.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41510to41600.sql
@@ -511,3 +511,19 @@ CREATE VIEW `cloud`.`host_view` AS
         `cloud`.`user` ON `user`.`uuid` = `last_annotation_view`.`user_uuid`
     GROUP BY
         `host`.`id`;
+
+CREATE TABLE IF NOT EXISTS `cloud`.`vm_migration` (
+    `id` bigint unsigned NOT NULL auto_increment,
+    `state` varchar(255) NOT NULL,
+    `instance_id` bigint unsigned NOT NULL,
+    `instance_name` varchar(255) NOT NULL,
+    `description` varchar(255),
+    `vm_type` varchar(255)  NOT NULL,
+    `source_host` varchar(255) NOT NULL,
+    `destination_host` varchar(255) NOT NULL,
+    `created` DATETIME,
+    `user_name` varchar(255) NOT NULL,
+    `account_id` bigint NOT NULL,
+    `domain_id` bigint NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
### Description
Currently its difficult to get the history of vm migrations
across the hosts if it has migrated several times in the past.
So store every migration entry in database so that it will be
easy for admins to track the migration of a particular vm across
different hosts.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
```
mysql> select * from vm_migration;
+----+-----------+-------------+---------------+-------------------------------------+--------------------+-------------+------------------+---------------------+-----------+------------+-----------+
| id | state     | instance_id | instance_name | description                         | vm_type            | source_host | destination_host | created             | user_name | account_id | domain_id |
+----+-----------+-------------+---------------+-------------------------------------+--------------------+-------------+------------------+---------------------+-----------+------------+-----------+
|  1 | Started   |          56 | i-2-56-VM     | Starting migration of vm i-2-56-VM  | User               | node85      | node84           | 2021-07-20 11:27:17 | admin     |          2 |         1 |
|  3 | Completed |          56 | i-2-56-VM     | Completed migration of vm i-2-56-VM | User               | node85      | node84           | 2021-07-20 11:27:35 | admin     |          2 |         1 |
| 52 | Completed |          66 | r-66-VM       | Completed migration of vm r-66-VM   | DomainRouter       | node84      | node85           | 2021-07-20 13:39:22 | admin     |          2 |         1 |
| 50 | Completed |           2 | s-2-VM        | Completed migration of vm s-2-VM    | SecondaryStorageVm | node85      | node84           | 2021-07-20 13:39:15 | admin     |          2 |         1 |
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
