### PR TITLE
Fix regression on create volume from snapshot

### DIFF
--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -185,6 +185,11 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
             pools = reorderPoolsByCapacity(plan, pools);
         }
 
+        if (vmProfile.getVirtualMachine() == null) {
+            s_logger.trace("The VM is null, skipping pools reordering by disk provisioning type.");
+            return pools;
+        }
+
         if (vmProfile.getHypervisorType() == HypervisorType.VMware &&
                 !storageMgr.DiskProvisioningStrictness.valueIn(plan.getDataCenterId())) {
             pools = reorderPoolsByDiskProvisioningType(pools, dskCh);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -898,7 +898,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             created = false;
             VolumeInfo vol = volFactory.getVolume(cmd.getEntityId());
             vol.stateTransit(Volume.Event.DestroyRequested);
-            throw new CloudRuntimeException("Failed to create volume: " + volume.getId(), e);
+            String message = String.format("Failed to create volume [%s] due to [%s].", volume.getId(), e.getMessage());
+            s_logger.error(message, e);
+            throw new CloudRuntimeException(message, e);
         } finally {
             if (!created) {
                 s_logger.trace("Decrementing volume resource count for account id=" + volume.getAccountId() + " as volume failed to create on the backend");

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -898,9 +898,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             created = false;
             VolumeInfo vol = volFactory.getVolume(cmd.getEntityId());
             vol.stateTransit(Volume.Event.DestroyRequested);
-            String message = String.format("Failed to create volume [%s] due to [%s].", volume.getId(), e.getMessage());
-            s_logger.error(message, e);
-            throw new CloudRuntimeException(message, e);
+            throw new CloudRuntimeException("Failed to create volume: " + volume.getId(), e);
         } finally {
             if (!created) {
                 s_logger.trace("Decrementing volume resource count for account id=" + volume.getAccountId() + " as volume failed to create on the backend");


### PR DESCRIPTION
### Description
PR #4640 added a condition validating if the VM is from hypervisor VMWare, in `AbstractStoragePoolAllocator::reorderPools(List<StoragePool>, VirtualMachineProfile, DeploymentPlan, DiskProfile)`.
https://github.com/apache/cloudstack/blob/450de92e6cdc6d5611ca4ba701660826d6c70141/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java#L188-L191

However, when creating a volume from a snapshot (without VM's id), ACS instantiates the VirtualMachineProfile without a VM:

https://github.com/apache/cloudstack/blob/75a2c0bd995abc39d02a82c96664f2aecac426d8/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java#L434

Which cause a NPE on:
https://github.com/apache/cloudstack/blob/450de92e6cdc6d5611ca4ba701660826d6c70141/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java#L188

The NPE is catch and throwed as a `CloudRuntimeException`.

This PR intends to add a validation if the VM is null before validating its hypervisor.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
It has been tested locally in a test lab.
1. I created VM;
2. I took a snapshot;
3. I tried to create a volume from the snapshot.
   - Before the nulls validation, it would throw an exception:
```
ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-1:ctx-7ec7e521 job-18849) (logid:43e9eb75) Unexpected exception while executing org.apache.cloudstack.api.command.admin.volume.CreateVolumeCmdByAdmin
com.cloud.utils.exception.CloudRuntimeException: Failed to create volume: xxxx
    at com.cloud.storage.VolumeApiServiceImpl.createVolume(VolumeApiServiceImpl.java:901)
    at com.cloud.storage.VolumeApiServiceImpl.createVolume(VolumeApiServiceImpl.java:201)
```
   - After the nulls validation, it created the volume.