### PR TITLE
CCC21 Hackathon: quick & dirty 2FA Google Authentication integration

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiServerService.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiServerService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.servlet.http.HttpSession;
 
 import com.cloud.exception.CloudAuthenticationException;
+import com.cloud.user.UserAccount;
 
 public interface ApiServerService {
     public boolean verifyRequest(Map<String, Object[]> requestParameters, Long userId, InetAddress remoteAddress) throws ServerApiException;
@@ -30,6 +31,8 @@ public interface ApiServerService {
 
     public ResponseObject loginUser(HttpSession session, String username, String password, Long domainId, String domainPath, InetAddress loginIpAddress,
             Map<String, Object[]> requestParameters) throws CloudAuthenticationException;
+
+    void check2FA(String code, UserAccount userAccount) throws CloudAuthenticationException;
 
     public void logoutUser(long userId);
 

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,16 @@
                 <version>${cs.codec.version}</version>
             </dependency>
             <dependency>
+                <groupId>de.taimos</groupId>
+                <artifactId>totp</artifactId>
+                <version>1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.zxing</groupId>
+                <artifactId>javase</artifactId>
+                <version>3.2.1</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>${cs.configuration.version}</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -90,6 +90,14 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
+            <groupId>de.taimos</groupId>
+            <artifactId>totp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>javase</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>${cs.commons-math3.version}</version>

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -1168,6 +1168,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
 
     @Override
     public void check2FA(String code, UserAccount userAccount) throws CloudAuthenticationException {
+        // TODO: in future get userAccount specific 2FA key
         String expectedCode = get2FACode(get2FAKey());
         if (!expectedCode.equals(code)) {
             s_logger.info("2FA matches user's input");

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -1170,8 +1170,9 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
     public void check2FA(String code, UserAccount userAccount) throws CloudAuthenticationException {
         // TODO: in future get userAccount specific 2FA key
         String expectedCode = get2FACode(get2FAKey());
-        if (!expectedCode.equals(code)) {
+        if (expectedCode.equals(code)) {
             s_logger.info("2FA matches user's input");
+            return;
         }
         throw new CloudAuthenticationException("two-factor authentication has failed for the user");
     }

--- a/server/src/main/java/com/cloud/api/auth/DefaultLoginAPIAuthenticatorCmd.java
+++ b/server/src/main/java/com/cloud/api/auth/DefaultLoginAPIAuthenticatorCmd.java
@@ -179,12 +179,12 @@ public class DefaultLoginAPIAuthenticatorCmd extends BaseCmd implements APIAuthe
                 if (userAccount != null && User.Source.SAML2 == userAccount.getSource()) {
                     throw new CloudAuthenticationException("User is not allowed CloudStack login");
                 }
-                ResponseObject loginResp = _apiServer.loginUser(session, username[0], pwd, domainId, domain, remoteAddress, params);
                 if (code2fa != null && !code2fa.isEmpty()) {
                     // again a hackathon shortcut here, ideally 2FA setting should be checked/enforced per user account
                     // that is we should check and enforce 2FA for user-accounts where this is enabled
                     _apiServer.check2FA(code2fa, userAccount);
                 }
+                ResponseObject loginResp = _apiServer.loginUser(session, username[0], pwd, domainId, domain, remoteAddress, params);
                 return ApiResponseSerializer.toSerializedString(loginResp, responseType);
             } catch (final CloudAuthenticationException ex) {
                 // TODO: fall through to API key, or just fail here w/ auth error? (HTTP 401)

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -44,6 +44,7 @@ export function login (arg) {
   params.append('command', 'login')
   params.append('username', arg.username || arg.email)
   params.append('password', arg.password)
+  params.append('code', arg.code)
   params.append('domain', arg.domain)
   params.append('response', 'json')
   return axios({

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -47,10 +47,15 @@
                   {{ name }}
                 </h4>
               </div>
-              <span v-if="resource.username">
-                <img src="https://www.google.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=otpauth://totp/Apache%20CloudStack%3Atest%40gmail.com?secret=7t4gabg72liipmq7n43lt3cw66fel4iz&issuer=Apache%20CloudStack"/>
-              </span>
             </slot>
+          </div>
+          <div>
+            <br/>
+            <a-divider/>
+            <p><b>2FA QR</b></p>
+            <span v-if="resource.username">
+              <img src="https://www.google.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=otpauth://totp/Apache%20CloudStack%3Atest%40gmail.com?secret=7t4gabg72liipmq7n43lt3cw66fel4iz&issuer=Apache%20CloudStack"/>
+            </span>
           </div>
           <slot name="actions">
             <div class="tags">

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -47,6 +47,9 @@
                   {{ name }}
                 </h4>
               </div>
+              <span v-if="resource.username">
+                <img src="https://www.google.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=otpauth://totp/Apache%20CloudStack%3Atest%40gmail.com?secret=7t4gabg72liipmq7n43lt3cw66fel4iz&issuer=Apache%20CloudStack"/>
+              </span>
             </slot>
           </div>
           <slot name="actions">

--- a/ui/src/views/auth/Login.vue
+++ b/ui/src/views/auth/Login.vue
@@ -91,6 +91,20 @@
         <a-form-item>
           <a-input
             size="large"
+            autocomplete="false"
+            placeholder="2FA Code"
+            v-decorator="[
+              'code',
+              {rules: [{ required: true, message: 'Please enter 2FA code' }], validateTrigger: 'blur'}
+            ]"
+          >
+            <a-icon slot="prefix" type="key" />
+          </a-input>
+        </a-form-item>
+
+        <a-form-item>
+          <a-input
+            size="large"
             type="text"
             :placeholder="$t('label.domain')"
             v-decorator="[
@@ -238,7 +252,7 @@ export default {
 
       state.loginBtn = true
 
-      const validateFieldsKey = customActiveKey === 'cs' ? ['username', 'password', 'domain'] : ['idp']
+      const validateFieldsKey = customActiveKey === 'cs' ? ['username', 'password', 'code', 'domain'] : ['idp']
 
       validateFields(validateFieldsKey, { force: true }, (err, values) => {
         if (!err) {
@@ -252,6 +266,7 @@ export default {
             delete loginParams.username
             loginParams[!state.loginType ? 'email' : 'username'] = values.username
             loginParams.password = values.password
+            loginParams.code = values.code
             loginParams.domain = values.domain
             if (!loginParams.domain) {
               loginParams.domain = '/'


### PR DESCRIPTION
- Hardcodes secretkey and QR code for user (can be generated with extension)
- No per-user 2FA check and enforcement (check is not enforced when 2FA code is not entered ;)
- User scans the code, log into portal using username, password and code

I'll close this next week. This is meant only as a PoC/hack for the 2FA feature, ideally we should:
- Have per user-account enforcement and checks
- Allow a pluggable framework to allow people support multiple 2-FA plugins, for ex. Google Authenticator, SMS, email OTP ...
- The QR code should be dynamically created uniquely per user-account

How it works now:
1. User scans his 2FA QR code from users page to their Google Authenticator app:
![Screenshot from 2021-11-12 15-46-16](https://user-images.githubusercontent.com/95203/141452016-0b5569bb-8dc8-433f-92b8-bfe00aa7c453.png)

2. Upon login they enter their username, password, 2FA code, domain:

![Screenshot from 2021-11-12 15-40-55](https://user-images.githubusercontent.com/95203/141449971-9358752b-4404-4232-92e3-28cca5c68247.png)

3. Upon failure:
![Screenshot from 2021-11-12 15-52-38](https://user-images.githubusercontent.com/95203/141451493-09b6fd7b-72da-4bba-b73f-15175197c780.png)

4. Upon success: (login as normal)
![Screenshot from 2021-11-12 15-42-27](https://user-images.githubusercontent.com/95203/141451959-8dbeecb7-c78c-4ae1-a1ff-8617ffe8867c.png)
