### PR TITLE
vmware: remove redundant configuration parameters defined - vmware.create.full.clone

### DIFF
--- a/api/src/main/java/com/cloud/hypervisor/HypervisorGuru.java
+++ b/api/src/main/java/com/cloud/hypervisor/HypervisorGuru.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cloudstack.backup.Backup;
-import org.apache.cloudstack.framework.config.ConfigKey;
 
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.to.NicTO;
@@ -35,8 +34,6 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
 
 public interface HypervisorGuru extends Adapter {
-    ConfigKey<Boolean> VmwareFullClone = new ConfigKey<Boolean>("Advanced", Boolean.class, "vmware.create.full.clone", "true",
-            "If set to true, creates guest VMs as full clones on ESX", false);
     HypervisorType getHypervisorType();
 
     /**

--- a/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/capacity/CapacityManager.java
@@ -76,7 +76,7 @@ public interface CapacityManager {
                     VmwareCreateCloneFullCK,
                     "false",
                     "If set to true, creates VMs as full clones on ESX hypervisor",
-                    true,
+                    false,
                     ConfigKey.Scope.StoragePool);
     static final ConfigKey<String> ImageStoreNFSVersion =
             new ConfigKey<String>(

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1556,7 +1556,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         if (HypervisorType.KVM == hypervisorType || HypervisorType.XenServer == hypervisorType || HypervisorType.Hyperv == hypervisorType || HypervisorType.LXC == hypervisorType) {
             return false;
         } else if (HypervisorType.VMware == hypervisorType) {
-            final Boolean fullClone = HypervisorGuru.VmwareFullClone.value();
+            final Boolean fullClone = CapacityManager.VmwareCreateCloneFull.value();
             return fullClone;
         } else {
             return ExecuteInSequence.value();

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -30,8 +30,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import com.cloud.exception.InvalidParameterValueException;
+
+import com.cloud.capacity.CapacityManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
@@ -56,7 +57,6 @@ import com.cloud.deploy.DeploymentPlanner;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
-import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.DiskOfferingVO;
@@ -206,7 +206,7 @@ public class VirtualMachineManagerImplTest {
     public void testExeceuteInSequence() {
         assertTrue(virtualMachineManagerImpl.getExecuteInSequence(HypervisorType.XenServer) == false);
         assertTrue(virtualMachineManagerImpl.getExecuteInSequence(HypervisorType.KVM) == false);
-        assertTrue(virtualMachineManagerImpl.getExecuteInSequence(HypervisorType.VMware) == HypervisorGuru.VmwareFullClone.value());
+        assertTrue(virtualMachineManagerImpl.getExecuteInSequence(HypervisorType.VMware) == CapacityManager.VmwareCreateCloneFull.value());
         assertTrue(virtualMachineManagerImpl.getExecuteInSequence(HypervisorType.Ovm3) == VirtualMachineManager.ExecuteInSequence.value());
     }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
+import com.cloud.capacity.CapacityManager;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.backup.Backup;
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
@@ -213,7 +214,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
     @Override @DB public Pair<Boolean, Long> getCommandHostDelegation(long hostId, Command cmd) {
         boolean needDelegation = false;
         if (cmd instanceof StorageSubSystemCommand) {
-            Boolean fullCloneEnabled = VmwareFullClone.value();
+            Boolean fullCloneEnabled = CapacityManager.VmwareCreateCloneFull.value();
             StorageSubSystemCommand c = (StorageSubSystemCommand)cmd;
             c.setExecuteInSequence(fullCloneEnabled);
         }
@@ -234,7 +235,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
                 inSeq = false;
             } else if ((destStoreTO.getRole() == DataStoreRole.Image) || (destStoreTO.getRole() == DataStoreRole.ImageCache)) {
                 inSeq = false;
-            } else if (!VmwareFullClone.value()) {
+            } else if (!CapacityManager.VmwareCreateCloneFull.value()) {
                 inSeq = false;
             }
             cpyCommand.setExecuteInSequence(inSeq);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/CleanupFullyClonedTemplatesTask.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/CleanupFullyClonedTemplatesTask.java
@@ -18,8 +18,8 @@ package com.cloud.hypervisor.vmware.manager;
 
 import com.cloud.api.query.dao.TemplateJoinDao;
 import com.cloud.api.query.vo.TemplateJoinVO;
+import com.cloud.capacity.CapacityManager;
 import com.cloud.hypervisor.Hypervisor;
-import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.storage.VMTemplateStoragePoolVO;
 import com.cloud.storage.dao.VMTemplatePoolDao;
 import com.cloud.template.TemplateManager;
@@ -74,7 +74,7 @@ public class CleanupFullyClonedTemplatesTask extends ManagedContextRunnable {
         mine = Thread.currentThread();
         s_logger.info("running job to mark fully cloned templates for gc in thread " + mine.getName());
 
-        if (HypervisorGuru.VmwareFullClone.value()) { // only run if full cloning is being used (might need to be more fine grained)
+        if (CapacityManager.VmwareCreateCloneFull.value()) { // only run if full cloning is being used (might need to be more fine grained)
             try {
                 queryAllPools();
             } catch (Throwable t) {

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -27,6 +27,7 @@ import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupRoutingCommand;
 import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.api.query.dao.TemplateJoinDao;
+import com.cloud.capacity.CapacityManager;
 import com.cloud.cluster.ClusterManager;
 import com.cloud.cluster.dao.ManagementServerHostPeerDao;
 import com.cloud.configuration.Config;
@@ -306,7 +307,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
             _storage.configure("StorageLayer", params);
         }
 
-        value = _configDao.getValue(Config.VmwareCreateFullClone.key());
+        value = String.valueOf(CapacityManager.VmwareCreateCloneFull.value());
         if (value == null) {
             _fullCloneFlag = false;
         } else {

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -1087,14 +1087,6 @@ public enum Config {
             "false",
             "Enable/Disable Nexus/Vmware dvSwitch in VMware environment",
             null),
-    VmwareCreateFullClone(
-            "Advanced",
-            ManagementServer.class,
-            Boolean.class,
-            "vmware.create.full.clone",
-            "true",
-            "If set to true, creates guest VMs as full clones on ESX",
-            null),
     VmwareServiceConsole(
             "Advanced",
             ManagementServer.class,


### PR DESCRIPTION
### Description

This PR removes redundant config parameter defined for "vmware.create.full.clone" at different scopes - Global and Storage pool level. Due to this, changing the value at global level doesn't change the value of the setting at the individual storage pool level, unless manually changed at storage pool level.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
