### PR TITLE
kvm: add MV Settings for virtual GPU hardware type and memory

### DIFF
--- a/api/src/main/java/com/cloud/vm/VmDetailConstants.java
+++ b/api/src/main/java/com/cloud/vm/VmDetailConstants.java
@@ -40,6 +40,10 @@ public interface VmDetailConstants {
     String KVM_VNC_PORT = "kvm.vnc.port";
     String KVM_VNC_ADDRESS = "kvm.vnc.address";
 
+    // KVM specific, custom virtual GPU hardware
+    String VIDEO_HARDWARE = "video.hardware";
+    String VIDEO_RAM = "video.ram";
+
     // Mac OSX guest specific (internal)
     String SMC_PRESENT = "smc.present";
     String FIRMWARE = "firmware";

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2498,7 +2498,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
             if (details.containsKey(VideoDef.VIDEO_RAM)) {
                 String value = details.get(VideoDef.VIDEO_RAM);
-                videoRam = NumbersUtil.parseInt(value, 0);
+                videoRam = NumbersUtil.parseInt(value, videoRam);
             }
         }
         return new VideoDef(videoHw, videoRam);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2427,7 +2427,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         devices.addDevice(createChannelDef(vmTO));
         devices.addDevice(createWatchDogDef());
-        devices.addDevice(createVideoDef());
+        devices.addDevice(createVideoDef(vmTO));
         devices.addDevice(createConsoleDef());
         devices.addDevice(createGraphicDef(vmTO));
         devices.addDevice(createTabletInputDef());
@@ -2488,7 +2488,17 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return new ConsoleDef(PTY, null, null, (short)0);
     }
 
