### PR TITLE
Add disk space in systemVM template registration script

### DIFF
--- a/scripts/storage/secondary/setup-sysvm-tmplt
+++ b/scripts/storage/secondary/setup-sysvm-tmplt
@@ -45,6 +45,8 @@ if [[ ! $@ =~ ^\-.+ ]]; then
 fi
 
 OPTERR=0
+DISKSPACE=2120000  #free disk space required in kilobytes
+
 while getopts 'h:f:d:u::'# OPTION
 do
   case $OPTION in


### PR DESCRIPTION
### Description

This PR adds missing diskspace parameter used to verify is there's sufficient space to proceed with template seeding
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Logs before fix:

```
++ df -P /tmp/tmp6771972685998036544/template/tmpl/1/202
+ destcap=557805568
+ '[' 557805568 -lt ']'
/usr/share/cloudstack-common/scripts/storage/secondary/setup-sysvm-tmplt: line 115: [: 557805568: unary operator expected
++ df -P /tmp/cloud/templates/
++ awk '{print $4}'
++ tail -1
+ localcap=16374084
+ '[' 16374084 -lt ']'
/usr/share/cloudstack-common/scripts/storage/secondary/setup-sysvm-tmplt: line 118: [: 16374084: unary operator expected
+ [[ 1 == \1 ]]
```

Post Fix:

```
++ df -P /tmp/tmp18429250753127863419/template/tmpl/1/208
++ awk '{print $4}'
++ tail -1
+ destcap=861523968
+ '[' 861523968 -lt 2120000 ']'
++ df -P /tmp/cloud/templates/
++ awk '{print $4}'
++ tail -1
+ localcap=16362228
+ '[' 16362228 -lt 2120000 ']'
+ [[ 1 == \1 ]]

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
