### PR TITLE
Fix systemVM template name in metadata file

### DIFF
--- a/engine/schema/templateConfig.sh
+++ b/engine/schema/templateConfig.sh
@@ -56,7 +56,7 @@ function createMetadataFile() {
   do
     section="$i"
     hvName=$(getGenericName $i)
-    templatename="systemvm-${i}-${CS_VERSION}"
+    templatename="systemvm-${i}-${CS_VERSION}.${CS_MINOR_VERSION}"
     checksum=$(getChecksum "$fileData" $hvName)
     downloadurl="${templates[$i]}"
     filename=$(echo ${downloadurl##*'/'})


### PR DESCRIPTION
### Description

This PR fixes the issue observed during upgrades, wherein, when a SystemVM template is already registered prior upgrade, the auto-upgrade path still gets invoked - which it shouldn't. The reason for this behavior is the incorrect name of the systemVM template placed in the metadata.ini file, which is used as an input during the upgrade process to identify the template names, checksums, download path, etc. In case of noredist builds, this would cause unnecessary re-registration; in case of non noredist builds, this could lead to the upgrade failing, as it fails to identify the registered template and invokes the auto-upgrade logic - which would fail(expected) due to the absence of the template files.

For ex, a snippet of the metadata.ini file (for KVM SystemVM template details)
```
...
[kvm]
templatename = systemvm-kvm-4.16 <--- incorrect template name (should be systemvm-kvm-4.16.0)
checksum = 2f3747a597396d4ee6a2605648808d1a
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-kvm.qcow2.bz2
filename = systemvmtemplate-4.16.0-kvm.qcow2.bz2
...
```
 <!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Upgraded the env from 4.15.2 to 4.16, by first registering the systemVM template - upgrade successful & doesn't re-register the template as template is found to be already present.

Pos Fix, the snippet of metadata.ini file looks as follows:
```
...
[kvm]
templatename = systemvm-kvm-4.16.0
checksum = 2f3747a597396d4ee6a2605648808d1a
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-kvm.qcow2.bz2
filename = systemvmtemplate-4.16.0-kvm.qcow2.bz2
...
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
