### PR TITLE
vmware: fix cpu reservation during vm scale

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -48,8 +48,6 @@ import java.util.stream.Collectors;
 import javax.naming.ConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import com.cloud.utils.script.Script;
-import com.cloud.hypervisor.vmware.mo.NetworkMO;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
@@ -234,6 +232,7 @@ import com.cloud.hypervisor.vmware.mo.HostMO;
 import com.cloud.hypervisor.vmware.mo.HostStorageSystemMO;
 import com.cloud.hypervisor.vmware.mo.HypervisorHostHelper;
 import com.cloud.hypervisor.vmware.mo.NetworkDetails;
+import com.cloud.hypervisor.vmware.mo.NetworkMO;
 import com.cloud.hypervisor.vmware.mo.PbmProfileManagerMO;
 import com.cloud.hypervisor.vmware.mo.StoragepodMO;
 import com.cloud.hypervisor.vmware.mo.TaskMO;
@@ -276,6 +275,7 @@ import com.cloud.utils.mgmt.JmxUtil;
 import com.cloud.utils.mgmt.PropertyMapDynamicBean;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.utils.nicira.nvp.plugin.NiciraNvpApiVersion;
+import com.cloud.utils.script.Script;
 import com.cloud.utils.ssh.SshHelper;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
@@ -1765,7 +1765,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             // Check if license supports the feature
             VmwareHelper.isFeatureLicensed(hyperHost, FeatureKeyConstants.HOTPLUG);
