### PR TITLE
ui: Prevent users from viewing - Project Configure Limit tab

### DIFF
--- a/ui/src/config/section/project.js
+++ b/ui/src/config/section/project.js
@@ -50,7 +50,7 @@ export default {
     },
     {
       name: 'limits',
-      show: (record, route, user) => { return ['Admin', 'DomainAdmin'].includes(user.roletype) || record.isCurrentUserProjectAdmin },
+      show: (record, route, user) => { return ['Admin', 'DomainAdmin'].includes(user.roletype) },
       component: () => import('@/components/view/ResourceLimitTab.vue')
     }
   ],


### PR DESCRIPTION
### Description

This PR fixes: https://github.com/apache/cloudstack/issues/5592.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Logged in as User - Don't see the configure Limits tab anymore:
![image](https://user-images.githubusercontent.com/10495417/138268461-5868d5a2-aea8-4581-a523-8aff7290e883.png)

vs old behaviour:
![image](https://user-images.githubusercontent.com/10495417/138268529-0279a6e9-76dd-46a8-8932-9a1ec0e27732.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
