### PR TITLE
Added a log line to HttpUploadServerHandler

### DIFF
--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/HttpUploadServerHandler.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/HttpUploadServerHandler.java
@@ -113,7 +113,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
     @Override
     public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
         if (msg instanceof HttpRequest) {
-            logger.trace(String.format("HTTP request: \n %s", msg));
+            logger.trace(String.format("HTTP request: %s", msg));
             HttpRequest request = this.request = (HttpRequest) msg;
             responseContent.setLength(0);
 

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/HttpUploadServerHandler.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/HttpUploadServerHandler.java
@@ -113,6 +113,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
     @Override
     public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
         if (msg instanceof HttpRequest) {
+            logger.trace(String.format("HTTP request: \n %s", msg));
             HttpRequest request = this.request = (HttpRequest) msg;
             responseContent.setLength(0);
 

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/HttpUploadServerHandler.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/HttpUploadServerHandler.java
@@ -113,7 +113,9 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
     @Override
     public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
         if (msg instanceof HttpRequest) {
-            logger.trace(String.format("HTTP request: %s", msg));
+            if (logger.isTraceEnabled()) {
+                logger.trace(String.format("HTTP request: %s", msg));
+            }
             HttpRequest request = this.request = (HttpRequest) msg;
             responseContent.setLength(0);
 


### PR DESCRIPTION
### Description

When I was trying to upload volumes using CloudMonkey + cURL, the upload would always timeout and the SSVM would not receive the volume's data, even though it was receiving the HTTP headers. By adding this log line, it was possible to find out that cURL sends, by default, a 'Expect: 100-continue' with the HTTP request, and then wait the SSVM response, which never happens. Therefore, this PR proposes to add this log line in case any problems like that in the future happens, they would be more easily discovered by enabling the TRACE log level in the SSVM.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### How Has This Been Tested?
Uploaded volumes using CMK + cURL and read the SSVM's log files.
