### PR TITLE
Remove logic that creates gap for multiple 'source NAT' in VR

### DIFF
--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -717,17 +717,10 @@ public class CommandSetupHelper {
 
             for (final PublicIpAddress ipAddr : ipAddrList) {
                 final boolean add = ipAddr.getState() == IpAddress.State.Releasing ? false : true;
-                boolean sourceNat = ipAddr.isSourceNat();
-                /* enable sourceNAT for the first ip of the public interface
-                * For additional public subnet source nat rule needs to be added for vm to reach ips in that subnet
-                */
-                if (firstIP) {
-                    sourceNat = true;
-                }
 
                 final String macAddress = vlanMacAddress.get(BroadcastDomainType.getValue(BroadcastDomainType.fromString(ipAddr.getVlanTag())));
 
-                final IpAddressTO ip = new IpAddressTO(ipAddr.getAccountId(), ipAddr.getAddress().addr(), add, firstIP, sourceNat, BroadcastDomainType.fromString(ipAddr.getVlanTag()).toString(), ipAddr.getGateway(),
+                final IpAddressTO ip = new IpAddressTO(ipAddr.getAccountId(), ipAddr.getAddress().addr(), add, firstIP, ipAddr.isSourceNat(), BroadcastDomainType.fromString(ipAddr.getVlanTag()).toString(), ipAddr.getGateway(),
                         ipAddr.getNetmask(), macAddress, networkRate, ipAddr.isOneToOneNat());
 
                 setIpAddressNetworkParams(ip, network, router);


### PR DESCRIPTION
### Description
In ACS, when a VPC has more than one public IP and a user tries to use the non `source NAT` IP with some feature/option (like `static NAT`, `port forwarding`, `VPN` and others), ACS adds the public IP (used for the feature/option) as `source NAT` in the `iptables` of the VR.

Example:
- VPC has one public IP `192.168.0.50` and it is defined as the `source NAT`.
- If we assign another public IP `192.168.0.51` to the VPC and use it to execute `port forwarding`, ACS will automatically add `192.168.0.51` as `source NAT` too.

This PR intends to remove this inconsistency created by ACS.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?
I tested locally, in a test lab.
1. Created a VPC;
2. Observed VR's `iptables`;
3. Added public IPs to the VPC, assigned functions, tested and removed them;
4. Before this change, every public IP would turn into a `source NAT` and mess up with the `iptables`. After the changes, the `source NAT` is kept along all the process and only the real function of the public IP is assigned.