### PR TITLE
ui: Fix Scale VM failure - missing args when custom compute offering is selected

### DIFF
--- a/ui/src/views/compute/ScaleVM.vue
+++ b/ui/src/views/compute/ScaleVM.vue
@@ -33,8 +33,8 @@
 
     <compute-selection
       v-if="selectedOffering && (selectedOffering.iscustomized || selectedOffering.iscustomizediops)"
-      :cpunumber-input-decorator="cpuNumberKey"
-      :cpuspeed-input-decorator="cpuSpeedKey"
+      :cpu-number-input-decorator="cpuNumberKey"
+      :cpu-speed-input-decorator="cpuSpeedKey"
       :memory-input-decorator="memoryKey"
       :computeOfferingId="selectedOffering.id"
       :isConstrained="'serviceofferingdetails' in selectedOffering"


### PR DESCRIPTION
### Description

This PR fixes the failure noticed during scale VM operation when a custom offering is selected. It observed that when cpuNumber / cpu speed is provided for the selected custom compute offering, it fails to pass the args properly

![image](https://user-images.githubusercontent.com/10495417/133038428-8769d837-3199-4e95-a05b-16eb375be10d.png)

![image](https://user-images.githubusercontent.com/10495417/133038445-7cd22d78-4dd8-4ba0-8d25-958684a425ae.png)

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Successfully scaled VM - args properly passed:
![image](https://user-images.githubusercontent.com/10495417/133038515-b4a8b14b-99d4-4f35-a68a-e00dcd2c58ff.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
