### PR TITLE
Add option to infer boot type and mode from template

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3885,6 +3885,8 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             throw new CloudRuntimeException("Invalid/null detail-options response object passed");
         }
 
+        options.put(ApiConstants.BootType.UEFI.toString(), Arrays.asList(ApiConstants.BootMode.LEGACY.toString(),
+            ApiConstants.BootMode.SECURE.toString()));
         options.put(VmDetailConstants.KEYBOARD, Arrays.asList("uk", "us", "jp", "fr"));
         options.put(VmDetailConstants.CPU_CORE_PER_SOCKET, Collections.emptyList());
         options.put(VmDetailConstants.ROOT_DISK_SIZE, Collections.emptyList());

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -503,8 +503,8 @@
                       v-if="vm.templateid && ['KVM', 'VMware', 'XenServer'].includes(hypervisor) && !template.deployasis">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
-                          v-decorator="['boottype', { initialValue: options.bootTypes && options.bootTypes.length > 0 ? options.bootTypes[0].id : undefined }]"
-                          @change="fetchBootModes"
+                          v-decorator="['boottype', { initialValue: bootType ? bootType : options.bootTypes && options.bootTypes.length > 0 ? options.bootTypes[0].id : undefined }]"
+                          @change="onBootTypeChange"
                           showSearch
                           optionFilterProp="children"
                           :filterOption="filterOption" >
@@ -515,7 +515,7 @@
                       </a-form-item>
                       <a-form-item :label="$t('label.bootmode')">
                         <a-select
-                          v-decorator="['bootmode', { initialValue: options.bootModes && options.bootModes.length > 0 ? options.bootModes[0].id : undefined }]"
+                          v-decorator="['bootmode', { initialValue: bootMode ? bootMode : options.bootModes && options.bootModes.length > 0 ? options.bootModes[0].id : undefined }]"
                           showSearch
                           optionFilterProp="children"
                           :filterOption="filterOption" >
@@ -786,6 +786,8 @@ export default {
       },
       instanceConfig: {},
       template: {},
+      bootType: '',
+      bootMode: '',
       templateConfigurations: [],
       templateNics: [],
       templateLicenses: [],
@@ -1442,6 +1444,9 @@ export default {
         if (template) {
           var size = template.size / (1024 * 1024 * 1024) || 0 // bytes to GB
           this.dataPreFill.minrootdisksize = Math.ceil(size)
+          this.bootType = this.template?.details?.UEFI ? 'UEFI' : ''
+          this.fetchBootModes(this.bootType)
+          this.bootMode = this.template?.details?.UEFI
         }
       } else if (name === 'isoid') {
         this.templateConfigurations = []
@@ -2218,7 +2223,8 @@ export default {
     },
     onBootTypeChange (value) {
       this.fetchBootModes(value)
-      this.updateFieldValue('bootmode', this.options.bootModes?.[0]?.id || undefined)
+      this.bootMode = this.options.bootModes?.[0]?.id || undefined
+      this.updateFieldValue('bootmode', this.bootMode)
     },
     handleNicsNetworkSelection (nicToNetworkSelection) {
       this.nicToNetworkSelection = nicToNetworkSelection

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -503,7 +503,7 @@
                       v-if="vm.templateid && ['KVM', 'VMware', 'XenServer'].includes(hypervisor) && !template.deployasis">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
-                          v-decorator="['boottype', { initialValue: bootType ? bootType : options.bootTypes && options.bootTypes.length > 0 ? options.bootTypes[0].id : undefined }]"
+                          v-decorator="['boottype', { initialValue: defaultBootType ? defaultBootType : options.bootTypes && options.bootTypes.length > 0 ? options.bootTypes[0].id : undefined }]"
                           @change="onBootTypeChange"
                           showSearch
                           optionFilterProp="children"
@@ -515,7 +515,7 @@
                       </a-form-item>
                       <a-form-item :label="$t('label.bootmode')">
                         <a-select
-                          v-decorator="['bootmode', { initialValue: bootMode ? bootMode : options.bootModes && options.bootModes.length > 0 ? options.bootModes[0].id : undefined }]"
+                          v-decorator="['bootmode', { initialValue: defaultBootMode ? defaultBootMode : options.bootModes && options.bootModes.length > 0 ? options.bootModes[0].id : undefined }]"
                           showSearch
                           optionFilterProp="children"
                           :filterOption="filterOption" >
@@ -786,8 +786,8 @@ export default {
       },
       instanceConfig: {},
       template: {},
-      bootType: '',
-      bootMode: '',
+      defaultBootType: '',
+      defaultBootMode: '',
       templateConfigurations: [],
       templateNics: [],
       templateLicenses: [],
@@ -1444,9 +1444,9 @@ export default {
         if (template) {
           var size = template.size / (1024 * 1024 * 1024) || 0 // bytes to GB
           this.dataPreFill.minrootdisksize = Math.ceil(size)
-          this.bootType = this.template?.details?.UEFI ? 'UEFI' : ''
-          this.fetchBootModes(this.bootType)
-          this.bootMode = this.template?.details?.UEFI
+          this.defaultBootType = this.template?.details?.UEFI ? 'UEFI' : ''
+          this.fetchBootModes(this.defaultBootType)
+          this.defaultBootMode = this.template?.details?.UEFI
         }
       } else if (name === 'isoid') {
         this.templateConfigurations = []
@@ -2223,8 +2223,8 @@ export default {
     },
     onBootTypeChange (value) {
       this.fetchBootModes(value)
-      this.bootMode = this.options.bootModes?.[0]?.id || undefined
-      this.updateFieldValue('bootmode', this.bootMode)
+      this.defaultBootMode = this.options.bootModes?.[0]?.id || undefined
+      this.updateFieldValue('bootmode', this.defaultBootMode)
     },
     handleNicsNetworkSelection (nicToNetworkSelection) {
       this.nicToNetworkSelection = nicToNetworkSelection


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/5932

- Adds the ability to set the boot type and mode in the template itself
- Infers the boot type and mode from the template details in the DeployVM form

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### Screenshots (if appropriate):

#### Add the UEFI : SECURE / LEGACY setting to the template :
![Screenshot from 2022-02-10 11-02-53](https://user-images.githubusercontent.com/8244774/153343972-0070aa11-02e5-4a5d-a285-fd9e7e1765b7.png)

![Screenshot from 2022-02-10 11-03-10](https://user-images.githubusercontent.com/8244774/153343987-dc41b4f7-ff38-4335-a42e-f65ab6ce806f.png)

#### Watch it inferred in the DeployVM form :

![Screenshot from 2022-02-10 11-04-35](https://user-images.githubusercontent.com/8244774/153344131-cd533702-0155-43a5-8bec-5fab105dbd29.png)



