### PR TITLE
ui: ignore failure to retrieve default.ui.page.size config

### DIFF
--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -262,9 +262,7 @@ const user = {
         api('listConfigurations', { name: 'default.ui.page.size' }).then(response => {
           const defaultListViewPageSize = parseInt(response.listconfigurationsresponse.configuration[0].value)
           commit('SET_DEFAULT_LISTVIEW_PAGE_SIZE', defaultListViewPageSize)
-        }).catch(error => {
-          reject(error)
-        })
+        }).catch(ignored => {})
 
         api('listLdapConfigurations').then(response => {
           const ldapEnable = (response.ldapconfigurationresponse.count > 0)


### PR DESCRIPTION
### Description

Fixes non-admin role(or roles that don't have `listCongifgurations` API access) login failure

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
API call fails but login works

![Screenshot from 2021-09-10 17-33-07](https://user-images.githubusercontent.com/153340/132850627-e8f8bb55-012b-41ed-8541-92d421067170.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
