### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,11 +186,11 @@ env:
              component/test_vpc_routers
              component/test_vpn_users"
 
-before_install: travis_wait 30 ./tools/travis/before_install.sh
+before_install: ./tools/travis/before_install.sh
 install: ./tools/travis/install.sh
-before_script: travis_wait 30 ./tools/travis/before_script.sh
+before_script: ./tools/travis/before_script.sh
 script:
-  - travis_wait 40 ./tools/travis/script.sh ${TESTS}
+  - ./tools/travis/script.sh ${TESTS}
 after_success: ./tools/travis/after_success.sh
 after_failure: ./tools/travis/after_failure.sh
 after_script: ./tools/travis/after_script.sh


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
