### PR TITLE
engine/schema: Use same upgrade path as 4.15.1-4.16.0 as for 4.15.2

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -199,6 +199,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.14.1.0", new Upgrade41400to41500())
                 .next("4.15.0.0", new Upgrade41500to41510())
                 .next("4.15.1.0", new Upgrade41510to41600())
+                .next("4.15.2.0", new Upgrade41510to41600())
                 .build();
     }
 


### PR DESCRIPTION
Introduce same Db upgrade path from both 4.15.1/4.15.2 to 4.16.0