### PR TITLE
ui: Fix search with same parameters

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1144,8 +1144,8 @@ export default {
           Object.assign(query, opts)
         }
       }
-      query.page = 1
-      query.pagesize = this.pageSize
+      query.page = '1'
+      query.pagesize = String(this.pageSize)
       if (JSON.stringify(query) === JSON.stringify(this.$route.query)) {
         this.fetchData(query)
         return


### PR DESCRIPTION
### Description

Fixes the error generated and fetches the data when searching using the same keyword

Go to VM / any listview page
Search for 'vm'
Search again for 'vm'
The data will not be fetched again and will throw an error
![Screenshot from 2021-08-25 11-08-28](https://user-images.githubusercontent.com/8244774/130732644-d494282e-277c-4ee7-be71-631d123fa0be.png)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

