### PR TITLE
ui: fix filtering readonly details while VM update

### DIFF
--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -173,8 +173,8 @@ export default {
         this.deployasistemplate = json.listtemplatesresponse.template[0].deployasis
       })
     },
-    filterOrReadOnlyDetails () {
-      for (var i = 0; i < this.details.length; i++) {
+    filterReadOnlyDetails () {
+      for (var i = this.details.length - 1; i >= 0; i--) {
         if (!this.allowEditOfDetail(this.details[i].name)) {
           this.details.splice(i, 1)
         }
@@ -261,16 +261,16 @@ export default {
       }
       this.error = false
       this.details.push({ name: this.newKey, value: this.newValue })
-      this.filterOrReadOnlyDetails()
+      this.filterReadOnlyDetails()
       this.runApi()
     },
     updateDetail (index) {
-      this.filterOrReadOnlyDetails()
+      this.filterReadOnlyDetails()
       this.runApi()
     },
     deleteDetail (index) {
       this.details.splice(index, 1)
-      this.filterOrReadOnlyDetails()
+      this.filterReadOnlyDetails()
       this.runApi()
     },
     onShowAddDetail () {

--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -267,6 +267,10 @@ export default {
         this.error = this.$t('message.error.provide.setting')
         return
       }
+      if (!this.allowEditOfDetail(this.newKey)) {
+        this.error = this.$t('error.unable.to.proceed')
+        return
+      }
       this.error = false
       this.details.push({ name: this.newKey, value: this.newValue })
       this.runApi()

--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -173,13 +173,6 @@ export default {
         this.deployasistemplate = json.listtemplatesresponse.template[0].deployasis
       })
     },
-    filterReadOnlyDetails () {
-      for (var i = this.details.length - 1; i >= 0; i--) {
-        if (!this.allowEditOfDetail(this.details[i].name)) {
-          this.details.splice(i, 1)
-        }
-      }
-    },
     allowEditOfDetail (name) {
       if (this.resource.readonlydetails) {
         if (this.resource.readonlydetails.split(',').map(item => item.trim()).includes(name)) {
@@ -211,6 +204,27 @@ export default {
         (this.resource.domainid === this.$store.getters.userInfo.domainid && this.resource.account === this.$store.getters.userInfo.account) ||
         this.resource.project && this.resource.projectid === this.$store.getters.project.id
     },
+    getDetailsParam (details) {
+      var params = {}
+      var filteredDetails = details
+      if (this.resource.readonlydetails && filteredDetails) {
+        filteredDetails = []
+        var readOnlyDetailNames = this.resource.readonlydetails.split(',').map(item => item.trim())
+        for (var detail of this.details) {
+          if (!readOnlyDetailNames.includes(detail.name)) {
+            filteredDetails.push(detail)
+          }
+        }
+      }
+      if (filteredDetails.length === 0) {
+        params.cleanupdetails = true
+      } else {
+        filteredDetails.forEach(function (item, index) {
+          params['details[0].' + item.name] = item.value
+        })
+      }
+      return params
+    },
     runApi () {
       var apiName = ''
       if (this.resourceType === 'UserVm') {
@@ -226,14 +240,8 @@ export default {
         return
       }
 
-      const params = { id: this.resource.id }
-      if (this.details.length === 0) {
-        params.cleanupdetails = true
-      } else {
-        this.details.forEach(function (item, index) {
-          params['details[0].' + item.name] = item.value
-        })
-      }
+      var params = { id: this.resource.id }
+      params = Object.assign(params, this.getDetailsParam(this.details))
       this.loading = true
       api(apiName, params).then(json => {
         var details = {}
@@ -261,16 +269,13 @@ export default {
       }
       this.error = false
       this.details.push({ name: this.newKey, value: this.newValue })
-      this.filterReadOnlyDetails()
       this.runApi()
     },
     updateDetail (index) {
-      this.filterReadOnlyDetails()
       this.runApi()
     },
     deleteDetail (index) {
       this.details.splice(index, 1)
-      this.filterReadOnlyDetails()
       this.runApi()
     },
     onShowAddDetail () {


### PR DESCRIPTION
### Description

Fixes #5724

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before fix (filtering of readonly details not working properly and updateVirtualMachine is called with rootDiskController setting)
Steps to reproduce:
- On a VMware env, as a regular user deploy a VM, stop it after deployment. Template shouldn't have nicAdapter specified
- Try to update VM with nicAdapter from UI by adding the new setting.
- Observe updateVirtualMachine API is called with rootDiskController in the details
![Screenshot from 2022-01-24 14-05-44](https://user-images.githubusercontent.com/153340/150748962-7267cdd2-beca-4cdd-8078-c91d6d7a5dfa.png)

After fix:
![Screenshot from 2022-01-24 14-06-35](https://user-images.githubusercontent.com/153340/150749382-4eb8411b-0f15-4e96-a252-bda0afca191b.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
