### PR TITLE
[Vmware] Prevent NPE on template registration if guest OS is removed

### DIFF
--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelperImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/deployasis/DeployAsIsHelperImpl.java
@@ -176,8 +176,8 @@ public class DeployAsIsHelperImpl implements DeployAsIsHelper {
             } else {
                 if (StringUtils.isNotEmpty(guestOsDescription)) {
                     for (GuestOSHypervisorVO guestOSHypervisorVO : guestOsMappings) {
-                        GuestOSVO guestOSVO = guestOSDao.findById(guestOSHypervisorVO.getGuestOsId());
-                        if (guestOsDescription.equalsIgnoreCase(guestOSVO.getDisplayName())) {
+                        GuestOSVO guestOSVO = guestOSDao.findByIdIncludingRemoved(guestOSHypervisorVO.getGuestOsId());
+                        if (guestOSVO != null && guestOsDescription.equalsIgnoreCase(guestOSVO.getDisplayName())) {
                             guestOsId = guestOSHypervisorVO.getGuestOsId();
                             break;
                         }


### PR DESCRIPTION
### Description

This PR fixes an NPE at template installation for Vmware 'Read VM settings from OVA', in case the matches guest OS is removed from database in CloudStack

````
2022-02-06 14:46:23,651 DEBUG [o.a.c.s.i.d.DeployAsIsHelperImpl] (RemoteHostEndPoint-1:ctx-602c7d2b) (logid:5cd127a6) Persisting template details hardware-item-GraphicsController-8 from OVF properties for template 398
2022-02-06 14:46:23,659 INFO  [o.a.c.s.i.d.DeployAsIsHelperImpl] (RemoteHostEndPoint-1:ctx-602c7d2b) (logid:5cd127a6) Guest OS information retrieved from the template: windows9Server64Guest - Microsoft Windows Server 2016 or later (64-bit)
2022-02-06 14:46:23,661 INFO  [o.a.c.s.i.d.DeployAsIsHelperImpl] (RemoteHostEndPoint-1:ctx-602c7d2b) (logid:5cd127a6) Minimum hardware version vmx-15 matched to hypervisor version 6.7. Checking guest OS supporting this version
2022-02-06 14:46:23,673 ERROR [o.a.c.s.i.d.DeployAsIsHelperImpl] (RemoteHostEndPoint-1:ctx-602c7d2b) (logid:5cd127a6) Error persisting deploy-as-is details for template 398
java.lang.NullPointerException
	at org.apache.cloudstack.storage.image.deployasis.DeployAsIsHelperImpl.retrieveTemplateGuestOsIdFromGuestOsInfo(DeployAsIsHelperImpl.java:178)
	at org.apache.cloudstack.storage.image.deployasis.DeployAsIsHelperImpl.handleGuestOsFromOVFDescriptor(DeployAsIsHelperImpl.java:202)
	at org.apache.cloudstack.storage.image.deployasis.DeployAsIsHelperImpl.persistTemplateDeployAsIsDetails(DeployAsIsHelperImpl.java:136)
	at org.apache.cloudstack.storage.image.BaseImageStoreDriverImpl.createTemplateAsyncCallback(BaseImageStoreDriverImpl.java:210)
	at jdk.internal.reflect.GeneratedMethodAccessor178.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
````

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Update a record on guest_os table set removed = now() to simulate its deletion
- Register template from URL selecting 'Read VM settings from OVA', assuming the template guest OS matches the removed guest OS