### PR TITLE
[Veeam] Change the VM assign flow logic in a Backup Offering

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -105,6 +105,7 @@ import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
+import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.VMInstanceVO;
@@ -287,24 +288,40 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
             throw new CloudRuntimeException("Failed to get the backup provider for the zone, please contact the administrator");
         }
 
-        vm.setBackupOfferingId(offering.getId());
-        vm.setBackupVolumes(createVolumeInfoFromVolumes(volumeDao.findByInstance(vm.getId())));
-        if (vmInstanceDao.update(vm.getId(), vm)) {
-            UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VM_BACKUP_OFFERING_ASSIGN, vm.getAccountId(), vm.getDataCenterId(), vm.getId(),
-                    "Backup-" + vm.getHostName() + "-" + vm.getUuid(), vm.getBackupOfferingId(), null, null,
-                    Backup.class.getSimpleName(), vm.getUuid());
-        } else {
-            throw new CloudRuntimeException("Failed to update VM assignment to the backup offering in the DB, please try again.");
-        }
+        return transactionAssignVMToBackupOffering(vm, offering, backupProvider) != null;
+    }
 
-        try {
-            if (backupProvider.assignVMToBackupOffering(vm, offering)) {
-                return vmInstanceDao.update(vm.getId(), vm);
+    private VMInstanceVO transactionAssignVMToBackupOffering(VMInstanceVO vm, BackupOfferingVO offering, BackupProvider backupProvider) {
+        return Transaction.execute(TransactionLegacy.CLOUD_DB, new TransactionCallback<VMInstanceVO>() {
+            @Override
+            public VMInstanceVO doInTransaction(final TransactionStatus status) {
+                try {
+                    long vmId = vm.getId();
+                    vm.setBackupOfferingId(offering.getId());
+                    vm.setBackupVolumes(createVolumeInfoFromVolumes(volumeDao.findByInstance(vmId)));
+
+                    if (vmInstanceDao.update(vmId, vm)) {
+                        if (backupProvider.assignVMToBackupOffering(vm, offering)) {
+                            vmInstanceDao.update(vmId, vm);
+                            UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VM_BACKUP_OFFERING_ASSIGN, vm.getAccountId(), vm.getDataCenterId(), vmId,
+                                    "Backup-" + vm.getHostName() + "-" + vm.getUuid(), vm.getBackupOfferingId(), null, null,
+                                    Backup.class.getSimpleName(), vm.getUuid());
+                            LOG.debug(String.format("VM [%s] successfully added to Backup Offering [%s].", ReflectionToStringBuilderUtils.reflectOnlySelectedFields(vm, "uuid", "instanceName", "backupOfferingId", "backupVolumes"),
+                                    ReflectionToStringBuilderUtils.reflectOnlySelectedFields(offering, "uuid", "name", "externalId", "provider")));
+                            return vm;
+                        }
+                    } else {
+                        throw new CloudRuntimeException("Failed to update VM assignment to the backup offering in the DB, please try again.");
+                    }
+                } catch (Exception e) {
+                    LOG.error(String.format("Failed to assign VM [%s] to the Backup Offering [%s], using provider [name: %s, class: %s], due to: [%s].",
+                            ReflectionToStringBuilderUtils.reflectOnlySelectedFields(vm, "uuid", "instanceName", "backupOfferingId", "backupVolumes"),
+                            ReflectionToStringBuilderUtils.reflectOnlySelectedFields(offering, "uuid", "name", "externalId", "provider"),
+                            backupProvider.getName(), backupProvider.getClass().getSimpleName(), e.getMessage()), e);
+                }
+                throw new CloudRuntimeException("Failed to assign the VM to the backup offering, please try removing the assignment and try again.");
             }
-        } catch (Exception e) {
-            LOG.error("Exception caught while assigning VM to backup offering by the backup provider", e);
-        }
-        throw new CloudRuntimeException("Failed to assign the VM to the backup offering, please try removing the assignment and try again.");
+        });
     }
 
     @Override


### PR DESCRIPTION
### Description

When assigning a VM to a Backup Offering, the information of the VM being attached to a Backup Offering is being saved in the DB before performing the assignment operation in Veeam. Therefore, if any error occurs in Veeam, no rollback is performed, which creates an inconsistency in the DB.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

It was tested in a local lab:
1. I created a new Backup Offering;
2. I shutdown the Veeam server (to simulate a problem in Veeam);
2. I tried to assign a VM to this new Backup Offering;
3. Before, an error occurred during the VM assignment process, but since the VM was already assigned to the Backup Offering in DB, it was necessary to remove this VM from the backup offering and try the assign again.
4. With this PR, this behavior is fixed.