### PR TITLE
API: Fix listSSHKeyPairs API when listing all resources (listall=true & projectid=-1)

### DIFF
--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -56,6 +56,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.utils.DateUtil;
@@ -878,7 +879,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             for (final Field field : clazz.getDeclaredFields()) {
                 sql.append(_table).append(".").append(DbUtil.getColumnName(field, overrides)).append(" = ? AND ");
             }
-            sql.delete(sql.length() - 4, sql.length());
+            removeAndClause(sql);
         }
 
         return sql.toString();
@@ -1262,10 +1263,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
 
     @DB()
     protected void addJoins(StringBuilder str, Collection<JoinBuilder<SearchCriteria<?>>> joins) {
+        boolean hasWhereClause = true;
         int fromIndex = str.lastIndexOf("WHERE");
         if (fromIndex == -1) {
             fromIndex = str.length();
-            str.append(" WHERE ");
+            hasWhereClause = false;
         } else {
             str.append(" AND ");
         }
@@ -1287,19 +1289,28 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             .append(" ");
             str.insert(fromIndex, onClause);
             String whereClause = join.getT().getWhereClause();
-            if ((whereClause != null) && !"".equals(whereClause)) {
-                str.append(" (").append(whereClause).append(") AND");
+            if (StringUtils.isNotEmpty(whereClause)) {
+                if (!hasWhereClause) {
+                    str.append(" WHERE ");
+                    hasWhereClause = true;
+                }
             }
             fromIndex += onClause.length();
         }
 
-        str.delete(str.length() - 4, str.length());
+        if (hasWhereClause) {
+            removeAndClause(str);
+        }
 
         for (JoinBuilder<SearchCriteria<?>> join : joins) {
             if (join.getT().getJoins() != null) {
                 addJoins(str, join.getT().getJoins());
             }
         }
+    }
+
+    private void removeAndClause(StringBuilder sql) {
+        sql.delete(sql.length() - 4, sql.length());
     }
 
     @Override

--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -1294,6 +1294,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
                     str.append(" WHERE ");
                     hasWhereClause = true;
                 }
+                str.append(" (").append(whereClause).append(") AND");
             }
             fromIndex += onClause.length();
         }


### PR DESCRIPTION
### Description

This PR fixes the issue noticed when listing all ssh key pairs including ones owned by projects. Exception:
```
(primateqa) 🐱 > list sshkeypairs listall=true projectid=-1
🙈 Error: (HTTP 530, error code 4250) DB Exception on: com.mysql.cj.jdbc.ClientPreparedStatement: SELECT ssh_keypairs.id, ssh_keypairs.uuid, ssh_keypairs.account_id, ssh_keypairs.domain_id, ssh_keypairs.keypair_name, ssh_keypairs.fingerprint, ssh_keypairs.public_key FROM ssh_keypairs  INNER JOIN account ON ssh_keypairs.account_id=account.id  WH ORDER BY ssh_keypairs.id DESC  LIMIT 0, 500
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
#### Post Fix:
```
(localcloud) 🐱 > list sshkeypairs listall=true page=1 pagesize=20 filter=name,
{
  "count": 1,
  "sshkeypair": [
    {
      "name": "ssh"
    }
  ]
}
(localcloud) 🐱 > list sshkeypairs listall=true projectid=-1 page=1 pagesize=20 filter=name,
{
  "count": 2,
  "sshkeypair": [
    {
      "name": "test"
    },
    {
      "name": "ssh"
    }
  ]
}
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
