### PR TITLE
marvin: Fix intermittent failure observed in test_02_list_snapshots_with_removed_data_store

### DIFF
--- a/test/integration/smoke/test_snapshots.py
+++ b/test/integration/smoke/test_snapshots.py
@@ -245,23 +245,30 @@ class TestSnapshotRootDisk(cloudstackTestCase):
             PASS,
             "Invalid response returned for list volumes")
         vol_uuid = vol_res[0].id
-        
-        # Create new Primary Storage
         clusters = list_clusters(
             self.apiclient,
             zoneid=self.zone.id
         )
         assert isinstance(clusters,list) and len(clusters)>0
 
+        self.cleanup.append(self.virtual_machine_with_disk)
+
+        # Attach created volume to vm, then detach it to be able to migrate it
+        self.virtual_machine_with_disk.stop(self.apiclient)
+        self.virtual_machine_with_disk.attach_volume(
+            self.apiclient,
+            vol
+        )
+
+        # Create new Primary Storage
         storage = StoragePool.create(self.apiclient,
                                      self.services["nfs2"],
                                      clusterid=clusters[0].id,
                                      zoneid=self.zone.id,
                                      podid=self.pod.id
                                      )
-        self.cleanup.append(self.virtual_machine_with_disk)
-        self.cleanup.append(storage)
 
+        self.cleanup.append(storage)
         self.assertEqual(
             storage.state,
             'Up',
@@ -296,29 +303,14 @@ class TestSnapshotRootDisk(cloudstackTestCase):
             "Check storage pool type "
         )
 
-        # Attach created volume to vm, then detach it to be able to migrate it
-        self.virtual_machine_with_disk.stop(self.apiclient)
-        self.virtual_machine_with_disk.attach_volume(
+        self.virtual_machine_with_disk.detach_volume(
             self.apiclient,
             vol
         )
-        detach_vol_res = self.virtual_machine_with_disk.detach_volume(
-            self.apiclient,
-            vol
-        )
-
-        if detach_vol_res.storageid != storage.id:
-            dest_store = storage
-        else:
-            all_stores = store_pools = list_storage_pools(self.apiclient)
-            for store in all_stores:
-                if store.id != storage.id:
-                    dest_store = store
-                    break
 
         # Migrate volume to new Primary Storage
         Volume.migrate(self.apiclient,
-                       storageid=dest_store.id,
+                       storageid=storage.id,
                        volumeid=vol.id
                        )
 
@@ -334,7 +326,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
         volume_migrated = volume_response[0]
         self.assertEqual(
             volume_migrated.storageid,
-            dest_store.id,
+            storage.id,
             "Check volume storage id"
         )
 

--- a/test/integration/smoke/test_snapshots.py
+++ b/test/integration/smoke/test_snapshots.py
@@ -302,14 +302,23 @@ class TestSnapshotRootDisk(cloudstackTestCase):
             self.apiclient,
             vol
         )
-        self.virtual_machine_with_disk.detach_volume(
+        detach_vol_res = self.virtual_machine_with_disk.detach_volume(
             self.apiclient,
             vol
         )
 
+        if detach_vol_res.storageid != storage.id:
+            dest_store = storage
+        else:
+            all_stores = store_pools = list_storage_pools(self.apiclient)
+            for store in all_stores:
+                if store.id != storage.id:
+                    dest_store = store
+                    break
+
         # Migrate volume to new Primary Storage
         Volume.migrate(self.apiclient,
-                       storageid=storage.id,
+                       storageid=dest_store.id,
                        volumeid=vol.id
                        )
 
@@ -325,7 +334,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
         volume_migrated = volume_response[0]
         self.assertEqual(
             volume_migrated.storageid,
-            storage.id,
+            dest_store.id,
             "Check volume storage id"
         )
 


### PR DESCRIPTION
### Description

This PR fixes the intermittent failure observed in test_02_list_snapshots_with_removed_data_store of the test_snapshot.py test suite. This reason for the failure seems to be that the volume created may already be present on the store (primary store) to which it is being migrated to. 
Test fails with the following exception:
```
2021-09-20 23:10:04,870 - CRITICAL - EXCEPTION: test_02_list_snapshots_with_removed_data_store:
 ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', ' 
 File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/usr/local/lib/python3.6/site-packages
 /marvin/lib/decoratorGenerators.py", line 30, in test_wrapper\n    return test(self, *args, **kwargs)\n', '  File "/marvin/tests/smoke
 /test_snapshots.py", line 313, in test_02_list_snapshots_with_removed_data_store\n    volumeid=vol.id\n', '  File "/usr/local
 /lib/python3.6/site-packages/marvin/lib/base.py", line 1262, in migrate\n    return (apiclient.migrateVolume(cmd))\n', '  File
  "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 2960, in migrateVolume\n    response
   = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-
   packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-
   packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local
   /lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 105, in __poll\n    % async_response)\n', "Exception: Job 
   failed: {accountid : 'aad96d33-1a29-11ec-a87e-1e007d00045e', userid : 'aadad1bb-1a29-11ec-a87e-1e007d00045e', cmd : 
   'org.apache.cloudstack.api.command.admin.volume.MigrateVolumeCmdByAdmin', jobstatus : 2, jobprocstatus : 0, 
   jobresultcode : 530, jobresulttype : 'object', jobresult : {errorcode : 431, errortext : 'Volume Vol[320|vm=null|DATADISK] is 
   already on the destination storage pool'}, created : '2021-09-20T23:09:24+0000', completed : '2021-09-20T23:09:24+0000', 
   jobid : '3ff4e636-610d-449e-b91c-7945c8bb7219'}\n"]
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Ran the test_snapshot.py test suite multiple times to validate that when volume is present on the store to which it is being migrated to(created storage pool), it chooses another pool from the available list of storage pools


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
