### PR TITLE
server: mark volume snapshots as Destroyed if it does not exist on primary and secondary storage when delete a volume

### DIFF
--- a/api/src/main/java/com/cloud/storage/snapshot/SnapshotApiService.java
+++ b/api/src/main/java/com/cloud/storage/snapshot/SnapshotApiService.java
@@ -118,4 +118,6 @@ public interface SnapshotApiService {
     Snapshot backupSnapshotFromVmSnapshot(Long snapshotId, Long vmId, Long volumeId, Long vmSnapshotId);
 
     SnapshotPolicy updateSnapshotPolicy(UpdateSnapshotPolicyCmd updateSnapshotPolicyCmd);
+
+    void markVolumeSnapshotsAsDestroyed(Volume volume);
 }

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -122,6 +122,7 @@ import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VMTemplatePoolDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeDetailsDao;
+import com.cloud.storage.snapshot.SnapshotApiService;
 import com.cloud.storage.snapshot.SnapshotManager;
 import com.cloud.storage.template.TemplateProp;
 import com.cloud.user.AccountManager;
@@ -194,6 +195,8 @@ public class VolumeServiceImpl implements VolumeService {
     private StorageManager _storageMgr;
     @Inject
     private AnnotationDao annotationDao;
+    @Inject
+    private SnapshotApiService snapshotApiService;
 
     private final static String SNAPSHOT_ID = "SNAPSHOT_ID";
 
@@ -468,6 +471,7 @@ public class VolumeServiceImpl implements VolumeService {
                         _snapshotStoreDao.remove(snapStoreVo.getId());
                     }
                 }
+                snapshotApiService.markVolumeSnapshotsAsDestroyed(vo);
             } else {
                 vo.processEvent(Event.OperationFailed);
                 apiResult.setResult(result.getResult());

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -448,9 +448,9 @@ public class VolumeServiceImpl implements VolumeService {
                     volDao.remove(vo.getId());
                 }
 
-                SnapshotDataStoreVO snapStoreVo = _snapshotStoreDao.findByVolume(vo.getId(), DataStoreRole.Primary);
+                List<SnapshotDataStoreVO> snapStoreVOs = _snapshotStoreDao.listAllByVolumeAndDataStore(vo.getId(), DataStoreRole.Primary);
 
-                if (snapStoreVo != null) {
+                for (SnapshotDataStoreVO snapStoreVo : snapStoreVOs) {
                     long storagePoolId = snapStoreVo.getDataStoreId();
                     StoragePoolVO storagePoolVO = storagePoolDao.findById(storagePoolId);
 

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1583,25 +1583,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 s_logger.warn("Failed to expunge volume: " + volumeId);
                 return null;
             }
-            markVolumeSnapshotsAsDestroyed(volume);
             removeVolume(volume.getId());
         }
 
         return volume;
-    }
-
-    private void markVolumeSnapshotsAsDestroyed(VolumeVO volume) {
-        if (!Storage.ImageFormat.QCOW2.equals(volume.getFormat())) {
-            return;
-        }
-        List<SnapshotVO> snapshots = _snapshotDao.listByVolumeId(volume.getId());
-        for (SnapshotVO snapshot: snapshots) {
-            List<SnapshotDataStoreVO> snapshotDataStoreVOs = _snapshotDataStoreDao.findBySnapshotId(snapshot.getId());
-            if (CollectionUtils.isEmpty(snapshotDataStoreVOs)) {
-                snapshot.setState(Snapshot.State.Destroyed);
-                _snapshotDao.update(snapshot.getId(), snapshot);
-            }
-        }
     }
 
     @Override

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1583,10 +1583,25 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 s_logger.warn("Failed to expunge volume: " + volumeId);
                 return null;
             }
+            markVolumeSnapshotsAsDestroyed(volume);
             removeVolume(volume.getId());
         }
 
         return volume;
+    }
+
+    private void markVolumeSnapshotsAsDestroyed(VolumeVO volume) {
+        if (!Storage.ImageFormat.QCOW2.equals(volume.getFormat())) {
+            return;
+        }
+        List<SnapshotVO> snapshots = _snapshotDao.listByVolumeId(volume.getId());
+        for (SnapshotVO snapshot: snapshots) {
+            List<SnapshotDataStoreVO> snapshotDataStoreVOs = _snapshotDataStoreDao.findBySnapshotId(snapshot.getId());
+            if (CollectionUtils.isEmpty(snapshotDataStoreVOs)) {
+                snapshot.setState(Snapshot.State.Destroyed);
+                _snapshotDao.update(snapshot.getId(), snapshot);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
when delete a volume in QCOW2 format, if volume snapshot does not exist on primary and secondary storage, mark the snapshot as Destroyed.

This fixes #5433 


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
