### PR TITLE
Fix security_groups for c8/suse

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -1369,13 +1369,13 @@ def verify_network_rules(vm_name, vm_id, vm_ip, vm_ip6, vm_mac, vif, brname, sec
         vm_id = vm_name.split("-")[-2]
 
     if brname is None:
-        brname = execute("virsh domiflist %s |grep -w '%s' |tr -s ' '|cut -d ' ' -f3" % (vm_name, vm_mac)).strip()
+        brname = execute("virsh domiflist %s |grep -w '%s' | awk '{print $3}'" % (vm_name, vm_mac)).strip()
     if not brname:
         print("Cannot find bridge")
         sys.exit(1)
 
     if vif is None:
-        vif = execute("virsh domiflist %s |grep -w '%s' |tr -s ' '|cut -d ' ' -f1" % (vm_name, vm_mac)).strip()
+        vif = execute("virsh domiflist %s |grep -w '%s' | awk '{print $1}'" % (vm_name, vm_mac)).strip()
     if not vif:
         print("Cannot find vif")
         sys.exit(1)

--- a/test/integration/component/test_multiple_nic_support.py
+++ b/test/integration/component/test_multiple_nic_support.py
@@ -224,7 +224,7 @@ class TestMulipleNicSupport(cloudstackTestCase):
                     cls.virtual_machine1.default_network_id = nic.networkid
                     break
         except Exception as e:
-            cls.fail(f"Exception while deploying virtual machine: {e}")
+            cls.fail("Exception while deploying virtual machine: %s" % {e})
 
         try:
             cls.virtual_machine2 = VirtualMachine.create(
@@ -243,7 +243,7 @@ class TestMulipleNicSupport(cloudstackTestCase):
                     cls.virtual_machine2.default_network_id = nic.networkid
                     break
         except Exception as e:
-            cls.fail(f"Exception while deploying virtual machine: {e}")
+            cls.fail("Exception while deploying virtual machine: %s" % {e})
 
         cls._cleanup.append(cls.virtual_machine1)
         cls._cleanup.append(cls.virtual_machine2)


### PR DESCRIPTION
### Description

Fixes fetching the bridge name for c8 / suse where the result of virsh domlist contains leading spaces
Used only in component tests, so not a functionality break

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

#### Before :

```
# virsh domiflist i-2-3-VM |grep -w '02:00:12:b0:00:01'
 vnet6       bridge   cloudbr1   virtio   02:00:12:b0:00:01    <- notice the leading space
# virsh domiflist i-2-3-VM |grep -w '02:00:12:b0:00:01' |tr -s ' '|cut -d ' ' -f3
bridge   <- Displays the second field
```

#### After :

```
# virsh domiflist i-2-3-VM |grep -w '02:00:12:b0:00:01'
 vnet6       bridge   cloudbr1   virtio   02:00:12:b0:00:01    <- notice the leading space
# virsh domiflist i-2-3-VM |grep -w '02:00:12:b0:00:01' | awk '{print $3}'
cloudbr1    <- Displays the bridge name
```