### PR TITLE
systemvmtemplate: bump to Debian 11.0.0 systemvmtemplate

### DIFF
--- a/systemvm/debian/etc/systemd/system/baremetal-vr.service
+++ b/systemvm/debian/etc/systemd/system/baremetal-vr.service
@@ -8,5 +8,5 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/cloud/bin
-ExecStart=/usr/bin/python /opt/cloud/bin/baremetal-vr.py
+ExecStart=/usr/bin/python3 /opt/cloud/bin/baremetal-vr.py
 Restart=on-failure

--- a/systemvm/debian/opt/cloud/bin/baremetal-vr.py
+++ b/systemvm/debian/opt/cloud/bin/baremetal-vr.py
@@ -16,13 +16,13 @@
 #under the License.
 
 import subprocess
-import urllib
 import hmac
 import hashlib
 import base64
 import traceback
 import logging
 import re
+import urllib.request, urllib.parse, urllib.error
 
 from flask import Flask
 
@@ -131,10 +131,10 @@ class Server(object):
             "mac": mac
         }
 
-        request = zip(reqs.keys(), reqs.values())
+        request = list(zip(list(reqs.keys()), list(reqs.values())))
         request.sort(key=lambda x: str.lower(x[0]))
-        hashStr = "&".join(["=".join([str.lower(r[0]), str.lower(urllib.quote_plus(str(r[1]))).replace("+", "%20").replace('=', '%3d')]) for r in request])
-        sig = urllib.quote_plus(base64.encodestring(hmac.new(secretkey, hashStr, hashlib.sha1).digest()).strip())
+        hashStr = "&".join(["=".join([str.lower(r[0]), str.lower(urllib.parse.quote_plus(str(r[1]))).replace("+", "%20").replace('=', '%3d')]) for r in request])
+        sig = urllib.parse.quote_plus(base64.encodestring(hmac.new(secretkey, hashStr, hashlib.sha1).digest()).strip())
         return sig
 
     def notify_provisioning_done(self, mac):

