### PR TITLE
ui: Add support to filter role permissions

### DIFF
--- a/ui/src/views/iam/RolePermissionTab.vue
+++ b/ui/src/views/iam/RolePermissionTab.vue
@@ -171,8 +171,14 @@ export default {
       }).finally(() => {
         this.loadingTable = false
         this.updateTable = false
+        this.updateApis()
         if (callback) callback()
       })
+    },
+    updateApis () {
+      this.apis = Object.keys(this.$store.getters.apis).sort((a, b) => a.localeCompare(b))
+      var apisSupported = this.rules?.map(rule => rule.rule) || []
+      this.apis = this.apis.filter(api => !apisSupported.includes(api))
     },
     changeOrder () {
       api('updateRolePermission', {}, 'POST', {


### PR DESCRIPTION
### Description

This PR provides support to filter role permissions i.e., only list the APIs which haven't already been added to a role
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?
Test user with 2 role permissions added - addAccountToProject & activateProject:
![image](https://user-images.githubusercontent.com/10495417/134165283-795ad746-5550-4c59-8d66-3e9e3f4d1b60.png)

On listing the APIs to add further permissions - notice that the above added APIs aren't included:
![image](https://user-images.githubusercontent.com/10495417/134165462-cce6212f-476c-491a-b3a0-3f270238e931.png)

Deleted one API - say, addAccountToProject:
![image](https://user-images.githubusercontent.com/10495417/134165510-2fa1f88c-b7e1-4e5a-89bf-5930cbd0cb7c.png)

Observed that this API is now available in the dropdown:
![image](https://user-images.githubusercontent.com/10495417/134165587-5068375f-934f-4f02-a4fc-e295f87ee549.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
