### PR TITLE
[Simulator] Fix NPE in SolidFireHostListener

### DIFF
--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireHostListener.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireHostListener.java
@@ -78,9 +78,10 @@ public class SolidFireHostListener implements HypervisorHostListener {
             return false;
         }
 
-        SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.PROVIDER_NAME,
-                clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
-
+        if (host.getClusterId() != null) {
+            SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.PROVIDER_NAME,
+                    clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
+        }
         handleVMware(host, true, ModifyTargetsCommand.TargetTypeToRemove.NEITHER);
 
         return true;

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireHostListener.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireHostListener.java
@@ -73,15 +73,19 @@ public class SolidFireHostListener implements HypervisorHostListener {
         HostVO host = hostDao.findById(hostId);
 
         if (host == null) {
-            LOGGER.error("Failed to add host by SolidFireHostListener as host was not found with id = " + hostId);
+            LOGGER.error(String.format("Failed to add host by SolidFireHostListener as host was not found with id = %s ", hostId));
 
             return false;
         }
 
-        if (host.getClusterId() != null) {
-            SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.PROVIDER_NAME,
-                    clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
+        if (host.getClusterId() == null) {
+            LOGGER.error("Failed to add host by SolidFireHostListener as host has no associated cluster id");
+            return false;
         }
+
+        SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.PROVIDER_NAME,
+                    clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
+
         handleVMware(host, true, ModifyTargetsCommand.TargetTypeToRemove.NEITHER);
 
         return true;

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireSharedHostListener.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireSharedHostListener.java
@@ -67,15 +67,18 @@ public class SolidFireSharedHostListener implements HypervisorHostListener {
         HostVO host = hostDao.findById(hostId);
 
         if (host == null) {
-            LOGGER.error("Failed to add host by SolidFireSharedHostListener as host was not found with id = " + hostId);
+            LOGGER.error(String.format("Failed to add host by SolidFireSharedHostListener as host was not found with id = %s ", hostId));
 
             return false;
         }
 
-        if (host.getClusterId() != null) {
-            SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.SHARED_PROVIDER_NAME,
-                    clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
+        if (host.getClusterId() == null) {
+            LOGGER.error("Failed to add host by SolidFireHostListener as host has no associated cluster id");
+            return false;
         }
+
+        SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.SHARED_PROVIDER_NAME,
+                    clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
 
         handleVMware(host, true, ModifyTargetsCommand.TargetTypeToRemove.NEITHER);
 

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireSharedHostListener.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireSharedHostListener.java
@@ -72,8 +72,10 @@ public class SolidFireSharedHostListener implements HypervisorHostListener {
             return false;
         }
 
-        SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.SHARED_PROVIDER_NAME,
-                clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
+        if (host.getClusterId() != null) {
+            SolidFireUtil.hostAddedToCluster(hostId, host.getClusterId(), SolidFireUtil.SHARED_PROVIDER_NAME,
+                    clusterDao, hostDao, storagePoolDao, storagePoolDetailsDao);
+        }
 
         handleVMware(host, true, ModifyTargetsCommand.TargetTypeToRemove.NEITHER);
 

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireSharedHostListener.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/provider/SolidFireSharedHostListener.java
@@ -73,7 +73,7 @@ public class SolidFireSharedHostListener implements HypervisorHostListener {
         }
 
         if (host.getClusterId() == null) {
-            LOGGER.error("Failed to add host by SolidFireHostListener as host has no associated cluster id");
+            LOGGER.error("Failed to add host by SolidFireSharedHostListener as host has no associated cluster id");
             return false;
         }
 


### PR DESCRIPTION
### Description

This PR NPE noticed on Simulator env when adding host (SSVM/CPVM) in SolidFireHostListener
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Error Logs:
```
2022-02-07 13:05:43,926 ERROR [c.c.s.l.StoragePoolMonitor] (Simulator-Agent-Mgr-1:ctx-b2c1f3d4) (logid:91a7c512) hostAdded(long) failed for storage provider SolidFire
java.lang.NullPointerException
        at org.apache.cloudstack.storage.datastore.provider.SolidFireHostListener.hostAdded(SolidFireHostListener.java:81)
        at com.cloud.storage.listener.StoragePoolMonitor.processHostAdded(StoragePoolMonitor.java:84)
        at com.cloud.agent.manager.AgentManagerImpl.notifyMonitorsOfNewlyAddedHost(AgentManagerImpl.java:551)
        at com.cloud.agent.manager.AgentManagerImpl.handleDirectConnectAgent(AgentManagerImpl.java:1532)
        at com.cloud.resource.ResourceManagerImpl.createHostAndAgent(ResourceManagerImpl.java:2377)
        at com.cloud.resource.ResourceManagerImpl.discoverHostsFull(ResourceManagerImpl.java:849)
        at com.cloud.resource.ResourceManagerImpl.discoverHosts(ResourceManagerImpl.java:648)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
        at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
        at com.sun.proxy.$Proxy210.discoverHosts(Unknown Source)
        at com.cloud.agent.manager.MockAgentManagerImpl$SystemVMHandler.run(MockAgentManagerImpl.java:367)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
2022-02-07 13:05:43,927 ERROR [c.c.s.l.StoragePoolMonitor] (Simulator-Agent-Mgr-1:ctx-b2c1f3d4) (logid:91a7c512) hostAdded(long) failed for storage provider SolidFireShared
java.lang.NullPointerException
        at org.apache.cloudstack.storage.datastore.provider.SolidFireSharedHostListener.hostAdded(SolidFireSharedHostListener.java:75)
        at com.cloud.storage.listener.StoragePoolMonitor.processHostAdded(StoragePoolMonitor.java:84)
        at com.cloud.agent.manager.AgentManagerImpl.notifyMonitorsOfNewlyAddedHost(AgentManagerImpl.java:551)
        at com.cloud.agent.manager.AgentManagerImpl.handleDirectConnectAgent(AgentManagerImpl.java:1532)
        at com.cloud.resource.ResourceManagerImpl.createHostAndAgent(ResourceManagerImpl.java:2377)
        at com.cloud.resource.ResourceManagerImpl.discoverHostsFull(ResourceManagerImpl.java:849)
        at com.cloud.resource.ResourceManagerImpl.discoverHosts(ResourceManagerImpl.java:648)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)

```

### How Has This Been Tested?



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
