### PR TITLE
api,api-discovery,ui: improve listAPIs and login

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/acl/APIChecker.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/APIChecker.java
@@ -23,11 +23,13 @@ import com.cloud.utils.component.Adapter;
 
 // APIChecker checks the ownership and access control to API requests
 public interface APIChecker extends Adapter {
+    boolean isEnabled();
+
     // Interface for checking access for a role using apiname
     // If true, apiChecker has checked the operation
     // If false, apiChecker is unable to handle the operation or not implemented
     // On exception, checkAccess failed don't allow
     boolean checkAccess(User user, String apiCommandName) throws PermissionDeniedException;
 
-    boolean checkAccess(Account account, User user, String apiCommandName, Role role) throws PermissionDeniedException;
+    boolean checkAccessWithoutEnabledCheck(Account account, User user, String apiCommandName, Role role) throws PermissionDeniedException;
 }

--- a/api/src/main/java/org/apache/cloudstack/acl/APIChecker.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/APIChecker.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.acl;
 
 import com.cloud.exception.PermissionDeniedException;
+import com.cloud.user.Account;
 import com.cloud.user.User;
 import com.cloud.utils.component.Adapter;
 
@@ -27,4 +28,6 @@ public interface APIChecker extends Adapter {
     // If false, apiChecker is unable to handle the operation or not implemented
     // On exception, checkAccess failed don't allow
     boolean checkAccess(User user, String apiCommandName) throws PermissionDeniedException;
+
+    boolean checkAccess(Account account, User user, String apiCommandName, Role role) throws PermissionDeniedException;
 }

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -376,6 +376,7 @@ public class ApiConstants {
     public static final String TIMEOUT = "timeout";
     public static final String TIMEZONE = "timezone";
     public static final String TIMEZONEOFFSET = "timezoneoffset";
+    public static final String TRIM = "trim";
     public static final String TYPE = "type";
     public static final String TRUST_STORE = "truststore";
     public static final String TRUST_STORE_PASSWORD = "truststorepass";

--- a/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
@@ -76,6 +76,14 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
         }
 
         final Role accountRole = roleService.findRole(account.getRoleId());
+        return checkAccess(account, user, commandName, accountRole);
+    }
+
+    @Override
+    public boolean checkAccess(Account account, User user, String commandName, Role accountRole) throws PermissionDeniedException {
+        if (isDisabled()) {
+            return true;
+        }
         if (accountRole == null || accountRole.getId() < 1L) {
             denyApiAccess(commandName);
         }

--- a/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
@@ -61,13 +61,14 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
         throw new PermissionDeniedException("The API " + commandName + " is denied for the account's role.");
     }
 
