### PR TITLE
Allow templates & ISOs from IPv6 host address.

### DIFF
--- a/utils/src/main/java/com/cloud/utils/UriUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UriUtils.java
@@ -283,9 +283,6 @@ public class UriUtils {
                 if (hostAddr.isAnyLocalAddress() || hostAddr.isLinkLocalAddress() || hostAddr.isLoopbackAddress() || hostAddr.isMulticastAddress()) {
                     throw new IllegalArgumentException("Illegal host specified in url");
                 }
-                if (hostAddr instanceof Inet6Address) {
-                    throw new IllegalArgumentException("IPV6 addresses not supported (" + hostAddr.getHostAddress() + ")");
-                }
             } catch (UnknownHostException uhe) {
                 throw new IllegalArgumentException("Unable to resolve " + host);
             }

--- a/utils/src/main/java/com/cloud/utils/UriUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UriUtils.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;


### PR DESCRIPTION
### Description

This PR removes a conditional in [com.cloud.utils.UriUtils.validateUrl(java.lang.String, java.lang.String)](https://github.com/apache/cloudstack/blob/44c08b5acc598972b4f0af576ffdea4e2447cb41/utils/src/main/java/com/cloud/utils/UriUtils.java#L286).

I don't see reasons to block IPv6 addresses when registering templates & ISOs.
Tested and the whole CloudStack template registration works fine when using IPv6 addresses (both on management node & template repository).

Please let me know if there are any know issues that justify blocking IPv6 addresses.

I've tested on a 4.16.0.0 environment, however, the PR's base branch is main.
I can rebase it for `4.16.1.0` if that sounds good.

Fixes: #3047

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Register a new template in the UI (from IPv6 host)
- Register a new kubernetes ISO (from IPv6 host)
- Check DB entries validating that all is correct
- Mount secondary storage and ensure that Template and ISO have been properly placed in their secondary storage folders

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
