### PR TITLE
api, ui: return default ui pagesize as part of capability response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.response.CapabilitiesResponse;
+import org.apache.cloudstack.config.ApiServiceConfiguration;
 import org.apache.log4j.Logger;
 
 import com.cloud.user.Account;
@@ -69,6 +70,7 @@ public class ListCapabilitiesCmd extends BaseCmd {
         if (capabilities.containsKey("apiLimitMax")) {
             response.setApiLimitMax((Integer)capabilities.get("apiLimitMax"));
         }
+        response.setDefaultUiPageSize((Long)capabilities.get(ApiServiceConfiguration.DefaultUIPageSize.key()));
         response.setObjectName("capability");
         response.setResponseName(getCommandName());
         this.setResponseObject(response);

--- a/api/src/main/java/org/apache/cloudstack/api/response/CapabilitiesResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/CapabilitiesResponse.java
@@ -100,6 +100,10 @@ public class CapabilitiesResponse extends BaseResponse {
     @Param(description = "true if experimental features for Kubernetes cluster such as Docker private registry are enabled, false otherwise")
     private boolean kubernetesClusterExperimentalFeaturesEnabled;
 
+    @SerializedName("defaultuipagesize")
+    @Param(description = "default page size in the UI for various views, value set in the configurations", since = "4.15.2")
+    private Long defaultUiPageSize;
+
     public void setSecurityGroupsEnabled(boolean securityGroupsEnabled) {
         this.securityGroupsEnabled = securityGroupsEnabled;
     }
@@ -174,5 +178,9 @@ public class CapabilitiesResponse extends BaseResponse {
 
     public void setKubernetesClusterExperimentalFeaturesEnabled(boolean kubernetesClusterExperimentalFeaturesEnabled) {
         this.kubernetesClusterExperimentalFeaturesEnabled = kubernetesClusterExperimentalFeaturesEnabled;
+    }
+
+    public void setDefaultUiPageSize(Long defaultUiPageSize) {
+        this.defaultUiPageSize = defaultUiPageSize;
     }
 }

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -538,6 +538,7 @@ import org.apache.cloudstack.api.command.user.vpn.UpdateVpnConnectionCmd;
 import org.apache.cloudstack.api.command.user.vpn.UpdateVpnCustomerGatewayCmd;
 import org.apache.cloudstack.api.command.user.vpn.UpdateVpnGatewayCmd;
 import org.apache.cloudstack.api.command.user.zone.ListZonesCmd;
+import org.apache.cloudstack.config.ApiServiceConfiguration;
 import org.apache.cloudstack.config.Configuration;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
@@ -3858,6 +3859,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         capabilities.put("allowUserViewAllDomainAccounts", allowUserViewAllDomainAccounts);
         capabilities.put("kubernetesServiceEnabled", kubernetesServiceEnabled);
         capabilities.put("kubernetesClusterExperimentalFeaturesEnabled", kubernetesClusterExperimentalFeaturesEnabled);
+        capabilities.put(ApiServiceConfiguration.DefaultUIPageSize.key(), ApiServiceConfiguration.DefaultUIPageSize.value());
         if (apiLimitEnabled) {
             capabilities.put("apiLimitInterval", apiLimitInterval);
             capabilities.put("apiLimitMax", apiLimitMax);

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -255,13 +255,9 @@ const user = {
         api('listCapabilities').then(response => {
           const result = response.listcapabilitiesresponse.capability
           commit('SET_FEATURES', result)
-        }).catch(error => {
-          reject(error)
-        })
-
-        api('listConfigurations', { name: 'default.ui.page.size' }).then(response => {
-          const defaultListViewPageSize = parseInt(response.listconfigurationsresponse.configuration[0].value)
-          commit('SET_DEFAULT_LISTVIEW_PAGE_SIZE', defaultListViewPageSize)
+          if (result && result.defaultuipagesize) {
+            commit('SET_DEFAULT_LISTVIEW_PAGE_SIZE', result.defaultuipagesize)
+          }
         }).catch(error => {
           reject(error)
         })


### PR DESCRIPTION
### Description

listConfigurations is not available for all roles and therefore not fit to use in UI for a generic functionality.
This PR makes default ui pagesize a part for listCapabilities API response to make it available for UI across different role accounts.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
