### PR TITLE
UI: Fix issue on volume snapshots wizard

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -921,7 +921,7 @@ export default {
           }
         }
         if (this.items.length > 0) {
-          if (!this.showAction) {
+          if (!this.showAction || this.dataView) {
             this.resource = this.items[0]
             this.$emit('change-resource', this.resource)
           }


### PR DESCRIPTION
### Description

This PR fixes an issue observed at the volume snapshot operation under the following conditions:

- Take volume snapshot of volume (click OK on the wizard)
- While the operation is still in progress, click Take volume snapshot again
- Wait until the first operation finishes
- Try taking volume snapshot -> ERROR: missing parameter volumeid

![image](https://user-images.githubusercontent.com/5295080/157047894-2e905fb0-d3a9-4eeb-8229-e09044fcfb49.png)


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Explained on the PR description