### PR TITLE
api: Fix response object for various APIs

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/ListProjectRolePermissionsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/ListProjectRolePermissionsCmd.java
@@ -32,10 +32,9 @@ import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.ProjectResponse;
 import org.apache.cloudstack.api.response.ProjectRolePermissionResponse;
 import org.apache.cloudstack.api.response.ProjectRoleResponse;
-import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.context.CallContext;
 
-@APICommand(name = ListProjectRolePermissionsCmd.APINAME, description = "Lists a project's project role permissions", responseObject = SuccessResponse.class,
+@APICommand(name = ListProjectRolePermissionsCmd.APINAME, description = "Lists a project's project role permissions", responseObject = ProjectRolePermissionResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {
         RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User}, since = "4.15.0")
 public class ListProjectRolePermissionsCmd extends BaseCmd {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/backup/AssignVirtualMachineToBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/backup/AssignVirtualMachineToBackupOfferingCmd.java
@@ -28,7 +28,6 @@ import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.BackupOfferingResponse;
-import org.apache.cloudstack.api.response.BackupResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.api.response.UserVmResponse;
 import org.apache.cloudstack.backup.BackupManager;
@@ -43,7 +42,7 @@ import com.cloud.exception.ResourceUnavailableException;
 
 @APICommand(name = AssignVirtualMachineToBackupOfferingCmd.APINAME,
         description = "Assigns a VM to a backup offering",
-        responseObject = BackupResponse.class, since = "4.14.0",
+        responseObject = SuccessResponse.class, since = "4.14.0",
         authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
 public class AssignVirtualMachineToBackupOfferingCmd extends BaseAsyncCmd {
     public static final String APINAME = "assignVirtualMachineToBackupOffering";

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
@@ -37,7 +37,6 @@ import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.command.user.UserCmd;
 import org.apache.cloudstack.api.response.ServiceOfferingResponse;
-import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.api.response.UserVmResponse;
 
 import com.cloud.event.EventTypes;
@@ -50,7 +49,7 @@ import com.cloud.uservm.UserVm;
 import com.cloud.vm.VirtualMachine;
 
 
-@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering.", responseObject = SuccessResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
+@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleVMCmd extends BaseAsyncCmd implements UserCmd {
     public static final Logger s_logger = Logger.getLogger(ScaleVMCmd.class.getName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/RestartVPCCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/RestartVPCCmd.java
@@ -35,7 +35,7 @@ import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.vpc.Vpc;
 import com.cloud.user.Account;
 
-@APICommand(name = "restartVPC", description = "Restarts a VPC", responseObject = VpcResponse.class, entityType = {Vpc.class},
+@APICommand(name = "restartVPC", description = "Restarts a VPC", responseObject = SuccessResponse.class, entityType = {Vpc.class},
 requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RestartVPCCmd extends BaseAsyncCmd {
     public static final Logger s_logger = Logger.getLogger(RestartVPCCmd.class.getName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/DeleteRemoteAccessVpnCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/DeleteRemoteAccessVpnCmd.java
@@ -96,6 +96,8 @@ public class DeleteRemoteAccessVpnCmd extends BaseAsyncCmd {
         if (! _ravService.destroyRemoteAccessVpnForIp(publicIpId, CallContext.current().getCallingAccount(), false)) {
                        throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to delete remote access vpn");
         }
+        SuccessResponse response = new SuccessResponse(getCommandName());
+        this.setResponseObject(response);
     }
 
     @Override

--- a/plugins/api/rate-limit/src/main/java/org/apache/cloudstack/api/command/admin/ratelimit/ResetApiLimitCmd.java
+++ b/plugins/api/rate-limit/src/main/java/org/apache/cloudstack/api/command/admin/ratelimit/ResetApiLimitCmd.java
@@ -28,7 +28,6 @@ import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.AccountResponse;
-import org.apache.cloudstack.api.response.ApiLimitResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -37,7 +36,7 @@ import org.apache.cloudstack.ratelimit.ApiRateLimitService;
 import com.cloud.configuration.Config;
 import com.cloud.user.Account;
 
-@APICommand(name = "resetApiLimit", responseObject = ApiLimitResponse.class, description = "Reset api count",
+@APICommand(name = "resetApiLimit", responseObject = SuccessResponse.class, description = "Reset api count",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ResetApiLimitCmd extends BaseCmd {
     private static final Logger s_logger = Logger.getLogger(ResetApiLimitCmd.class.getName());


### PR DESCRIPTION
### Description

This PR fixes the API response objects specified in the APICommand annotation, which is used by listAPIs. This is in-turn used by cloudstack-go SDK to generated the structures to represent the response. Incorrect responseObjects result in issues parsing the response.

<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Tests written for the cloudstack-go SDK ran successfully:
- listAPIs for the corresponding APIs reflects the correct details:
for eg.,

Prior Fix:
```
(primateqa) 🐱 > list apis name=resetApiLimit
{
  "api": [
    {
      "description": "Reset api count",
      "isasync": false,
      "name": "resetApiLimit",
      "params": [
        {
          "description": "the ID of the acount whose limit to be reset",
          "length": 255,
          "name": "account",
          "related": "enableAccount,listAccounts,listAccounts",
          "required": false,
          "type": "uuid"
        }
      ],
      "related": "getApiLimit",
      "response": [
        {
          "description": "the UUID of the latest async job acting on this object",
          "name": "jobid",
          "type": "string"
        },
        {
          "description": "seconds left to reset counters",
          "name": "expireAfter",
          "type": "long"
        },
        {
          "description": "the current status of the latest async job acting on this object",
          "name": "jobstatus",
          "type": "integer"
        },
        {},
        {
          "description": "the account name of the api remaining count",
          "name": "account",
          "type": "string"
        },
        {
          "description": "number of api already issued",
          "name": "apiIssued",
          "type": "int"
        },
        {},
        {
          "description": "currently allowed number of apis",
          "name": "apiAllowed",
          "type": "int"
        },
        {
          "description": "the account uuid of the api remaining count",
          "name": "accountid",
          "type": "string"
        }
      ]
    }
  ],
  "count": 1
}
```

Post Fix:
```
(localcloud) 🐱 > list apis name=resetApiLimit
{
  "api": [
    {
      "description": "Reset api count",
      "isasync": false,
      "name": "resetApiLimit",
      "params": [
        {
          "description": "the ID of the acount whose limit to be reset",
          "length": 255,
          "name": "account",
          "related": "enableAccount,listAccounts,listAccounts",
          "required": false,
          "type": "uuid"
        }
      ],
      "response": [
        {},
        {
          "description": "the UUID of the latest async job acting on this object",
          "name": "jobid",
          "type": "string"
        },
        {
          "description": "the current status of the latest async job acting on this object",
          "name": "jobstatus",
          "type": "integer"
        },
        {
          "description": "true if operation is executed successfully",
          "name": "success",
          "type": "boolean"
        },
        {
          "description": "any text associated with the success or failure",
          "name": "displaytext",
          "type": "string"
        },
        {}
      ]
    }
  ],
  "count": 1
}
```
Same holds true for the other APIs

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
