### PR TITLE
test: Fix travis failure - test_outofbandmanagement.py

### DIFF
--- a/test/integration/smoke/test_outofbandmanagement.py
+++ b/test/integration/smoke/test_outofbandmanagement.py
@@ -15,23 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-import marvin
 from marvin.cloudstackTestCase import *
 from marvin.cloudstackAPI import *
 from marvin.lib.utils import *
 from marvin.lib.base import *
 from marvin.lib.common import *
-from marvin.lib.utils import (random_gen)
 from nose.plugins.attrib import attr
 
 from ipmisim.ipmisim import IpmiServerContext, IpmiServer, ThreadedIpmiServer
 
 import random
 import socket
-import sys
 import _thread
-import time
 
 
 class TestOutOfBandManagement(cloudstackTestCase):
@@ -47,7 +42,9 @@ class TestOutOfBandManagement(cloudstackTestCase):
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.host = None
         cls.cleanup = []
-        cls.skipIfMSIsUnsupported(cls)
+        cls.hypervisor = cls.testClient.getHypervisorInfo()
+        if (cls.hypervisor.lower() != "simulator"):
+            cls.skipIfMSIsUnsupported(cls)
 
         # use random port for ipmisim
         s = socket.socket()


### PR DESCRIPTION
### Description

This PR fixes the travis test failure noticed on the main branch - 
```
ERROR: test suite for <class 'integration.smoke.test_outofbandmanagement.TestOutOfBandManagement'>
----------------------------------------------------------------------
Traceback (most recent call last):

  File "/home/travis/.local/lib/python3.6/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "/home/travis/.local/lib/python3.6/site-packages/nose/suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "/home/travis/.local/lib/python3.6/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "/home/travis/.local/lib/python3.6/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/travis/build/apache/cloudstack/test/integration/smoke/test_outofbandmanagement.py", line 50, in setUpClass
    cls.skipIfMSIsUnsupported(cls)
  File "/home/travis/build/apache/cloudstack/test/integration/smoke/test_outofbandmanagement.py", line 99, in skipIfMSIsUnsupported
    os_details = SshClient(self.mgtSvrDetails["mgtSvrIp"], 22, self.mgtSvrDetails["user"], self.mgtSvrDetails["passwd"]).execute \
  File "/home/travis/.local/lib/python3.6/site-packages/marvin/sshClient.py", line 81, in __init__
    raise internalError("SSH Connection Failed")
marvin.cloudstackException.internalError: SSH Connection Failed
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Ran the smoke test - test_outofbandmanagement.py on simulator env - passes

```
nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=setup/dev/advanced.cfg -s -a tags=advanced --hypervisor=simulator test/integration/smoke/test_outofbandmanagement.py

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/Aug_20_2021_11_24_00_P3BZHV. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_oobm_background_powerstate_sync | Status : SUCCESS ===

=== TestName: test_oobm_configure_default_driver | Status : SUCCESS ===

=== TestName: test_oobm_configure_invalid_driver | Status : SUCCESS ===

=== TestName: test_oobm_disable_feature_invalid | Status : SUCCESS ===

=== TestName: test_oobm_disable_feature_valid | Status : SUCCESS ===

=== TestName: test_oobm_enable_feature_invalid | Status : SUCCESS ===

=== TestName: test_oobm_enable_feature_valid | Status : SUCCESS ===

=== TestName: test_oobm_enabledisable_across_clusterzones | Status : SUCCESS ===

=== TestName: test_oobm_issue_power_cycle | Status : SUCCESS ===

=== TestName: test_oobm_issue_power_off | Status : SUCCESS ===

=== TestName: test_oobm_issue_power_on | Status : SUCCESS ===

=== TestName: test_oobm_issue_power_reset | Status : SUCCESS ===

=== TestName: test_oobm_issue_power_soft | Status : SUCCESS ===

=== TestName: test_oobm_issue_power_status | Status : SUCCESS ===

=== TestName: test_oobm_multiple_mgmt_server_ownership | Status : SUCCESS ===

=== TestName: test_oobm_zchange_password | Status : SUCCESS ===

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
