### PR TITLE
Allow public templates with no url to be migrated

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -179,7 +179,8 @@ public class DataMigrationUtility {
         List<TemplateDataStoreVO> templates = templateDataStoreDao.listByStoreId(srcDataStore.getId());
         for (TemplateDataStoreVO template : templates) {
             VMTemplateVO templateVO = templateDao.findById(template.getTemplateId());
-            if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && templateVO != null && !templateVO.isPublicTemplate() &&
+            if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && templateVO != null &&
+                    (!templateVO.isPublicTemplate() || (templateVO.isPublicTemplate() && templateVO.getUrl() == null)) &&
                     templateVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator) {
                 files.add(templateFactory.getTemplate(template.getTemplateId(), srcDataStore));
             }

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -122,7 +122,11 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         activeTmpltSearch.and("store_id", activeTmpltSearch.entity().getDataStoreId(), SearchCriteria.Op.EQ);
         activeTmpltSearch.and("type", activeTmpltSearch.entity().getTemplateType(), SearchCriteria.Op.EQ);
         activeTmpltSearch.and("templateState", activeTmpltSearch.entity().getTemplateState(), SearchCriteria.Op.EQ);
-        activeTmpltSearch.and("public", activeTmpltSearch.entity().isPublicTemplate(), SearchCriteria.Op.EQ);
+        activeTmpltSearch.and().op("public", activeTmpltSearch.entity().isPublicTemplate(), SearchCriteria.Op.EQ);
+        activeTmpltSearch.or().op("publicNoUrl", activeTmpltSearch.entity().isPublicTemplate(), SearchCriteria.Op.EQ);
+        activeTmpltSearch.and("url", activeTmpltSearch.entity().getUrl(), SearchCriteria.Op.NULL);
+        activeTmpltSearch.cp();
+        activeTmpltSearch.cp();
         activeTmpltSearch.done();
 
         // select distinct pair (template_id, zone_id)
@@ -528,6 +532,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         sc.setParameters("type", TemplateType.USER);
         sc.setParameters("templateState", VirtualMachineTemplate.State.Active);
         sc.setParameters("public", Boolean.FALSE);
+        sc.setParameters("publicNoUrl",Boolean.TRUE);
         return searchIncludingRemoved(sc, null, null, false);
     }
 


### PR DESCRIPTION
### Description

This PR allows migration of public templates that are created from snapshots / volumes. Data migration across secondary stores initially excluded all public templates on the pretext that public templates are automatically synced when a new image store is added; however, this assumption isn't true for templates marked as "public" when created from snapshots / volumes. Such templates can be identified if their url is null
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Initial Behavior:
1. Created a snapshot and then created a template from that snapshot and marked the template as public
2. Added another image store
3. Validated that the template doesn't get synced
4. Attempted migration of resources from one store to another - all public templates including the one created from the snapshot is left behind

New Behavior:
```
MariaDB [cloud]>  select * from vm_template  // template created from snapshot
*************************** 15. row ***************************
                  id: 202
         unique_name: 202-2-1367573b-68d3-3bfe-977a-bdc2bf9936d1
                name: PublicTempFromSnap
                uuid: 08c14c2e-4440-4c3f-9feb-546ca1ae022f
              public: 1
            featured: 0
                type: USER
                 hvm: 0
                bits: 64
                 url: NULL
              format: QCOW2
             created: 2021-09-02 11:42:55
             removed: NULL
          account_id: 2
            checksum: NULL
        display_text: PublicTempFromSnap
     enable_password: 0
       enable_sshkey: 0
         guest_os_id: 99
            bootable: 1
         prepopulate: 0
         cross_zones: 0
         extractable: 1
     hypervisor_type: KVM
  source_template_id: 4
        template_tag: NULL
            sort_key: 0
                size: 8589934592
               state: Active
        update_count: 0
             updated: NULL
dynamically_scalable: 0
  parent_template_id: NULL
     direct_download: 0
        deploy_as_is: 0
15 rows in set (0.00 sec)

MariaDB [cloud]> select * from template_store_ref  where template_id = 202\G <-- secondary store template reference before migration (store_id = 1)
*************************** 1. row ***************************
                  id: 8
            store_id: 1
         template_id: 202
             created: 2021-09-02 11:42:55
        last_updated: NULL
              job_id: NULL
        download_pct: 100
                size: 8589934592
          store_role: Image
       physical_size: 1622409216
      download_state: DOWNLOADED
           error_str: NULL
          local_path: NULL
        install_path: template/tmpl/2/202/5ed48fa5-69b9-4297-94a6-0a75cebdaf25.qcow2
                 url: NULL
               state: Ready
           destroyed: 0
             is_copy: 0
        update_count: 2
             ref_cnt: 0
             updated: 2021-09-02 11:43:15
download_url_created: NULL
        download_url: NULL
1 row in set (0.00 sec)

MariaDB [cloud]> select * from template_store_ref  where template_id = 202\G < -- template store ref after migration (store_id = 2)
*************************** 1. row ***************************
                  id: 17
            store_id: 2
         template_id: 202
             created: 2021-09-02 11:42:55
        last_updated: NULL
              job_id: NULL
        download_pct: 100
                size: 8589934592
          store_role: Image
       physical_size: 1622409216
      download_state: DOWNLOADED
           error_str: NULL
          local_path: NULL
        install_path: template/tmpl/2/202/5ed48fa5-69b9-4297-94a6-0a75cebdaf25.qcow2
                 url: NULL
               state: Ready
           destroyed: 0
             is_copy: 0
        update_count: 2
             ref_cnt: 0
             updated: 2021-09-02 12:25:14
download_url_created: NULL
        download_url: NULL
1 row in set (0.00 sec)

```

Also attempted deletion of store 1 prior initiating migration - with the public template (created from snapshot) present - fails as expected:
![image](https://user-images.githubusercontent.com/10495417/131844347-676b397c-a083-4267-8d9c-344097354488.png)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
