### PR TITLE
KVM Agent disconnect hook feature

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/disconnecthook/DisconnectHook.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/disconnecthook/DisconnectHook.java
@@ -18,7 +18,7 @@
 //
 package com.cloud.hypervisor.kvm.resource.disconnecthook;
 
-/*
+/**
 DisconnectHooks can be used to cleanup/cancel long running commands when
 connection to the management server is interrupted (which results in job
 failure). Agent CommandWrappers can register a hook with the

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/disconnecthook/DisconnectHook.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/disconnecthook/DisconnectHook.java
@@ -1,0 +1,59 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.hypervisor.kvm.resource.disconnecthook;
+
+/*
+DisconnectHooks can be used to cleanup/cancel long running commands when
+connection to the management server is interrupted (which results in job
+failure). Agent CommandWrappers can register a hook with the
+libvirtComputingResource at the beginning of processing, and
+libvirtComputingResource will call it upon disconnect. The CommandWrapper can
+also remove the hook upon completion of the command.
+
+DisconnectHooks should implement a run() method that is safe to call and will
+fail cleanly if there is no cleanup to do. Otherwise the CommandWrapper
+registering/deregistering the hook should account for any race conditions
+introduced by the ordering of when the command is processed and when the hook
+is registered/deregistered.
+
+If a timeout is set, the hook's run() will be interrupted. It will be up to
+run() to determine what to do with the InterruptedException, but the hook
+processing will not wait any longer for the hook to complete.
+
+Avoid doing anything time intensive as DisconnectHooks will delay agent
+shutdown.
+*/
+
+public abstract class DisconnectHook extends Thread {
+    // Default timeout is 10 seconds
+    long timeoutMs = 10000;
+
+    public DisconnectHook(String name) {
+        super();
+        this.setName(this.getClass().getName() + "-" + name);
+    }
+
+    public DisconnectHook(String name, long timeout) {
+        this(name);
+        this.timeoutMs = timeout;
+    }
+
+    public long getTimeoutMs(){ return timeoutMs; }
+
+}

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/disconnecthook/MigrationCancelHook.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/disconnecthook/MigrationCancelHook.java
@@ -1,0 +1,49 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.hypervisor.kvm.resource.disconnecthook;
+
+import org.apache.log4j.Logger;
+
+import org.libvirt.Domain;
+import org.libvirt.LibvirtException;
+
+public class MigrationCancelHook extends DisconnectHook {
+    private static final Logger LOGGER = Logger.getLogger(MigrationCancelHook.class.getName());
+
+    Domain _migratingDomain;
+    String _vmName;
+
+    public MigrationCancelHook(Domain migratingDomain) throws LibvirtException {
+        super(migratingDomain.getName());
+        _migratingDomain = migratingDomain;
+        _vmName = migratingDomain.getName();
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("Interrupted migration of " + _vmName);
+        try {
+            if (_migratingDomain.abortJob() == 0) {
+                LOGGER.warn("Aborted migration job for " + _vmName);
+            }
+        } catch (LibvirtException ex) {
+            LOGGER.warn("Failed to abort migration job for " + _vmName, ex);
+        }
+    }
+}

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/DisconnectHooksTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/DisconnectHooksTest.java
@@ -123,7 +123,7 @@ public class DisconnectHooksTest {
     public void addAndRunHooksOneWithTimeout() {
         // test that hook stops running when we exceed timeout
         long timeout = 500;
-        TestHook hook1 = new TestHook(timeout, timeout + 10);
+        TestHook hook1 = new TestHook(timeout, timeout + 100);
         TestHook hook2 = new TestHook();
         libvirtComputingResource.addDisconnectHook(hook1);
         libvirtComputingResource.addDisconnectHook(hook2);
@@ -146,8 +146,8 @@ public class DisconnectHooksTest {
         // test that hooks stop running when we exceed timeout
         // test for parallel timeout rather than additive
         long timeout = 500;
-        TestHook hook1 = new TestHook(timeout, timeout + 10);
-        TestHook hook2 = new TestHook(timeout, timeout + 10);
+        TestHook hook1 = new TestHook(timeout, timeout + 100);
+        TestHook hook2 = new TestHook(timeout, timeout + 100);
         libvirtComputingResource.addDisconnectHook(hook1);
         libvirtComputingResource.addDisconnectHook(hook2);
         libvirtComputingResource.disconnected();

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/DisconnectHooksTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/DisconnectHooksTest.java
@@ -1,0 +1,191 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.hypervisor.kvm.resource;
+
+import com.cloud.hypervisor.kvm.resource.disconnecthook.DisconnectHook;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DisconnectHooksTest {
+    class TestHook extends DisconnectHook {
+        private boolean _started = false;
+        private boolean _executed = false;
+        private boolean _withTimeout = false;
+
+        private long _runtime;
+
+        public TestHook() { super("foo"); }
+
+        public TestHook(long timeout, long runtime) {
+            super("foo", timeout);
+            _withTimeout = true;
+            _runtime = runtime;
+        }
+
+        @Override
+        public void run() {
+            _started = true;
+            if (this._withTimeout) {
+                try {
+                    Thread.sleep(this._runtime);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("TestHook interrupted while sleeping");
+                }
+            }
+            this._executed = true;
+        }
+
+        protected boolean hasRun() {
+            return _executed;
+        }
+
+        protected boolean hasStarted() {
+            return _started;
+        }
+    }
+
+    LibvirtComputingResource libvirtComputingResource;
+
+    @Before
+    public void setup() {
+        libvirtComputingResource = new LibvirtComputingResource();
+    }
+
+    @Test
+    public void addHookWithoutRun() {
+        TestHook hook = new TestHook();
+        libvirtComputingResource = new LibvirtComputingResource();
+        libvirtComputingResource.addDisconnectHook(hook);
+
+        // test that we added hook but did not run it
+        Assert.assertEquals(1, libvirtComputingResource._disconnectHooks.size());
+        Assert.assertFalse(hook.hasRun());
+    }
+
+    @Test
+    public void addHookWithRun() {
+        TestHook hook = new TestHook();
+        libvirtComputingResource = new LibvirtComputingResource();
+        libvirtComputingResource.addDisconnectHook(hook);
+
+        // test that we added hook but did not run it
+        Assert.assertEquals(1, libvirtComputingResource._disconnectHooks.size());
+        Assert.assertFalse(hook.hasRun());
+
+        // test that we run and remove hook on disconnect
+        libvirtComputingResource.disconnected();
+
+        Assert.assertTrue(hook.hasRun());
+        Assert.assertEquals(0, libvirtComputingResource._disconnectHooks.size());
+    }
+
+    @Test
+    public void addAndRemoveHooksWithAndWithoutRun() {
+        TestHook hook1 = new TestHook();
+        TestHook hook2 = new TestHook();
+        libvirtComputingResource.addDisconnectHook(hook1);
+        libvirtComputingResource.addDisconnectHook(hook2);
+
+        Assert.assertEquals(2, libvirtComputingResource._disconnectHooks.size());
+        Assert.assertFalse(hook1.hasRun());
+        Assert.assertFalse(hook2.hasRun());
+
+        // remove first hook but leave second hook
+        libvirtComputingResource.removeDisconnectHook(hook1);
+        libvirtComputingResource.disconnected();
+
+        // ensure removed hook did not run
+        Assert.assertFalse(hook1.hasRun());
+
+        // ensure remaining hook did run
+        Assert.assertTrue(hook2.hasRun());
+        Assert.assertEquals(0, libvirtComputingResource._disconnectHooks.size());
+    }
+
+    @Test
+    public void addAndRunHooksOneWithTimeout() {
+        // test that hook stops running when we exceed timeout
+        long timeout = 500;
+        TestHook hook1 = new TestHook(timeout, timeout + 10);
+        TestHook hook2 = new TestHook();
+        libvirtComputingResource.addDisconnectHook(hook1);
+        libvirtComputingResource.addDisconnectHook(hook2);
+        libvirtComputingResource.disconnected();
+        Assert.assertTrue(hook2.hasRun());
+
+        try {
+            Thread.sleep(timeout);
+        } catch (Exception ignored){}
+
+        Assert.assertTrue(hook1.hasStarted());
+        Assert.assertFalse(hook1.isAlive());
+        Assert.assertFalse(hook1.hasRun());
+
+        Assert.assertEquals(0, libvirtComputingResource._disconnectHooks.size());
+    }
+
+    @Test
+    public void addAndRunTwoHooksWithTimeout() {
+        // test that hooks stop running when we exceed timeout
+        // test for parallel timeout rather than additive
+        long timeout = 500;
+        TestHook hook1 = new TestHook(timeout, timeout + 10);
+        TestHook hook2 = new TestHook(timeout, timeout + 10);
+        libvirtComputingResource.addDisconnectHook(hook1);
+        libvirtComputingResource.addDisconnectHook(hook2);
+        libvirtComputingResource.disconnected();
+
+        // if the timeouts were additive (e.g. if we were sequentially looping through join(timeout)), the second Hook
+        // would get enough time to complete (500 for first Hook and 500 for itself) and not be interrupted.
+        try {
+            Thread.sleep(timeout*2);
+        } catch (Exception ignored){}
+
+        Assert.assertTrue(hook1.hasStarted());
+        Assert.assertFalse(hook1.isAlive());
+        Assert.assertFalse(hook1.hasRun());
+        Assert.assertTrue(hook2.hasStarted());
+        Assert.assertFalse(hook2.isAlive());
+        Assert.assertFalse(hook2.hasRun());
+
+        Assert.assertEquals(0, libvirtComputingResource._disconnectHooks.size());
+    }
+
+    @Test
+    public void addAndRunTimeoutHooksToCompletion() {
+        // test we can run to completion if we don't take as long as timeout, and they run parallel
+        long timeout = 500;
+        TestHook hook1 = new TestHook(timeout, timeout - 100);
+        TestHook hook2 = new TestHook(timeout, timeout - 100);
+        libvirtComputingResource.addDisconnectHook(hook1);
+        libvirtComputingResource.addDisconnectHook(hook2);
+        libvirtComputingResource.disconnected();
+
+        try {
+            Thread.sleep(timeout);
+        } catch (Exception ignored){}
+
+        Assert.assertTrue(hook1.hasStarted());
+        Assert.assertTrue(hook1.hasRun());
+        Assert.assertTrue(hook2.hasStarted());
+        Assert.assertTrue(hook2.hasRun());
+        Assert.assertEquals(0, libvirtComputingResource._disconnectHooks.size());
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a way for KVM agent CommandWrappers to register code to run in case of an Agent disconnect event.  When KVM agents lose communication to the management cluster, outstanding work sent to the agent is considered failed, however the work may continue on and run to completion. This is not a big issue for things like live migration where a VM will eventually move to another host and then CloudStack will sync up with the new state, but it becomes more important for long running tasks like volume copy, where we may want to attempt to stop a copy or do some cleanup.

This change doesn't introduce much in the way of behavioral changes, it just adds the framework for CommandWrappers to utilize.  It does add simple "example" that provides cancellation of VM live migration upon agent disconnect.

The functionality is simple, we provide LibvirtComputingResource with a list to store DisconnectHooks, and then it implements the `disconnected()` method to call these hooks in the event of a loss of connectivity. These DisconnectHooks are basically just Java Thread types with a little extra metadata, which are executed in parallel with a best-effort timeout. 

The CommandWrappers are responsible for providing the implementation for their own DisconnectHooks (one or many), registering them prior to doing their work, and un-registering them when work is complete. The implementer of a DisconnectHook is responsible for dealing with any race conditions - in the live migration example it is understood that it's possible for the hook to be called immediately after live migration has succeeded but before the CommandWrapper can de-register the hook. Therefore cancellation of live migration is treated as best-effort and any errors are logged and ignored.

### Alternatives Considered
There are probably better designs for this - perhaps the agent could queue results and the management server could hold onto commands and wait for reconnect to get the results. However, that would be a larger effort, and we would still need to handle agent service stop. This DisconnectHook implementation also works for stopping of the KVM agent service and gives CommandWrappers a way to respond to that.

The DisconnectHooks themselves could be Runnables instead of Threads. I chose Threads simply because it's more straightforward to run them in parallel, however I'm open to suggestions and any changes requested as well.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?
This is a feature I've been using in production for years, and would like to fold it back into upstream 
