### PR TITLE
assume a property is one when it isn't a number

### DIFF
--- a/core/src/main/java/com/cloud/storage/template/OVAProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/OVAProcessor.java
@@ -246,7 +246,17 @@ public class OVAProcessor extends AdapterBase implements Processor {
             NodeList diskElements = new OVFHelper().getElementsByTagNameAndPrefix(ovfDoc, "Disk", "ovf");
             for (int i = 0; i < diskElements.getLength(); i++) {
                 Element disk = (Element)diskElements.item(i);
-                long diskSize = Long.parseLong(disk.getAttribute("ovf:capacity"));
+                String diskSizeValue = disk.getAttribute("ovf:capacity");
+                long diskSize = 1;
+                try {
+                    diskSize = Long.parseLong(diskSizeValue);
+                } catch (NumberFormatException e) {
+                    // ASSUMEably the diskSize contains a property for replacement
+                    LOGGER.warn(String.format("the disksize for disk %s is not a valid number: %s", disk.getAttribute("diskId"), diskSizeValue));
+                    // TODO parse the property to get any value can not be done at registration time
+                    //  and will have to be done at deploytime, so for orchestration purposes
+                    //  we now assume, a value of one
+                }
                 String allocationUnits = disk.getAttribute("ovf:capacityAllocationUnits");
                 diskSize = OVFHelper.getDiskVirtualSize(diskSize, allocationUnits, ovfFileName);
                 virtualSize += diskSize;


### PR DESCRIPTION
### Description

This PR handles an OVA that uses a property replacement for a disksize value
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
