### PR TITLE
Fix of creating volumes from snapshots without backup to secondary storage

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -114,6 +114,7 @@ import com.cloud.storage.ScopeType;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.Storage;
 import com.cloud.storage.Storage.ImageFormat;
+import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.StorageManager;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.VMTemplateStorageResourceAssoc;
@@ -124,6 +125,7 @@ import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeDetailsDao;
+import com.cloud.storage.snapshot.SnapshotManager;
 import com.cloud.template.TemplateManager;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.user.Account;
@@ -454,18 +456,25 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
             if (snapInfo == null) {
                 throw new CloudRuntimeException("Cannot find snapshot " + snapshot.getId());
             }
-            // We need to copy the snapshot onto secondary.
-            SnapshotStrategy snapshotStrategy = _storageStrategyFactory.getSnapshotStrategy(snapshot, SnapshotOperation.BACKUP);
-            snapshotStrategy.backupSnapshot(snapInfo);
 
-            // Attempt to grab it again.
-            snapInfo = snapshotFactory.getSnapshot(snapshot.getId(), dataStoreRole);
-            if (snapInfo == null) {
-                throw new CloudRuntimeException("Cannot find snapshot " + snapshot.getId() + " on secondary and could not create backup");
+            boolean backupSnapToSecondary = SnapshotManager.BackupSnapshotAfterTakingSnapshot.value() == null || SnapshotManager.BackupSnapshotAfterTakingSnapshot.value();
+
+            StoragePoolVO srcPool = _storagePoolDao.findById(snapInfo.getBaseVolume().getPoolId());
+            // We need to copy the snapshot onto secondary.
+            //Skipping the backup to secondary storage with NFS/FS could be supported when CLOUDSTACK-5297 is accepted with small enhancement in:
+            //KVMStorageProcessor::createVolumeFromSnapshot and CloudStackPrimaryDataStoreDriverImpl::copyAsync/createAsync
+            if ((!backupSnapToSecondary && (srcPool.getPoolType() == StoragePoolType.NetworkFilesystem || srcPool.getPoolType() == StoragePoolType.Filesystem))) {
+                SnapshotStrategy snapshotStrategy = _storageStrategyFactory.getSnapshotStrategy(snapshot, SnapshotOperation.BACKUP);
+                snapshotStrategy.backupSnapshot(snapInfo);
+                // Attempt to grab it again.
+                snapInfo = snapshotFactory.getSnapshot(snapshot.getId(), dataStoreRole);
+                if (snapInfo == null) {
+                    throw new CloudRuntimeException("Cannot find snapshot " + snapshot.getId() + " on secondary and could not create backup");
+                }
             }
         }
         // don't try to perform a sync if the DataStoreRole of the snapshot is equal to DataStoreRole.Primary
