### PR TITLE
Fix export snapshot and template to secondary storage to export only required disk

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -1242,9 +1242,10 @@ public class VmwareStorageProcessor implements StorageProcessor {
             DatacenterMO dcMo = new DatacenterMO(context, hyperHost.getHyperHostDatacenter());
             ManagedObjectReference morPool = hyperHost.getHyperHostOwnerResourcePool();
             VirtualDisk requiredDisk = volumeDeviceInfo.first();
-            vmMo.createFullCloneWithSpecificDisk(templateUniqueName, dcMo.getVmFolder(), morPool, requiredDisk);
-            clonedVm = dcMo.findVm(templateUniqueName);
-            clonedVm.tagAsWorkerVM();
+            clonedVm = vmMo.createFullCloneWithSpecificDisk(templateUniqueName, dcMo.getVmFolder(), morPool, requiredDisk);
+            if (clonedVm == null) {
+                throw new Exception(String.format("Failed to clone VM with name %s during create template from volume operation", templateUniqueName));
+            }
             clonedVm.exportVm(secondaryMountPoint + "/" + installPath, templateUniqueName, false, false);
 
             // Get VMDK filename
@@ -1829,14 +1830,10 @@ public class VmwareStorageProcessor implements StorageProcessor {
                 DatacenterMO dcMo = new DatacenterMO(context, hyperHost.getHyperHostDatacenter());
                 ManagedObjectReference morPool = hyperHost.getHyperHostOwnerResourcePool();
                 VirtualDisk requiredDisk = volumeDeviceInfo.first();
-                vmMo.createFullCloneWithSpecificDisk(exportName, dcMo.getVmFolder(), morPool, requiredDisk);
-                clonedVm = dcMo.findVm(exportName);
+                clonedVm = vmMo.createFullCloneWithSpecificDisk(exportName, dcMo.getVmFolder(), morPool, requiredDisk);
                 if (clonedVm == null) {
-                    String msg = "Failed to clone VM. volume path: " + volumePath;
-                    s_logger.error(msg);
-                    throw new Exception(msg);
+                    throw new Exception(String.format("Failed to clone VM with name %s during export volume operation", exportName));
                 }
-                clonedVm.tagAsWorkerVM();
                 vmMo = clonedVm;
             }
             vmMo.exportVm(exportPath, exportName, false, false);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -1244,9 +1244,6 @@ public class VmwareStorageProcessor implements StorageProcessor {
             VirtualDisk requiredDisk = volumeDeviceInfo.first();
             vmMo.createFullCloneWithSpecificDisk(templateUniqueName, dcMo.getVmFolder(), morPool, requiredDisk);
             clonedVm = dcMo.findVm(templateUniqueName);
-
-            checkIfVMHasOnlyRequiredDisk(clonedVm, requiredDisk);
-
             clonedVm.tagAsWorkerVM();
             clonedVm.exportVm(secondaryMountPoint + "/" + installPath, templateUniqueName, false, false);
 
@@ -1839,7 +1836,6 @@ public class VmwareStorageProcessor implements StorageProcessor {
                     s_logger.error(msg);
                     throw new Exception(msg);
                 }
-                checkIfVMHasOnlyRequiredDisk(clonedVm, requiredDisk);
                 clonedVm.tagAsWorkerVM();
                 vmMo = clonedVm;
             }
@@ -1851,19 +1847,6 @@ public class VmwareStorageProcessor implements StorageProcessor {
                 s_logger.debug(String.format("Destroying cloned VM: %s with its disks", clonedVm.getName()));
                 clonedVm.destroy();
             }
-        }
-    }
-
-    private void checkIfVMHasOnlyRequiredDisk(VirtualMachineMO clonedVm, VirtualDisk requiredDisk) throws Exception {
-
-        s_logger.info(String.format("Checking if Cloned VM %s is created only with required Disk, if not detach the remaining disks", clonedVm.getName()));
-        VirtualDisk[] vmDisks = clonedVm.getAllDiskDevice();
-        if (vmDisks.length != 1) {
-            String baseName = VmwareHelper.getDiskDeviceFileName(requiredDisk);
-            s_logger.info(String.format("Detaching all disks for the cloned VM: %s except disk with base name: %s, key=%d", clonedVm.getName(), baseName, requiredDisk.getKey()));
-            clonedVm.detachAllDisksExcept(VmwareHelper.getDiskDeviceFileName(requiredDisk), null);
-        } else {
-            s_logger.info(String.format("Cloned VM %s is created only with required Disk", clonedVm.getName()));
         }
     }
 

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -801,24 +801,27 @@ public class VirtualMachineMO extends BaseMO {
         VirtualMachineMO clonedVm = dcMo.findVm(vmName);
         VirtualDisk[] vmDisks = clonedVm.getAllDiskDevice();
         s_logger.debug(String.format("Checking if VM %s is created only with required Disk, if not detach the remaining disks", vmName));
-        if (vmDisks.length != 1) {
-            VirtualDisk requiredCloneDisk = null;
-            for (VirtualDisk vmDisk: vmDisks) {
-                if (vmDisk.getKey() == requiredDisk.getKey()) {
-                    requiredCloneDisk = vmDisk;
-                    break;
-                }
-            }
-            if (requiredCloneDisk != null) {
-                String baseName = VmwareHelper.getDiskDeviceFileName(requiredCloneDisk);
-                s_logger.debug(String.format("Detaching all disks for the VM: %s except disk with base name: %s, key=%d", vmName, baseName, requiredCloneDisk.getKey()));
-                clonedVm.detachAllDisksExcept(baseName, null);
-            } else {
-                s_logger.error(String.format("Failed to identify required disk in VM %s", vmName));
-            }
-        } else {
+        if (vmDisks.length == 1) {
             s_logger.debug(String.format("VM %s is created only with required Disk", vmName));
+            return;
         }
+
+        VirtualDisk requiredCloneDisk = null;
+        for (VirtualDisk vmDisk: vmDisks) {
+            if (vmDisk.getKey() == requiredDisk.getKey()) {
+                requiredCloneDisk = vmDisk;
+                break;
+            }
+        }
+        if (requiredCloneDisk == null) {
+            s_logger.error(String.format("Failed to identify required disk in VM %s", vmName));
+            return;
+        }
+
+        String baseName = VmwareHelper.getDiskDeviceFileName(requiredCloneDisk);
+        s_logger.debug(String.format("Detaching all disks for the VM: %s except disk with base name: %s, key=%d", vmName, baseName, requiredCloneDisk.getKey()));
+        clonedVm.detachAllDisksExcept(baseName, null);
+
     }
 
     public boolean createFullClone(String cloneName, ManagedObjectReference morFolder, ManagedObjectReference morResourcePool, ManagedObjectReference morDs, Storage.ProvisioningType diskProvisioningType)

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -801,7 +801,7 @@ public class VirtualMachineMO extends BaseMO {
         VirtualMachineMO clonedVm = dcMo.findVm(vmName);
         VirtualDisk[] vmDisks = clonedVm.getAllDiskDevice();
         s_logger.debug(String.format("Checking if VM %s is created only with required Disk, if not detach the remaining disks", vmName));
-        if (vmDisks.length == 1) {
+        if (vmDisks.length == 1 && vmDisks[0].getKey() == requiredDisk.getKey()) {
             s_logger.debug(String.format("VM %s is created only with required Disk", vmName));
             return;
         }


### PR DESCRIPTION
### Description

This PR fixes issue #5498 where multiple volumes of a VM are exported to secondary storage upon taking snapshot of a single volume in case of VMware
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #5498 

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Created a VM with multiple disks
2. Created snapshot of one disk (also a recurring snapshot). (before creating a snapshot, add some data to the disk)
3. Check secondary storage snapshot folder to have only one disk
4. Created a volume from the snapshot above (to check subsequent operations on that snapshot are working fine)
5. Attached the above volume to a VM and made sure it is the proper disk by checking the data created before in Step 2

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
