### PR TITLE
marvin: fix exception logging

### DIFF
--- a/tools/marvin/marvin/cloudstackException.py
+++ b/tools/marvin/marvin/cloudstackException.py
@@ -58,7 +58,12 @@ class internalError(Exception):
 
 def GetDetailExceptionInfo(e):
     if e is not None:
-        exc_type, exc_value, exc_traceback = sys.exc_info()
+        if type(e) is str:
+            return e
+        elif type(e) is tuple:
+            (exc_type, exc_value, exc_traceback) = e
+        else:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
         return str(repr(traceback.format_exception(
             exc_type, exc_value, exc_traceback)))
     else:


### PR DESCRIPTION
### Description

Fixes #5203

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
Tested marvin logs with and without changes while making ACS throw exception for an async API
```
[root@pr5201-t1929-kvm-centos7-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr5201-t1929-kvm-centos7-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_deploy_vm_iso.py

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Sep_02_2021_08_56_13_EU0IU4 All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_deploy_vm_from_iso | Status : EXCEPTION ===

=== Final results are now copied to: /marvin//MarvinLogs/test_deploy_vm_iso_AWJQLB ===
[root@pr5201-t1929-kvm-centos7-marvin marvin]# cat /marvin//MarvinLogs/test_deploy_vm_iso_AWJQLB/failed_plus_exceptions.txt 
2021-09-02 08:56:26,082 - CRITICAL - EXCEPTION: test_deploy_vm_from_iso: ['NoneType: None\n']
[root@pr5201-t1929-kvm-centos7-marvin marvin]# rm -f /usr/local/lib/python3.6/site-packages/marvin/cloudstackException.py 
[root@pr5201-t1929-kvm-centos7-marvin marvin]# vi /usr/local/lib/python3.6/site-packages/marvin/cloudstackException.py
[root@pr5201-t1929-kvm-centos7-marvin marvin]# python3 -m py_compile /usr/local/lib/python3.6/site-packages/marvin/cloudstackException.py
[root@pr5201-t1929-kvm-centos7-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr5201-t1929-kvm-centos7-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_deploy_vm_iso.py

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Sep_02_2021_08_57_49_DQLC8J All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_deploy_vm_from_iso | Status : EXCEPTION ===

=== Final results are now copied to: /marvin//MarvinLogs/test_deploy_vm_iso_1X0ZMN ===
[root@pr5201-t1929-kvm-centos7-marvin marvin]# cat /marvin//MarvinLogs/test_deploy_vm_iso_1X0ZMN/failed_plus_exceptions.txt 
2021-09-02 08:58:02,358 - CRITICAL - EXCEPTION: test_deploy_vm_from_iso: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_deploy_vm_iso.py", line 150, in test_deploy_vm_from_iso\n    hypervisor=self.hypervisor\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 672, in create\n    virtual_machine = apiclient.deployVirtualMachine(cmd, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 2625, in deployVirtualMachine\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 105, in __poll\n    % async_response)\n', 'Exception: Job failed: {accountid : \'f91ae009-0bb0-11ec-85de-1e0050000361\', userid : \'f91c23af-0bb0-11ec-85de-1e0050000361\', cmd : \'org.apache.cloudstack.api.command.admin.vm.DeployVMCmdByAdmin\', jobstatus : 2, jobprocstatus : 0, jobresultcode : 530, jobresulttype : \'object\', jobresult : {errorcode : 533, errortext : \'Unable to create a deployment for VM instance {id: "33", name: "i-35-33-VM", uuid: "6a8e9431-8a31-4a4e-be22-b4a9f97283b9", type="User"}\'}, jobinstancetype : \'VirtualMachine\', jobinstanceid : \'6a8e9431-8a31-4a4e-be22-b4a9f97283b9\', created : \'2021-09-02T08:57:55+0000\', completed : \'2021-09-02T08:57:55+0000\', jobid : \'9fcc8cf6-6433-423d-8577-c8972b6235b9\'}\n']
```