### PR TITLE
server: Add support to encrypt https.keystore.password in server.properties

### DIFF
--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -42,7 +42,7 @@ https.keystore=/etc/cloudstack/management/cloud.jks
 # http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration/en/latest/management.html?highlight=jasypt#changing-the-database-password
 https.keystore.password=vmops.com
 # If an encrypted password is used, specify the encryption type - valid types: file, env (set environment variable CLOUD_SECRET_KEY), web
-# db.cloud.encryption.type=none
+# password.encryption.type=none
 
 # The path to webapp directory
 webapp.dir=/usr/share/cloudstack-management/webapp

--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -38,7 +38,11 @@ https.port=8443
 
 # The keystore and manager passwords are assumed to be same.
 https.keystore=/etc/cloudstack/management/cloud.jks
+# If you want to encrypt the password follow the steps mentioned at:
+# http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration/en/latest/management.html?highlight=jasypt#changing-the-database-password
 https.keystore.password=vmops.com
+# If an encrypted password is used, specify the encryption type - valid types: file, env (set environment variable CLOUD_SECRET_KEY), web
+# db.cloud.encryption.type=none
 
 # The path to webapp directory
 webapp.dir=/usr/share/cloudstack-management/webapp

--- a/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
@@ -19,12 +19,12 @@
 package org.apache.cloudstack;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.util.Properties;
 
 import com.cloud.utils.Pair;
+import com.cloud.utils.server.ServerProperties;
 import org.apache.commons.daemon.Daemon;
 import org.apache.commons.daemon.DaemonContext;
 import org.eclipse.jetty.jmx.MBeanContainer;
