### PR TITLE
Prevent double counting storage pools

### DIFF
--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -2075,6 +2075,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         if (poolId != null) {
             sc.addAnd("hostOrPoolId", SearchCriteria.Op.EQ, poolId);
         }
+        sc.addAnd("parent", SearchCriteria.Op.EQ, 0);
         if (poolId != null) {
             pools.add(_storagePoolDao.findById(poolId));
         } else {

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -2075,7 +2075,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         if (poolId != null) {
             sc.addAnd("hostOrPoolId", SearchCriteria.Op.EQ, poolId);
         }
-        sc.addAnd("parent", SearchCriteria.Op.EQ, 0);
+        sc.addAnd("parent", SearchCriteria.Op.EQ, 0L);
         if (poolId != null) {
             pools.add(_storagePoolDao.findById(poolId));
         } else {


### PR DESCRIPTION
### Description

Currenly, getStoragePoolUsedStats method fetch all pools
independed if a pool have a parent. Therefore as soon
as a datastore cluster is used, the cluster and the storages it contains are calculated together
The change fetch all storages without cluster and all datastore cluster

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
tested in own env.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
