### PR TITLE
Prevent upgrade failures if there are existing annotations permissions

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/RolePermissionChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/RolePermissionChecker.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade;
+
+import org.apache.log4j.Logger;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class RolePermissionChecker {
+
+    final static Logger LOG = Logger.getLogger(RolePermissionChecker.class);
+
+    private static final String checkAnnotationRulesPermissionPreparedStatement =
+            "SELECT permission FROM `cloud`.`role_permissions` WHERE role_id = ? AND rule = ?";
+    private static final String insertAnnotationRulePermissionPreparedStatement =
+            "INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), ?, ?, 'ALLOW')";
+
+    public RolePermissionChecker() {
+    }
+
+    public boolean existsRolePermissionByRoleIdAndRule(Connection conn, long roleId, String rule) {
+        try {
+            PreparedStatement pstmt = conn.prepareStatement(checkAnnotationRulesPermissionPreparedStatement);
+            pstmt.setLong(1, roleId);
+            pstmt.setString(2, rule);
+            ResultSet rs = pstmt.executeQuery();
+            return rs != null && rs.next();
+        } catch (SQLException e) {
+            LOG.error("Error on existsRolePermissionByRoleIdAndRule: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    public void insertAnnotationRulePermission(Connection conn, long roleId, String rule) {
+        try {
+            PreparedStatement pstmt = conn.prepareStatement(insertAnnotationRulePermissionPreparedStatement);
+            pstmt.setLong(1, roleId);
+            pstmt.setString(2, rule);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            LOG.error("Error on insertAnnotationRulePermission: " + e.getMessage(), e);
+        }
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
@@ -97,9 +97,9 @@ public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate
             if (rolePermission == null) {
                 LOG.debug("Inserting role permission for role: " + roleType.getId() + " and rule: " + ruleString);
                 roleService.createRolePermission(role, rule, RolePermissionEntity.Permission.ALLOW, null);
-            } else if (RolePermissionEntity.Permission.DENY.equals(rolePermission.getPermission())) {
-                LOG.debug("Updating role permission for role: " + roleType.getId() + " and rule: " + ruleString);
-                roleService.updateRolePermission(role, rolePermission, RolePermissionEntity.Permission.ALLOW);
+            } else {
+                LOG.debug("Found existing role permission for role: " + roleType.getId() + " and rule: " + ruleString +
+                        ", not updating it");
             }
         }
     }

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
@@ -70,7 +70,7 @@ public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate
     @Override
     public void performDataMigration(Connection conn) {
         generateUuidForExistingSshKeyPairs(conn);
-        generateAnnotationPermissions(conn);
+       populateAnnotationPermissions(conn);
     }
 
     private void generateAnnotationPermissions(Connection conn) {
@@ -80,7 +80,7 @@ public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate
         }
     }
 
-    private void checkAnnotationPermissionExists(Connection conn, RoleType roleType, List<String> rules) {
+    private void checkAndPersistAnnotationPermissions(Connection conn, RoleType roleType, List<String> rules) {
         LOG.debug("Checking the annotation permissions for the role: " + roleType.getId());
         for (String rule : rules) {
             LOG.debug("Checking the annotation permissions for the role: " + roleType.getId() + " and rule: " + rule);

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
@@ -70,7 +70,7 @@ public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate
     @Override
     public void performDataMigration(Connection conn) {
         generateUuidForExistingSshKeyPairs(conn);
-       populateAnnotationPermissions(conn);
+        populateAnnotationPermissions(conn);
     }
 
     private void generateAnnotationPermissions(Connection conn) {

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
@@ -26,22 +26,25 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.cloud.upgrade.SystemVmTemplateRegistration;
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RolePermission;
+import org.apache.cloudstack.acl.RolePermissionEntity;
+import org.apache.cloudstack.acl.RoleService;
 import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.acl.Rule;
 import org.apache.log4j.Logger;
 
 import com.cloud.utils.exception.CloudRuntimeException;
+
+import javax.inject.Inject;
 
 public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate {
 
     final static Logger LOG = Logger.getLogger(Upgrade41520to41600.class);
     private SystemVmTemplateRegistration systemVmTemplateRegistration;
 
-    private static final String checkAnnotationRulesPermissionPreparedStatement =
-            "SELECT permission FROM `cloud`.`role_permissions` WHERE role_id = ? AND rule = ?";
-    private static final String insertAnnotationRulePermissionPreparedStatement =
-            "INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), ?, ?, 'ALLOW')";
-    private static final String updateAnnotationRulePermissionPreparedStatement =
-            "UPDATE `cloud`.`role_permissions` SET permission = 'ALLOW' WHERE rule = ? AND role_id = ?";
+    @Inject
+    RoleService roleService;
 
     public Upgrade41520to41600() {
     }
@@ -80,60 +83,24 @@ public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate
 
     private void generateAnnotationPermissions(Connection conn) {
         List<String> annotationRules = Arrays.asList("listAnnotations", "addAnnotation", "removeAnnotation");
-        checkAnnotationPermissionExists(conn, RoleType.ResourceAdmin, annotationRules);
-        checkAnnotationPermissionExists(conn, RoleType.DomainAdmin, annotationRules);
-        checkAnnotationPermissionExists(conn, RoleType.User, annotationRules);
+        for (RoleType roleType : Arrays.asList(RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User)) {
+            checkAnnotationPermissionExists(conn, roleType, annotationRules);
+        }
     }
 
     private void checkAnnotationPermissionExists(Connection conn, RoleType roleType, List<String> rules) {
-        LOG.debug("Checking if annotation permissions exists for the role: " + roleType.getId());
-        for (String rule : rules) {
-            try {
-                PreparedStatement pstmt = conn.prepareStatement(checkAnnotationRulesPermissionPreparedStatement);
-                pstmt.setLong(1, roleType.getId());
-                pstmt.setString(2, rule);
-                ResultSet rs = pstmt.executeQuery();
-                if (rs != null && rs.next()) {
-                    String permission = rs.getString(1);
-                    if (!permission.equalsIgnoreCase("allow")) {
-                        updateExistingRulePermission(conn, roleType, rule);
-                    }
-                } else {
-                    insertAnnotationRulePermission(conn, roleType, rule);
-                }
-                if (!rs.isClosed())  {
-                    rs.close();
-                }
-                if (!pstmt.isClosed())  {
-                    pstmt.close();
-                }
-            } catch (SQLException e) {
-                LOG.error("Error on checkAnnotationPermission: " + e.getMessage(), e);
+        LOG.debug("Checking the annotation permissions for the role: " + roleType.getId());
+        for (String ruleString : rules) {
+            Role role = roleService.findRole(roleType.getId());
+            Rule rule = new Rule(ruleString);
+            RolePermission rolePermission = roleService.findRolePermissionByRoleIdAndRule(roleType.getId(), ruleString);
+            if (rolePermission == null) {
+                LOG.debug("Inserting role permission for role: " + roleType.getId() + " and rule: " + ruleString);
+                roleService.createRolePermission(role, rule, RolePermissionEntity.Permission.ALLOW, null);
+            } else if (RolePermissionEntity.Permission.DENY.equals(rolePermission.getPermission())) {
+                LOG.debug("Updating role permission for role: " + roleType.getId() + " and rule: " + ruleString);
+                roleService.updateRolePermission(role, rolePermission, RolePermissionEntity.Permission.ALLOW);
             }
-        }
-    }
-
-    private void updateExistingRulePermission(Connection conn, RoleType roleType, String rule) {
-        LOG.debug("Updating permission rule for: " + rule + " and role: " + roleType.getId());
-        try {
-            PreparedStatement pstmt = conn.prepareStatement(updateAnnotationRulePermissionPreparedStatement);
-            pstmt.setLong(1, roleType.getId());
-            pstmt.setString(2, rule);
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            LOG.error("Error on insertAnnotationRulePermission: " + e.getMessage(), e);
-        }
-    }
-
-    private void insertAnnotationRulePermission(Connection conn, RoleType roleType, String rule) {
-        LOG.debug("Inserting permission rule for: " + rule + " and role: " + roleType.getId());
-        try {
-            PreparedStatement pstmt = conn.prepareStatement(insertAnnotationRulePermissionPreparedStatement);
-            pstmt.setLong(1, roleType.getId());
-            pstmt.setString(2, rule);
-            pstmt.executeQuery();
-        } catch (SQLException e) {
-            LOG.error("Error on insertAnnotationRulePermission: " + e.getMessage(), e);
         }
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41520to41600.java
@@ -73,10 +73,10 @@ public class Upgrade41520to41600 implements DbUpgrade, DbUpgradeSystemVmTemplate
         populateAnnotationPermissions(conn);
     }
 
-    private void generateAnnotationPermissions(Connection conn) {
+    private void populateAnnotationPermissions(Connection conn) {
         List<String> annotationRules = Arrays.asList("listAnnotations", "addAnnotation", "removeAnnotation");
         for (RoleType roleType : Arrays.asList(RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User)) {
-            checkAnnotationPermissionExists(conn, roleType, annotationRules);
+            checkAndPersistAnnotationPermissions(conn, roleType, annotationRules);
         }
     }
 

--- a/engine/schema/src/main/resources/META-INF/db/schema-41520to41600.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41520to41600.sql
@@ -727,17 +727,6 @@ CREATE TABLE `cloud`.`resource_icon` (
 
 ALTER TABLE `cloud`.`annotations` ADD COLUMN `admins_only` tinyint(1) unsigned NOT NULL DEFAULT 1;
 
--- Allow annotations for resource admins, domain admins and users
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'listAnnotations', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'addAnnotation', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'removeAnnotation', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'listAnnotations', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'addAnnotation', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'removeAnnotation', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'listAnnotations', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'addAnnotation', 'ALLOW');
-INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'removeAnnotation', 'ALLOW');
-
 -- Add uuid for ssh keypairs
 ALTER TABLE `cloud`.`ssh_keypairs` ADD COLUMN `uuid` varchar(40) AFTER `id`;
 

--- a/engine/schema/src/main/resources/META-INF/db/schema-41520to41600.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41520to41600.sql
@@ -728,15 +728,15 @@ CREATE TABLE `cloud`.`resource_icon` (
 ALTER TABLE `cloud`.`annotations` ADD COLUMN `admins_only` tinyint(1) unsigned NOT NULL DEFAULT 1;
 
 -- Allow annotations for resource admins, domain admins and users
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'listAnnotations', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'addAnnotation', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'removeAnnotation', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'listAnnotations', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'addAnnotation', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'removeAnnotation', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'listAnnotations', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'addAnnotation', 'ALLOW');
-INSERT INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'removeAnnotation', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'listAnnotations', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'addAnnotation', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 2, 'removeAnnotation', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'listAnnotations', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'addAnnotation', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 3, 'removeAnnotation', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'listAnnotations', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'addAnnotation', 'ALLOW');
+INSERT IGNORE INTO `cloud`.`role_permissions` (uuid, role_id, rule, permission) VALUES (UUID(), 4, 'removeAnnotation', 'ALLOW');
 
 -- Add uuid for ssh keypairs
 ALTER TABLE `cloud`.`ssh_keypairs` ADD COLUMN `uuid` varchar(40) AFTER `id`;


### PR DESCRIPTION
### Description

This PR prevents upgrade failures in the specific case in which the annotations are allowed as part of the role permissions for some roles.
Fixes: #5617 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Create a vanilla environment
- Upgrade a 4.15.2 environment without adding any role permission