### PR TITLE
[marvin, VMware] Fix test_06_disk_offering_strictness_false observed on 'main' branch

### DIFF
--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -25,8 +25,10 @@ from marvin.lib.utils import (isAlmostEqual,
                               cleanup_resources,
                               random_gen)
 from marvin.lib.base import (ServiceOffering,
+                             Configurations,
                              DiskOffering,
                              Account,
+                             StoragePool,
                              VirtualMachine)
 from marvin.lib.common import (list_service_offering,
                                list_virtual_machines,
@@ -716,6 +718,8 @@ class TestServiceOfferings(cloudstackTestCase):
         if self.hypervisor.lower() == "lxc":
             self.skipTest("Skipping this test for {} due to bug CS-38153".format(self.hypervisor))
 
+        self.updateVmwareSettings(False)
+
         offering_data = {
             'displaytext': 'TestDiskOfferingStrictnessFalse',
             'cpuspeed': 512,
@@ -811,7 +815,26 @@ class TestServiceOfferings(cloudstackTestCase):
             "Check service offering of the VM"
         )
 
+        self.updateVmwareSettings(True)
+
         return
+
+    def updateVmwareSettings(self, tearDown):
+        value = "false"
+        if not tearDown:
+            value = "true"
+        if self.hypervisor.lower() == 'vmware':
+            Configurations.update(self.apiclient,
+                                  "vmware.create.full.clone",
+                                  value)
+            allStoragePools = StoragePool.list(
+                self.apiclient
+            )
+            for pool in allStoragePools:
+                Configurations.update(self.apiclient,
+                                      storageid=pool.id,
+                                      name="vmware.create.full.clone",
+                                      value=value)
 
 class TestCpuCapServiceOfferings(cloudstackTestCase):
 


### PR DESCRIPTION
### Description

This PR fixes the test failure observed on main branch for `test_06_disk_offering_strictness_false`
The main reason for the failure, is that the volume fails to resize on change of service offering reporting that the volume has a parent.
```
022-02-14 07:22:01,410 ERROR [c.c.h.v.r.VmwareResource] (DirectAgent-80:ctx-df1ac830 10.0.34.173, job-59/job-60, cmd: ResizeVolumeCommand) (logid:02e59892) Resize of volume in VM [name: i-6-7-VM] is not supported because Disk device [path: i-6-7-VM] has Parents: [6000C296-e4fb-b280-4d56-8e62cda83de9].
2022-02-14 07:22:01,410 ERROR [c.c.h.v.r.VmwareResource] (DirectAgent-80:ctx-df1ac830 10.0.34.173, job-59/job-60, cmd: ResizeVolumeCommand) (logid:02e59892) Failed to resize volume of VM [name: i-6-7-VM] due to: [Resize of volume in VM [name: i-6-7-VM] is not supported because Disk device [path: i-6-7-VM] has Parents: [6000C296-e4fb-b280-4d56-8e62cda83de9].].
java.lang.Exception: Resize of volume in VM [name: i-6-7-VM] is not supported because Disk device [path: i-6-7-VM] has Parents: [6000C296-e4fb-b280-4d56-8e62cda83de9].
        at com.cloud.hypervisor.vmware.resource.VmwareResource.getDiskAfterResizeDiskValidations(VmwareResource.java:951)
        at com.cloud.hypervisor.vmware.resource.VmwareResource.execute(VmwareResource.java:878)
        at com.cloud.hypervisor.vmware.resource.VmwareResource.executeRequest(VmwareResource.java:569)
        at com.cloud.agent.manager.DirectAgentAttache$Task.runInContext(DirectAgentAttache.java:315)
        at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
        at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
        at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
        at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
        at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)

```
For resizing volumes in VMware it is required that `vmware.create.full.clone` be true. Hence, the test has been modified to set it to true at the start of the test and reset it back on completion.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
