### PR TITLE
compatibility fix for Packer v1.7.4, update debian template to 10.10.0

### DIFF
--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -1,51 +1,8 @@
 {
   "_license": "Apache License 2.0",
-  "description": "CloudStack SystemVM template",
-  "provisioners": [
-    {
-      "type": "shell",
-      "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
-      "scripts": [
-        "scripts/apt_upgrade.sh",
-        "scripts/configure_grub.sh",
-        "scripts/configure_locale.sh",
-        "scripts/configure_networking.sh",
-        "scripts/configure_acpid.sh",
-        "scripts/install_systemvm_packages.sh",
-        "scripts/configure_conntrack.sh",
-        "scripts/authorized_keys.sh",
-        "scripts/configure_persistent_config.sh",
-        "scripts/configure_login.sh",
-        "../cloud_scripts_shar_archive.sh",
-        "scripts/configure_systemvm_services.sh",
-        "scripts/cleanup.sh",
-        "scripts/finalize.sh"
-      ]
-    }
-  ],
   "builders": [
     {
-      "type": "qemu",
       "accelerator": "kvm",
-      "headless": true,
-      "qemuargs": [
-        [ "-m", "500M" ],
-        [ "-smp", "1" ]
-      ],
-      "format": "qcow2",
-      "disk_size": 2500,
-      "disk_interface": "virtio",
-      "net_device": "virtio-net",
-      "iso_url": "https://cdimage.debian.org/debian-cd/10.8.0/amd64/iso-cd/debian-10.8.0-amd64-netinst.iso",
-      "iso_checksum": "934336d266535c91fcd12cd122c81f8261721efa117fdcb9a31615caa96c5c5ce3454ed5f28f1b25a7b1b5f44631fdfa78a93adb6445e2e2caaf6455ab344cf8",
-      "iso_checksum_type": "sha512",
-      "output_directory": "../dist",
-      "http_directory": "http",
-      "vm_name": "systemvmtemplate",
-      "ssh_username": "cloud",
-      "ssh_password": "cloud",
-      "ssh_wait_timeout": "30m",
-      "boot_wait": "5s",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -64,8 +21,56 @@
         "console-keymaps-at/keymap=us <wait>",
         "<enter><wait>"
       ],
-
-      "shutdown_command": "sudo halt -p"
+      "boot_wait": "5s",
+      "disk_interface": "virtio",
+      "disk_size": "2500M",
+      "format": "qcow2",
+      "headless": true,
+      "http_directory": "http",
+      "iso_checksum": "sha512:87b4c9dd135718304a1b3e68423fe1b03ed52eb67f60563ad14a846aeaaecf53c064dae0f128b2633041992bbc8124b68b6767b529d80487754959b38558e637",
+      "iso_url": "https://cdimage.debian.org/debian-cd/10.10.0/amd64/iso-cd/debian-10.10.0-amd64-netinst.iso",
+      "net_device": "virtio-net",
+      "output_directory": "../dist",
+      "qemuargs": [
+        [
+          "-m",
+          "500M"
+        ],
+        [
+          "-smp",
+          "1"
+        ]
+      ],
+      "shutdown_command": "sudo halt -p",
+      "ssh_password": "cloud",
+      "ssh_timeout": "30m",
+      "ssh_username": "cloud",
+      "type": "qemu",
+      "vm_name": "systemvmtemplate"
+    }
+  ],
+  "description": "CloudStack SystemVM template",
+  "provisioners": [
+    {
+      "execute_command": "echo 'cloud' | sudo -u root -S bash {{.Path}}",
+      "scripts": [
+        "scripts/apt_upgrade.sh",
+        "scripts/configure_grub.sh",
+        "scripts/configure_locale.sh",
+        "scripts/configure_networking.sh",
+        "scripts/configure_acpid.sh",
+        "scripts/install_systemvm_packages.sh",
+        "scripts/configure_conntrack.sh",
+        "scripts/authorized_keys.sh",
+        "scripts/configure_persistent_config.sh",
+        "scripts/configure_login.sh",
+        "../cloud_scripts_shar_archive.sh",
+        "scripts/configure_systemvm_services.sh",
+        "scripts/cleanup.sh",
+        "scripts/finalize.sh"
+      ],
+      "type": "shell"
     }
   ]
 }
+


### PR DESCRIPTION
### Description

Update version of Debian iso to 10.10.0 which is the latest available version.
Fix the template.json file to be compatible with recent version of packer, tested on `Packer v1.7.4`; file generated from `packer fix template.json` command


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

systemvm template build tested in our internal CI-CD. Possible this is a breaking change on non updated packer build system.