### PR TITLE
ui: Fix wrong label for addBrocadeVcsDevice

### DIFF
--- a/ui/src/views/infra/network/ServiceProvidersTab.vue
+++ b/ui/src/views/infra/network/ServiceProvidersTab.vue
@@ -380,7 +380,7 @@ export default {
               api: 'addBrocadeVcsDevice',
               listView: true,
               icon: 'plus',
-              label: 'label.add.bigswitchbcf.device',
+              label: 'label.add.brocadevcs.device',
               args: ['hostname', 'username', 'password']
             },
             {


### PR DESCRIPTION
### Description

Fixes the incorrect label for NSP when adding a new Brocade device

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):

#### Before :

![Screenshot from 2021-10-25 13-25-52](https://user-images.githubusercontent.com/8244774/138656679-fa271a3e-1ea7-4a87-83db-66bfb1a69eae.png)

#### After :

![Screenshot from 2021-10-25 13-25-01](https://user-images.githubusercontent.com/8244774/138656615-fc5e189d-0fac-4ae2-afba-13271cfc5dd2.png)

