### PR TITLE
Marvin: change some vlans in test_data.py

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -205,7 +205,7 @@ test_data = {
     "network2": {
         "name": "Test Network Shared",
         "displaytext": "Test Network Shared",
-        "vlan": 1201,
+        "vlan": 4000,
         "gateway": "172.16.15.1",
         "netmask": "255.255.255.0",
         "startip": "172.16.15.21",
@@ -1756,7 +1756,7 @@ test_data = {
             "netmask": "255.255.255.0",
             "startip": "10.223.59.200",
             "endip": "10.223.59.240",
-            "vlan": "1000"
+            "vlan": "4005"
         },
         "netscaler": {
             "ipaddress": "",
@@ -1939,7 +1939,7 @@ test_data = {
             "netmask": "255.255.255.0",
             "startip": "10.223.59.200",
             "endip": "10.223.59.240",
-            "vlan": "1000"
+            "vlan": "4005"
         },
         "netscaler": {
             "ipaddress": "",


### PR DESCRIPTION
### Description

This PR fixes the test failures with test_nic.py in some trillian tests.

see errors below:
```
test_01_nic (tests.smoke.test_nic.TestNic): DEBUG: Exception during NIC test SETUP!: Execute cmd: createnetwork failed, due to: errorCode: 431, errorText:The VLAN tag to use for new guest network, 1201 is already being used for dynamic vlan allocation for the guest network in zone pr5201-t2497-vmware-70u1
```


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
