### PR TITLE
Fix #3448 quota calculation for monthly tariffs

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -139,16 +139,15 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         }
         s_logger.info("Getting pending quota records for account=" + account.getAccountName());
         for (UsageVO usageRecord : usageRecords.first()) {
-            BigDecimal aggregationRatio = new BigDecimal(_aggregationDuration).divide(s_minutesInMonth, 8, RoundingMode.HALF_EVEN);
             switch (usageRecord.getUsageType()) {
             case QuotaTypes.RUNNING_VM:
-                List<QuotaUsageVO> lq = updateQuotaRunningVMUsage(usageRecord, aggregationRatio);
+                List<QuotaUsageVO> lq = updateQuotaRunningVMUsage(usageRecord);
                 if (!lq.isEmpty()) {
                     quotaListForAccount.addAll(lq);
                 }
                 break;
             case QuotaTypes.ALLOCATED_VM:
-                QuotaUsageVO qu = updateQuotaAllocatedVMUsage(usageRecord, aggregationRatio);
+                QuotaUsageVO qu = updateQuotaAllocatedVMUsage(usageRecord);
                 if (qu != null) {
                     quotaListForAccount.add(qu);
                 }
@@ -159,7 +158,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             case QuotaTypes.VOLUME:
             case QuotaTypes.VM_SNAPSHOT:
             case QuotaTypes.BACKUP:
-                qu = updateQuotaDiskUsage(usageRecord, aggregationRatio, usageRecord.getUsageType());
+                qu = updateQuotaDiskUsage(usageRecord, usageRecord.getUsageType());
                 if (qu != null) {
                     quotaListForAccount.add(qu);
                 }
@@ -170,7 +169,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             case QuotaTypes.NETWORK_OFFERING:
             case QuotaTypes.SECURITY_GROUP:
             case QuotaTypes.VPN_USERS:
-                qu = updateQuotaRaw(usageRecord, aggregationRatio, usageRecord.getUsageType());
+                qu = updateQuotaRaw(usageRecord, usageRecord.getUsageType());
                 if (qu != null) {
                     quotaListForAccount.add(qu);
                 }
@@ -333,7 +332,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         return true;
     }
 
-    public QuotaUsageVO updateQuotaDiskUsage(UsageVO usageRecord, final BigDecimal aggregationRatio, final int quotaType) {
+    public QuotaUsageVO updateQuotaDiskUsage(UsageVO usageRecord, final int quotaType) {
         QuotaUsageVO quota_usage = null;
         QuotaTariffVO tariff = _quotaTariffDao.findTariffPlanByUsageType(quotaType, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0) {
@@ -352,7 +351,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         return quota_usage;
     }
 
-    public List<QuotaUsageVO> updateQuotaRunningVMUsage(UsageVO usageRecord, final BigDecimal aggregationRatio) {
+    public List<QuotaUsageVO> updateQuotaRunningVMUsage(UsageVO usageRecord) {
         List<QuotaUsageVO> quotalist = new ArrayList<QuotaUsageVO>();
         QuotaUsageVO quota_usage;
         BigDecimal cpuquotausgage, speedquotausage, memoryquotausage, vmusage;
@@ -410,7 +409,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         return quotalist;
     }
 
-    public QuotaUsageVO updateQuotaAllocatedVMUsage(UsageVO usageRecord, final BigDecimal aggregationRatio) {
+    public QuotaUsageVO updateQuotaAllocatedVMUsage(UsageVO usageRecord) {
         QuotaUsageVO quota_usage = null;
         QuotaTariffVO tariff = _quotaTariffDao.findTariffPlanByUsageType(QuotaTypes.ALLOCATED_VM, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0) {
@@ -428,7 +427,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         return quota_usage;
     }
 
-    public QuotaUsageVO updateQuotaRaw(UsageVO usageRecord, final BigDecimal aggregationRatio, final int ruleType) {
+    public QuotaUsageVO updateQuotaRaw(UsageVO usageRecord, final int ruleType) {
         QuotaUsageVO quota_usage = null;
         QuotaTariffVO tariff = _quotaTariffDao.findTariffPlanByUsageType(ruleType, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0) {

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -340,7 +340,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             BigDecimal quotaUsgage;
             BigDecimal onehourcostpergb;
             BigDecimal noofgbinuse;
-            onehourcostpergb = tariff.getCurrencyValue().multiply(aggregationRatio);
+            onehourcostpergb = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             noofgbinuse = new BigDecimal(usageRecord.getSize()).divide(s_gb, 8, RoundingMode.HALF_EVEN);
             quotaUsgage = new BigDecimal(usageRecord.getRawUsage()).multiply(onehourcostpergb).multiply(noofgbinuse);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), usageRecord.getUsageType(),
@@ -368,7 +368,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         QuotaTariffVO tariff = _quotaTariffDao.findTariffPlanByUsageType(QuotaTypes.CPU_NUMBER, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0 && serviceoffering.getCpu() != null) {
             BigDecimal cpu = new BigDecimal(serviceoffering.getCpu());
-            onehourcostpercpu = tariff.getCurrencyValue().multiply(aggregationRatio);
+            onehourcostpercpu = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             cpuquotausgage = rawusage.multiply(onehourcostpercpu).multiply(cpu);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), QuotaTypes.CPU_NUMBER,
                     cpuquotausgage, usageRecord.getStartDate(), usageRecord.getEndDate());
@@ -377,8 +377,8 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         }
         tariff = _quotaTariffDao.findTariffPlanByUsageType(QuotaTypes.CPU_CLOCK_RATE, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0 && serviceoffering.getSpeed() != null) {
-            BigDecimal speed = new BigDecimal(serviceoffering.getSpeed() / 100.00);
-            onehourcostper100mhz = tariff.getCurrencyValue().multiply(aggregationRatio);
+            BigDecimal speed = new BigDecimal(serviceoffering.getSpeed()*serviceoffering.getCpu() / 100.00);
+            onehourcostper100mhz = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             speedquotausage = rawusage.multiply(onehourcostper100mhz).multiply(speed);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), QuotaTypes.CPU_CLOCK_RATE,
                     speedquotausage, usageRecord.getStartDate(), usageRecord.getEndDate());
@@ -388,7 +388,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         tariff = _quotaTariffDao.findTariffPlanByUsageType(QuotaTypes.MEMORY, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0 && serviceoffering.getRamSize() != null) {
             BigDecimal memory = new BigDecimal(serviceoffering.getRamSize());
-            onehourcostper1mb = tariff.getCurrencyValue().multiply(aggregationRatio);
+            onehourcostper1mb = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             memoryquotausage = rawusage.multiply(onehourcostper1mb).multiply(memory);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), QuotaTypes.MEMORY, memoryquotausage,
                     usageRecord.getStartDate(), usageRecord.getEndDate());
@@ -397,7 +397,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         }
         tariff = _quotaTariffDao.findTariffPlanByUsageType(QuotaTypes.RUNNING_VM, usageRecord.getEndDate());
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0) {
-            onehourcostforvmusage = tariff.getCurrencyValue().multiply(aggregationRatio);
+            onehourcostforvmusage = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             vmusage = rawusage.multiply(onehourcostforvmusage);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), QuotaTypes.RUNNING_VM, vmusage,
                     usageRecord.getStartDate(), usageRecord.getEndDate());
@@ -416,7 +416,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0) {
             BigDecimal vmusage;
             BigDecimal onehourcostforvmusage;
-            onehourcostforvmusage = tariff.getCurrencyValue().multiply(aggregationRatio);
+            onehourcostforvmusage = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             vmusage = new BigDecimal(usageRecord.getRawUsage()).multiply(onehourcostforvmusage);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), QuotaTypes.ALLOCATED_VM, vmusage,
                     usageRecord.getStartDate(), usageRecord.getEndDate());
