### PR TITLE
Update VM priority (cpu_chares) when live scaling it

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -77,6 +77,9 @@ import org.libvirt.DomainSnapshot;
 import org.libvirt.LibvirtException;
 import org.libvirt.MemoryStatistic;
 import org.libvirt.Network;
+import org.libvirt.SchedParameter;
+import org.libvirt.SchedUlongParameter;
+import org.libvirt.VcpuInfo;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -186,7 +189,6 @@ import com.cloud.vm.VirtualMachine.PowerState;
 import com.cloud.vm.VmDetailConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cloudstack.utils.bytescale.ByteScaleUtils;
-import org.libvirt.VcpuInfo;
 
 /**
  * LibvirtComputingResource execute requests on the computing/routing host using
@@ -4620,5 +4622,38 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     public static long countDomainRunningVcpus(Domain dm) throws LibvirtException {
         VcpuInfo vcpus[] = dm.getVcpusInfo();
         return Arrays.stream(vcpus).filter(vcpu -> vcpu.state.equals(VcpuInfo.VcpuState.VIR_VCPU_RUNNING)).count();
+    }
+
+    /**
+     * Retrieves the cpu_shares (priority) of the running VM <br/>
+     * @param dm domain of the VM.
+     * @return the value of cpu_shares of the running VM.
+     * @throws org.libvirt.LibvirtException
+     **/
+    public static Integer getCpuShares(Domain dm) throws LibvirtException {
+        int cpu_shares = 0;
+        for (SchedParameter c : dm.getSchedulerParameters()) {
+            if (c.field.equals("cpu_shares")) {
+                cpu_shares = Integer.parseInt(c.getValueAsString());
+                return cpu_shares;
+            }
+        }
+        s_logger.warn(String.format("Could not get cpu_shares of domain: [%s]. Returning default value of 0. ", dm.getName()));
+        return cpu_shares;
+    }
+
+    /**
+     * Set the cpu_shares (priority) of the running VM <br/>
+     * @param dm domain of the VM.
+     * @param cpuShares new priority of the running VM.
+     * @throws org.libvirt.LibvirtException
+     **/
+    public static void setCpuShares(Domain dm, Integer cpuShares) throws LibvirtException {
+        SchedUlongParameter[] params = new SchedUlongParameter[1];
+        params[0] = new SchedUlongParameter();
+        params[0].field = "cpu_shares";
+        params[0].value = cpuShares;
+
+        dm.setSchedulerParameters(params);
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -74,6 +74,7 @@ import org.libvirt.DomainInterfaceStats;
 import org.libvirt.LibvirtException;
 import org.libvirt.MemoryStatistic;
 import org.libvirt.NodeInfo;
+import org.libvirt.SchedUlongParameter;
 import org.libvirt.StorageVol;
 import org.libvirt.jna.virDomainMemoryStats;
 import org.mockito.BDDMockito;
@@ -5783,5 +5784,58 @@ public class LibvirtComputingResourceTest {
         Mockito.when(libvirtComputingResourceSpy.getHypervisorQemuVersion()).thenReturn(hypervisorQemuVersion);
         libvirtComputingResourceSpy.setDiskIoDriver(diskDef);
         return diskDef;
+    }
+
+    private SchedUlongParameter[] createSchedParametersWithCpuSharesOf2000 () {
+        SchedUlongParameter[] params = new SchedUlongParameter[1];
+        params[0] = new SchedUlongParameter();
+        params[0].field = "cpu_shares";
+        params[0].value = 2000;
+
+        return params;
+    }
+
+    private SchedUlongParameter[] createSchedParametersWithoutCpuShares () {
+        SchedUlongParameter[] params = new SchedUlongParameter[1];
+        params[0] = new SchedUlongParameter();
+        params[0].field = "weight";
+        params[0].value = 200;
+
+        return params;
+    }
+
+    @Test
+    public void getCpuSharesTestReturnCpuSharesIfFound() throws LibvirtException {
+        SchedUlongParameter[] cpuSharesOf2000 = createSchedParametersWithCpuSharesOf2000();
+
+        Mockito.when(domainMock.getSchedulerParameters()).thenReturn(cpuSharesOf2000);
+        int cpuShares = LibvirtComputingResource.getCpuShares(domainMock);
+
+        Assert.assertEquals(2000, cpuShares);
+    }
+
+    @Test
+    public void getCpuSharesTestReturnZeroIfCpuSharesNotFound() throws LibvirtException {
+        SchedUlongParameter[] withoutCpuShares = createSchedParametersWithoutCpuShares();
+
+        Mockito.when(domainMock.getSchedulerParameters()).thenReturn(withoutCpuShares);
+        int actualValue = LibvirtComputingResource.getCpuShares(domainMock);
+
+        Assert.assertEquals(0, actualValue);
+    }
+
+    @Test
+    public void setCpuSharesTestSuccessfullySetCpuShares() throws LibvirtException {
+        LibvirtComputingResource.setCpuShares(domainMock, 2000);
+        Mockito.verify(domainMock, times(1)).setSchedulerParameters(Mockito.argThat(schedParameters -> {
+            if (schedParameters == null || schedParameters.length > 1 || !(schedParameters[0] instanceof SchedUlongParameter)) {
+                return false;
+            }
+            SchedUlongParameter param = (SchedUlongParameter) schedParameters[0];
+            if (param.field != "cpu_shares" || param.value != 2000) {
+                return false;
+            }
+            return true;
+        }));
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
@@ -78,7 +78,8 @@ public class LibvirtScaleVmCommandWrapperTest extends TestCase {
 
         long memory = ByteScaleUtils.bytesToKib(vmTo.getMaxRam());
         int vcpus = vmTo.getCpus();
-        scalingDetails = String.format("%s memory to [%s KiB] and CPU cores to [%s]", vmTo.toString(), memory, vcpus);
+        int cpuShares = vcpus * vmTo.getSpeed();
+        scalingDetails = String.format("%s memory to [%s KiB], CPU cores to [%s] and cpu_shares to [%s]", vmTo.toString(), memory, vcpus, cpuShares);
 
         PowerMockito.mockStatic(LibvirtComputingResource.class);
     }
@@ -240,5 +241,41 @@ public class LibvirtScaleVmCommandWrapperTest extends TestCase {
         Mockito.doThrow(Exception.class).when(libvirtComputingResourceMock).getLibvirtUtilitiesHelper();
 
         libvirtScaleVmCommandWrapperSpy.execute(scaleVmCommandMock, libvirtComputingResourceMock);
+    }
+
+    @Test
+    public void updateCpuSharesTestOldSharesLessThanNewSharesUpdateShares() throws LibvirtException {
+        int oldShares = 2000;
+        int newShares = 3000;
+
+        PowerMockito.when(LibvirtComputingResource.getCpuShares(Mockito.any())).thenReturn(oldShares);
+        libvirtScaleVmCommandWrapperSpy.updateCpuShares(domainMock, newShares);
+
+        PowerMockito.verifyStatic(LibvirtComputingResource.class, Mockito.times(1));
+        libvirtComputingResourceMock.setCpuShares(domainMock, newShares);
+    }
+
+    @Test
+    public void updateCpuSharesTestOldSharesHigherThanNewSharesDoNothing() throws LibvirtException {
+        int oldShares = 3000;
+        int newShares = 2000;
+
+        PowerMockito.when(LibvirtComputingResource.getCpuShares(Mockito.any())).thenReturn(oldShares);
+        libvirtScaleVmCommandWrapperSpy.updateCpuShares(domainMock, newShares);
+
+        PowerMockito.verifyStatic(LibvirtComputingResource.class, Mockito.times(0));
+        libvirtComputingResourceMock.setCpuShares(domainMock, newShares);
+    }
+
+    @Test
+    public void updateCpuSharesTestOldSharesEqualsNewSharesDoNothing() throws LibvirtException {
+        int oldShares = 2000;
+        int newShares = 2000;
+
+        PowerMockito.when(LibvirtComputingResource.getCpuShares(Mockito.any())).thenReturn(oldShares);
+        libvirtScaleVmCommandWrapperSpy.updateCpuShares(domainMock, newShares);
+
+        PowerMockito.verifyStatic(LibvirtComputingResource.class, Mockito.times(0));
+        libvirtComputingResourceMock.setCpuShares(domainMock, newShares);
     }
 }


### PR DESCRIPTION
### Description

This PR addresses an issue when live scaling a VM with the KVM hypervisor. When the VM has the CPU cores or CPU speed increased, the cpu_shares (priority) of the VM is not updated accordingly. To overcome that, it was needed to manually restart the VM or using the command: `virsh schedinfo --domain <vm_internal_name> --live  cpu_shares=<cpu_shares_value>`. This PR changes this to automatically update the cpu_shares when the CPU cores or speed is increased. It is worth mention that the current behavior caused steal time when VMs would compete for the CPU after a dynamic scale process.

Steps to reproduce:
- Host
    - 6 vCPUs X 2.39Ghz
    - 16GB RAM

- Custom service offering
    - 1 to 6 vCPUs
    - 2.35Ghz

- VM (deploy config)
    - 1 vCPU
    - 1024MB RAM

The cpu_shares of a VM is calculated as follow:
`cpu_shares = number of vCPUs X vCPU frequency in Mhz`

Using the command `virsh schedinfo --domain <internal_vm_name>` the cpu_shares displayed was 2350, which is expected. However, when live scaling the VM to 4 vCPUs, which should return 9400 shares, it was the initial 2350 shares. If the VM is restarted, however, the 9400 shares is used, as it should without the need to restart the VM.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

Using the same configuration and steps I used to describe the bug. Then, when live scaling a VM, it returns the correct cpu_shares without the need to restart it. Therefore, when the VM with the 2350 shares is live scaled to 4 vCPUs, the cpu_shares when using the command mentioned above, returned the correct value of 9400.

Moreover, I created unit tests for the affected methods.
