### PR TITLE
Fix iptable rules in ubuntu 20 for bridge name

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -185,7 +185,7 @@ def destroy_network_rules_for_nic(vm_name, vm_ip, vm_mac, vif, sec_ips):
         logging.debug("Ignoring failure to delete ebtable rules for vm: " + vm_name)
 
 def get_bridge_physdev(brname):
-    physdev = execute("bridge -o link show | awk '/master %s / && !/^[0-9]+: vnet/ {print $2}' | head -1 | cut -d ':' -f1" % brname)
+    physdev = execute("bridge -o link show | awk '/master %s / && !/^[0-9]+: vnet/ {print $2}' | head -1 | cut -d ':' -f1 | cut -d '@' -f1" % brname)
     return physdev.strip()
 
 


### PR DESCRIPTION
### Description
In ubuntu20 the interface name contains @ synbol and
because of that even the iptable rules for brdige name
contains this symbol which causes ping issues.
Remove the @ symbol from iptable rule to fix the issue


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [X] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

This the output from ubuntu16

```
# bridge -o link show | awk '/master breth0-2999 / && !/^[0-9]+: vnet/ {print $2}'
eth0.2999
```

And iptable rule is
```
-A BF-breth0-2999 -m physdev --physdev-out eth0.2999 --physdev-is-bridged -j ACCEPT
```


This is the output from ubuntu20

```
# bridge -o link show | awk '/master brens3-2999 / && !/^[0-9]+: vnet/ {print $2}'
ens3.2999@ens3
```

And iptable rule is

```
-A BF-brens3-2999 -m physdev --physdev-out ens3.2999@ens3 --physdev-is-bridged -j ACCEPT
```


After the fix, below is the output from ubuntu20

```
# bridge -o link show | awk '/master brens3-1989 / && !/^[0-9]+: vnet/ {print $2}'
ens3.1989@ens3
```

iptable rule is

```
-A BF-brens3-1989 -m physdev --physdev-out ens3.1989 --physdev-is-bridged -j ACCEPT
```


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
