### PR TITLE
api: Fix search cluster by name

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1146,7 +1146,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         final SearchBuilder<ClusterVO> sb = _clusterDao.createSearchBuilder();
         sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
-        sb.and("name", sb.entity().getName(), SearchCriteria.Op.LIKE);
+        sb.and("name", sb.entity().getName(), SearchCriteria.Op.EQ);
         sb.and("podId", sb.entity().getPodId(), SearchCriteria.Op.EQ);
         sb.and("dataCenterId", sb.entity().getDataCenterId(), SearchCriteria.Op.EQ);
         sb.and("hypervisorType", sb.entity().getHypervisorType(), SearchCriteria.Op.EQ);
@@ -1159,7 +1159,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if (name != null) {
-            sc.setParameters("name", "%" + name + "%");
+            sc.setParameters("name", name);
         }
 
         if (podId != null) {


### PR DESCRIPTION
### Description

This PR fixes an issue noticed while searching for clusters based on name. When the 'name' parameter is passed, it treats it as a keyword to be searched (https://github.com/apache/cloudstack-cloudmonkey/issues/109). 
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
#### Prior Fix:
```
(localcloud) 🐱 > list clusters name=Pool1 filter=name,id,
{
  "cluster": [
    {
      "id": "0b02dfba-27b8-4371-ad16-23d6df57ffca",
      "name": "Pool1"
    },
    {
      "id": "dc6a03fd-7d33-47cd-9bc0-a15c8fcda139",
      "name": "Pool10"
    }
  ],
  "count": 2
}

```
#### Post Fix:
```
(localcloud) 🐱 > list clusters name=Pool1 filter=name,id,
{
  "cluster": [
    {
      "id": "11d536bb-7719-4c39-8ecc-eca11d2ef3bf",
      "name": "Pool1"
    }
  ],
  "count": 1
}
(localcloud) 🐱 > list clusters name=Pool filter=name,id,
(localcloud) 🐱 > list clusters keyword=Pool1 filter=name,id,
{
  "cluster": [
    {
      "id": "11d536bb-7719-4c39-8ecc-eca11d2ef3bf",
      "name": "Pool1"
    },
    {
      "id": "67fd82e2-ab33-4b7f-af5b-95a6a38b4191",
      "name": "Pool10"
    }
  ],
  "count": 2
}


```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
