### PR TITLE
api: Fix list templates when no secondary stores present

### DIFF
--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
@@ -427,7 +427,9 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         sc.setParameters("template_id", templateId);
         sc.setParameters("download_state", Status.BYPASSED);
         sc.setParameters("destroyed", false);
-        sc.setParameters("storeids", storeIds);
+        if (storeIds != null && storeIds.length > 0) {
+            sc.setParameters("storeids", storeIds);
+        }
         return search(sc, null);
     }
 


### PR DESCRIPTION
### Description

This PR fixes listTemplates' API response when no stores are present. Currenty, when there are no secondary stores, listing templates leads to a DB exception.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Prior Fix:
```
(localcloud) SBCM5> > list templates templatefilter=all filter=id,downloaddetails
🙈 Error: (HTTP 530, error code 4250) DB Exception on: com.mysql.cj.jdbc.ClientPreparedStatement: SELECT template_store_ref.id, template_store_ref.store_id, template_store_ref.template_id, template_store_ref.store_role, template_store_ref.created, template_store_ref.last_updated, template_store_ref.download_pct, template_store_ref.size, template_store_ref.physical_size, template_store_ref.download_state, template_store_ref.local_path, template_store_ref.error_str, template_store_ref.job_id, template_store_ref.install_path, template_store_ref.url, template_store_ref.download_url, template_store_ref.download_url_created, template_store_ref.is_copy, template_store_ref.destroyed, template_store_ref.update_count, template_store_ref.updated, template_store_ref.state, template_store_ref.ref_cnt FROM template_store_ref WHERE template_store_ref.template_id = 203  AND template_store_ref.download_state != 'BYPASSED'  AND template_store_ref.destroyed = 0  AND template_store_ref.store_id IN ) 
(localcloud) SBCM5> > list templates templatefilter=all

```

Post Fix:

```
(localcloud) SBCM5> > list templates templatefilter=all filter=id,downloaddetails
{
  "count": 3,
  "template": [
    {
      "downloaddetails": [],
      "id": "47339986-99f8-482e-86f1-0a052608b0ff"
    },
    {
      "downloaddetails": [],
      "id": "2b121919-beb6-4987-a522-00b93e3bd240"
    },
    {
      "downloaddetails": [],
      "id": "8ca30d40-151b-11ec-9958-1e00e300025a"
    }
  ]
}

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
