### PR TITLE
server: do not return inaccessible entity details to normal users

### DIFF
--- a/server/src/main/java/com/cloud/acl/DomainChecker.java
+++ b/server/src/main/java/com/cloud/acl/DomainChecker.java
@@ -178,19 +178,20 @@ public class DomainChecker extends AdapterBase implements SecurityChecker {
         } else {
             if (_accountService.isNormalUser(caller.getId())) {
                 Account account = _accountDao.findById(entity.getAccountId());
+                String errorMessage = String.format("%s does not have permission to operate with resource", caller);
                 if (account != null && account.getType() == Account.ACCOUNT_TYPE_PROJECT) {
                     //only project owner can delete/modify the project
                     if (accessType != null && accessType == AccessType.ModifyProject) {
                         if (!_projectMgr.canModifyProjectAccount(caller, account.getId())) {
-                            throw new PermissionDeniedException(caller + " does not have permission to operate with resource " + entity);
+                            throw new PermissionDeniedException(errorMessage);
                         }
                     } else if (!_projectMgr.canAccessProjectAccount(caller, account.getId())) {
-                        throw new PermissionDeniedException(caller + " does not have permission to operate with resource " + entity);
+                        throw new PermissionDeniedException(errorMessage);
                     }
                     checkOperationPermitted(caller, entity);
                 } else {
                     if (caller.getId() != entity.getAccountId()) {
-                        throw new PermissionDeniedException(caller + " does not have permission to operate with resource " + entity);
+                        throw new PermissionDeniedException(errorMessage);
                     }
                 }
             }


### PR DESCRIPTION
### Description

Fixes #5534

As pre 3.x APIs allow using internal DB IDs, even normal users can use internal IDs.
This fix removes additional information in error message when the caller doesn't have access to the resource.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

*Before*
```
(local) 🐤 > list accounts id=2
🙈 Error: (HTTP 531, error code 4365) Acct[c6de2628-5a8e-4d68-a95d-2f407db1612d-user] -- Account {"id": 4, "name": "user", "uuid": "c6de2628-5a8e-4d68-a95d-2f407db1612d"} does not have permission to operate with resource Acct[54e1efd3-6951-11ec-919d-645d8651f45a-admin] -- Account {"id": 2, "name": "admin", "uuid": "54e1efd3-6951-11ec-919d-645d8651f45a"}
```

*After*
```
(local) 🐬 > list accounts id=2
🙈 Error: (HTTP 531, error code 4365) Acct[c6de2628-5a8e-4d68-a95d-2f407db1612d-user] -- Account {"id": 4, "name": "user", "uuid": "c6de2628-5a8e-4d68-a95d-2f407db1612d"} does not have permission to operate with resource
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
