### PR TITLE
api, ui: fix NPE with deployVirtualMachine when null boottype

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
-import com.cloud.utils.StringUtils;
-
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
 import org.apache.cloudstack.api.ACL;
@@ -70,6 +68,7 @@ import com.cloud.network.Network.IpAddresses;
 import com.cloud.offering.DiskOffering;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.uservm.UserVm;
+import com.cloud.utils.StringUtils;
 import com.cloud.utils.net.Dhcp;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.VirtualMachine;
@@ -293,7 +292,8 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             }
         }
         if (ApiConstants.BootType.UEFI.equals(getBootType())) {
-            customparameterMap.put(getBootType().toString(), getBootMode().toString());
+            ApiConstants.BootMode mode = getBootMode();
+            customparameterMap.put(getBootType().toString(), mode != null ? mode.toString() : "");
         }
 
         if (rootdisksize != null && !customparameterMap.containsKey("rootdisksize")) {
@@ -310,11 +310,11 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
                 String mode = bootMode.trim().toUpperCase();
                 return ApiConstants.BootMode.valueOf(mode);
             } catch (IllegalArgumentException e) {
-                String errMesg = "Invalid bootMode " + bootMode + "Specified for vm " + getName()
-                        + " Valid values are:  "+ Arrays.toString(ApiConstants.BootMode.values());
-                s_logger.warn(errMesg);
-                throw new InvalidParameterValueException(errMesg);
-                }
+                String msg = String.format("Invalid bootMode %s specified for VM: %s. Valid values are: %s",
+                        bootMode, getName(), Arrays.toString(ApiConstants.BootMode.values()));
+                s_logger.warn(msg);
+                throw new InvalidParameterValueException(msg);
+            }
         }
         return null;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -264,7 +264,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return domainId;
     }
 
-    public ApiConstants.BootType  getBootType() {
+    public ApiConstants.BootType getBootType() {
         if (StringUtils.isNotBlank(bootType)) {
             try {
                 String type = bootType.trim().toUpperCase();
@@ -292,8 +292,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             }
         }
         if (ApiConstants.BootType.UEFI.equals(getBootType())) {
-            ApiConstants.BootMode mode = getBootMode();
-            customparameterMap.put(getBootType().toString(), mode != null ? mode.toString() : "");
+            customparameterMap.put(getBootType().toString(), getBootMode().toString());
         }
 
         if (rootdisksize != null && !customparameterMap.containsKey("rootdisksize")) {
@@ -312,9 +311,15 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             } catch (IllegalArgumentException e) {
                 String msg = String.format("Invalid bootMode %s specified for VM: %s. Valid values are: %s",
                         bootMode, getName(), Arrays.toString(ApiConstants.BootMode.values()));
-                s_logger.warn(msg);
+                s_logger.error(msg);
                 throw new InvalidParameterValueException(msg);
             }
+        }
+        if (ApiConstants.BootType.UEFI.equals(getBootType())) {
+            String msg = String.format("%s must be specified for the VM with boot type: %s. Valid values are: %s",
+                    ApiConstants.BOOT_MODE, getBootType(), Arrays.toString(ApiConstants.BootMode.values()));
+            s_logger.error(msg);
+            throw new InvalidParameterValueException(msg);
         }
         return null;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -309,8 +309,8 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
                 String mode = bootMode.trim().toUpperCase();
                 return ApiConstants.BootMode.valueOf(mode);
             } catch (IllegalArgumentException e) {
-                String msg = String.format("Invalid bootMode %s specified for VM: %s. Valid values are: %s",
-                        bootMode, getName(), Arrays.toString(ApiConstants.BootMode.values()));
+                String msg = String.format("Invalid %s: %s specified for VM: %s. Valid values are: %s",
+                        ApiConstants.BOOT_MODE, bootMode, getName(), Arrays.toString(ApiConstants.BootMode.values()));
                 s_logger.error(msg);
                 throw new InvalidParameterValueException(msg);
             }

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -487,7 +487,7 @@
                 <template slot="description" v-if="zoneSelected">
                   <span>
                     {{ $t('label.isadvanced') }}
-                    <a-switch @change="val => { this.showDetails = val }" :checked="this.showDetails" style="margin-left: 10px"/>
+                    <a-switch @change="val => { showDetails = val }" :checked="showDetails" style="margin-left: 10px"/>
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div
@@ -495,9 +495,8 @@
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
                           :autoFocus="vm.templateid && ['KVM', 'VMware'].includes(hypervisor) && !template.deployasis"
-                          v-decorator="['boottype']"
-                          @change="fetchBootModes"
-                        >
+                          v-decorator="['boottype', { initialValue: options.bootTypes && options.bootTypes.length > 0 ? options.bootTypes[0].id : undefined }]"
+                          @change="onBootTypeChange">
                           <a-select-option v-for="bootType in options.bootTypes" :key="bootType.id">
                             {{ bootType.description }}
                           </a-select-option>
@@ -505,7 +504,7 @@
                       </a-form-item>
                       <a-form-item :label="$t('label.bootmode')">
                         <a-select
-                          v-decorator="['bootmode']">
+                          v-decorator="['bootmode', { initialValue: options.bootModes && options.bootModes.length > 0 ? options.bootModes[0].id : undefined }]">
                           <a-select-option v-for="bootMode in options.bootModes" :key="bootMode.id">
                             {{ bootMode.description }}
                           </a-select-option>
