### PR TITLE
UI: Fix Dedicating resource to a domain

### DIFF
--- a/ui/src/components/view/DedicateData.vue
+++ b/ui/src/components/view/DedicateData.vue
@@ -67,6 +67,9 @@ export default {
     DedicateModal
   },
   inject: ['parentFetchData'],
+  created () {
+    this.fetchData()
+  },
   data () {
     return {
       modalActive: false,


### PR DESCRIPTION
### Description

This PR fixes UI issue seen when dedicating an infra component - zone, pod, host, cluster to a domain
Currently, even when the resource is dedicated, it doesn't reflect on the UI - leading to the following state:
![image](https://user-images.githubusercontent.com/10495417/157610117-ad26d332-2afa-402d-aa95-162e84a678df.png)


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
On dedicating a zone to a domain - it appears as follows:
![image](https://user-images.githubusercontent.com/10495417/157610298-8cca0bc4-3fe3-4dd6-833e-185ca4274d05.png)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
