### PR TITLE
New API endpoint to update pod management network IP range

### DIFF
--- a/api/src/main/java/com/cloud/configuration/ConfigurationService.java
+++ b/api/src/main/java/com/cloud/configuration/ConfigurationService.java
@@ -210,7 +210,6 @@ public interface ConfigurationService {
      * @throws com.cloud.exception.ConcurrentOperationException
      * @return Success
      */
-
     void updatePodIpRange(UpdatePodManagementNetworkIpRangeCmd cmd) throws ConcurrentOperationException;
 
     /**

--- a/api/src/main/java/com/cloud/configuration/ConfigurationService.java
+++ b/api/src/main/java/com/cloud/configuration/ConfigurationService.java
@@ -24,6 +24,7 @@ import org.apache.cloudstack.api.command.admin.network.CreateNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.DeleteManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.network.DeleteNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.UpdateNetworkOfferingCmd;
+import org.apache.cloudstack.api.command.admin.network.UpdatePodManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateDiskOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateServiceOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.DeleteDiskOfferingCmd;
@@ -202,6 +203,15 @@ public interface ConfigurationService {
      * @param cmd - The command specifying pod ID, start IP, end IP.
      */
     void deletePodIpRange(DeleteManagementNetworkIpRangeCmd cmd) throws ResourceUnavailableException, ConcurrentOperationException;
+
+    /**
+     * Updates a mutually exclusive IP range in the pod.
+     * @param cmd - The command specifying pod ID, current Start IP, current End IP, new Start IP, new End IP.
+     * @throws com.cloud.exception.ConcurrentOperationException
+     * @return Success
+     */
+
+    void updatePodIpRange(UpdatePodManagementNetworkIpRangeCmd cmd) throws ConcurrentOperationException;
 
     /**
      * Edits a pod in the database. Will not allow you to edit pods that are being used anywhere in the system.

--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -327,6 +327,7 @@ public class EventTypes {
 
     public static final String EVENT_MANAGEMENT_IP_RANGE_CREATE = "MANAGEMENT.IP.RANGE.CREATE";
     public static final String EVENT_MANAGEMENT_IP_RANGE_DELETE = "MANAGEMENT.IP.RANGE.DELETE";
+    public static final String EVENT_MANAGEMENT_IP_RANGE_UPDATE = "MANAGEMENT.IP.RANGE.UPDATE";
 
     public static final String EVENT_STORAGE_IP_RANGE_CREATE = "STORAGE.IP.RANGE.CREATE";
     public static final String EVENT_STORAGE_IP_RANGE_DELETE = "STORAGE.IP.RANGE.DELETE";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -98,6 +98,8 @@ public class ApiConstants {
     public static final String CUSTOMIZED_IOPS = "customizediops";
     public static final String CUSTOM_ID = "customid";
     public static final String CUSTOM_JOB_ID = "customjobid";
+    public static final String CURRENT_START_IP = "currentstartip";
+    public static final String CURRENT_END_IP = "currentendip";
     public static final String MIN_IOPS = "miniops";
     public static final String MAX_IOPS = "maxiops";
     public static final String HYPERVISOR_SNAPSHOT_RESERVE = "hypervisorsnapshotreserve";
@@ -252,6 +254,8 @@ public class ApiConstants {
     public static final String NIC = "nic";
     public static final String NIC_NETWORK_LIST = "nicnetworklist";
     public static final String NIC_IP_ADDRESS_LIST = "nicipaddresslist";
+    public static final String NEW_START_IP = "newstartip";
+    public static final String NEW_END_IP = "newendip";
     public static final String NUM_RETRIES = "numretries";
     public static final String OFFER_HA = "offerha";
     public static final String IS_SYSTEM_OFFERING = "issystem";

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
@@ -40,7 +40,7 @@ import com.cloud.user.Account;
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false,
         authorized = {RoleType.Admin})
-public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd{
+public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd {
 
     public static final Logger s_logger = Logger.getLogger(UpdatePodManagementNetworkIpRangeCmd.class);
 
@@ -117,7 +117,7 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd{
 
     @Override
     public String getEventDescription() {
-        return "Updating pod management IP range " + getNewStartIP() + "-" + getNewEndIP()+ " of Pod: " + getPodId();
+        return "Updating pod management IP range " + getNewStartIP() + "-" + getNewEndIP() + " of Pod: " + getPodId();
     }
     @Override
     public String getCommandName() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
@@ -32,7 +32,6 @@ import com.cloud.event.EventTypes;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.user.Account;
 
-
 @APICommand(name = UpdatePodManagementNetworkIpRangeCmd.APINAME,
         description = "Updates a management network IP range. Only allowed when no IPs are allocated.",
         responseObject = SuccessResponse.class,
@@ -109,7 +108,6 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd {
         return newEndIp;
     }
 
-
     @Override
     public String getEventType() {
         return EventTypes.EVENT_MANAGEMENT_IP_RANGE_UPDATE;
@@ -119,6 +117,7 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd {
     public String getEventDescription() {
         return "Updating pod management IP range " + getNewStartIP() + "-" + getNewEndIP() + " of Pod: " + getPodId();
     }
+
     @Override
     public String getCommandName() {
         return APINAME.toLowerCase() + BaseAsyncCmd.RESPONSE_SUFFIX;
@@ -135,6 +134,7 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
+
         try {
             _configService.updatePodIpRange(this);
             SuccessResponse response = new SuccessResponse(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
@@ -30,12 +30,13 @@ import org.apache.log4j.Logger;
 
 import com.cloud.event.EventTypes;
 import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.user.Account;
 
 @APICommand(name = UpdatePodManagementNetworkIpRangeCmd.APINAME,
         description = "Updates a management network IP range. Only allowed when no IPs are allocated.",
         responseObject = SuccessResponse.class,
-        since = "4.15.0.0",
+        since = "4.16.0.0",
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false,
         authorized = {RoleType.Admin})
@@ -134,6 +135,9 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
+        if (getNewStartIP() == null && getNewEndIP() == null) {
+            throw new InvalidParameterValueException("Either new starting IP address or new ending IP address must be specified");
+        }
 
         try {
             _configService.updatePodIpRange(this);

--- a/api/src/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
@@ -117,7 +117,7 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd{
 
     @Override
     public String getEventDescription() {
-        return "Updating pod management IP range " + getNewStartIP()+"-"+getNewEndIP()+ " of Pod: " + getPodId();
+        return "Updating pod management IP range " + getNewStartIP() + "-" + getNewEndIP()+ " of Pod: " + getPodId();
     }
     @Override
     public String getCommandName() {
@@ -143,7 +143,7 @@ public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd{
             s_logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
         } catch (Exception e) {
-            s_logger.warn("Failed to update pod management IP range " + getNewStartIP()+"-"+getNewEndIP()+ " of Pod: " + getPodId(), e);
+            s_logger.warn("Failed to update pod management IP range " + getNewStartIP() + "-" + getNewEndIP() + " of Pod: " + getPodId(), e);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());
         }
     }

--- a/api/src/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/network/UpdatePodManagementNetworkIpRangeCmd.java
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.network;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseAsyncCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.PodResponse;
+import org.apache.cloudstack.api.response.SuccessResponse;
+import org.apache.log4j.Logger;
+
+import com.cloud.event.EventTypes;
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.user.Account;
+
+
+@APICommand(name = UpdatePodManagementNetworkIpRangeCmd.APINAME,
+        description = "Updates a management network IP range. Only allowed when no IPs are allocated.",
+        responseObject = SuccessResponse.class,
+        since = "4.15.0.0",
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = false,
+        authorized = {RoleType.Admin})
+public class UpdatePodManagementNetworkIpRangeCmd extends BaseAsyncCmd{
+
+    public static final Logger s_logger = Logger.getLogger(UpdatePodManagementNetworkIpRangeCmd.class);
+
+    public static final String APINAME = "updatePodManagementNetworkIpRange";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+    @Parameter(name = ApiConstants.POD_ID,
+            type = CommandType.UUID,
+            entityType = PodResponse.class,
+            required = true,
+            description = "UUID of POD, where the IP range belongs to.",
+            validations = {ApiArgValidator.PositiveNumber})
+    private Long podId;
+
+    @Parameter(name = ApiConstants.CURRENT_START_IP,
+            type = CommandType.STRING,
+            entityType = PodResponse.class,
+            required = true,
+            description = "The current starting IP address.",
+            validations = {ApiArgValidator.NotNullOrEmpty})
+    private String currentStartIp;
+
+    @Parameter(name = ApiConstants.CURRENT_END_IP,
+            type = CommandType.STRING,
+            entityType = PodResponse.class,
+            required = true,
+            description = "The current ending IP address.",
+            validations = {ApiArgValidator.NotNullOrEmpty})
+    private String currentEndIp;
+
+    @Parameter(name = ApiConstants.NEW_START_IP,
+            type = CommandType.STRING,
+            description = "The new starting IP address.",
+            validations = {ApiArgValidator.NotNullOrEmpty})
+    private String newStartIp;
+
+    @Parameter(name = ApiConstants.NEW_END_IP,
+            type = CommandType.STRING,
+            description = "The new ending IP address.",
+            validations = {ApiArgValidator.NotNullOrEmpty})
+    private String newEndIp;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getPodId() {
+        return podId;
+    }
+
+    public String getCurrentStartIP() {
+        return currentStartIp;
+    }
+
+    public String getCurrentEndIP() {
+        return currentEndIp;
+    }
+
+    public String getNewStartIP() {
+        return newStartIp;
+    }
+
+    public String getNewEndIP() {
+        return newEndIp;
+    }
+
+
+    @Override
+    public String getEventType() {
+        return EventTypes.EVENT_MANAGEMENT_IP_RANGE_UPDATE;
+    }
+
+    @Override
+    public String getEventDescription() {
+        return "Updating pod management IP range " + getNewStartIP()+"-"+getNewEndIP()+ " of Pod: " + getPodId();
+    }
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + BaseAsyncCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return Account.ACCOUNT_ID_SYSTEM;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    @Override
+    public void execute() {
+        try {
+            _configService.updatePodIpRange(this);
+            SuccessResponse response = new SuccessResponse(getCommandName());
+            this.setResponseObject(response);
+        } catch (ConcurrentOperationException ex) {
+            s_logger.warn("Exception: ", ex);
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
+        } catch (Exception e) {
+            s_logger.warn("Failed to update pod management IP range " + getNewStartIP()+"-"+getNewEndIP()+ " of Pod: " + getPodId(), e);
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());
+        }
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterIpAddressDao.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterIpAddressDao.java
@@ -41,6 +41,8 @@ public interface DataCenterIpAddressDao extends GenericDao<DataCenterIpAddressVO
 
     List<DataCenterIpAddressVO> listByPodIdDcId(long podId, long dcId);
 
+    List<DataCenterIpAddressVO> listIpAddressUsage(final long podId, final long dcId, final boolean onlyListAllocated);
+
     int countIPs(long podId, long dcId, boolean onlyCountAllocated);
 
     int countIPs(long dcId, boolean onlyCountAllocated);

--- a/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 
-
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.log4j.Logger;
@@ -235,6 +234,17 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
     public List<DataCenterIpAddressVO> listByPodIdDcId(long podId, long dcId) {
         SearchCriteria<DataCenterIpAddressVO> sc = AllFieldsSearch.create();
         sc.setParameters("pod", podId);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<DataCenterIpAddressVO> listIpAddressUsage(final long podId, final long dcId, final boolean onlyListAllocated) {
+        SearchCriteria<DataCenterIpAddressVO> sc = createSearchCriteria();
+        if(onlyListAllocated) {
+            sc.addAnd("takenAt", SearchCriteria.Op.NNULL);
+        }
+                sc.addAnd("podId", SearchCriteria.Op.EQ, podId);
+        sc.addAnd("dataCenterId", SearchCriteria.Op.EQ, dcId);
         return listBy(sc);
     }
 

--- a/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
@@ -243,7 +243,7 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
         if(onlyListAllocated) {
             sc.addAnd("takenAt", SearchCriteria.Op.NNULL);
         }
-                sc.addAnd("podId", SearchCriteria.Op.EQ, podId);
+        sc.addAnd("podId", SearchCriteria.Op.EQ, podId);
         sc.addAnd("dataCenterId", SearchCriteria.Op.EQ, dcId);
         return listBy(sc);
     }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -54,6 +54,7 @@ import org.apache.cloudstack.api.command.admin.network.CreateNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.DeleteManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.network.DeleteNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.UpdateNetworkOfferingCmd;
+import org.apache.cloudstack.api.command.admin.network.UpdatePodManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateDiskOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateServiceOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.DeleteDiskOfferingCmd;
@@ -1519,6 +1520,162 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         } catch (final Exception e) {
             s_logger.error("Unable to delete Pod " + podId + "IP range due to " + e.getMessage(), e);
             throw new CloudRuntimeException("Failed to delete Pod " + podId + "IP range. Please contact Cloud Support.");
+        }
+    }
+
+    @Override
+    @DB
+    public void updatePodIpRange(final UpdatePodManagementNetworkIpRangeCmd cmd) throws ConcurrentOperationException {
+        final long podId = cmd.getPodId();
+        final String currentStartIP= cmd.getCurrentStartIP();
+        final String currentEndIP= cmd.getCurrentEndIP();
+        final HostPodVO pod = _podDao.findById(podId);
+
+        String newStartIP = cmd.getNewStartIP();
+        String newEndIP = cmd.getNewEndIP();
+        String vlan = null;
+
+        if(newStartIP == null){
+            newStartIP= currentStartIP;
+        }
+
+        if(newEndIP == null){
+            newEndIP= currentEndIP;
+        }
+
+        if(pod == null) {
+            throw new InvalidParameterValueException("Unable to find pod by id " + podId);
+        }
+
+        final String[] existingPodIpRanges = pod.getDescription().split(",");
+        if(existingPodIpRanges.length == 0) {
+            throw new InvalidParameterValueException("The IP range cannot be found since the existing IP range is empty.");
+        }
+
+        verifyIPRangeParameters(currentStartIP,currentEndIP);
+        verifyIPRangeParameters(newStartIP,newEndIP);
+        checkIpRangeContainsTakenAddresses(pod,currentStartIP,currentEndIP,newStartIP,newEndIP);
+
+        boolean foundRange = false;
+
+        for(String podIpRange: existingPodIpRanges) {
+            final String[] existingPodIpRange = podIpRange.split("-");
+
+            if(existingPodIpRange.length > 1) {
+                if (!NetUtils.isValidIp4(existingPodIpRange[0]) || !NetUtils.isValidIp4(existingPodIpRange[1])) {
+                    continue;
+                }
+                if (currentStartIP.equals(existingPodIpRange[0]) && currentEndIP.equals(existingPodIpRange[1])) {
+                    foundRange = true;
+                    vlan = existingPodIpRange[3];
+                }
+                if (!foundRange && NetUtils.ipRangesOverlap(newStartIP, newEndIP, existingPodIpRange[0], existingPodIpRange[1])) {
+                    throw new InvalidParameterValueException("The Start IP and EndIP address range overlap with private IP :" + existingPodIpRange[0] + "-" + existingPodIpRange[1]);
+                }
+            }
+        }
+
+        if(!foundRange) {
+            throw new InvalidParameterValueException("The input IP range: " + currentStartIP + "-" + currentEndIP + " of pod: " + podId + " is not present. Please input an existing range.");
+        }
+
+        List<Long> currentIPRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
+        List<Long> newIPRange = listAllIPsWithintheRange(newStartIP,newEndIP);
+
+        try {
+            final String finalNewEndIP = newEndIP;
+            final String finalNewStartIP = newStartIP;
+            final Integer vlanId = vlan.equals(Vlan.UNTAGGED) ? null : Integer.parseInt(vlan);
+
+            Transaction.execute(new TransactionCallbackNoReturn() {
+                @Override
+                public void doInTransactionWithoutResult(final TransactionStatus status) {
+                    final long zoneId = pod.getDataCenterId();
+                    pod.setDescription(pod.getDescription().replace(currentStartIP+"-", finalNewStartIP +"-").replace(currentEndIP,
+                            finalNewEndIP));
+
+                    HostPodVO lock = null;
+
+                    try {
+                        lock = _podDao.acquireInLockTable(podId);
+                        if (lock == null) {
+                            String msg = "Unable to acquire lock on table to update the ip range of POD: " + pod.getName() + ", Update failed.";
+                            s_logger.warn(msg);
+                            throw new CloudRuntimeException(msg);
+                        }
+                        List<Long> iPAddressesToAdd = new ArrayList(newIPRange);
+                        iPAddressesToAdd.removeAll(currentIPRange);
+                        if (iPAddressesToAdd.size()>0){
+                            for(Long startIP : iPAddressesToAdd){
+                                _zoneDao.addPrivateIpAddress(zoneId, podId, NetUtils.long2Ip(startIP), NetUtils.long2Ip(startIP), false, vlanId);
+                            }
+                        }else {
+                            currentIPRange.removeAll(newIPRange);
+                            if(currentIPRange.size()>0){
+                                for (Long startIP: currentIPRange){
+                                    if(!_privateIpAddressDao.deleteIpAddressByPodDc(NetUtils.long2Ip(startIP),podId,zoneId)){
+                                        throw new CloudRuntimeException("Failed to remove private ip address: " + NetUtils.long2Ip(startIP) + " of Pod: " + podId + " DC: " + pod.getDataCenterId());
+                                    }
+                                }
+                            }
+                        }
+                        _podDao.update(podId, pod);
+                    } finally {
+                        if (lock != null) {
+                            _podDao.releaseFromLockTable(podId);
+                        }
+                    }
+                }
+            });
+        } catch (final Exception e) {
+            s_logger.error("Unable to update Pod " + podId + " IP range due to " + e.getMessage(), e);
+            throw new CloudRuntimeException("Failed to update Pod " + podId + " IP range. Please contact Cloud Support.");
+        }
+    }
+
+    public List<Long> listAllIPsWithintheRange(String startIp, String endIP){
+        verifyIPRangeParameters(startIp,endIP);
+        long startIPLong = NetUtils.ip2Long(startIp);
+        long endIPLong = NetUtils.ip2Long(endIP);
+
+        List<Long> listOfIpsinRange = new ArrayList<>();
+        while (startIPLong<=endIPLong){
+            listOfIpsinRange.add(startIPLong);
+            startIPLong++;
+        }
+        return listOfIpsinRange;
+    }
+
+    private void verifyIPRangeParameters(String startIP, String endIp){
+
+        if (!Strings.isNullOrEmpty(startIP) && !NetUtils.isValidIp4(startIP)) {
+            throw new InvalidParameterValueException("The current start address of the IP range "+startIP+" is not a valid IP address.");
+        }
+
+        if (!Strings.isNullOrEmpty(endIp) && !NetUtils.isValidIp4(endIp)) {
+            throw new InvalidParameterValueException("The current end address of the IP range "+endIp +" is not a valid IP address.");
+        }
+
+        if (NetUtils.ip2Long(startIP) > NetUtils.ip2Long(endIp)) {
+            throw new InvalidParameterValueException("The start IP address must have a lower value than the end IP address.");
+        }
+
+    }
+
+    private void checkIpRangeContainsTakenAddresses(final HostPodVO pod,final String currentStartIP, final String currentEndIP,final String newStartIp, final String newEndIp ){
+        List<Long> newIPRange = listAllIPsWithintheRange(newStartIp,newEndIp);
+        List<Long> currentIPRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
+        List<Long> takenIpsList = new ArrayList<>();
+        final List<DataCenterIpAddressVO> takenIps = _privateIpAddressDao.listIpAddressUsage(pod.getId(),pod.getDataCenterId(),true);
+
+        for (DataCenterIpAddressVO takenIp : takenIps) {
+            takenIpsList.add(NetUtils.ip2Long(takenIp.getIpAddress()));
+        }
+
+        takenIpsList.retainAll(currentIPRange);
+        if(!newIPRange.containsAll(takenIpsList)){
+            throw new InvalidParameterValueException("The IP range does not contain some IP addresses that have "
+                    + "already been taken. Please adjust your IP range to include all IP addresses already taken.");
         }
     }
 

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1527,41 +1527,68 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @DB
     public void updatePodIpRange(final UpdatePodManagementNetworkIpRangeCmd cmd) throws ConcurrentOperationException {
         final long podId = cmd.getPodId();
-        final String currentStartIP= cmd.getCurrentStartIP();
-        final String currentEndIP= cmd.getCurrentEndIP();
+        final String currentStartIP = cmd.getCurrentStartIP();
+        final String currentEndIP = cmd.getCurrentEndIP();
         final HostPodVO pod = _podDao.findById(podId);
 
         String newStartIP = cmd.getNewStartIP();
         String newEndIP = cmd.getNewEndIP();
-        String vlan = null;
 
-        if(newStartIP == null){
-            newStartIP= currentStartIP;
+        if (newStartIP == null) {
+            newStartIP = currentStartIP;
         }
 
-        if(newEndIP == null){
-            newEndIP= currentEndIP;
+        if (newEndIP == null) {
+            newEndIP = currentEndIP;
         }
 
-        if(pod == null) {
+        if (pod == null) {
             throw new InvalidParameterValueException("Unable to find pod by id " + podId);
         }
 
         final String[] existingPodIpRanges = pod.getDescription().split(",");
-        if(existingPodIpRanges.length == 0) {
+        if (existingPodIpRanges.length == 0) {
             throw new InvalidParameterValueException("The IP range cannot be found since the existing IP range is empty.");
         }
 
-        verifyIPRangeParameters(currentStartIP,currentEndIP);
-        verifyIPRangeParameters(newStartIP,newEndIP);
+        verifyIpRangeParameters(currentStartIP,currentEndIP);
+        verifyIpRangeParameters(newStartIP,newEndIP);
         checkIpRangeContainsTakenAddresses(pod,currentStartIP,currentEndIP,newStartIP,newEndIP);
 
-        boolean foundRange = false;
+        String vlan = verifyPodIpRangeExists(existingPodIpRanges,currentStartIP,currentEndIP,newStartIP,newEndIP);
 
-        for(String podIpRange: existingPodIpRanges) {
+        List<Long> currentIpRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
+        List<Long> newIpRange = listAllIPsWithintheRange(newStartIP,newEndIP);
+
+        try {
+            final String finalNewEndIP = newEndIP;
+            final String finalNewStartIP = newStartIP;
+            final Integer vlanId = vlan.equals(Vlan.UNTAGGED) ? null : Integer.parseInt(vlan);
+
+            Transaction.execute(new TransactionCallbackNoReturn() {
+                @Override
+                public void doInTransactionWithoutResult(final TransactionStatus status) {
+                    final long zoneId = pod.getDataCenterId();
+                    pod.setDescription(pod.getDescription().replace(currentStartIP + "-",
+                            finalNewStartIP + "-").replace(currentEndIP, finalNewEndIP));
+                    updatePodIpRangeInDb(zoneId,podId,vlanId,pod,newIpRange,currentIpRange);
+                }
+            });
+        } catch (final Exception e) {
+            s_logger.error("Unable to update Pod " + podId + " IP range due to " + e.getMessage(), e);
+            throw new CloudRuntimeException("Failed to update Pod " + podId + " IP range. Please contact Cloud Support.");
+        }
+    }
+
+    private String verifyPodIpRangeExists(String[] existingPodIpRanges, String currentStartIP,
+            String currentEndIP, String newStartIP, String newEndIP) {
+        boolean foundRange = false;
+        String vlan = null;
+
+        for (String podIpRange: existingPodIpRanges) {
             final String[] existingPodIpRange = podIpRange.split("-");
 
-            if(existingPodIpRange.length > 1) {
+            if (existingPodIpRange.length > 1) {
                 if (!NetUtils.isValidIp4(existingPodIpRange[0]) || !NetUtils.isValidIp4(existingPodIpRange[1])) {
                     continue;
                 }
@@ -1575,96 +1602,82 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         }
 
-        if(!foundRange) {
+        if (!foundRange) {
             throw new InvalidParameterValueException("The input IP range: " + currentStartIP + "-" + currentEndIP + " of pod: " + podId + " is not present. Please input an existing range.");
         }
 
-        List<Long> currentIPRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
-        List<Long> newIPRange = listAllIPsWithintheRange(newStartIP,newEndIP);
+        return vlan;
+    }
 
+    private void updatePodIpRangeInDb (long zoneId, long podId, Integer vlanId, HostPodVO pod, List<Long> newIpRange, List<Long> currentIpRange) {
+        HostPodVO lock = null;
         try {
-            final String finalNewEndIP = newEndIP;
-            final String finalNewStartIP = newStartIP;
-            final Integer vlanId = vlan.equals(Vlan.UNTAGGED) ? null : Integer.parseInt(vlan);
-
-            Transaction.execute(new TransactionCallbackNoReturn() {
-                @Override
-                public void doInTransactionWithoutResult(final TransactionStatus status) {
-                    final long zoneId = pod.getDataCenterId();
-                    pod.setDescription(pod.getDescription().replace(currentStartIP+"-", finalNewStartIP +"-").replace(currentEndIP,
-                            finalNewEndIP));
-
-                    HostPodVO lock = null;
-
-                    try {
-                        lock = _podDao.acquireInLockTable(podId);
-                        if (lock == null) {
-                            String msg = "Unable to acquire lock on table to update the ip range of POD: " + pod.getName() + ", Update failed.";
-                            s_logger.warn(msg);
-                            throw new CloudRuntimeException(msg);
-                        }
-                        List<Long> iPAddressesToAdd = new ArrayList(newIPRange);
-                        iPAddressesToAdd.removeAll(currentIPRange);
-                        if (iPAddressesToAdd.size()>0){
-                            for(Long startIP : iPAddressesToAdd){
-                                _zoneDao.addPrivateIpAddress(zoneId, podId, NetUtils.long2Ip(startIP), NetUtils.long2Ip(startIP), false, vlanId);
-                            }
-                        }else {
-                            currentIPRange.removeAll(newIPRange);
-                            if(currentIPRange.size()>0){
-                                for (Long startIP: currentIPRange){
-                                    if(!_privateIpAddressDao.deleteIpAddressByPodDc(NetUtils.long2Ip(startIP),podId,zoneId)){
-                                        throw new CloudRuntimeException("Failed to remove private ip address: " + NetUtils.long2Ip(startIP) + " of Pod: " + podId + " DC: " + pod.getDataCenterId());
-                                    }
-                                }
-                            }
-                        }
-                        _podDao.update(podId, pod);
-                    } finally {
-                        if (lock != null) {
-                            _podDao.releaseFromLockTable(podId);
+            lock = _podDao.acquireInLockTable(podId);
+            if (lock == null) {
+                String msg = "Unable to acquire lock on table to update the ip range of POD: " + pod.getName() + ", Update failed.";
+                s_logger.warn(msg);
+                throw new CloudRuntimeException(msg);
+            }
+            List<Long> iPaddressesToAdd = new ArrayList(newIpRange);
+            iPaddressesToAdd.removeAll(currentIpRange);
+            if (iPaddressesToAdd.size() > 0) {
+                for (Long startIP : iPaddressesToAdd) {
+                    _zoneDao.addPrivateIpAddress(zoneId, podId, NetUtils.long2Ip(startIP), NetUtils.long2Ip(startIP), false, vlanId);
+                }
+            } else {
+                currentIpRange.removeAll(newIpRange);
+                if (currentIpRange.size() > 0) {
+                    for (Long startIP: currentIpRange) {
+                        if (!_privateIpAddressDao.deleteIpAddressByPodDc(NetUtils.long2Ip(startIP),podId,zoneId)) {
+                            throw new CloudRuntimeException("Failed to remove private ip address: " + NetUtils.long2Ip(startIP) + " of Pod: " + podId + " DC: " + pod.getDataCenterId());
                         }
                     }
                 }
-            });
+            }
+            _podDao.update(podId, pod);
         } catch (final Exception e) {
-            s_logger.error("Unable to update Pod " + podId + " IP range due to " + e.getMessage(), e);
+            s_logger.error("Unable to update Pod " + podId + " IP range due to database error " + e.getMessage(), e);
             throw new CloudRuntimeException("Failed to update Pod " + podId + " IP range. Please contact Cloud Support.");
+        }  finally {
+            if (lock != null) {
+                _podDao.releaseFromLockTable(podId);
+            }
         }
     }
 
-    public List<Long> listAllIPsWithintheRange(String startIp, String endIP){
-        verifyIPRangeParameters(startIp,endIP);
-        long startIPLong = NetUtils.ip2Long(startIp);
-        long endIPLong = NetUtils.ip2Long(endIP);
+    private List<Long> listAllIPsWithintheRange(String startIp, String endIP) {
+        verifyIpRangeParameters(startIp,endIP);
+        long startIpLong = NetUtils.ip2Long(startIp);
+        long endIpLong = NetUtils.ip2Long(endIP);
 
         List<Long> listOfIpsinRange = new ArrayList<>();
-        while (startIPLong<=endIPLong){
-            listOfIpsinRange.add(startIPLong);
-            startIPLong++;
+        while (startIpLong <= endIpLong) {
+            listOfIpsinRange.add(startIpLong);
+            startIpLong++;
         }
         return listOfIpsinRange;
     }
 
-    private void verifyIPRangeParameters(String startIP, String endIp){
+    private void verifyIpRangeParameters(String startIP, String endIp) {
 
         if (!Strings.isNullOrEmpty(startIP) && !NetUtils.isValidIp4(startIP)) {
-            throw new InvalidParameterValueException("The current start address of the IP range "+startIP+" is not a valid IP address.");
+            throw new InvalidParameterValueException("The current start address of the IP range " + startIP + " is not a valid IP address.");
         }
 
         if (!Strings.isNullOrEmpty(endIp) && !NetUtils.isValidIp4(endIp)) {
-            throw new InvalidParameterValueException("The current end address of the IP range "+endIp +" is not a valid IP address.");
+            throw new InvalidParameterValueException("The current end address of the IP range " + endIp + " is not a valid IP address.");
         }
 
         if (NetUtils.ip2Long(startIP) > NetUtils.ip2Long(endIp)) {
             throw new InvalidParameterValueException("The start IP address must have a lower value than the end IP address.");
         }
-
     }
 
-    private void checkIpRangeContainsTakenAddresses(final HostPodVO pod,final String currentStartIP, final String currentEndIP,final String newStartIp, final String newEndIp ){
-        List<Long> newIPRange = listAllIPsWithintheRange(newStartIp,newEndIp);
-        List<Long> currentIPRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
+    private void checkIpRangeContainsTakenAddresses(final HostPodVO pod,final String currentStartIP,
+            final String currentEndIP,final String newStartIp, final String newEndIp) {
+
+        List<Long> newIpRange = listAllIPsWithintheRange(newStartIp,newEndIp);
+        List<Long> currentIpRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
         List<Long> takenIpsList = new ArrayList<>();
         final List<DataCenterIpAddressVO> takenIps = _privateIpAddressDao.listIpAddressUsage(pod.getId(),pod.getDataCenterId(),true);
 
@@ -1672,8 +1685,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             takenIpsList.add(NetUtils.ip2Long(takenIp.getIpAddress()));
         }
 
-        takenIpsList.retainAll(currentIPRange);
-        if(!newIPRange.containsAll(takenIpsList)){
+        takenIpsList.retainAll(currentIpRange);
+        if (!newIpRange.containsAll(takenIpsList)) {
             throw new InvalidParameterValueException("The IP range does not contain some IP addresses that have "
                     + "already been taken. Please adjust your IP range to include all IP addresses already taken.");
         }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1555,7 +1555,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         verifyIpRangeParameters(newStartIP,newEndIP);
         checkIpRangeContainsTakenAddresses(pod,currentStartIP,currentEndIP,newStartIP,newEndIP);
 
-        String vlan = verifyPodIpRangeExists(existingPodIpRanges,currentStartIP,currentEndIP,newStartIP,newEndIP);
+        String vlan = verifyPodIpRangeExists(podId,existingPodIpRanges,currentStartIP,currentEndIP,newStartIP,newEndIP);
 
         List<Long> currentIpRange = listAllIPsWithintheRange(currentStartIP,currentEndIP);
         List<Long> newIpRange = listAllIPsWithintheRange(newStartIP,newEndIP);
@@ -1580,7 +1580,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
     }
 
-    private String verifyPodIpRangeExists(String[] existingPodIpRanges, String currentStartIP,
+    private String verifyPodIpRangeExists(long podId,String[] existingPodIpRanges, String currentStartIP,
             String currentEndIP, String newStartIP, String newEndIP) {
         boolean foundRange = false;
         String vlan = null;

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -146,6 +146,7 @@ import org.apache.cloudstack.api.command.admin.network.UpdateNetworkCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.network.UpdateNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.UpdateNetworkServiceProviderCmd;
 import org.apache.cloudstack.api.command.admin.network.UpdatePhysicalNetworkCmd;
+import org.apache.cloudstack.api.command.admin.network.UpdatePodManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.network.UpdateStorageNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateDiskOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateServiceOfferingCmd;
@@ -3033,6 +3034,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(UpdateRegionCmd.class);
         cmdList.add(ListAlertsCmd.class);
         cmdList.add(ListCapacityCmd.class);
+        cmdList.add(UpdatePodManagementNetworkIpRangeCmd.class);
         cmdList.add(UploadCustomCertificateCmd.class);
         cmdList.add(ConfigureVirtualRouterElementCmd.class);
         cmdList.add(CreateVirtualRouterElementCmd.class);

--- a/server/src/test/java/com/cloud/vpc/MockConfigurationManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockConfigurationManagerImpl.java
@@ -29,6 +29,7 @@ import org.apache.cloudstack.api.command.admin.network.CreateNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.DeleteManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.network.DeleteNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.network.UpdateNetworkOfferingCmd;
+import org.apache.cloudstack.api.command.admin.network.UpdatePodManagementNetworkIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateDiskOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.CreateServiceOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.DeleteDiskOfferingCmd;
@@ -199,6 +200,14 @@ public class MockConfigurationManagerImpl extends ManagerBase implements Configu
      */
     @Override
     public void deletePodIpRange(DeleteManagementNetworkIpRangeCmd cmd) throws ResourceUnavailableException, ConcurrentOperationException {
+        // TODO Auto-generated method stub
+        return;
+    }
+
+    /* (non-Javadoc)
+     * @see com.cloud.configuration.ConfigurationService#updatePodIpRange(org.apache.cloudstack.api.command.admin.network.UpdatePodManagementNetworkIpRangeCmd)
+     */
+    public void updatePodIpRange(final UpdatePodManagementNetworkIpRangeCmd cmd) throws ConcurrentOperationException {
         // TODO Auto-generated method stub
         return;
     }


### PR DESCRIPTION
### Description

This PR introduces a new API endpoint to update pod management network IP range.

Currently, pod management IP range can only be expanded under the same subnet. Editing the current pod IP management range is a challenge, especially as the list of IP ranges is greater than one. The purpose of this feature is to allow ADMINS to be able to update size of IP range of management pod, upwards or downwards.

This PR extends from #4010

- Updatepodmanagementnetworkiprange will update already existing IP ranges. Will not create a new IP range.
- Will increase/reduce available IPs within the range.
- PodID/Currentstartip/CurrentendIp are mandatory fields. Newstartip and Newendip are optional fields and one of them should be specified. When anyone is left blank, Newstartip will be set to Currentstartip and Newendip will be set to Currentendip.
- API only available to root admin and does not have any sensitive information passed.
- Will output success response -true/false
- Does not alter structure of DB, but will update contents.


**When to use**

- Reducing size of existing IP range
- Increasing size of existing IP range

**How to use**

Run `list pods` command to see existing IP ranges
```
> list pods
{
  "count": 1,
  "pod": [
    {
      "allocationstate": "Enabled",
      "endip": [
        "172.16.15.210",
        "172.16.15.204"
      ],
      "forsystemvms": [
        "0",
        "0"
      ],
      "gateway": "172.16.15.1",
      "id": "1407da22-a131-4dbd-86a3-45210a26897e",
      "name": "POD0",
      "netmask": "255.255.255.0",
      "startip": [
        "172.16.15.205",
        "172.16.15.2"
      ],
      "vlanid": [
        "vlan://untagged",
        "vlan://untagged"
      ],
      "zoneid": "3ab731d6-efd5-418c-ab2b-cacbfc4b88f0",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```
2. Update the IP range you'd like to change. In our case, we want to increase the range `172.16.15.205-172.16.15.210` to `172.16.15.205-172.16.15.215`. Use the command `update podmanagementnetworkiprange`

```
> update podmanagementnetworkiprange podid=1407da22-a131-4dbd-86a3-45210a26897e currentstartip=172.16.15.205 currentendip=172.16.15.210 newendip=172.16.15.215
{
  "success": true
}
```
To reduce size of range to `172.16.15.205-172.16.15.207`
```
> update podmanagementnetworkiprange podid=1407da22-a131-4dbd-86a3-45210a26897e currentstartip=172.16.15.205 currentendip=172.16.15.215 newendip=172.16.15.207
{
  "success": true
}
```
Confirm by running `list pods` again
```
> list pods 
{
  "count": 1,
  "pod": [
    {
      "allocationstate": "Enabled",
      "endip": [
        "172.16.15.207",
        "172.16.15.204"
      ],
      "forsystemvms": [
        "0",
        "0"
      ],
      "gateway": "172.16.15.1",
      "id": "1407da22-a131-4dbd-86a3-45210a26897e",
      "name": "POD0",
      "netmask": "255.255.255.0",
      "startip": [
        "172.16.15.205",
        "172.16.15.2"
      ],
      "vlanid": [
        "vlan://untagged",
        "vlan://untagged"
      ],
      "zoneid": "3ab731d6-efd5-418c-ab2b-cacbfc4b88f0",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Manual Tests** (with PR# 4010)
- Test for invalid parameters for Currentstartip/Currentendip/Newstartip/Newendip
- Test for invalid current IP range
- Test for overlapping IP range extensions
- Test for non-existent IP range
- Test for Newstartip>Newendip
- Test for duplicate IP range
- Test for invalid Pod ID
- Test to reduce existing IP range to not include already allocated IPs

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
