### PR TITLE
UI: Reword the setting panel warning

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2193,7 +2193,7 @@
 "label.templatetype": "Template Type",
 "label.tftp.dir": "TFTP Directory",
 "label.tftpdir": "Tftp root directory",
-"label.theme.alert": "The settings panel is only visible in the development environment, please save for the changes to take effect.",
+"label.theme.alert": "Please save for the changes to take effect.",
 "label.theme.color": "Theme Color",
 "label.theme.cyan": "Cyan",
 "label.theme.dark": "Dark Style",


### PR DESCRIPTION
### Description

This PR simply rewords the warning on the setting panel which was outdated

Old:
<img width="353" alt="Screen Shot 2022-02-21 at 22 41 53" src="https://user-images.githubusercontent.com/5295080/155047935-dd68b734-aff9-4b22-8326-c8109552e7a5.png">

New:
<img width="353" alt="Screen Shot 2022-02-21 at 23 01 09" src="https://user-images.githubusercontent.com/5295080/155049502-cb0fb7c3-e4c3-4661-b813-7f566848a492.png">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
