### PR TITLE
ui: Allow domain admin to configure subdomain limits

### DIFF
--- a/ui/src/config/section/domain.js
+++ b/ui/src/config/section/domain.js
@@ -47,7 +47,7 @@ export default {
     },
     {
       name: 'limits',
-      show: (record, route, user) => { return ['Admin'].includes(user.roletype) },
+      show: (record, route, user) => { return ['Admin'].includes(user.roletype) || (['DomainAdmin'].includes(user.roletype) && record.id !== user.domainid) },
       component: () => import('@/components/view/ResourceLimitTab.vue')
     },
     {


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/5973
Allows domain admins to update subdomain limits

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![Screenshot from 2022-02-10 15-30-37](https://user-images.githubusercontent.com/8244774/153383681-773bf2ee-9b1f-4979-99a0-6825056e8f15.png)

