### PR TITLE
[UI] Dont show project view menu when user doesn't have permission

### DIFF
--- a/ui/src/components/header/ProjectMenu.vue
+++ b/ui/src/components/header/ProjectMenu.vue
@@ -65,8 +65,7 @@ export default {
   data () {
     return {
       projects: [],
-      loading: false,
-      showProjectMenu: true
+      loading: false
     }
   },
   created () {
@@ -75,7 +74,6 @@ export default {
   methods: {
     fetchData () {
       if (this.isDisabled()) {
-        this.showProjectMenu = false
         return
       }
       var page = 1

--- a/ui/src/components/header/ProjectMenu.vue
+++ b/ui/src/components/header/ProjectMenu.vue
@@ -18,7 +18,7 @@
 <template>
   <span class="header-notice-opener">
     <a-select
-      v-if="showProjectMenu"
+      v-if="!isDisabled()"
       class="project-select"
       :defaultValue="$t('label.default.view')"
       :loading="loading"

--- a/ui/src/components/header/ProjectMenu.vue
+++ b/ui/src/components/header/ProjectMenu.vue
@@ -18,11 +18,11 @@
 <template>
   <span class="header-notice-opener">
     <a-select
+      v-if="showProjectMenu"
       class="project-select"
       :defaultValue="$t('label.default.view')"
       :loading="loading"
       :value="($store.getters.project && 'id' in $store.getters.project) ? ($store.getters.project.displaytext || $store.getters.project.name) : $t('label.default.view')"
-      :disabled="isDisabled()"
       :filterOption="filterProject"
       @change="changeProject"
       @focus="fetchData"
@@ -65,7 +65,8 @@ export default {
   data () {
     return {
       projects: [],
-      loading: false
+      loading: false,
+      showProjectMenu: true
     }
   },
   created () {
@@ -74,6 +75,7 @@ export default {
   methods: {
     fetchData () {
       if (this.isDisabled()) {
+        this.showProjectMenu = false
         return
       }
       var page = 1


### PR DESCRIPTION
### Description

This PR improves clarity to the user concerning the project list view component. The current behavior disables the project view menu when an Account does not have permission to list projects. However, that can be a bit confusing for users, if they have no permission to list projects, then, the expected behavior would be to hide the component that the user does not have access to (that is what happens with other components). Therefore, this PR aims to hide the project view when the user does not have the permission list projects.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):
**Before:**
![image](https://user-images.githubusercontent.com/42067040/157512976-46cd262e-411c-4ddc-8a48-eb7b9c252ae5.png)

**After:**
![image](https://user-images.githubusercontent.com/42067040/157512995-edc27fac-b55e-4117-beba-ed92020046e4.png)

### How Has This Been Tested?
This was tested in a local lab.

Login with an Account that had the permission to the api `listProjects`:
It displayed the Project Menu view as expected.

Login with an Account that didn't have the permission to the api `listProjects`:
The Project View Menu is not shown, as the **After** image in the Screenshots section.
