### PR TITLE
Fix: allow executing CopyCommand operations in parallel when it is set

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/hypervisor/HypervisorGuruManager.java
+++ b/engine/components-api/src/main/java/com/cloud/hypervisor/HypervisorGuruManager.java
@@ -24,4 +24,6 @@ public interface HypervisorGuruManager extends Manager {
     HypervisorGuru getGuru(HypervisorType hypervisorType);
 
     long getGuruProcessedCommandTargetHost(long hostId, Command cmd);
+
+    long getGuruProcessedCommandTargetHost(long hostId, Command cmd, HypervisorType hypervisorType);
 }

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -345,8 +345,12 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                     final long targetHostId = _hvGuruMgr.getGuruProcessedCommandTargetHost(host.getId(), cmd, host.getHypervisorType());
                     answer = easySend(targetHostId, cmd);
                 } catch (final Exception e) {
-                    s_logger.error("Error sending command " + cmd.getClass().getName() + " to host: " +
-                            host.getUuid(), e);
+                    String errorMsg = String.format("Error sending command %s to host %s, due to %s", cmd.getClass().getName(),
+                            host.getUuid(), e.getLocalizedMessage());
+                    s_logger.error(errorMsg);
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug(errorMsg, e);
+                    }
                 }
                 if (answer != null) {
                     return answer;

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -39,7 +39,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.configuration.Config;
-import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.utils.NumbersUtil;
 import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.ca.CAManager;

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.configuration.Config;
+import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.utils.NumbersUtil;
 import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.ca.CAManager;
@@ -342,10 +343,12 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 }
                 Answer answer = null;
                 try {
-
-                    final long targetHostId = _hvGuruMgr.getGuruProcessedCommandTargetHost(host.getId(), cmd);
+                    HypervisorGuru hvGuru = _hvGuruMgr.getGuru(host.getHypervisorType());
+                    Pair<Boolean, Long> result = hvGuru.getCommandHostDelegation(host.getId(), cmd);
+                    final long targetHostId = result.first() ? result.second() : host.getId();
                     answer = easySend(targetHostId, cmd);
                 } catch (final Exception e) {
+                    s_logger.error("Error sending command to host", e);
                 }
                 if (answer != null) {
                     return answer;

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -343,12 +343,11 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 }
                 Answer answer = null;
                 try {
-                    HypervisorGuru hvGuru = _hvGuruMgr.getGuru(host.getHypervisorType());
-                    Pair<Boolean, Long> result = hvGuru.getCommandHostDelegation(host.getId(), cmd);
-                    final long targetHostId = result.first() ? result.second() : host.getId();
+                    final long targetHostId = _hvGuruMgr.getGuruProcessedCommandTargetHost(host.getId(), cmd, host.getHypervisorType());
                     answer = easySend(targetHostId, cmd);
                 } catch (final Exception e) {
-                    s_logger.error("Error sending command to host", e);
+                    s_logger.error("Error sending command " + cmd.getClass().getName() + " to host: " +
+                            host.getUuid(), e);
                 }
                 if (answer != null) {
                     return answer;

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruManagerImpl.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruManagerImpl.java
@@ -81,6 +81,13 @@ public class HypervisorGuruManagerImpl extends ManagerBase implements Hypervisor
         return hostId;
     }
 
+    @Override
+    public long getGuruProcessedCommandTargetHost(long hostId, Command cmd, HypervisorType hypervisorType) {
+        HypervisorGuru guru = getGuru(hypervisorType);
+        Pair<Boolean, Long> result = guru.getCommandHostDelegation(hostId, cmd);
+        return result.first() ? result.second() : hostId;
+    }
+
     public List<HypervisorGuru> getHvGuruList() {
         return _hvGuruList;
     }


### PR DESCRIPTION
### Description

This PR fixes the CopyCommand execute in sequence issue observed in #5925 
Fixes: #5925

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

