### PR TITLE
[UI] fix delete domain

### DIFF
--- a/ui/src/views/iam/DomainActionForm.vue
+++ b/ui/src/views/iam/DomainActionForm.vue
@@ -180,7 +180,7 @@ export default {
       this.fillEditFormFieldValues()
     }
   },
-  inject: ['parentCloseAction', 'parentFetchData'],
+  inject: ['parentCloseAction', 'parentFetchData', 'parentForceRerender'],
   methods: {
     handleSubmit (e) {
       e.preventDefault()
@@ -249,6 +249,7 @@ export default {
                     successMethod: result => {
                       if (this.action.api === 'deleteDomain') {
                         this.parentFetchData()
+                        this.parentForceRerender()
                       }
                       if (this.action.response) {
                         const description = this.action.response(result.jobresult)

--- a/ui/src/views/iam/DomainView.vue
+++ b/ui/src/views/iam/DomainView.vue
@@ -60,6 +60,7 @@
         :tabs="$route.meta.tabs" />
       <tree-view
         v-else
+        :key="treeViewKey"
         :treeData="treeData"
         :treeSelected="treeSelected"
         :treeStore="domainStore"
@@ -105,6 +106,7 @@ export default {
       resource: {},
       loading: false,
       selectedRowKeys: [],
+      treeViewKey: 0,
       treeData: [],
       treeSelected: {},
       showAction: false,
@@ -158,7 +160,8 @@ export default {
   provide () {
     return {
       parentCloseAction: this.closeAction,
-      parentFetchData: this.fetchData
+      parentFetchData: this.fetchData,
+      parentForceRerender: this.forceRerender
     }
   },
   methods: {
@@ -323,6 +326,9 @@ export default {
     },
     closeAction () {
       this.showAction = false
+    },
+    forceRerender () {
+      this.treeViewKey += 1
     }
   }
 }


### PR DESCRIPTION
### Description
When deleting a domain, the UI shows an error, but successfully deletes the domain. This happens because the UI does not refresh the domain list and requests the deleted domain's information, thus ACS would return an error. This was partially fixed on PR #5710, but the changes were insufficient.

In case there is only 2 domains, for example: 'ROOT' and 'A', when deleting 'A' the UI does not show the previous error, but it still shows the deleted domain's information. The proposed solution to this problem is to force the UI to refresh the component that shows the domain information. Therefore, this PR is intended to introduce these changes.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### How Has This Been Tested?
This was tested in a local lab:
 - Make the domain list have only the ROOT and any other domain;
 - Delete the domain;
 - The ROOT information should be shown, and the ROOT should be selected.
