### PR TITLE
ui: show tags only for supported resources

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -772,7 +772,8 @@ export default {
       this.showKeys = false
       this.setData()
 
-      if ('tags' in this.resource) {
+      console.log(this.resourceType)
+      if ('tags' in this.resource && !['PrimaryStorage'].includes(this.resourceType)) {
         this.tags = this.resource.tags
       } else if (this.resourceType) {
         this.getTags()

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -651,7 +651,7 @@
         </div>
       </div>
 
-      <div class="account-center-tags" v-if="!isStatic && resourceType && 'listTags' in $store.getters.apis">
+      <div class="account-center-tags" v-if="!isStatic && resourceType && tagsSupportingResourceTypes.includes(this.resourceType) && 'listTags' in $store.getters.apis">
         <a-divider/>
         <a-spin :spinning="loadingTags">
           <div class="title">{{ $t('label.tags') }}</div>
@@ -772,10 +772,12 @@ export default {
       this.showKeys = false
       this.setData()
 
-      if ('tags' in this.resource && !['PrimaryStorage'].includes(this.resourceType)) {
-        this.tags = this.resource.tags
-      } else if (this.resourceType) {
-        this.getTags()
+      if (this.tagsSupportingResourceTypes.includes(this.resourceType)) {
+        if ('tags' in this.resource) {
+          this.tags = this.resource.tags
+        } else if (this.resourceType) {
+          this.getTags()
+        }
       }
       if ('apikey' in this.resource) {
         this.getUserKeys()
@@ -794,6 +796,12 @@ export default {
     await this.getIcons()
   },
   computed: {
+    tagsSupportingResourceTypes () {
+      return ['UserVm', 'Template', 'ISO', 'Volume', 'Snapshot', 'Backup', 'Network',
+        'LoadBalancer', 'PortForwardingRule', 'FirewallRule', 'SecurityGroup', 'SecurityGroupRule',
+        'PublicIpAddress', 'Project', 'Account', 'Vpc', 'NetworkACL', 'StaticRoute', 'VMSnapshot',
+        'RemoteAccessVpn', 'User', 'SnapshotPolicy', 'VpcOffering']
+    },
     name () {
       return this.resource.displayname || this.resource.displaytext || this.resource.name || this.resource.username ||
         this.resource.ipaddress || this.resource.virtualmachinename || this.resource.templatetype

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -772,7 +772,6 @@ export default {
       this.showKeys = false
       this.setData()
 
-      console.log(this.resourceType)
       if ('tags' in this.resource && !['PrimaryStorage'].includes(this.resourceType)) {
         this.tags = this.resource.tags
       } else if (this.resourceType) {


### PR DESCRIPTION
### Description

Tags in info card of the UI are related to tags functionality(create/delete/listTags API)
UI was incorrectly showing storage tags as these tags in the UI.

Fixes #5727

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before:
![Screenshot from 2021-12-21 16-17-51](https://user-images.githubusercontent.com/153340/147036380-577cdcdb-0617-47e6-bd52-7378f6556a9c.png)


After:
![Screenshot from 2021-12-23 12-27-52](https://user-images.githubusercontent.com/153340/147201257-749cbb24-8f6a-411f-b404-d770fc62ba2c.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Using UI

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
