### PR TITLE
vmware: fix NPE for volume migration CLUSTER to ZONE-wide pool

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/org/apache/cloudstack/storage/motion/VmwareStorageMotionStrategy.java
+++ b/plugins/hypervisors/vmware/src/main/java/org/apache/cloudstack/storage/motion/VmwareStorageMotionStrategy.java
@@ -179,7 +179,7 @@ public class VmwareStorageMotionStrategy implements DataMotionStrategy {
             if (hostId == null) {
                 throw new CloudRuntimeException("Offline Migration failed, unable to find suitable host for worker VM placement in the cluster of storage pool: " + sourcePool.getName());
             }
-            hostGuidInTargetCluster = getHostGuidInTargetCluster(sourcePool.getClusterId(), targetPool, sourceScopeType);
+            hostGuidInTargetCluster = getHostGuidInTargetCluster(sourcePool.getClusterId(), targetPool, targetScopeType);
         } else if (ScopeType.CLUSTER.equals(targetScopeType)) {
             hostId = findSuitableHostIdForWorkerVmPlacement(targetPool.getClusterId());
             if (hostId == null) {


### PR DESCRIPTION
### Description

Scope type of source pool is passed in the method, incorrectly, instead of the target pool.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested migration of a detached volume before and after fix.
Before:
```
2021-10-15 09:10:04,450 DEBUG [o.a.c.s.m.VmwareStorageMotionStrategy] (API-Job-Executor-1:ctx-89474df1 job-71 ctx-85827e6b) (logid:a4b3b869) class org.apache.cloudstack.storage.motion.VmwareStorageMotionStrategy can handle the request because 13(e284f229-e4b3-4095-b5e2-460ee86a3101) and 16(87d94dff-1402-4f9a-a726-5b3f5249d002) share the pod
2021-10-15 09:10:04,453 ERROR [o.a.c.s.v.VolumeServiceImpl] (API-Job-Executor-1:ctx-89474df1 job-71 ctx-85827e6b) (logid:a4b3b869) Failed to copy volume:java.lang.NullPointerException
2021-10-15 09:10:04,453 DEBUG [o.a.c.s.v.VolumeServiceImpl] (API-Job-Executor-1:ctx-89474df1 job-71 ctx-85827e6b) (logid:a4b3b869) Failed to copy volume.
java.lang.NullPointerException
	at org.apache.cloudstack.storage.motion.VmwareStorageMotionStrategy.getHostGuidInTargetCluster(VmwareStorageMotionStrategy.java:143)
	at org.apache.cloudstack.storage.motion.VmwareStorageMotionStrategy.getHostIdForVmAndHostGuidInTargetClusterForWorkerVm(VmwareStorageMotionStrategy.java:184)
	at org.apache.cloudstack.storage.motion.VmwareStorageMotionStrategy.getHostIdForVmAndHostGuidInTargetCluster(VmwareStorageMotionStrategy.java:204)
	at org.apache.cloudstack.storage.motion.VmwareStorageMotionStrategy.copyAsync(VmwareStorageMotionStrategy.java:245)
	at org.apache.cloudstack.storage.motion.DataMotionServiceImpl.copyAsync(DataMotionServiceImpl.java:84)
	at org.apache.cloudstack.storage.motion.DataMotionServiceImpl.copyAsync(DataMotionServiceImpl.java:106)
	
```

After: **migration successful**


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
