### PR TITLE
Add YouTube channel link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ via Github pull requests.
 * Design [documents](https://cwiki.apache.org/confluence/display/CLOUDSTACK/Design)
 * API [documentation](https://cloudstack.apache.org/api.html)
 * How to [contribute](CONTRIBUTING.md)
+* [YouTube channel](https://www.youtube.com/ApacheCloudStack)
 
 ## Getting Involved and Contributing
 
@@ -89,7 +90,6 @@ developer [page](http://cloudstack.apache.org/developers.html) for contributing 
 * [Blog](https://blogs.apache.org/cloudstack)
 * [Twitter](https://twitter.com/cloudstack)
 * [Events and meetup](http://cloudstackcollab.org/)
-* [YouTube channel](https://www.youtube.com/ApacheCloudStack)
 
 ## Reporting Security Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ via Github pull requests.
 * Design [documents](https://cwiki.apache.org/confluence/display/CLOUDSTACK/Design)
 * API [documentation](https://cloudstack.apache.org/api.html)
 * How to [contribute](CONTRIBUTING.md)
-* You can find some interesting videos at the [Apache CloudStack](https://www.youtube.com/ApacheCloudStack) YouTube channel
+* Check the [YouTube channel](https://www.youtube.com/ApacheCloudStack) for presentations, interviews, and more
 
 ## Getting Involved and Contributing
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ developer [page](http://cloudstack.apache.org/developers.html) for contributing 
 * [Blog](https://blogs.apache.org/cloudstack)
 * [Twitter](https://twitter.com/cloudstack)
 * [Events and meetup](http://cloudstackcollab.org/)
+* [YouTube channel](https://www.youtube.com/ApacheCloudStack)
 
 ## Reporting Security Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ via Github pull requests.
 * Design [documents](https://cwiki.apache.org/confluence/display/CLOUDSTACK/Design)
 * API [documentation](https://cloudstack.apache.org/api.html)
 * How to [contribute](CONTRIBUTING.md)
-* [YouTube channel](https://www.youtube.com/ApacheCloudStack)
+* You can find some interesting videos at the [Apache CloudStack](https://www.youtube.com/ApacheCloudStack) YouTube channel
 
 ## Getting Involved and Contributing
 


### PR DESCRIPTION
### Description

I could not find references for the YouTube channel at the README. 
Even though the README file is not a great "marketing platform", I think that it is still worth mentioning the YT channel in the README.
