### PR TITLE
xcp-ng: allow passing vm boot options

### DIFF
--- a/plugins/hypervisors/xenserver/pom.xml
+++ b/plugins/hypervisors/xenserver/pom.xml
@@ -48,5 +48,10 @@
             <artifactId>xen-api</artifactId>
             <version>${cs.xapi.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.6.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -319,7 +319,9 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 details.put("username", username);
                 params.put("username", username);
                 details.put("password", password);
-                details.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.toString(isUefiSupported(prodVersion)));
+                if (isUefiSupported(prodVersion)) {
+                    details.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
+                }
                 params.put("password", password);
                 params.put("zone", Long.toString(dcId));
                 params.put("guid", record.uuid);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -33,6 +33,7 @@ import javax.persistence.EntityExistsException;
 import org.apache.cloudstack.hypervisor.xenserver.XenserverConfigs;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.xmlrpc.XmlRpcException;
 
 import com.cloud.agent.AgentManager;
@@ -129,7 +130,8 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
         if (StringUtils.isEmpty(hostProductVersion)) {
             return false;
         }
-        return hostProductVersion.compareTo(MIN_UEFI_SUPPORTED_VERSION) >= 0;
+        ComparableVersion version = new ComparableVersion(hostProductVersion);
+        return version.compareTo(new ComparableVersion(MIN_UEFI_SUPPORTED_VERSION)) >= 0;
     }
 
     protected XcpServerDiscoverer() {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -31,6 +31,7 @@ import javax.naming.ConfigurationException;
 import javax.persistence.EntityExistsException;
 
 import org.apache.cloudstack.hypervisor.xenserver.XenserverConfigs;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
@@ -121,6 +122,15 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
 
     private String xenServerIsoName = TemplateManager.XS_TOOLS_ISO;
     private String xenServerIsoDisplayText = "XenServer Tools Installer ISO (xen-pv-drv-iso)";
+
+    public final static String MIN_UEFI_SUPPORTED_VERSION = "8.2";
+
+    public static boolean isUefiSupported(String hostProductVersion) {
+        if (StringUtils.isEmpty(hostProductVersion)) {
+            return false;
+        }
+        return hostProductVersion.compareTo(MIN_UEFI_SUPPORTED_VERSION) >= 0;
+    }
 
     protected XcpServerDiscoverer() {
     }
@@ -309,6 +319,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 details.put("username", username);
                 params.put("username", username);
                 details.put("password", password);
+                details.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.toString(isUefiSupported(prodVersion)));
                 params.put("password", password);
                 params.put("zone", Long.toString(dcId));
                 params.put("guid", record.uuid);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1955,7 +1955,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         boolean isSecure = bootType.equals(ApiConstants.BootType.UEFI.toString()) &&
                 ApiConstants.BootMode.SECURE.toString().equals(bootMode);
         final Map<String, String> bootParams = vm.getHVMBootParams(conn);
-        bootParams.replace("firmware", bootType);
+        bootParams.replace("firmware", bootType.toLowerCase());
         vm.setHVMBootParams(conn, bootParams);
         final Map<String, String> platform = vm.getPlatform(conn);
         platform.put("secureboot", isSecure ? "true" : "false");

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1952,13 +1952,13 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         if (!ApiConstants.BootType.UEFI.toString().equals(bootType)) {
             bootType = ApiConstants.BootType.BIOS.toString();
         }
-        boolean isSecure = bootType.equals(ApiConstants.BootType.UEFI.toString()) &&
+        Boolean isSecure = bootType.equals(ApiConstants.BootType.UEFI.toString()) &&
                 ApiConstants.BootMode.SECURE.toString().equals(bootMode);
         final Map<String, String> bootParams = vm.getHVMBootParams(conn);
         bootParams.replace("firmware", bootType.toLowerCase());
         vm.setHVMBootParams(conn, bootParams);
         final Map<String, String> platform = vm.getPlatform(conn);
