### PR TITLE
ui: update vm haenable only for supported vms

### DIFF
--- a/ui/src/views/compute/EditVM.vue
+++ b/ui/src/views/compute/EditVM.vue
@@ -59,7 +59,7 @@
           v-decorator="['isdynamicallyscalable']"
           :disabled="!canDynamicScalingEnabled()" />
       </a-form-item>
-      <a-form-item>
+      <a-form-item v-if="serviceOffering ? serviceOffering.offerha : false">
         <tooltip-label slot="label" :title="$t('label.haenable')" :tooltip="apiParams.haenable.description"/>
         <a-switch
           :default-checked="resource.haenable"


### PR DESCRIPTION
### Description
Fixes #5743

For VMs which have service offering that does not allow HA, haenable option will be not shown in the UpdateVM UI form.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
VM with offering that doesn't offer HA
![Screenshot from 2022-01-11 12-55-14](https://user-images.githubusercontent.com/153340/148899008-d872f4fd-7310-424b-8688-75cabfd511b8.png)

VM with offering that offer HA
![Screenshot from 2022-01-11 12-55-55](https://user-images.githubusercontent.com/153340/148899022-12acbd0f-4d4b-408a-914c-a65b306b1390.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