-            VmwareHelper.setVmScaleUpConfig(vmConfigSpec, vmSpec.getCpus(), vmSpec.getMaxSpeed(), vmSpec.getMinSpeed(), (int) requestedMaxMemoryInMb, ramMb,
+            VmwareHelper.setVmScaleUpConfig(vmConfigSpec, vmSpec.getCpus(), vmSpec.getMaxSpeed(), getReservedCpuMHZ(vmSpec), (int) requestedMaxMemoryInMb, ramMb,
                     vmSpec.getLimitCpuUse());
 
             if (!vmMo.configureVm(vmConfigSpec)) {


### PR DESCRIPTION
### Description

Fixes #5706

Correctly set CPU reservation while scaling a dynamically scalable VM.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Before fix** (CPU reservation is set using offering's CPU speed for the VM after scaling even when global setting vmware.reserve.cpu is false):

```
> deploy virtualmachine zoneid=d295b42c-c67b-4224-9ea7-4777ce3e788e templateid=a9c03b25-4c1e-11ec-b0f8-1e006d000305 serviceofferingid=cdb3674b-aab0-4d75-a09f-a1ad48046bd6 networkids=4cf8b5b5-d2a9-475f-9bd4-5d872ce66c13 name=v1
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 2,
    "cpuspeed": 1000,
    "created": "2021-11-23T08:37:28+0000",
    "details": {
      "cpuOvercommitRatio": "4.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "ide"
    },
    "displayname": "v1",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "a9bbca90-4c1e-11ec-b0f8-1e006d000305",
    "guestosid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "haenable": false,
    "hasannotations": false,
    "hostid": "22f5a5da-88dd-476b-97af-54b53d2a8040",
    "hostname": "10.0.34.196",
    "hypervisor": "VMware",
    "id": "1f3e742b-c220-4353-b80f-9328b9127128",
    "instancename": "i-2-12-VM",
    "isdynamicallyscalable": true,
    "jobid": "1d821c40-7165-447b-a20a-a78feacd404e",
    "jobstatus": 0,
    "lastupdated": "2021-11-23T08:37:40+0000",
    "memory": 1024,
    "name": "v1",
    "nic": [
      {
        "broadcasturi": "vlan://1871",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "14715db2-d9e8-4bed-bf47-00c6a118d5ad",
        "isdefault": true,
        "isolationuri": "vlan://1871",
        "macaddress": "02:00:5c:b6:00:0a",
        "networkid": "4cf8b5b5-d2a9-475f-9bd4-5d872ce66c13",
        "networkname": "L2-1",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "CentOS 5.3 (64-bit)",
    "ostypeid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "cdb3674b-aab0-4d75-a09f-a1ad48046bd6",
    "serviceofferingname": "2vCPU1G",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "a9c03b25-4c1e-11ec-b0f8-1e006d000305",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "c3206062-4c1e-11ec-b0f8-1e006d000305",
    "username": "admin",
    "zoneid": "d295b42c-c67b-4224-9ea7-4777ce3e788e",
    "zonename": "pr5700-t2575-vmware-65u2"
  }
}
```
![Screenshot from 2021-11-23 14-08-18](https://user-images.githubusercontent.com/153340/142992828-31915c4d-3629-4a70-a344-147c465f6a59.png)

```
> scale virtualmachine id=1f3e742b-c220-4353-b80f-9328b9127128 serviceofferingid=f57056ba-db2e-4801-b391-4d825a8eb221 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 2,
    "cpuspeed": 1000,
    "cpuused": "NaN%",
    "created": "2021-11-23T08:37:28+0000",
    "details": {
      "cpuOvercommitRatio": "4.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "ide"
    },
    "diskioread": 11,
    "diskiowrite": 0,
    "diskkbsread": 345,
    "diskkbswrite": 0,
    "displayname": "v1",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "a9bbca90-4c1e-11ec-b0f8-1e006d000305",
    "guestosid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "haenable": false,
    "hasannotations": false,
    "hostid": "22f5a5da-88dd-476b-97af-54b53d2a8040",
    "hostname": "10.0.34.196",
    "hypervisor": "VMware",
    "id": "1f3e742b-c220-4353-b80f-9328b9127128",
    "instancename": "i-2-12-VM",
    "isdynamicallyscalable": true,
    "lastupdated": "2021-11-23T08:37:40+0000",
    "memory": 2048,
    "memoryintfreekbs": 0,
    "memorykbs": 1048576,
    "memorytargetkbs": 1048576,
    "name": "v1",
    "networkkbsread": 0,
    "networkkbswrite": 0,
    "nic": [
      {
        "broadcasturi": "vlan://1871",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "14715db2-d9e8-4bed-bf47-00c6a118d5ad",
        "isdefault": true,
        "isolationuri": "vlan://1871",
        "macaddress": "02:00:5c:b6:00:0a",
        "networkid": "4cf8b5b5-d2a9-475f-9bd4-5d872ce66c13",
        "networkname": "L2-1",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "CentOS 5.3 (64-bit)",
    "ostypeid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "f57056ba-db2e-4801-b391-4d825a8eb221",
    "serviceofferingname": "2vCPU2G",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "a9c03b25-4c1e-11ec-b0f8-1e006d000305",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "c3206062-4c1e-11ec-b0f8-1e006d000305",
    "username": "admin",
    "zoneid": "d295b42c-c67b-4224-9ea7-4777ce3e788e",
    "zonename": "pr5700-t2575-vmware-65u2"
  }
}
```
![Screenshot from 2021-11-23 14-09-22](https://user-images.githubusercontent.com/153340/142992915-985dc05d-371f-4dc6-96b2-1bdd32d3e8a2.png)


**After fix** (CPU reservation is set to 0 for the VM after scaling when global setting vmware.reserve.cpu is false):
```
> deploy virtualmachine zoneid=d295b42c-c67b-4224-9ea7-4777ce3e788e templateid=a9c03b25-4c1e-11ec-b0f8-1e006d000305 serviceofferingid=cdb3674b-aab0-4d75-a09f-a1ad48046bd6 networkids=4cf8b5b5-d2a9-475f-9bd4-5d872ce66c13 name=v2
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 2,
    "cpuspeed": 1000,
    "created": "2021-11-23T08:59:53+0000",
    "details": {
      "cpuOvercommitRatio": "4.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "ide"
    },
    "displayname": "v2",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "a9bbca90-4c1e-11ec-b0f8-1e006d000305",
    "guestosid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "haenable": false,
    "hasannotations": false,
    "hostid": "8dc1aeec-49fa-4fe9-a176-098d754a3efb",
    "hostname": "10.0.34.112",
    "hypervisor": "VMware",
    "id": "693fb47f-84ee-4dd1-acc9-fe7477d3d6e6",
    "instancename": "i-2-13-VM",
    "isdynamicallyscalable": true,
    "jobid": "107b12ff-aad4-44a7-869a-78cab0291782",
    "jobstatus": 0,
    "lastupdated": "2021-11-23T09:00:06+0000",
    "memory": 1024,
    "name": "v2",
    "nic": [
      {
        "broadcasturi": "vlan://1871",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "5085808c-ad64-4cbf-b410-f65558efeeea",
        "isdefault": true,
        "isolationuri": "vlan://1871",
        "macaddress": "02:00:12:46:00:0b",
        "networkid": "4cf8b5b5-d2a9-475f-9bd4-5d872ce66c13",
        "networkname": "L2-1",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "CentOS 5.3 (64-bit)",
    "ostypeid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "cdb3674b-aab0-4d75-a09f-a1ad48046bd6",
    "serviceofferingname": "2vCPU1G",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "a9c03b25-4c1e-11ec-b0f8-1e006d000305",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "c3206062-4c1e-11ec-b0f8-1e006d000305",
    "username": "admin",
    "zoneid": "d295b42c-c67b-4224-9ea7-4777ce3e788e",
    "zonename": "pr5700-t2575-vmware-65u2"
  }
}
```

![Screenshot from 2021-11-23 14-30-26](https://user-images.githubusercontent.com/153340/142996109-e760998e-17b3-4a5b-ba93-bf48b995da5f.png)


```
> scale virtualmachine id=693fb47f-84ee-4dd1-acc9-fe7477d3d6e6 serviceofferingid=f57056ba-db2e-4801-b391-4d825a8eb221 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 2,
    "cpuspeed": 1000,
    "cpuused": "0%",
    "created": "2021-11-23T08:59:53+0000",
    "details": {
      "cpuOvercommitRatio": "4.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "ide"
    },
    "diskioread": 0,
    "diskiowrite": 0,
    "diskkbsread": 11,
    "diskkbswrite": 0,
    "displayname": "v2",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "a9bbca90-4c1e-11ec-b0f8-1e006d000305",
    "guestosid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "haenable": false,
    "hasannotations": false,
    "hostid": "8dc1aeec-49fa-4fe9-a176-098d754a3efb",
    "hostname": "10.0.34.112",
    "hypervisor": "VMware",
    "id": "693fb47f-84ee-4dd1-acc9-fe7477d3d6e6",
    "instancename": "i-2-13-VM",
    "isdynamicallyscalable": true,
    "lastupdated": "2021-11-23T09:00:06+0000",
    "memory": 2048,
    "memoryintfreekbs": 786432,
    "memorykbs": 1048576,
    "memorytargetkbs": 1048576,
    "name": "v2",
    "networkkbsread": 0,
    "networkkbswrite": 0,
    "nic": [
      {
        "broadcasturi": "vlan://1871",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "5085808c-ad64-4cbf-b410-f65558efeeea",
        "isdefault": true,
        "isolationuri": "vlan://1871",
        "macaddress": "02:00:12:46:00:0b",
        "networkid": "4cf8b5b5-d2a9-475f-9bd4-5d872ce66c13",
        "networkname": "L2-1",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "CentOS 5.3 (64-bit)",
    "ostypeid": "a9c4b2bd-4c1e-11ec-b0f8-1e006d000305",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "f57056ba-db2e-4801-b391-4d825a8eb221",
    "serviceofferingname": "2vCPU2G",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "a9c03b25-4c1e-11ec-b0f8-1e006d000305",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "c3206062-4c1e-11ec-b0f8-1e006d000305",
    "username": "admin",
    "zoneid": "d295b42c-c67b-4224-9ea7-4777ce3e788e",
    "zonename": "pr5700-t2575-vmware-65u2"
  }
}
```

![Screenshot from 2021-11-23 14-31-18](https://user-images.githubusercontent.com/153340/142996052-a6c0add8-cb96-4686-95ba-8ab40371fbf0.png)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
