### PR TITLE
server: improve attach volume in specific cases

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -33,8 +33,6 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
-import com.cloud.api.query.dao.ServiceOfferingJoinDao;
-import com.cloud.api.query.vo.ServiceOfferingJoinVO;
 import org.apache.cloudstack.api.command.user.volume.AttachVolumeCmd;
 import org.apache.cloudstack.api.command.user.volume.CreateVolumeCmd;
 import org.apache.cloudstack.api.command.user.volume.DetachVolumeCmd;
@@ -101,6 +99,8 @@ import com.cloud.agent.api.ModifyTargetsCommand;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.api.ApiDBUtils;
+import com.cloud.api.query.dao.ServiceOfferingJoinDao;
+import com.cloud.api.query.vo.ServiceOfferingJoinVO;
 import com.cloud.configuration.Config;
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.configuration.Resource.ResourceType;
@@ -176,6 +176,7 @@ import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
+import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.VmWork;
 import com.cloud.vm.VmWorkAttachVolume;
@@ -288,6 +289,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     private StorageUtil storageUtil;
     @Inject
     public TaggedResourceService taggedResourceService;
+    @Inject
+    VirtualMachineManager virtualMachineManager;
 
     protected Gson _gson;
 
@@ -3217,31 +3220,40 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         return "clustered file systems";
     }
 
