### PR TITLE
marvin: Refactor - cleanup of resource after test run

### DIFF
--- a/test/integration/smoke/test_snapshots.py
+++ b/test/integration/smoke/test_snapshots.py
@@ -97,6 +97,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
                     mode=cls.services["mode"]
                 )
 
+            cls._cleanup.append(cls.virtual_machine_with_disk)
             cls._cleanup.append(cls.service_offering)
             cls._cleanup.append(cls.account)
             cls._cleanup.append(cls.disk_offering)
@@ -250,8 +251,6 @@ class TestSnapshotRootDisk(cloudstackTestCase):
             zoneid=self.zone.id
         )
         assert isinstance(clusters,list) and len(clusters)>0
-
-        self.cleanup.append(self.virtual_machine_with_disk)
 
         # Attach created volume to vm, then detach it to be able to migrate it
         self.virtual_machine_with_disk.stop(self.apiclient)


### PR DESCRIPTION
### Description

This PR addresses comment: https://github.com/apache/cloudstack/pull/5483#discussion_r714628413 - ensures consistency in the way resources are created and added for cleanup
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Ran the test_snapshot.py test suite to validate nothing's broken

```
nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=/marvin/ref-trl-1852-v-M7-pearl-dsilva-advanced-cfg -s -a tags=advanced --hypervisor=vmware /marvin/tests/smoke/test_snapshots.py 

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Sep_23_2021_09_41_54_FN5EED All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
====Trying SSH Connection: Host:10.0.35.224 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.0.35.224 port : 22 SUCCESSFUL===
{Cmd: mkdir -p %s /mnt/tmp via Host: 10.0.35.224} {returns: []}
{Cmd: mount -t nfs 10.0.32.4:/acs/secondary/ref-trl-1852-v-M7-pearl-dsilva/ref-trl-1852-v-M7-pearl-dsilva-sec1 /mnt/tmp via Host: 10.0.35.224} {returns: []}
{Cmd: test -f /mnt/tmp/snapshots/34/111/acebf6bd-5cd3-4865-9d94-eb027f91f9a4/acebf6bd-5cd3-4865-9d94-eb027f91f9a4.ovf && echo 'snapshot exists' via Host: 10.0.35.224} {returns: ['snapshot exists']}
{Cmd: cd via Host: 10.0.35.224} {returns: []}
{Cmd: umount /mnt/tmp via Host: 10.0.35.224} {returns: []}
=== TestName: test_01_snapshot_root_disk | Status : SUCCESS ===

=== TestName: test_02_list_snapshots_with_removed_data_store | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs//VOBMFO ===
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
