### PR TITLE
ui: Fix CreateKubernetesCluster for ha

### DIFF
--- a/ui/src/views/compute/CreateKubernetesCluster.vue
+++ b/ui/src/views/compute/CreateKubernetesCluster.vue
@@ -135,7 +135,7 @@
           <template #label>
             <tooltip-label :title="$t('label.haenable')" :tooltip="apiParams.haenable?.description || ''"/>
           </template>
-          <a-switch v-model:cheked="form.haenable" />
+          <a-switch v-model:checked="form.haenable" />
         </a-form-item>
         <a-form-item v-if="form.haenable">
           <template #label>
@@ -459,7 +459,8 @@ export default {
         if (this.isValidValueForKey(values, 'noderootdisksize') && values.noderootdisksize > 0) {
           params.noderootdisksize = values.noderootdisksize
         }
-        if (this.isValidValueForKey(values, 'controlnodes') && values.controlnodes > 0) {
+        if (this.isValidValueForKey(values, 'haenable') && values.haenable &&
+          this.isValidValueForKey(values, 'controlnodes') && values.controlnodes > 0) {
           params.controlnodes = values.controlnodes
         }
         if (this.isValidValueForKey(values, 'externalloadbalanceripaddress') && values.externalloadbalanceripaddress !== '') {


### PR DESCRIPTION
### Description

Fixes the issue of always sending 2 control plan nodes in the CreateKubernetesCluster vue

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
