### PR TITLE
Create UpdateBackupOffering API

### DIFF
--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -521,6 +521,7 @@ public class EventTypes {
     public static final String EVENT_VM_BACKUP_SCHEDULE_CONFIGURE = "BACKUP.SCHEDULE.CONFIGURE";
     public static final String EVENT_VM_BACKUP_SCHEDULE_DELETE = "BACKUP.SCHEDULE.DELETE";
     public static final String EVENT_VM_BACKUP_USAGE_METRIC = "BACKUP.USAGE.METRIC";
+    public static final String EVENT_VM_BACKUP_EDIT = "BACKUP.OFFERING.EDIT";
 
     // external network device events
     public static final String EVENT_EXTERNAL_NVP_CONTROLLER_ADD = "PHYSICAL.NVPCONTROLLER.ADD";

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
@@ -27,6 +27,7 @@ import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.BackupOfferingResponse;
 import org.apache.cloudstack.backup.BackupManager;
 import org.apache.cloudstack.backup.BackupOffering;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.exception.InvalidParameterValueException;
@@ -75,6 +76,10 @@ public class UpdateBackupOfferingCmd extends BaseCmd {
     @Override
     public void execute() {
         try {
+            if (StringUtils.isAllEmpty(name, description)) {
+                throw new InvalidParameterValueException(String.format("Can't update Backup Offering [id: %s] because there is no change in name or description.", id));
+            }
+
             BackupOffering result = backupManager.updateBackupOffering(this);
 
             if (result == null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.backup;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.BackupOfferingResponse;
+import org.apache.cloudstack.backup.BackupManager;
+import org.apache.cloudstack.backup.BackupOffering;
+import org.apache.log4j.Logger;
+
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.user.Account;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+@APICommand(name = "updateBackupOffering", description = "Updates a backup offering.", responseObject = BackupOfferingResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+public class UpdateBackupOfferingCmd extends BaseCmd {
+    private static final Logger LOGGER = Logger.getLogger(UpdateBackupOfferingCmd.class.getName());
+    private static final String RESPONSE_NAME = "updatebackupofferingresponse";
+
+    @Inject
+    private BackupManager backupManager;
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = BackupOfferingResponse.class, required = true, description = "The ID of the Backup Offering to be updated")
+    private Long id;
+
+    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "The description of the Backup Offering to be updated")
+    private String description;
+
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "The name of the Backup Offering to be updated")
+    private String name;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+    @Override
+    public void execute() {
+        try {
+            BackupOffering result = backupManager.updateBackupOffering(this);
+
+            if (result == null) {
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to update backup offering [id: %s, name: %s, description: %s].", id, name, description));
+            }
+            BackupOfferingResponse response = _responseGenerator.createBackupOfferingResponse(result);
+            response.setResponseName(getCommandName());
+            this.setResponseObject(response);
+        } catch (CloudRuntimeException e) {
+            ApiErrorCode paramError = e instanceof InvalidParameterValueException ? ApiErrorCode.PARAM_ERROR : ApiErrorCode.INTERNAL_ERROR;
+            LOGGER.error(String.format("Failed to update Backup Offering [id: %s] due to: [%s].", id, e.getMessage()), e);
+            throw new ServerApiException(paramError, e.getMessage());
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return RESPONSE_NAME;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return Account.ACCOUNT_ID_SYSTEM;
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
@@ -33,7 +33,8 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.user.Account;
 import com.cloud.utils.exception.CloudRuntimeException;
 
-@APICommand(name = "updateBackupOffering", description = "Updates a backup offering.", responseObject = BackupOfferingResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = "updateBackupOffering", description = "Updates a backup offering.", responseObject = BackupOfferingResponse.class,
+requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, since = "4.16.0")
 public class UpdateBackupOfferingCmd extends BaseCmd {
     private static final Logger LOGGER = Logger.getLogger(UpdateBackupOfferingCmd.class.getName());
     private static final String APINAME = "updateBackupOffering";

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
@@ -36,7 +36,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @APICommand(name = "updateBackupOffering", description = "Updates a backup offering.", responseObject = BackupOfferingResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateBackupOfferingCmd extends BaseCmd {
     private static final Logger LOGGER = Logger.getLogger(UpdateBackupOfferingCmd.class.getName());
-    private static final String RESPONSE_NAME = "updatebackupofferingresponse";
+    private static final String APINAME = "updateBackupOffering";
 
     @Inject
     private BackupManager backupManager;
@@ -91,7 +91,7 @@ public class UpdateBackupOfferingCmd extends BaseCmd {
 
     @Override
     public String getCommandName() {
-        return RESPONSE_NAME;
+        return APINAME.toLowerCase() + BaseCmd.RESPONSE_SUFFIX;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
+++ b/api/src/main/java/org/apache/cloudstack/backup/BackupManager.java
@@ -20,6 +20,7 @@ package org.apache.cloudstack.backup;
 import java.util.List;
 
 import org.apache.cloudstack.api.command.admin.backup.ImportBackupOfferingCmd;
+import org.apache.cloudstack.api.command.admin.backup.UpdateBackupOfferingCmd;
 import org.apache.cloudstack.api.command.user.backup.CreateBackupScheduleCmd;
 import org.apache.cloudstack.api.command.user.backup.ListBackupOfferingsCmd;
 import org.apache.cloudstack.api.command.user.backup.ListBackupsCmd;
@@ -137,4 +138,6 @@ public interface BackupManager extends BackupService, Configurable, PluggableSer
      * @return returns operation success
      */
     boolean deleteBackup(final Long backupId);
+
+    BackupOffering updateBackupOffering(UpdateBackupOfferingCmd updateBackupOfferingCmd);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/backup/BackupOfferingVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/backup/BackupOfferingVO.java
@@ -93,6 +93,10 @@ public class BackupOfferingVO implements BackupOffering {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public String getExternalId() {
         return externalId;
     }
@@ -118,6 +122,10 @@ public class BackupOfferingVO implements BackupOffering {
 
     public String getDescription() {
         return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public Date getCreated() {

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -65,7 +65,6 @@ import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.api.ApiDispatcher;
@@ -1069,9 +1068,6 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
 
         LOG.debug(String.format("Trying to update Backup Offering [id: %s, name: %s, description: %s] to [name: %s, description: %s].",
                 backupOfferingVO.getUuid(), backupOfferingVO.getName(), backupOfferingVO.getDescription(), name, description));
-        if (StringUtils.isAllEmpty(name, description)) {
-            throw new InvalidParameterValueException(String.format("Can't update Backup Offering [id: %s] because there is no change in name or description.", backupOfferingVO.getId()));
-        }
 
         BackupOfferingVO offering = backupOfferingDao.createForUpdate(id);
         List<String> fields = new ArrayList<>();

--- a/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.backup;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.apache.cloudstack.api.command.admin.backup.UpdateBackupOfferingCmd;
+import org.apache.cloudstack.backup.dao.BackupOfferingDao;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import com.cloud.exception.InvalidParameterValueException;
+
+public class BackupManagerTest {
+    @Spy
+    @InjectMocks
+    BackupManagerImpl backupManager = new BackupManagerImpl();
+
+    @Mock
+    BackupOfferingDao backupOfferingDao;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(backupOfferingDao.findById(null)).thenReturn(null);
+        when(backupOfferingDao.findById(123l)).thenReturn(null);
+
+        BackupOfferingVO offering = Mockito.spy(BackupOfferingVO.class);
+        when(offering.getId()).thenReturn(1234l);
+        when(offering.getName()).thenCallRealMethod();
+        when(offering.getDescription()).thenCallRealMethod();
+
+        BackupOfferingVO offeringUpdate = Mockito.spy(BackupOfferingVO.class);
+        when(offeringUpdate.getId()).thenReturn(1234l);
+        when(offeringUpdate.getName()).thenReturn("Old name");
+        when(offeringUpdate.getDescription()).thenReturn("Old description");
+
+        when(backupOfferingDao.findById(1234l)).thenReturn(offering);
+        when(backupOfferingDao.createForUpdate(1234l)).thenReturn(offeringUpdate);
+        when(backupOfferingDao.update(1234l, offeringUpdate)).thenAnswer(answer -> {
+            offering.setName("New name");
+            offering.setDescription("New description");
+            return true;
+        });
+    }
+
+    @Test
+    public void testExceptionWhenUpdateWithNullId() {
+        try {
+            Long id = null;
+
+            UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
+            when(cmd.getId()).thenReturn(id);
+
+            backupManager.updateBackupOffering(cmd);
+        } catch (InvalidParameterValueException e) {
+            assertEquals("Unable to find Backup Offering with id: [null].", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testExceptionWhenUpdateWithNonExistentId() {
+        try {
+            Long id = 123l;
+
+            UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
+            when(cmd.getId()).thenReturn(id);
+
+            backupManager.updateBackupOffering(cmd);
+        } catch (InvalidParameterValueException e) {
+            assertEquals("Unable to find Backup Offering with id: [123].", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testExceptionWhenUpdateWithoutChanges() {
+        try {
+            Long id = 1234l;
+
+            UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
+            when(cmd.getId()).thenReturn(id);
+            when(cmd.getName()).thenReturn(null);
+            when(cmd.getDescription()).thenReturn(null);
+
+            backupManager.updateBackupOffering(cmd);
+        } catch (InvalidParameterValueException e) {
+            assertEquals("Can't update Backup Offering [id: 1234] because there is no change in name or description.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdateBackupOfferingSuccess() {
+        Long id = 1234l;
+
+        UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
+        when(cmd.getId()).thenReturn(id);
+        when(cmd.getName()).thenReturn("New name");
+        when(cmd.getDescription()).thenReturn("New description");
+
+        BackupOffering updated = backupManager.updateBackupOffering(cmd);
+        assertEquals("New name", updated.getName());
+        assertEquals("New description", updated.getDescription());
+    }
+}


### PR DESCRIPTION
### Description

This PR intends to create a new API to allow users to edit name and description of Backup Offerings.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):


### How Has This Been Tested?
- I imported a new *Backup Offering*;
- Using *cloud-monkey*, I changed the name of this *Backup Offering*, and checked, in DB, UI and listBackupOfferings API if the change was performed correctly;
- Using *cloud-monkey*, I changed the description of this *Backup Offering*, and checked, in DB, UI and listBackupOfferings API if the change was performed correctly;
Using *cloud-monkey*, I changed the name and description of this *Backup Offering*, and checked, in DB, UI and listBackupOfferings API if the change was performed correctly.

Also, I added some unit tests.