### PR TITLE
UI: Add router links to notifications and show error description

### DIFF
--- a/ui/src/components/header/HeaderNotice.vue
+++ b/ui/src/components/header/HeaderNotice.vue
@@ -33,11 +33,12 @@
             </a-list-item-meta>
           </a-list-item>
           <a-list-item v-for="(notice, index) in notices" :key="index">
-            <a-list-item-meta :title="notice.title" :description="notice.description">
+            <div slot="title"> {{ notice.path }} </div>
+            <a-list-item-meta :title="notice.title">
               <a-avatar :style="notificationAvatar[notice.status].style" :icon="notificationAvatar[notice.status].icon" slot="avatar"/>
-              <span v-if="getResourceName(notice.description, 'name') && notice.path" slot="description"><router-link :to="{ path: notice.path}"> {{ getResourceName(notice.description, "name") + ' - ' }}</router-link></span>
-              <span v-if="getResourceName(notice.description, 'name') && notice.path" slot="description"> {{ getResourceName(notice.description, "msg") }}</span>
-              <span v-else slot="description"> {{ notice.description }} </span>
+              <span slot="description" v-if="getResourceName(notice.description, 'name') && notice.path"><router-link :to="{ path: notice.path}"> {{ getResourceName(notice.description, "name") + ' - ' }}</router-link></span>
+              <span slot="description" v-if="getResourceName(notice.description, 'name') && notice.path"> {{ getResourceName(notice.description, "msg") }}</span>
+              <span slot="description" v-else> {{ notice.description }} </span>
             </a-list-item-meta>
           </a-list-item>
         </a-list>

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -500,21 +500,6 @@ export default {
         })
       }
     })
-    eventBus.$on('update-job-details', (jobId, resourceId) => {
-      const fullPath = this.$route.fullPath
-      const path = this.$route.path
-      var jobs = this.$store.getters.headerNotices.map(job => {
-        if (job.jobid === jobId) {
-          if (resourceId && !path.includes(resourceId)) {
-            job.path = path + '/' + resourceId
-          } else {
-            job.path = fullPath
-          }
-        }
-        return job
-      })
-      this.$store.commit('SET_HEADER_NOTICES', jobs)
-    })
 
     eventBus.$on('update-resource-state', (selectedItems, resource, state, jobid) => {
       if (selectedItems.length === 0) {
@@ -1059,7 +1044,8 @@ export default {
           showLoading: showLoading,
           catchMessage: this.$t('error.fetching.async.job.result'),
           action,
-          bulkAction: `${this.selectedItems.length > 0}` && this.showGroupActionModal
+          bulkAction: `${this.selectedItems.length > 0}` && this.showGroupActionModal,
+          resourceId: resource
         })
       })
     },

--- a/ui/src/views/compute/StartVirtualMachine.vue
+++ b/ui/src/views/compute/StartVirtualMachine.vue
@@ -100,7 +100,6 @@
 
 <script>
 import { api } from '@/api'
-import eventBus from '@/config/eventBus'
 import TooltipLabel from '@/components/widgets/TooltipLabel'
 
 export default {
@@ -232,8 +231,6 @@ export default {
             successMessage: `${this.$t('label.action.start.instance')} ${this.resource.name}`,
             response: (result) => { return result.virtualmachine && result.virtualmachine.password ? `The password of VM <b>${result.virtualmachine.displayname}</b> is <b>${result.virtualmachine.password}</b>` : null }
           })
-          const resourceId = this.resource.id
-          eventBus.$emit('update-job-details', jobId, resourceId)
           this.closeAction()
         }).catch(error => {
           this.$notifyError(error)


### PR DESCRIPTION
### Description

Add router links to the notification list - which aids in traversing to the respective resource in case of failed jobs/ operations. This was added as part of #5034; however, during recent refactor of the UI around header notices, this minor enhancement was reverted. This PR also brings back the old behavior of showing the error description in the notification list so that one may not have to filter through events to see the reason for a failure

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):


### How Has This Been Tested?
#### Current Behavior:
![image](https://user-images.githubusercontent.com/10495417/131823854-14fb0ac8-f7ab-4799-bec1-af96ff5bc82b.png)


#### New Behavior:
![image](https://user-images.githubusercontent.com/10495417/131823978-4dc3d595-5735-42fe-acdd-be07e289a2af.png)




<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
