### PR TITLE
upgrade/systemvm: add template zone entries

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java
@@ -475,7 +475,6 @@ public class SystemVmTemplateRegistration {
             templateZoneVO = new VMTemplateZoneVO(zoneId, templateId, new java.util.Date());
             templateZoneVO = vmTemplateZoneDao.persist(templateZoneVO);
         } else {
-            templateZoneVO.setRemoved(GenericDaoBase.DATE_TO_NULL);
             templateZoneVO.setLastUpdated(new java.util.Date());
             if (vmTemplateZoneDao.update(templateZoneVO.getId(), templateZoneVO)) {
                 templateZoneVO = null;


### PR DESCRIPTION
### Description

Fixes #5641

When registering a system VM template during an upgrade, entries in `cloud.template_zone_ref` must be created for the new template.
For a cross-zones template, an entry for each zone must be added.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
