### PR TITLE
[UI] Fixed RBD storage connection bug when there are multiple '/', '+' characters in 'RADOS Secret' in Add Primary Storage

### DIFF
--- a/ui/src/views/infra/AddPrimaryStorage.vue
+++ b/ui/src/views/infra/AddPrimaryStorage.vue
@@ -547,8 +547,8 @@ export default {
       /*  Replace the + and / symbols by - and _ to have URL-safe base64 going to the API
           It's hacky, but otherwise we'll confuse java.net.URI which splits the incoming URI
       */
-      secret = secret.replace('+', '-')
-      secret = secret.replace('/', '_')
+      secret = secret.replace(/\+/g, '-')
+      secret = secret.replace(/\//g, '_')
       if (id !== null && secret !== null) {
         monitor = id + ':' + secret + '@' + monitor
       }

--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -2091,8 +2091,8 @@ export default {
     },
     rbdURL (monitor, pool, id, secret) {
       let url
-      secret = secret.replace('+', '-')
-      secret = secret.replace('/', '_')
+      secret = secret.replace(/\+/g, '-')
+      secret = secret.replace(/\//g, '_')
       if (id != null && secret != null) {
         monitor = id + ':' + secret + '@' + monitor
       }


### PR DESCRIPTION
This PR fixes an issue where the RBD storage connection fails when there are multiple '/', '+' characters in the RADOS Secret in the Add Primary Storage UI.

The current code uses replace() to only change the first position where that character is found.

To solve this problem, we modify the code to use a regular expression as a parameter to replace() to achieve the same result as replaceAll .

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial