### PR TITLE
api: Fix pagination for list PublicIPAddresses

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -2199,8 +2199,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
         List<? extends IpAddress> wPagination = com.cloud.utils.StringUtils.applyPagination(addrs, cmd.getStartIndex(), cmd.getPageSizeVal());
         if (wPagination != null) {
-            Pair<List<? extends IpAddress>, Integer> listWPagination = new Pair<List<? extends IpAddress>, Integer>(wPagination, addrs.size());
-            return listWPagination;
+            return new Pair<List<? extends IpAddress>, Integer>(wPagination, addrs.size());
         }
         return new Pair<>(addrs, addrs.size());
     }

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -2111,7 +2111,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             }
         }
 
-        final Filter searchFilter = new Filter(IPAddressVO.class, "address", false, cmd.getStartIndex(), cmd.getPageSizeVal());
+        final Filter searchFilter = new Filter(IPAddressVO.class, "address", false, null, null);
         final SearchBuilder<IPAddressVO> sb = _publicIpAddressDao.createSearchBuilder();
         Long domainId = null;
         Boolean isRecursive = null;
@@ -2197,7 +2197,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             sc2.setParameters("ids", freeAddrIds.toArray());
             addrs.addAll(_publicIpAddressDao.search(sc2, searchFilter)); // Allocated + Free
         }
-
+        List<? extends IpAddress> wPagination = com.cloud.utils.StringUtils.applyPagination(addrs, cmd.getStartIndex(), cmd.getPageSizeVal());
+        if (wPagination != null) {
+            Pair<List<? extends IpAddress>, Integer> listWPagination = new Pair<List<? extends IpAddress>, Integer>(wPagination, addrs.size());
+            return listWPagination;
+        }
         return new Pair<>(addrs, addrs.size());
     }
 


### PR DESCRIPTION
### Description


Fixes: https://github.com/apache/cloudstack/issues/5229
This PR fixes the issue noticed while listing public IP addresses wrt pagination. The count is set to the number of items being returned as opposed to the total number of entities (here, public IPs)
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
via cmk:

Prior Fix:
```
## Total number of ip addresses returned without pagination
list publicipaddresses  listall=true filter=id
{
  "count": 55,
  "publicipaddress": [
    {
       ....
    }
    ]
}    

## With Pagination

 list publicipaddresses  pagesize=5 page=1 listall=true filter=id
{
  "count": 5,    <--- while count has to be 55, it returns 5 which is the value of pagesize
  "publicipaddress": [
    {
      "id": "152f39af-1af7-4413-bbf1-1132b1708a9d"
    },
    {
      "id": "cbd3f921-53b5-45a6-9a1b-8c5877e9be34"
    },
    {
      "id": "425204aa-8efd-400a-bc07-98a14fae00b3"
    },
    {
      "id": "dc5b206d-db46-4ab5-9ede-da63261648e5"
    },
    {
      "id": "437fb07f-2c9e-4583-805b-710474c045be"
    }
  ]
}

```
Post Fix:
```
## Total number of addresses without pagination:
SBCM5> > list publicipaddresses listall=true filter=id
{
  "count": 20,
  "publicipaddress": [
    {
      ....
    }
  ]
}
  
## With Pagination:  
SBCM5> > list publicipaddresses listall=true filter=id, page=1 pagesize=5
{
  "count": 20,  <--- Returns the actual number of public IP addresses
  "publicipaddress": [
    {
      "id": "a000effc-0dea-4a84-8299-2de2e38b6d79"
    },
    {
      "id": "c0d594a4-bca2-43c2-bbb2-32ab9eea13a4"
    },
    {
      "id": "d270125d-9578-4d56-9453-96a80c00e721"
    },
    {
      "id": "8fe27d41-ab1a-41e2-8e24-0c78ab389603"
    },
    {
      "id": "04466b5d-b61f-4ff2-9d41-c4354966acf4"
    }
  ]
}

```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
