### PR TITLE
[VMware][Deploy-as-is] OVF properties not importing when template is uploaded from local

### DIFF
--- a/core/src/main/java/org/apache/cloudstack/storage/command/UploadStatusAnswer.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/UploadStatusAnswer.java
@@ -20,6 +20,7 @@
 package org.apache.cloudstack.storage.command;
 
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.to.OVFInformationTO;
 import com.cloud.utils.Pair;
 
 public class UploadStatusAnswer extends Answer {
@@ -34,6 +35,7 @@ public class UploadStatusAnswer extends Answer {
     private int downloadPercent = 0;
     private Pair<String, String> guestOsInfo;
     private String minimumHardwareVersion;
+    private OVFInformationTO ovfInformationTO;
 
     protected UploadStatusAnswer() {
     }
@@ -103,5 +105,13 @@ public class UploadStatusAnswer extends Answer {
 
     public String getMinimumHardwareVersion() {
         return minimumHardwareVersion;
+    }
+
+    public OVFInformationTO getOvfInformationTO() {
+        return ovfInformationTO;
+    }
+
+    public void setOvfInformationTO(OVFInformationTO ovfInformationTO) {
+        this.ovfInformationTO = ovfInformationTO;
     }
 }

--- a/core/src/main/java/org/apache/cloudstack/storage/command/UploadStatusAnswer.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/UploadStatusAnswer.java
@@ -21,7 +21,6 @@ package org.apache.cloudstack.storage.command;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.to.OVFInformationTO;
-import com.cloud.utils.Pair;
 
 public class UploadStatusAnswer extends Answer {
     public static enum UploadStatus {
@@ -33,8 +32,6 @@ public class UploadStatusAnswer extends Answer {
     private long physicalSize = 0;
     private String installPath = null;
     private int downloadPercent = 0;
-    private Pair<String, String> guestOsInfo;
-    private String minimumHardwareVersion;
     private OVFInformationTO ovfInformationTO;
 
     protected UploadStatusAnswer() {
@@ -89,22 +86,6 @@ public class UploadStatusAnswer extends Answer {
 
     public void setDownloadPercent(int downloadPercent) {
         this.downloadPercent = downloadPercent;
-    }
-
-    public Pair<String, String> getGuestOsInfo() {
-        return guestOsInfo;
-    }
-
-    public void setGuestOsInfo(Pair<String, String> guestOsInfo) {
-        this.guestOsInfo = guestOsInfo;
-    }
-
-    public void setMinimumHardwareVersion(String minimumHardwareVersion) {
-        this.minimumHardwareVersion = minimumHardwareVersion;
-    }
-
-    public String getMinimumHardwareVersion() {
-        return minimumHardwareVersion;
     }
 
     public OVFInformationTO getOvfInformationTO() {

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import com.cloud.agent.api.to.NfsTO;
+import com.cloud.agent.api.to.OVFInformationTO;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Upload;
 import org.apache.cloudstack.storage.image.deployasis.DeployAsIsHelper;
@@ -207,8 +208,9 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         TemplateDataStoreVO tmpltStoreVO = _templateStoreDao.findByStoreTemplate(store.getId(), obj.getId());
         if (tmpltStoreVO != null) {
             if (tmpltStoreVO.getDownloadState() == VMTemplateStorageResourceAssoc.Status.DOWNLOADED) {
-                if (template.isDeployAsIs()) {
-                    boolean persistDeployAsIs = deployAsIsHelper.persistTemplateDeployAsIsDetails(template.getId(), answer, tmpltStoreVO);
+                if (template.isDeployAsIs() && answer != null) {
+                    OVFInformationTO ovfInformationTO = answer.getOvfInformationTO();
+                    boolean persistDeployAsIs = deployAsIsHelper.persistTemplateOVFInformationAndUpdateGuestOS(template.getId(), ovfInformationTO, tmpltStoreVO);
                     if (!persistDeployAsIs) {
                         LOGGER.info("Failed persisting deploy-as-is template details for template " + template.getName());
                         return null;

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelperImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelperImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.cloudstack.storage.image.deployasis;
 
-import com.cloud.agent.api.storage.DownloadAnswer;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.OVFInformationTO;
 import com.cloud.agent.api.to.deployasis.OVFConfigurationTO;

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelperImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelperImpl.java
@@ -337,7 +337,7 @@ public class DeployAsIsHelperImpl implements DeployAsIsHelper {
         return map;
     }
 
-    private void persistTemplateDeployAsIsInformationTOList(long templateId,
+    public void persistTemplateDeployAsIsInformationTOList(long templateId,
                                                             List<? extends TemplateDeployAsIsInformationTO> informationTOList) {
         for (TemplateDeployAsIsInformationTO informationTO : informationTOList) {
             String propKey = getKeyFromInformationTO(informationTO);

--- a/server/src/main/java/com/cloud/storage/ImageStoreUploadMonitorImpl.java
+++ b/server/src/main/java/com/cloud/storage/ImageStoreUploadMonitorImpl.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.storage;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -25,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.agent.api.to.OVFInformationTO;
+import com.cloud.agent.api.to.deployasis.TemplateDeployAsIsInformationTO;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.utils.Pair;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -424,6 +427,15 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                                     templateUpdate.setGuestOSId(guestOsId);
                                 } catch (CloudRuntimeException e) {
                                     s_logger.error("Could not map the guest OS to a CloudStack guest OS", e);
+                                }
+                                OVFInformationTO ovfInformationTO = answer.getOvfInformationTO();
+                                if (ovfInformationTO != null) {
+                                    s_logger.debug("Receiving ovfInformation TO");
+                                    List<List<? extends TemplateDeployAsIsInformationTO>> informationList = Arrays.asList(ovfInformationTO.getNetworks(), ovfInformationTO.getProperties());
+                                    for (List<? extends TemplateDeployAsIsInformationTO> infoList : informationList) {
+                                        s_logger.debug("Persisting information " + infoList.getClass());
+                                        deployAsIsHelper.persistTemplateDeployAsIsInformationTOList(tmpTemplate.getId(), infoList);
+                                    }
                                 }
                             }
                             _templateDao.update(tmpTemplate.getId(), templateUpdate);

--- a/server/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelper.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelper.java
@@ -18,9 +18,11 @@ package org.apache.cloudstack.storage.image.deployasis;
 
 import com.cloud.agent.api.storage.DownloadAnswer;
 import com.cloud.agent.api.to.NicTO;
+import com.cloud.agent.api.to.deployasis.TemplateDeployAsIsInformationTO;
 import com.cloud.vm.VirtualMachineProfile;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
 
+import java.util.List;
 import java.util.Map;
 
 public interface DeployAsIsHelper {
@@ -30,4 +32,5 @@ public interface DeployAsIsHelper {
     Map<Integer, String> getAllocatedVirtualMachineNicsAdapterMapping(VirtualMachineProfile vm, NicTO[] nics);
     Long retrieveTemplateGuestOsIdFromGuestOsInfo(long templateId, String guestOsType, String guestOsDescription,
                                                   String minimumHardwareVersion);
+    void persistTemplateDeployAsIsInformationTOList(long templateId, List<? extends TemplateDeployAsIsInformationTO> informationTOList);
 }

--- a/server/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelper.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelper.java
@@ -16,21 +16,16 @@
 // under the License.
 package org.apache.cloudstack.storage.image.deployasis;
 
-import com.cloud.agent.api.storage.DownloadAnswer;
 import com.cloud.agent.api.to.NicTO;
-import com.cloud.agent.api.to.deployasis.TemplateDeployAsIsInformationTO;
+import com.cloud.agent.api.to.OVFInformationTO;
 import com.cloud.vm.VirtualMachineProfile;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
 
-import java.util.List;
 import java.util.Map;
 
 public interface DeployAsIsHelper {
 
-    boolean persistTemplateDeployAsIsDetails(long templateId, DownloadAnswer answer, TemplateDataStoreVO tmpltStoreVO);
+    boolean persistTemplateOVFInformationAndUpdateGuestOS(long templateId, OVFInformationTO ovfInformationTO, TemplateDataStoreVO tmpltStoreVO);
     Map<String, String> getVirtualMachineDeployAsIsProperties(VirtualMachineProfile vmId);
     Map<Integer, String> getAllocatedVirtualMachineNicsAdapterMapping(VirtualMachineProfile vm, NicTO[] nics);
-    Long retrieveTemplateGuestOsIdFromGuestOsInfo(long templateId, String guestOsType, String guestOsDescription,
-                                                  String minimumHardwareVersion);
-    void persistTemplateDeployAsIsInformationTOList(long templateId, List<? extends TemplateDeployAsIsInformationTO> informationTOList);
 }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -2282,6 +2282,9 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 answer.setDownloadPercent(100);
                 answer.setGuestOsInfo(uploadEntity.getGuestOsInfo());
                 answer.setMinimumHardwareVersion(uploadEntity.getMinimumHardwareVersion());
+                if (uploadEntity.getOvfInformationTO() != null) {
+                    answer.setOvfInformationTO(uploadEntity.getOvfInformationTO());
+                }
                 uploadEntityStateMap.remove(entityUuid);
                 return answer;
             } else if (uploadEntity.getUploadState() == UploadEntity.Status.IN_PROGRESS) {
@@ -3430,6 +3433,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                     if (info.ovfInformationTO.getHardwareSection() != null) {
                         uploadEntity.setMinimumHardwareVersion(info.ovfInformationTO.getHardwareSection().getMinimiumHardwareVersion());
                     }
+                    uploadEntity.setOvfInformationTO(info.ovfInformationTO);
                 }
                 break;
             }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -2280,8 +2280,6 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 answer.setInstallPath(uploadEntity.getTmpltPath());
                 answer.setPhysicalSize(uploadEntity.getPhysicalSize());
                 answer.setDownloadPercent(100);
-                answer.setGuestOsInfo(uploadEntity.getGuestOsInfo());
-                answer.setMinimumHardwareVersion(uploadEntity.getMinimumHardwareVersion());
                 if (uploadEntity.getOvfInformationTO() != null) {
                     answer.setOvfInformationTO(uploadEntity.getOvfInformationTO());
                 }
@@ -3427,12 +3425,6 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 uploadEntity.setVirtualSize(info.virtualSize);
                 uploadEntity.setPhysicalSize(info.size);
                 if (info.ovfInformationTO != null) {
-                    if (info.ovfInformationTO.getGuestOsInfo() != null) {
-                        uploadEntity.setGuestOsInfo(info.ovfInformationTO.getGuestOsInfo());
-                    }
-                    if (info.ovfInformationTO.getHardwareSection() != null) {
-                        uploadEntity.setMinimumHardwareVersion(info.ovfInformationTO.getHardwareSection().getMinimiumHardwareVersion());
-                    }
                     uploadEntity.setOvfInformationTO(info.ovfInformationTO);
                 }
                 break;

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadEntity.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadEntity.java
@@ -18,6 +18,7 @@
 package org.apache.cloudstack.storage.template;
 
 
+import com.cloud.agent.api.to.OVFInformationTO;
 import com.cloud.storage.Storage;
 import com.cloud.utils.Pair;
 
@@ -38,6 +39,7 @@ public class UploadEntity {
     private long processTimeout;
     private Pair<String, String> guestOsInfo;
     private String minimumHardwareVersion;
+    private OVFInformationTO ovfInformationTO;
 
     public static enum ResourceType {
         VOLUME, TEMPLATE
@@ -225,5 +227,13 @@ public class UploadEntity {
 
     public String getMinimumHardwareVersion() {
         return minimumHardwareVersion;
+    }
+
+    public OVFInformationTO getOvfInformationTO() {
+        return ovfInformationTO;
+    }
+
+    public void setOvfInformationTO(OVFInformationTO ovfInformationTO) {
+        this.ovfInformationTO = ovfInformationTO;
     }
 }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadEntity.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadEntity.java
@@ -20,7 +20,6 @@ package org.apache.cloudstack.storage.template;
 
 import com.cloud.agent.api.to.OVFInformationTO;
 import com.cloud.storage.Storage;
-import com.cloud.utils.Pair;
 
 public class UploadEntity {
     private long downloadedsize;
@@ -37,8 +36,6 @@ public class UploadEntity {
     private String description;
     private long contentLength;
     private long processTimeout;
-    private Pair<String, String> guestOsInfo;
-    private String minimumHardwareVersion;
     private OVFInformationTO ovfInformationTO;
 
     public static enum ResourceType {
@@ -211,22 +208,6 @@ public class UploadEntity {
 
     public void setContentLength(long contentLength) {
         this.contentLength = contentLength;
-    }
-
-    public Pair<String, String> getGuestOsInfo() {
-        return guestOsInfo;
-    }
-
-    public void setGuestOsInfo(Pair<String, String> guestOsInfo) {
-        this.guestOsInfo = guestOsInfo;
-    }
-
-    public void setMinimumHardwareVersion(String minimumHardwareVersion) {
-        this.minimumHardwareVersion = minimumHardwareVersion;
-    }
-
-    public String getMinimumHardwareVersion() {
-        return minimumHardwareVersion;
     }
 
     public OVFInformationTO getOvfInformationTO() {


### PR DESCRIPTION
### Description

This PR adds the missing template details when combining: OVA template upload from local + Read VM settings from OVA

Fixes: #5808 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Upload a OVA template from local
- Verify the template_deploy_as_is_details table and the VM deployment wizard
- Deploy VM and ensure properties/configurations/etc are set