### PR TITLE
ubuntu: Fix failure to scp diagnostic data file from SSVM

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/diagnostics/DiagnosticsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/diagnostics/DiagnosticsServiceImpl.java
@@ -340,8 +340,8 @@ public class DiagnosticsServiceImpl extends ManagerBase implements PluggableServ
             File dataDirectory = new File(dataDirectoryInSecondaryStore);
             boolean existsInSecondaryStore = dataDirectory.exists() || dataDirectory.mkdir();
             if (existsInSecondaryStore) {
-                // scp from system VM to mounted sec storage directory
-                File permKey = new File("/var/cloudstack/management/.ssh/id_rsa");
+                String homeDir = System.getProperty("user.home");
+                File permKey = new File(homeDir + "/.ssh/id_rsa");
                 SshHelper.scpFrom(vmSshIp, 3922, "root", permKey, dataDirectoryInSecondaryStore, diagnosticsFile);
             }
 


### PR DESCRIPTION
### Description

On trying to get the diagnostic data from SSVM, we face the following issue:
```
Copying /root/diagnostics_files_20210827-051515.zip from 10.0.38.15 to secondary store NFS://10.0.32.4/acs/secondary/ref-trl-1680-v-Mu20-pearl-dsilva/ref-trl-1680-v-Mu20-pearl-dsilva-sec1
2021-08-27 05:15:15,280 ERROR [o.a.c.d.DiagnosticsServiceImpl] (API-Job-Executor-27:ctx-ec0ca00b job-33 ctx-43bee1c6) (logid:8d3dba6c) Exception caught during scp from 10.0.38.15 to secondary store /var/lib/cloudstack/mnt/32987160773173.3029c5e3/diagnostics: 
java.io.FileNotFoundException: /var/cloudstack/management/.ssh/id_rsa (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at java.base/java.io.FileReader.<init>(FileReader.java:75)
	at com.trilead.ssh2.Connection.authenticateWithPublicKey(Connection.java:504)
	at com.cloud.utils.ssh.SshHelper.scpFrom(SshHelper.java:69)
	at org.apache.cloudstack.diagnostics.DiagnosticsServiceImpl.copyToSecondaryStorageVMware(DiagnosticsServiceImpl.java:345)
	at org.apache.cloudstack.diagnostics.DiagnosticsServiceImpl.copyZipFileToSecondaryStorage(DiagnosticsServiceImpl.java:256)
	at org.apache.cloudstack.diagnostics.DiagnosticsServiceImpl.getDiagnosticsDataCommand(DiagnosticsServiceImpl.java:225)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```
This is because, on ubuntu, the id_rsa file is placed at `/var/lib/cloudstack/management/.ssh/`
This PR fixes the above mentioned issue

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Successfully ran getDiagnosticsData 
![image](https://user-images.githubusercontent.com/10495417/131119183-36ad91dd-5892-4ab3-a7da-815003d384d4.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