-        if (!DataStoreRole.Primary.equals(dataStoreRole)) {
+        if (!DataStoreRole.Primary.equals(snapInfo.getDataStore().getRole())) {
             try {
                 // sync snapshot to region store if necessary
                 DataStore snapStore = snapInfo.getDataStore();

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/SnapshotDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/SnapshotDataStoreDao.java
@@ -68,6 +68,8 @@ StateDao<ObjectInDataStoreStateMachine.State, ObjectInDataStoreStateMachine.Even
 
     SnapshotDataStoreVO findByVolume(long volumeId, DataStoreRole role);
 
+    SnapshotDataStoreVO findByVolume(long snapshotId, long volumeId, DataStoreRole role);
+
     /**
      * List all snapshots in 'snapshot_store_ref' by volume and data store role. Therefore, it is possible to list all snapshots that are in the primary storage or in the secondary storage.
      */

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotDataFactoryImpl.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotDataFactoryImpl.java
@@ -92,7 +92,7 @@ public class SnapshotDataFactoryImpl implements SnapshotDataFactory {
         }
         SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findBySnapshot(snapshotId, role);
         if (snapshotStore == null) {
-            snapshotStore = snapshotStoreDao.findByVolume(snapshot.getVolumeId(), role);
+            snapshotStore = snapshotStoreDao.findByVolume(snapshotId, snapshot.getVolumeId(), role);
             if (snapshotStore == null) {
                 return null;
             }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/SnapshotDataStoreDaoImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/SnapshotDataStoreDaoImpl.java
@@ -142,6 +142,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
         volumeSearch = createSearchBuilder();
         volumeSearch.and("volume_id", volumeSearch.entity().getVolumeId(), SearchCriteria.Op.EQ);
         volumeSearch.and("store_role", volumeSearch.entity().getRole(), SearchCriteria.Op.EQ);
+        volumeSearch.and("snapshot_id", volumeSearch.entity().getSnapshotId(), SearchCriteria.Op.EQ);
         volumeSearch.done();
 
         stateSearch = createSearchBuilder();
@@ -360,6 +361,15 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
     @Override
     public SnapshotDataStoreVO findByVolume(long volumeId, DataStoreRole role) {
         SearchCriteria<SnapshotDataStoreVO> sc = volumeSearch.create();
+        sc.setParameters("volume_id", volumeId);
+        sc.setParameters("store_role", role);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public SnapshotDataStoreVO findByVolume(long snapshotId, long volumeId, DataStoreRole role) {
+        SearchCriteria<SnapshotDataStoreVO> sc = volumeSearch.create();
+        sc.setParameters("snapshot_id", snapshotId);
         sc.setParameters("volume_id", volumeId);
         sc.setParameters("store_role", role);
         return findOneBy(sc);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -85,6 +85,7 @@ import com.ceph.rados.exceptions.RadosException;
 import com.ceph.rbd.Rbd;
 import com.ceph.rbd.RbdException;
 import com.ceph.rbd.RbdImage;
+import com.ceph.rbd.jna.RbdSnapInfo;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.storage.PrimaryStorageDownloadAnswer;
 import com.cloud.agent.api.to.DataObjectType;
@@ -1594,39 +1595,72 @@ public class KVMStorageProcessor implements StorageProcessor {
             final DataStoreTO imageStore = srcData.getDataStore();
             final VolumeObjectTO volume = snapshot.getVolume();
 
-            if (!(imageStore instanceof NfsTO)) {
+            if (!(imageStore instanceof NfsTO) && !(imageStore instanceof PrimaryDataStoreTO)) {
                 return new CopyCmdAnswer("unsupported protocol");
             }
-
-            final NfsTO nfsImageStore = (NfsTO)imageStore;
 
             final String snapshotFullPath = snapshot.getPath();
             final int index = snapshotFullPath.lastIndexOf("/");
             final String snapshotPath = snapshotFullPath.substring(0, index);
             final String snapshotName = snapshotFullPath.substring(index + 1);
-            final KVMStoragePool secondaryPool = storagePoolMgr.getStoragePoolByURI(nfsImageStore.getUrl() + File.separator + snapshotPath);
-            final KVMPhysicalDisk snapshotDisk = secondaryPool.getPhysicalDisk(snapshotName);
+            KVMPhysicalDisk snapshotDisk = null;
+            KVMPhysicalDisk disk = null;
+            if (imageStore instanceof NfsTO) {
+                final NfsTO nfsImageStore = (NfsTO)imageStore;
+                final KVMStoragePool secondaryPool = storagePoolMgr.getStoragePoolByURI(nfsImageStore.getUrl() + File.separator + snapshotPath);
+                snapshotDisk = secondaryPool.getPhysicalDisk(snapshotName);
+                if (volume.getFormat() == ImageFormat.RAW) {
+                    snapshotDisk.setFormat(PhysicalDiskFormat.RAW);
+                } else if (volume.getFormat() == ImageFormat.QCOW2) {
+                    snapshotDisk.setFormat(PhysicalDiskFormat.QCOW2);
+                }
 
-            if (volume.getFormat() == ImageFormat.RAW) {
-                snapshotDisk.setFormat(PhysicalDiskFormat.RAW);
-            } else if (volume.getFormat() == ImageFormat.QCOW2) {
-                snapshotDisk.setFormat(PhysicalDiskFormat.QCOW2);
+                final String primaryUuid = pool.getUuid();
+                final KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(pool.getPoolType(), primaryUuid);
+                final String volUuid = UUID.randomUUID().toString();
+
+                Map<String, String> details = cmd.getOptions2();
+
+                String path = details != null ? details.get(DiskTO.IQN) : null;
+
+                storagePoolMgr.connectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path, details);
+
+                disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, path != null ? path : volUuid, primaryPool, cmd.getWaitInMillSeconds());
+
+                storagePoolMgr.disconnectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path);
+            } else {
+                final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO) imageStore;
+                KVMStoragePool srcPool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
+                snapshotDisk = srcPool.getPhysicalDisk(volume.getPath());
+                KVMStoragePool destPool = storagePoolMgr.getStoragePool(pool.getPoolType(), pool.getUuid());
+                VolumeObjectTO newVol = (VolumeObjectTO) destData;
+                if (primaryStore.getPoolType() == StoragePoolType.RBD) {
+                    s_logger.debug(String.format("Attempting to create volume from RBD snapshot %s", snapshotName));
+                    if (pool.getPoolType() == StoragePoolType.RBD) {
+                        disk = createRBDvolumeFromRBDSnapshot(snapshotDisk, snapshotName, newVol.getUuid(),
+                                PhysicalDiskFormat.RAW, newVol.getSize(), destPool, cmd.getWaitInMillSeconds());
+                        s_logger.debug(String.format("Created RBD volume %s from snapshot %s", disk, snapshotDisk));
+                    } else {
+                        Map<String, String> details = cmd.getOptions2();
+
+                        String path = details != null ? details.get(DiskTO.IQN) : null;
+
+                        storagePoolMgr.connectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path, details);
+
+                        snapshotDisk.setPath(snapshotDisk.getPath() + "@" + snapshotName);
+                        disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, path != null ? path : newVol.getUuid(),
+                                destPool, cmd.getWaitInMillSeconds());
+
+                        storagePoolMgr.disconnectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path);
+                        s_logger.debug(String.format("Created RBD volume %s from snapshot %s", disk, snapshotDisk));
+
+                    }
+                }
             }
 
-            final String primaryUuid = pool.getUuid();
-            final KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(pool.getPoolType(), primaryUuid);
-            final String volUuid = UUID.randomUUID().toString();
-
-            Map<String, String> details = cmd.getOptions2();
-
-            String path = details != null ? details.get(DiskTO.IQN) : null;
-
-            storagePoolMgr.connectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path, details);
-
-            KVMPhysicalDisk disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, path != null ? path : volUuid, primaryPool, cmd.getWaitInMillSeconds());
-
-            storagePoolMgr.disconnectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path);
-
+            if (disk == null) {
+                return new CopyCmdAnswer("Could not create volume from snapshot");
+            }
             final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setPath(disk.getName());
             newVol.setSize(disk.getVirtualSize());
