### PR TITLE
[UI] Added account field to upload volume

### DIFF
--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -98,12 +98,8 @@ export default {
           docHelp: 'adminguide/storage.html#uploading-an-existing-volume-to-a-virtual-machine',
           label: 'label.upload.volume.from.url',
           listView: true,
-          args: ['url', 'name', 'zoneid', 'format', 'diskofferingid', 'checksum'],
-          mapping: {
-            format: {
-              options: ['RAW', 'VHD', 'VHDX', 'OVA', 'QCOW2']
-            }
-          }
+          popup: true,
+          component: () => import('@/views/storage/UploadVolume.vue')
         },
         {
           api: 'attachVolume',

--- a/ui/src/views/storage/UploadVolume.vue
+++ b/ui/src/views/storage/UploadVolume.vue
@@ -1,20 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 <template>
   <div class="form-layout" v-ctrl-enter="handleSubmit">
     <span v-if="uploadPercentage > 0">
@@ -27,22 +10,12 @@
         :form="form"
         @submit="handleSubmit"
         layout="vertical">
-        <a-form-item :label="$t('label.templatefileupload')">
-          <a-upload-dragger
-            :multiple="false"
-            :fileList="fileList"
-            :remove="handleRemove"
-            :beforeUpload="beforeUpload"
-            v-decorator="['file', {
-              rules: [{ required: true, message: `${this.$t('message.error.required.input')}`}]
-            }]">
-            <p class="ant-upload-drag-icon">
-              <a-icon type="cloud-upload" />
-            </p>
-            <p class="ant-upload-text" v-if="fileList.length === 0">
-              {{ $t('label.volume.volumefileupload.description') }}
-            </p>
-          </a-upload-dragger>
+        <a-form-item :label="$t('label.url')">
+          <a-input
+            v-decorator="['url', {
+              rules: [{ required: true, message: `${this.$t('message.error.required.input')}` }]
+            }]"
+            :placeholder="apiParams.url.description"/>
         </a-form-item>
         <a-form-item>
           <tooltip-label slot="label" :title="$t('label.name')" :tooltip="apiParams.name.description"/>
@@ -86,7 +59,7 @@
               initialValue: formats[0],
               rules: [
                 {
-                  required: false,
+                  required: true,
                   message: `${this.$t('message.error.select')}`
                 }
               ]
@@ -98,6 +71,27 @@
             }" >
             <a-select-option v-for="format in formats" :key="format">
               {{ format }}
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+        <a-form-item>
+          <tooltip-label slot="label" :title="$t('label.diskofferingid')" :tooltip="apiParams.diskofferingid.description || 'Disk Offering'"/>
+          <a-select
+            v-decorator="['diskofferingid', {
+              initialValue: selectedDiskOfferingId,
+              rules: [{ required: false, message: $t('message.error.select') }]}]"
+            :loading="loading"
+            @change="id => onChangeDiskOffering(id)"
+            showSearch
+            optionFilterProp="children"
+            :filterOption="(input, option) => {
+              return option.componentOptions.children[0].text.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            }" >
+            <a-select-option
+              v-for="(offering, index) in offerings"
+              :value="offering.id"
+              :key="index">
+              {{ offering.displaytext || offering.name }}
             </a-select-option>
           </a-select>
         </a-form-item>
@@ -152,24 +146,24 @@
 
 <script>
 import { api } from '@/api'
