### PR TITLE
Filter dedicated and non-dedicated VLAN in API listPublicIPAddresses

### DIFF
--- a/server/src/test/java/com/cloud/server/ManagementServerImplTest.java
+++ b/server/src/test/java/com/cloud/server/ManagementServerImplTest.java
@@ -16,12 +16,20 @@
 // under the License.
 package com.cloud.server;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.cloudstack.api.command.user.ssh.RegisterSSHKeyPairCmd;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,6 +37,8 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.cloud.dc.VlanVO;
+import com.cloud.dc.dao.VlanDao;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.user.Account;
 import com.cloud.user.SSHKeyPair;
@@ -45,7 +55,7 @@ public class ManagementServerImplTest {
     SSHKeyPairVO existingPair;
 
     @Mock
-    Account account;
+    Account accountMock;
 
     @Mock
     SSHKeyPairDao sshKeyPairDao;
@@ -55,43 +65,54 @@ public class ManagementServerImplTest {
     SSHKeyPair sshKeyPair;
 
     @Spy
-    ManagementServerImpl spy;
+    ManagementServerImpl managementServerImplSpy;
+
+    @Mock
+    VlanDao vlanDaoMock;
+
+    @Mock
+    VlanVO vlanVoMock1, vlanVoMock2;
+
+    @Before
+    public void setup() {
+        managementServerImplSpy._vlanDao = vlanDaoMock;
+    }
 
     @Test(expected = InvalidParameterValueException.class)
     public void testDuplicateRegistraitons(){
         String accountName = "account";
         String publicKeyString = "ssh-rsa very public";
-        String publicKeyMaterial = spy.getPublicKeyFromKeyKeyMaterial(publicKeyString);
+        String publicKeyMaterial = managementServerImplSpy.getPublicKeyFromKeyKeyMaterial(publicKeyString);
 
-        Mockito.lenient().doReturn(account).when(spy).getCaller();
-        Mockito.lenient().doReturn(account).when(spy).getOwner(regCmd);
+        Mockito.lenient().doReturn(accountMock).when(managementServerImplSpy).getCaller();
+        Mockito.lenient().doReturn(accountMock).when(managementServerImplSpy).getOwner(regCmd);
 
-        Mockito.doNothing().when(spy).checkForKeyByName(regCmd, account);
+        Mockito.doNothing().when(managementServerImplSpy).checkForKeyByName(regCmd, accountMock);
         Mockito.lenient().doReturn(accountName).when(regCmd).getAccountName();
 
         Mockito.doReturn(publicKeyString).when(regCmd).getPublicKey();
         Mockito.doReturn("name").when(regCmd).getName();
 
-        spy._sshKeyPairDao = sshKeyPairDao;
-        Mockito.doReturn(1L).when(account).getAccountId();
-        Mockito.doReturn(1L).when(account).getDomainId();
+        managementServerImplSpy._sshKeyPairDao = sshKeyPairDao;
+        Mockito.doReturn(1L).when(accountMock).getAccountId();
+        Mockito.doReturn(1L).when(accountMock).getDomainId();
         Mockito.doReturn(Mockito.mock(SSHKeyPairVO.class)).when(sshKeyPairDao).persist(any(SSHKeyPairVO.class));
 
         lenient().when(sshKeyPairDao.findByName(1L, 1L, "name")).thenReturn(null).thenReturn(null);
         when(sshKeyPairDao.findByPublicKey(1L, 1L, publicKeyMaterial)).thenReturn(null).thenReturn(existingPair);
 
-        spy.registerSSHKeyPair(regCmd);
-        spy.registerSSHKeyPair(regCmd);
+        managementServerImplSpy.registerSSHKeyPair(regCmd);
+        managementServerImplSpy.registerSSHKeyPair(regCmd);
     }
     @Test
     public void testSuccess(){
         String accountName = "account";
         String publicKeyString = "ssh-rsa very public";
-        String publicKeyMaterial = spy.getPublicKeyFromKeyKeyMaterial(publicKeyString);
+        String publicKeyMaterial = managementServerImplSpy.getPublicKeyFromKeyKeyMaterial(publicKeyString);
 
-        Mockito.lenient().doReturn(1L).when(account).getAccountId();
-        Mockito.doReturn(1L).when(account).getAccountId();
-        spy._sshKeyPairDao = sshKeyPairDao;
+        Mockito.lenient().doReturn(1L).when(accountMock).getAccountId();
+        Mockito.doReturn(1L).when(accountMock).getAccountId();
+        managementServerImplSpy._sshKeyPairDao = sshKeyPairDao;
 
 
         //Mocking the DAO object functions - NO object found in DB
@@ -102,9 +123,110 @@ public class ManagementServerImplTest {
         //Mocking the User Params
         Mockito.doReturn(accountName).when(regCmd).getName();
         Mockito.doReturn(publicKeyString).when(regCmd).getPublicKey();
-        Mockito.doReturn(account).when(spy).getOwner(regCmd);
+        Mockito.doReturn(accountMock).when(managementServerImplSpy).getOwner(regCmd);
 
-        spy.registerSSHKeyPair(regCmd);
-        Mockito.verify(spy, Mockito.times(3)).getPublicKeyFromKeyKeyMaterial(anyString());
+        managementServerImplSpy.registerSSHKeyPair(regCmd);
+        Mockito.verify(managementServerImplSpy, Mockito.times(3)).getPublicKeyFromKeyKeyMaterial(anyString());
+    }
+
+    @Test
+    public void validateRetrieveDedicatedVlans() {
+        List<VlanVO> expectedResult = Arrays.asList(vlanVoMock1);
+
+        Mockito.doReturn(expectedResult).when(vlanDaoMock).listDedicatedVlans(Mockito.anyLong());
+
+        List<VlanVO> result = managementServerImplSpy.retrieveDedicatedVlans(0, "");
+
+        Assert.assertEquals(expectedResult, result);
+        Mockito.verify(vlanDaoMock).listDedicatedVlans(Mockito.anyLong());
+    }
+
+    @Test
+    public void validateRetrieveZoneWideNonDedicatedVlansAccountWithoutAccessToPublicIps() {
+        List<VlanVO> expectedResult = new ArrayList<>();
+
+        Mockito.doReturn(false).when(managementServerImplSpy).getUseSystemPublicIpsValueIn(Mockito.anyLong());
+
+        List<VlanVO> result = managementServerImplSpy.retrieveZoneWideNonDedicatedVlans(0, "", 0);
+
+        Assert.assertEquals(expectedResult, result);
+        Mockito.verify(vlanDaoMock, never()).listZoneWideNonDedicatedVlans(Mockito.anyLong());
+    }
+
+    @Test
+    public void validateRetrieveZoneWideNonDedicatedVlansAccountWithAccessToPublicIps() {
+        List<VlanVO> expectedResult = Arrays.asList(vlanVoMock2);
+
+        Mockito.doReturn(true).when(managementServerImplSpy).getUseSystemPublicIpsValueIn(Mockito.anyLong());
+        Mockito.doReturn(expectedResult).when(vlanDaoMock).listZoneWideNonDedicatedVlans(Mockito.anyLong());
+
+        List<VlanVO> result = managementServerImplSpy.retrieveZoneWideNonDedicatedVlans(0, "", 0);
+
+        Assert.assertEquals(expectedResult, result);
+        Mockito.verify(vlanDaoMock).listZoneWideNonDedicatedVlans(Mockito.anyLong());
+    }
+
+    @Test
+    public void validateRetrieveAvailableVlanDbIdsForAccountWithNonDedicatedAndDedicatedVlans() {
+        List<Long> expectedResult = Arrays.asList(1l, 2l);
+        Mockito.doReturn(expectedResult.get(0)).when(vlanVoMock1).getId();
+        Mockito.doReturn(expectedResult.get(1)).when(vlanVoMock2).getId();
+        Mockito.doReturn(1l).when(accountMock).getId();
+
+        Mockito.doReturn(Arrays.asList(vlanVoMock1)).when(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.doReturn(Arrays.asList(vlanVoMock2)).when(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+
+        List<Long> result = managementServerImplSpy.retrieveAvailableVlanDbIdsForAccount(1l, accountMock);
+
+        Mockito.verify(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.verify(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+        assertArrayEquals(expectedResult.toArray(), result.toArray());
+    }
+
+    @Test
+    public void validateRetrieveAvailableVlanDbIdsForAccountWithNonDedicatedAndWithoutDedicatedVlans() {
+        List<Long> expectedResult = Arrays.asList(1l);
+        Mockito.doReturn(expectedResult.get(0)).when(vlanVoMock1).getId();
+        Mockito.doReturn(1l).when(accountMock).getId();
+
+        Mockito.doReturn(Arrays.asList(vlanVoMock1)).when(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.doReturn(new ArrayList<>()).when(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+
+        List<Long> result = managementServerImplSpy.retrieveAvailableVlanDbIdsForAccount(1l, accountMock);
+
+        Mockito.verify(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.verify(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+        assertArrayEquals(expectedResult.toArray(), result.toArray());
+    }
+
+    @Test
+    public void validateRetrieveAvailableVlanDbIdsForAccountWithoutNonDedicatedAndWithDedicatedVlans() {
+        List<Long> expectedResult = Arrays.asList(2l);
+        Mockito.doReturn(expectedResult.get(0)).when(vlanVoMock2).getId();
+        Mockito.doReturn(1l).when(accountMock).getId();
+
+        Mockito.doReturn(new ArrayList<>()).when(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.doReturn(Arrays.asList(vlanVoMock2)).when(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+
+        List<Long> result = managementServerImplSpy.retrieveAvailableVlanDbIdsForAccount(1l, accountMock);
+
+        Mockito.verify(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.verify(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+        assertArrayEquals(expectedResult.toArray(), result.toArray());
+    }
+
+    @Test
+    public void validateRetrieveAvailableVlanDbIdsForAccountWithoutNonDedicatedAndDedicatedVlans() {
+        List<Long> expectedResult = Arrays.asList(-1l);
+        Mockito.doReturn(1l).when(accountMock).getId();
+
+        Mockito.doReturn(new ArrayList<>()).when(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.doReturn(new ArrayList<>()).when(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+
+        List<Long> result = managementServerImplSpy.retrieveAvailableVlanDbIdsForAccount(1l, accountMock);
+
+        Mockito.verify(managementServerImplSpy).retrieveZoneWideNonDedicatedVlans(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
+        Mockito.verify(managementServerImplSpy).retrieveDedicatedVlans(Mockito.anyLong(), Mockito.anyString());
+        assertArrayEquals(expectedResult.toArray(), result.toArray());
     }
 }


### PR DESCRIPTION
### Description
In ACS, when we are listing public IPs to allocate, to a VPC, for instance, all IPs are listed, even the ones dedicated to an account different from the one that is calling the API. If we tried to allocate an IP dedicated to another account, ACS would return an error. Therefore, this PR intends to filter dedicated and non-dedicated VLANs in API `listPublicIPAddresses`.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?
I added unit tests and tested locally, in a test lab.
1. Created VPCs to account `A` and `B`;
2. Dedicated some IPs to `A` and some`to `B`;
3. Enabled non-dedicated VLANs to A;
4. Before this change, account `A` would see non-dedicated and `B`'s IPs and `B` would see non-dedicated and `A`'s IPs. After this change, `A` only can see its IPs and non-dedicated and `B` only see its IPs as well.