@@ -434,7 +434,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         if (tariff != null && tariff.getCurrencyValue().compareTo(BigDecimal.ZERO) != 0) {
             BigDecimal ruleusage;
             BigDecimal onehourcost;
-            onehourcost = tariff.getCurrencyValue().multiply(aggregationRatio);
+            onehourcost = tariff.getCurrencyValue().divide(s_hoursInMonth, 8, RoundingMode.HALF_DOWN);
             ruleusage = new BigDecimal(usageRecord.getRawUsage()).multiply(onehourcost);
             quota_usage = new QuotaUsageVO(usageRecord.getId(), usageRecord.getZoneId(), usageRecord.getAccountId(), usageRecord.getDomainId(), ruleType, ruleusage,
                     usageRecord.getStartDate(), usageRecord.getEndDate());

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
@@ -151,7 +151,7 @@ public class QuotaManagerImplTest extends TestCase {
 
         QuotaUsageVO quotaUsageVO = new QuotaUsageVO();
         quotaUsageVO.setAccountId(2L);
-        Mockito.doReturn(quotaUsageVO).when(quotaManager).updateQuotaAllocatedVMUsage(Mockito.eq(usageVO), Mockito.any(BigDecimal.class));
+        Mockito.doReturn(quotaUsageVO).when(quotaManager).updateQuotaAllocatedVMUsage(Mockito.eq(usageVO));
 
         assertTrue(quotaManager.aggregatePendingQuotaRecordsForAccount(accountVO, new Pair<List<? extends UsageVO>, Integer>(null, 0)).size() == 0);
         assertTrue(quotaManager.aggregatePendingQuotaRecordsForAccount(accountVO, usageRecords).size() == 1);
@@ -172,11 +172,11 @@ public class QuotaManagerImplTest extends TestCase {
 
         QuotaUsageVO qu = quotaManager.updateQuotaNetwork(usageVO, UsageTypes.NETWORK_BYTES_SENT);
         assertTrue(qu.getQuotaUsed().compareTo(BigDecimal.ZERO) > 0);
-        qu = quotaManager.updateQuotaAllocatedVMUsage(usageVO, new BigDecimal(0.5));
+        qu = quotaManager.updateQuotaAllocatedVMUsage(usageVO);
         assertTrue(qu.getQuotaUsed().compareTo(BigDecimal.ZERO) > 0);
-        qu = quotaManager.updateQuotaDiskUsage(usageVO, new BigDecimal(0.5), UsageTypes.VOLUME);
+        qu = quotaManager.updateQuotaDiskUsage(usageVO, UsageTypes.VOLUME);
         assertTrue(qu.getQuotaUsed().compareTo(BigDecimal.ZERO) > 0);
-        qu = quotaManager.updateQuotaRaw(usageVO, new BigDecimal(0.5), UsageTypes.VPN_USERS);
+        qu = quotaManager.updateQuotaRaw(usageVO, UsageTypes.VPN_USERS);
         assertTrue(qu.getQuotaUsed().compareTo(BigDecimal.ZERO) > 0);
 
         Mockito.verify(quotaUsageDao, Mockito.times(4)).persistQuotaUsage(Mockito.any(QuotaUsageVO.class));


### PR DESCRIPTION
### Description

The quota calculation has been wrong for monthly tariffs (like Compute-Month, GB-Month, etc) for so much time but even when #3448 was reported it was closed without evaluation.

The wrong calculation was the price per hour, it was taking the monthly tariff and multiplying by the aggregation ratio which has no sense at all.

The right price per hour is the monthly tariff divided by the standard number of hours in a month.

Fixes #3448.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [X] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### How Has This Been Tested?
Partial execution of the component with a test vector.
Tracing the values and compared with spreadsheet.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