@@ -116,7 +116,7 @@ public class ServerDaemon implements Daemon {
         LOG.info("Server configuration file found: " + confFile.getAbsolutePath());
 
         try {
-            final Properties properties = PropertiesUtil.loadFromFile(confFile);
+            final Properties properties = ServerProperties.getServerProperties();
             if (properties == null) {
                 return;
             }
@@ -131,8 +131,8 @@ public class ServerDaemon implements Daemon {
             setWebAppLocation(properties.getProperty(WEBAPP_DIR));
             setAccessLogFile(properties.getProperty(ACCESS_LOG, "access.log"));
             setSessionTimeout(Integer.valueOf(properties.getProperty(SESSION_TIMEOUT, "30")));
-        } catch (final IOException e) {
-            LOG.warn("Failed to load configuration from server.properties file", e);
+        } catch (final IllegalStateException e) {
+            LOG.warn("Failed to read configuration from server.properties file", e);
         } finally {
             // make sure that at least HTTP is enabled if both of them are set to false (misconfiguration)
             if (!httpEnable && !httpsEnable) {

--- a/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
@@ -19,6 +19,9 @@
 package org.apache.cloudstack;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.util.Properties;
@@ -116,7 +119,8 @@ public class ServerDaemon implements Daemon {
         LOG.info("Server configuration file found: " + confFile.getAbsolutePath());
 
         try {
-            final Properties properties = ServerProperties.getServerProperties();
+            InputStream is = new FileInputStream(confFile);
+            final Properties properties = ServerProperties.getServerProperties(is);
             if (properties == null) {
                 return;
             }
@@ -131,7 +135,7 @@ public class ServerDaemon implements Daemon {
             setWebAppLocation(properties.getProperty(WEBAPP_DIR));
             setAccessLogFile(properties.getProperty(ACCESS_LOG, "access.log"));
             setSessionTimeout(Integer.valueOf(properties.getProperty(SESSION_TIMEOUT, "30")));
-        } catch (final IllegalStateException e) {
+        } catch (final IOException e) {
             LOG.warn("Failed to read configuration from server.properties file", e);
         } finally {
             // make sure that at least HTTP is enabled if both of them are set to false (misconfiguration)

--- a/utils/src/main/java/com/cloud/utils/crypt/EncryptionSecretKeyChecker.java
+++ b/utils/src/main/java/com/cloud/utils/crypt/EncryptionSecretKeyChecker.java
@@ -45,6 +45,8 @@ public class EncryptionSecretKeyChecker {
     private static final String s_altKeyFile = "key";
     private static final String s_keyFile = "key";
     private static final String s_envKey = "CLOUD_SECRET_KEY";
+    public static final String dbEncryptionType = "db.cloud.encryption.type";
+    public static final String passwordEncryptionType = "password.encryption.type";
     private static StandardPBEStringEncryptor s_encryptor = new StandardPBEStringEncryptor();
     private static boolean s_useEncryption = false;
 
@@ -55,8 +57,8 @@ public class EncryptionSecretKeyChecker {
         DbProperties.getDbProperties();
     }
 
-    public void check(Properties dbProps) throws IOException {
-        String encryptionType = dbProps.getProperty("db.cloud.encryption.type");
+    public void check(Properties dbProps, String property) throws IOException {
+        String encryptionType = dbProps.getProperty(property);
 
         s_logger.debug("Encryption Type: " + encryptionType);
 
@@ -116,7 +118,7 @@ public class EncryptionSecretKeyChecker {
                     throw new CloudRuntimeException("Accept failed on " + port);
                 }
             } catch (IOException ioex) {
-                throw new CloudRuntimeException("Error initializing secret key reciever", ioex);
+                throw new CloudRuntimeException("Error initializing secret key receiver", ioex);
             }
         } else {
             throw new CloudRuntimeException("Invalid encryption type: " + encryptionType);

--- a/utils/src/main/java/com/cloud/utils/crypt/EncryptionSecretKeyChecker.java
+++ b/utils/src/main/java/com/cloud/utils/crypt/EncryptionSecretKeyChecker.java
@@ -45,8 +45,6 @@ public class EncryptionSecretKeyChecker {
     private static final String s_altKeyFile = "key";
     private static final String s_keyFile = "key";
     private static final String s_envKey = "CLOUD_SECRET_KEY";
-    public static final String dbEncryptionType = "db.cloud.encryption.type";
-    public static final String passwordEncryptionType = "password.encryption.type";
     private static StandardPBEStringEncryptor s_encryptor = new StandardPBEStringEncryptor();
     private static boolean s_useEncryption = false;
 
@@ -57,8 +55,8 @@ public class EncryptionSecretKeyChecker {
         DbProperties.getDbProperties();
     }
 
-    public void check(Properties dbProps, String property) throws IOException {
-        String encryptionType = dbProps.getProperty(property);
+    public void check(Properties properties, String property) throws IOException {
+        String encryptionType = properties.getProperty(property);
 
         s_logger.debug("Encryption Type: " + encryptionType);
 

--- a/utils/src/main/java/com/cloud/utils/db/DbProperties.java
+++ b/utils/src/main/java/com/cloud/utils/db/DbProperties.java
@@ -39,10 +39,11 @@ public class DbProperties {
 
     private static Properties properties = new Properties();
     private static boolean loaded = false;
+    public static final String dbEncryptionType = "db.cloud.encryption.type";
 
     protected static Properties wrapEncryption(Properties dbProps) throws IOException {
         EncryptionSecretKeyChecker checker = new EncryptionSecretKeyChecker();
-        checker.check(dbProps, EncryptionSecretKeyChecker.dbEncryptionType);
+        checker.check(dbProps, dbEncryptionType);
 
         if (EncryptionSecretKeyChecker.useEncryption()) {
             return dbProps;
@@ -77,7 +78,7 @@ public class DbProperties {
                 }
 
                 EncryptionSecretKeyChecker checker = new EncryptionSecretKeyChecker();
-                checker.check(dbProps, EncryptionSecretKeyChecker.dbEncryptionType);
+                checker.check(dbProps, dbEncryptionType);
 
                 if (EncryptionSecretKeyChecker.useEncryption()) {
                     StandardPBEStringEncryptor encryptor = EncryptionSecretKeyChecker.getEncryptor();

--- a/utils/src/main/java/com/cloud/utils/db/DbProperties.java
+++ b/utils/src/main/java/com/cloud/utils/db/DbProperties.java
@@ -42,7 +42,7 @@ public class DbProperties {
 
     protected static Properties wrapEncryption(Properties dbProps) throws IOException {
         EncryptionSecretKeyChecker checker = new EncryptionSecretKeyChecker();
-        checker.check(dbProps);
+        checker.check(dbProps, EncryptionSecretKeyChecker.dbEncryptionType);
 
         if (EncryptionSecretKeyChecker.useEncryption()) {
             return dbProps;
@@ -77,7 +77,7 @@ public class DbProperties {
                 }
 
                 EncryptionSecretKeyChecker checker = new EncryptionSecretKeyChecker();
-                checker.check(dbProps);
+                checker.check(dbProps, EncryptionSecretKeyChecker.dbEncryptionType);
 
                 if (EncryptionSecretKeyChecker.useEncryption()) {
                     StandardPBEStringEncryptor encryptor = EncryptionSecretKeyChecker.getEncryptor();

--- a/utils/src/main/java/com/cloud/utils/server/ServerProperties.java
+++ b/utils/src/main/java/com/cloud/utils/server/ServerProperties.java
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.utils.server;
+
+import com.cloud.utils.PropertiesUtil;
+import com.cloud.utils.crypt.EncryptionSecretKeyChecker;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.properties.EncryptableProperties;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class ServerProperties {
+    private static final Logger log = Logger.getLogger(ServerProperties.class);
+
+    private static Properties properties = new Properties();
+    private static boolean loaded = false;
+
+    public synchronized static Properties getServerProperties() {
+        if (!loaded) {
+            Properties serverProps = new Properties();
+            InputStream is = null;
+            try {
+                File props = PropertiesUtil.findConfigFile("server.properties");
+                if (props != null && props.exists()) {
+                    is = new FileInputStream(props);
+                }
+
+                if (is == null) {
+                    is = PropertiesUtil.openStreamFromURL("server.properties");
+                }
+
+                if (is == null) {
+                    System.err.println("Failed to find server.properties");
+                    log.error("Failed to find server.properties");
+                }
+
+                if (is != null) {
+                    serverProps.load(is);
+                }
+
+                EncryptionSecretKeyChecker checker = new EncryptionSecretKeyChecker();
+                checker.check(serverProps);
+
+                if (EncryptionSecretKeyChecker.useEncryption()) {
+                    StandardPBEStringEncryptor encryptor = EncryptionSecretKeyChecker.getEncryptor();
+                    EncryptableProperties encrServerProps = new EncryptableProperties(encryptor);
+                    encrServerProps.putAll(serverProps);
+                    serverProps = encrServerProps;
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to load server.properties", e);
+            } finally {
+                IOUtils.closeQuietly(is);
+            }
+
+            properties = serverProps;
+            loaded = true;
+        }
+
+        return properties;
+    }
+}

--- a/utils/src/main/java/com/cloud/utils/server/ServerProperties.java
+++ b/utils/src/main/java/com/cloud/utils/server/ServerProperties.java
@@ -31,6 +31,7 @@ public class ServerProperties {
 
     private static Properties properties = new Properties();
     private static boolean loaded = false;
+    public static final String passwordEncryptionType = "password.encryption.type";
 
     public synchronized static Properties getServerProperties(InputStream inputStream) {
         if (!loaded) {
@@ -39,7 +40,7 @@ public class ServerProperties {
                 serverProps.load(inputStream);
 
                 EncryptionSecretKeyChecker checker = new EncryptionSecretKeyChecker();
-                checker.check(serverProps, EncryptionSecretKeyChecker.passwordEncryptionType);
+                checker.check(serverProps, passwordEncryptionType);
 
                 if (EncryptionSecretKeyChecker.useEncryption()) {
                     StandardPBEStringEncryptor encryptor = EncryptionSecretKeyChecker.getEncryptor();

--- a/utils/src/test/java/com/cloud/utils/crypto/EncryptionSecretKeyCheckerTest.java
+++ b/utils/src/test/java/com/cloud/utils/crypto/EncryptionSecretKeyCheckerTest.java
@@ -39,7 +39,7 @@ public class EncryptionSecretKeyCheckerTest {
     Assert.assertNotNull(checker);
     Properties properties = DbProperties.getDbProperties();
     properties.setProperty("db.cloud.encryption.type", "file");
-    checker.check(properties, EncryptionSecretKeyChecker.dbEncryptionType);
+    checker.check(properties, DbProperties.dbEncryptionType);
   }
 
 }

--- a/utils/src/test/java/com/cloud/utils/crypto/EncryptionSecretKeyCheckerTest.java
+++ b/utils/src/test/java/com/cloud/utils/crypto/EncryptionSecretKeyCheckerTest.java
@@ -39,7 +39,7 @@ public class EncryptionSecretKeyCheckerTest {
     Assert.assertNotNull(checker);
     Properties properties = DbProperties.getDbProperties();
     properties.setProperty("db.cloud.encryption.type", "file");
-    checker.check(properties);
+    checker.check(properties, EncryptionSecretKeyChecker.dbEncryptionType);
   }
 
 }


### PR DESCRIPTION
### Description

This PR addresses: https://github.com/apache/cloudstack/issues/4293 - facilitates a means to use encrypted password for `https.keystore.password` in `server.properties`
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?
Based On (temporary) logs added:

#### Without Encryption:
With following values in server.properties:
```
# The keystore and manager passwords are assumed to be same.
https.keystore=/etc/cloudstack/management/cloud.jks
https.keystore.password=vmops.com
```

On restarting MS - following logs were seen:
```
2021-09-16 09:47:56,957 INFO  [o.a.c.ServerDaemon] (main:null) (logid:) Server configuration file found: /etc/cloudstack/management/server.properties
2021-09-16 09:47:56,969 DEBUG [c.c.u.c.EncryptionSecretKeyChecker] (main:null) (logid:) Encryption Type: null
2021-09-16 09:47:56,973 INFO  [o.a.c.ServerDaemon] (main:null) (logid:) https keystore password: vmops.com

```

#### With Encryption:
server.properties content for keystore password:
```
# The keystore and manager passwords are assumed to be same.
https.keystore=/etc/cloudstack/management/cloud.jks
password.encryption.type=file
https.keystore.password=ENC(fPtPanqc/cI7iwxifO+EM3SfPX0gev1U)
```

On restarting MS:
```
2021-09-16 09:50:50,715 INFO  [o.a.c.ServerDaemon] (main:null) (logid:) Server configuration file found: /etc/cloudstack/management/server.properties
2021-09-16 09:50:50,727 DEBUG [c.c.u.c.EncryptionSecretKeyChecker] (main:null) (logid:) Encryption Type: file
2021-09-16 09:50:50,788 INFO  [o.a.c.ServerDaemon] (main:null) (logid:) https keystore password: newPassword
2021-09-16 09:50:50,791 INFO  [o.a.c.ServerDaemon] (main:null) (logid:) Initializing server daemon on null, with http.enable=true, http.port=8080, https.enable=false, https.port=8443, context.path=/client

```

Steps followed to encrypt the password for https.keystore.password:
```
[root@ref-trl-1795-k-M7-pearl-dsilva-mgmt1 ~]#  java -classpath /usr/share/cloudstack-common/lib/jasypt-1.9.3.jar org.jasypt.intf.cli.JasyptPBEStringEncryptionCLI encrypt.sh input="newPassword" password="`cat /etc/cloudstack/management/key`" verbose=true

----ENVIRONMENT-----------------

Runtime: Red Hat, Inc. OpenJDK 64-Bit Server VM 11.0.12+7-LTS 

----ARGUMENTS-------------------

input: newPassword
password: password
verbose: true

----OUTPUT----------------------

fPtPanqc/cI7iwxifO+EM3SfPX0gev1U


```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
