### PR TITLE
server: find suitable disk offering for volume upload

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/dao/DiskOfferingDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/DiskOfferingDao.java
@@ -34,4 +34,6 @@ public interface DiskOfferingDao extends GenericDao<DiskOfferingVO, Long> {
 
     List<DiskOfferingVO> listAllBySizeAndProvisioningType(long size, Storage.ProvisioningType provisioningType);
 
+    List<DiskOfferingVO> findCustomDiskOfferings();
+
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/DiskOfferingDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/DiskOfferingDaoImpl.java
@@ -29,6 +29,7 @@ import javax.persistence.EntityExistsException;
 import org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDao;
 import org.springframework.stereotype.Component;
 
+import com.cloud.offering.DiskOffering;
 import com.cloud.offering.DiskOffering.Type;
 import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.Storage;
@@ -171,6 +172,18 @@ public class DiskOfferingDaoImpl extends GenericDaoBase<DiskOfferingVO, Long> im
         } catch (SQLException e) {
             throw new CloudRuntimeException("Exception while listing disk offerings by size: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public List<DiskOfferingVO> findCustomDiskOfferings() {
+        SearchBuilder<DiskOfferingVO> sb = createSearchBuilder();
+        sb.and("type", sb.entity().getType(), SearchCriteria.Op.EQ);
+        sb.and("customized", sb.entity().isCustomized(), SearchCriteria.Op.EQ);
+        sb.done();
+        SearchCriteria<DiskOfferingVO> sc = sb.create();
+        sc.setParameters("customized", true);
+        sc.setParameters("type", DiskOffering.Type.Disk.toString());
+        return listBy(sc);
     }
 
     @Override

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
@@ -30,8 +30,6 @@ public interface DiskOfferingJoinDao extends GenericDao<DiskOfferingJoinVO, Long
 
     List<DiskOfferingJoinVO> findByZoneId(long zoneId);
 
-    List<DiskOfferingJoinVO> findCustomDiskOfferingsByZoneId(long zoneId);
-
     DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO dof);
 
     DiskOfferingJoinVO newDiskOfferingView(DiskOffering dof);

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
@@ -30,7 +30,7 @@ public interface DiskOfferingJoinDao extends GenericDao<DiskOfferingJoinVO, Long
 
     List<DiskOfferingJoinVO> findByZoneId(long zoneId);
 
-    List<DiskOfferingJoinVO> findCustomOfferingsByZoneId(long zoneId);
+    List<DiskOfferingJoinVO> findCustomDiskOfferingsByZoneId(long zoneId);
 
     DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO dof);
 

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
@@ -30,6 +30,8 @@ public interface DiskOfferingJoinDao extends GenericDao<DiskOfferingJoinVO, Long
 
     List<DiskOfferingJoinVO> findByZoneId(long zoneId);
 
+    List<DiskOfferingJoinVO> findCustomIopsOfferingsByZoneId(long zoneId);
+
     DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO dof);
 
     DiskOfferingJoinVO newDiskOfferingView(DiskOffering dof);

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDao.java
@@ -30,7 +30,7 @@ public interface DiskOfferingJoinDao extends GenericDao<DiskOfferingJoinVO, Long
 
     List<DiskOfferingJoinVO> findByZoneId(long zoneId);
 
-    List<DiskOfferingJoinVO> findCustomIopsOfferingsByZoneId(long zoneId);
+    List<DiskOfferingJoinVO> findCustomOfferingsByZoneId(long zoneId);
 
     DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO dof);
 

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
@@ -90,15 +90,15 @@ public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, 
     }
 
     @Override
