### PR TITLE
[UI] Edit backup offering

### DIFF
--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -220,7 +220,6 @@ export default {
         icon: 'edit',
         label: 'label.edit',
         dataView: true,
-        groupAction: true,
         popup: true,
         groupMap: (selection) => { return selection.map(x => { return { id: x } }) },
         args: ['name', 'description']

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -206,7 +206,7 @@ export default {
       docHelp: 'adminguide/virtual_machines.html#backup-offerings',
       permission: ['listBackupOfferings', 'listInfrastructure'],
       columns: ['name', 'description', 'zonename'],
-      details: ['name', 'id', 'description', 'externalid', 'zone', 'created'],
+      details: ['name', 'id', 'description', 'externalid', 'zone', 'allowuserdrivenbackups', 'created'],
       actions: [{
         api: 'importBackupOffering',
         icon: 'plus',
@@ -215,6 +215,15 @@ export default {
         listView: true,
         popup: true,
         component: () => import('@/views/offering/ImportBackupOffering.vue')
+      }, {
+        api: 'updateBackupOffering',
+        icon: 'edit',
+        label: 'label.edit',
+        dataView: true,
+        groupAction: true,
+        popup: true,
+        groupMap: (selection) => { return selection.map(x => { return { id: x } }) },
+        args: ['name', 'description']
       }, {
         api: 'deleteBackupOffering',
         icon: 'delete',


### PR DESCRIPTION
### Description

This PR allows users to edit a name and description of a Backup Offering

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/31869303/135672968-31903f72-0ed1-4601-b7ba-a7de93ac78e2.png)
![image](https://user-images.githubusercontent.com/31869303/135673016-f07f7891-3f73-4367-b7ae-1f75b9ce84fc.png)
![image](https://user-images.githubusercontent.com/31869303/135673056-396626bf-2532-420d-8ce7-a1f476afce6d.png)
![image](https://user-images.githubusercontent.com/31869303/135673148-82cd7a85-a18a-4afa-a7d9-c1e81a34a57b.png)
![image](https://user-images.githubusercontent.com/31869303/135673168-a124dc58-0d2e-4d8d-9a65-36d6fc15917b.png)


### How Has This Been Tested?
I tested in a local lab.
1. I imported a Backup Offering;
2. I edited the name of this offering;
3. I edited the description of this offering.
4. I checked, in UI and DB if changes are applied.