@@ -1637,6 +1671,74 @@ public class KVMStorageProcessor implements StorageProcessor {
             s_logger.debug("Failed to createVolumeFromSnapshot: ", e);
             return new CopyCmdAnswer(e.toString());
         }
+    }
+
+    private KVMPhysicalDisk createRBDvolumeFromRBDSnapshot(KVMPhysicalDisk volume, String snapshotName, String name,
+            PhysicalDiskFormat format, long size, KVMStoragePool destPool, int timeout) {
+
+        KVMStoragePool srcPool = volume.getPool();
+        KVMPhysicalDisk disk = null;
+        String newUuid = name;
+        int rbdFeatures = 61;
+
+        format = PhysicalDiskFormat.RAW;
+        disk = new KVMPhysicalDisk(destPool.getSourceDir() + "/" + newUuid, newUuid, destPool);
+        disk.setFormat(format);
+        if (size > volume.getVirtualSize()) {
+            disk.setSize(size);
+            disk.setVirtualSize(size);
+        } else {
+            disk.setSize(volume.getVirtualSize());
+            disk.setVirtualSize(disk.getSize());
+        }
+
+        try {
+
+            Rados r = new Rados(srcPool.getAuthUserName());
+            r.confSet("mon_host", srcPool.getSourceHost() + ":" + srcPool.getSourcePort());
+            r.confSet("key", srcPool.getAuthSecret());
+            r.confSet("client_mount_timeout", "30");
+            r.connect();
+
+            IoCTX io = r.ioCtxCreate(srcPool.getSourceDir());
+            Rbd rbd = new Rbd(io);
+            RbdImage srcImage = rbd.open(volume.getName());
+
+            List<RbdSnapInfo> snaps = srcImage.snapList();
+            boolean snapFound = false;
+            for (RbdSnapInfo snap : snaps) {
+                if (snapshotName.equals(snap.name)) {
+                    snapFound = true;
+                    break;
+                }
+            }
+
+            if (!snapFound) {
+                return null;
+            }
+            srcImage.snapProtect(snapshotName);
+
+            rbd.clone(volume.getName(), snapshotName, io, disk.getName(), rbdFeatures, 0);
+            RbdImage diskImage = rbd.open(disk.getName());
+            if (disk.getVirtualSize() > volume.getVirtualSize()) {
+                diskImage.resize(disk.getVirtualSize());
+            }
+
+            diskImage.flatten();
+            rbd.close(diskImage);
+
+            srcImage.snapUnprotect(snapshotName);
+            rbd.close(srcImage);
+            r.ioCtxDestroy(io);
+        } catch (RadosException e) {
+            s_logger.error(String.format("Failed due to %s", e.getMessage()));
+            disk = null;
+        } catch (RbdException e) {
+            s_logger.error(String.format("Failed due to: %s", e.getMessage()));
+            disk = null;
+        }
+
+        return disk;
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -79,7 +79,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
     private static final int RBD_FEATURE_OBJECT_MAP = 8;
     private static final int RBD_FEATURE_FAST_DIFF = 16;
     private static final int RBD_FEATURE_DEEP_FLATTEN = 32;
-    private int rbdFeatures = RBD_FEATURE_LAYERING + RBD_FEATURE_EXCLUSIVE_LOCK + RBD_FEATURE_OBJECT_MAP + RBD_FEATURE_FAST_DIFF + RBD_FEATURE_DEEP_FLATTEN;
+    public static final int RBD_FEATURES = RBD_FEATURE_LAYERING + RBD_FEATURE_EXCLUSIVE_LOCK + RBD_FEATURE_OBJECT_MAP + RBD_FEATURE_FAST_DIFF + RBD_FEATURE_DEEP_FLATTEN;
     private int rbdOrder = 0; /* Order 0 means 4MB blocks (the default) */
 
     public LibvirtStorageAdaptor(StorageLayer storage) {
@@ -1103,7 +1103,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                         s_logger.debug("The source image " + srcPool.getSourceDir() + "/" + template.getName() +
                                 " is RBD format 1. We have to perform a regular copy (" + toHumanReadableSize(disk.getVirtualSize()) + " bytes)");
 
-                        rbd.create(disk.getName(), disk.getVirtualSize(), rbdFeatures, rbdOrder);
+                        rbd.create(disk.getName(), disk.getVirtualSize(), RBD_FEATURES, rbdOrder);
                         RbdImage destImage = rbd.open(disk.getName());
 
                         s_logger.debug("Starting to copy " + srcImage.getName() +  " to " + destImage.getName() + " in Ceph pool " + srcPool.getSourceDir());
@@ -1140,7 +1140,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                             srcImage.snapProtect(rbdTemplateSnapName);
                         }
 
-                        rbd.clone(template.getName(), rbdTemplateSnapName, io, disk.getName(), rbdFeatures, rbdOrder);
+                        rbd.clone(template.getName(), rbdTemplateSnapName, io, disk.getName(), RBD_FEATURES, rbdOrder);
                         s_logger.debug("Succesfully cloned " + template.getName() + "@" + rbdTemplateSnapName + " to " + disk.getName());
                         /* We also need to resize the image if the VM was deployed with a larger root disk size */
                         if (disk.getVirtualSize() > template.getVirtualSize()) {
@@ -1180,7 +1180,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
 
                     s_logger.debug("Creating " + disk.getName() + " on the destination cluster " + rDest.confGet("mon_host") + " in pool " +
                             destPool.getSourceDir());
-                    dRbd.create(disk.getName(), disk.getVirtualSize(), rbdFeatures, rbdOrder);
+                    dRbd.create(disk.getName(), disk.getVirtualSize(), RBD_FEATURES, rbdOrder);
 
                     RbdImage srcImage = sRbd.open(template.getName());
                     RbdImage destImage = dRbd.open(disk.getName());

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
@@ -316,14 +316,14 @@ public class CloudStackPrimaryDataStoreDriverImpl implements PrimaryDataStoreDri
             if (storagePoolVO != null && storagePoolVO.getPoolType() == Storage.StoragePoolType.CLVM) {
                 return true;
             }
-        } else if (srcData.getType() == DataObjectType.SNAPSHOT && destData.getType() == DataObjectType.VOLUME) {
+        } else if (DataObjectType.SNAPSHOT.equals(srcData.getType()) && DataObjectType.VOLUME.equals(destData.getType())) {
             DataStore srcStore = srcData.getDataStore();
-            if (srcStore.getRole() == DataStoreRole.Primary && destStore.getRole() == DataStoreRole.Primary) {
+            if (DataStoreRole.Primary.equals(srcStore.getRole()) && DataStoreRole.Primary.equals(destStore.getRole())) {
                 StoragePoolVO srcStoragePoolVO = primaryStoreDao.findById(srcStore.getId());
                 StoragePoolVO dstStoragePoolVO = primaryStoreDao.findById(destStore.getId());
-                if (srcStoragePoolVO != null && srcStoragePoolVO.getPoolType() == StoragePoolType.RBD
-                        && dstStoragePoolVO != null && (dstStoragePoolVO.getPoolType() == StoragePoolType.RBD
-                        || dstStoragePoolVO.getPoolType() == StoragePoolType.NetworkFilesystem)) {
+                if (srcStoragePoolVO != null && StoragePoolType.RBD.equals(srcStoragePoolVO.getPoolType())
+                        && dstStoragePoolVO != null && (StoragePoolType.RBD.equals(dstStoragePoolVO.getPoolType())
+                        || StoragePoolType.NetworkFilesystem.equals(dstStoragePoolVO.getPoolType()))) {
                     return true;
                 }
             }

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
@@ -69,6 +69,7 @@ import com.cloud.storage.CreateSnapshotPayload;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.ResizeVolumePayload;
 import com.cloud.storage.Storage;
+import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.StorageManager;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.Volume;
@@ -287,6 +288,20 @@ public class CloudStackPrimaryDataStoreDriverImpl implements PrimaryDataStoreDri
                 }
                 CopyCommandResult result = new CopyCommandResult("", answer);
                 callback.complete(result);
+            } else if (srcdata.getType() == DataObjectType.SNAPSHOT && destData.getType() == DataObjectType.VOLUME) {
+                SnapshotObjectTO srcTO = (SnapshotObjectTO) srcdata.getTO();
+                CopyCommand cmd = new CopyCommand(srcTO, destData.getTO(), StorageManager.PRIMARY_STORAGE_DOWNLOAD_WAIT.value(), true);
+                EndPoint ep = epSelector.select(srcdata, destData);
+                CopyCmdAnswer answer = null;
+                if (ep == null) {
+                    String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
+                    s_logger.error(errMsg);
+                    answer = new CopyCmdAnswer(errMsg);
+                } else {
+                    answer = (CopyCmdAnswer) ep.sendMessage(cmd);
+                }
+                CopyCommandResult result = new CopyCommandResult("", answer);
+                callback.complete(result);
             }
         }
     }
