### PR TITLE
api,server,engine/schema: admin listvm api clusterid

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ListVMsCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ListVMsCmdByAdmin.java
@@ -16,19 +16,18 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.vm;
 
-import org.apache.cloudstack.api.response.ClusterResponse;
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.command.admin.AdminCmd;
 import org.apache.cloudstack.api.command.user.vm.ListVMsCmd;
+import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.PodResponse;
 import org.apache.cloudstack.api.response.StoragePoolResponse;
 import org.apache.cloudstack.api.response.UserVmResponse;
+import org.apache.log4j.Logger;
 
 import com.cloud.vm.VirtualMachine;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ListVMsCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ListVMsCmdByAdmin.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.vm;
 
+import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -52,6 +53,10 @@ public class ListVMsCmdByAdmin extends ListVMsCmd implements AdminCmd {
             description="the storage ID where vm's volumes belong to")
     private Long storageId;
 
+    @Parameter(name = ApiConstants.CLUSTER_ID, type = CommandType.UUID, entityType = ClusterResponse.class,
+            description = "the cluster ID", since = "4.16.0")
+    private Long clusterId;
+
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -69,4 +74,7 @@ public class ListVMsCmdByAdmin extends ListVMsCmd implements AdminCmd {
         return storageId;
     }
 
+    public Long getClusterId() {
+        return clusterId;
+    }
 }

--- a/engine/schema/src/main/resources/META-INF/db/schema-41520to41600.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41520to41600.sql
@@ -456,6 +456,7 @@ SELECT
     `host`.`id` AS `host_id`,
     `host`.`uuid` AS `host_uuid`,
     `host`.`name` AS `host_name`,
+    `host`.`cluster_id` AS `cluster_id`,
     `vm_template`.`id` AS `template_id`,
     `vm_template`.`uuid` AS `template_uuid`,
     `vm_template`.`name` AS `template_name`,

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -991,11 +991,12 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         Object hostId = null;
         Object storageId = null;
         if (_accountMgr.isRootAdmin(caller.getId())) {
-            ListVMsCmdByAdmin adminCmd = (ListVMsCmdByAdmin)cmd;
-            pod = adminCmd.getPodId();
-            clusterId = adminCmd.getClusterId();
-            hostId = adminCmd.getHostId();
-            storageId = adminCmd.getStorageId();
+            pod = cmd.getPodId();
+            if (cmd instanceof ListVMsCmdByAdmin) {
+                clusterId = ((ListVMsCmdByAdmin)cmd).getClusterId();
+            }
+            hostId = cmd.getHostId();
+            storageId = cmd.getStorageId();
         }
 
         sb.and("displayName", sb.entity().getDisplayName(), SearchCriteria.Op.LIKE);

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -30,10 +30,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import com.cloud.resource.icon.dao.ResourceIconDao;
-import com.cloud.server.ResourceManagerUtil;
-import com.cloud.storage.dao.VMTemplateDetailsDao;
-import com.cloud.vm.VirtualMachineManager;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.affinity.AffinityGroupDomainMapVO;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
@@ -62,6 +58,7 @@ import org.apache.cloudstack.api.command.admin.storage.ListStoragePoolsCmd;
 import org.apache.cloudstack.api.command.admin.storage.ListStorageTagsCmd;
 import org.apache.cloudstack.api.command.admin.template.ListTemplatesCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.user.ListUsersCmd;
+import org.apache.cloudstack.api.command.admin.vm.ListVMsCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.zone.ListZonesCmdByAdmin;
 import org.apache.cloudstack.api.command.user.account.ListAccountsCmd;
 import org.apache.cloudstack.api.command.user.account.ListProjectAccountsCmd;
@@ -206,6 +203,8 @@ import com.cloud.projects.dao.ProjectAccountDao;
 import com.cloud.projects.dao.ProjectDao;
 import com.cloud.projects.dao.ProjectInvitationDao;
 import com.cloud.resource.ResourceManager;
+import com.cloud.resource.icon.dao.ResourceIconDao;
+import com.cloud.server.ResourceManagerUtil;
 import com.cloud.server.ResourceMetaDataService;
 import com.cloud.server.ResourceTag;
 import com.cloud.server.ResourceTag.ResourceObjectType;
@@ -224,6 +223,7 @@ import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.Volume;
 import com.cloud.storage.dao.StoragePoolTagsDao;
 import com.cloud.storage.dao.VMTemplateDao;
+import com.cloud.storage.dao.VMTemplateDetailsDao;
 import com.cloud.tags.ResourceTagVO;
 import com.cloud.tags.dao.ResourceTagDao;
 import com.cloud.template.VirtualMachineTemplate.State;
@@ -251,6 +251,7 @@ import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.UserVmDao;
@@ -986,12 +987,15 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         Object securityGroupId = cmd.getSecurityGroupId();
         Object isHaEnabled = cmd.getHaEnabled();
         Object pod = null;
+        Long clusterId = null;
         Object hostId = null;
         Object storageId = null;
         if (_accountMgr.isRootAdmin(caller.getId())) {
-            pod = cmd.getPodId();
-            hostId = cmd.getHostId();
-            storageId = cmd.getStorageId();
+            ListVMsCmdByAdmin adminCmd = (ListVMsCmdByAdmin)cmd;
+            pod = adminCmd.getPodId();
+            clusterId = adminCmd.getClusterId();
+            hostId = adminCmd.getHostId();
+            storageId = adminCmd.getStorageId();
         }
 
         sb.and("displayName", sb.entity().getDisplayName(), SearchCriteria.Op.LIKE);
