### PR TITLE
Fix UI issue 5777 Root disk size is not shown as 'Disk Size' on VM deployment.

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1133,6 +1133,10 @@ export default {
         this.vm.disksizetotalgb = this.diskSize
       }
 
+      if (this.serviceOffering.rootdisksize) {
+        this.vm.disksizetotalgb = this.serviceOffering.rootdisksize
+      }
+
       if (this.networks) {
         this.vm.networks = this.networks
         this.vm.defaultnetworkid = this.defaultnetworkid

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1129,12 +1129,10 @@ export default {
         this.vm.hostname = host.name
       }
 
-      if (this.diskSize) {
-        this.vm.disksizetotalgb = this.diskSize
-      }
-
       if (this.serviceOffering.rootdisksize) {
         this.vm.disksizetotalgb = this.serviceOffering.rootdisksize
+      } else if (this.diskSize) {
+        this.vm.disksizetotalgb = this.diskSize
       }
 
       if (this.networks) {


### PR DESCRIPTION
### Description

In the UI, when selecting a service offering that has a root disk enforced, stills show the root disk size of the template (or the custom size gave by the user). This PR fixes this issue, that thas been reported in #5777.
Fixes: #5777

Now the UI dynamically changes the root disk size according to the following variables, following the priority order:
1. Service offering size (highest priority)
2. Custom size set by the user
3. Template size

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):
#### 1. Choose template, set custom rootdisk size to 123GB
![image](https://user-images.githubusercontent.com/5025148/146909575-7f9e96d8-38de-4bfa-95a3-652e23f70445.png)

#### 2. Choose an offering with root disk size set to 30
![image](https://user-images.githubusercontent.com/5025148/146909691-74805dbc-6a37-49e2-b1bb-ed1b36004c74.png)

#### 3. Change to another offering, e.g. with 50G
![image](https://user-images.githubusercontent.com/5025148/146909743-5513855b-63b4-454d-b2d1-0554ddaf4333.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Build UI (npm run serve)
2. Choose a template -- root disk size matches with the template
3. Set custom root disk size to 123GB -- UI updated with the new root disk size
4. Choose an offering with root disk size set to 30 -- UI changes to the service offering root disk size
5. Change to another offering, e.g. with 50G -- again, the UI updates


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
