### PR TITLE
api: Fix RestartNetwork response type

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/RestartNetworkCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/RestartNetworkCmd.java
@@ -26,7 +26,6 @@ import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
-import org.apache.cloudstack.api.response.IPAddressResponse;
 import org.apache.cloudstack.api.response.NetworkResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 
@@ -40,7 +39,7 @@ import com.cloud.network.Network;
 
 @APICommand(name = "restartNetwork",
             description = "Restarts the network; includes 1) restarting network elements - virtual routers, DHCP servers 2) reapplying all public IPs 3) reapplying loadBalancing/portForwarding rules",
-        responseObject = IPAddressResponse.class, entityType = {Network.class},
+        responseObject = SuccessResponse.class, entityType = {Network.class},
             requestHasSensitiveInfo = false,
             responseHasSensitiveInfo = false)
 public class RestartNetworkCmd extends BaseAsyncCmd {


### PR DESCRIPTION
### Description

This PR fixes the restartNetwork response type. This has repercussions in the cloudstack-go auto-generated code, as the response doesn't get correctly parsed. Currently, the APICommand annotation indicates that the response type is `IpAddressResponse` as opposed to `SuccessResponse`
```
(localcloud) SBCM5> > list apis name=restartNetwork filter=response,
{
  "api": [
    {
      "response": [
        {
          "description": "true if this ip is system ip (was allocated as a part of deployVm or createLbRule)",
          "name": "issystem",
          "type": "boolean"
        },
        {
          "description": "virtual machine display name the ip address is assigned to (not null only for static nat Ip)",
          "name": "virtualmachinedisplayname",
          "type": "string"
        },
        {
          "description": "the VLAN associated with the IP address",
          "name": "vlanname",
          "type": "string"
        },
        {
          "description": "virtual machine (dnat) ip address (not null only for static nat Ip)",
          "name": "vmipaddress",
          "type": "string"
        },
        {
          "description": "the name of the zone the public IP address belongs to",
          "name": "zonename",
          "type": "string"
        },
        {
          "description": "the ID of the VLAN associated with the IP address. This parameter is visible to ROOT admins only",
          "name": "vlanid",
          "type": "string"
        },
        {
          "description": "the current status of the latest async job acting on this object",
          "name": "jobstatus",
          "type": "integer"
        },
        {
          "description": "is public ip for display to the regular user",
          "name": "fordisplay",
          "type": "boolean"
        },
        {
          "description": "the name of the Network where ip belongs to",
          "name": "networkname",
          "type": "string"
        },
        {
          "description": "public IP address id",
          "name": "id",
          "type": "string"
        },
        {
          "description": "VPC name the ip belongs to",
          "name": "vpcname",
          "type": "string"
        },
        {
          "description": "the domain the public IP address is associated with",
          "name": "domain",
          "type": "string"
        },
        {
          "description": "the name of the Network associated with the IP address",
          "name": "associatednetworkname",
          "type": "string"
        },
        {
          "description": "public IP address",
          "name": "ipaddress",
          "type": "string"
        },
        {
          "description": "purpose of the IP address. In Acton this value is not null for Ips with isSystem=true, and can have either StaticNat or LB value",
          "name": "purpose",
          "type": "string"
        },
        {
          "description": "the project id of the ipaddress",
          "name": "projectid",
          "type": "string"
        },
        {
          "description": "true if this ip is for static nat, false otherwise",
          "name": "isstaticnat",
          "type": "boolean"
        },
        {
          "description": "the ID of the Network associated with the IP address",
          "name": "associatednetworkid",
          "type": "string"
        },
        {
          "description": "date the public IP address was acquired",
          "name": "allocated",
          "type": "date"
        },
        {
          "description": "true if the IP address is a source nat address, false otherwise",
          "name": "issourcenat",
          "type": "boolean"
        },
        {
          "description": "the account the public IP address is associated with",
          "name": "account",
          "type": "string"
        },
        {
          "description": "the ID of the Network where ip belongs to",
          "name": "networkid",
          "type": "string"
        },
        {
          "description": "virtual machine id the ip address is assigned to (not null only for static nat Ip)",
          "name": "virtualmachineid",
          "type": "string"
        },
        {},
        {
          "description": "the physical network this belongs to",
          "name": "physicalnetworkid",
          "type": "string"
        },
        {
          "description": "the project name of the address",
          "name": "project",
          "type": "string"
        },
        {
          "description": "the virtual network for the IP address",
          "name": "forvirtualnetwork",
          "type": "boolean"
        },
        {},
        {
          "description": "is public IP portable across the zones",
          "name": "isportable",
          "type": "boolean"
        },
        {
          "description": "the UUID of the latest async job acting on this object",
          "name": "jobid",
          "type": "string"
        },
        {
          "description": "VPC id the ip belongs to",
          "name": "vpcid",
          "type": "string"
        },
        {
          "description": "the domain ID the public IP address is associated with",
          "name": "domainid",
          "type": "string"
        },
        {
          "description": "the list of resource tags associated with ip address",
          "name": "tags",
          "response": [
            {
              "description": "tag value",
              "name": "value",
              "type": "string"
            },
            {
              "description": "id of the resource",
              "name": "resourceid",
              "type": "string"
            },
            {
              "description": "the project id the tag belongs to",
              "name": "projectid",
              "type": "string"
            },
            {
              "description": "customer associated with the tag",
              "name": "customer",
              "type": "string"
            },
            {
              "description": "tag key name",
              "name": "key",
              "type": "string"
            },
            {
              "description": "the account associated with the tag",
              "name": "account",
              "type": "string"
            },
            {
              "description": "the domain associated with the tag",
              "name": "domain",
              "type": "string"
            },
            {
              "description": "resource type",
              "name": "resourcetype",
              "type": "string"
            },
            {
              "description": "the ID of the domain associated with the tag",
              "name": "domainid",
              "type": "string"
            },
            {
              "description": "the project name where tag belongs to",
              "name": "project",
              "type": "string"
            }
          ],
          "type": "list"
        },
        {
          "description": "virtual machine name the ip address is assigned to (not null only for static nat Ip)",
          "name": "virtualmachinename",
          "type": "string"
        },
        {
          "description": "the ID of the zone the public IP address belongs to",
          "name": "zoneid",
          "type": "string"
        },
        {
          "description": "State of the ip address. Can be: Allocatin, Allocated and Releasing",
          "name": "state",
          "type": "string"
        }
      ]
    }
  ],
  "count": 1
}
```
which doesn't match the actual response:
```
"queryasyncjobresultresponse": {
	"accountid": "27ef5ba2-5fe0-11ea-9a56-1e006800018c",
	"userid": "27f2484f-5fe0-11ea-9a56-1e006800018c",
	"cmd": "org.apache.cloudstack.api.command.user.network.RestartNetworkCmd",
	"jobstatus": 1,
	"jobprocstatus": 0,
	"jobresultcode": 0,
	"jobresulttype": "object",
	"jobresult": {
		"success": true
	},
        "created": "2021-10-04T05:37:23+0000",
	"completed": "2021-10-04T05:37:41+0000",
	"jobid": "09b1ab5d-02d0-410f-b373-6520962b98eb"
}
			}
```
Correspondingly, the cloudstack-go auto-generated code uses the above response for restartNetwork API to form the struct to represent the response and eventually fails to parse the response. 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

- verified output of listAPIs for restartNetwork:
```
(localcloud) SBCM5> > list apis name=restartNetwork filter=response,
{
  "api": [
    {
      "response": [
        {
          "description": "the current status of the latest async job acting on this object",
          "name": "jobstatus",
          "type": "integer"
        },
        {
          "description": "any text associated with the success or failure",
          "name": "displaytext",
          "type": "string"
        },
        {},
        {
          "description": "true if operation is executed successfully",
          "name": "success",
          "type": "boolean"
        },
        {},
        {
          "description": "the UUID of the latest async job acting on this object",
          "name": "jobid",
          "type": "string"
        }
      ]
    }
  ],
  "count": 1
}

```

- Ran test for restartNetwork in cloudstack-go - Ran successfully:
Prior Fix:
```
/usr/local/go/bin/go tool test2json -t /tmp/GoLand/___TestNetworkService_RestartNetworkWithCleanUp_in_github_com_apache_cloudstack_go_v2_cloudstack.test -test.v -test.paniconexit0 -test.run ^\QTestNetworkService_RestartNetworkWithCleanUp\E$
=== RUN   TestNetworkService_RestartNetworkWithCleanUp
    NetworkService_test.go:132: Failed to restart network with cleanup due to: json: cannot unmarshal bool into Go value of type cloudstack.RestartNetworkResponse
--- FAIL: TestNetworkService_RestartNetworkWithCleanUp (0.00s)

FAIL

```
Post Fix:
```
=== RUN   TestNetworkService_RestartNetworkWithCleanUp
--- PASS: TestNetworkService_RestartNetworkWithCleanUp (0.00s)
PASS
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
