### PR TITLE
Refactor GroupByExtension to improve test logic

### DIFF
--- a/framework/db/src/test/java/com/cloud/utils/db/GroupByTest.java
+++ b/framework/db/src/test/java/com/cloud/utils/db/GroupByTest.java
@@ -30,8 +30,19 @@ import com.cloud.utils.Pair;
 import com.cloud.utils.db.SearchCriteria.Func;
 import com.cloud.utils.db.SearchCriteria.Op;
 
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.any;
+
 
 public class GroupByTest {
+
+    public static GroupBy<SearchBaseExtension, String, String> mockGroupBy1(final SearchBaseExtension builder) {
+        GroupBy<SearchBaseExtension, String, String> mockInstance = spy(new GroupBy(builder));
+        mockInstance._builder = builder;
+        doNothing().when(mockInstance).init(any(SearchBaseExtension.class));
+        return mockInstance;
+    }
 
     protected static final String EXPECTED_QUERY = "BASE GROUP BY FIRST(TEST_TABLE.TEST_COLUMN), MAX(TEST_TABLE.TEST_COLUMN) HAVING COUNT(TEST_TABLE2.TEST_COLUMN2) > ? ";
     protected static final DbTestDao dao = new DbTestDao();
@@ -42,7 +53,8 @@ public class GroupByTest {
     public void testToSql() {
         // Prepare
         final StringBuilder sb = new StringBuilder("BASE");
-        final GroupByExtension groupBy = new GroupByExtension(new SearchBaseExtension(String.class, String.class));
+        // Construct mock object
+        final GroupBy<SearchBaseExtension, String, String> groupBy = GroupByTest.mockGroupBy1(new SearchBaseExtension(String.class, String.class));
 
         final Attribute att = new Attribute("TEST_TABLE", "TEST_COLUMN");
         final Attribute att2 = new Attribute("TEST_TABLE2", "TEST_COLUMN2");
@@ -100,17 +112,6 @@ public class GroupByTest {
 
 }
 
-class GroupByExtension extends GroupBy<SearchBaseExtension, String, String> {
-
-    public GroupByExtension(final SearchBaseExtension builder) {
-        super(builder);
-        _builder = builder;
-    }
-
-    @Override
-    protected void init(final SearchBaseExtension builder) {
-    }
-}
 
 class SearchBaseExtension extends SearchBase<SearchBaseExtension, String, String>{
 


### PR DESCRIPTION
### Description

Fixes: #5479 
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Jira

- [OPENNLP-1338](https://issues.apache.org/jira/browse/OPENNLP-1338)

### Description

#### Replace test class [GroupByExtension](https://github.com/apache/cloudstack/blob/bf6266188c89a5487383f216333ae10e878d2c10/framework/db/src/test/java/com/cloud/utils/db/GroupByTest.java#L103) by mocking object and improve test design
<hr>

##### Motivation

- Decouple test class `GroupByExtension` from production class `GroupBy`.
- Remove the redundant test child class `GroupByExtension`
- Make testing logic more explict.

<hr>

##### Key changed/added classes in this PR
 * Created mocking object to replace test subclass `GroupByExtension`, decoupled test from production code.
 * Created method that return the mocking object for code reuse.

<hr>
