### PR TITLE
[XenServer/XCP-ng] Sync the 'platform' setting according to the 'cpu.corespersocket' setting

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1901,7 +1901,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     }
 
     protected void syncPlatformAndCoresPerSocketSettings(String coresPerSocket, Map<String, String> platform) {
-        if (org.apache.commons.lang3.StringUtils.isBlank(coresPerSocket) || MapUtils.isEmpty(platform)) {
+        if (org.apache.commons.lang3.StringUtils.isBlank(coresPerSocket) || platform == null) {
             return;
         }
         if (platform.containsKey(PLATFORM_CORES_PER_SOCKET_KEY)) {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -226,6 +226,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     protected static final HashMap<VmPowerState, PowerState> s_powerStatesTable;
 
     public static final String XS_TOOLS_ISO_AFTER_70 = "guest-tools.iso";
+    protected static final String PLATFORM_CORES_PER_SOCKET_KEY = "cores-per-socket";
 
     static {
         s_powerStatesTable = new HashMap<VmPowerState, PowerState>();
@@ -1899,13 +1900,25 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         }
     }
 
+    protected void syncPlatformAndCoresPerSocketSettings(String coresPerSocket, Map<String, String> platform) {
+        if (coresPerSocket == null) {
+            return;
+        }
+        if (platform.containsKey(PLATFORM_CORES_PER_SOCKET_KEY)) {
+            s_logger.debug("Updating the cores per socket value from: " + platform.get(PLATFORM_CORES_PER_SOCKET_KEY) + " to " + coresPerSocket);
+        }
+        platform.put(PLATFORM_CORES_PER_SOCKET_KEY, coresPerSocket);
+    }
+
     protected void finalizeVmMetaData(final VM vm, final VM.Record vmr, final Connection conn, final VirtualMachineTO vmSpec) throws Exception {
 
         final Map<String, String> details = vmSpec.getDetails();
         if (details != null) {
             final String platformstring = details.get(VmDetailConstants.PLATFORM);
+            final String coresPerSocket = details.get(VmDetailConstants.CPU_CORE_PER_SOCKET);
             if (platformstring != null && !platformstring.isEmpty()) {
                 final Map<String, String> platform = StringUtils.stringToMap(platformstring);
+                syncPlatformAndCoresPerSocketSettings(coresPerSocket, platform);
                 vm.setPlatform(conn, platform);
             } else {
                 final String timeoffset = details.get(VmDetailConstants.TIME_OFFSET);
@@ -1914,10 +1927,9 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                     platform.put(VmDetailConstants.TIME_OFFSET, timeoffset);
                     vm.setPlatform(conn, platform);
                 }
-                final String coresPerSocket = details.get(VmDetailConstants.CPU_CORE_PER_SOCKET);
                 if (coresPerSocket != null) {
                     final Map<String, String> platform = vm.getPlatform(conn);
-                    platform.put("cores-per-socket", coresPerSocket);
+                    syncPlatformAndCoresPerSocketSettings(coresPerSocket, platform);
                     vm.setPlatform(conn, platform);
                 }
             }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1901,7 +1901,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     }
 
     protected void syncPlatformAndCoresPerSocketSettings(String coresPerSocket, Map<String, String> platform) {
-        if (coresPerSocket == null) {
+        if (org.apache.commons.lang3.StringUtils.isBlank(coresPerSocket) || MapUtils.isEmpty(platform)) {
             return;
         }
         if (platform.containsKey(PLATFORM_CORES_PER_SOCKET_KEY)) {


### PR DESCRIPTION
### Description

The 'platform' setting is retrieved after a VM is stopped with the platform parameters obtained from Xen/XCP for a certain VM. If a user added the setting 'cpu.corespersocket', it was ignored and the setting was never applied as it was mutually exclusive with the platform 'setting'.

This PR fixes the previous behavior, in the following way:
- If 'cpu.corespersocket'=X AND the 'platform' setting does not contain 'cores-per-socket' -> 'cores-per-socket:X' parameter is added to the 'platform' setting which is sent to Xen/XCP
- If 'cpu.corespersocket'=X AND the 'platform' setting contains 'cores-per-socket:Y' -> The 'platform' setting is updated, containing: 'cores-per-socket:X'
- If 'cpu.corespersocket' is not set, nothing changes

Fixes: #5695 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Deploy a VM using an offering with 2 CPUs (use >=2 CPUs for tests)
- Stop VM -> Settings -> Check the 'platform' setting is visible and does not contain the 'cores-per-socket' parameter
- Add the setting 'cpu.corespersocket' = 2 (CPU number must be a multiple of cores per socket)
- Start VM -> Stop VM -> Check the 'platform' setting contains the parameter 'cores-per-socket:2'
- Edit the setting 'cpu.corespersocket' = 1 (CPU number must be a multiple of cores per socket)
- Start VM -> Stop VM -> Check the 'platform' setting contains the parameter 'cores-per-socket:1'