-        platform.put("secureboot", Boolean.toString(isSecure));
+        platform.put("secureboot", isSecure.toString());
         vm.setPlatform(conn, platform);
     }
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
+import static com.cloud.hypervisor.xenserver.discoverer.XcpServerDiscoverer.isUefiSupported;
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 import java.io.BufferedReader;
@@ -1790,6 +1791,9 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             }
             details.put("product_brand", productBrand);
             details.put("product_version", _host.getProductVersion());
+            if (isUefiSupported(_host.getProductVersion())) {
+                details.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
+            }
             if (hr.softwareVersion.get("product_version_text_short") != null) {
                 details.put("product_version_text_short", hr.softwareVersion.get("product_version_text_short"));
                 cmd.setHypervisorVersion(hr.softwareVersion.get("product_version_text_short"));

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1440,7 +1440,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             throw new CloudRuntimeException("Unable to finalize VM MetaData: " + vmSpec);
         }
         try {
-            setVmBootDetails(vm, conn, vmSpec.getBootMode(), vmSpec.getBootType());
+            setVmBootDetails(vm, conn, vmSpec.getBootType(), vmSpec.getBootMode());
         } catch (final XenAPIException | XmlRpcException e) {
             throw new CloudRuntimeException(String.format("Unable to handle VM boot options: %s", vmSpec), e);
         }
@@ -1958,7 +1958,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         bootParams.replace("firmware", bootType.toLowerCase());
         vm.setHVMBootParams(conn, bootParams);
         final Map<String, String> platform = vm.getPlatform(conn);
-        platform.put("secureboot", isSecure ? "true" : "false");
+        platform.put("secureboot", Boolean.toString(isSecure));
         vm.setPlatform(conn, platform);
     }
 

--- a/plugins/hypervisors/xenserver/src/test/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscovererTest.java
+++ b/plugins/hypervisors/xenserver/src/test/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscovererTest.java
@@ -17,6 +17,7 @@
 
 package com.cloud.hypervisor.xenserver.discoverer;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
@@ -69,5 +70,26 @@ public class XcpServerDiscovererTest {
         inOrder.verify(vmTemplateVOMock).setUrl(null);
         inOrder.verify(vmTemplateVOMock).setDisplayText("XenServer Tools Installer ISO (xen-pv-drv-iso)");
         inOrder.verify(vmTemplateDao).update(1L, vmTemplateVOMock);
+    }
+
+    @Test
+    public void uefiSupportedVersionTest() {
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("8.2"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("8.2.0"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("8.2.1"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("9"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("9.1"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("9.1.0"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("10"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("10.1"));
+        Assert.assertTrue(XcpServerDiscoverer.isUefiSupported("10.1.0"));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported(null));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported(""));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported("abc"));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported("0"));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported("7.4"));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported("8"));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported("8.1"));
+        Assert.assertFalse(XcpServerDiscoverer.isUefiSupported("8.1.0"));
     }
 }

--- a/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -123,7 +123,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
                 isVMDeployedWithUefi = true;
             }
         }
