### PR TITLE
[UI] Fixes: edit tariff quota and allow user driven backups parameter in Import Backup Offering

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -479,8 +479,7 @@ export default {
       parentSearch: this.onSearch,
       parentChangeFilter: this.changeFilter,
       parentChangeResource: this.changeResource,
-      parentPollActionCompletion: this.pollActionCompletion,
-      parentEditTariffAction: () => {}
+      parentPollActionCompletion: this.pollActionCompletion
     }
   },
   data () {

--- a/ui/src/views/offering/ImportBackupOffering.vue
+++ b/ui/src/views/offering/ImportBackupOffering.vue
@@ -78,7 +78,7 @@
       <a-form-item>
         <tooltip-label slot="label" :title="$t('label.allowuserdrivenbackups')" :tooltip="apiParams.allowuserdrivenbackups.description"/>
         <a-switch
-          v-decorator="['allowuserdrivenbackups']"
+          v-decorator="['allowuserdrivenbackups', { initialValue: true }]"
           :default-checked="true"/>
       </a-form-item>
       <div :span="24" class="action-button">
@@ -167,7 +167,7 @@ export default {
             params[key] = input
           }
         }
-        params.allowuserdrivenbackups = values.allowuserdrivenbackups == null ? true : values.allowuserdrivenbackups
+        params.allowuserdrivenbackups = values.allowuserdrivenbackups
         this.loading = true
         const title = this.$t('label.import.offering')
         api('importBackupOffering', params).then(json => {

--- a/ui/src/views/offering/ImportBackupOffering.vue
+++ b/ui/src/views/offering/ImportBackupOffering.vue
@@ -167,7 +167,7 @@ export default {
             params[key] = input
           }
         }
-        params.allowuserdrivenbackups = values.allowuserdrivenbackups ? values.allowuserdrivenbackups : true
+        params.allowuserdrivenbackups = values.allowuserdrivenbackups == null ? true : values.allowuserdrivenbackups
         this.loading = true
         const title = this.$t('label.import.offering')
         api('importBackupOffering', params).then(json => {

--- a/ui/src/views/plugins/quota/EditTariffValueWizard.vue
+++ b/ui/src/views/plugins/quota/EditTariffValueWizard.vue
@@ -112,7 +112,7 @@ export default {
 
         this.loading = true
 
-        api('quotaTariffUpdate', params, 'GET').then(json => {
+        api('quotaTariffUpdate', {}, 'POST', params).then(json => {
           const tariffResponse = json.quotatariffupdateresponse.quotatariff || {}
           if (Object.keys(tariffResponse).length > 0) {
             const effectiveDate = moment(tariffResponse.effectiveDate).format(this.pattern)

--- a/ui/src/views/plugins/quota/EditTariffValueWizard.vue
+++ b/ui/src/views/plugins/quota/EditTariffValueWizard.vue
@@ -112,7 +112,7 @@ export default {
 
         this.loading = true
 
-        api('quotaTariffUpdate', {}, 'POST', params).then(json => {
+        api('quotaTariffUpdate', params, 'GET').then(json => {
           const tariffResponse = json.quotatariffupdateresponse.quotatariff || {}
           if (Object.keys(tariffResponse).length > 0) {
             const effectiveDate = moment(tariffResponse.effectiveDate).format(this.pattern)
@@ -122,7 +122,7 @@ export default {
             }
             this.parentFetchData()
           }
-
+          this.$message.success(`${this.$t('message.setting.updated')} ${this.resource.description}`)
           this.onClose()
         }).catch(error => {
           this.$notification.error({

--- a/ui/src/views/plugins/quota/QuotaTariff.vue
+++ b/ui/src/views/plugins/quota/QuotaTariff.vue
@@ -37,8 +37,8 @@ export default {
   },
   data () {
     return {
-      tariffAction: false,
-      tariffResource: {}
+      tariffAction: this.tariffAction,
+      tariffResource: this.tariffResource
     }
   },
   provide: function () {
@@ -54,6 +54,7 @@ export default {
     showTariffAction (showAction, resource) {
       this.tariffAction = showAction
       this.tariffResource = resource
+      this.loading = false
     }
   }
 }


### PR DESCRIPTION
### Description

1. In UI, with Backup Plugin enabled, a new tab inside Service Offerings, called Backup Offerings, appears. In this tab, users can import a Backup Offering. However, regardless of what the user chooses, the `Allow User Driven Backups` parameter is always send as true

2. In UI, with Quota Plugin enabled, a new tab, called Quota, appears. In this tab there is a component called Tariff, which is responsible for displaying the tariffs of each resource. In addition, in this view there is an edit button that, when clicked, does nothing.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
1.
![image](https://user-images.githubusercontent.com/31869303/133452664-241492ab-81ca-418a-9426-1e58ee59870a.png)

2. 
![image](https://user-images.githubusercontent.com/31869303/133452145-b4bda529-f4be-4429-b828-0e507baca586.png)


### How Has This Been Tested?
1. I imported a Backup Offering with `Allow User Driven Backups` parameter as `false` and checked, using cloud-monkey and in the DB if this parameter as correctly set.
2. I edited a Quota Tariff, waited until the effective start day, and check if, in UI, the new value appears.
