### PR TITLE
Allow traffic from private gateway to internet

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -504,7 +504,7 @@ class CsIP:
                             self.fw.append(["filter", "front", "-A FORWARD -s %s -d %s -j ACL_INBOUND_%s" %
                                             (self.address["network"], address["network"], address["device"])])
                 # Accept packet from private gateway if VPC VR is used as gateway
-                self.fw.append(["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" %
+                self.fw.append(["filter", "front", "-A FORWARD -s %s ! -d %s -j ACCEPT" %
                                 (self.address['network'], self.address['network'])])
 
         if self.get_type() in ["public"]:


### PR DESCRIPTION
### Description
When private gateway is configured, the external server
which are connected through private gateway cannot send
traffic to outside world. Add a source iptable rule so
that the servers which are connected through private gateway
can ping the public IP's




<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Configure the private gateway in a vpc
2. Configure an external dedicated server to use the private gateway to communicate with the outside world as well as with the instances in the cloudstack
3. by default we can ping the dedicated server from the outside world and we cannot ping from dedicated server to the outside world. However we can ping only from dedicated server to the virtual router
4. after this change we are able to ping to the outside world

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
