### PR TITLE
simulator: Add support to scale a VM

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -965,10 +965,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         /* Only works for KVM/XenServer/VMware (or "Any") for now, and volumes with 'None' since they're just allocated in DB */
 
         HypervisorType hypervisorType = _volsDao.getHypervisorType(volume.getId());
-
-        if (hypervisorType != HypervisorType.KVM && hypervisorType != HypervisorType.XenServer
-                && hypervisorType != HypervisorType.VMware && hypervisorType != HypervisorType.Any
-                && hypervisorType != HypervisorType.None) {
+        List<HypervisorType> supportedHypervisors = Arrays.asList(HypervisorType.KVM, HypervisorType.XenServer,
+                HypervisorType.VMware, HypervisorType.Any, HypervisorType.None);
+        if (!supportedHypervisors.contains(hypervisorType)) {
             throw new InvalidParameterValueException("Hypervisor " + hypervisorType + " does not support volume resize");
         }
 

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -294,6 +294,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     protected Gson _gson;
 
+    private static final List<HypervisorType> SupportedHypervisorsForVolResize = Arrays.asList(HypervisorType.KVM, HypervisorType.XenServer,
+            HypervisorType.VMware, HypervisorType.Any, HypervisorType.None);
     private List<StoragePoolAllocator> _storagePoolAllocators;
 
     private List<HypervisorType> supportingDefaultHV;
@@ -965,9 +967,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         /* Only works for KVM/XenServer/VMware (or "Any") for now, and volumes with 'None' since they're just allocated in DB */
 
         HypervisorType hypervisorType = _volsDao.getHypervisorType(volume.getId());
-        List<HypervisorType> supportedHypervisors = Arrays.asList(HypervisorType.KVM, HypervisorType.XenServer,
-                HypervisorType.VMware, HypervisorType.Any, HypervisorType.None);
-        if (!supportedHypervisors.contains(hypervisorType)) {
+        if (!SupportedHypervisorsForVolResize.contains(hypervisorType)) {
             throw new InvalidParameterValueException("Hypervisor " + hypervisorType + " does not support volume resize");
         }
 

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1263,8 +1263,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 rootVolumeOfVm.setDiskOfferingId(newRootDiskOffering.getId());
                 _volsDao.update(rootVolumeOfVm.getId(), rootVolumeOfVm);
             }
-
-            _volumeService.resizeVolume(resizeVolumeCmd);
+            HypervisorType hypervisorType = _volsDao.getHypervisorType(rootVolumeOfVm.getId());
+            if (HypervisorType.Simulator != hypervisorType) {
+                _volumeService.resizeVolume(resizeVolumeCmd);
+            } else if (newRootDiskOffering.getDiskSize() > 0 && currentRootDiskOffering.getDiskSize() != newRootDiskOffering.getDiskSize()) {
+                throw new InvalidParameterValueException("Hypervisor " + hypervisorType + " does not support volume resize");
+            }
         }
 
         _itMgr.upgradeVmDb(vmId, newServiceOffering, currentServiceOffering);


### PR DESCRIPTION
### Description

This PR addresses https://github.com/apache/cloudstack/issues/5508 - where in vm scale operation is not allowed even when there is no resizing required to be performed.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
1. Performed scale VM operation from one compute (fixed) offering type w/o root disk size to another - successful
2. Performed scale VM operation from a compute(fixed) offering  w/o root disk size to a custom constrained / unconstrained offering without any root disk size - successful
3. performed scale VM operation from a compute offering with root disk size to a one without any root disk size  - successful
4. performed scaleVM operation from a compute offering w/o root disk size to a one with root disk size specified - fails with:
![image](https://user-images.githubusercontent.com/10495417/134904731-be6cb38f-9099-4761-9ce0-8978b460a9d8.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