-    protected VideoDef createVideoDef() {
+    protected VideoDef createVideoDef(VirtualMachineTO vmTO) {
+        Map<String, String> details = vmTO.getDetails();
+        if (details != null) {
+            if (details.containsKey(VideoDef.VIDEO_MODEL)) {
+                _videoHw = details.get(VideoDef.VIDEO_MODEL);
+            }
+            if (details.containsKey(VideoDef.VIDEO_RAM)) {
+                String value = details.get(VideoDef.VIDEO_RAM);
+                _videoRam = NumbersUtil.parseInt(value, 0);
+            }
+        }
         return new VideoDef(_videoHw, _videoRam);
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2493,11 +2493,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         String videoHw = _videoHw;
         int videoRam = _videoRam;
         if (details != null) {
-            if (details.containsKey(VideoDef.VIDEO_MODEL)) {
-                videoHw = details.get(VideoDef.VIDEO_MODEL);
+            if (details.containsKey(VmDetailConstants.VIDEO_HARDWARE)) {
+                videoHw = details.get(VmDetailConstants.VIDEO_HARDWARE);
             }
-            if (details.containsKey(VideoDef.VIDEO_RAM)) {
-                String value = details.get(VideoDef.VIDEO_RAM);
+            if (details.containsKey(VmDetailConstants.VIDEO_RAM)) {
+                String value = details.get(VmDetailConstants.VIDEO_RAM);
                 videoRam = NumbersUtil.parseInt(value, videoRam);
             }
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2490,16 +2490,18 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     protected VideoDef createVideoDef(VirtualMachineTO vmTO) {
         Map<String, String> details = vmTO.getDetails();
+        String videoHw = _videoHw;
+        int videoRam = _videoRam;
         if (details != null) {
             if (details.containsKey(VideoDef.VIDEO_MODEL)) {
-                _videoHw = details.get(VideoDef.VIDEO_MODEL);
+                videoHw = details.get(VideoDef.VIDEO_MODEL);
             }
             if (details.containsKey(VideoDef.VIDEO_RAM)) {
                 String value = details.get(VideoDef.VIDEO_RAM);
-                _videoRam = NumbersUtil.parseInt(value, 0);
+                videoRam = NumbersUtil.parseInt(value, 0);
             }
         }
-        return new VideoDef(_videoHw, _videoRam);
+        return new VideoDef(videoHw, videoRam);
     }
 
     protected RngDef createRngDef() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1628,9 +1628,13 @@ public class LibvirtVMDef {
         @Override
         public String toString() {
             StringBuilder videoBuilder = new StringBuilder();
-            if (_videoModel != null && !_videoModel.isEmpty() && _videoRam != 0){
+            if (_videoModel != null && !_videoModel.isEmpty()){
                 videoBuilder.append("<video>\n");
-                videoBuilder.append("<model type='" + _videoModel + "' vram='" + _videoRam + "'/>\n");
+                if (_videoRam != 0) {
+                    videoBuilder.append("<model type='" + _videoModel + "' vram='" + _videoRam + "'/>\n");
+                } else {
+                    videoBuilder.append("<model type='" + _videoModel + "'/>\n");
+                }
                 videoBuilder.append("</video>\n");
                 return videoBuilder.toString();
             }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1613,6 +1613,10 @@ public class LibvirtVMDef {
     }
 
     public static class VideoDef {
+
+        public static final String VIDEO_MODEL = "video.hardware";
+        public static final String VIDEO_RAM = "video.ram";
+
         private String _videoModel;
         private int _videoRam;
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1613,10 +1613,6 @@ public class LibvirtVMDef {
     }
 
     public static class VideoDef {
-
-        public static final String VIDEO_MODEL = "video.hardware";
-        public static final String VIDEO_RAM = "video.ram";
-
         private String _videoModel;
         private int _videoRam;
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -627,7 +627,7 @@ public class LibvirtComputingResourceTest {
         libvirtComputingResourceSpy._videoRam = 200;
         libvirtComputingResourceSpy._videoHw = "vGPU";
 
-        VideoDef videoDef = libvirtComputingResourceSpy.createVideoDef();
+        VideoDef videoDef = libvirtComputingResourceSpy.createVideoDef(to);
         Document domainDoc = parse(videoDef.toString());
         assertXpath(domainDoc, "/video/model/@type", "vGPU");
         assertXpath(domainDoc, "/video/model/@vram", "200");

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3880,7 +3880,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         if (HypervisorType.KVM.equals(hypervisorType)) {
             options.put(VmDetailConstants.ROOT_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
-            options.put(VmDetailConstants.VIDEO_RAM, Arrays.asList("16384", "32768", "65536"));
+            options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3879,6 +3879,8 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
         if (HypervisorType.KVM.equals(hypervisorType)) {
             options.put(VmDetailConstants.ROOT_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
+            options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
+            options.put(VmDetailConstants.VIDEO_RAM, Arrays.asList("16384", "32768", "65536"));
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {


### PR DESCRIPTION
### Description

Add MV Settings for virtual GPU hardware type and memory.
The default virtual GPU hardware model type is cirrus.
KVM libvirt are support cirrus, vga, qxl and virtio.
Set the value in MV setting to override /etc/cloudstack/agent/agent.properties
video.hardware=qxl (override vm.video.hardware)
video.ram=32768 (override vm.video.ram)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12134066/134788497-de1596bd-71e2-48a0-9ff2-98afb1354b51.png)
![image](https://user-images.githubusercontent.com/12134066/134788523-62771bf8-aa6b-4b47-9422-90a91e8fe8f5.png)

![image](https://user-images.githubusercontent.com/12134066/134788530-e036140a-a544-44a9-8bf2-7151779d70a6.png)
![image](https://user-images.githubusercontent.com/12134066/134788543-6a348804-0f57-4945-b877-6884da90c812.png)

### How Has This Been Tested?
I had test windows 10 and ubuntu 20.04 on CloudStack 4.15.2
In my test set "video.hardware=qxl, video.ram=32768" on windows 10 can get better performance.
And set "video.hardware=virtio, video.ram=32768" on ubuntu 20.04 can get better performance.
Windows driver "Stable virtio-win ISO" is from [here](https://github.com/virtio-win/virtio-win-pkg-scripts/blob/master/README.md).
