### PR TITLE
Create profiles to download systemvm-templates

### DIFF
--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -156,10 +156,10 @@
     </build>
     <profiles>
         <profile>
-            <id>template-create</id>
+            <id>download-kvm-systemvm-template</id>
             <activation>
                 <property>
-                    <name>noredist</name>
+                    <name>downloadKvmSystemVmTemplate</name>
                 </property>
             </activation>
             <build>
@@ -186,6 +186,30 @@
                                     <md5>${kvm.checksum}</md5>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>download-vmware-systemvm-template</id>
+            <activation>
+                <property>
+                    <name>downloadVmwareSystemVmTemplate</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>${cs.resources-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <executions>
                             <execution>
                                 <id>download-vmware-template</id>
                                 <goals>
@@ -198,6 +222,30 @@
                                     <md5>${vmware.checksum}</md5>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>download-xenserver-systemvm-template</id>
+            <activation>
+                <property>
+                    <name>downloadXenserverSystemVmTemplate</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>${cs.resources-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <executions>
                             <execution>
                                 <id>download-xenserver-template</id>
                                 <goals>
@@ -208,6 +256,78 @@
                                     <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${xen.checksum}</md5>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>download-ovm-systemvm-template</id>
+            <activation>
+                <property>
+                    <name>downloadOvmSystemVmTemplate</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>${cs.resources-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>download-ovm-template</id>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <checkSignature>true</checkSignature>
+                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-ovm.raw.bz2</url>
+                                    <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
+                                    <md5>${ovm.checksum}</md5>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>download-hyperv-systemvm-template</id>
+            <activation>
+                <property>
+                    <name>downloadHypervSystemVmTemplate</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>${cs.resources-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>download-hyperv-template</id>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <checkSignature>true</checkSignature>
+                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-hyperv.vhd.zip</url>
+                                    <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
+                                    <md5>${hyperv.checksum}</md5>
                                 </configuration>
                             </execution>
                         </executions>

--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -159,7 +159,7 @@
             <id>download-kvm-systemvm-template</id>
             <activation>
                 <property>
-                    <name>downloadKvmSystemVmTemplate</name>
+                    <name>systemvm-kvm</name>
                 </property>
             </activation>
             <build>
@@ -195,7 +195,7 @@
             <id>download-vmware-systemvm-template</id>
             <activation>
                 <property>
-                    <name>downloadVmwareSystemVmTemplate</name>
+                    <name>systemvm-vmware</name>
                 </property>
             </activation>
             <build>
@@ -231,7 +231,7 @@
             <id>download-xenserver-systemvm-template</id>
             <activation>
                 <property>
-                    <name>downloadXenserverSystemVmTemplate</name>
+                    <name>systemvm-xen</name>
                 </property>
             </activation>
             <build>
@@ -267,7 +267,7 @@
             <id>download-ovm-systemvm-template</id>
             <activation>
                 <property>
-                    <name>downloadOvmSystemVmTemplate</name>
+                    <name>systemvm-ovm</name>
                 </property>
             </activation>
             <build>
@@ -303,7 +303,7 @@
             <id>download-hyperv-systemvm-template</id>
             <activation>
                 <property>
-                    <name>downloadHypervSystemVmTemplate</name>
+                    <name>systemvm-hyperv</name>
                 </property>
             </activation>
             <build>

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -207,7 +207,7 @@ if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
    FLAGS="$FLAGS -Dsimulator"
 fi
 
-if [ "%{_temp}" != "" ]; then
+if [ \"%{_temp}\" != "" ]; then
     echo "Adding flags to package requested templates"
     FLAGS="$FLAGS `rpm --eval %{?_temp}`"
 fi

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -207,6 +207,11 @@ if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
    FLAGS="$FLAGS -Dsimulator"
 fi
 
+if [ "%{_temp}" != "" ]; then
+    echo "Adding flags to package requested templates"
+    FLAGS="$FLAGS `rpm --eval %{?_temp}`"
+fi
+
 mvn -Psystemvm,developer $FLAGS clean package
 cd ui && npm install && npm run build && cd ..
 

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -200,6 +200,11 @@ if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
    FLAGS="$FLAGS -Dsimulator"
 fi
 
+if [ "%{_temp}" != "" ]; then
+    echo "Adding flags to package requested templates"
+    FLAGS="$FLAGS `rpm --eval %{?_temp}`"
+fi
+
 mvn -Psystemvm,developer $FLAGS clean package
 cd ui && npm install && npm run build && cd ..
 

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -200,7 +200,7 @@ if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
    FLAGS="$FLAGS -Dsimulator"
 fi
 
-if [ "%{_temp}" != "" ]; then
+if [ \"%{_temp}\" != "" ]; then
     echo "Adding flags to package requested templates"
     FLAGS="$FLAGS `rpm --eval %{?_temp}`"
 fi

--- a/packaging/suse15/cloud.spec
+++ b/packaging/suse15/cloud.spec
@@ -202,7 +202,7 @@ if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
    FLAGS="$FLAGS -Dsimulator"
 fi
 
-if [ "%{_temp}" != "" ]; then
+if [ \"%{_temp}\" != "" ]; then
     echo "Adding flags to package requested templates"
     FLAGS="$FLAGS `rpm --eval %{?_temp}`"
 fi

--- a/packaging/suse15/cloud.spec
+++ b/packaging/suse15/cloud.spec
@@ -202,6 +202,11 @@ if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
    FLAGS="$FLAGS -Dsimulator"
 fi
 
+if [ "%{_temp}" != "" ]; then
+    echo "Adding flags to package requested templates"
+    FLAGS="$FLAGS `rpm --eval %{?_temp}`"
+fi
+
 mvn -Psystemvm,developer $FLAGS clean package
 cd ui && npm install && npm run build && cd ..
 


### PR DESCRIPTION
### Description
As I pointed on thread [[VOTE] Apache Cloudstack 4.16.0.0 RC1](https://lists.apache.org/thread.html/rc061a4da7bd50b49ff99b41f059cb4088b998929033755e4b87f631d%40%3Cdev.cloudstack.apache.org%3E), regarding the auto upgrading `systemvms-templates`; the code will  `autoupgrade` the `systemvm-templates` if the templates are found locally. To generate the template during the build, one has to activate the `noredist profile` when building the packages, which is necessary (normally used to) only to VMWare.

Some people, might not want the noredist JARs from VMware, and therefore will not build with this profile. Furthermore, package `cloudstack-management` goes from **~100Mb** to more than **1.5Gb** when using the `noredist` while executing the 4.16.0.0 build. It happens due to `cloudstack/engine/schema/pom.xml` automatically downloading XenServer, KVM, and VMware `systemvms-templates`. Every time that we build the packages, it will download all these systemvms-templates, and we are unable to decide which one is necessary.

This PR intends to create specific profiles for each systemvm-template. Therefore, one can build ACS only for the hypervisor it needs, and if it needs to use the auto update of the system VM templates; one can decide not to use this feature and keep manually registering the templates only when they are needed.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor

### How Has This Been Tested?
I built the packages with all the profiles:
- `-DdownloadKvmSystemVmTemplate`
- `-DdownloadHypervSystemVmTemplate`
- `-DdownloadVmwareSystemVmTemplate`
- `-DdownloadXenserverSystemVmTemplate`
- `-DdownloadOvmSystemVmTemplate`

And then I built them separately.