### PR TITLE
[UI] Change permission to access console proxy button

### DIFF
--- a/ui/src/components/widgets/Console.vue
+++ b/ui/src/components/widgets/Console.vue
@@ -17,7 +17,7 @@
 
 <template>
   <a
-    v-if="['vm', 'systemvm', 'router', 'ilbvm'].includes($route.meta.name) && 'updateVirtualMachine' in $store.getters.apis"
+    v-if="['vm', 'systemvm', 'router', 'ilbvm'].includes($route.meta.name) && 'listVirtualMachines' in $store.getters.apis"
     :href="server + '/console?cmd=access&vm=' + resource.id"
     target="_blank">
     <a-button style="margin-left: 5px" shape="circle" type="dashed" :size="size" :disabled="['Stopped', 'Error', 'Destroyed'].includes(resource.state)" >


### PR DESCRIPTION
### Description

This PR fixes #5623.

Also, some more information that is not present in the issue in question:

- Although the proxy console access button does not appear in the UI, users with access permission to the VM in question have access to the console as well. Simply generate the console access link using another user, copy that link, and, on the user without access to the console button, type that link.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### How Has This Been Tested?
Its tested in a local lab, trying to reproduce the steps of the *issue* #5623.