### PR TITLE
UI: show SSH keys step in VM deployment only if user can 'listSSHKeyPairs'

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -391,6 +391,7 @@
                 </template>
               </a-step>
               <a-step
+                v-if="isUserAllowedToListSshKeys"
                 :title="this.$t('label.sshkeypairs')"
                 :status="zoneSelected ? 'process' : 'wait'">
                 <template slot="description">
@@ -1058,6 +1059,9 @@ export default {
     },
     showSecurityGroupSection () {
       return (this.networks.length > 0 && this.zone.securitygroupsenabled) || (this.zone && this.zone.networktype === 'Basic')
+    },
+    isUserAllowedToListSshKeys () {
+      return Boolean('listSSHKeyPairs' in this.$store.getters.apis)
     },
     dynamicScalingVmConfigValue () {
       return this.options.dynamicScalingVmConfig?.[0]?.value === 'true'


### PR DESCRIPTION
### Description

This PR Fixes issue #5765 _UI: SSH key option should not be presented if not allowed/support_.
After applying this patch, the VM deployment via UI shows the SSH Keys step only if the user/account has access to the [listSSHKeyPairs](https://cloudstack.apache.org/api/apidocs-4.15/apis/listSSHKeyPairs.html) command.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #5765

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
#### 1.User that can list SSH Keys:
![image](https://user-images.githubusercontent.com/5025148/147249547-4c5718ca-67fd-4606-877e-ab1025c7da26.png)

#### 2.User that is not allowed to list SSH Keys:
![image](https://user-images.githubusercontent.com/5025148/147249710-16bbc1b4-e4c2-4229-98bd-1c20e43f047c.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Deploy VM via user that has access to listSSHKeyPairs
2. UI shows all keys the user can access
3. create role type that don't allow `listSSHKeyPairs`
4. Deploy VM via user that is not allowed to call API command `listSSHKeyPairs`
5. UI does not present the SSH keys step to the user

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
