### PR TITLE
api: List details of template download state for stores corresponding to a zone

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/TemplateDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/TemplateDataStoreDao.java
@@ -66,7 +66,7 @@ public interface TemplateDataStoreDao extends GenericDao<TemplateDataStoreVO, Lo
 
     List<TemplateDataStoreVO> listByTemplate(long templateId);
 
-    List<TemplateDataStoreVO> listByTemplateNotBypassed(long templateId);
+    List<TemplateDataStoreVO> listByTemplateNotBypassed(long templateId, Long... storeIds);
 
     TemplateDataStoreVO findByTemplateZoneReady(long templateId, Long zoneId);
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
@@ -99,6 +99,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         templateSearch.and("template_id", templateSearch.entity().getTemplateId(), SearchCriteria.Op.EQ);
         templateSearch.and("download_state", templateSearch.entity().getDownloadState(), SearchCriteria.Op.NEQ);
         templateSearch.and("destroyed", templateSearch.entity().getDestroyed(), SearchCriteria.Op.EQ);
+        templateSearch.and("storeids", templateSearch.entity().getDataStoreId(), Op.IN);
         templateSearch.done();
 
         templateRoleSearch = createSearchBuilder();
@@ -421,11 +422,12 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
     }
 
     @Override
-    public List<TemplateDataStoreVO> listByTemplateNotBypassed(long templateId) {
+    public List<TemplateDataStoreVO> listByTemplateNotBypassed(long templateId, Long... storeIds) {
         SearchCriteria<TemplateDataStoreVO> sc = templateSearch.create();
         sc.setParameters("template_id", templateId);
         sc.setParameters("download_state", Status.BYPASSED);
         sc.setParameters("destroyed", false);
+        sc.setParameters("storeids", (Object) storeIds);
         return search(sc, null);
     }
 

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
@@ -427,7 +427,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         sc.setParameters("template_id", templateId);
         sc.setParameters("download_state", Status.BYPASSED);
         sc.setParameters("destroyed", false);
-        sc.setParameters("storeids", (Object) storeIds);
+        sc.setParameters("storeids", storeIds);
         return search(sc, null);
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -156,7 +156,9 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
 
     @Override
     public TemplateResponse newTemplateResponse(EnumSet<ApiConstants.DomainDetails> detailsView, ResponseView view, TemplateJoinVO template) {
-        List<TemplateDataStoreVO> templatesInStore = _templateStoreDao.listByTemplateNotBypassed(template.getId());
+        List<ImageStoreVO> storesInZone = dataStoreDao.listStoresByZoneId(template.getDataCenterId());
+        Long[] storeIds = storesInZone.stream().map(ImageStoreVO::getId).toArray(Long[]::new);
+        List<TemplateDataStoreVO> templatesInStore = _templateStoreDao.listByTemplateNotBypassed(template.getId(), storeIds);
         List<Map<String, String>> downloadProgressDetails = new ArrayList();
         HashMap<String, String> downloadDetailInImageStores = null;
         for (TemplateDataStoreVO templateInStore : templatesInStore) {


### PR DESCRIPTION

### Description

This PR filters images stores belonging to a zone while listing the download details of the template in a specific zone

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
#### Prior Fix:
```
(localcloud) 🐱 > list templates id=ef78027a-06ed-11ec-b12a-5254009b8de5 (CentOS 5.5(64-bit) no GUI (KVM)) templatefilter=all filter=name,zonename,zoneid,downloaddetails
{
  "count": 2,
  "template": [
    {
      "downloaddetails": [
        {
          "datastore": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec1",  <--- store of zone1
          "downloadPercent": "100",
          "downloadState": "DOWNLOADED"
        },
        {
          "datastore": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec2",  <--- store of zone2
          "downloadPercent": "100",
          "downloadState": "DOWNLOAD_IN_PROGRESS"
        }
      ],
      "name": "CentOS 5.5(64-bit) no GUI (KVM)",
      "zoneid": "acdaf7ed-453f-472d-be42-113f09752667",
      "zonename": "z1"
    },
    {
      "downloaddetails": [
        {
          "datastore": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec1",  <--- store of zone1
          "downloadPercent": "100",
          "downloadState": "DOWNLOADED"
        },
        {
          "datastore": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec2",  <--- store of zone2
          "downloadPercent": "100",
          "downloadState": "DOWNLOAD_IN_PROGRESS"
        }
      ],
      "name": "CentOS 5.5(64-bit) no GUI (KVM)",
      "zoneid": "59dc8b78-85c5-4a24-9d0c-6f79578a0633",
      "zonename": "z2"
    }
  ]
}
```

#### Post Fix:
```
(localcloud) 🐱 > list templates id=ef78027a-06ed-11ec-b12a-5254009b8de5 (CentOS 5.5(64-bit) no GUI (KVM)) templatefilter=all filter=name,zonename,zoneid,downloaddetails
{
  "count": 2,
  "template": [
    {
      "downloaddetails": [
        {
          "datastore": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec1",
          "downloadPercent": "100",
          "downloadState": "DOWNLOADED"
        }
      ],
      "name": "CentOS 5.5(64-bit) no GUI (KVM)",
      "zoneid": "acdaf7ed-453f-472d-be42-113f09752667",
      "zonename": "z1"
    },
    {
      "downloaddetails": [
        {
          "datastore": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec2",
          "downloadPercent": "100",
          "downloadState": "DOWNLOADED"
        }
      ],
      "name": "CentOS 5.5(64-bit) no GUI (KVM)",
      "zoneid": "59dc8b78-85c5-4a24-9d0c-6f79578a0633",
      "zonename": "z2"
    }
  ]
}
```

#### Image store details for reference
```
(localcloud) 🐱 > list imagestores filter=name,zonename,
{
  "count": 2,
  "imagestore": [
    {
      "name": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec2",
      "zonename": "z2"
    },
    {
      "name": "nfs://172.20.0.1/export/testing/qa1-testzone415-e0bb22b0-kvm/sec1",
      "zonename": "z1"
    }
  ]
}

```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
