### PR TITLE
Fix HostMetricsResponse unit test

### DIFF
--- a/plugins/metrics/src/test/java/org/apache/cloudstack/response/HostMetricsResponseTest.java
+++ b/plugins/metrics/src/test/java/org/apache/cloudstack/response/HostMetricsResponseTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.cloudstack.response;
 
+import java.text.DecimalFormat;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,11 +26,13 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 public class HostMetricsResponseTest {
 
+    final char decimalSeparator = ((DecimalFormat) DecimalFormat.getInstance()).getDecimalFormatSymbols().getDecimalSeparator();
+
     @Test
     public void testSetCpuAllocatedWithZeroCpu() {
         final HostMetricsResponse hostResponse = new HostMetricsResponse();
-        hostResponse.setCpuAllocated("50.25%", 0, 1000L);
-        Assert.assertEquals("0.00 Ghz", hostResponse.getCpuAllocatedGhz());
+        hostResponse.setCpuAllocated(String.format("50%s25%%", decimalSeparator), 0, 1000L);
+        Assert.assertEquals(String.format("0%s00 Ghz", decimalSeparator), hostResponse.getCpuAllocatedGhz());
     }
 
     @Test
@@ -46,9 +50,10 @@ public class HostMetricsResponseTest {
 
     @Test
     public void testSetCpuAllocatedWithValidCpu() {
+        String expected = String.format("5%s03 Ghz", decimalSeparator);
         final HostMetricsResponse hostResponse = new HostMetricsResponse();
-        hostResponse.setCpuAllocated("50.25%", 10, 1000L);
-        Assert.assertEquals("5.03 Ghz", hostResponse.getCpuAllocatedGhz());
+        hostResponse.setCpuAllocated(String.format("50%s25%%", decimalSeparator), 10, 1000L);
+        Assert.assertEquals(expected, hostResponse.getCpuAllocatedGhz());
     }
 
 }


### PR DESCRIPTION
### Description

The unit tests of class `HostMetricsResponse` will fail when they are executed on machines with `locale` other than `en_US`. This happens because locales can have distinct decimal separators, for instance, `.` in `en_US` and `,` in `pt_BR`.

This PR solves the mentioned problem by modifying the tests to use the decimal separator character according to the Locale set on the local machine (which is running the tests), instead of using a hardcoded decimal separator.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

I ran the unit tests of class `HostMetricsResponse` with locale `pt_BR` and `en_US`. In both cases, the tests passed.