### PR TITLE
Validate version when writing systemVM's checksum in metadata.ini

### DIFF
--- a/engine/schema/templateConfig.sh
+++ b/engine/schema/templateConfig.sh
@@ -45,8 +45,9 @@ function getGenericName() {
 function getChecksum() {
   local fileData="$1"
   local hvName=$2
+  local buildingVersion="$CS_VERSION.$CS_MINOR_VERSION"
   while IFS= read -r line; do
-    if [[ $line == *"$hvName"* ]]; then
+    if [[ "$line" == *"$buildingVersion-$hvName"* ]]; then
       echo "$(cut -d' ' -f1 <<<"$line")"
     fi
   done <<< "$fileData"


### PR DESCRIPTION
### Description

When building ACS, module `engine-schema` downloads the system VMs' checksums from https://download.cloudstack.org/systemvm/X/ through `templateConfig.sh` and puts them into `metadata.ini`. The method that gets the checksums only validates the hypervisor name, which works fine when we have only the major version; however, when we also have minor versions, it ends up adding all checksums of a hypervisor into `metadata.ini`:

```sh
lab@management:~$ cat /usr/share/cloudstack-management/templates/systemvm/metadata.ini

[ovm3]
templatename = systemvm-ovm3-4.16.0
checksum = 38f84087c5d96548c50a2b52a2856fef
d889b6e490018360f93e54240d74bf93
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-ovm.raw.bz2
filename = systemvmtemplate-4.16.0-ovm.raw.bz2

[xenserver]
templatename = systemvm-xenserver-4.16.0
checksum = 6015c93583c7388e6b3e0e7bc6e3517c
3ccf327c1b0a9c96c506547bf1a6869a
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-xen.vhd.bz2
filename = systemvmtemplate-4.16.0-xen.vhd.bz2

[vmware]
templatename = systemvm-vmware-4.16.0
checksum = 606db78c5d138e96d53b4699e77789b2
f55d3b858b708f3103660d83021cb702
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-vmware.ova
filename = systemvmtemplate-4.16.0-vmware.ova

[hyperv]
templatename = systemvm-hyperv-4.16.0
checksum = 88fe0da9ebaa27d710af708131b9bf32
2d21855fe179a7ce214ffc46c77fac8d
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-hyperv.vhd.zip
filename = systemvmtemplate-4.16.0-hyperv.vhd.zip

[lxc]
templatename = systemvm-lxc-4.16.0
checksum = 2f3747a597396d4ee6a2605648808d1a
5108eeb0547912a41cb2bc508985f89f
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-kvm.qcow2.bz2
filename = systemvmtemplate-4.16.0-kvm.qcow2.bz2

[kvm]
templatename = systemvm-kvm-4.16.0
checksum = 2f3747a597396d4ee6a2605648808d1a
5108eeb0547912a41cb2bc508985f89f
downloadurl = https://download.cloudstack.org/systemvm/4.16/systemvmtemplate-4.16.0-kvm.qcow2.bz2
filename = systemvmtemplate-4.16.0-kvm.qcow2.bz2
```

When we run the management-server, this behavior causes an error that blocks ACS bootstrap:

```
2022-02-23 01:49:14,993 ERROR [c.c.u.SystemVmTemplateRegistration] (main:null) (logid:) Failed to parse systemVM template metadata file: /usr/share/cloudstack-management/templates/systemvm/metadata.ini
org.ini4j.InvalidFileFormatException: parse error (at line: 5): d889b6e490018360f93e54240d74bf93
	at org.ini4j.spi.AbstractParser.parseError(AbstractParser.java:53)
	at org.ini4j.spi.AbstractParser.parseOptionLine(AbstractParser.java:85)
	at org.ini4j.spi.IniParser.parse(IniParser.java:101)
	at org.ini4j.spi.IniParser.parse(IniParser.java:62)
	at org.ini4j.Ini.load(Ini.java:109)
```

This PR intends to validate also the version when getting the system VMs' checksums.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### How Has This Been Tested?
I built the packages, installed into a local lab, verified the file `metadata.ini` (which must have only the checksum of the version being built) and started the management-server.