### PR TITLE
api, server: fix add-remove vpn user without vpn owner

### DIFF
--- a/api/src/main/java/com/cloud/network/vpn/RemoteAccessVpnService.java
+++ b/api/src/main/java/com/cloud/network/vpn/RemoteAccessVpnService.java
@@ -43,8 +43,6 @@ public interface RemoteAccessVpnService {
 
     List<? extends VpnUser> listVpnUsers(long vpnOwnerId, String userName);
 
-    void removeVpnUserWithoutValidVpnOwner(long id);
-
     boolean applyVpnUsers(long vpnOwnerId, String userName, boolean forRemove) throws ResourceUnavailableException;
 
     boolean applyVpnUsers(long vpnOwnerId, String userName) throws ResourceUnavailableException;

--- a/api/src/main/java/com/cloud/network/vpn/RemoteAccessVpnService.java
+++ b/api/src/main/java/com/cloud/network/vpn/RemoteAccessVpnService.java
@@ -43,6 +43,10 @@ public interface RemoteAccessVpnService {
 
     List<? extends VpnUser> listVpnUsers(long vpnOwnerId, String userName);
 
+    void removeVpnUserWithoutValidVpnOwner(long id);
+
+    boolean applyVpnUsers(long vpnOwnerId, String userName, boolean forRemove) throws ResourceUnavailableException;
+
     boolean applyVpnUsers(long vpnOwnerId, String userName) throws ResourceUnavailableException;
 
     Pair<List<? extends RemoteAccessVpn>, Integer> searchForRemoteAccessVpns(ListRemoteAccessVpnsCmd cmd);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
@@ -121,7 +121,6 @@ public class AddVpnUserCmd extends BaseAsyncCreateCmd {
         Account account = _entityMgr.findById(Account.class, vpnUser.getAccountId());
         try {
             if (!_ravService.applyVpnUsers(vpnUser.getAccountId(), userName)) {
-                _ravService.removeVpnUserWithoutValidVpnOwner(vpnUser.getId());
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user");
             }
         } catch (Exception ex) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
@@ -121,6 +121,7 @@ public class AddVpnUserCmd extends BaseAsyncCreateCmd {
         Account account = _entityMgr.findById(Account.class, vpnUser.getAccountId());
         try {
             if (!_ravService.applyVpnUsers(vpnUser.getAccountId(), userName)) {
+                _ravService.removeVpnUserWithoutValidVpnOwner(vpnUser.getId());
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user");
             }
         } catch (Exception ex) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/RemoveVpnUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/RemoveVpnUserCmd.java
@@ -120,9 +120,8 @@ public class RemoveVpnUserCmd extends BaseAsyncCmd {
         }
 
         boolean appliedVpnUsers = false;
-
         try {
-            appliedVpnUsers = _ravService.applyVpnUsers(ownerId, userName);
+            appliedVpnUsers = _ravService.applyVpnUsers(ownerId, userName, true);
         } catch (ResourceUnavailableException ex) {
             String errorMessage = String.format("Failed to refresh VPN user=[%s] due to resource unavailable. VPN owner id=[%s].", userName, ownerId);
             s_logger.error(errorMessage, ex);

--- a/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -532,12 +532,6 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
     @DB
     @Override
-    public void removeVpnUserWithoutValidVpnOwner(long id) {
-        _vpnUsersDao.remove(id);
-    }
-
-    @DB
-    @Override
     public boolean applyVpnUsers(long vpnOwnerId, String userName, boolean forRemove) throws  ResourceUnavailableException {
         Account caller = CallContext.current().getCallingAccount();
         Account owner = _accountDao.findById(vpnOwnerId);

--- a/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -16,15 +16,15 @@
 // under the License.
 package com.cloud.network.vpn;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
-
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.command.user.vpn.ListRemoteAccessVpnsCmd;
@@ -33,6 +33,8 @@ import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.domain.DomainVO;
@@ -91,9 +93,6 @@ import com.cloud.utils.db.TransactionCallbackWithException;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
-import java.lang.reflect.InvocationTargetException;
-import java.util.stream.Collectors;
-import org.apache.commons.collections.CollectionUtils;
 
 public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAccessVpnService, Configurable {
     private final static Logger s_logger = Logger.getLogger(RemoteAccessVpnManagerImpl.class);
@@ -500,8 +499,28 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
     }
 
     @DB
+    private boolean removeVpnUserWithoutRemoteAccessVpn(long vpnOwnerId, String userName) {
+        VpnUserVO vpnUser = _vpnUsersDao.findByAccountAndUsername(vpnOwnerId, userName);
+        if (vpnUser == null) {
+            s_logger.error(String.format("VPN user not found with ownerId: %d and username: %s", vpnOwnerId, userName));
+            return false;
+        }
+        if (!State.Revoke.equals(vpnUser.getState())) {
+            s_logger.error(String.format("VPN user with ownerId: %d and username: %s is not in revoked state, current state: %s", vpnOwnerId, userName, vpnUser.getState()));
+            return false;
+        }
+        return _vpnUsersDao.remove(vpnUser.getId());
+    }
+
+    @DB
     @Override
-    public boolean applyVpnUsers(long vpnOwnerId, String userName) throws  ResourceUnavailableException {
+    public void removeVpnUserWithoutValidVpnOwner(long id) {
+        _vpnUsersDao.remove(id);
+    }
+
+    @DB
+    @Override
+    public boolean applyVpnUsers(long vpnOwnerId, String userName, boolean forRemove) throws  ResourceUnavailableException {
         Account caller = CallContext.current().getCallingAccount();
         Account owner = _accountDao.findById(vpnOwnerId);
         _accountMgr.checkAccess(caller, null, true, owner);
@@ -510,7 +529,10 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
         List<RemoteAccessVpnVO> vpns = _remoteAccessVpnDao.findByAccount(vpnOwnerId);
 
         if (CollectionUtils.isEmpty(vpns)) {
-            s_logger.debug(String.format("Unable to add VPN user due to there are no remote access VPNs configured on %s to apply VPN user.", owner.toString()));
+            if (forRemove) {
+                return removeVpnUserWithoutRemoteAccessVpn(vpnOwnerId, userName);
+            }
+            s_logger.error(String.format("Unable to add VPN user due to there are no remote access VPNs configured on %s to apply VPN user.", owner.toString()));
             return false;
         }
 
@@ -595,6 +617,12 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
         }
 
         return success;
+    }
+
+    @DB
+    @Override
+    public boolean applyVpnUsers(long vpnOwnerId, String userName) throws  ResourceUnavailableException {
+        return applyVpnUsers(vpnOwnerId, userName, false);
     }
 
     @Override

--- a/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -142,10 +142,13 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
         if (CollectionUtils.isNotEmpty(vpns)) {
             List<RemoteAccessVpnVO> validVpns = new ArrayList<>();
             for (RemoteAccessVpnVO vpn : vpns) {
-                Network network = _networkMgr.getNetwork(vpn.getNetworkId());
-                if (Network.State.Implemented.equals(network.getState())) {
-                    validVpns.add(vpn);
+                if (vpn.getNetworkId() != null) {
+                    Network network = _networkMgr.getNetwork(vpn.getNetworkId());
+                    if (!Network.State.Implemented.equals(network.getState())) {
+                        continue;
+                    }
                 }
+                validVpns.add(vpn);
             }
             vpns = validVpns;
         }


### PR DESCRIPTION
### Description

Fixes #5711

- When the owner account does not have VPN access, VPN user should be added in Add state
- While removing VPN user when the owner account has no VPN, VPN user should be deleted from the database.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
