### PR TITLE
Externalize config to enable manually setting CPU topology on KVM VM

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -270,3 +270,6 @@ iscsi.session.cleanup.enabled=false
 # This parameter specifies the heartbeat update timeout in ms; The default value is 60000ms (1 min).
 # Depending on the use case, this timeout might need increasing/decreasing.
 # heartbeat.update.timeout=60000
+
+# Enable manually setting CPU's topology on KVM's VM.
+# enable.manually.setting.cpu.topology.on.kvm.vm=true

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -32,6 +32,13 @@ public class AgentProperties{
     */
     public static final Property<Integer> HEARTBEAT_UPDATE_TIMEOUT = new Property<Integer>("heartbeat.update.timeout", 60000);
 
+    /**
+     * Enable manually setting CPU's topology on KVM's VM. <br>
+     * Data type: boolean.<br>
+     * Default value: true.
+     */
+    public static final Property<Boolean> ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM = new Property<Boolean>("enable.manually.setting.cpu.topology.on.kvm.vm", true);
+
     public static class Property <T>{
         private final String name;
         private final T defaultValue;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -109,6 +109,8 @@ import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.agent.dao.impl.PropertiesStorage;
+import com.cloud.agent.properties.AgentProperties;
+import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import com.cloud.agent.resource.virtualnetwork.VRScripts;
 import com.cloud.agent.resource.virtualnetwork.VirtualRouterDeployer;
 import com.cloud.agent.resource.virtualnetwork.VirtualRoutingResource;
@@ -410,6 +412,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected CPUStat _cpuStat = new CPUStat();
     protected MemStat _memStat = new MemStat(_dom0MinMem, _dom0OvercommitMem);
     private final LibvirtUtilitiesHelper libvirtUtilitiesHelper = new LibvirtUtilitiesHelper();
+
+    protected Boolean enableManuallySettingCpuTopologyOnKvmVm = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM);
 
     protected long getHypervisorLibvirtVersion() {
         return _hypervisorLibvirtVersion;
@@ -4502,6 +4506,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     private void setCpuTopology(CpuModeDef cmd, int vcpus, Map<String, String> details) {
+        if (!enableManuallySettingCpuTopologyOnKvmVm) {
+            s_logger.info(String.format("Skipping manually setting CPU topology on VM's XML due to it is disabled in agent.properties {\"property\": \"%s\", \"value\": %s}.",
+              AgentProperties.ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM.getName(), enableManuallySettingCpuTopologyOnKvmVm));
+            return;
+        }
         // multi cores per socket, for larger core configs
         int numCoresPerSocket = -1;
         if (details != null) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -4507,7 +4507,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     private void setCpuTopology(CpuModeDef cmd, int vcpus, Map<String, String> details) {
         if (!enableManuallySettingCpuTopologyOnKvmVm) {
-            s_logger.info(String.format("Skipping manually setting CPU topology on VM's XML due to it is disabled in agent.properties {\"property\": \"%s\", \"value\": %s}.",
+            s_logger.debug(String.format("Skipping manually setting CPU topology on VM's XML due to it is disabled in agent.properties {\"property\": \"%s\", \"value\": %s}.",
               AgentProperties.ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM.getName(), enableManuallySettingCpuTopologyOnKvmVm));
             return;
         }


### PR DESCRIPTION
### Description
When starting a VM on KVM, ACS sets VM's CPU topology through a calculation of CPU sockets and CPU cores per socket on VM's XML. Along the calculation, for instance, it assumes that a VM that use 12 vCPUs automatically works with 2 sockets and 6 cores, or a VM that use 16 vCPUs automatically works 4 sockets and 4 cores:

https://github.com/apache/cloudstack/blob/d6a77a72f00d01e82b536c2b9d43c00690ee96fd/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java#L4504-L4524

This behavior is arbitrary and operators cannot choose to use it or not.

By default ([fedora - Setting KVM processor affinities](https://docs.fedoraproject.org/en-US/Fedora/13/html/Virtualization_Guide/ch25s06.html)), if we not determine the CPU topology, the hypervisor will alloc the VM on any available CPU; Therefore, this PR intends to externalize a property (`enable.manually.setting.cpu.topology.on.kvm.vm`) on `agent.properties` to allow the operators to decide if they want to do the calculation or not. The default behavior still will be to do the calculation.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?
It was tested on a local lab.

- I created a host with 1 socket and 8 cores;
- I created a VM with 8 vCPUs;
- When the property doesn't exist in the file or when it is true, the topology is set:
   - `<topology sockets='2' cores='4' threads='1'/>`;
- When the property is set to `false`, the topology is not set;