### PR TITLE
Hide settings button if not on development mode

### DIFF
--- a/ui/src/components/page/GlobalLayout.vue
+++ b/ui/src/components/page/GlobalLayout.vue
@@ -63,7 +63,7 @@
       </a-drawer>
     </template>
 
-    <template>
+    <template v-if="isDevelopmentMode">
       <drawer :visible="showSetting" placement="right">
         <div slot="handler">
           <a-button type="primary" size="large">
@@ -129,6 +129,9 @@ export default {
     ...mapState({
       mainMenu: state => state.permission.addRouters
     }),
+    isDevelopmentMode () {
+      return process.env.NODE_ENV === 'development'
+    },
     contentPaddingLeft () {
       if (!this.fixSidebar || this.isMobile()) {
         return '0'

--- a/ui/src/components/view/Setting.vue
+++ b/ui/src/components/view/Setting.vue
@@ -108,11 +108,10 @@
       </a-list>
     </setting-item>
 
-    <div class="setting-action">
+    <div v-if="isDevelopmentMode" class="setting-action">
       <a-divider style="margin: 15px 0;" />
-      <a-alert v-if="isDevelopmentMode" class="setting-action-alert" :message="$t('label.theme.alert')" type="warning" show-icon />
+      <a-alert class="setting-action-alert" :message="$t('label.theme.alert')" type="warning" show-icon />
       <a-button
-        v-if="isDevelopmentMode"
         class="setting-action-btn"
         icon="copy"
         @click="saveSetting">{{ $t('label.save.setting') }}</a-button>

--- a/ui/src/components/view/Setting.vue
+++ b/ui/src/components/view/Setting.vue
@@ -108,7 +108,7 @@
       </a-list>
     </setting-item>
 
-    <div v-if="isDevelopmentMode" class="setting-action">
+    <div class="setting-action">
       <a-divider style="margin: 15px 0;" />
       <a-alert class="setting-action-alert" :message="$t('label.theme.alert')" type="warning" show-icon />
       <a-button
@@ -152,9 +152,6 @@ export default {
   computed: {
     projectView () {
       return Boolean(this.$store.getters.project && this.$store.getters.project.id)
-    },
-    isDevelopmentMode () {
-      return process.env.NODE_ENV === 'development'
     },
     pageStyles () {
       const arrStyle = [

--- a/ui/src/components/view/Setting.vue
+++ b/ui/src/components/view/Setting.vue
@@ -110,8 +110,9 @@
 
     <div class="setting-action">
       <a-divider style="margin: 15px 0;" />
-      <a-alert class="setting-action-alert" :message="$t('label.theme.alert')" type="warning" show-icon />
+      <a-alert v-if="isDevelopmentMode" class="setting-action-alert" :message="$t('label.theme.alert')" type="warning" show-icon />
       <a-button
+        v-if="isDevelopmentMode"
         class="setting-action-btn"
         icon="copy"
         @click="saveSetting">{{ $t('label.save.setting') }}</a-button>
@@ -152,6 +153,9 @@ export default {
   computed: {
     projectView () {
       return Boolean(this.$store.getters.project && this.$store.getters.project.id)
+    },
+    isDevelopmentMode () {
+      return process.env.NODE_ENV === 'development'
     },
     pageStyles () {
       const arrStyle = [


### PR DESCRIPTION
### Description

This PR displays the Settings widget only in development mode 
![Screenshot from 2021-09-10 09-51-19](https://user-images.githubusercontent.com/5295080/132855979-800e81ea-cf80-4d74-9400-0c0a329526b0.png)

After the fix in production:
![Screenshot from 2021-09-10 09-49-53](https://user-images.githubusercontent.com/5295080/132855864-2b4865f7-802e-4eec-86f1-b1659ddc021b.png)

After the fix in development:
![Screenshot from 2021-09-10 09-51-19](https://user-images.githubusercontent.com/5295080/132855988-6268b28c-30ca-4c95-acc0-0e5fc90f5e97.png)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
