### PR TITLE
Bypass empty string check for username and password

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/host/AddHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/host/AddHostCmd.java
@@ -54,7 +54,7 @@ public class AddHostCmd extends BaseCmd {
     @Parameter(name = ApiConstants.CLUSTER_NAME, type = CommandType.STRING, description = "the cluster name for the host")
     private String clusterName;
 
-    @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING, required = true, description = "the password for the host")
+    @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING, description = "the password for the host")
     private String password;
 
     @Parameter(name = ApiConstants.POD_ID, type = CommandType.UUID, entityType = PodResponse.class, required = true, description = "the Pod ID for the host")
@@ -63,7 +63,7 @@ public class AddHostCmd extends BaseCmd {
     @Parameter(name = ApiConstants.URL, type = CommandType.STRING, required = true, description = "the host URL")
     private String url;
 
-    @Parameter(name = ApiConstants.USERNAME, type = CommandType.STRING, required = true, description = "the username for the host")
+    @Parameter(name = ApiConstants.USERNAME, type = CommandType.STRING, description = "the username for the host")
     private String username;
 
     @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class, required = true, description = "the Zone ID for the host")

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/host/AddHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/host/AddHostCmd.java
@@ -54,7 +54,10 @@ public class AddHostCmd extends BaseCmd {
     @Parameter(name = ApiConstants.CLUSTER_NAME, type = CommandType.STRING, description = "the cluster name for the host")
     private String clusterName;
 
-    @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING, description = "the password for the host")
+    @Parameter(name = ApiConstants.USERNAME, type = CommandType.STRING, description = "the username for the host; required to be passed for hypervisors other than VMWare")
+    private String username;
+
+    @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING, description = "the password for the host; required to be passed for hypervisors other than VMWare")
     private String password;
 
     @Parameter(name = ApiConstants.POD_ID, type = CommandType.UUID, entityType = PodResponse.class, required = true, description = "the Pod ID for the host")
@@ -62,9 +65,6 @@ public class AddHostCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.URL, type = CommandType.STRING, required = true, description = "the host URL")
     private String url;
-
-    @Parameter(name = ApiConstants.USERNAME, type = CommandType.STRING, description = "the username for the host")
-    private String username;
 
     @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class, required = true, description = "the Zone ID for the host")
     private Long zoneId;

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -24,6 +24,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -70,6 +71,7 @@ public class ParamProcessWorker implements DispatchWorker {
     private static final Logger s_logger = Logger.getLogger(ParamProcessWorker.class.getName());
     public final DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
     public final DateFormat newInputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    public static final List<String> avoidList = new ArrayList<>(Arrays.asList("username", "password"));
 
     @Inject
     protected AccountManager _accountMgr;
@@ -94,6 +96,9 @@ public class ParamProcessWorker implements DispatchWorker {
     }
 
     private void validateNonEmptyString(final Object param, final String argName) {
+        if (avoidList.contains(argName)) {
+            return;
+        }
         if (param == null || Strings.isNullOrEmpty(param.toString())) {
             throw new InvalidParameterValueException(String.format("Empty or null value provided for API arg: %s", argName));
         }

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -41,6 +41,7 @@ import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.ApiArgValidator;
+import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCreateCmd;
 import org.apache.cloudstack.api.BaseCmd;
@@ -71,7 +72,7 @@ public class ParamProcessWorker implements DispatchWorker {
     private static final Logger s_logger = Logger.getLogger(ParamProcessWorker.class.getName());
     public final DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
     public final DateFormat newInputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    public static final List<String> avoidList = new ArrayList<>(Arrays.asList("username", "password"));
+    public static final List<String> avoidList = new ArrayList<>(Arrays.asList(ApiConstants.USERNAME, ApiConstants.PASSWORD));
 
     @Inject
     protected AccountManager _accountMgr;

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -24,7 +24,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -41,7 +40,6 @@ import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.ApiArgValidator;
-import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCreateCmd;
 import org.apache.cloudstack.api.BaseCmd;
@@ -72,7 +70,6 @@ public class ParamProcessWorker implements DispatchWorker {
     private static final Logger s_logger = Logger.getLogger(ParamProcessWorker.class.getName());
     public final DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
     public final DateFormat newInputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    public static final List<String> avoidList = new ArrayList<>(Arrays.asList(ApiConstants.USERNAME, ApiConstants.PASSWORD));
 
     @Inject
     protected AccountManager _accountMgr;
@@ -97,9 +94,6 @@ public class ParamProcessWorker implements DispatchWorker {
     }
 
     private void validateNonEmptyString(final Object param, final String argName) {
-        if (avoidList.contains(argName)) {
-            return;
-        }
         if (param == null || Strings.isNullOrEmpty(param.toString())) {
             throw new InvalidParameterValueException(String.format("Empty or null value provided for API arg: %s", argName));
         }

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -688,7 +688,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         if ((clusterName != null || clusterId != null) && podId == null) {
             throw new InvalidParameterValueException("Can't specify cluster without specifying the pod");
         }
-        if (!hypervisorType.equalsIgnoreCase(HypervisorType.VMware.toString()) &&
+        if (!HypervisorType.VMware.toString().equalsIgnoreCase(hypervisorType) &&
                 (Strings.isNullOrEmpty(username) || Strings.isNullOrEmpty(password))) {
             throw new InvalidParameterValueException("Username and Password need to be provided.");
         }

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -44,6 +44,7 @@ import com.cloud.storage.dao.DiskOfferingDao;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.VirtualMachineProfileImpl;
+import com.google.common.base.Strings;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.command.admin.cluster.AddClusterCmd;
 import org.apache.cloudstack.api.command.admin.cluster.DeleteClusterCmd;
@@ -686,6 +687,10 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         if ((clusterName != null || clusterId != null) && podId == null) {
             throw new InvalidParameterValueException("Can't specify cluster without specifying the pod");
+        }
+        if (!hypervisorType.equalsIgnoreCase(HypervisorType.VMware.toString()) &&
+                (Strings.isNullOrEmpty(username) || Strings.isNullOrEmpty(password))) {
+            throw new InvalidParameterValueException("Username and Password need to be provided.");
         }
 
         if (clusterId != null) {


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/5332
This PR attempts to bypass the empty string check added in ParamProcessorValidator - for username and password, so that in case of vmware, it doesn't fail during addition of hosts (where username and password is obtained from cluster details)
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Added a host to a VMware cluster via UI without any issues.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
