### PR TITLE
Enhance log message in FirstFitPlanner

### DIFF
--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -373,7 +373,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
                 clusterListForVmAllocation.removeAll(clustersCrossingThreshold);
 
                 String warnMessageForClusterReachedCapacityThreshold = String.format(
-                        "Cannot allocate cluster list %s for vm creation since their allocated percentage crosses the disable capacity threshold defined at each cluster at"
+                        "Cannot allocate cluster list %s for VM creation since their allocated percentage crosses the disable capacity threshold defined at each cluster at"
                         + " Global Settings Configuration [name: %s, value: %s] for capacity Type : %s, skipping these clusters", clustersCrossingThreshold.toString(),
                         configurationName, String.valueOf(configurationValue), CapacityVO.getCapacityName(capacity));
                 s_logger.warn(warnMessageForClusterReachedCapacityThreshold);

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.capacity.CapacityVO;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
@@ -353,12 +354,16 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
                 return;
             }
 
+            String configurationName = ClusterCPUCapacityDisableThreshold.key();
+            float configurationValue = ClusterCPUCapacityDisableThreshold.value();
             if (capacity == Capacity.CAPACITY_TYPE_CPU) {
                 clustersCrossingThreshold =
                         capacityDao.listClustersCrossingThreshold(capacity, plan.getDataCenterId(), ClusterCPUCapacityDisableThreshold.key(), cpu_requested);
             } else if (capacity == Capacity.CAPACITY_TYPE_MEMORY) {
                 clustersCrossingThreshold =
                         capacityDao.listClustersCrossingThreshold(capacity, plan.getDataCenterId(), ClusterMemoryCapacityDisableThreshold.key(), ram_requested);
+                configurationName = ClusterMemoryCapacityDisableThreshold.key();
+                configurationValue = ClusterMemoryCapacityDisableThreshold.value();
             }
 
             if (clustersCrossingThreshold != null && clustersCrossingThreshold.size() != 0) {
@@ -367,8 +372,11 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
                 // Remove clusters crossing disabled threshold
                 clusterListForVmAllocation.removeAll(clustersCrossingThreshold);
 
-                s_logger.debug("Cannot allocate cluster list " + clustersCrossingThreshold.toString() + " for vm creation since their allocated percentage" +
-                        " crosses the disable capacity threshold defined at each cluster/ at global value for capacity Type : " + capacity + ", skipping these clusters");
+                String warnMessageForClusterReachedCapacityThreshold = String.format(
+                        "Cannot allocate cluster list %s for vm creation since their allocated percentage crosses the disable capacity threshold defined at each cluster at"
+                                + " global value [settings: %s, value: %s] for capacity Type : %s, skipping these clusters", clustersCrossingThreshold.toString(),
+                        configurationName, String.valueOf(configurationValue), CapacityVO.getCapacityName(capacity));
+                s_logger.warn(warnMessageForClusterReachedCapacityThreshold);
             }
 
         }

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -374,7 +374,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
 
                 String warnMessageForClusterReachedCapacityThreshold = String.format(
                         "Cannot allocate cluster list %s for vm creation since their allocated percentage crosses the disable capacity threshold defined at each cluster at"
-                                + " global value [settings: %s, value: %s] for capacity Type : %s, skipping these clusters", clustersCrossingThreshold.toString(),
+                        + " global value [settings: %s, value: %s] for capacity Type : %s, skipping these clusters", clustersCrossingThreshold.toString(),
                         configurationName, String.valueOf(configurationValue), CapacityVO.getCapacityName(capacity));
                 s_logger.warn(warnMessageForClusterReachedCapacityThreshold);
             }

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -374,7 +374,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
 
                 String warnMessageForClusterReachedCapacityThreshold = String.format(
                         "Cannot allocate cluster list %s for vm creation since their allocated percentage crosses the disable capacity threshold defined at each cluster at"
-                        + " global value [settings: %s, value: %s] for capacity Type : %s, skipping these clusters", clustersCrossingThreshold.toString(),
+                        + " Global Settings Configuration [name: %s, value: %s] for capacity Type : %s, skipping these clusters", clustersCrossingThreshold.toString(),
                         configurationName, String.valueOf(configurationValue), CapacityVO.getCapacityName(capacity));
                 s_logger.warn(warnMessageForClusterReachedCapacityThreshold);
             }


### PR DESCRIPTION
### Description

When cluster reached capacity threshold log message is:
`"capacity threshold defined at each cluster/ at global value for capacity Type : 0"`
Admins hardly remember the Capacity Type and it can take a while to look at which is the resource for the respective ID.


This PR adds a log message pointing to the capacity name (e.g. Memory / CPU) as well as global settings parameter name and value to be looked at.
Additionally, this PR also proposes to change the log message from DEBUG to Warning, as it gives relevant information in case of exceptions, and might enforce production environments to have log level at debugging instead of info.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor
