### PR TITLE
Add toggle button on the UI for list including elements in projects.

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1299,7 +1299,6 @@
 "label.link.domain.to.ldap": "Link Domain to LDAP",
 "label.linklocalip": "Link Local IP Address",
 "label.linux": "Linux",
-"label.list.all.projects": "All Projects",
 "label.list.ciscoasa1000v": "ASA 1000v",
 "label.list.ciscovnmc": "Cisco VNMC",
 "label.list.nodes": "List nodes",

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1299,6 +1299,7 @@
 "label.link.domain.to.ldap": "Link Domain to LDAP",
 "label.linklocalip": "Link Local IP Address",
 "label.linux": "Linux",
+"label.list.all.projects": "All Projects",
 "label.list.ciscoasa1000v": "ASA 1000v",
 "label.list.ciscovnmc": "Cisco VNMC",
 "label.list.nodes": "List nodes",

--- a/ui/src/store/getters.js
+++ b/ui/src/store/getters.js
@@ -30,6 +30,7 @@ const getters = {
   userInfo: state => state.user.info,
   addRouters: state => state.permission.addRouters,
   multiTab: state => state.app.multiTab,
+  listAllProjects: state => state.app.listAllProjects,
   headerNotices: state => state.user.headerNotices,
   isLdapEnabled: state => state.user.isLdapEnabled,
   cloudian: state => state.user.cloudian,

--- a/ui/src/store/modules/app.js
+++ b/ui/src/store/modules/app.js
@@ -46,6 +46,7 @@ const app = {
     inverted: true,
     multiTab: true,
     metrics: false,
+    listAllProjects: false,
     server: ''
   },
   mutations: {
@@ -99,6 +100,9 @@ const app = {
     SET_METRICS: (state, bool) => {
       state.metrics = bool
     },
+    SET_LIST_ALL_PROJECTS: (state, bool) => {
+      state.listAllProjects = bool
+    },
     SET_USE_BROWSER_TIMEZONE: (state, bool) => {
       Vue.ls.set(USE_BROWSER_TIMEZONE, bool)
       state.usebrowsertimezone = bool
@@ -150,6 +154,9 @@ const app = {
     },
     SetMetrics ({ commit }, bool) {
       commit('SET_METRICS', bool)
+    },
+    SetListAllProjects ({ commit }, bool) {
+      commit('SET_LIST_ALL_PROJECTS', bool)
     },
     SetUseBrowserTimezone ({ commit }, bool) {
       commit('SET_USE_BROWSER_TIMEZONE', bool)

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -42,8 +42,8 @@
                 <a-switch
                   v-if="!projectView && hasProjectId"
                   style="margin-left: 8px"
-                  :checked-children="$t('label.list.all.projects')"
-                  :un-checked-children="$t('label.list.all.projects')"
+                  :checked-children="$t('label.projects')"
+                  :un-checked-children="$t('label.projects')"
                   :checked="$store.getters.listAllProjects"
                   @change="(checked, event) => { $store.dispatch('SetListAllProjects', checked) }"/>
                 <a-tooltip placement="right">

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -39,6 +39,13 @@
                   :un-checked-children="$t('label.metrics')"
                   :checked="$store.getters.metrics"
                   @change="(checked, event) => { $store.dispatch('SetMetrics', checked) }"/>
+                <a-switch
+                  v-if="!projectView && hasProjectId"
+                  style="margin-left: 8px"
+                  :checked-children="$t('label.list.all.projects')"
+                  :un-checked-children="$t('label.list.all.projects')"
+                  :checked="$store.getters.listAllProjects"
+                  @change="(checked, event) => { $store.dispatch('SetListAllProjects', checked) }"/>
                 <a-tooltip placement="right">
                   <template slot="title">
                     {{ $t('label.filterby') }}
@@ -504,6 +511,7 @@ export default {
       showAction: false,
       dataView: false,
       projectView: false,
+      hasProjectId: false,
       selectedFilter: '',
       filters: [],
       searchFilters: [],
@@ -634,6 +642,9 @@ export default {
     },
     '$store.getters.metrics' (oldVal, newVal) {
       this.fetchData()
+    },
+    '$store.getters.listAllProjects' (oldVal, newVal) {
+      this.fetchData()
     }
   },
   computed: {
@@ -740,6 +751,7 @@ export default {
       }
 
       this.projectView = Boolean(store.getters.project && store.getters.project.id)
+      this.hasProjectId = ['vm', 'vmgroup', 'ssh', 'affinitygroup', 'volume', 'snapshot', 'vmsnapshot', 'guestnetwork', 'vpc', 'securitygroups', 'publicip', 'vpncustomergateway', 'template', 'iso', 'event'].includes(this.$route.name)
 
       if ((this.$route && this.$route.params && this.$route.params.id) || this.$route.query.dataView) {
         this.dataView = true
@@ -829,6 +841,10 @@ export default {
         } else if (this.$route.path.startsWith('/ldapsetting/')) {
           params.hostname = this.$route.params.id
         }
+      }
+
+      if (this.$store.getters.listAllProjects && !this.projectView) {
+        params.projectid = '-1'
       }
 
       params.page = this.page


### PR DESCRIPTION
### Description

This PR allows listing elements that are in projects when in the Default view.
Nowadays, Admins cannot list in the UI many relevant data, unless entering in each of the projects, which can be humanly not feasible considering 10s or 100s of projects.

For example, one Admin cannot list all VMs, SSH keys, affinity groups, volumes, not even events that happen in a project in order to track all the events.

The UI tabs that are considered for this proposed PR are:
1. 'vm',
2. 'vmgroup',
3. 'ssh',
4. 'affinitygroup',
5. 'volume',
6. 'snapshot',
7. 'vmsnapshot',
8. 'guestnetwork',
9. 'vpc',
10. 'securitygroups',
11. 'publicip',
12. 'vpncustomergateway',
13. 'template',
14. 'iso',
15. 'event'

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [X] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
#### VMs
![image](https://user-images.githubusercontent.com/5025148/146761807-90187db9-ebd0-4ceb-ae6a-2766c8e7fbfc.png)

![image](https://user-images.githubusercontent.com/5025148/146761962-3498b748-4343-4b29-98d6-81dbd0042367.png)


#### Events
![image](https://user-images.githubusercontent.com/5025148/146761678-608f9205-0696-4e63-a272-d14b71f35f03.png)

![image](https://user-images.githubusercontent.com/5025148/146761687-ba6404b1-306c-4147-84a2-edf9fd8e2a80.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Build and run new UI
- Log in with admin account
- check tabs on default view
- check tabs on a project
- log with a "normal" user
- ensure that the user can list only elements in his own project

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
