### PR TITLE
ui: Pass rootdisksize only if template is not deployasis

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -156,7 +156,7 @@
                           <div v-if="template.deployasis">  {{ this.$t('message.deployasis') }} </div>
                         </span>
                         <disk-size-selection
-                          v-show="showRootDiskSizeChanger"
+                          v-if="showRootDiskSizeChanger"
                           input-decorator="rootdisksize"
                           :preFillContent="dataPreFill"
                           :isCustomized="true"
@@ -1723,11 +1723,12 @@ export default {
           deployVmData.templateid = values.isoid
         }
 
-        if (values.rootdisksize && values.rootdisksize > 0) {
+        if (this.showRootDiskSizeChanger && values.rootdisksize && values.rootdisksize > 0) {
           deployVmData.rootdisksize = values.rootdisksize
-        } else if (this.rootDiskSizeFixed > 0) {
+        } else if (this.rootDiskSizeFixed > 0 && !this.template.deployasis) {
           deployVmData.rootdisksize = this.rootDiskSizeFixed
         }
+
         if (values.hypervisor && values.hypervisor.length > 0) {
           deployVmData.hypervisor = values.hypervisor
         }


### PR DESCRIPTION
### Description

Fixes the issue of not being able to deploy a VM from a deploy-as-is template
<img width="461" alt="Screen Shot 2022-02-15 at 00 09 32" src="https://user-images.githubusercontent.com/8244774/153991444-743aeb4e-1f52-4050-9d46-69611985ca01.png">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial
