### PR TITLE
xcp-ng: fix vm boot options

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1441,7 +1441,8 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             throw new CloudRuntimeException("Unable to finalize VM MetaData: " + vmSpec);
         }
         try {
-            setVmBootDetails(vm, conn, vmSpec.getBootType(), vmSpec.getBootMode());
+            String bootMode = org.apache.commons.lang3.StringUtils.defaultIfEmpty(vmSpec.getDetails().get(ApiConstants.BootType.UEFI.toString()), null);
+            setVmBootDetails(vm, conn, bootMode == null ? null : ApiConstants.BootType.UEFI.toString(), bootMode);
         } catch (final XenAPIException | XmlRpcException e) {
             throw new CloudRuntimeException(String.format("Unable to handle VM boot options: %s", vmSpec), e);
         }


### PR DESCRIPTION
### Description

Use value boot option values from VM details directly similar to other hypervisor plugins instead of relying on boot properties explicitly set for `VirtualMachineTO`.

Fixes #5535 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
