### PR TITLE
vm-import: fix unmanaged instance listing

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -162,4 +162,5 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
 
     void updateSystemVmTemplateId(long templateId, Hypervisor.HypervisorType hypervisorType);
 
+    List<VMInstanceVO> listByHostOrLastHostOrHostPod(long hostId, long podId);
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -966,11 +966,12 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     @Override
     public List<VMInstanceVO> listByHostOrLastHostOrHostPod(long hostId, long podId) {
         SearchBuilder<VMInstanceVO> sb = createSearchBuilder();
-        sb.or("hostId", sb.entity().getHostId(), Op.EQ);
+        sb.or().op("hostId", sb.entity().getHostId(), Op.EQ);
         sb.or("lastHostId", sb.entity().getLastHostId(), Op.EQ);
         sb.and().op("hostIdNull", sb.entity().getHostId(), SearchCriteria.Op.NULL);
         sb.and("lastHostIdNull", sb.entity().getHostId(), SearchCriteria.Op.NULL);
         sb.and("podId", sb.entity().getPodIdToDeployIn(), Op.EQ);
+        sb.cp();
         sb.cp();
         sb.done();
         SearchCriteria<VMInstanceVO> sc = sb.create();

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -28,12 +28,12 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.cloud.hypervisor.Hypervisor;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.tags.dao.ResourceTagDao;
 import com.cloud.utils.DateUtil;
@@ -961,6 +961,18 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         } catch (Throwable e) {
             throw new CloudRuntimeException("Caught: " + sql, e);
         }
+    }
 
+    @Override
+    public List<VMInstanceVO> listByHostOrLastHostOrHostPod(long hostId, long podId) {
+        SearchCriteria<VMInstanceVO> sc = createSearchCriteria();
+        sc.addOr("hostId", SearchCriteria.Op.EQ, hostId);
+        sc.addOr("lastHostId", SearchCriteria.Op.EQ, hostId);
+        SearchCriteria<VMInstanceVO> podSc = createSearchCriteria();
+        podSc.addAnd("hostId", Op.NULL);
+        podSc.addAnd("lastHostId", Op.NULL);
+        podSc.addAnd("podIdToDeployIn", SearchCriteria.Op.EQ, podId);
+        sc.addOr("pod", SearchCriteria.Op.SC, podSc);
+        return listBy(sc);
     }
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -965,14 +965,18 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
 
     @Override
     public List<VMInstanceVO> listByHostOrLastHostOrHostPod(long hostId, long podId) {
-        SearchCriteria<VMInstanceVO> sc = createSearchCriteria();
-        sc.addOr("hostId", SearchCriteria.Op.EQ, hostId);
-        sc.addOr("lastHostId", SearchCriteria.Op.EQ, hostId);
-        SearchCriteria<VMInstanceVO> podSc = createSearchCriteria();
-        podSc.addAnd("hostId", Op.NULL);
-        podSc.addAnd("lastHostId", Op.NULL);
-        podSc.addAnd("podIdToDeployIn", SearchCriteria.Op.EQ, podId);
-        sc.addOr("pod", SearchCriteria.Op.SC, podSc);
+        SearchBuilder<VMInstanceVO> sb = createSearchBuilder();
+        sb.or("hostId", sb.entity().getHostId(), Op.EQ);
+        sb.or("lastHostId", sb.entity().getLastHostId(), Op.EQ);
+        sb.and().op("hostIdNull", sb.entity().getHostId(), SearchCriteria.Op.NULL);
+        sb.and("lastHostIdNull", sb.entity().getHostId(), SearchCriteria.Op.NULL);
+        sb.and("podId", sb.entity().getPodIdToDeployIn(), Op.EQ);
+        sb.cp();
+        sb.done();
+        SearchCriteria<VMInstanceVO> sc = sb.create();
+        sc.setParameters("hostId", String.valueOf(hostId));
+        sc.setParameters("lastHostId", String.valueOf(hostId));
+        sc.setParameters("podId", String.valueOf(podId));
         return listBy(sc);
     }
 }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -363,18 +364,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     }
 
     private List<String> getHostManagedVms(Host host) {
-        List<String> managedVms = new ArrayList<>();
-        List<VMInstanceVO> instances = vmDao.listByHostId(host.getId());
-        for (VMInstanceVO instance : instances) {
-            managedVms.add(instance.getInstanceName());
-        }
-        instances = vmDao.listByLastHostIdAndStates(host.getId(),
-                VirtualMachine.State.Stopped, VirtualMachine.State.Destroyed,
-                VirtualMachine.State.Expunging, VirtualMachine.State.Error,
-                VirtualMachine.State.Unknown, VirtualMachine.State.Shutdown);
-        for (VMInstanceVO instance : instances) {
-            managedVms.add(instance.getInstanceName());
-        }
+        List<VMInstanceVO> instances = vmDao.listByHostOrLastHostOrHostPod(host.getId(), host.getPodId());
+        List<String> managedVms = instances.stream().map(VMInstanceVO::getInstanceName).collect(Collectors.toList());
         return managedVms;
     }
 


### PR DESCRIPTION
### Description

