### PR TITLE
ui: select newly created network in deploy vm

### DIFF
--- a/ui/src/views/compute/wizard/NetworkSelection.vue
+++ b/ui/src/views/compute/wizard/NetworkSelection.vue
@@ -22,7 +22,7 @@
       :placeholder="$t('label.search')"
       v-model="filter"
       @search="handleSearch" />
-    <a-button type="primary" @click="showCreateForm = true" style="float: right; margin-right: 5px; z-index: 8">
+    <a-button type="primary" @click="onCreateNetworkClick" style="float: right; margin-right: 5px; z-index: 8">
       {{ $t('label.create.network') }}
     </a-button>
     <a-table
@@ -139,7 +139,8 @@ export default {
         page: 1,
         pageSize: 10,
         keyword: null
-      }
+      },
+      networksBeforeCreate: null
     }
   },
   computed: {
@@ -222,6 +223,32 @@ export default {
           }
         }
       }
+    },
+    items () {
+      if (this.items && this.items.length > 0 &&
+        this.networksBeforeCreate) {
+        var user = this.$store.getters.userInfo
+        for (var network of this.items) {
+          if (user.account !== network.account ||
+            user.domainid !== network.domainid ||
+            (new Date()).getTime() - Date.parse(network.created) > 30000) {
+            continue
+          }
+          var networkFoundInNewList = false
+          for (var oldNetwork of this.networksBeforeCreate) {
+            if (oldNetwork.id === network.id) {
+              networkFoundInNewList = true
+              break
+            }
+          }
+          if (!networkFoundInNewList) {
+            this.selectedRowKeys.push(network.id)
+            this.$emit('select-network-item', this.selectedRowKeys)
+            break
+          }
+        }
+        this.networksBeforeCreate = null
+      }
     }
   },
   beforeCreate () {
@@ -289,6 +316,10 @@ export default {
           resolve(error)
         })
       })
+    },
+    onCreateNetworkClick () {
+      this.networksBeforeCreate = this.items
+      this.showCreateForm = true
     }
   }
 }


### PR DESCRIPTION
### Description

Form tries to find newly created network which belongs to the same account, created in last 30s and was not present in the networks list before opening create network dialog.
<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before:

![newnetworkafter](https://user-images.githubusercontent.com/153340/132653117-e89e779e-80e2-4b3b-85a1-55103488fb7c.gif)

After:

![newnetworkbefore](https://user-images.githubusercontent.com/153340/132652964-27d76e06-20e0-4e12-b865-2506b7d0a70e.gif)


