### PR TITLE
utils: remove duplicate commons-lang3 dependency

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -197,10 +197,6 @@
             <artifactId>commons-email</artifactId>
             <version>1.5</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
The same is declared at lines 128-131 in utils/pom.xml. This fixes mvn build warning.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)