### PR TITLE
ui: Go back for delete actions before querying async job

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -972,6 +972,9 @@ export default {
             break
           }
         }
+        if ((action.icon === 'delete' || ['archiveEvents', 'archiveAlerts', 'unmanageVirtualMachine'].includes(action.api)) && this.dataView) {
+          this.$router.go(-1)
+        }
         if (['addLdapConfiguration', 'deleteLdapConfiguration'].includes(action.api)) {
           this.$store.dispatch('UpdateConfiguration')
         }
@@ -1057,12 +1060,8 @@ export default {
         api(...args).then(json => {
           this.handleResponse(json, resourceName, action).then(jobId => {
             hasJobId = jobId
-            if ((action.icon === 'delete' || ['archiveEvents', 'archiveAlerts', 'unmanageVirtualMachine'].includes(action.api)) && this.dataView) {
-              this.$router.go(-1)
-            } else {
-              if (!hasJobId) {
-                this.fetchData()
-              }
+            if (!hasJobId) {
+              this.fetchData()
             }
           })
           this.closeAction()


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/5352
Navigates back in history before querying the result of an async job for any delete action
Querying the result leads to a page refresh which can cause an error if it is a delete action and the page has not been changed

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial
