### PR TITLE
Allow users to list VMs by Backup Offering Id

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ListVMsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ListVMsCmd.java
@@ -37,6 +37,7 @@ import org.apache.cloudstack.api.ApiConstants.VMDetails;
 import org.apache.cloudstack.api.BaseListTaggedResourcesCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
+import org.apache.cloudstack.api.response.BackupOfferingResponse;
 import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.InstanceGroupResponse;
 import org.apache.cloudstack.api.response.IsoVmResponse;
@@ -132,6 +133,9 @@ public class ListVMsCmd extends BaseListTaggedResourcesCmd implements UserCmd {
     @Parameter(name = ApiConstants.SERVICE_OFFERING_ID, type = CommandType.UUID, entityType = ServiceOfferingResponse.class, description = "list by the service offering", since = "4.4")
     private Long serviceOffId;
 
+    @Parameter(name = ApiConstants.BACKUP_OFFERING_ID, type = CommandType.UUID, entityType = BackupOfferingResponse.class, description = "list by the backup offering", since = "4.17")
+    private Long backupOffId;
+
     @Parameter(name = ApiConstants.DISPLAY_VM, type = CommandType.BOOLEAN, description = "list resources by display flag; only ROOT admin is eligible to pass this parameter", since = "4.4", authorized = {RoleType.Admin})
     private Boolean display;
 
@@ -178,6 +182,10 @@ public class ListVMsCmd extends BaseListTaggedResourcesCmd implements UserCmd {
 
     public Long getServiceOfferingId() {
         return serviceOffId;
+    }
+
+    public Long getBackupOfferingId() {
+        return backupOffId;
     }
 
     public Long getZoneId() {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -985,6 +985,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         Object keyPairName = cmd.getKeyPairName();
         Object serviceOffId = cmd.getServiceOfferingId();
         Object securityGroupId = cmd.getSecurityGroupId();
+        Object backupOfferingId = cmd.getBackupOfferingId();
         Object isHaEnabled = cmd.getHaEnabled();
         Object pod = null;
         Long clusterId = null;
@@ -1017,6 +1018,11 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         if (serviceOffId != null) {
             sb.and("serviceOfferingId", sb.entity().getServiceOfferingId(), SearchCriteria.Op.EQ);
         }
+
+        if (backupOfferingId != null) {
+            sb.and("backupOfferingId", sb.entity().getBackupOfferingId(), SearchCriteria.Op.EQ);
+        }
+
         if (display != null) {
             sb.and("display", sb.entity().isDisplayVm(), SearchCriteria.Op.EQ);
         }
@@ -1101,6 +1107,10 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
         if (serviceOffId != null) {
             sc.setParameters("serviceOfferingId", serviceOffId);
+        }
+
+        if (backupOfferingId != null) {
+            sc.setParameters("backupOfferingId", backupOfferingId);
         }
 
         if (securityGroupId != null) {

--- a/server/src/main/java/com/cloud/api/query/vo/UserVmJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/UserVmJoinVO.java
@@ -629,6 +629,10 @@ public class UserVmJoinVO extends BaseViewWithTagInformationVO implements Contro
         return backupOfferingUuid;
     }
 
+    public Long getBackupOfferingId() {
+        return backupOfferingId;
+    }
+
     public String getBackupOfferingName() {
         return backupOfferingName;
     }


### PR DESCRIPTION
### Description

Using the VMWare hypervisor, and with Veeam integration enabled, it is not possible, via API, list the VMs that are assigned to a Backup Offering. 

This PR extends the listVMs API to allow users to list the VMs that have particular Backup Offerings.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):


### How Has This Been Tested?
It was tested in a local laboratory:
1. I have assigned two VMs to a Backup Offering;
2. Using cloudmonkey, I listed the VMs that use this Backup Offering;
3. The two VMs were correctly listed;
4. I removed one of the VMs from the Backup Offering and repeated step 2.
5. Only one VM was listed;
6. Finally I removed the other VM and repeated step 2;
7. No VMs were listed.