-    public boolean isDisabled() {
-        return !roleService.isEnabled();
+    @Override
+    public boolean isEnabled() {
+        return roleService.isEnabled();
     }
 
     @Override
     public boolean checkAccess(User user, String commandName) throws PermissionDeniedException {
-        if (isDisabled()) {
+        if (!isEnabled()) {
             return true;
         }
         Account account = accountService.getAccount(user.getAccountId());
@@ -76,14 +77,11 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
         }
 
         final Role accountRole = roleService.findRole(account.getRoleId());
-        return checkAccess(account, user, commandName, accountRole);
+        return checkAccessWithoutEnabledCheck(account, user, commandName, accountRole);
     }
 
     @Override
-    public boolean checkAccess(Account account, User user, String commandName, Role accountRole) throws PermissionDeniedException {
-        if (isDisabled()) {
-            return true;
-        }
+    public boolean checkAccessWithoutEnabledCheck(Account account, User user, String commandName, Role accountRole) throws PermissionDeniedException {
         if (accountRole == null || accountRole.getId() < 1L) {
             denyApiAccess(commandName);
         }

--- a/plugins/acl/dynamic-role-based/src/test/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessCheckerTest.java
+++ b/plugins/acl/dynamic-role-based/src/test/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessCheckerTest.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.acl;
 import java.lang.reflect.Field;
 import java.util.Collections;
 
+import org.apache.cloudstack.acl.RolePermissionEntity.Permission;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +33,6 @@ import com.cloud.user.AccountService;
 import com.cloud.user.AccountVO;
 import com.cloud.user.User;
 import com.cloud.user.UserVO;
-
-import org.apache.cloudstack.acl.RolePermissionEntity.Permission;
 
 import junit.framework.TestCase;
 
@@ -77,7 +76,7 @@ public class DynamicRoleBasedAPIAccessCheckerTest extends TestCase {
         Mockito.when(roleService.findRole(Mockito.anyLong())).thenReturn((RoleVO) getTestRole());
 
         // Enabled plugin
-        Mockito.doReturn(false).when(apiAccessChecker).isDisabled();
+        Mockito.doReturn(true).when(apiAccessChecker).isEnabled();
         Mockito.doCallRealMethod().when(apiAccessChecker).checkAccess(Mockito.any(User.class), Mockito.anyString());
     }
 

--- a/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
+++ b/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
@@ -60,7 +60,7 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
 
     @Override
     public boolean isEnabled() {
-        return !roleService.isEnabled();
+        return roleService.isEnabled();
     }
 
     @Override

--- a/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
+++ b/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
@@ -70,6 +70,14 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
         }
 
         Account userAccount = accountService.getAccount(user.getAccountId());
+        return checkAccess(userAccount, user, apiCommandName, null);
+    }
+
+    @Override
+    public boolean checkAccess(Account userAccount, User user, String apiCommandName, Role role) throws PermissionDeniedException {
+        if (isDisabled()) {
+            return true;
+        }
         Project project = CallContext.current().getProject();
         if (project == null) {
             return true;

--- a/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
+++ b/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
@@ -58,26 +58,23 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
         throw new PermissionDeniedException("The API " + commandName + " is denied for the user's/account's project role.");
     }
 
-
-    public boolean isDisabled() {
+    @Override
+    public boolean isEnabled() {
         return !roleService.isEnabled();
     }
 
     @Override
     public boolean checkAccess(User user, String apiCommandName) throws PermissionDeniedException {
-        if (isDisabled()) {
+        if (!isEnabled()) {
             return true;
         }
 
         Account userAccount = accountService.getAccount(user.getAccountId());
-        return checkAccess(userAccount, user, apiCommandName, null);
+        return checkAccessWithoutEnabledCheck(userAccount, user, apiCommandName, null);
     }
 
     @Override
-    public boolean checkAccess(Account userAccount, User user, String apiCommandName, Role role) throws PermissionDeniedException {
-        if (isDisabled()) {
-            return true;
-        }
+    public boolean checkAccessWithoutEnabledCheck(Account userAccount, User user, String apiCommandName, Role role) throws PermissionDeniedException {
         Project project = CallContext.current().getProject();
         if (project == null) {
             return true;

--- a/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -64,13 +64,14 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
         }
     }
 
-    public boolean isDisabled() {
-        return roleService.isEnabled();
+    @Override
+    public boolean isEnabled() {
+        return !roleService.isEnabled();
     }
 
     @Override
     public boolean checkAccess(User user, String commandName) throws PermissionDeniedException {
-        if (isDisabled()) {
+        if (!isEnabled()) {
             return true;
         }
 
@@ -80,14 +81,11 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
         }
 
         final Role accountRole = roleService.findRole(account.getRoleId());
-        return checkAccess(account, user, commandName, accountRole);
+        return checkAccessWithoutEnabledCheck(account, user, commandName, accountRole);
     }
 
     @Override
-    public boolean checkAccess(Account account, User user, String commandName, Role accountRole) throws PermissionDeniedException {
-        if (isDisabled()) {
-            return true;
-        }
+    public boolean checkAccessWithoutEnabledCheck(Account account, User user, String commandName, Role accountRole) throws PermissionDeniedException {
         RoleType roleType = accountRole.getRoleType();
         boolean isAllowed =
                 commandsPropertiesOverrides.contains(commandName) ? commandsPropertiesRoleBasedApisMap.get(roleType).contains(commandName) : annotationRoleBasedApisMap.get(

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/command/user/discovery/ListApisCmd.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/command/user/discovery/ListApisCmd.java
@@ -52,7 +52,7 @@ public class ListApisCmd extends BaseCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "API name")
     private String name;
 
-    @Parameter(name = ApiConstants.TRIM, type = CommandType.BOOLEAN, description = "To return response parameter in API response or not", since = "4.16.1")
+    @Parameter(name = ApiConstants.TRIM, type = CommandType.BOOLEAN, description = "To return only API names or not", since = "4.16.1")
     private Boolean trim;
 
     @Override

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/command/user/discovery/ListApisCmd.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/command/user/discovery/ListApisCmd.java
@@ -18,9 +18,8 @@ package org.apache.cloudstack.api.command.user.discovery;
 
 import javax.inject.Inject;
 
+import org.apache.cloudstack.acl.Role;
 import org.apache.cloudstack.acl.RoleType;
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -31,7 +30,9 @@ import org.apache.cloudstack.api.response.ApiDiscoveryResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.discovery.ApiDiscoveryService;
+import org.apache.log4j.Logger;
 
+import com.cloud.user.Account;
 import com.cloud.user.User;
 
 @APICommand(name = "listApis",
@@ -51,11 +52,16 @@ public class ListApisCmd extends BaseCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "API name")
     private String name;
 
+    @Parameter(name = ApiConstants.TRIM, type = CommandType.BOOLEAN, description = "To return response parameter in API response or not", since = "4.16.1")
+    private Boolean trim;
+
     @Override
     public void execute() throws ServerApiException {
         if (_apiDiscoveryService != null) {
             User user = CallContext.current().getCallingUser();
-            ListResponse<ApiDiscoveryResponse> response = (ListResponse<ApiDiscoveryResponse>)_apiDiscoveryService.listApis(user, name);
+            Account account = CallContext.current().getCallingAccount();
+            Role role = roleService.findRole(account.getRoleId());
+            ListResponse<ApiDiscoveryResponse> response = (ListResponse<ApiDiscoveryResponse>) _apiDiscoveryService.listApis(account, user, name, role, Boolean.TRUE.equals(trim));
             if (response == null) {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Api Discovery plugin was unable to find an api by that name or process any apis");
             }

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/response/ApiDiscoveryResponse.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/response/ApiDiscoveryResponse.java
@@ -16,13 +16,14 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.cloud.serializer.Param;
-import com.google.gson.annotations.SerializedName;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 
-import java.util.HashSet;
-import java.util.Set;
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 @SuppressWarnings("unused")
 public class ApiDiscoveryResponse extends BaseResponse {
@@ -57,6 +58,10 @@ public class ApiDiscoveryResponse extends BaseResponse {
     @SerializedName(ApiConstants.TYPE)
     @Param(description = "response field type")
     private String type;
+
+    public ApiDiscoveryResponse(String name) {
+        this.name = name;
+    }
 
     public ApiDiscoveryResponse() {
         params = new HashSet<ApiParameterResponse>();

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryService.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryService.java
@@ -16,12 +16,14 @@
 // under the License.
 package org.apache.cloudstack.discovery;
 
+import org.apache.cloudstack.acl.Role;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 
+import com.cloud.user.Account;
 import com.cloud.user.User;
 import com.cloud.utils.component.PluggableService;
 
 public interface ApiDiscoveryService extends PluggableService {
-    ListResponse<? extends BaseResponse> listApis(User user, String apiName);
+    ListResponse<? extends BaseResponse> listApis(Account account, User user, String apiName, Role role, boolean trim);
 }

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -217,13 +217,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         if (!trim) {
             return response;
         }
-        ApiDiscoveryResponse r = new ApiDiscoveryResponse();
-        r.setName(response.getName());
-        r.setDescription(response.getDescription());
-        r.setSince(response.getSince());
-        r.setAsync(response.getAsync());
-        r.setRelated(response.getRelated());
-        r.setParams(response.getParams());
+        ApiDiscoveryResponse r = new ApiDiscoveryResponse(response.getName());
         r.setObjectName(response.getObjectName());
         return r;
     }

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -238,13 +239,14 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         if (account == null)
             return null;
 
+        List<APIChecker> enabledCheckers = _apiAccessCheckers.stream().filter(APIChecker::isEnabled).collect(Collectors.toList());
         if (name != null) {
             if (!s_apiNameDiscoveryResponseMap.containsKey(name))
                 return null;
 
-            for (APIChecker apiChecker : _apiAccessCheckers) {
+            for (APIChecker apiChecker : enabledCheckers) {
                 try {
-                    apiChecker.checkAccess(account, user, name, role);
+                    apiChecker.checkAccessWithoutEnabledCheck(account, user, name, role);
                 } catch (Exception ex) {
                     s_logger.debug("API discovery access check failed for " + name + " with " + ex.getMessage());
                     return null;
@@ -255,9 +257,9 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         } else {
             for (String apiName : s_apiNameDiscoveryResponseMap.keySet()) {
                 boolean isAllowed = true;
-                for (APIChecker apiChecker : _apiAccessCheckers) {
+                for (APIChecker apiChecker : enabledCheckers) {
                     try {
-                        apiChecker.checkAccess(account, user, apiName, role);
+                        apiChecker.checkAccessWithoutEnabledCheck(account, user, apiName, role);
                     } catch (Exception ex) {
                         isAllowed = false;
                         break;

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -260,6 +260,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
                         apiChecker.checkAccess(account, user, apiName, role);
                     } catch (Exception ex) {
                         isAllowed = false;
+                        break;
                     }
                 }
                 if (isAllowed)

--- a/plugins/api/discovery/src/test/java/org/apache/cloudstack/discovery/ApiDiscoveryTest.java
+++ b/plugins/api/discovery/src/test/java/org/apache/cloudstack/discovery/ApiDiscoveryTest.java
@@ -85,6 +85,7 @@ public class ApiDiscoveryTest {
         s_discoveryService._apiAccessCheckers = mock(List.class);
         s_discoveryService._services = mock(List.class);
 
+        when(s_apiChecker.isEnabled()).thenReturn(true);
         when(s_apiChecker.checkAccess(any(User.class), anyString())).thenReturn(true);
         when(s_pluggableService.getCommands()).thenReturn(new ArrayList<Class<?>>());
         when(s_discoveryService._apiAccessCheckers.iterator()).thenReturn(Arrays.asList(s_apiChecker).iterator());
@@ -143,7 +144,7 @@ public class ApiDiscoveryTest {
         if (responses != null) {
             assertTrue("No. of response items > 2", responses.getCount().intValue() == 2);
             for (ApiDiscoveryResponse response : responses.getResponses()) {
-                assertTrue("API response param is not empty", response.getApiResponse().isEmpty());
+                assertTrue("API response param is not empty", response.getApiResponse() == null);
             }
         }
     }

--- a/plugins/api/rate-limit/src/main/java/org/apache/cloudstack/ratelimit/ApiRateLimitServiceImpl.java
+++ b/plugins/api/rate-limit/src/main/java/org/apache/cloudstack/ratelimit/ApiRateLimitServiceImpl.java
@@ -140,20 +140,22 @@ public class ApiRateLimitServiceImpl extends AdapterBase implements APIChecker, 
     }
 
     @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
     public boolean checkAccess(User user, String apiCommandName) throws PermissionDeniedException {
         // check if api rate limiting is enabled or not
         if (!enabled) {
             return true;
         }
         Account account = _accountService.getAccount(user.getAccountId());
-        return checkAccess(account, user, apiCommandName, null);
+        return checkAccessWithoutEnabledCheck(account, user, apiCommandName, null);
     }
 
     @Override
-    public boolean checkAccess(Account account, User user, String apiCommandName, Role role) throws PermissionDeniedException {
-        if (!enabled) {
-            return true;
-        }
+    public boolean checkAccessWithoutEnabledCheck(Account account, User user, String apiCommandName, Role role) throws PermissionDeniedException {
         if (_accountService.isRootAdmin(account.getId())) {
             // no API throttling on root admin
             return true;

--- a/ui/src/components/view/ActionButton.vue
+++ b/ui/src/components/view/ActionButton.vue
@@ -35,7 +35,7 @@
         class="button-action-badge"
         :overflowCount="9"
         :count="actionBadge[action.api] ? actionBadge[action.api].badgeNum : 0"
-        v-if="action.api in $store.getters.apis &&
+        v-if="!loading && action.api in $store.getters.apis && $store.getters.apis[action.api].params !== undefined &&
           action.showBadge && (
             (!dataView && ((action.listView && ('show' in action ? action.show(resource, $store.getters) : true)) || (action.groupAction && selectedRowKeys.length > 0 && ('groupShow' in action ? action.groupShow(selectedItems, $store.getters) : true)))) ||
             (dataView && action.dataView && ('show' in action ? action.show(resource, $store.getters) : true))
@@ -55,7 +55,7 @@
         </a-button>
       </a-badge>
       <a-button
-        v-if="action.api in $store.getters.apis &&
+        v-if="!loading && action.api in $store.getters.apis && $store.getters.apis[action.api].params !== undefined &&
           !action.showBadge && (
             (!dataView && ((action.listView && ('show' in action ? action.show(resource, $store.getters) : true)) || (action.groupAction && selectedRowKeys.length > 0 && ('groupShow' in action ? action.groupShow(selectedItems, $store.getters) : true)))) ||
             (dataView && action.dataView && ('show' in action ? action.show(resource, $store.getters) : true))

--- a/ui/src/permission.js
+++ b/ui/src/permission.js
@@ -75,6 +75,9 @@ router.beforeEach((to, from, next) => {
               } else {
                 next({ path: redirect })
               }
+              if (!apis.listUsers.params) {
+                store.dispatch('GetApis')
+              }
             })
           })
           .catch(() => {

--- a/ui/src/permission.js
+++ b/ui/src/permission.js
@@ -75,9 +75,6 @@ router.beforeEach((to, from, next) => {
               } else {
                 next({ path: redirect })
               }
-              if (!apis.listUsers.params) {
-                store.dispatch('GetApis')
-              }
             })
           })
           .catch(() => {

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -225,8 +225,6 @@ const user = {
             store.dispatch('GenerateRoutes', { apis }).then(() => {
               router.addRoutes(store.getters.addRouters)
             })
-            hide()
-            message.success(i18n.t('message.sussess.discovering.feature'))
           }).catch(error => {
             reject(error)
           })
@@ -245,6 +243,8 @@ const user = {
             store.dispatch('GenerateRoutes', { apis }).then(() => {
               router.addRoutes(store.getters.addRouters)
             })
+            hide()
+            message.success(i18n.t('message.sussess.discovering.feature'))
           }).catch(error => {
             reject(error)
           })

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -213,7 +213,7 @@ const user = {
           }).catch(error => {
             reject(error)
           })
-          api('listApis').then(response => {
+          api('listApis', { trim: true }).then(response => {
             const apis = {}
             const apiList = response.listapisresponse.api
             for (var idx = 0; idx < apiList.length; idx++) {
@@ -322,7 +322,7 @@ const user = {
     },
     ProjectView ({ commit }, projectid) {
       return new Promise((resolve, reject) => {
-        api('listApis', { projectid: projectid }).then(response => {
+        api('listApis', { projectid: projectid, trim: true }).then(response => {
           const apis = {}
           const apiList = response.listapisresponse.api
           for (var idx = 0; idx < apiList.length; idx++) {

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -230,6 +230,24 @@ const user = {
           }).catch(error => {
             reject(error)
           })
+          api('listApis').then(response => {
+            const apis = {}
+            const apiList = response.listapisresponse.api
+            for (var idx = 0; idx < apiList.length; idx++) {
+              const api = apiList[idx]
+              const apiName = api.name
+              apis[apiName] = {
+                params: api.params,
+                response: api.response
+              }
+            }
+            commit('SET_APIS', apis)
+            store.dispatch('GenerateRoutes', { apis }).then(() => {
+              router.addRoutes(store.getters.addRouters)
+            })
+          }).catch(error => {
+            reject(error)
+          })
         }
 
         api('listUsers', { username: Cookies.get('username') }).then(response => {
@@ -261,28 +279,6 @@ const user = {
           const cloudian = response.cloudianisenabledresponse.cloudianisenabled || {}
           commit('SET_CLOUDIAN', cloudian)
         }).catch(ignored => {
-        })
-      })
-    },
-
-    GetApis ({ commit }) {
-      return new Promise((resolve, reject) => {
-        console.log('Retrieving APIs with full response')
-        api('listApis').then(response => {
-          const apis = {}
-          const apiList = response.listapisresponse.api
-          for (var idx = 0; idx < apiList.length; idx++) {
-            const api = apiList[idx]
-            const apiName = api.name
-            apis[apiName] = {
-              params: api.params,
-              response: api.response
-            }
-          }
-          commit('SET_APIS', apis)
-          resolve(apis)
-        }).catch(error => {
-          reject(error)
         })
       })
     },

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -218,11 +218,7 @@ const user = {
             const apiList = response.listapisresponse.api
             for (var idx = 0; idx < apiList.length; idx++) {
               const api = apiList[idx]
-              const apiName = api.name
-              apis[apiName] = {
-                params: api.params,
-                response: api.response
-              }
+              apis[api.name] = {}
             }
             commit('SET_APIS', apis)
             resolve(apis)
@@ -265,6 +261,28 @@ const user = {
           const cloudian = response.cloudianisenabledresponse.cloudianisenabled || {}
           commit('SET_CLOUDIAN', cloudian)
         }).catch(ignored => {
+        })
+      })
+    },
+
+    GetApis ({ commit }) {
+      return new Promise((resolve, reject) => {
+        console.log('Retrieving APIs with full response')
+        api('listApis').then(response => {
+          const apis = {}
+          const apiList = response.listapisresponse.api
+          for (var idx = 0; idx < apiList.length; idx++) {
+            const api = apiList[idx]
+            const apiName = api.name
+            apis[apiName] = {
+              params: api.params,
+              response: api.response
+            }
+          }
+          commit('SET_APIS', apis)
+          resolve(apis)
+        }).catch(error => {
+          reject(error)
         })
       })
     },
@@ -322,7 +340,7 @@ const user = {
     },
     ProjectView ({ commit }, projectid) {
       return new Promise((resolve, reject) => {
-        api('listApis', { projectid: projectid, trim: true }).then(response => {
+        api('listApis', { projectid: projectid }).then(response => {
           const apis = {}
           const apiList = response.listapisresponse.api
           for (var idx = 0; idx < apiList.length; idx++) {

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -787,7 +787,7 @@ export default {
         return
       }
 
-      if (!this.columnKeys || this.columnKeys.length === 0) {
+      if (store.getters.apis[this.apiName].response && (!this.columnKeys || this.columnKeys.length === 0)) {
         for (const field of store.getters.apis[this.apiName].response) {
           this.columnKeys.push(field.name)
         }

--- a/ui/src/views/infra/InfraSummary.vue
+++ b/ui/src/views/infra/InfraSummary.vue
@@ -31,14 +31,16 @@
             {{ $t('label.refresh') }}
           </a-button>
           <a-button
+            v-if="sslUploadAllowed"
             style="margin-left: 12px; margin-top: 4px"
             icon="safety-certificate"
             size="small"
             shape="round"
-            @click="sslFormVisible = true">
+            @click="openSslModal">
             {{ $t('label.sslcertificates') }}
           </a-button>
           <a-modal
+            v-if="sslFormVisible"
             :title="$t('label.sslcertificates')"
             :visible="sslFormVisible"
             :footer="null"
@@ -192,10 +194,15 @@ export default {
   },
   beforeCreate () {
     this.form = this.$form.createForm(this)
-    this.apiParams = this.$getApiParams('uploadCustomCertificate')
+    this.apiParams = {}
   },
   created () {
     this.fetchData()
+  },
+  computed: {
+    sslUploadAllowed () {
+      return 'uploadCustomCertificate' in this.$store.getters.apis && this.$store.getters.apis.uploadCustomCertificate.params
+    }
   },
   methods: {
     fetchData () {
@@ -226,6 +233,11 @@ export default {
       this.intermediateCertificates = []
       this.sslFormSubmitting = false
       this.sslFormVisible = false
+    },
+
+    openSslModal () {
+      this.apiParams = this.$getApiParams('uploadCustomCertificate')
+      this.sslFormVisible = true
     },
 
     sslModalClose () {


### PR DESCRIPTION
### Description

Partially fixes #5266

- Allows calling listAPIs API to not return anything except API name in the response.
- Refactored retrieving account and role details  during access check for each available API.
- Refactored checkAccess caller to query only enabled checkers.
- In UI, during login make two lisApis call. First to retrieve only API names to show appropriate UI and second in background to retrieve complete API data. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