When the host and last host ID is not set for the VM, it may appear in the list of unmanaged instances.
This change fixes the behaviour by filtering unmanaged instances list for the host for the following three criteria:
- host is set as host_id for the VM
- host is set as the last_host_id for the VM
- pod of the host is set as the pod_id for the VM and both host_id and last_host_id is NULL

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

**Clusters:**
```
(localcloud) SBCM5> > list clusters filter=id,name,podid,podname
{
  "cluster": [
    {
      "id": "3d79b022-0fd9-4f51-805d-ef71bef562c5",
      "name": "p1-c1",
      "podid": "c9e2eccc-9c94-4a9e-a971-fa15a0bf59c2",
      "podname": "Pod1"
    },
    {
      "id": "a5b2a7b8-f897-4d5f-889f-a9f1321e7c2b",
      "name": "10.0.35.234/Trillian/p1-c2",
      "podid": "c9e2eccc-9c94-4a9e-a971-fa15a0bf59c2",
      "podname": "Pod1"
    }
  ],
  "count": 2
}
```
Zone has two VMs. One managed VM - **t1**. Other unmanaged VM - **test123**. In the below tests, without PR changes ACS wrongly lists both VMs as unmanaged VMs. After changes ACS correctly lists only _test123_ as the unmanaged VM.

**VMs list in the environment after inter-cluster migration of VM - t1:**
```
(localcloud) SBCM5> > list virtualmachines filter=id,name
{
  "count": 1,
  "virtualmachine": [
    {
      "id": "7ce5dab4-ddad-4f25-85f1-8e3992ccb0a0",
      "name": "t1"
    }
  ]
}
(localcloud) SBCM5> > list volumes virtualmachineid=7ce5dab4-ddad-4f25-85f1-8e3992ccb0a0 
{
  "count": 1,
  "volume": [
    {
      "account": "admin",
      "chaininfo": "{\"diskDeviceBusName\":\"ide0:1\",\"diskChain\":[\"[4f37137963f1317e9709563c8f57983e] i-2-5-VM/i-2-5-VM.vmdk\"]}",
      "clusterid": "3d79b022-0fd9-4f51-805d-ef71bef562c5",
      "clustername": "p1-c1",
      "created": "2021-09-06T10:17:07+0000",
      "destroyed": false,
      "deviceid": 0,
      "diskioread": 27,
      "diskiowrite": 9,
      "diskkbsread": 1155,
      "diskkbswrite": 74,
      "displayvolume": true,
      "domain": "ROOT",
      "domainid": "09046ad8-0bda-11ec-a29c-1e0094000118",
      "hypervisor": "VMware",
      "id": "c1340b3e-37dc-4959-af84-e1b5e7395efe",
      "isextractable": true,
      "name": "ROOT-5",
      "path": "i-2-5-VM",
      "podid": "c9e2eccc-9c94-4a9e-a971-fa15a0bf59c2",
      "podname": "Pod1",
      "provisioningtype": "thin",
      "quiescevm": false,
      "serviceofferingdisplaytext": "Small Instance",
      "serviceofferingid": "0820dfc7-d843-4120-9df6-ee4e216083f5",
      "serviceofferingname": "Small Instance",
      "size": 2147483648,
      "state": "Ready",
      "storage": "ps1",
      "storageid": "4f371379-63f1-317e-9709-563c8f57983e",
      "storagetype": "shared",
      "supportsstoragesnapshot": false,
      "tags": [],
      "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
      "templateid": "0907e0f0-0bda-11ec-a29c-1e0094000118",
      "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
      "type": "ROOT",
      "virtualmachineid": "7ce5dab4-ddad-4f25-85f1-8e3992ccb0a0",
      "vmdisplayname": "t1",
      "vmname": "t1",
      "vmstate": "Stopped",
      "zoneid": "1991b455-cebf-4507-88c4-8c8a467971c3",
      "zonename": "pr4774-t1933-vmware-67u3"
    }
  ]
}
```

**Unmanaged instances list before fix:**
```
(localcloud) SBCM5> > list unmanagedinstances clusterid=3d79b022-0fd9-4f51-805d-ef71bef562c5 filter=name,hostid,hostname,clusterid
{
  "count": 2,
  "unmanagedinstance": [
    {
      "clusterid": "3d79b022-0fd9-4f51-805d-ef71bef562c5",
      "hostid": "4b7798ef-745c-4595-9715-be976dfbe963",
      "hostname": "10.0.34.154",
      "name": "test123"
    },
    {
      "clusterid": "3d79b022-0fd9-4f51-805d-ef71bef562c5",
      "hostid": "4b7798ef-745c-4595-9715-be976dfbe963",
      "hostname": "10.0.34.154",
      "name": "i-2-5-VM"
    }
  ]
}
```

**Unmanaged instances list after fix:**
```
(localcloud) SBCM5> > list unmanagedinstances clusterid=3d79b022-0fd9-4f51-805d-ef71bef562c5 filter=name,hostid,hostname,clusterid
{
  "count": 1,
  "unmanagedinstance": [
    {
      "clusterid": "3d79b022-0fd9-4f51-805d-ef71bef562c5",
      "hostid": "4b7798ef-745c-4595-9715-be976dfbe963",
      "hostname": "10.0.34.154",
      "name": "test123"
    }
  ]
}
```