-    public List<DiskOfferingJoinVO> findCustomIopsOfferingsByZoneId(long zoneId) {
+    public List<DiskOfferingJoinVO> findCustomOfferingsByZoneId(long zoneId) {
         SearchBuilder<DiskOfferingJoinVO> sb = createSearchBuilder();
         sb.and("zoneId", sb.entity().getZoneId(), SearchCriteria.Op.FIND_IN_SET);
-        sb.and("customizedIops", sb.entity().isCustomized(), SearchCriteria.Op.EQ);
+        sb.and("customized", sb.entity().isCustomized(), SearchCriteria.Op.EQ);
         sb.done();
 
         SearchCriteria<DiskOfferingJoinVO> sc = sb.create();
         sc.setParameters("zoneId", String.valueOf(zoneId));
-        sc.setParameters("customizedIops", true);
+        sc.setParameters("customized", true);
         return listBy(sc);
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
@@ -19,11 +19,8 @@ package com.cloud.api.query.dao;
 import java.util.List;
 import java.util.Map;
 
-import com.cloud.api.ApiDBUtils;
-import com.cloud.dc.VsphereStoragePolicyVO;
-import com.cloud.dc.dao.VsphereStoragePolicyDao;
-import com.cloud.server.ResourceTag;
-import com.cloud.user.AccountManager;
+import javax.inject.Inject;
+
 import org.apache.cloudstack.annotation.AnnotationService;
 import org.apache.cloudstack.annotation.dao.AnnotationDao;
 import org.apache.cloudstack.api.ApiConstants;
@@ -32,15 +29,18 @@ import org.apache.cloudstack.context.CallContext;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
+import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.vo.DiskOfferingJoinVO;
+import com.cloud.dc.VsphereStoragePolicyVO;
+import com.cloud.dc.dao.VsphereStoragePolicyDao;
 import com.cloud.offering.DiskOffering;
 import com.cloud.offering.ServiceOffering;
+import com.cloud.server.ResourceTag;
+import com.cloud.user.AccountManager;
 import com.cloud.utils.db.Attribute;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
-
-import javax.inject.Inject;
 
 @Component
 public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, Long> implements DiskOfferingJoinDao {
@@ -86,6 +86,19 @@ public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, 
 
         SearchCriteria<DiskOfferingJoinVO> sc = sb.create();
         sc.setParameters("zoneId", String.valueOf(zoneId));
+        return listBy(sc);
+    }
+
+    @Override
+    public List<DiskOfferingJoinVO> findCustomIopsOfferingsByZoneId(long zoneId) {
+        SearchBuilder<DiskOfferingJoinVO> sb = createSearchBuilder();
+        sb.and("zoneId", sb.entity().getZoneId(), SearchCriteria.Op.FIND_IN_SET);
+        sb.and("customizedIops", sb.entity().isCustomized(), SearchCriteria.Op.EQ);
+        sb.done();
+
+        SearchCriteria<DiskOfferingJoinVO> sc = sb.create();
+        sc.setParameters("zoneId", String.valueOf(zoneId));
+        sc.setParameters("customizedIops", true);
         return listBy(sc);
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
@@ -90,15 +90,19 @@ public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, 
     }
 
     @Override
-    public List<DiskOfferingJoinVO> findCustomOfferingsByZoneId(long zoneId) {
+    public List<DiskOfferingJoinVO> findCustomDiskOfferingsByZoneId(long zoneId) {
         SearchBuilder<DiskOfferingJoinVO> sb = createSearchBuilder();
-        sb.and("zoneId", sb.entity().getZoneId(), SearchCriteria.Op.FIND_IN_SET);
+        sb.and("type", sb.entity().getType(), SearchCriteria.Op.EQ);
         sb.and("customized", sb.entity().isCustomized(), SearchCriteria.Op.EQ);
+        sb.and().op("zoneId", sb.entity().getZoneId(), SearchCriteria.Op.FIND_IN_SET);
+        sb.or("zoneIdNull", sb.entity().getZoneId(), SearchCriteria.Op.NULL);
+        sb.cp();
         sb.done();
 
         SearchCriteria<DiskOfferingJoinVO> sc = sb.create();
         sc.setParameters("zoneId", String.valueOf(zoneId));
         sc.setParameters("customized", true);
+        sc.setParameters("type", DiskOffering.Type.Disk.toString());
         return listBy(sc);
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
@@ -90,23 +90,6 @@ public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, 
     }
 
     @Override
-    public List<DiskOfferingJoinVO> findCustomDiskOfferingsByZoneId(long zoneId) {
-        SearchBuilder<DiskOfferingJoinVO> sb = createSearchBuilder();
-        sb.and("type", sb.entity().getType(), SearchCriteria.Op.EQ);
-        sb.and("customized", sb.entity().isCustomized(), SearchCriteria.Op.EQ);
-        sb.and().op("zoneId", sb.entity().getZoneId(), SearchCriteria.Op.FIND_IN_SET);
-        sb.or("zoneIdNull", sb.entity().getZoneId(), SearchCriteria.Op.NULL);
-        sb.cp();
-        sb.done();
-
-        SearchCriteria<DiskOfferingJoinVO> sc = sb.create();
-        sc.setParameters("zoneId", String.valueOf(zoneId));
-        sc.setParameters("customized", true);
-        sc.setParameters("type", DiskOffering.Type.Disk.toString());
-        return listBy(sc);
-    }
-
-    @Override
     public DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO offering) {
 
         DiskOfferingResponse diskOfferingResponse = new DiskOfferingResponse();

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -498,12 +498,14 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         DiskOfferingVO diskOfferingVO = _diskOfferingDao.findByUniqueName("Cloud.com-Custom");
         if (diskOfferingVO != null) {
             DiskOfferingJoinVO diskOfferingJoinVO = diskOfferingJoinDao.findById(diskOfferingVO.getId());
-            if (diskOfferingJoinVO != null && org.apache.commons.lang3.StringUtils.isEmpty(diskOfferingJoinVO.getZoneId())) {
-                return diskOfferingJoinVO.getId();
-            }
-            List<String> zoneIds = Arrays.stream(diskOfferingJoinVO.getZoneId().split(",")).collect(Collectors.toList());
-            if (zoneIds.contains(String.valueOf(zoneId))) {
-                return diskOfferingJoinVO.getId();
+            if (diskOfferingJoinVO != null) {
+                if (org.apache.commons.lang3.StringUtils.isEmpty(diskOfferingJoinVO.getZoneId())) {
+                    return diskOfferingJoinVO.getId();
+                }
+                List<String> zoneIds = Arrays.stream(diskOfferingJoinVO.getZoneId().split(",")).collect(Collectors.toList());
+                if (zoneIds.contains(String.valueOf(zoneId))) {
+                    return diskOfferingJoinVO.getId();
+                }
             }
         }
         List<DiskOfferingJoinVO> offerings = diskOfferingJoinDao.findCustomIopsOfferingsByZoneId(zoneId);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -497,7 +497,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         return UUID.randomUUID().toString();
     }
 
-    private Long getDefaultCustomOffering(long zoneId) {
+    private Long getDefaultCustomOfferingId(long zoneId) {
         DiskOfferingVO diskOfferingVO = _diskOfferingDao.findByUniqueName(CUSTOM_DISK_OFFERING_UNIQUE_NAME);
         if (diskOfferingVO == null || !DiskOffering.State.Active.equals(diskOfferingVO.getState())) {
             return null;
@@ -516,8 +516,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         return null;
     }
 
-    private Long getCustomDiskOfferingForVolumeUpload(long zoneId) {
-        Long offeringId = getDefaultCustomOffering(zoneId);
+    private Long getCustomDiskOfferingIdForVolumeUpload(long zoneId) {
+        Long offeringId = getDefaultCustomOfferingId(zoneId);
         if (offeringId != null) {
             return offeringId;
         }
@@ -544,7 +544,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 volume.setDomainId((owner == null) ? Domain.ROOT_DOMAIN : owner.getDomainId());
 
                 if (diskOfferingId == null) {
-                    Long customDiskOfferingId = getCustomDiskOfferingForVolumeUpload(zoneId);
+                    Long customDiskOfferingId = getCustomDiskOfferingIdForVolumeUpload(zoneId);
                     if (customDiskOfferingId == null) {
                         DataCenter zone = _dcDao.findById(zoneId);
                         throw new CloudRuntimeException(String.format("Unable to find custom disk offering in zone: %s for volume upload", zone.getUuid()));

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -486,13 +486,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             if (!diskOffering.isCustomized()) {
                 throw new InvalidParameterValueException("Please specify a custom sized disk offering.");
             }
-            DiskOfferingJoinVO diskOfferingJoinVO = diskOfferingJoinDao.findById(diskOfferingId);
-            if (!org.apache.commons.lang3.StringUtils.isEmpty(diskOfferingJoinVO.getZoneId())) {
-                List<String> zoneIds = Arrays.stream(diskOfferingJoinVO.getZoneId().split(",")).collect(Collectors.toList());
-                if (!zoneIds.contains(String.valueOf(zoneId))) {
-                    throw new InvalidParameterValueException("Please specify a custom sized disk offering available in the zone.");
-                }
-            }
             _configMgr.checkDiskOfferingAccess(volumeOwner, diskOffering, zone);
         }
 

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -498,7 +498,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         DiskOfferingVO diskOfferingVO = _diskOfferingDao.findByUniqueName("Cloud.com-Custom");
         if (diskOfferingVO != null) {
             DiskOfferingJoinVO diskOfferingJoinVO = diskOfferingJoinDao.findById(diskOfferingVO.getId());
-            if (org.apache.commons.lang3.StringUtils.isEmpty(diskOfferingJoinVO.getZoneId())) {
+            if (diskOfferingJoinVO != null && org.apache.commons.lang3.StringUtils.isEmpty(diskOfferingJoinVO.getZoneId())) {
                 return diskOfferingJoinVO.getId();
             }
             List<String> zoneIds = Arrays.stream(diskOfferingJoinVO.getZoneId().split(",")).collect(Collectors.toList());

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -486,7 +486,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             if (!diskOffering.isCustomized()) {
                 throw new InvalidParameterValueException("Please specify a custom sized disk offering.");
             }
-
+            DiskOfferingJoinVO diskOfferingJoinVO = diskOfferingJoinDao.findById(diskOfferingId);
+            if (!org.apache.commons.lang3.StringUtils.isEmpty(diskOfferingJoinVO.getZoneId())) {
+                List<String> zoneIds = Arrays.stream(diskOfferingJoinVO.getZoneId().split(",")).collect(Collectors.toList());
+                if (!zoneIds.contains(String.valueOf(zoneId))) {
+                    throw new InvalidParameterValueException("Please specify a custom sized disk offering available in the zone.");
+                }
+            }
             _configMgr.checkDiskOfferingAccess(volumeOwner, diskOffering, zone);
         }
 
@@ -521,7 +527,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (offeringId != null) {
             return offeringId;
         }
-        List<DiskOfferingJoinVO> offerings = diskOfferingJoinDao.findCustomOfferingsByZoneId(zoneId);
+        List<DiskOfferingJoinVO> offerings = diskOfferingJoinDao.findCustomDiskOfferingsByZoneId(zoneId);
         if (CollectionUtils.isNotEmpty(offerings)) {
             return offerings.get(0).getId();
         }

--- a/ui/src/views/storage/UploadLocalVolume.vue
+++ b/ui/src/views/storage/UploadLocalVolume.vue
@@ -69,13 +69,30 @@
             optionFilterProp="children"
             :filterOption="(input, option) => {
               return option.componentOptions.propsData.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
-            }" >
+            }"
+            @change="onZoneChange" >
             <a-select-option :value="zone.id" v-for="zone in zones" :key="zone.id" :label="zone.name || zone.description">
               <span>
                 <resource-icon v-if="zone.icon" :image="zone.icon.base64image" size="1x" style="margin-right: 5px"/>
                 <a-icon v-else type="global" style="margin-right: 5px"/>
                 {{ zone.name || zone.description }}
               </span>
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+        <a-form-item>
+          <tooltip-label slot="label" :title="$t('label.diskofferingid')" :tooltip="apiParams.diskofferingid.description"/>
+          <a-select
+            v-decorator="['diskofferingid', {}]"
+            :loading="offeringLoading"
+            :placeholder="apiParams.diskofferingid.description"
+            showSearch
+            optionFilterProp="children"
+            :filterOption="(input, option) => {
+              return option.componentOptions.propsData.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            }" >
+            <a-select-option v-for="opt in offerings" :key="opt.id">
+              {{ opt.displaytext || opt.name }}
             </a-select-option>
           </a-select>
         </a-form-item>
@@ -133,6 +150,8 @@ export default {
     return {
       fileList: [],
       zones: [],
+      offerings: [],
+      offeringLoading: false,
       formats: ['RAW', 'VHD', 'VHDX', 'OVA', 'QCOW2'],
       zoneSelected: '',
       uploadParams: null,
@@ -153,9 +172,32 @@ export default {
         if (json && json.listzonesresponse && json.listzonesresponse.zone) {
           this.zones = json.listzonesresponse.zone
           if (this.zones.length > 0) {
-            this.zoneSelected = this.zones[0].id
+            this.onZoneChange(this.zones[0].id)
           }
         }
+      })
+    },
+    onZoneChange (zoneId) {
+      this.zoneSelected = this.zones[0].id
+      this.fetchDiskOfferings(zoneId)
+    },
+    fetchDiskOfferings (zoneId) {
+      this.offeringLoading = true
+      this.offerings = [{ id: -1, name: '' }]
+      this.form.setFieldsValue({
+        diskofferingid: undefined
+      })
+      api('listDiskOfferings', {
+        zoneid: zoneId,
+        listall: true
+      }).then(json => {
+        for (var offering of json.listdiskofferingsresponse.diskoffering) {
+          if (offering.iscustomized) {
+            this.offerings.push(offering)
+          }
+        }
+      }).finally(() => {
+        this.offeringLoading = false
       })
     },
     handleRemove (file) {
@@ -188,7 +230,7 @@ export default {
         }
         this.loading = true
         api('getUploadParamsForVolume', params).then(json => {
-          this.uploadParams = (json.postuploadvolumeresponse && json.postuploadvolumeresponse.getuploadparams) ? json.postuploadvolumeresponse.getuploadparams : ''
+          this.uploadParams = json.postuploadvolumeresponse?.getuploadparams || ''
           const { fileList } = this
           if (this.fileList.length > 1) {
             this.$notification.error({
@@ -224,12 +266,20 @@ export default {
           }).catch(e => {
             this.$notification.error({
               message: this.$t('message.upload.failed'),
-              description: `${this.$t('message.upload.iso.failed.description')} -  ${e}`,
+              description: `${this.$t('message.upload.volume.failed')} -  ${e}`,
               duration: 0
             })
           }).finally(() => {
             this.loading = false
           })
+        }).catch(e => {
+          this.$notification.error({
+            message: this.$t('message.upload.failed'),
+            description: `${this.$t('message.upload.volume.failed')} -  ${e?.response?.data?.postuploadvolumeresponse?.errortext || e}`,
+            duration: 0
+          })
+        }).finally(() => {
+          this.loading = false
         })
       })
     },

--- a/ui/src/views/storage/UploadLocalVolume.vue
+++ b/ui/src/views/storage/UploadLocalVolume.vue
@@ -92,7 +92,7 @@
               return option.componentOptions.propsData.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
             }" >
             <a-select-option v-for="opt in offerings" :key="opt.id">
-              {{ opt.displaytext || opt.name }}
+              {{ opt.name || opt.displaytext }}
             </a-select-option>
           </a-select>
         </a-form-item>


### PR DESCRIPTION
### Description

Fixes #5696

- Find suitable custom disk offering for volume upload based on the zone.
- In UI, added diskoffering option in Upload volume from local.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![Screenshot from 2022-01-28 13-47-08](https://user-images.githubusercontent.com/153340/151511778-c8aea8d8-8650-4fc4-aef2-ec54b0b09fa6.png)


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- Deployed an env with 2 zones
- _Tested volume upload local/url without passing diskoffering_ 
- Deleted default custom disk offering, created two separate custom disk offerings for the two zones and then:

1. Tested local/url volume upload to both zones, one by one without passing offering
2. Tested local/url  volume upload to both zones, one by one while passing offering
3. Tested local/url  volume upload to first zone while passing offering offering from second zone


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
