### PR TITLE
Fix hv_ss_reserve value for volumes on migration

### DIFF
--- a/api/src/main/java/com/cloud/vm/DiskProfile.java
+++ b/api/src/main/java/com/cloud/vm/DiskProfile.java
@@ -44,6 +44,7 @@ public class DiskProfile {
     private String cacheMode;
     private Long minIops;
     private Long maxIops;
+    private Long newDiskOfferingId;
 
     private HypervisorType hyperType;
 
@@ -247,4 +248,11 @@ public class DiskProfile {
         this.maxIops = maxIops;
     }
 
+    public Long getNewDiskOfferingId() {
+        return newDiskOfferingId;
+    }
+
+    public void setNewDiskOfferingId(Long newDiskOfferingId) {
+        this.newDiskOfferingId = newDiskOfferingId;
+    }
 }

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -2382,10 +2382,12 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             Volume volume = volumeDiskProfilePair.first();
             DiskProfile diskProfile = volumeDiskProfilePair.second();
             VolumeVO volumeVO = _volumeDao.findById(volume.getId());
+            Long newDiskOfferingId = diskProfile.getNewDiskOfferingId();
 
-            if (volumeVO.getHypervisorSnapshotReserve() == null) {
+            if (volumeVO.getHypervisorSnapshotReserve() == null || volumeVO.getHypervisorSnapshotReserve() == 0) {
                 // update the volume's hv_ss_reserve (hypervisor snapshot reserve) from a disk offering (used for managed storage)
-                volService.updateHypervisorSnapshotReserveForVolume(getDiskOfferingVO(volumeVO), volumeVO.getId(), getHypervisorType(volumeVO));
+                volService.updateHypervisorSnapshotReserveForVolume(getDiskOfferingForSnapshotReserve(volumeVO, newDiskOfferingId),
+                        volumeVO.getId(), getHypervisorType(volumeVO));
 
                 // hv_ss_reserve field might have been updated; refresh from DB to make use of it in getDataObjectSizeIncludingHypervisorSnapshotReserve
                 volumeVO = _volumeDao.findById(volume.getId());
@@ -2585,8 +2587,8 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         return volume.getSize();
     }
 
-    private DiskOfferingVO getDiskOfferingVO(Volume volume) {
-        Long diskOfferingId = volume.getDiskOfferingId();
+    private DiskOfferingVO getDiskOfferingForSnapshotReserve(Volume volume, Long newDiskOfferingId) {
+        Long diskOfferingId = newDiskOfferingId == null ? volume.getDiskOfferingId() : newDiskOfferingId;
 
         return _diskOfferingDao.findById(diskOfferingId);
     }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2820,8 +2820,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new CloudRuntimeException("Storage pool " + destPool.getName() + " is not suitable to migrate volume " + vol.getName());
         }
 
+        DiskOfferingVO newDiskOffering = retrieveAndValidateNewDiskOffering(cmd);
         HypervisorType hypervisorType = _volsDao.getHypervisorType(volumeId);
         DiskProfile diskProfile = new DiskProfile(vol, diskOffering, hypervisorType);
+        diskProfile.setNewDiskOfferingId(newDiskOffering.getId());
         Pair<Volume, DiskProfile> volumeDiskProfilePair = new Pair<>(vol, diskProfile);
         if (!storageMgr.storagePoolHasEnoughSpace(Collections.singletonList(volumeDiskProfilePair), destPool)) {
             throw new CloudRuntimeException("Storage pool " + destPool.getName() + " does not have enough space to migrate volume " + vol.getName());
@@ -2866,7 +2868,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
         }
 
-        DiskOfferingVO newDiskOffering = retrieveAndValidateNewDiskOffering(cmd);
         validateConditionsToReplaceDiskOfferingOfVolume(vol, newDiskOffering, destPool);
 
         if (vm != null) {


### PR DESCRIPTION
### Description

This PR updates the volume hv_ss_reserve value for managed storage on volume migration attempt, so it can correctly set the destination size value
Fixes: #5915 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

