### PR TITLE
Fix iptable rules when chain reference count is 0

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -1327,9 +1327,11 @@ def add_fw_framework(brname):
 
     try:
         refs = int(execute("""iptables -n -L %s | awk '/%s(.*)references/ {gsub(/\(/, "") ;print $3}'""" % (brfw,brfw)).strip())
+        refs_in = int(execute("""iptables -n -L %s-IN | awk '/%s-IN(.*)references/ {gsub(/\(/, "") ;print $3}'""" % (brfw,brfw)).strip())
+        refs_out = int(execute("""iptables -n -L %s-OUT | awk '/%s-OUT(.*)references/ {gsub(/\(/, "") ;print $3}'""" % (brfw,brfw)).strip())
         refs6 = int(execute("""ip6tables -n -L %s | awk '/%s(.*)references/ {gsub(/\(/, "") ;print $3}'""" % (brfw,brfw)).strip())
 
-        if refs == 0:
+        if refs == 0 or refs_in == 0 or refs_out == 0:
             execute("iptables -I FORWARD -i " + brname + " -j DROP")
             execute("iptables -I FORWARD -o " + brname + " -j DROP")
             execute("iptables -I FORWARD -i " + brname + " -m physdev --physdev-is-bridged -j " + brfw)


### PR DESCRIPTION
### Description
Sometimes the chain reference count is 0 and in that case
proper iptables rules are not applied. Because of this, ping fails.
So check the reference count for the main chain and as well as
-IN and -OUT chain as well


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [X] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

**Before the fix**

**Iptable rules on NON working node**

```
# iptables -n -L | grep BF-brbond0-94
BF-brbond0-94  all  --  0.0.0.0/0            0.0.0.0/0            PHYSDEV match --physdev-is-bridged
BF-brbond0-94  all  --  0.0.0.0/0            0.0.0.0/0            PHYSDEV match --physdev-is-bridged
Chain BF-brbond0-94 (2 references)
Chain BF-brbond0-94-IN (0 references) <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
Chain BF-brbond0-94-OUT (0 references)
```

```
# iptables-save |grep -w BF-brbond0-94
:BF-brbond0-94 - [0:0]
:BF-brbond0-94-IN - [0:0]
:BF-brbond0-94-OUT - [0:0]
-A FORWARD -o brbond0-94 -m physdev --physdev-is-bridged -j BF-brbond0-94
-A FORWARD -i brbond0-94 -m physdev --physdev-is-bridged -j BF-brbond0-94
-A BF-brbond0-94-IN -m physdev --physdev-in vnet7 --physdev-is-bridged -j i-2-6394-def
-A BF-brbond0-94-OUT -m physdev --physdev-out vnet7 --physdev-is-bridged -j i-2-6394-def
```

The iptables-save command is missing bond rule


**iptable rules on WORKING node**

```
# iptables -n -L | grep BF-brbond0-94
BF-brbond0-94  all  --  0.0.0.0/0            0.0.0.0/0            PHYSDEV match --physdev-is-bridged
BF-brbond0-94  all  --  0.0.0.0/0            0.0.0.0/0            PHYSDEV match --physdev-is-bridged
Chain BF-brbond0-94 (2 references)
BF-brbond0-94-IN  all  --  0.0.0.0/0            0.0.0.0/0            PHYSDEV match --physdev-is-in --physdev-is-bridged
BF-brbond0-94-OUT  all  --  0.0.0.0/0            0.0.0.0/0            PHYSDEV match --physdev-is-out --physdev-is-bridged
Chain BF-brbond0-94-IN (1 references)
Chain BF-brbond0-94-OUT (1 references) <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
```

```
# iptables-save |grep -w BF-brbond0-94
:BF-brbond0-94 - [0:0]
:BF-brbond0-94-IN - [0:0]
:BF-brbond0-94-OUT - [0:0]
-A FORWARD -o brbond0-94 -m physdev --physdev-is-bridged -j BF-brbond0-94
-A FORWARD -i brbond0-94 -m physdev --physdev-is-bridged -j BF-brbond0-94
-A BF-brbond0-94 -m state --state RELATED,ESTABLISHED -j ACCEPT
-A BF-brbond0-94 -m physdev --physdev-is-in --physdev-is-bridged -j BF-brbond0-94-IN <<<<<<<<<<<<<<<<<<<
-A BF-brbond0-94 -m physdev --physdev-is-out --physdev-is-bridged -j BF-brbond0-94-OUT <<<<<<<<<<<<<<<<
-A BF-brbond0-94 -m physdev --physdev-out bond0.94 --physdev-is-bridged -j ACCEPT <<<<<<<<<<<<<<<<<<<<
```


**After the fix**

iptable rules from the security_group.log file

```
2021-08-17 14:42:54,168 - bridge -o link show | awk '/master brbond0-94 / && !/^[0-9]+: vnet/ {print $2}' | head -1 | cut -d ':' -f1
2021-08-17 14:42:54,183 - iptables -n -L BF-brbond0-94 | awk '/BF-brbond0-94(.*)references/ {gsub(/\(/, "") ;print $3}'
2021-08-17 14:42:54,192 - iptables -n -L BF-brbond0-94-IN | awk '/BF-brbond0-94-IN(.*)references/ {gsub(/\(/, "") ;print $3}'
2021-08-17 14:42:54,201 - iptables -n -L BF-brbond0-94-OUT | awk '/BF-brbond0-94-OUT(.*)references/ {gsub(/\(/, "") ;print $3}'
2021-08-17 14:42:54,209 - ip6tables -n -L BF-brbond0-94 | awk '/BF-brbond0-94(.*)references/ {gsub(/\(/, "") ;print $3}'
2021-08-17 14:42:54,213 - ip6tables -I FORWARD -i brbond0-94 -j DROP
2021-08-17 14:42:54,217 - ip6tables -I FORWARD -o brbond0-94 -j DROP
2021-08-17 14:42:54,220 - ip6tables -I FORWARD -i brbond0-94 -m physdev --physdev-is-bridged -j BF-brbond0-94
2021-08-17 14:42:54,224 - ip6tables -I FORWARD -o brbond0-94 -m physdev --physdev-is-bridged -j BF-brbond0-94
2021-08-17 14:42:54,228 - ip6tables -A BF-brbond0-94 -m state --state RELATED,ESTABLISHED -j ACCEPT
2021-08-17 14:42:54,231 - ip6tables -A BF-brbond0-94 -m physdev --physdev-is-bridged --physdev-is-in -j BF-brbond0-94-IN
2021-08-17 14:42:54,235 - ip6tables -A BF-brbond0-94 -m physdev --physdev-is-bridged --physdev-is-out -j BF-brbond0-94-OUT
2021-08-17 14:42:54,239 - ip6tables -A BF-brbond0-94 -m physdev --physdev-is-bridged --physdev-out bond0.94 -j ACCEPT
2021-08-17 14:42:54,243 - iptables-save |grep physdev-is-bridged |grep FORWARD |grep BF |grep '\-o' | grep -w brbond0-94|awk '{print $9}' | head -1
2021-08-17 14:42:54,272 - iptables-save | awk '/BF(.*)physdev-is-bridged(.*)i-2-6394-def/ { sub(/-A/, "-D", $1) ; print }'
2021-08-17 14:42:54,293 - ip6tables-save | awk '/BF(.*)physdev-is-bridged(.*)i-2-6394-def/ { sub(/-A/, "-D", $1) ; print }'
2021-08-17 14:42:54,299 - ebtables -t nat -L PREROUTING | grep i-2-6394-VM
```
### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
