### PR TITLE
Fix storage cleanup corner case preventing VM deletion

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -684,7 +684,6 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
             destVol.setUuid(uuid);
             destVol.setInstanceId(instanceId);
             update(srcVolId, srcVol);
-            detachVolume(srcVolId);
             update(destVolId, destVol);
             _tagsDao.updateResourceId(srcVolId, destVolId, ResourceObjectType.Volume);
         } catch (Exception e) {

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -1869,6 +1869,7 @@ public class VolumeServiceImpl implements VolumeService {
 
         long sourceVolumeId = sourceVolume.getId();
         volDao.updateUuid(sourceVolumeId, destinationVolume.getId());
+        volDao.detachVolume(sourceVolumeId);
 
         s_logger.info(String.format("Cleaning up %s on storage [%s].", sourceVolumeVo.getVolumeDescription(), sourceVolumeVo.getPoolId()));
         destroyVolume(sourceVolumeId);
@@ -2063,6 +2064,7 @@ public class VolumeServiceImpl implements VolumeService {
                 srcVolume.processEvent(Event.OperationSuccessed);
                 destVolume.processEvent(Event.MigrationCopySucceeded, result.getAnswer());
                 volDao.updateUuid(srcVolume.getId(), destVolume.getId());
+                volDao.detachVolume(srcVolume.getId());
                 try {
                     destroyVolume(srcVolume.getId());
                     srcVolume = volFactory.getVolume(srcVolume.getId());


### PR DESCRIPTION
### Description

This PR prevents a corner case for the storage cleanup task observed in Vmware in which:
- There are storage pool migrations for the ROOT disk of a VM
- After the migrations, the volumes table creates new volume records, marking the ones to be deleted with state = 'Destroy'
- The storage cleanup task will attempt to expunge the volumes in 'Destroy' state, but if there are underlying storage issues then this task is not completed
- Once the storage issues are solved and the current volume is on the same storage pool as one of the volumes to be removed then the VM can be completely removed 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