@@ -294,12 +309,23 @@ public class CloudStackPrimaryDataStoreDriverImpl implements PrimaryDataStoreDri
     @Override
     public boolean canCopy(DataObject srcData, DataObject destData) {
         //BUG fix for CLOUDSTACK-4618
-        DataStore store = destData.getDataStore();
-        if (store.getRole() == DataStoreRole.Primary && srcData.getType() == DataObjectType.TEMPLATE
+        DataStore destStore = destData.getDataStore();
+        if (destStore.getRole() == DataStoreRole.Primary && srcData.getType() == DataObjectType.TEMPLATE
                 && (destData.getType() == DataObjectType.TEMPLATE || destData.getType() == DataObjectType.VOLUME)) {
-            StoragePoolVO storagePoolVO = primaryStoreDao.findById(store.getId());
+            StoragePoolVO storagePoolVO = primaryStoreDao.findById(destStore.getId());
             if (storagePoolVO != null && storagePoolVO.getPoolType() == Storage.StoragePoolType.CLVM) {
                 return true;
+            }
+        } else if (srcData.getType() == DataObjectType.SNAPSHOT && destData.getType() == DataObjectType.VOLUME) {
+            DataStore srcStore = srcData.getDataStore();
+            if (srcStore.getRole() == DataStoreRole.Primary && destStore.getRole() == DataStoreRole.Primary) {
+                StoragePoolVO srcStoragePoolVO = primaryStoreDao.findById(srcStore.getId());
+                StoragePoolVO dstStoragePoolVO = primaryStoreDao.findById(destStore.getId());
+                if (srcStoragePoolVO != null && srcStoragePoolVO.getPoolType() == StoragePoolType.RBD
+                        && dstStoragePoolVO != null && (dstStoragePoolVO.getPoolType() == StoragePoolType.RBD
+                        || dstStoragePoolVO.getPoolType() == StoragePoolType.NetworkFilesystem)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
### Description

Fixes #4433 

- `snapshot.backup.to.secondary=false`
- Create 2 or more snapshots on Ceph/NFS
- Create volume/template from a snapshot. The snapshot first is copied to secondary storage
- Create volume/template from the second snapshot. The snapshot is not copied to secondary because the snapshot info is retrieved with the wrong SQL query. Operation fails.

The problem appears on Ceph/NFS but it probably affects other storage plugins.
Bypassing secondary storage is supported only for Ceph primary storage, but it didn't cover the functionality to create volumes from snapshots which are kept only on Ceph.

With this fix, if you create snapshots only on NFS and try to create volume/template from a snapshot first, the snapshots are copied to secondary storage. For Ceph, the snapshot will be copied to secondary only when you create a template from a snapshot.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?

Manual tests
hypervisor KVM
- create RBD volumes from RBD snapshots - the snapshots are not copied to secondary storage
- create NFS volumes from RBD snapshots - the snapshots are not copied to secondary storage
- create templates from RBD snapshots - the snapshot is copied to secondary storage
- create templates from NFS snapshots - the snapshot is copied to secondary storage
- create NFS volumes from NFS snapshots - the snapshot is copied to secondary storage

