### PR TITLE
Set isrecursive to false when listall=true by default for users

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/BaseListDomainResourcesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/BaseListDomainResourcesCmd.java
@@ -16,7 +16,10 @@
 // under the License.
 package org.apache.cloudstack.api;
 
+import com.cloud.user.Account;
+
 import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.context.CallContext;
 
 public abstract class BaseListDomainResourcesCmd extends BaseListCmd implements IBaseListDomainResourcesCmd {
 
@@ -42,7 +45,10 @@ public abstract class BaseListDomainResourcesCmd extends BaseListCmd implements 
     @Override
     public boolean isRecursive() {
         if (listAll()) {
-            return recursive == null ? true : recursive;
+            Account caller = CallContext.current().getCallingAccount();
+            if (caller.getType() != Account.Type.NORMAL) {
+                return recursive == null ? true : recursive;
+            }
         }
         return recursive == null ? false : recursive;
     }

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2925,7 +2925,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         if ((_accountMgr.isNormalUser(account.getId()) || _accountMgr.isDomainAdmin(account.getId())) || account.getType() == Account.Type.RESOURCE_DOMAIN_ADMIN) {
             if (isRecursive) { // domain + all sub-domains
                 if (account.getType() == Account.Type.NORMAL) {
-                    throw new InvalidParameterValueException("Only ROOT admins and Domain admins can list disk offerings with isrecursive=true");
+                    isRecursive = false;
                 }
             }
         }
@@ -3153,7 +3153,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             }
             if (isRecursive) { // domain + all sub-domains
                 if (caller.getType() == Account.Type.NORMAL) {
-                    throw new InvalidParameterValueException("Only ROOT admins and Domain admins can list service offerings with isrecursive=true");
+                    isRecursive = false;
                 }
             }
         } else {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2925,7 +2925,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         if ((_accountMgr.isNormalUser(account.getId()) || _accountMgr.isDomainAdmin(account.getId())) || account.getType() == Account.Type.RESOURCE_DOMAIN_ADMIN) {
             if (isRecursive) { // domain + all sub-domains
                 if (account.getType() == Account.Type.NORMAL) {
-                    isRecursive = false;
+                    throw new InvalidParameterValueException("Only ROOT admins and Domain admins can list disk offerings with isrecursive=true");
                 }
             }
         }
@@ -3153,7 +3153,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             }
             if (isRecursive) { // domain + all sub-domains
                 if (caller.getType() == Account.Type.NORMAL) {
-                    isRecursive = false;
+                    throw new InvalidParameterValueException("Only ROOT admins and Domain admins can list service offerings with isrecursive=true");
                 }
             }
         } else {


### PR DESCRIPTION
### Description

Sets isrecursive=false for users when listall=true by default to prevent any permission issues when listing resources as a user

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Screenshots (if appropriate):


### How Has This Been Tested?

