### PR TITLE
[Vmware] Use host FQDN if host IP is not found on VNC command

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -1184,17 +1184,18 @@ public class VirtualMachineMO extends BaseMO {
         VirtualMachineConfigInfo configInfo = getConfigInfo();
         List<OptionValue> values = configInfo.getExtraConfig();
 
+        String hostKey = StringUtils.isBlank(summary.getHostIp()) ? hostMo.getHostName() : summary.getHostIp();
         if (values != null) {
             for (OptionValue option : values) {
                 if (option.getKey().equals("RemoteDisplay.vnc.port")) {
                     String value = (String)option.getValue();
                     if (value != null) {
-                        return new Pair<String, Integer>(summary.getHostIp(), Integer.parseInt(value));
+                        return new Pair<String, Integer>(hostKey, Integer.parseInt(value));
                     }
                 }
             }
         }
-        return new Pair<String, Integer>(summary.getHostIp(), 0);
+        return new Pair<String, Integer>(hostKey, 0);
     }
 
     // vmdkDatastorePath: [datastore name] vmdkFilePath


### PR DESCRIPTION
### Description

This PR uses the host name if the host IP is not found on Vmware for Vmware 7 console proxy websocket URL 
Fixes: #5413 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