-import { axios } from '../../utils/request'
 import ResourceIcon from '@/components/view/ResourceIcon'
 import TooltipLabel from '@/components/widgets/TooltipLabel'
 
 export default {
-  name: 'UploadLocalVolume',
+  name: 'UploadVolume',
   components: {
     ResourceIcon,
     TooltipLabel
   },
   data () {
     return {
-      fileList: [],
       zones: [],
       domainList: [],
       accountList: [],
       formats: ['RAW', 'VHD', 'VHDX', 'OVA', 'QCOW2'],
+      offerings: [],
       zoneSelected: '',
+      selectedDiskOfferingId: null,
       domainId: null,
       account: null,
       uploadParams: null,
@@ -180,50 +174,35 @@ export default {
   },
   beforeCreate () {
     this.form = this.$form.createForm(this)
-    this.apiParams = this.$getApiParams('getUploadParamsForVolume')
+    this.apiParams = this.$getApiParams('uploadVolume')
   },
   created () {
     this.fetchData()
   },
   methods: {
-    listZones () {
-      api('listZones', { showicon: true }).then(json => {
-        if (json && json.listzonesresponse && json.listzonesresponse.zone) {
-          this.zones = json.listzonesresponse.zone
-          if (this.zones.length > 0) {
-            this.zoneSelected = this.zones[0].id
-          }
-        }
-      })
-    },
-    handleRemove (file) {
-      const index = this.fileList.indexOf(file)
-      const newFileList = this.fileList.slice()
-      newFileList.splice(index, 1)
-      this.fileList = newFileList
-    },
-    beforeUpload (file) {
-      this.fileList = [...this.fileList, file]
-      return false
-    },
-    handleDomainChange (domain) {
-      this.domainId = domain
-      if ('listAccounts' in this.$store.getters.apis) {
-        this.fetchAccounts()
-      }
-    },
-    handleAccountChange (acc) {
-      if (acc) {
-        this.account = acc.name
-      } else {
-        this.account = acc
-      }
-    },
     fetchData () {
-      this.listZones()
+      this.loading = true
+      api('listZones', { showicon: true }).then(json => {
+        this.zones = json.listzonesresponse.zone || []
+        this.selectedZoneId = this.zones[0].id || ''
+        this.fetchDiskOfferings(this.selectedZoneId)
+      }).finally(() => {
+        this.loading = false
+      })
       if ('listDomains' in this.$store.getters.apis) {
         this.fetchDomains()
       }
+    },
+    fetchDiskOfferings (zoneId) {
+      this.loading = true
+      api('listDiskOfferings', {
+        zoneid: zoneId,
+        listall: true
+      }).then(json => {
+        this.offerings = json.listdiskofferingsresponse.diskoffering || []
+      }).finally(() => {
+        this.loading = false
+      })
     },
     fetchDomains () {
       this.domainLoading = true
@@ -254,6 +233,24 @@ export default {
         this.$notifyError(error)
       })
     },
+    onChangeDiskOffering (id) {
+      const offering = this.offerings.filter(x => x.id === id)
+      this.customDiskOffering = offering[0]?.iscustomized || false
+      this.isCustomizedDiskIOps = offering[0]?.iscustomizediops || false
+    },
+    handleDomainChange (domain) {
+      this.domainId = domain
+      if ('listAccounts' in this.$store.getters.apis) {
+        this.fetchAccounts()
+      }
+    },
+    handleAccountChange (acc) {
+      if (acc) {
+        this.account = acc.name
+      } else {
+        this.account = acc
+      }
+    },
     handleSubmit (e) {
       e.preventDefault()
       if (this.loading) return
@@ -261,62 +258,28 @@ export default {
         if (err) {
           return
         }
-        const params = {}
+        const params = {
+        }
         for (const key in values) {
           const input = values[key]
           if (input === undefined) {
-            continue
-          }
-          if (key === 'file') {
             continue
           }
           params[key] = input
         }
         params.domainId = this.domainId
         this.loading = true
-        api('getUploadParamsForVolume', params).then(json => {
-          this.uploadParams = (json.postuploadvolumeresponse && json.postuploadvolumeresponse.getuploadparams) ? json.postuploadvolumeresponse.getuploadparams : ''
-          const { fileList } = this
-          if (this.fileList.length > 1) {
-            this.$notification.error({
-              message: this.$t('message.upload.volume.failed'),
-              description: this.$t('message.upload.file.limit'),
-              duration: 0
-            })
-          }
-          const formData = new FormData()
-          fileList.forEach(file => {
-            formData.append('files[]', file)
+        api('uploadVolume', params).then(json => {
+          this.$notification.success({
+            message: this.$t('message.success.upload'),
+            description: this.$t('message.success.upload.volume.description')
           })
-          this.uploadPercentage = 0
-          axios.post(this.uploadParams.postURL,
-            formData,
-            {
-              headers: {
-                'Content-Type': 'multipart/form-data',
-                'X-signature': this.uploadParams.signature,
-                'X-expires': this.uploadParams.expires,
-                'X-metadata': this.uploadParams.metadata
-              },
-              onUploadProgress: (progressEvent) => {
-                this.uploadPercentage = Number(parseFloat(100 * progressEvent.loaded / progressEvent.total).toFixed(1))
-              },
-              timeout: 86400000
-            }).then((json) => {
-            this.$notification.success({
-              message: this.$t('message.success.upload'),
-              description: this.$t('message.success.upload.volume.description')
-            })
-            this.closeAction()
-          }).catch(e => {
-            this.$notification.error({
-              message: this.$t('message.upload.failed'),
-              description: `${this.$t('message.upload.iso.failed.description')} -  ${e}`,
-              duration: 0
-            })
-          }).finally(() => {
-            this.loading = false
-          })
+          this.closeAction()
+          this.$emit('refresh-data')
+        }).catch(error => {
+          this.$notifyError(error)
+        }).finally(() => {
+          this.loading = false
         })
       })
     },
@@ -328,11 +291,11 @@ export default {
 </script>
 
 <style scoped lang="less">
-  .form-layout {
-    width: 80vw;
+.form-layout {
+  width: 80vw;
 
-    @media (min-width: 700px) {
-      width: 550px;
-    }
+  @media (min-width: 700px) {
+    width: 550px;
   }
+}
 </style>

--- a/ui/src/views/storage/UploadVolume.vue
+++ b/ui/src/views/storage/UploadVolume.vue
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 <template>
   <div class="form-layout" v-ctrl-enter="handleSubmit">
     <span v-if="uploadPercentage > 0">


### PR DESCRIPTION
### Description

This PR adds two fields (account and domain) to 'upload volume from local' and 'upload volume from URL' forms. Since the API already supports this feature, only UI changes were made.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/48719461/151813585-5fb576e2-be0b-46b3-9b7d-390435aa9c90.png)
![image](https://user-images.githubusercontent.com/48719461/151813618-404f3ed3-7a1c-41bd-8a3c-def9034dd149.png)

### How Has This Been Tested?

This was tested in a local lab by uploading multiple volumes to different accounts at different domains, using both forms, and checking if they were correctly assigned.

