### PR TITLE
Fix of revert RBD snapshots

### DIFF
--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -312,7 +312,10 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
 
         SnapshotInfo snapshotInfo = snapshotFactory.getSnapshot(snapshotId, dataStoreRole);
         if (snapshotInfo == null) {
-            throw new CloudRuntimeException("snapshot:" + snapshotId + " not exist in data store");
+            snapshotInfo = snapshotFactory.getSnapshot(snapshotId, DataStoreRole.Primary);
+            if (snapshotInfo == null) {
+                throw new CloudRuntimeException(String.format("snapshot [%s] does not exists in data store", snapshotId));
+            }
         }
 
         SnapshotStrategy snapshotStrategy = _storageStrategyFactory.getSnapshotStrategy(snapshot, SnapshotOperation.REVERT);

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -313,7 +313,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         SnapshotInfo snapshotInfo = snapshotFactory.getSnapshot(snapshotId, dataStoreRole);
 
         if (snapshotInfo == null) {
-            throw new CloudRuntimeException(String.format("snapshot [%s] does not exists in data store", snapshotId));
+            throw new CloudRuntimeException(String.format("snapshot %s [%s] does not exists in data store", snapshot.getName(), snapshot.getUuid()));
         }
 
         SnapshotStrategy snapshotStrategy = _storageStrategyFactory.getSnapshotStrategy(snapshot, SnapshotOperation.REVERT);
@@ -1243,7 +1243,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
 
                 SnapshotDataStoreVO snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, dataStoreRole);
                 if (snapshotStoreRef == null) {
-                    throw new CloudRuntimeException(String.format("Could not find snapshot with id [%] on [%]", snapshotId, snapshot.getLocationType()));
+                    throw new CloudRuntimeException(String.format("Could not find snapshot %s [%s] on [%s]", snapshot.getName(), snapshot.getUuid(), snapshot.getLocationType()));
                 }
                 UsageEventUtils.publishUsageEvent(EventTypes.EVENT_SNAPSHOT_CREATE, snapshot.getAccountId(), snapshot.getDataCenterId(), snapshotId, snapshot.getName(), null, null,
                         snapshotStoreRef.getPhysicalSize(), volume.getSize(), snapshot.getClass().getName(), snapshot.getUuid());

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -307,7 +307,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             }
         }
 
-        DataStoreRole dataStoreRole = getDataStoreRole(snapshot, _snapshotStoreDao, dataStoreMgr);
+        DataStoreRole dataStoreRole = getDataStoreRole(snapshot);
 
         SnapshotInfo snapshotInfo = snapshotFactory.getSnapshot(snapshotId, dataStoreRole);
         if (snapshotInfo == null) {
@@ -586,7 +586,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             return false;
         }
 
-        DataStoreRole dataStoreRole = getDataStoreRole(snapshotCheck, _snapshotStoreDao, dataStoreMgr);
+        DataStoreRole dataStoreRole = getDataStoreRole(snapshotCheck);
 
         SnapshotDataStoreVO snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, dataStoreRole);
 
@@ -1237,7 +1237,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             try {
                 postCreateSnapshot(volume.getId(), snapshotId, payload.getSnapshotPolicyId());
 
-                DataStoreRole dataStoreRole = getDataStoreRole(snapshot, _snapshotStoreDao, dataStoreMgr);
+                DataStoreRole dataStoreRole = getDataStoreRole(snapshot);
 
                 SnapshotDataStoreVO snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, dataStoreRole);
                 if (snapshotStoreRef == null) {
@@ -1327,8 +1327,8 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         }
     }
 
-    private DataStoreRole getDataStoreRole(Snapshot snapshot, SnapshotDataStoreDao snapshotStoreDao, DataStoreManager dataStoreMgr) {
-        List<SnapshotDataStoreVO> snapshots = snapshotStoreDao.findBySnapshotId(snapshot.getId());
+    private DataStoreRole getDataStoreRole(Snapshot snapshot) {
+        List<SnapshotDataStoreVO> snapshots = _snapshotStoreDao.findBySnapshotId(snapshot.getId());
         if (CollectionUtils.isEmpty(snapshots)) {
             return null;
         }

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -1241,7 +1241,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
 
                 SnapshotDataStoreVO snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, dataStoreRole);
                 if (snapshotStoreRef == null) {
-                    throw new CloudRuntimeException("Could not find snapshot");
+                    throw new CloudRuntimeException(String.format("Could not find snapshot with id [%] on [%]", snapshotId, snapshot.getLocationType()));
                 }
                 UsageEventUtils.publishUsageEvent(EventTypes.EVENT_SNAPSHOT_CREATE, snapshot.getAccountId(), snapshot.getDataCenterId(), snapshotId, snapshot.getName(), null, null,
                         snapshotStoreRef.getPhysicalSize(), volume.getSize(), snapshot.getClass().getName(), snapshot.getUuid());

--- a/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
+++ b/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
@@ -537,12 +537,11 @@ public class SnapshotManagerTest {
 
     private void getDataStore()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Method declaredMethod = SnapshotManagerImpl.class.getDeclaredMethod("getDataStoreRole", Snapshot.class, SnapshotDataStoreDao.class, DataStoreManager.class);
+        Method declaredMethod = SnapshotManagerImpl.class.getDeclaredMethod("getDataStoreRole", Snapshot.class);
         declaredMethod.setAccessible(true);
         List<SnapshotDataStoreVO> dataStoreSnapshots = new ArrayList<>();
         dataStoreSnapshots.add(snapshotStoreMock);
         when(snapshotStoreDao.findBySnapshotId(anyLong())).thenReturn(dataStoreSnapshots);
-        Class<SnapshotManagerImpl> snapshotMgrClass = SnapshotManagerImpl.class;
-        when(declaredMethod.invoke(snapshotMgrClass.newInstance(),snapshotMock, snapshotStoreDao, dataStoreManager)).thenReturn(DataStoreRole.Primary);
+        when(declaredMethod.invoke(_snapshotMgr, snapshotMock)).thenReturn(DataStoreRole.Primary);
     }
 }