@@ -1002,6 +1006,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         sb.and("stateNIN", sb.entity().getState(), SearchCriteria.Op.NIN);
         sb.and("dataCenterId", sb.entity().getDataCenterId(), SearchCriteria.Op.EQ);
         sb.and("podId", sb.entity().getPodId(), SearchCriteria.Op.EQ);
+        sb.and("clusterId", sb.entity().getClusterId(), SearchCriteria.Op.EQ);
         sb.and("hypervisorType", sb.entity().getHypervisorType(), SearchCriteria.Op.EQ);
         sb.and("hostIdEQ", sb.entity().getHostId(), SearchCriteria.Op.EQ);
         sb.and("templateId", sb.entity().getTemplateId(), SearchCriteria.Op.EQ);
@@ -1173,6 +1178,10 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 if (state == null) {
                     sc.setParameters("stateNEQ", "Destroyed");
                 }
+            }
+
+            if (clusterId != null) {
+                sc.setParameters("clusterId", clusterId);
             }
 
             if (hostId != null) {

--- a/server/src/main/java/com/cloud/api/query/vo/UserVmJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/UserVmJoinVO.java
@@ -142,6 +142,9 @@ public class UserVmJoinVO extends BaseViewWithTagInformationVO implements Contro
     @Column(name = "private_mac_address", updatable = true, nullable = true)
     private String privateMacAddress;
 
+    @Column(name = "cluster_id", updatable = true, nullable = false)
+    private Long clusterId;
+
     @Column(name = "pod_id", updatable = true, nullable = false)
     private Long podId;
 
@@ -528,6 +531,10 @@ public class UserVmJoinVO extends BaseViewWithTagInformationVO implements Contro
 
     public Long getLastHostId() {
         return lastHostId;
+    }
+
+    public Long getClusterId() {
+        return clusterId;
     }
 
     public Long getPodId() {


### PR DESCRIPTION
### Description

Add clusterid parameter in listVirtualMachines API for admin

Import-Export Instances UI relies on cluster filtering for managed instances. Without clusterid param support in `listVirtualMachines` API for admins it lists all VMs in the zone.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
**Before:**
![Screenshot from 2021-11-03 00-36-22](https://user-images.githubusercontent.com/153340/139930566-dd20d38a-9b7c-491d-94cb-c876db1630b0.png)

**After:**
![Screenshot from 2021-11-03 00-45-50](https://user-images.githubusercontent.com/153340/139930604-2cde179c-2b20-4144-9ab4-0bc6cbefd293.png)


Using cmk after changes:
```
(localcloud) 🐱 > list clusters filter=id,name,hypervisortype
{
  "cluster": [
    {
      "hypervisortype": "VMware",
      "id": "209e64fb-481f-4864-9a24-2c0a63352eee",
      "name": "p1-c1"
    },
    {
      "hypervisortype": "KVM",
      "id": "681e9c6f-70db-4725-a6eb-d7979ddf4acc",
      "name": "p1-c2"
    }
  ],
  "count": 2
}
(localcloud) 🐱 > list virtualmachines filter=id,name,hypervisor,hostid,hostname
{
  "count": 2,
  "virtualmachine": [
    {
      "hostid": "eb31f76b-bae8-404b-a0a1-3287cf827c6b",
      "hostname": "10.0.34.240",
      "hypervisor": "VMware",
      "id": "3a6f7f06-2b2c-4da7-95b2-046d1181284a",
      "name": "vmw-vm2"
    },
    {
      "hostid": "96b347f3-abcf-427d-bb7f-a1190f94d96e",
      "hostname": "ref-trl-2130-v-M7-abhishek-kumar-kvm2",
      "hypervisor": "KVM",
      "id": "a360b8d3-bdf1-4067-842d-bee12ca17f9e",
      "name": "kvm-vm1"
    }
  ]
}
(localcloud) 🐱 > list virtualmachines filter=id,name,hypervisor,hostid,hostname clusterid=209e64fb-481f-4864-9a24-2c0a63352eee 
{
  "count": 1,
  "virtualmachine": [
    {
      "hostid": "eb31f76b-bae8-404b-a0a1-3287cf827c6b",
      "hostname": "10.0.34.240",
      "hypervisor": "VMware",
      "id": "3a6f7f06-2b2c-4da7-95b2-046d1181284a",
      "name": "vmw-vm2"
    }
  ]
}
(localcloud) 🐱 > list virtualmachines filter=id,name,hypervisor,hostid,hostname clusterid=681e9c6f-70db-4725-a6eb-d7979ddf4acc 
{
  "count": 1,
  "virtualmachine": [
    {
      "hostid": "96b347f3-abcf-427d-bb7f-a1190f94d96e",
      "hostname": "ref-trl-2130-v-M7-abhishek-kumar-kvm2",
      "hypervisor": "KVM",
      "id": "a360b8d3-bdf1-4067-842d-bee12ca17f9e",
      "name": "kvm-vm1"
    }
  ]
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
