### PR TITLE
Fix permission issue during Diagnostic service garbage collection

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/diagnostics/DiagnosticsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/diagnostics/DiagnosticsServiceImpl.java
@@ -18,7 +18,6 @@
 package org.apache.cloudstack.diagnostics;
 
 import static org.apache.cloudstack.diagnostics.DiagnosticsHelper.getTimeDifference;
-import static org.apache.cloudstack.diagnostics.DiagnosticsHelper.umountSecondaryStorage;
 import static org.apache.cloudstack.diagnostics.fileprocessor.DiagnosticsFilesList.RouterDefaultSupportedFiles;
 import static org.apache.cloudstack.diagnostics.fileprocessor.DiagnosticsFilesList.SystemVMDefaultSupportedFiles;
 
@@ -352,8 +351,6 @@ public class DiagnosticsServiceImpl extends ManagerBase implements PluggableServ
             String msg = String.format("Exception caught during scp from %s to secondary store %s: ", vmSshIp, dataDirectoryInSecondaryStore);
             LOGGER.error(msg, e);
             return new Pair<>(false, msg);
-        } finally {
-            umountSecondaryStorage(mountPoint);
         }
 
         return new Pair<>(success, "File copied to secondary storage successfully");
@@ -481,17 +478,11 @@ public class DiagnosticsServiceImpl extends ManagerBase implements PluggableServ
 
         private void cleanupOldDiagnosticFiles(DataStore store) {
             String mountPoint = null;
-            try {
-                mountPoint = serviceImpl.mountManager.getMountPoint(store.getUri(), null);
-                if (StringUtils.isNotBlank(mountPoint)) {
-                    File directory = new File(mountPoint + File.separator + DIAGNOSTICS_DIRECTORY);
-                    if (directory.isDirectory()) {
-                        deleteOldDiagnosticsFiles(directory, store.getName());
-                    }
-                }
-            } finally {
-                if (StringUtils.isNotBlank(mountPoint)) {
-                    umountSecondaryStorage(mountPoint);
+            mountPoint = serviceImpl.mountManager.getMountPoint(store.getUri(), null);
+            if (StringUtils.isNotBlank(mountPoint)) {
+                File directory = new File(mountPoint + File.separator + DIAGNOSTICS_DIRECTORY);
+                if (directory.isDirectory()) {
+                    deleteOldDiagnosticsFiles(directory, store.getName());
                 }
             }
         }


### PR DESCRIPTION
### Description

This PR attempts to fix the permission issue observed during unmounting of secondary store(s) during the diagnostic service run (on VMware) and the Diagnostic service garbage collector:
```
2021-09-23 05:17:58,206 DEBUG [o.a.c.s.NfsMountManager] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Executing while with timeout : 10000
2021-09-23 05:17:58,263 DEBUG [o.a.c.s.NfsMountManager] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Execution is successful.
2021-09-23 05:17:58,267 DEBUG [o.a.c.s.NfsMountManager] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Executing: sudo chmod 1777 /var/cloudstack/mnt/32989157261914.7b4126ed
2021-09-23 05:17:58,275 DEBUG [o.a.c.s.NfsMountManager] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Executing while with timeout : 10000
2021-09-23 05:17:58,292 DEBUG [o.a.c.s.NfsMountManager] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Execution is successful.
2021-09-23 05:17:58,300 DEBUG [o.a.c.d.DiagnosticsHelper] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Executing: /bin/bash -c umount /var/cloudstack/mnt/32989157261914.7b4126ed
2021-09-23 05:17:58,304 DEBUG [o.a.c.d.DiagnosticsHelper] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Executing while with timeout : 3600000
2021-09-23 05:17:58,305 DEBUG [o.a.c.d.DiagnosticsHelper] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) Exit value is 1
2021-09-23 05:17:58,306 DEBUG [o.a.c.d.DiagnosticsHelper] (BackgroundTaskPollManager-1:ctx-d5fcff87) (logid:779879f6) umount: /var/cloudstack/mnt/32989157261914.7b4126ed: umount failed: Operation not permitted

```
This can be solved in one of 2 ways, 
1. Do not unmount the secondary store across successive runs of the diagnostic service clean up job or collection of diagnostic data(on vmware)
2. Fix the issue of unmount (by running the umount command using sudo) and clean up the mount path so that during successive runs a new mount path can be created - https://github.com/shapeblue/cloudstack/commit/a9b460869b8f244f4b3db3cc3973f3419dffed83

Current solution follows Option 1 as it seems to be a simpler fix, and the storage unmount happens during Cloudstack Management service restarts

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested on KVM and VMware env - reduced the GC interval for diagnostic service - 'diagnostics.data.gc.interval' and observed  no more failures and on restart of MS, the store is unmounted and path is deleted


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
