### PR TITLE
Add ID search capability to sshkeypairs

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ssh/ListSSHKeyPairsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ssh/ListSSHKeyPairsCmd.java
@@ -40,6 +40,8 @@ public class ListSSHKeyPairsCmd extends BaseListProjectAndAccountResourcesCmd {
     /////////////////////////////////////////////////////
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = SSHKeyPairResponse.class, description = "the ID of the ssh keypair")
+    private Long id;
 
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "A key pair name to look for")
     private String name;
@@ -50,6 +52,9 @@ public class ListSSHKeyPairsCmd extends BaseListProjectAndAccountResourcesCmd {
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
+    public Long getId() {
+        return id;
+    }
 
     public String getName() {
         return name;

--- a/api/src/main/java/org/apache/cloudstack/api/response/SSHKeyPairResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SSHKeyPairResponse.java
@@ -21,8 +21,12 @@ import com.google.gson.annotations.SerializedName;
 import org.apache.cloudstack.api.ApiConstants;
 
 import com.cloud.serializer.Param;
-import org.apache.cloudstack.api.BaseResponseWithAnnotations;
+import com.cloud.user.SSHKeyPair;
 
+import org.apache.cloudstack.api.BaseResponseWithAnnotations;
+import org.apache.cloudstack.api.EntityReference;
+
+@EntityReference(value = SSHKeyPair.class)
 public class SSHKeyPairResponse extends BaseResponseWithAnnotations {
 
     @SerializedName(ApiConstants.ID)

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -4152,6 +4152,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public Pair<List<? extends SSHKeyPair>, Integer> listSSHKeyPairs(final ListSSHKeyPairsCmd cmd) {
+        final Long id = cmd.getId();
         final String name = cmd.getName();
         final String fingerPrint = cmd.getFingerprint();
         final String keyword = cmd.getKeyword();
@@ -4170,6 +4171,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         final SearchCriteria<SSHKeyPairVO> sc = sb.create();
         _accountMgr.buildACLSearchCriteria(sc, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
+
+        if (id != null) {
+            sc.addAnd("id", SearchCriteria.Op.EQ, id);
+        }
 
         if (name != null) {
             sc.addAnd("name", SearchCriteria.Op.EQ, name);

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -605,7 +605,7 @@
         <div v-for="item in $route.meta.related" :key="item.path">
           <router-link
             v-if="$router.resolve('/' + item.name).route.name !== '404'"
-            :to="{ path: '/' + item.name + '?' + item.param + '=' + (item.value ? resource[item.value] : item.param === 'account' ? resource.name + '&domainid=' + resource.domainid : resource.id) }">
+            :to="{ path: '/' + item.name + '?' + item.param + '=' + (item.value ? resource[item.value] : item.param === 'account' ? resource.name + '&domainid=' + resource.domainid : item.param === 'keypair' ? resource.name : resource.id) }">
             <a-button style="margin-right: 10px" :icon="$router.resolve('/' + item.name).route.meta.icon" >
               {{ $t('label.view') + ' ' + $t(item.title) }}
             </a-button>


### PR DESCRIPTION
### Description

This PR adds the search by ID capability to SSH Key pairs to bring it at par with accounts
Also needed as a UI fix

In a 4.16 env, try to view the second / third sshkey. It tries to fetch it by id which does not work and leads to the first keypair always displayed

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

```
(localhost) 🐱 > list sshkeypairs id=5210f701-b13e-4ff7-8aab-eb24ee81526a filter=id,name
{
  "count": 1,
  "sshkeypair": [
    {
      "id": "5210f701-b13e-4ff7-8aab-eb24ee81526a",
      "name": "b"
    }
  ]
}
(localhost) 🐱 > list sshkeypairs filter=id,name
{
  "count": 3,
  "sshkeypair": [
    {
      "id": "d1348275-e203-46bf-a985-45dc2a1b331f",
      "name": "c"
    },
    {
      "id": "5210f701-b13e-4ff7-8aab-eb24ee81526a",
      "name": "b"
    },
    {
      "id": "b4430a09-5b9d-49e4-be55-156e1b7ebd72",
      "name": "a"
    }
  ]
}
```