--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -36,8 +36,8 @@ function add_backports() {
   sed -i '/deb-src/d' /etc/apt/sources.list
   sed -i '/backports/d' /etc/apt/sources.list
   sed -i '/security/d' /etc/apt/sources.list
-  echo 'deb http://http.debian.net/debian buster-backports main' >> /etc/apt/sources.list
-  echo 'deb http://security.debian.org/debian-security buster/updates main' >> /etc/apt/sources.list
+  echo 'deb http://http.debian.net/debian bullseye-backports main' >> /etc/apt/sources.list
+  echo 'deb http://security.debian.org/debian-security bullseye/updates main' >> /etc/apt/sources.list
 }
 
 function apt_upgrade() {
@@ -56,8 +56,6 @@ function apt_upgrade() {
 
   apt-get -q -y upgrade
   apt-get -q -y dist-upgrade
-  apt-get -q -y upgrade -t buster-backports
-  apt-get -q -y dist-upgrade -t buster-backports
 
   apt-get -y autoremove --purge
   apt-get autoclean

--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -37,7 +37,7 @@ function add_backports() {
   sed -i '/backports/d' /etc/apt/sources.list
   sed -i '/security/d' /etc/apt/sources.list
   echo 'deb http://http.debian.net/debian bullseye-backports main' >> /etc/apt/sources.list
-  echo 'deb http://security.debian.org/debian-security bullseye/updates main' >> /etc/apt/sources.list
+  echo 'deb http://security.debian.org/debian-security bullseye-security main' >> /etc/apt/sources.list
 }
 
 function apt_upgrade() {

--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -60,7 +60,6 @@ function apt_upgrade() {
   apt-get -y autoremove --purge
   apt-get autoclean
   apt-get clean
-  reboot
 }
 
 return 2>/dev/null || apt_upgrade

--- a/tools/appliance/systemvmtemplate/scripts/configure_systemvm_services.sh
+++ b/tools/appliance/systemvmtemplate/scripts/configure_systemvm_services.sh
@@ -65,7 +65,7 @@ function install_cloud_scripts() {
     /etc/profile.d/cloud.sh /etc/cron.daily/* /etc/cron.hourly/*
 
   chmod +x /root/health_checks/*
-  chmod -x /etc/systemd/system/*
+  chmod -x /etc/systemd/system/* || true
 
   systemctl daemon-reload
   systemctl enable cloud-early-config
@@ -108,7 +108,7 @@ function configure_services() {
   systemctl disable haproxy
   systemctl disable keepalived
   systemctl disable radvd
-  systemctl disable strongswan
+  systemctl disable strongswan-starter
   systemctl disable x11-common
   systemctl disable xl2tpd
   systemctl disable vgauth

--- a/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
+++ b/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
@@ -42,7 +42,7 @@ function install_packages() {
 
   debconf_packages
 
-  local apt_get="apt-get --no-install-recommends -q -y -t buster-backports"
+  local apt_get="apt-get --no-install-recommends -q -y"
 
   ${apt_get} install grub-legacy \
     rsyslog logrotate cron net-tools ifupdown tmux vim-tiny htop netbase iptables nftables \

--- a/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
+++ b/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
@@ -47,10 +47,11 @@ function install_packages() {
   ${apt_get} install grub-legacy \
     rsyslog logrotate cron net-tools ifupdown tmux vim-tiny htop netbase iptables nftables \
     openssh-server e2fsprogs tcpdump iftop socat wget coreutils systemd \
-    python python3 bzip2 sed gawk diffutils grep gzip less tar telnet ftp rsync traceroute psmisc lsof procps \
+    python python3 python3-flask ieee-data \
+    bzip2 sed gawk diffutils grep gzip less tar telnet ftp rsync traceroute psmisc lsof procps \
     inetutils-ping iputils-arping httping curl \
     dnsutils zip unzip ethtool uuid file iproute2 acpid sudo \
-    sysstat python-netaddr \
+    sysstat \
     apache2 ssl-cert \
     dnsmasq dnsmasq-utils \
     nfs-common \
@@ -59,18 +60,20 @@ function install_packages() {
     xenstore-utils libxenstore3.0 \
     ipvsadm conntrackd libnetfilter-conntrack3 \
     keepalived irqbalance \
-    ipcalc \
     openjdk-11-jre-headless \
-    ipset \
+    ipcalc ipset \
     iptables-persistent \
     libtcnative-1 libssl-dev libapr1-dev \
-    python-flask \
     haproxy \
     haveged \
     radvd \
     sharutils genisoimage \
     strongswan libcharon-extra-plugins libstrongswan-extra-plugins strongswan-charon strongswan-starter \
     virt-what open-vm-tools qemu-guest-agent hyperv-daemons
+
+  # python2-netaddr workaround
+  wget https://github.com/shapeblue/cloudstack-nonoss/raw/main/python-netaddr_0.7.19-1_all.deb
+  dpkg -i python-netaddr_0.7.19-1_all.deb
 
   apt-get -y autoremove --purge
   apt-get clean

--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -27,8 +27,8 @@
       "format": "qcow2",
       "headless": true,
       "http_directory": "http",
-      "iso_checksum": "sha512:87b4c9dd135718304a1b3e68423fe1b03ed52eb67f60563ad14a846aeaaecf53c064dae0f128b2633041992bbc8124b68b6767b529d80487754959b38558e637",
-      "iso_url": "https://cdimage.debian.org/debian-cd/10.10.0/amd64/iso-cd/debian-10.10.0-amd64-netinst.iso",
+      "iso_checksum": "sha512:5f6aed67b159d7ccc1a90df33cc8a314aa278728a6f50707ebf10c02e46664e383ca5fa19163b0a1c6a4cb77a39587881584b00b45f512b4a470f1138eaa1801",
+      "iso_url": "https://cdimage.debian.org/debian-cd/11.0.0/amd64/iso-cd/debian-11.0.0-amd64-netinst.iso",
       "net_device": "virtio-net",
       "output_directory": "../dist",
       "qemuargs": [

--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -23,7 +23,7 @@
       ],
       "boot_wait": "5s",
       "disk_interface": "virtio",
-      "disk_size": "2500M",
+      "disk_size": "4000M",
       "format": "qcow2",
       "headless": true,
       "http_directory": "http",


### PR DESCRIPTION
Debian 11 "bullseye" systemvmtemplate.
The 4.15.1 systemvmtemplate used buster-backports so likely the difference between that and Debian 11 (kernel and major packages) hopefully won't be huge.