### PR TITLE
s2svpn: Set initial state as Connecting

### DIFF
--- a/api/src/main/java/com/cloud/network/Site2SiteVpnConnection.java
+++ b/api/src/main/java/com/cloud/network/Site2SiteVpnConnection.java
@@ -24,7 +24,7 @@ import org.apache.cloudstack.api.InternalIdentity;
 
 public interface Site2SiteVpnConnection extends ControlledEntity, InternalIdentity, Displayable {
     enum State {
-        Pending, Connected, Disconnected, Error,
+        Pending, Connecting, Connected, Disconnected, Error,
     }
 
     @Override

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -817,7 +817,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             }
             final List<String> ipList = new ArrayList<String>();
             for (final Site2SiteVpnConnectionVO conn : conns) {
-                if (conn.getState() != Site2SiteVpnConnection.State.Connected && conn.getState() != Site2SiteVpnConnection.State.Disconnected) {
+                if (conn.getState() != Site2SiteVpnConnection.State.Connected && conn.getState() != Site2SiteVpnConnection.State.Disconnected  && conn.getState() != Site2SiteVpnConnection.State.Connecting) {
                     continue;
                 }
                 final Site2SiteCustomerGateway gw = _s2sCustomerGatewayDao.findById(conn.getCustomerGatewayId());
@@ -853,7 +853,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                         throw new CloudRuntimeException("Unable to acquire lock for site to site vpn connection id " + conn.getId());
                     }
                     try {
-                        if (conn.getState() != Site2SiteVpnConnection.State.Connected && conn.getState() != Site2SiteVpnConnection.State.Disconnected) {
+                        if (conn.getState() != Site2SiteVpnConnection.State.Connected && conn.getState() != Site2SiteVpnConnection.State.Disconnected && conn.getState() != Site2SiteVpnConnection.State.Connecting) {
                             continue;
                         }
                         final Site2SiteVpnConnection.State oldState = conn.getState();

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -817,7 +817,8 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             }
             final List<String> ipList = new ArrayList<String>();
             for (final Site2SiteVpnConnectionVO conn : conns) {
-                if (conn.getState() != Site2SiteVpnConnection.State.Connected && conn.getState() != Site2SiteVpnConnection.State.Disconnected  && conn.getState() != Site2SiteVpnConnection.State.Connecting) {
+                if (conn.getState() != Site2SiteVpnConnection.State.Connected && conn.getState() != Site2SiteVpnConnection.State.Disconnected
+                    && conn.getState() != Site2SiteVpnConnection.State.Connecting) {
                     continue;
                 }
                 final Site2SiteCustomerGateway gw = _s2sCustomerGatewayDao.findById(conn.getCustomerGatewayId());

--- a/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -347,7 +347,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
                 if (conn.isPassive()) {
                     conn.setState(State.Disconnected);
                 } else {
-                    conn.setState(State.Connected);
+                    conn.setState(State.Connecting);
                 }
                 _vpnConnectionDao.persist(conn);
                 return conn;

--- a/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -530,7 +530,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
                     continue;
                 }
                 try {
-                    if (conn.getState() == State.Connected || conn.getState() == State.Error) {
+                    if (conn.getState() == State.Connected || conn.getState() == State.Connecting || conn.getState() == State.Error) {
                         stopVpnConnection(conn.getId());
                     }
                     startVpnConnection(conn.getId());
@@ -608,7 +608,8 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         if (conn.getState() == State.Pending) {
             conn.setState(State.Disconnected);
         }
-        if (conn.getState() == State.Connected || conn.getState() == State.Error || conn.getState() == State.Disconnected) {
+        if (conn.getState() == State.Connected || conn.getState() == State.Error
+            || conn.getState() == State.Disconnected || conn.getState() == State.Connecting) {
             stopVpnConnection(id);
         }
         startVpnConnection(id);
@@ -795,7 +796,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
                 throw new CloudRuntimeException("Unable to acquire lock on " + conn);
             }
             try {
-                if (conn.getState() == Site2SiteVpnConnection.State.Connected) {
+                if (conn.getState() == Site2SiteVpnConnection.State.Connected || conn.getState() == Site2SiteVpnConnection.State.Connecting) {
                     conn.setState(Site2SiteVpnConnection.State.Disconnected);
                     _vpnConnectionDao.persist(conn);
                 }

--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -618,7 +618,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         self.logger.debug("Network %s created in VPC %s" % (ntwk2.id, vpc2.id))
 
         vm1 = None
-        # Deploy a vm in network 2
+        # Deploy a vm in network 1
         try:
             vm1 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
                                         templateid=self.template.id,
@@ -990,7 +990,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         self.cleanup.append(ntwk2)
         self.logger.debug("Network %s created in VPC %s" % (ntwk2.id, vpc2.id))
 
-        # Deploy a vm in network 2
+        # Deploy a vm in network 1
         vm1 = None
         try:
             vm1 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
@@ -1370,7 +1370,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         self.logger.debug("Network %s created in VPC %s" % (ntwk2.id, vpc2.id))
 
         vm1 = None
-        # Deploy a vm in network 2
+        # Deploy a vm in network 1
         try:
             vm1 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
                                         templateid=self.template.id,


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/5179

Sets the initial state of an s2svpn as connecting

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

#### Initial State :

![Screenshot from 2021-08-17 15-38-27](https://user-images.githubusercontent.com/8244774/129712963-eef360dd-8bcd-4a08-9c43-b8615d35a6fd.png)

#### Invalid gateway :

![Screenshot from 2021-08-17 15-53-30](https://user-images.githubusercontent.com/8244774/129712891-0c1d5e80-e53f-45da-980f-144eacdae668.png)

#### Valid gateway :

![Screenshot from 2021-08-17 16-12-30](https://user-images.githubusercontent.com/8244774/129713071-6d97811a-7523-4058-8be1-ffb8500ecccf.png)

### How has this been tested ?

```
Test Site 2 Site VPN Across redundant VPCs ... === TestName: test_01_redundant_vpc_site2site_vpn | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across VPCs ... === TestName: test_01_vpc_site2site_vpn_multiple_options | Status : SUCCESS ===
ok
Test Remote Access VPN in VPC ... === TestName: test_01_vpc_remote_access_vpn | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across VPCs ... === TestName: test_01_vpc_site2site_vpn | Status : SUCCESS ===
ok
```