@@ -1228,39 +1227,21 @@ export default {
       await this.fetchAllTemplates()
     },
     fetchBootTypes () {
-      const bootTypes = []
-
-      bootTypes.push({
-        id: 'BIOS',
-        description: 'BIOS'
-      })
-      bootTypes.push({
-        id: 'UEFI',
-        description: 'UEFI'
-      })
-
-      this.options.bootTypes = bootTypes
+      this.options.bootTypes = [
+        { id: 'BIOS', description: 'BIOS' },
+        { id: 'UEFI', description: 'UEFI' }
+      ]
       this.$forceUpdate()
     },
     fetchBootModes (bootType) {
-      const bootModes = []
-
+      const bootModes = [
+        { id: 'LEGACY', description: 'LEGACY' }
+      ]
       if (bootType === 'UEFI') {
-        bootModes.push({
-          id: 'LEGACY',
-          description: 'LEGACY'
-        })
-        bootModes.push({
-          id: 'SECURE',
-          description: 'SECURE'
-        })
-      } else {
-        bootModes.push({
-          id: 'LEGACY',
-          description: 'LEGACY'
-        })
+        bootModes.unshift(
+          { id: 'SECURE', description: 'SECURE' }
+        )
       }
-
       this.options.bootModes = bootModes
       this.$forceUpdate()
     },
@@ -2035,6 +2016,10 @@ export default {
     },
     updateIOPSValue (input, value) {
       this[input] = value
+    },
+    onBootTypeChange (value) {
+      this.fetchBootModes(value)
+      this.updateFieldValue('bootmode', this.options.bootModes[0].id)
     }
   }
 }

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -2019,7 +2019,7 @@ export default {
     },
     onBootTypeChange (value) {
       this.fetchBootModes(value)
-      this.updateFieldValue('bootmode', this.options.bootModes[0].id)
+      this.updateFieldValue('bootmode', this.options.bootModes?.[0]?.id || undefined)
     }
   }
 }


### PR DESCRIPTION
### Description

Fixes NPE when UEFI is used for boot mode but no boot type is passed.
```
ERROR [c.c.a.ApiServer] (qtp661543645-300:ctx-3e8b622e ctx-0499e8d9) (logid:980273bb) unhandled exception executing api command: [Ljava.lang.String;@69003076
java.lang.NullPointerException
	at org.apache.cloudstack.api.command.user.vm.DeployVMCmd.getDetails(DeployVMCmd.java:296)
	at com.cloud.vm.UserVmManagerImpl.createVirtualMachine(UserVmManagerImpl.java:5253)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy199.createVirtualMachine(Unknown Source)
	at org.apache.cloudstack.api.command.user.vm.DeployVMCmd.create(DeployVMCmd.java:719)
```
<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Using cmk:

**With empty bootmode and boottype=UEFI**
```
(local) 🙉 > deploy virtualmachine zoneid=681d6964-e25b-4d5d-866b-7dab67ee292c templateid=cc517531-076b-11ec-9cda-645d8651f45a serviceofferingid=c0cdd2af-2126-4f5f-8b21-b7d4353f6b12 boottype=UEFI bootmode=
🙈 Error: (HTTP 431, error code 4350) bootmode must be specified for the VM with boot type: UEFI. Valid values are: [LEGACY, SECURE]
```

**With invalid bootmode and boottype=UEFI**
```
(local) 🙊 > deploy virtualmachine zoneid=681d6964-e25b-4d5d-866b-7dab67ee292c templateid=cc517531-076b-11ec-9cda-645d8651f45a serviceofferingid=c0cdd2af-2126-4f5f-8b21-b7d4353f6b12 boottype=UEFI bootmode=SEC
🙈 Error: (HTTP 431, error code 4350) Invalid bootmode: SEC specified for VM: null. Valid values are: [LEGACY, SECURE]
```

**With valid bootmode and boottype=UEFI**
```
(local) 🐈 > deploy virtualmachine zoneid=681d6964-e25b-4d5d-866b-7dab67ee292c templateid=cc517531-076b-11ec-9cda-645d8651f45a serviceofferingid=c0cdd2af-2126-4f5f-8b21-b7d4353f6b12 boottype=UEFI bootmode=SECURE
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "secure",
    "boottype": "Uefi",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-08-31T16:17:12+0530",
    "details": {
      "UEFI": "SECURE"
    },
    "displayname": "QA-88fabf69-c2ad-4a49-ab95-be250c00eec1",
```

**With no bootmode and boottype=BIOS**
```
(local) 🐙 > deploy virtualmachine zoneid=681d6964-e25b-4d5d-866b-7dab67ee292c templateid=cc517531-076b-11ec-9cda-645d8651f45a serviceofferingid=c0cdd2af-2126-4f5f-8b21-b7d4353f6b12 boottype=BIOS
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-08-31T16:42:43+0530",
    "details": {},
    "displayname": "QA-835e0877-98e2-4e6a-a807-ee5551880172",
```

**With empty bootmode and boottype=BIOS**
```
(local) 🐿 > deploy virtualmachine zoneid=681d6964-e25b-4d5d-866b-7dab67ee292c templateid=cc517531-076b-11ec-9cda-645d8651f45a serviceofferingid=c0cdd2af-2126-4f5f-8b21-b7d4353f6b12 boottype=BIOS bootmode=
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-08-31T16:43:35+0530",
    "details": {},
    "displayname": "QA-e3a64620-9499-4770-81b1-6758b7fe057d",
```

**Without bootmode and boottype**
```
(local) 🐋 > deploy virtualmachine zoneid=681d6964-e25b-4d5d-866b-7dab67ee292c templateid=cc517531-076b-11ec-9cda-645d8651f45a serviceofferingid=c0cdd2af-2126-4f5f-8b21-b7d4353f6b12
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2021-08-31T16:42:49+0530",
    "details": {},
    "displayname": "QA-57c6e8c2-8327-43a6-9d9c-52c14fe72a3c",
```