### PR TITLE
Updated pod response, grouped the parameters: "startip, endip, vlanid, forsystemvms" as ip range response and added to ipranges parameter.

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -565,6 +565,7 @@ public class ApiConstants {
     public static final String TRAFFIC_TYPE_IMPLEMENTOR = "traffictypeimplementor";
     public static final String KEYWORD = "keyword";
     public static final String LIST_ALL = "listall";
+    public static final String IP_RANGES = "ipranges";
     public static final String SPECIFY_IP_RANGES = "specifyipranges";
     public static final String IS_SOURCE_NAT = "issourcenat";
     public static final String IS_STATIC_NAT = "isstaticnat";

--- a/api/src/main/java/org/apache/cloudstack/api/response/IpRangeResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/IpRangeResponse.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.response;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseResponse;
+
+import com.cloud.serializer.Param;
+
+@SuppressWarnings("unused")
+public class IpRangeResponse extends BaseResponse {
+
+    @SerializedName(ApiConstants.START_IP)
+    @Param(description = "the starting IP for the range")
+    private String startIp;
+
+    @SerializedName(ApiConstants.END_IP)
+    @Param(description = "the ending IP for the range")
+    private String endIp;
+
+    @SerializedName(ApiConstants.FOR_SYSTEM_VMS)
+    @Param(description = "indicates if range is dedicated for CPVM and SSVM")
+    private String forSystemVms;
+
+    @SerializedName(ApiConstants.VLAN_ID)
+    @Param(description = "indicates Vlan ID for the range")
+    private String vlanId;
+
+    public String getStartIp() {
+        return startIp;
+    }
+
+    public void setStartIp(String startIp) {
+        this.startIp = startIp;
+    }
+
+    public String getEndIp() {
+        return endIp;
+    }
+
+    public void setEndIp(String endIp) {
+        this.endIp = endIp;
+    }
+
+    public void setForSystemVms(String forSystemVms) {
+        this.forSystemVms = forSystemVms;
+    }
+
+    public String getForSystemVms() {
+        return forSystemVms;
+    }
+
+    public String getVlanId() {
+        return vlanId;
+    }
+
+    public void setVlanId(String vlanId) {
+        this.vlanId = vlanId;
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/response/PodResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/PodResponse.java
@@ -29,15 +29,15 @@ import com.cloud.serializer.Param;
 
 @EntityReference(value = Pod.class)
 public class PodResponse extends BaseResponseWithAnnotations {
-    @SerializedName("id")
+    @SerializedName(ApiConstants.ID)
     @Param(description = "the ID of the Pod")
     private String id;
 
-    @SerializedName("name")
+    @SerializedName(ApiConstants.NAME)
     @Param(description = "the name of the Pod")
     private String name;
 
-    @SerializedName("zoneid")
+    @SerializedName(ApiConstants.ZONE_ID)
     @Param(description = "the Zone ID of the Pod")
     private String zoneId;
 
@@ -45,37 +45,45 @@ public class PodResponse extends BaseResponseWithAnnotations {
     @Param(description = "the Zone name of the Pod")
     private String zoneName;
 
-    @SerializedName("gateway")
+    @SerializedName(ApiConstants.GATEWAY)
     @Param(description = "the gateway of the Pod")
     private String gateway;
 
-    @SerializedName("netmask")
+    @SerializedName(ApiConstants.NETMASK)
     @Param(description = "the netmask of the Pod")
     private String netmask;
 
-    @SerializedName("startip")
-    @Param(description = "the starting IP for the Pod")
+    @SerializedName(ApiConstants.IP_RANGES)
+    @Param(description = "the IP ranges for the Pod", responseObject = IpRangeResponse.class, since = "4.16.0")
+    private List<IpRangeResponse> ipRanges;
+
+    @Deprecated(since = "4.16")
+    @SerializedName(ApiConstants.START_IP)
+    @Param(description = "the starting IP for the Pod. This parameter is deprecated, please use 'startip' from ipranges parameter.")
     private List<String> startIp;
 
-    @SerializedName("endip")
-    @Param(description = "the ending IP for the Pod")
+    @Deprecated(since = "4.16")
+    @SerializedName(ApiConstants.END_IP)
+    @Param(description = "the ending IP for the Pod. This parameter is deprecated, please use 'endip' from ipranges parameter.")
     private List<String> endIp;
 
-    @SerializedName("forsystemvms")
-    @Param(description = "indicates if range is dedicated for CPVM and SSVM")
+    @Deprecated(since = "4.16")
+    @SerializedName(ApiConstants.FOR_SYSTEM_VMS)
+    @Param(description = "indicates if range is dedicated for CPVM and SSVM. This parameter is deprecated, please use 'forsystemvms' from ipranges parameter.")
     private List<String> forSystemVms;
 
-    @SerializedName("vlanid")
-    @Param(description = "indicates Vlan ID for the range")
+    @Deprecated(since = "4.16")
+    @SerializedName(ApiConstants.VLAN_ID)
+    @Param(description = "indicates Vlan ID for the range. This parameter is deprecated, please use 'vlanid' from ipranges parameter.")
     private List<String> vlanId;
 
-    @SerializedName("allocationstate")
+    @SerializedName(ApiConstants.ALLOCATION_STATE)
     @Param(description = "the allocation state of the Pod")
     private String allocationState;
 
-    @SerializedName("capacity")
+    @SerializedName(ApiConstants.CAPACITY)
     @Param(description = "the capacity of the Pod", responseObject = CapacityResponse.class)
-    private List<CapacityResponse> capacitites;
+    private List<CapacityResponse> capacities;
 
     public String getId() {
         return id;
@@ -125,6 +133,10 @@ public class PodResponse extends BaseResponseWithAnnotations {
         this.netmask = netmask;
     }
 
+    public void setIpRanges(List<IpRangeResponse> ipRanges) {
+        this.ipRanges = ipRanges;
+    }
+
     public List<String> getStartIp() {
         return startIp;
     }
@@ -165,11 +177,11 @@ public class PodResponse extends BaseResponseWithAnnotations {
         this.allocationState = allocationState;
     }
 
-    public List<CapacityResponse> getCapacitites() {
-        return capacitites;
+    public List<CapacityResponse> getCapacities() {
+        return capacities;
     }
 
-    public void setCapacitites(List<CapacityResponse> capacitites) {
-        this.capacitites = capacitites;
+    public void setCapacities(List<CapacityResponse> capacities) {
+        this.capacities = capacities;
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -85,6 +85,7 @@ import org.apache.cloudstack.api.response.ImageStoreResponse;
 import org.apache.cloudstack.api.response.InstanceGroupResponse;
 import org.apache.cloudstack.api.response.InternalLoadBalancerElementResponse;
 import org.apache.cloudstack.api.response.IpForwardingRuleResponse;
+import org.apache.cloudstack.api.response.IpRangeResponse;
 import org.apache.cloudstack.api.response.IsolationMethodResponse;
 import org.apache.cloudstack.api.response.LBHealthCheckPolicyResponse;
 import org.apache.cloudstack.api.response.LBHealthCheckResponse;
@@ -1082,24 +1083,40 @@ public class ApiResponseHelper implements ResponseGenerator {
     @Override
     public PodResponse createPodResponse(Pod pod, Boolean showCapacities) {
         String[] ipRange = new String[2];
-        List<String> startIp = new ArrayList<String>();
-        List<String> endIp = new ArrayList<String>();
+        List<String> startIps = new ArrayList<String>();
+        List<String> endIps = new ArrayList<String>();
         List<String> forSystemVms = new ArrayList<String>();
         List<String> vlanIds = new ArrayList<String>();
+
+        List<IpRangeResponse> ipRanges = new ArrayList<>();
 
         if (pod.getDescription() != null && pod.getDescription().length() > 0) {
             final String[] existingPodIpRanges = pod.getDescription().split(",");
 
             for(String podIpRange: existingPodIpRanges) {
+                IpRangeResponse ipRangeResponse = new IpRangeResponse();
                 final String[] existingPodIpRange = podIpRange.split("-");
 
-                startIp.add(((existingPodIpRange.length > 0) && (existingPodIpRange[0] != null)) ? existingPodIpRange[0] : "");
-                endIp.add(((existingPodIpRange.length > 1) && (existingPodIpRange[1] != null)) ? existingPodIpRange[1] : "");
-                forSystemVms.add((existingPodIpRange.length > 2) && (existingPodIpRange[2] != null) ? existingPodIpRange[2] : "0");
-                vlanIds.add((existingPodIpRange.length > 3) &&
+                String startIp = ((existingPodIpRange.length > 0) && (existingPodIpRange[0] != null)) ? existingPodIpRange[0] : "";
+                ipRangeResponse.setStartIp(startIp);
+                startIps.add(startIp);
+
+                String endIp = ((existingPodIpRange.length > 1) && (existingPodIpRange[1] != null)) ? existingPodIpRange[1] : "";
+                ipRangeResponse.setEndIp(endIp);
+                endIps.add(endIp);
+
+                String forSystemVm = (existingPodIpRange.length > 2) && (existingPodIpRange[2] != null) ? existingPodIpRange[2] : "0";
+                ipRangeResponse.setForSystemVms(forSystemVm);
+                forSystemVms.add(forSystemVm);
+
+                String vlanId = (existingPodIpRange.length > 3) &&
                         (existingPodIpRange[3] != null && !existingPodIpRange[3].equals("untagged")) ?
                         BroadcastDomainType.Vlan.toUri(existingPodIpRange[3]).toString() :
-                        BroadcastDomainType.Vlan.toUri(Vlan.UNTAGGED).toString());
+                        BroadcastDomainType.Vlan.toUri(Vlan.UNTAGGED).toString();
+                ipRangeResponse.setVlanId(vlanId);
+                vlanIds.add(vlanId);
+
+                ipRanges.add(ipRangeResponse);
             }
         }
 
@@ -1112,8 +1129,9 @@ public class ApiResponseHelper implements ResponseGenerator {
             podResponse.setZoneName(zone.getName());
         }
         podResponse.setNetmask(NetUtils.getCidrNetmask(pod.getCidrSize()));
-        podResponse.setStartIp(startIp);
-        podResponse.setEndIp(endIp);
+        podResponse.setIpRanges(ipRanges);
+        podResponse.setStartIp(startIps);
+        podResponse.setEndIp(endIps);
         podResponse.setForSystemVms(forSystemVms);
         podResponse.setVlanId(vlanIds);
         podResponse.setGateway(pod.getGateway());
@@ -1142,7 +1160,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             }
             // Do it for stats as well.
             capacityResponses.addAll(getStatsCapacityresponse(null, null, pod.getId(), pod.getDataCenterId()));
-            podResponse.setCapacitites(new ArrayList<CapacityResponse>(capacityResponses));
+            podResponse.setCapacities(new ArrayList<CapacityResponse>(capacityResponses));
         }
         podResponse.setHasAnnotation(annotationDao.hasAnnotations(pod.getUuid(), AnnotationService.EntityType.POD.name(),
                 _accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())));

--- a/ui/src/views/infra/network/IpRangesTabManagement.vue
+++ b/ui/src/views/infra/network/IpRangesTabManagement.vue
@@ -229,17 +229,17 @@ export default {
         this.total = response.listpodsresponse.count || 0
         this.pods = response.listpodsresponse.pod ? response.listpodsresponse.pod : []
         for (const pod of this.pods) {
-          if (pod && pod.startip && pod.startip.length > 0) {
-            for (var idx = 0; idx < pod.startip.length; idx++) {
+          if (pod && pod.ipranges && pod.ipranges.length > 0) {
+            for (var idx = 0; idx < pod.ipranges.length; idx++) {
               this.items.push({
                 id: pod.id,
                 name: pod.name,
                 gateway: pod.gateway,
                 netmask: pod.netmask,
-                vlanid: pod.vlanid[idx],
-                startip: pod.startip[idx],
-                endip: pod.endip[idx],
-                forsystemvms: pod.forsystemvms[idx] === '1'
+                vlanid: pod.ipranges[idx].vlanid,
+                startip: pod.ipranges[idx].startip,
+                endip: pod.ipranges[idx].endip,
+                forsystemvms: pod.ipranges[idx].forsystemvms === '1'
               })
             }
           }


### PR DESCRIPTION
### Description
This PR updates the pod response, grouped the parameters: startip, endip, vlanid, forsystemvms as ip range response and added to ipranges parameter (a new parameter to hold the list of IP range details).

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<img width="641" alt="Pod_IpRanges" src="https://user-images.githubusercontent.com/12028987/132653299-4441ce0c-0267-412b-85f3-0792a3b126c5.png">


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Manually tested the updated API response.

Before changes:

```
(cloudcmk) > list pods
{
  "count": 1,
  "pod": [
    {
      "allocationstate": "Enabled",
      "endip": [
        "10.0.36.60",
        "10.0.36.69"
      ],
      "forsystemvms": [
        "0",
        "1"
      ],
      "gateway": "10.0.32.1",
      "hasannotations": false,
      "id": "43ffd982-8942-4c9a-88f3-002dc7f5d411",
      "name": "Pod1",
      "netmask": "255.255.240.0",
      "startip": [
        "10.0.36.41",
        "10.0.36.67"
      ],
      "vlanid": [
        "vlan://untagged",
        "vlan://untagged"
      ],
      "zoneid": "be8e7d3e-2f57-433d-9c93-208949e2ec1d",
      "zonename": "ref-trl-1773-k-M7-suresh-anaparti"
    }
  ]
}
```

After changes: New parameter ipranges holds the list of ip ranges. Old parameters would be deprecated (kept for backward compatibility).

```
(cloudcmk) > list pods
{
  "count": 1,
  "pod": [
    {
      "allocationstate": "Enabled",
      "endip": [
        "10.0.36.60",
        "10.0.36.69"
      ],
      "forsystemvms": [
        "0",
        "1"
      ],
      "gateway": "10.0.32.1",
      "hasannotations": false,
      "id": "43ffd982-8942-4c9a-88f3-002dc7f5d411",
      "ipranges": [
        {
          "endip": "10.0.36.60",
          "forsystemvms": "0",
          "startip": "10.0.36.41",
          "vlanid": "vlan://untagged"
        },
        {
          "endip": "10.0.36.69",
          "forsystemvms": "1",
          "startip": "10.0.36.67",
          "vlanid": "vlan://untagged"
        }
      ],
      "name": "Pod1",
      "netmask": "255.255.240.0",
      "startip": [
        "10.0.36.41",
        "10.0.36.67"
      ],
      "vlanid": [
        "vlan://untagged",
        "vlan://untagged"
      ],
      "zoneid": "be8e7d3e-2f57-433d-9c93-208949e2ec1d",
      "zonename": "ref-trl-1773-k-M7-suresh-anaparti"
    }
  ]
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