+    private HostVO getHostForVmVolumeAttach(UserVmVO vm, StoragePoolVO volumeToAttachStoragePool) {
+        HostVO host = null;
+        Pair<Long, Long> clusterAndHostId =  virtualMachineManager.findClusterAndHostIdForVm(vm.getId());
+        Long hostId = clusterAndHostId.second();
+        Long clusterId = clusterAndHostId.first();
+        if (hostId == null && clusterId!= null &&
+                State.Stopped.equals(vm.getState()) &&
+                volumeToAttachStoragePool != null &&
+                !ScopeType.HOST.equals(volumeToAttachStoragePool.getScope())) {
+            List<HostVO> hosts = _hostDao.findHypervisorHostInCluster(clusterId);
+            if (!hosts.isEmpty()) {
+                host = hosts.get(0);
+            }
+        }
+        if (host == null && hostId != null) {
+            host = _hostDao.findById(hostId);
+        }
+        return host;
+    }
+
     private VolumeVO sendAttachVolumeCommand(UserVmVO vm, VolumeVO volumeToAttach, Long deviceId) {
         String errorMsg = "Failed to attach volume " + volumeToAttach.getName() + " to VM " + vm.getHostName();
         boolean sendCommand = vm.getState() == State.Running;
         AttachAnswer answer = null;
-        Long hostId = vm.getHostId();
-
-        if (hostId == null) {
-            hostId = vm.getLastHostId();
-
-            HostVO host = _hostDao.findById(hostId);
-
-            if (host != null && host.getHypervisorType() == HypervisorType.VMware) {
-                sendCommand = true;
-            }
+        StoragePoolVO volumeToAttachStoragePool = _storagePoolDao.findById(volumeToAttach.getPoolId());
+        HostVO host = getHostForVmVolumeAttach(vm, volumeToAttachStoragePool);
+        Long hostId = host == null ? null : host.getId();
+        if (host != null && host.getHypervisorType() == HypervisorType.VMware) {
+            sendCommand = true;
         }
 
-        HostVO host = null;
-        StoragePoolVO volumeToAttachStoragePool = _storagePoolDao.findById(volumeToAttach.getPoolId());
-
-        if (hostId != null) {
-            host = _hostDao.findById(hostId);
-
-            if (host != null && host.getHypervisorType() == HypervisorType.XenServer && volumeToAttachStoragePool != null && volumeToAttachStoragePool.isManaged()) {
-                sendCommand = true;
-            }
+        if (host != null && host.getHypervisorType() == HypervisorType.XenServer &&
+                volumeToAttachStoragePool != null && volumeToAttachStoragePool.isManaged()) {
+            sendCommand = true;
         }
 
         if (volumeToAttachStoragePool != null) {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3225,7 +3225,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         Pair<Long, Long> clusterAndHostId =  virtualMachineManager.findClusterAndHostIdForVm(vm.getId());
         Long hostId = clusterAndHostId.second();
         Long clusterId = clusterAndHostId.first();
-        if (hostId == null && clusterId!= null &&
+        if (hostId == null && clusterId != null &&
                 State.Stopped.equals(vm.getState()) &&
                 volumeToAttachStoragePool != null &&
                 !ScopeType.HOST.equals(volumeToAttachStoragePool.getScope())) {


### PR DESCRIPTION
### Description

When a VM is in the Stopped state and the host for it is not found then the server skips sending AttachCommand to the hypervisor. This creates issue with the volume operations if done immediately (without starting the VM).
Change tries to improve this case and finds a suitable host in the VM's cluster when the volume is not in a HOST scope pool.

Fixes #5372 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Using cmk on VMware env with multiple clusters:

```
(localcloud) SBCM5> > list clusters filter=id,name,hypervisortype,
{
  "cluster": [
    {
      "hypervisortype": "VMware",
      "id": "2525592f-d07c-40bc-84a3-5bfa218ba67d",
      "name": "p1-c1"
    },
    {
      "hypervisortype": "VMware",
      "id": "fce17f98-abd2-4571-a875-97d787119d9f",
      "name": "10.0.33.157/Trillian/p1-c2"
    }
  ],
  "count": 2
}
(localcloud) SBCM5> > list storagepools filter=id,name,clusterid,clustername
{
  "count": 2,
  "storagepool": [
    {
      "clusterid": "fce17f98-abd2-4571-a875-97d787119d9f",
      "clustername": "10.0.33.157/Trillian/p1-c2",
      "id": "54fad842-a0e7-3be0-a415-7e8a22433c4f",
      "name": "ps2"
    },
    {
      "clusterid": "2525592f-d07c-40bc-84a3-5bfa218ba67d",
      "clustername": "p1-c1",
      "id": "b6dddca0-3f55-3871-ad19-20fdba65709c",
      "name": "pr5201-t1787-vmware-67u3-esxi-pri1"
    }
  ]
}
(localcloud) SBCM5> > deploy virtualmachine zoneid=8dca85c3-1d3f-482b-aa7c-562be2bdf05c serviceofferingid=4b57c829-ea2e-4f8f-93f5-7c88365f4dc1 templateid=0717b6fc-aea8-4311-8981-e3ebd85aca0f networkids=acba9c02-1bbd-4044-bd79-6360e3f7b7b4 clusterid=2525592f-d07c-40bc-84a3-5bfa218ba67d  
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-08-27T08:37:57+0000",
    "details": {
      "cpuOvercommitRatio": "2.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "osdefault"
    },
    "displayname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "guestosid": "3519aaec-06f3-11ec-aa0b-1e00d000026f",
    "haenable": false,
    "hostid": "dc0bd716-40b0-4b03-8c2d-0bb0055b67cf",
    "hostname": "10.0.33.102",
    "hypervisor": "VMware",
    "id": "1ba5511c-4194-420f-a9c5-f277918c70c4",
    "instancename": "i-2-93-VM",
    "isdynamicallyscalable": false,
    "jobid": "208c874e-c7f0-48cb-9f6b-0af1cf16efdc",
    "jobstatus": 0,
    "lastupdated": "2021-08-27T08:38:12+0000",
    "memory": 512,
    "name": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "nic": [
      {
        "broadcasturi": "vlan://1454",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "33b63209-0411-4dfd-a9fb-d9dd8d2d977e",
        "isdefault": true,
        "isolationuri": "vlan://1454",
        "macaddress": "02:00:71:e4:00:01",
        "networkid": "acba9c02-1bbd-4044-bd79-6360e3f7b7b4",
        "networkname": "l2-2",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "Amazon Linux 2 (64 bit)",
    "ostypeid": "3519aaec-06f3-11ec-aa0b-1e00d000026f",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "4b57c829-ea2e-4f8f-93f5-7c88365f4dc1",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "ma",
    "templateid": "0717b6fc-aea8-4311-8981-e3ebd85aca0f",
    "templatename": "ma",
    "userid": "3dd13f46-06f3-11ec-aa0b-1e00d000026f",
    "username": "admin",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > stop virtualmachine id=1ba5511c-4194-420f-a9c5-f277918c70c4 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "cpuused": "0%",
    "created": "2021-08-27T08:37:57+0000",
    "details": {
      "Message.ReservedCapacityFreed.Flag": "false",
      "cpuOvercommitRatio": "2.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "osdefault"
    },
    "diskioread": 20,
    "diskiowrite": 1,
    "diskkbsread": 509,
    "diskkbswrite": 4,
    "displayname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "guestosid": "3519aaec-06f3-11ec-aa0b-1e00d000026f",
    "haenable": false,
    "hypervisor": "VMware",
    "id": "1ba5511c-4194-420f-a9c5-f277918c70c4",
    "instancename": "i-2-93-VM",
    "isdynamicallyscalable": false,
    "jobid": "f40db8a0-e62e-450f-a8f3-d6a86266533d",
    "jobstatus": 0,
    "lastupdated": "2021-08-27T08:38:58+0000",
    "memory": 512,
    "memoryintfreekbs": 0,
    "memorykbs": 524288,
    "memorytargetkbs": 524288,
    "name": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "networkkbsread": 0,
    "networkkbswrite": 0,
    "nic": [
      {
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "33b63209-0411-4dfd-a9fb-d9dd8d2d977e",
        "isdefault": true,
        "macaddress": "02:00:71:e4:00:01",
        "networkid": "acba9c02-1bbd-4044-bd79-6360e3f7b7b4",
        "networkname": "l2-2",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "Amazon Linux 2 (64 bit)",
    "ostypeid": "3519aaec-06f3-11ec-aa0b-1e00d000026f",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "4b57c829-ea2e-4f8f-93f5-7c88365f4dc1",
    "serviceofferingname": "Small Instance",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "ma",
    "templateid": "0717b6fc-aea8-4311-8981-e3ebd85aca0f",
    "templatename": "ma",
    "userid": "3dd13f46-06f3-11ec-aa0b-1e00d000026f",
    "username": "admin",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > migrate virtualmachine virtualmachineid=1ba5511c-4194-420f-a9c5-f277918c70c4 storageid=54fad842-a0e7-3be0-a415-7e8a22433c4f
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "cpuused": "0%",
    "created": "2021-08-27T08:37:57+0000",
    "details": {
      "Message.ReservedCapacityFreed.Flag": "false",
      "cpuOvercommitRatio": "2.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "osdefault"
    },
    "diskioread": 20,
    "diskiowrite": 1,
    "diskkbsread": 509,
    "diskkbswrite": 4,
    "displayname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "guestosid": "3519aaec-06f3-11ec-aa0b-1e00d000026f",
    "haenable": false,
    "hypervisor": "VMware",
    "id": "1ba5511c-4194-420f-a9c5-f277918c70c4",
    "instancename": "i-2-93-VM",
    "isdynamicallyscalable": false,
    "lastupdated": "2021-08-27T08:39:44+0000",
    "memory": 512,
    "memoryintfreekbs": 0,
    "memorykbs": 524288,
    "memorytargetkbs": 524288,
    "name": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "networkkbsread": 0,
    "networkkbswrite": 0,
    "nic": [
      {
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "33b63209-0411-4dfd-a9fb-d9dd8d2d977e",
        "isdefault": true,
        "macaddress": "02:00:71:e4:00:01",
        "networkid": "acba9c02-1bbd-4044-bd79-6360e3f7b7b4",
        "networkname": "l2-2",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "Amazon Linux 2 (64 bit)",
    "ostypeid": "3519aaec-06f3-11ec-aa0b-1e00d000026f",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "4b57c829-ea2e-4f8f-93f5-7c88365f4dc1",
    "serviceofferingname": "Small Instance",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "ma",
    "templateid": "0717b6fc-aea8-4311-8981-e3ebd85aca0f",
    "templatename": "ma",
    "userid": "3dd13f46-06f3-11ec-aa0b-1e00d000026f",
    "username": "admin",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
```
VM in DB at this point:
```
MariaDB [cloud]> SELECT id,name,host_id,last_host_id,pod_id from vm_instance where uuid='1ba5511c-4194-420f-a9c5-f277918c70c4'\G
*************************** 1. row ***************************
          id: 93
        name: VM-1ba5511c-4194-420f-a9c5-f277918c70c4
     host_id: NULL
last_host_id: NULL
      pod_id: 1
1 row in set (0.00 sec)
```

Before change (volume doesn't get chaininfo on attach):
```
(localcloud) SBCM5> > create volume diskofferingid=cbccf460-a250-4b39-aa42-3e1c0af45bfe zoneid=8dca85c3-1d3f-482b-aa7c-562be2bdf05c 
{
  "volume": {
    "account": "admin",
    "created": "2021-08-27T08:40:14+0000",
    "destroyed": false,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "cbccf460-a250-4b39-aa42-3e1c0af45bfe",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "hypervisor": "None",
    "id": "8d8e719c-47f8-4e6c-b00a-7be0cd5ee208",
    "isextractable": true,
    "jobid": "7c7fe265-3b3f-49c9-b583-185591fd6306",
    "jobstatus": 0,
    "name": "d7d41337-095e-487c-814d-b7f0d9577872",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Allocated",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > attach volume virtualmachineid=1ba5511c-4194-420f-a9c5-f277918c70c4 id=8d8e719c-47f8-4e6c-b00a-7be0cd5ee208 
{
  "volume": {
    "account": "admin",
    "attached": "2021-08-27T08:40:49+0000",
    "clusterid": "fce17f98-abd2-4571-a875-97d787119d9f",
    "clustername": "10.0.33.157/Trillian/p1-c2",
    "created": "2021-08-27T08:40:14+0000",
    "destroyed": false,
    "deviceid": 1,
    "diskioread": 0,
    "diskiowrite": 0,
    "diskkbsread": 0,
    "diskkbswrite": 0,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "cbccf460-a250-4b39-aa42-3e1c0af45bfe",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "hypervisor": "VMware",
    "id": "8d8e719c-47f8-4e6c-b00a-7be0cd5ee208",
    "isextractable": true,
    "jobid": "6c5d8fa4-d394-4484-8233-d781c8f8695d",
    "jobstatus": 0,
    "name": "d7d41337-095e-487c-814d-b7f0d9577872",
    "path": "d5d174de274b42acbc9e070f07e27e42",
    "podid": "10e00f54-43eb-4b37-8f18-c2b4fe64e1e8",
    "podname": "Pod1",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Ready",
    "storage": "ps2",
    "storageid": "54fad842-a0e7-3be0-a415-7e8a22433c4f",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "virtualmachineid": "1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmdisplayname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmstate": "Stopped",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > create snapshot volumeid=8d8e719c-47f8-4e6c-b00a-7be0cd5ee208 
{
  "accountid": "3dcfb4f2-06f3-11ec-aa0b-1e00d000026f",
  "cmd": "org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotCmd",
  "completed": "2021-08-27T08:41:09+0000",
  "created": "2021-08-27T08:41:07+0000",
  "jobid": "7a279409-e7b6-4b08-9244-43568ee133eb",
  "jobinstanceid": "c21bde3a-de5e-40de-b384-fb46af6ef12f",
  "jobinstancetype": "Snapshot",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "Failed to create snapshot due to an internal error creating snapshot for volume 8d8e719c-47f8-4e6c-b00a-7be0cd5ee208"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "3dd13f46-06f3-11ec-aa0b-1e00d000026f"
}
```

Error in MS:
```
(localcloud) SBCM5> > create volume diskofferingid=cbccf460-a250-4b39-aa42-3e1c0af45bfe zoneid=8dca85c3-1d3f-482b-aa7c-562be2bdf05c name=afterchange
{
  "volume": {
    "account": "admin",
    "created": "2021-08-27T08:46:55+0000",
    "destroyed": false,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "cbccf460-a250-4b39-aa42-3e1c0af45bfe",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "hypervisor": "None",
    "id": "4ef26077-849a-4ced-8ac7-7b23fc83f86e",
    "isextractable": true,
    "jobid": "8ab62a62-4af2-42bd-aa7d-ab34dedc9bde",
    "jobstatus": 0,
    "name": "afterchange",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Allocated",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > attach volume id=4ef26077-849a-4ced-8ac7-7b23fc83f86e virtualmachineid=1ba5511c-4194-420f-a9c5-f277918c70c4 
{
  "volume": {
    "account": "admin",
    "attached": "2021-08-27T08:47:16+0000",
    "chaininfo": "{\"diskDeviceBusName\":\"scsi0:1\",\"diskChain\":[\"[54fad842a0e73be0a4157e8a22433c4f] i-2-93-VM/816e02a3c9904995898e93678ce0f993.vmdk\"]}",
    "clusterid": "fce17f98-abd2-4571-a875-97d787119d9f",
    "clustername": "10.0.33.157/Trillian/p1-c2",
    "created": "2021-08-27T08:46:55+0000",
    "destroyed": false,
    "deviceid": 2,
    "diskioread": 0,
    "diskiowrite": 0,
    "diskkbsread": 0,
    "diskkbswrite": 0,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "cbccf460-a250-4b39-aa42-3e1c0af45bfe",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "hypervisor": "VMware",
    "id": "4ef26077-849a-4ced-8ac7-7b23fc83f86e",
    "isextractable": true,
    "jobid": "32470f20-03ce-4dfb-bf73-a3acd9ed73ab",
    "jobstatus": 0,
    "name": "afterchange",
    "path": "816e02a3c9904995898e93678ce0f993",
    "podid": "10e00f54-43eb-4b37-8f18-c2b4fe64e1e8",
    "podname": "Pod1",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Ready",
    "storage": "ps2",
    "storageid": "54fad842-a0e7-3be0-a415-7e8a22433c4f",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "virtualmachineid": "1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmdisplayname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmstate": "Stopped",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > create snapshot volumeid=4ef26077-849a-4ced-8ac7-7b23fc83f86e name=snapafterchange
{
  "snapshot": {
    "account": "admin",
    "created": "2021-08-27T08:47:49+0000",
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "id": "60186b18-f5c5-4138-96b7-65be99c8915a",
    "intervaltype": "MANUAL",
    "name": "snapafterchange",
    "physicalsize": 23304704,
    "revertable": false,
    "snapshottype": "MANUAL",
    "state": "BackedUp",
    "tags": [],
    "virtualsize": 5368709120,
    "volumeid": "4ef26077-849a-4ced-8ac7-7b23fc83f86e",
    "volumename": "afterchange",
    "volumetype": "DATADISK",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c"
  }
}
```


After change:
```
(localcloud) SBCM5> > create volume diskofferingid=cbccf460-a250-4b39-aa42-3e1c0af45bfe zoneid=8dca85c3-1d3f-482b-aa7c-562be2bdf05c name=afterchange
{
  "volume": {
    "account": "admin",
    "created": "2021-08-27T08:46:55+0000",
    "destroyed": false,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "cbccf460-a250-4b39-aa42-3e1c0af45bfe",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "hypervisor": "None",
    "id": "4ef26077-849a-4ced-8ac7-7b23fc83f86e",
    "isextractable": true,
    "jobid": "8ab62a62-4af2-42bd-aa7d-ab34dedc9bde",
    "jobstatus": 0,
    "name": "afterchange",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Allocated",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > attach volume id=4ef26077-849a-4ced-8ac7-7b23fc83f86e virtualmachineid=1ba5511c-4194-420f-a9c5-f277918c70c4 
{
  "volume": {
    "account": "admin",
    "attached": "2021-08-27T08:47:16+0000",
    "chaininfo": "{\"diskDeviceBusName\":\"scsi0:1\",\"diskChain\":[\"[54fad842a0e73be0a4157e8a22433c4f] i-2-93-VM/816e02a3c9904995898e93678ce0f993.vmdk\"]}",
    "clusterid": "fce17f98-abd2-4571-a875-97d787119d9f",
    "clustername": "10.0.33.157/Trillian/p1-c2",
    "created": "2021-08-27T08:46:55+0000",
    "destroyed": false,
    "deviceid": 2,
    "diskioread": 0,
    "diskiowrite": 0,
    "diskkbsread": 0,
    "diskkbswrite": 0,
    "diskofferingdisplaytext": "Small Disk, 5 GB",
    "diskofferingid": "cbccf460-a250-4b39-aa42-3e1c0af45bfe",
    "diskofferingname": "Small",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "hypervisor": "VMware",
    "id": "4ef26077-849a-4ced-8ac7-7b23fc83f86e",
    "isextractable": true,
    "jobid": "32470f20-03ce-4dfb-bf73-a3acd9ed73ab",
    "jobstatus": 0,
    "name": "afterchange",
    "path": "816e02a3c9904995898e93678ce0f993",
    "podid": "10e00f54-43eb-4b37-8f18-c2b4fe64e1e8",
    "podname": "Pod1",
    "provisioningtype": "thin",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Ready",
    "storage": "ps2",
    "storageid": "54fad842-a0e7-3be0-a415-7e8a22433c4f",
    "storagetype": "shared",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "virtualmachineid": "1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmdisplayname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmname": "VM-1ba5511c-4194-420f-a9c5-f277918c70c4",
    "vmstate": "Stopped",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c",
    "zonename": "pr5201-t1787-vmware-67u3"
  }
}
(localcloud) SBCM5> > create snapshot volumeid=4ef26077-849a-4ced-8ac7-7b23fc83f86e name=snapafterchange
{
  "snapshot": {
    "account": "admin",
    "created": "2021-08-27T08:47:49+0000",
    "domain": "ROOT",
    "domainid": "2578d517-06f3-11ec-aa0b-1e00d000026f",
    "id": "60186b18-f5c5-4138-96b7-65be99c8915a",
    "intervaltype": "MANUAL",
    "name": "snapafterchange",
    "physicalsize": 23304704,
    "revertable": false,
    "snapshottype": "MANUAL",
    "state": "BackedUp",
    "tags": [],
    "virtualsize": 5368709120,
    "volumeid": "4ef26077-849a-4ced-8ac7-7b23fc83f86e",
    "volumename": "afterchange",
    "volumetype": "DATADISK",
    "zoneid": "8dca85c3-1d3f-482b-aa7c-562be2bdf05c"
  }
}

```
