### PR TITLE
[VMware] Update SCSI controllers for VMs

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1805,6 +1805,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         int requiredNumScsiControllers = VmwareHelper.MAX_SCSI_CONTROLLER_COUNT - scsiControllerInfo.first();
         int availableBusNum = scsiControllerInfo.second() + 1; // method returned current max. bus number
 
+        if (DiskControllerType.getType(scsiDiskController) != scsiControllerInfo.third()) {
+            s_logger.debug(String.format("Change controller type from: %s to: %s", scsiControllerInfo.third().toString(),
+                    scsiDiskController));
+            vmMo.tearDownDevices(new Class<?>[]{VirtualSCSIController.class});
+            vmMo.addScsiDeviceControllers(DiskControllerType.getType(scsiDiskController));
+            return;
+        }
+
         if (requiredNumScsiControllers == 0) {
             return;
         }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -2297,12 +2297,11 @@ public class VirtualMachineMO extends BaseMO {
         switch (type) {
             case pvscsi:
                 return new ParaVirtualSCSIController();
-            case lsilogic:
-                return new VirtualLsiLogicController();
             case lsisas1068:
                 return new VirtualLsiLogicSASController();
             case buslogic:
                 return new VirtualBusLogicController();
+            case lsilogic:
             default:
                 return new VirtualLsiLogicController();
         }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -2301,7 +2301,6 @@ public class VirtualMachineMO extends BaseMO {
                 return new VirtualLsiLogicSASController();
             case buslogic:
                 return new VirtualBusLogicController();
-            case lsilogic:
             default:
                 return new VirtualLsiLogicController();
         }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -2293,6 +2293,43 @@ public class VirtualMachineMO extends BaseMO {
         throw new Exception("VMware Paravirtual SCSI Controller Not Found");
     }
 
+    protected VirtualSCSIController getScsiController(DiskControllerType type) {
+        switch (type) {
+            case pvscsi:
+                return new ParaVirtualSCSIController();
+            case lsilogic:
+                return new VirtualLsiLogicController();
+            case lsisas1068:
+                return new VirtualLsiLogicSASController();
+            case buslogic:
+                return new VirtualBusLogicController();
+            default:
+                return new VirtualLsiLogicController();
+        }
+    }
+
+    public void addScsiDeviceControllers(DiskControllerType type) throws Exception {
+        VirtualMachineConfigSpec vmConfig = new VirtualMachineConfigSpec();
+        int busNum = 0;
+        while (busNum < VmwareHelper.MAX_SCSI_CONTROLLER_COUNT) {
+            VirtualSCSIController scsiController = getScsiController(type);
+            scsiController.setSharedBus(VirtualSCSISharing.NO_SHARING);
+            scsiController.setBusNumber(busNum);
+            scsiController.setKey(busNum - VmwareHelper.MAX_SCSI_CONTROLLER_COUNT);
+            VirtualDeviceConfigSpec scsiControllerSpec = new VirtualDeviceConfigSpec();
+            scsiControllerSpec.setDevice(scsiController);
+            scsiControllerSpec.setOperation(VirtualDeviceConfigSpecOperation.ADD);
+            vmConfig.getDeviceChange().add(scsiControllerSpec);
+            busNum++;
+        }
+
+        if (configureVm(vmConfig)) {
+            s_logger.info("Successfully added SCSI controllers.");
+        } else {
+            throw new Exception("Unable to add Scsi controllers to the VM " + getName());
+        }
+    }
+
     public void ensurePvScsiDeviceController(int requiredNumScsiControllers, int availableBusNum) throws Exception {
         VirtualMachineConfigSpec vmConfig = new VirtualMachineConfigSpec();
 


### PR DESCRIPTION
### Description

This PR allows updating the root disk controller type on a stopped VM via the 'rootDiskController' setting

Fixes: #5877 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Start VM from a template with 'ide' root disk controller setting
- Stop VM
- Change the 'rootDiskController' setting to 'pvscsi'
- Start VM
- Verify the SCSI controllers on VMware Center is set to VMware Paravirtual 

- Stop VM
- Change the 'rootDiskController' setting to 'lsisas1068'
- Start VM
- Verify the SCSI controllers on VMware Center is set to LSI Logic SAS