### PR TITLE
UI: Restrict viewing project invitation options when configuration is disabled

### DIFF
--- a/ui/src/config/section/project.js
+++ b/ui/src/config/section/project.js
@@ -70,6 +70,7 @@ export default {
       docHelp: 'adminguide/projects.html#accepting-a-membership-invitation',
       listView: true,
       popup: true,
+      show: (record, store) => { return store.features.projectinviterequired },
       component: () => import('@/views/project/InvitationTokenTemplate.vue')
     },
     {
@@ -84,6 +85,7 @@ export default {
       param: {
         state: 'Pending'
       },
+      show: (record, store) => { return store.features.projectinviterequired },
       component: () => import('@/views/project/InvitationsTemplate.vue')
     },
     {


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack/issues/5570

### Description

This PR fixes the issue where in the Project invitation and Token buttons are visible when Global setting 'project.invite.required' is false
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

'project.invite.required' when true:
![image](https://user-images.githubusercontent.com/10495417/136911569-0679449f-8c26-4d17-9e5b-a2f93179015b.png)

'project.invite.required' when false:
![image](https://user-images.githubusercontent.com/10495417/136911787-1ea0da34-3aac-448d-aee4-93927ba7acec.png)

Verified as Root Admin and user

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
