### PR TITLE
[Veeam] Fix full backup VM restore exception

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -533,7 +533,8 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         try {
             vm = guru.importVirtualMachineFromBackup(zoneId, domainId, accountId, userId, vmInternalName, backup);
         } catch (final Exception e) {
-            LOG.error("Failed to import VM from backup restoration", e);
+            LOG.error(String.format("Failed to import VM [vmInternalName: %s] from backup restoration [%s] with hypervisor [type: %s] due to: [%s].", vmInternalName,
+                    ReflectionToStringBuilderUtils.reflectOnlySelectedFields(backup, "id", "uuid", "vmId", "externalId", "backupType"), hypervisorType, e.getMessage()), e);
             throw new CloudRuntimeException("Error during vm backup restoration and import: " + e.getMessage());
         }
         if (vm == null) {

--- a/server/src/test/java/com/cloud/hypervisor/KVMGuruTest.java
+++ b/server/src/test/java/com/cloud/hypervisor/KVMGuruTest.java
@@ -452,4 +452,42 @@ public class KVMGuruTest {
         Assert.assertEquals(platformEmulator, virtualMachineTo.getPlatformEmulator());
     }
 
+    @Test
+    public void testGetClusterIdFromVMHost() {
+        Mockito.when(vm.getHostId()).thenReturn(123l);
+        HostVO vo = new HostVO("");
+        Long expected = 5l;
+        vo.setClusterId(expected);
+
+        Mockito.when(hostDao.findById(123l)).thenReturn(vo);
+
+        Long clusterId = guru.findClusterOfVm(vm);
+
+        Assert.assertEquals(expected, clusterId);
+    }
+
+    @Test
+    public void testGetClusterIdFromLastVMHost() {
+        Mockito.when(vm.getHostId()).thenReturn(null);
+        Mockito.when(vm.getLastHostId()).thenReturn(321l);
+        HostVO vo = new HostVO("");
+        Long expected = 7l;
+        vo.setClusterId(expected);
+
+        Mockito.when(hostDao.findById(321l)).thenReturn(vo);
+
+        Long clusterId = guru.findClusterOfVm(vm);
+
+        Assert.assertEquals(expected, clusterId);
+    }
+
+    @Test
+    public void testGetNullWhenVMThereIsNoInformationOfUsedHosts() {
+        Mockito.when(vm.getHostId()).thenReturn(null);
+        Mockito.when(vm.getLastHostId()).thenReturn(null);
+
+        Long clusterId = guru.findClusterOfVm(vm);
+
+        Assert.assertNull(clusterId);
+    }
 }


### PR DESCRIPTION
### Description

Using the VMWare hypervisor, and with Veeam integration enabled, a full restore of a VM using a backup in Veeam occurs correctly, but in ACS an exception is thrown: `Restore VM Backup (607c2bbf-2c23-49a1-9549-cd402441dcb5) Error during vm backup restore and import: Invalid string format`

Upon adding more logs to the restore process, it was discovered that this was because the VM being restored had no value in the `hostid` attribute.

This PR fixes this behavior, increments the logs in the restore process for VMs using backups and adds new unit tests.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
It was tested in a local laboratory:
1. I have assigned one VM to a Backup Offering;
2. I backed up the VM manually;
3. I tried to perform a full VM restore using this backup;
4. Before, there was an exception in ACS, now the restore finishes without problems.
