### PR TITLE
Added hot plugging of vifs in case of VMware isolated networks

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/to/IpAddressTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/IpAddressTO.java
@@ -18,6 +18,8 @@ package com.cloud.agent.api.to;
 
 import com.cloud.network.Networks.TrafficType;
 
+import java.util.Map;
+
 public class IpAddressTO {
 
     private long accountId;
@@ -36,6 +38,8 @@ public class IpAddressTO {
     private Integer nicDevId;
     private boolean newNic;
     private boolean isPrivateGateway;
+    private NicTO nicTO;
+    Map<String, String> details;
 
     public IpAddressTO(long accountId, String ipAddress, boolean add, boolean firstIP, boolean sourceNat, String broadcastUri, String vlanGateway, String vlanNetmask,
             String vifMacAddress, Integer networkRate, boolean isOneToOneNat) {
@@ -141,5 +145,22 @@ public class IpAddressTO {
 
     public void setPrivateGateway(boolean isPrivateGateway) {
         this.isPrivateGateway = isPrivateGateway;
+    }
+
+    public NicTO getNicTO() {
+        return nicTO;
+    }
+
+    public void setNicTO(NicTO nicTO) {
+        this.nicTO = nicTO;
+    }
+
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VmwareVmImplementer.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VmwareVmImplementer.java
@@ -214,7 +214,7 @@ class VmwareVmImplementer {
             NicTO[] nics = to.getNics();
 
             // reserve extra NICs
-            NicTO[] expandedNics = new NicTO[nics.length + vmwareMgr.getRouterExtraPublicNics()];
+            NicTO[] expandedNics = new NicTO[nics.length];
             int i = 0;
             int deviceId = -1;
             for (i = 0; i < nics.length; i++) {
@@ -227,7 +227,7 @@ class VmwareVmImplementer {
             long networkId = publicNicProfile.getNetworkId();
             NetworkVO network = networkDao.findById(networkId);
 
-            for (; i < nics.length + vmwareMgr.getRouterExtraPublicNics(); i++) {
+            for (; i < nics.length; i++) {
                 NicTO nicTo = new NicTO();
 
                 nicTo.setDeviceId(deviceId++);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManager.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManager.java
@@ -85,8 +85,6 @@ public interface VmwareManager {
 
     Pair<Integer, Integer> getAddiionalVncPortRange();
 
-    int getRouterExtraPublicNics();
-
     boolean beginExclusiveOperation(int timeOutSeconds);
 
     void endExclusiveOperation();

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -253,7 +253,6 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     private String _recycleHungWorker = "false";
     private int _additionalPortRangeStart;
     private int _additionalPortRangeSize;
-    private int _routerExtraPublicNics = 2;
     private int _vCenterSessionTimeout = 1200000; // Timeout in milliseconds
     private String _rootDiskController = DiskControllerType.ide.toString();
 
@@ -373,8 +372,6 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
             s_logger.warn("Invalid port range size (" + _additionalPortRangeSize + " for range starts at " + _additionalPortRangeStart);
             _additionalPortRangeSize = Math.min(1000, 65535 - _additionalPortRangeStart);
         }
-
-        _routerExtraPublicNics = NumbersUtil.parseInt(_configDao.getValue(Config.RouterExtraPublicNics.key()), 2);
 
         _vCenterSessionTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.VmwareVcenterSessionTimeout.key()), 1200) * 1000;
         s_logger.info("VmwareManagerImpl config - vmware.vcenter.session.timeout: " + _vCenterSessionTimeout);
@@ -1067,11 +1064,6 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     @Override
     public Pair<Integer, Integer> getAddiionalVncPortRange() {
         return new Pair<Integer, Integer>(_additionalPortRangeStart, _additionalPortRangeSize);
-    }
-
-    @Override
-    public int getRouterExtraPublicNics() {
-        return _routerExtraPublicNics;
     }
 
     @Override

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1268,26 +1268,38 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.info("Executing resource PlugNicCommand " + _gson.toJson(cmd));
         }
 
+        try {
+            VirtualEthernetCardType nicDeviceType = null;
+            if (cmd.getDetails() != null) {
+                nicDeviceType = VirtualEthernetCardType.valueOf(cmd.getDetails().get("nicAdapter"));
+            }
+            plugNicCommandInternal(cmd.getVmName(), nicDeviceType, cmd.getNic(), cmd.getVMType());
+            return new PlugNicAnswer(cmd, true, "success");
+        } catch (Exception e) {
+            s_logger.error("Unexpected exception: ", e);
+            return new PlugNicAnswer(cmd, false, "Unable to execute PlugNicCommand due to " + e.toString());
+        }
+    }
+
+    private void plugNicCommandInternal(String vmName, VirtualEthernetCardType nicDeviceType, NicTO nicTo, VirtualMachine.Type vmType) throws Exception {
         getServiceContext().getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
         VmwareContext context = getServiceContext();
-        try {
-            VmwareHypervisorHost hyperHost = getHyperHost(context);
+        VmwareHypervisorHost hyperHost = getHyperHost(context);
 
-            String vmName = cmd.getVmName();
-            VirtualMachineMO vmMo = hyperHost.findVmOnHyperHost(vmName);
+        VirtualMachineMO vmMo = hyperHost.findVmOnHyperHost(vmName);
 
-            if (vmMo == null) {
-                if (hyperHost instanceof HostMO) {
-                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO) hyperHost).getParentMor());
-                    vmMo = clusterMo.findVmOnHyperHost(vmName);
-                }
+        if (vmMo == null) {
+            if (hyperHost instanceof HostMO) {
+                ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO) hyperHost).getParentMor());
+                vmMo = clusterMo.findVmOnHyperHost(vmName);
             }
+        }
 
-            if (vmMo == null) {
-                String msg = "Router " + vmName + " no longer exists to execute PlugNic command";
-                s_logger.error(msg);
-                throw new Exception(msg);
-            }
+        if (vmMo == null) {
+            String msg = "Router " + vmName + " no longer exists to execute PlugNic command";
+            s_logger.error(msg);
+            throw new Exception(msg);
+        }
 
             /*
             if(!isVMWareToolsInstalled(vmMo)){
@@ -1296,54 +1308,45 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 return new PlugNicAnswer(cmd, false, "Unable to execute PlugNicCommand due to " + errMsg);
             }
              */
-            // Fallback to E1000 if no specific nicAdapter is passed
-            VirtualEthernetCardType nicDeviceType = VirtualEthernetCardType.E1000;
-            Map<String, String> details = cmd.getDetails();
-            if (details != null) {
-                nicDeviceType = VirtualEthernetCardType.valueOf((String) details.get("nicAdapter"));
-            }
+        // Fallback to E1000 if no specific nicAdapter is passed
+        if (nicDeviceType == null) {
+            nicDeviceType = VirtualEthernetCardType.E1000;
+        }
 
-            // find a usable device number in VMware environment
-            VirtualDevice[] nicDevices = vmMo.getSortedNicDevices();
-            int deviceNumber = -1;
-            for (VirtualDevice device : nicDevices) {
-                if (device.getUnitNumber() > deviceNumber)
-                    deviceNumber = device.getUnitNumber();
-            }
-            deviceNumber++;
+        // find a usable device number in VMware environment
+        VirtualDevice[] nicDevices = vmMo.getSortedNicDevices();
+        int deviceNumber = -1;
+        for (VirtualDevice device : nicDevices) {
+            if (device.getUnitNumber() > deviceNumber)
+                deviceNumber = device.getUnitNumber();
+        }
+        deviceNumber++;
 
-            NicTO nicTo = cmd.getNic();
-            VirtualDevice nic;
-            Pair<ManagedObjectReference, String> networkInfo = prepareNetworkFromNicInfo(vmMo.getRunningHost(), nicTo, false, cmd.getVMType());
-            String dvSwitchUuid = null;
-            if (VmwareHelper.isDvPortGroup(networkInfo.first())) {
-                ManagedObjectReference dcMor = hyperHost.getHyperHostDatacenter();
-                DatacenterMO dataCenterMo = new DatacenterMO(context, dcMor);
-                ManagedObjectReference dvsMor = dataCenterMo.getDvSwitchMor(networkInfo.first());
-                dvSwitchUuid = dataCenterMo.getDvSwitchUuid(dvsMor);
-                s_logger.info("Preparing NIC device on dvSwitch : " + dvSwitchUuid);
-                nic = VmwareHelper.prepareDvNicDevice(vmMo, networkInfo.first(), nicDeviceType, networkInfo.second(), dvSwitchUuid,
-                        nicTo.getMac(), deviceNumber + 1, true, true);
-            } else {
-                s_logger.info("Preparing NIC device on network " + networkInfo.second());
-                nic = VmwareHelper.prepareNicDevice(vmMo, networkInfo.first(), nicDeviceType, networkInfo.second(),
-                        nicTo.getMac(), deviceNumber + 1, true, true);
-            }
+        VirtualDevice nic;
+        Pair<ManagedObjectReference, String> networkInfo = prepareNetworkFromNicInfo(vmMo.getRunningHost(), nicTo, false, vmType);
+        String dvSwitchUuid = null;
+        if (VmwareHelper.isDvPortGroup(networkInfo.first())) {
+            ManagedObjectReference dcMor = hyperHost.getHyperHostDatacenter();
+            DatacenterMO dataCenterMo = new DatacenterMO(context, dcMor);
+            ManagedObjectReference dvsMor = dataCenterMo.getDvSwitchMor(networkInfo.first());
+            dvSwitchUuid = dataCenterMo.getDvSwitchUuid(dvsMor);
+            s_logger.info("Preparing NIC device on dvSwitch : " + dvSwitchUuid);
+            nic = VmwareHelper.prepareDvNicDevice(vmMo, networkInfo.first(), nicDeviceType, networkInfo.second(), dvSwitchUuid,
+                    nicTo.getMac(), deviceNumber + 1, true, true);
+        } else {
+            s_logger.info("Preparing NIC device on network " + networkInfo.second());
+            nic = VmwareHelper.prepareNicDevice(vmMo, networkInfo.first(), nicDeviceType, networkInfo.second(),
+                    nicTo.getMac(), deviceNumber + 1, true, true);
+        }
 
-            VirtualMachineConfigSpec vmConfigSpec = new VirtualMachineConfigSpec();
-            VirtualDeviceConfigSpec deviceConfigSpec = new VirtualDeviceConfigSpec();
-            deviceConfigSpec.setDevice(nic);
-            deviceConfigSpec.setOperation(VirtualDeviceConfigSpecOperation.ADD);
+        VirtualMachineConfigSpec vmConfigSpec = new VirtualMachineConfigSpec();
+        VirtualDeviceConfigSpec deviceConfigSpec = new VirtualDeviceConfigSpec();
+        deviceConfigSpec.setDevice(nic);
+        deviceConfigSpec.setOperation(VirtualDeviceConfigSpecOperation.ADD);
 
-            vmConfigSpec.getDeviceChange().add(deviceConfigSpec);
-            if (!vmMo.configureVm(vmConfigSpec)) {
-                throw new Exception("Failed to configure devices when running PlugNicCommand");
-            }
-
-            return new PlugNicAnswer(cmd, true, "success");
-        } catch (Exception e) {
-            s_logger.error("Unexpected exception: ", e);
-            return new PlugNicAnswer(cmd, false, "Unable to execute PlugNicCommand due to " + e.toString());
+        vmConfigSpec.getDeviceChange().add(deviceConfigSpec);
+        if (!vmMo.configureVm(vmConfigSpec)) {
+            throw new Exception("Failed to configure devices when running PlugNicCommand");
         }
     }
 
@@ -1613,7 +1616,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 }
 
                 if (addVif) {
-                    plugPublicNic(vmMo, vlanId, ip);
+                    NicTO nicTO = ip.getNicTO();
+                    VirtualEthernetCardType nicDeviceType = null;
+                    if (ip.getDetails() != null) {
+                        nicDeviceType = VirtualEthernetCardType.valueOf(ip.getDetails().get("nicAdapter"));
+                    }
+                    plugNicCommandInternal(routerName, nicDeviceType, nicTO, VirtualMachine.Type.DomainRouter);
                     publicNicInfo = vmMo.getNicDeviceIndex(publicNeworkName);
                     if (publicNicInfo.first().intValue() >= 0) {
                         networkUsage(controlIp, "addVif", "eth" + publicNicInfo.first());
@@ -2312,39 +2320,6 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VirtualDevice nic;
             int nicMask = 0;
             int nicCount = 0;
-
-            if (vmSpec.getType() == VirtualMachine.Type.DomainRouter) {
-                int extraPublicNics = mgr.getRouterExtraPublicNics();
-                if (extraPublicNics > 0 && vmSpec.getDetails().containsKey("PeerRouterInstanceName")) {
-                    //Set identical MAC address for RvR on extra public interfaces
-                    String peerRouterInstanceName = vmSpec.getDetails().get("PeerRouterInstanceName");
-
-                    VirtualMachineMO peerVmMo = hyperHost.findVmOnHyperHost(peerRouterInstanceName);
-                    if (peerVmMo == null) {
-                        peerVmMo = hyperHost.findVmOnPeerHyperHost(peerRouterInstanceName);
-                    }
-
-                    if (peerVmMo != null) {
-                        String oldMacSequence = generateMacSequence(nics);
-
-                        for (int nicIndex = nics.length - extraPublicNics; nicIndex < nics.length; nicIndex++) {
-                            VirtualDevice nicDevice = peerVmMo.getNicDeviceByIndex(nics[nicIndex].getDeviceId());
-                            if (nicDevice != null) {
-                                String mac = ((VirtualEthernetCard) nicDevice).getMacAddress();
-                                if (mac != null) {
-                                    s_logger.info("Use same MAC as previous RvR, the MAC is " + mac + " for extra NIC with device id: " + nics[nicIndex].getDeviceId());
-                                    nics[nicIndex].setMac(mac);
-                                }
-                            }
-                        }
-
-                        if (!StringUtils.isBlank(vmSpec.getBootArgs())) {
-                            String newMacSequence = generateMacSequence(nics);
-                            vmSpec.setBootArgs(replaceNicsMacSequenceInBootArgs(oldMacSequence, newMacSequence, vmSpec));
-                        }
-                    }
-                }
-            }
 
             VirtualEthernetCardType nicDeviceType;
 

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2063,7 +2063,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             buf.append(" dnssearchorder=").append(domain_suffix);
         }
 
-        if (profile.getHypervisorType() == HypervisorType.VMware || profile.getHypervisorType() == HypervisorType.Hyperv) {
+        if (profile.getHypervisorType() == HypervisorType.Hyperv) {
             buf.append(" extra_pubnics=" + _routerExtraPublicNics);
         }
 


### PR DESCRIPTION
### Description

This PR fixes #5716 where isolated network VR failed to deploy when Vmxnet3 adapter type is used and when router.extra.public.nics is not 0. This is because of the extra nics that are reserved in the VR based on the global setting router.extra.public.nics.

To address the issue we have now implemented nic hot plugging for isolated networks because systemvm templates had open-vm-tools installed and support hot plugging which is what is already used in the case of VPC VR.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Steps to reproduce:
1. Set the global setting vmware.systemvm.nic.device.type to Vmxnet3 and router.extra.public.nics to some value (not 0)
2. Create an isolated network and VM in it.
3. VR will stuck in starting state

After the fix, following are the test cases that are performed
1. Set the global setting vmware.systemvm.nic.device.type to Vmxnet3. router.extra.public.nics is not used in VMware anymore.
2. Create an isolated network N1 and VM in it
3. Add a new IP range with different vlan under "Physical Network Guest Public".
4. Aquire an IP from the above range in the network N1
5. Enable staticnat on that IP
6. Observed VR interfaces a new interface is created dynamically

Followed the same steps with vmware.systemvm.nic.device.type value E1000 and VR came up and subsequent operations of acquiring IP, enabling static NAT worked fine.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
