### PR TITLE
engine/schema: add unique constraint for sshkeys UUID column

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41520to41600-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41520to41600-cleanup.sql
@@ -19,4 +19,4 @@
 -- Schema upgrade cleanup from 4.15.2.0 to 4.16.0.0
 --;
 
-ALTER TABLE `cloud`.`ssh_keypairs` MODIFY COLUMN `uuid` varchar(40) NOT NULL UNIQUE;
+ALTER TABLE `cloud`.`ssh_keypairs` ADD CONSTRAINT `uc_ssh_keypairs__uuid` UNIQUE (`uuid`);


### PR DESCRIPTION
This adds unique constraints much like other tables, instead of using
query that maybe incompatible with older 5.x mysql servers.

Fixes #5564