### PR TITLE
mvn: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <cs.clover-maven-plugin.version>4.4.1</cs.clover-maven-plugin.version>
 
         <!-- Logging versions -->
-        <cs.reload4j.version>1.2.18.4</cs.reload4j.version>
+        <cs.reload4j.version>1.2.19</cs.reload4j.version>
         <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
         <cs.logging.version>1.1.1</cs.logging.version>
 
@@ -95,7 +95,7 @@
         <cs.commons-validator.version>1.6</cs.commons-validator.version>
         <cs.configuration.version>1.10</cs.configuration.version>
         <cs.daemon.version>1.2.3</cs.daemon.version>
-        <cs.dbcp.version>2.8.0</cs.dbcp.version>
+        <cs.dbcp.version>2.9.0</cs.dbcp.version>
         <cs.discovery.version>0.5</cs.discovery.version>
         <cs.lang.version>2.6</cs.lang.version>
         <cs.pool.version>2.9.0</cs.pool.version>
@@ -133,9 +133,9 @@
         <cs.google-http-client>1.38.1</cs.google-http-client>
         <cs.groovy.version>2.4.17</cs.groovy.version>
         <cs.gson.version>1.7.2</cs.gson.version>
-        <cs.guava.version>30.1-jre</cs.guava.version>
+        <cs.guava.version>31.1-jre</cs.guava.version>
         <cs.httpclient.version>4.5.13</cs.httpclient.version>
-        <cs.httpcore.version>4.4.14</cs.httpcore.version>
+        <cs.httpcore.version>4.4.15</cs.httpcore.version>
         <cs.influxdb-java.version>2.21</cs.influxdb-java.version>
         <cs.jackson.version>2.12.1</cs.jackson.version>
         <cs.jasypt.version>1.9.3</cs.jasypt.version>
@@ -146,10 +146,10 @@
         <cs.jaxb.version>2.3.0</cs.jaxb.version>
         <cs.jaxws.version>2.3.2-1</cs.jaxws.version>
         <cs.jersey-client.version>2.26</cs.jersey-client.version>
-        <cs.jetty.version>9.4.44.v20210927</cs.jetty.version>
+        <cs.jetty.version>9.4.45.v20220203</cs.jetty.version>
         <cs.jetty-maven-plugin.version>9.4.27.v20200227</cs.jetty-maven-plugin.version>
         <cs.jna.version>5.5.0</cs.jna.version>
-        <cs.joda-time.version>2.10.9</cs.joda-time.version>
+        <cs.joda-time.version>2.10.13</cs.joda-time.version>
         <cs.jpa.version>2.2.1</cs.jpa.version>
         <cs.jsch.version>0.1.55</cs.jsch.version>
         <cs.json.version>20090211</cs.json.version>
@@ -160,7 +160,7 @@
         <cs.mysql.version>8.0.19</cs.mysql.version>
         <cs.neethi.version>2.0.4</cs.neethi.version>
         <cs.nitro.version>10.1</cs.nitro.version>
-        <cs.opensaml.version>2.6.4</cs.opensaml.version>
+        <cs.opensaml.version>2.6.6</cs.opensaml.version>
         <cs.rados-java.version>0.6.0</cs.rados-java.version>
         <cs.java-linstor.version>0.3.0</cs.java-linstor.version>
         <cs.reflections.version>0.9.12</cs.reflections.version>
@@ -173,7 +173,7 @@
         <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
         <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
         <cs.xstream.version>1.4.19</cs.xstream.version>
-        <org.springframework.version>5.3.3</org.springframework.version>
+        <org.springframework.version>5.3.16</org.springframework.version>
         <cs.ini.version>0.5.4</cs.ini.version>
         <cs.gmaven.version>1.12.0</cs.gmaven.version>
     </properties>

--- a/services/console-proxy/server/pom.xml
+++ b/services/console-proxy/server/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Upgrades the following dependencies:
- reload4j
- dbcp
- guava
- httpcore
- jetty
- joda-time
- opensaml
- spring framework
- websockets lib (console proxy)