### PR TITLE
use physical size instead of virtual size for migration.

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/DataObject.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/DataObject.java
@@ -33,6 +33,8 @@ public interface DataObject {
 
     Long getSize();
 
+    long getPhysicalSize();
+
     DataObjectType getType();
 
     String getUuid();

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/SecondaryStorageService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/SecondaryStorageService.java
@@ -39,5 +39,6 @@ public interface SecondaryStorageService {
         }
 
     }
-    AsyncCallFuture<DataObjectResult> migrateData(DataObject srcDataObject, DataStore srcDatastore, DataStore destDatastore, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain);
+    AsyncCallFuture<DataObjectResult> migrateData(DataObject srcDataObject, DataStore srcDatastore, DataStore destDatastore, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain,
+                                                  Map<DataObject, Pair<List<TemplateInfo>, Long>> templateChain);
 }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -102,7 +102,7 @@ public class DataMigrationUtility {
         List<SnapshotDataStoreVO> snapshots = snapshotDataStoreDao.listByStoreId(srcDataStoreId, DataStoreRole.Image);
         for (SnapshotDataStoreVO snapshot : snapshots) {
             isReady &= (Arrays.asList(validStates).contains(snapshot.getState()));
-            LOGGER.trace(String.format("snapshot state: ", snapshot.getState()));
+            LOGGER.trace(String.format("template state: %s", template.getState()));
         }
         List<VolumeDataStoreVO> volumes = volumeDataStoreDao.listByStoreId(srcDataStoreId);
         for (VolumeDataStoreVO volume : volumes) {

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -107,7 +107,7 @@ public class DataMigrationUtility {
         List<VolumeDataStoreVO> volumes = volumeDataStoreDao.listByStoreId(srcDataStoreId);
         for (VolumeDataStoreVO volume : volumes) {
             isReady &= (Arrays.asList(validStates).contains(volume.getState()));
-            LOGGER.trace(String.format("template state: %s", template.getState()));
+            LOGGER.trace(String.format("volume state: %s", volume.getState()));
         }
         return isReady;
     }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -35,6 +35,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreState
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.TemplateDataFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.TemplateInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.storage.ImageStoreService;
@@ -113,11 +114,16 @@ public class DataMigrationUtility {
         return;
     }
 
-    protected Long getFileSize(DataObject file, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain) {
+    protected Long getFileSize(DataObject file, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain, Map<DataObject, Pair<List<TemplateInfo>, Long>> templateChain) {
         Long size = file.getPhysicalSize();
         Pair<List<SnapshotInfo>, Long> chain = snapshotChain.get(file);
+        Pair<List<TemplateInfo>, Long> tempChain = templateChain.get(file);
+
         if (file instanceof SnapshotInfo && chain.first() != null && !chain.first().isEmpty()) {
             size = chain.second();
+        }
+        if (file instanceof TemplateInfo && tempChain.first() != null && !tempChain.first().isEmpty()) {
+            size = tempChain.second();
         }
         return size;
     }
@@ -144,9 +150,10 @@ public class DataMigrationUtility {
         return new ArrayList<>(temp.keySet());
     }
 
-    protected List<DataObject> getSortedValidSourcesList(DataStore srcDataStore, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChains) {
+    protected List<DataObject> getSortedValidSourcesList(DataStore srcDataStore, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChains,
+                                                         Map<DataObject, Pair<List<TemplateInfo>, Long>> childTemplates) {
         List<DataObject> files = new ArrayList<>();
-        files.addAll(getAllReadyTemplates(srcDataStore));
+        files.addAll(getAllReadyTemplates(srcDataStore, childTemplates));
         files.addAll(getAllReadySnapshotsAndChains(srcDataStore, snapshotChains));
         files.addAll(getAllReadyVolumes(srcDataStore));
 
@@ -173,19 +180,28 @@ public class DataMigrationUtility {
         return files;
     }
 
-    protected List<DataObject> getAllReadyTemplates(DataStore srcDataStore) {
+    protected List<DataObject> getAllReadyTemplates(DataStore srcDataStore, Map<DataObject, Pair<List<TemplateInfo>, Long>> childTemplates) {
 
-        List<DataObject> files = new LinkedList<>();
+        List<TemplateInfo> files = new LinkedList<>();
         List<TemplateDataStoreVO> templates = templateDataStoreDao.listByStoreId(srcDataStore.getId());
         for (TemplateDataStoreVO template : templates) {
             VMTemplateVO templateVO = templateDao.findById(template.getTemplateId());
             if (template.getState() == ObjectInDataStoreStateMachine.State.Ready && templateVO != null &&
                     (!templateVO.isPublicTemplate() || (templateVO.isPublicTemplate() && templateVO.getUrl() == null)) &&
-                    templateVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator) {
+                    templateVO.getHypervisorType() != Hypervisor.HypervisorType.Simulator && templateVO.getParentTemplateId() == null) {
                 files.add(templateFactory.getTemplate(template.getTemplateId(), srcDataStore));
             }
         }
-        return files;
+        for (TemplateInfo template: files) {
+            List<VMTemplateVO> children = templateDao.listByParentTemplatetId(template.getId());
+            List<TemplateInfo> temps = new ArrayList<>();
+            temps.add(template);
+            for(VMTemplateVO child : children) {
+                temps.add(templateFactory.getTemplate(child.getId(), srcDataStore));
+            }
+            childTemplates.put(template, new Pair<>(temps, getTotalChainSize(temps)));
+        }
+        return (List<DataObject>) (List<?>) files;
     }
 
     /** Returns parent snapshots and snapshots that do not have any children; snapshotChains comprises of the snapshot chain info
@@ -217,20 +233,19 @@ public class DataMigrationUtility {
                     chain.addAll(children);
                 }
             }
-            snapshotChains.put(parent, new Pair<List<SnapshotInfo>, Long>(chain, getSizeForChain(chain)));
+            snapshotChains.put(parent, new Pair<List<SnapshotInfo>, Long>(chain, getTotalChainSize(chain)));
         }
 
         return (List<DataObject>) (List<?>) files;
     }
 
-    protected Long getSizeForChain(List<SnapshotInfo> chain) {
+    protected Long getTotalChainSize(List<? extends DataObject> chain) {
         Long size = 0L;
-        for (SnapshotInfo snapshot : chain) {
-            size += snapshot.getPhysicalSize();
+        for (DataObject dataObject : chain) {
+            size += dataObject.getPhysicalSize();
         }
         return size;
     }
-
 
     protected List<DataObject> getAllReadyVolumes(DataStore srcDataStore) {
         List<DataObject> files = new LinkedList<>();

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -97,7 +97,7 @@ public class DataMigrationUtility {
         List<TemplateDataStoreVO> templates = templateDataStoreDao.listByStoreId(srcDataStoreId);
         for (TemplateDataStoreVO template : templates) {
             isReady &= (Arrays.asList(validStates).contains(template.getState()));
-            LOGGER.trace(String.format("template state: ", template.getState()));
+            LOGGER.trace(String.format("template state: %s", template.getState()));
         }
         List<SnapshotDataStoreVO> snapshots = snapshotDataStoreDao.listByStoreId(srcDataStoreId, DataStoreRole.Image);
         for (SnapshotDataStoreVO snapshot : snapshots) {

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -107,7 +107,7 @@ public class DataMigrationUtility {
         List<VolumeDataStoreVO> volumes = volumeDataStoreDao.listByStoreId(srcDataStoreId);
         for (VolumeDataStoreVO volume : volumes) {
             isReady &= (Arrays.asList(validStates).contains(volume.getState()));
-            LOGGER.trace(String.format("volume state: ", volume.getState()));
+            LOGGER.trace(String.format("template state: %s", template.getState()));
         }
         return isReady;
     }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -102,7 +102,7 @@ public class DataMigrationUtility {
         List<SnapshotDataStoreVO> snapshots = snapshotDataStoreDao.listByStoreId(srcDataStoreId, DataStoreRole.Image);
         for (SnapshotDataStoreVO snapshot : snapshots) {
             isReady &= (Arrays.asList(validStates).contains(snapshot.getState()));
-            LOGGER.trace(String.format("template state: %s", template.getState()));
+            LOGGER.trace(String.format("snapshot state: %s", snapshot.getState()));
         }
         List<VolumeDataStoreVO> volumes = volumeDataStoreDao.listByStoreId(srcDataStoreId);
         for (VolumeDataStoreVO volume : volumes) {

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/DataMigrationUtility.java
@@ -114,7 +114,7 @@ public class DataMigrationUtility {
     }
 
     protected Long getFileSize(DataObject file, Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain) {
-        Long size = file.getSize();
+        Long size = file.getPhysicalSize();
         Pair<List<SnapshotInfo>, Long> chain = snapshotChain.get(file);
         if (file instanceof SnapshotInfo && chain.first() != null && !chain.first().isEmpty()) {
             size = chain.second();
@@ -159,8 +159,8 @@ public class DataMigrationUtility {
         Collections.sort(files, new Comparator<DataObject>() {
             @Override
             public int compare(DataObject o1, DataObject o2) {
-                Long size1 = o1.getSize();
-                Long size2 = o2.getSize();
+                Long size1 = o1.getPhysicalSize();
+                Long size2 = o2.getPhysicalSize();
                 if (o1 instanceof SnapshotInfo) {
                     size1 = snapshotChains.get(o1).second();
                 }
@@ -226,7 +226,7 @@ public class DataMigrationUtility {
     protected Long getSizeForChain(List<SnapshotInfo> chain) {
         Long size = 0L;
         for (SnapshotInfo snapshot : chain) {
-            size += snapshot.getSize();
+            size += snapshot.getPhysicalSize();
         }
         return size;
     }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -194,8 +194,8 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
                 destDatastoreId = orderedDS.get(1);
             }
 
-            if (chosenFileForMigration.getSize() > storageCapacities.get(destDatastoreId).first()) {
-                s_logger.debug("file: " + chosenFileForMigration.getId() + " too large to be migrated to " + destDatastoreId);
+            if (chosenFileForMigration.getPhysicalSize() > storageCapacities.get(destDatastoreId).first()) {
+                s_logger.debug("file: " + chosenFileForMigration.getUuid() + " too large to be migrated to " + destDatastoreId);
                 continue;
             }
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.storage.Volume;
 import org.apache.cloudstack.api.response.MigrationResponse;
 import org.apache.cloudstack.engine.orchestration.service.StorageOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -44,6 +44,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.SecondaryStorageServic
 import org.apache.cloudstack.engine.subsystem.api.storage.SecondaryStorageService.DataObjectResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.TemplateInfo;
 import org.apache.cloudstack.framework.async.AsyncCallFuture;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
@@ -144,7 +145,8 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
         migrationHelper.checkIfCompleteMigrationPossible(migrationPolicy, srcDataStoreId);
         DataStore srcDatastore = dataStoreManager.getDataStore(srcDataStoreId, DataStoreRole.Image);
         Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChains = new HashMap<>();
-        files = migrationHelper.getSortedValidSourcesList(srcDatastore, snapshotChains);
+        Map<DataObject, Pair<List<TemplateInfo>, Long>> childTemplates = new HashMap<>();
+        files = migrationHelper.getSortedValidSourcesList(srcDatastore, snapshotChains, childTemplates);
 
         if (files.isEmpty()) {
             return new MigrationResponse(String.format("No files in Image store: %s to migrate", srcDatastore.getId()), migrationPolicy.toString(), true);
@@ -201,8 +203,8 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
                 continue;
             }
 
-            if (shouldMigrate(chosenFileForMigration, srcDatastore.getId(), destDatastoreId, storageCapacities, snapshotChains, migrationPolicy)) {
-                storageCapacities = migrateAway(chosenFileForMigration, storageCapacities, snapshotChains, srcDatastore, destDatastoreId, executor, futures);
+            if (shouldMigrate(chosenFileForMigration, srcDatastore.getId(), destDatastoreId, storageCapacities, snapshotChains, childTemplates, migrationPolicy)) {
+                storageCapacities = migrateAway(chosenFileForMigration, storageCapacities, snapshotChains, childTemplates, srcDatastore, destDatastoreId, executor, futures);
             } else {
                 if (migrationPolicy == MigrationPolicy.BALANCE) {
                     continue;
@@ -243,10 +245,19 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
         return new Pair<String, Boolean>(message, success);
     }
 
-    protected Map<Long, Pair<Long, Long>> migrateAway(DataObject chosenFileForMigration, Map<Long, Pair<Long, Long>> storageCapacities,
-                               Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChains, DataStore srcDatastore, Long destDatastoreId, ThreadPoolExecutor executor,
-    List<Future<AsyncCallFuture<DataObjectResult>>> futures) {
-        Long fileSize = migrationHelper.getFileSize(chosenFileForMigration, snapshotChains);
+    protected Map<Long, Pair<Long, Long>> migrateAway(
+            DataObject chosenFileForMigration,
+            Map<Long, Pair<Long, Long>> storageCapacities,
+            Map<DataObject,
+            Pair<List<SnapshotInfo>, Long>> snapshotChains,
+            Map<DataObject, Pair<List<TemplateInfo>, Long>> templateChains,
+            DataStore srcDatastore,
+            Long destDatastoreId,
+            ThreadPoolExecutor executor,
+            List<Future<AsyncCallFuture<DataObjectResult>>> futures) {
+
+        Long fileSize = migrationHelper.getFileSize(chosenFileForMigration, snapshotChains, templateChains);
+
         storageCapacities = assumeMigrate(storageCapacities, srcDatastore.getId(), destDatastoreId, fileSize);
         long activeSsvms = migrationHelper.activeSSVMCount(srcDatastore);
         long totalJobs = activeSsvms * numConcurrentCopyTasksPerSSVM;
@@ -259,6 +270,9 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
         MigrateDataTask task = new MigrateDataTask(chosenFileForMigration, srcDatastore, dataStoreManager.getDataStore(destDatastoreId, DataStoreRole.Image));
         if (chosenFileForMigration instanceof SnapshotInfo ) {
             task.setSnapshotChains(snapshotChains);
+        }
+        if (chosenFileForMigration instanceof TemplateInfo) {
+            task.setTemplateChain(templateChains);
         }
         futures.add((executor.submit(task)));
         s_logger.debug(String.format("Migration of %s: %s is initiated. ", chosenFileForMigration.getType().name(), chosenFileForMigration.getUuid()));
@@ -380,13 +394,19 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
      * @param migrationPolicy determines whether a "Balance" or "Complete" migration operation is to be performed
      * @return
      */
-    private boolean shouldMigrate(DataObject chosenFile, Long srcDatastoreId, Long destDatastoreId, Map<Long, Pair<Long, Long>> storageCapacities,
-                                  Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChains, MigrationPolicy migrationPolicy) {
+    private boolean shouldMigrate(
+            DataObject chosenFile,
+            Long srcDatastoreId,
+            Long destDatastoreId,
+            Map<Long, Pair<Long, Long>> storageCapacities,
+            Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChains,
+            Map<DataObject, Pair<List<TemplateInfo>, Long>> templateChains,
+            MigrationPolicy migrationPolicy) {
 
         if (migrationPolicy == MigrationPolicy.BALANCE) {
             double meanStdDevCurrent = getStandardDeviation(storageCapacities);
 
-            Long fileSize = migrationHelper.getFileSize(chosenFile, snapshotChains);
+            Long fileSize = migrationHelper.getFileSize(chosenFile, snapshotChains, templateChains);
             Map<Long, Pair<Long, Long>> proposedCapacities = assumeMigrate(storageCapacities, srcDatastoreId, destDatastoreId, fileSize);
             double meanStdDevAfter = getStandardDeviation(proposedCapacities);
 
@@ -432,6 +452,7 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
         private DataStore srcDataStore;
         private DataStore destDataStore;
         private Map<DataObject, Pair<List<SnapshotInfo>, Long>> snapshotChain;
+        private Map<DataObject, Pair<List<TemplateInfo>, Long>> templateChain;
         public MigrateDataTask(DataObject file, DataStore srcDataStore, DataStore destDataStore) {
             this.file = file;
             this.srcDataStore = srcDataStore;
@@ -445,13 +466,19 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
         public Map<DataObject, Pair<List<SnapshotInfo>, Long>> getSnapshotChain() {
             return snapshotChain;
         }
+        public Map<DataObject, Pair<List<TemplateInfo>, Long>> getTemplateChain() {
+            return templateChain;
+        }
+        public void setTemplateChain(Map<DataObject, Pair<List<TemplateInfo>, Long>> templateChain) {
+            this.templateChain = templateChain;
+        }
         public DataObject getFile() {
             return file;
         }
 
         @Override
         public AsyncCallFuture<DataObjectResult> call() throws Exception {
-            return secStgSrv.migrateData(file, srcDataStore, destDataStore, snapshotChain);
+            return secStgSrv.migrateData(file, srcDataStore, destDataStore, snapshotChain, templateChain);
         }
     }
 }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -44,8 +44,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.SecondaryStorageServic
 import org.apache.cloudstack.engine.subsystem.api.storage.SecondaryStorageService.DataObjectResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
-import org.apache.cloudstack.engine.subsystem.api.storage.TemplateInfo;
-import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.framework.async.AsyncCallFuture;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -198,7 +198,7 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
             }
 
             if (chosenFileForMigration.getPhysicalSize() > storageCapacities.get(destDatastoreId).first()) {
-                s_logger.debug(String.format("%s: %s too large to be migrated to %s", getObjectType(chosenFileForMigration), chosenFileForMigration.getUuid(), destDatastoreId));
+                s_logger.debug(String.format("%s: %s too large to be migrated to %s",  chosenFileForMigration.getType().name() , chosenFileForMigration.getUuid(), destDatastoreId));
                 skipped += 1;
                 continue;
             }
@@ -217,19 +217,6 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
         Date end = new Date();
         handleSnapshotMigration(srcDataStoreId, start, end, migrationPolicy, futures, storageCapacities, executor);
         return handleResponse(futures, migrationPolicy, message, success);
-    }
-
-    private String getObjectType(DataObject dataObject) {
-        if (dataObject instanceof VolumeInfo) {
-            return "volume";
-        }
-        if (dataObject instanceof SnapshotInfo) {
-            return "snapshot";
-        }
-        if (dataObject instanceof TemplateInfo) {
-            return "template";
-        }
-        return "file";
     }
 
     protected Pair<String, Boolean> migrateCompleted(Long destDatastoreId, DataStore srcDatastore, List<DataObject> files, MigrationPolicy migrationPolicy, int skipped) {
@@ -276,7 +263,7 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
             task.setSnapshotChains(snapshotChains);
         }
         futures.add((executor.submit(task)));
-        s_logger.debug(String.format("Migration of %s: %s is initiated. ", getObjectType(chosenFileForMigration), chosenFileForMigration.getUuid()));
+        s_logger.debug(String.format("Migration of %s: %s is initiated. ", chosenFileForMigration.getType().name(), chosenFileForMigration.getUuid()));
         return storageCapacities;
     }
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/StorageOrchestrator.java
@@ -250,7 +250,7 @@ public class StorageOrchestrator extends ManagerBase implements StorageOrchestra
             }
         } else {
             message = "Migration completed";
-            if (migrationPolicy == MigrationPolicy.COMPLETE && skipped != 0) {
+            if (migrationPolicy == MigrationPolicy.COMPLETE && skipped > 0) {
                 message += ". Not all data objects were migrated. Some were probably skipped due to lack of storage capacity.";
                 success = false;
             }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/store/TemplateObject.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/store/TemplateObject.java
@@ -142,6 +142,15 @@ public class TemplateObject implements TemplateInfo {
     }
 
     @Override
+    public long getPhysicalSize() {
+        TemplateDataStoreVO templateDataStoreVO = templateStoreDao.findByTemplate(imageVO.getId(), DataStoreRole.Image);
+        if (templateDataStoreVO != null) {
+            return templateDataStoreVO.getPhysicalSize();
+        }
+        return imageVO.getSize();
+    }
+
+    @Override
     public DataObjectType getType() {
         return DataObjectType.TEMPLATE;
     }

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeObject.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeObject.java
@@ -232,6 +232,15 @@ public class VolumeObject implements VolumeInfo {
     }
 
     @Override
+    public long getPhysicalSize() {
+        VolumeDataStoreVO volumeDataStoreVO = volumeStoreDao.findByVolume(volumeVO.getId());
+        if (volumeDataStoreVO != null) {
+            return volumeDataStoreVO.getPhysicalSize();
+        }
+        return volumeVO.getSize();
+    }
+
+    @Override
     public Long getBytesReadRate() {
         return getLongValueFromDiskOfferingVoMethod(DiskOfferingVO::getBytesReadRate);
     }

--- a/server/src/main/java/org/apache/cloudstack/diagnostics/to/DiagnosticsDataObject.java
+++ b/server/src/main/java/org/apache/cloudstack/diagnostics/to/DiagnosticsDataObject.java
@@ -60,6 +60,11 @@ public class DiagnosticsDataObject implements DataObject {
     }
 
     @Override
+    public long getPhysicalSize() {
+        return 0;
+    }
+
+    @Override
     public DataObjectType getType() {
         return dataTO.getObjectType();
     }


### PR DESCRIPTION
### Description

This PR fails a migrateData command if any of the files fail to migrate.
In addition it tries to calculate capacity based on the actual size on disk the template takes, and not the virtual size.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #5654
Fixes: #5655

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

create a test env and add templates.
set a large size in vm_template.size in the DB to an enormous size (add 7 or 8 zeros to it)
migrate:
```
> migrate secondarystoragedata srcpool=9166e328-608a-4469-8899-4374507e2e20 destpools=e23c6295-82f4-4878-8437-4417944e1653
{
  "imagestore": {
    "message": "Migration completed. Not all data objects were migrated. Some were probably skipped due to lack of storage capacity.. successful migrations: 1",
    "migrationtype": "COMPLETE",
    "success": false
  }
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