-        s_logger.info(" Guest VM is requested with Cusotm[UEFI] Boot Type "+ isVMDeployedWithUefi);
+        s_logger.info(" Guest VM is requested with Custom[UEFI] Boot Type "+ isVMDeployedWithUefi);
 
 
         if (type == Host.Type.Storage) {

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -491,10 +491,9 @@
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div
-                      v-if="vm.templateid && ['KVM', 'VMware'].includes(hypervisor) && !template.deployasis">
+                      v-if="vm.templateid && ['KVM', 'VMware', 'Xenserver'].includes(hypervisor) && !template.deployasis">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
-                          :autoFocus="vm.templateid && ['KVM', 'VMware'].includes(hypervisor) && !template.deployasis"
                           v-decorator="['boottype']"
                           @change="fetchBootModes"
                         >

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -491,7 +491,7 @@
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div
-                      v-if="vm.templateid && ['KVM', 'VMware', 'Xenserver'].includes(hypervisor) && !template.deployasis">
+                      v-if="vm.templateid && ['KVM', 'VMware', 'XenServer'].includes(hypervisor) && !template.deployasis">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
                           v-decorator="['boottype']"


### PR DESCRIPTION
### Description
Allows selecting boot type and boot mode for Xenserver/XCP-ng in UI.
XCP-ng 8.2 allows UEFI boot type for guest VMs.
Changes allow setting and updating the host's UEFI capability in DB while adding or re-connection. It allows honoring VM details while orchestrating VM start on XCP-ng hypervisor

Addresses #5204 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- Deployed ACS 4.15.1 env with 2x XCP-ng 8.1 hosts
- Deployed Windows 10, Windows Server 2019, and Windows Server 2008 R2 VMs
- Stopped VMs to upgrade XCP-ng hosts.
- Upgraded ACS and upgraded XCP-ng hosts to 8.2
- Started VMs. <- VM started fine (had to change guest_os for Windows Server 2008 R2 VM) 

Also, tested Windows Server 2019 deployment with UEFI boot type:
```
(localcloud) SBCM5> > list virtualmachines id=a5187ead-dba6-4a27-831d-4edd8cf6f9d8 filter=id,name,hostid,hostname,state,templateid,templatename,guestosid,details,
{
  "count": 1,
  "virtualmachine": [
    {
      "details": {
        "UEFI": "LEGACY",
        "cpuOvercommitRatio": "3.0",
        "hypervisortoolsversion": "xenserver61",
        "memoryOvercommitRatio": "2.0",
        "platform": "device-model:qemu-upstream-uefi;videoram:8;viridian_stimer:true;apic:true;device_id:0002;viridian:true;timeoffset:0;viridian_reference_tsc:true;hpet:true;nx:true;viridian_time_ref_count:true;viridian_crash_ctl:true;vga:std;viridian_apic_assist:true;cores-per-socket:2;pae:true;acpi:1;secureboot:false"
      },
      "guestosid": "030bb751-0498-11ec-b7f6-1e00cb00014b",
      "hostid": "6f6a1c45-7d22-4045-b619-b6a63851afbd",
      "hostname": "pr5335-t1757-xcpng81-xs2",
      "id": "a5187ead-dba6-4a27-831d-4edd8cf6f9d8",
      "name": "t18",
      "state": "Running",
      "templateid": "20e24144-932e-46c7-b6a6-1d61ca645e0b",
      "templatename": "WinServer2019"
    }
  ]
}
(localcloud) SBCM5> > list hosts id=6f6a1c45-7d22-4045-b619-b6a63851afbd filter=id,name,hypervisor,hypervisorversion,details
{
  "count": 1,
  "host": [
    {
      "hypervisor": "XenServer",
      "hypervisorversion": "8.2.0",
      "id": "6f6a1c45-7d22-4045-b619-b6a63851afbd",
      "name": "pr5335-t1757-xcpng81-xs2"
    }
  ]
}
```

```
[11:54 pr5335-t1757-xcpng81-xs2 ~]# xe vm-list uuid=061f8ba3-0add-3ca8-a488-692369f6c55a params=uuid,name-label,platform,HVM-boot-params
uuid ( RO)               : 061f8ba3-0add-3ca8-a488-692369f6c55a
         name-label ( RW): i-2-21-VM
           platform (MRW): timeoffset: 0; device-model: qemu-upstream-uefi; videoram: 8; viridian_stimer: true; apic: true; device_id: 0002; viridian: true; viridian_reference_tsc: true; hpet: true; nx: true; viridian_time_ref_count: true; viridian_crash_ctl: true; vga: std; viridian_apic_assist: true; cores-per-socket: 2; pae: true; acpi: 1; secureboot: false
    HVM-boot-params (MRW): firmware: uefi; order: dc
```


![Screenshot from 2021-08-24 16-52-53](https://user-images.githubusercontent.com/153340/130608902-90c64589-140b-40f0-868f-d2081658aa58.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
