### PR TITLE
Fixing error in kube smoke tests

### DIFF
--- a/test/integration/smoke/test_kubernetes_clusters.py
+++ b/test/integration/smoke/test_kubernetes_clusters.py
@@ -615,7 +615,7 @@ class TestKubernetesCluster(cloudstackTestCase):
     def waitForAutoscalerPodInRunningState(self, cluster_id, retries=5, interval=60):
         k8s_config = self.fetchKubernetesClusterConfig(cluster_id)
         cfg = io.StringIO(k8s_config.configdata)
-        cfg = yaml.load(cfg)
+        cfg = yaml.safe_load(cfg)
         # Adding this so we don't get certificate exceptions
         cfg['clusters'][0]['cluster']['insecure-skip-tls-verify']=True
         config.load_kube_config_from_dict(cfg)


### PR DESCRIPTION
### Description

Fixes the test failure in `test_04_autoscale_kubernetes_cluster`
Caused by using a newer version of the yaml lib with python3

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Results 

```
TestName: test_04_autoscale_kubernetes_cluster | Status : SUCCESS
```
