### PR TITLE
ui: Show host as unsecure in listview

### DIFF
--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -135,8 +135,9 @@
       </span>
       <span v-else>{{ text }}</span>
     </span>
-    <template slot="state" slot-scope="text">
-      <status :text="text ? text : ''" displayText />
+    <template slot="state" slot-scope="text, record">
+      <status v-if="$route.path.startsWith('/host')" :text="getHostState(record)" displayText />
+      <status v-else :text="text ? text : ''" displayText />
     </template>
     <template slot="allocationstate" slot-scope="text">
       <status :text="text ? text : ''" displayText />
@@ -578,6 +579,12 @@ export default {
       }
 
       return record.nic.filter(e => { return e.ip6address }).map(e => { return e.ip6address }).join(', ') || text
+    },
+    getHostState (host) {
+      if (host && host.hypervisor === 'KVM' && host.state === 'Up' && host.details && host.details.secured !== 'true') {
+        return 'Unsecure'
+      }
+      return host.state
     }
   }
 }

--- a/ui/src/components/widgets/Status.vue
+++ b/ui/src/components/widgets/Status.vue
@@ -127,6 +127,7 @@ export default {
         case 'created':
         case 'maintenance':
         case 'pending':
+        case 'unsecure':
           status = 'warning'
           break
       }


### PR DESCRIPTION
### Description

Matches the legacy UI of showing the host as insecure 
Fixes https://github.com/apache/cloudstack/issues/5256

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):

![Screenshot from 2021-08-09 11-03-05](https://user-images.githubusercontent.com/8244774/128663840-c2bac484-6f6d-4fb7-adef-5b9c80ac4fef.png)

![Screenshot from 2021-08-09 11-02-30](https://user-images.githubusercontent.com/8244774/128663819-5b2b5038-c14b-4054-8b63-6190bad1c2fb.png)