--- a/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
+++ b/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
@@ -23,6 +23,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -30,6 +33,7 @@ import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
@@ -149,6 +153,8 @@ public class SnapshotManagerTest {
     SnapshotDataStoreVO snapshotStoreMock;
     @Mock
     SnapshotService snapshotSrv;
+    @Mock
+    DataStoreManager dataStoreManager;
 
     @Mock
     GlobalLock globalLockMock;
@@ -326,22 +332,24 @@ public class SnapshotManagerTest {
 
     // vm on Xenserver, return null
     @Test
-    public void testRevertSnapshotF2() {
+    public void testRevertSnapshotF2() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getState()).thenReturn(State.Stopped);
         when(vmMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.XenServer);
         when(volumeMock.getFormat()).thenReturn(ImageFormat.VHD);
+        getDataStore();
         Snapshot snapshot = _snapshotMgr.revertSnapshot(TEST_SNAPSHOT_ID);
         Assert.assertNull(snapshot);
     }
 
     // vm on KVM, successful
     @Test
-    public void testRevertSnapshotF3() {
+    public void testRevertSnapshotF3() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getState()).thenReturn(State.Stopped);
         when(vmMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
         when(volumeMock.getFormat()).thenReturn(ImageFormat.QCOW2);
+        getDataStore();
         when (snapshotStrategy.revertSnapshot(Mockito.any(SnapshotInfo.class))).thenReturn(true);
         when(_volumeDao.update(anyLong(), any(VolumeVO.class))).thenReturn(true);
         Snapshot snapshot = _snapshotMgr.revertSnapshot(TEST_SNAPSHOT_ID);
@@ -525,5 +533,16 @@ public class SnapshotManagerTest {
         Mockito.verify(_snapshotMgr, timesVerification).updateSnapshotPolicy(Mockito.any(SnapshotPolicyVO.class), Mockito.anyString(), Mockito.anyString(),
           Mockito.any(DateUtil.IntervalType.class), Mockito.anyInt(), Mockito.anyBoolean(), Mockito.anyBoolean());
         Mockito.verify(_snapshotMgr, timesVerification).createTagsForSnapshotPolicy(Mockito.any(), Mockito.any());
+    }
+
+    private void getDataStore()
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Method declaredMethod = SnapshotManagerImpl.class.getDeclaredMethod("getDataStoreRole", Snapshot.class, SnapshotDataStoreDao.class, DataStoreManager.class);
+        declaredMethod.setAccessible(true);
+        List<SnapshotDataStoreVO> dataStoreSnapshots = new ArrayList<>();
+        dataStoreSnapshots.add(snapshotStoreMock);
+        when(snapshotStoreDao.findBySnapshotId(anyLong())).thenReturn(dataStoreSnapshots);
+        Class<SnapshotManagerImpl> snapshotMgrClass = SnapshotManagerImpl.class;
+        when(declaredMethod.invoke(snapshotMgrClass.newInstance(),snapshotMock, snapshotStoreDao, dataStoreManager)).thenReturn(DataStoreRole.Primary);
     }
 }


### PR DESCRIPTION
### Description

If a snapshot is taken only on Primary storage with the option "snapshot.backup.to.secondary" disabled, and after this when you enable the option the revert will fail. Added check if there isn't a snapshot on Secondary storage to check for it on Primary.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?
4.15 and main with KVM hypervisors

set `snapshot.backup.to.secondary` to `false`
take one or more snapshots
set `snapshot.backup.to.secondary` to `true`
try to revert the snapshot. The operation will fail with "snapshot [snapshot ID] does not exists in data store"

