### PR TITLE
test: sleep 30s after restarting mgt server in test_kubernetes_supported_versions.py

### DIFF
--- a/test/integration/smoke/test_kubernetes_supported_versions.py
+++ b/test/integration/smoke/test_kubernetes_supported_versions.py
@@ -94,7 +94,9 @@ class TestKubernetesSupportedVersion(cloudstackTestCase):
         #Waits for management to come up in 5 mins, when it's up it will continue
         timeout = time.time() + 300
         while time.time() < timeout:
-            if cls.isManagementUp() is True: return
+            if cls.isManagementUp() is True:
+                time.sleep(30)
+                return
             time.sleep(5)
         return cls.fail("Management server did not come up, failing")
 


### PR DESCRIPTION
### Description

This PR fixes test failure with test_secondary_storage.py

mgmt server is restarted in cleanup of test_kubernetes_supported_versions.py as last step.

in some smoke tests, test_secondary_storage.py is run behind test_kubernetes_supported_versions.py. 
but in  test_secondary_storage.py it checks if all hosts are Up as first step.
sometimes, the mgmt server is Up, but hosts are still in Connecting state. this causes the test failure with test_secondary_storage.py

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
