### PR TITLE
travis: Fix failing list vms & snapshots tests

### DIFF
--- a/test/integration/component/test_acl_listsnapshot.py
+++ b/test/integration/component/test_acl_listsnapshot.py
@@ -457,7 +457,7 @@ class TestSnapshotList(cloudstackTestCase):
     def test_listSnapshot_as_domainadmin_listall_true_rec_false(self):
         """
         Test listing of Snapshots by passing listall="true" and isrecusriv="false" parameter as domain admin
-        Validate that it returns all the Snapshots that is owned by accounts in this domain and all its subdomain
+        Validate that it returns all the Snapshots that is owned by accounts in this domain.
         """
 
         self.apiclient.connection.apiKey = self.user_d1_apikey
@@ -465,7 +465,7 @@ class TestSnapshotList(cloudstackTestCase):
         snapshotList = Snapshot.list(self.apiclient, listall="true", isrecursive="false")
         self.debug("List as Domain Admin  - listall=true,isrecursive=false %s" % snapshotList)
 
-        self.assertEqual(len(snapshotList) == 9,
+        self.assertEqual(len(snapshotList) == 3,
                          True,
                          "Number of items in list response check failed!!")
 
@@ -645,7 +645,8 @@ class TestSnapshotList(cloudstackTestCase):
     def test_listSnapshot_as_domainadmin_domainid_listall_true(self):
         """
         Test listing of Snapshots by passing domainId and listall="true" parameter as domain admin
-        Validate that it returns all the Snapshots in the domain passed
+        Validate that it returns all the Snapshots in the domain passed. When listall="true" and isrescursive
+        isn't passed them isrecursive is treated as 'true'
         """
 
         self.apiclient.connection.apiKey = self.user_d1_apikey
@@ -653,7 +654,7 @@ class TestSnapshotList(cloudstackTestCase):
         snapshotList = Snapshot.list(self.apiclient, domainid=self.domain_11.id, listall="true")
         self.debug("List as Domain Admin passing domainId  - listall=true %s" % snapshotList)
 
-        self.assertEqual(len(snapshotList) == 3,
+        self.assertEqual(len(snapshotList) == 4,
                          True,
                          "Number of items in list response check failed!!")
 
@@ -1391,7 +1392,7 @@ class TestSnapshotList(cloudstackTestCase):
     def test_listSnapshot_as_rootadmin_domainid_listall_true(self):
         """
         Test listing of Snapshots by passing domainid and listall="true" parameter as admin
-        Validate that it returns all the Snapshots in the domain passed
+        Validate that it returns all the Snapshots in the domain passed and its subdomains
         """
 
         self.apiclient.connection.apiKey = self.user_a_apikey
@@ -1399,7 +1400,7 @@ class TestSnapshotList(cloudstackTestCase):
         snapshotList = Snapshot.list(self.apiclient, domainid=self.domain_11.id, listall="true")
         self.debug("List as ROOT Admin passing domainId  - listall=true %s" % snapshotList)
 
-        self.assertEqual(len(snapshotList) == 3,
+        self.assertEqual(len(snapshotList) == 4,
                          True,
                          "Number of items in list response check failed!!")
 

--- a/test/integration/component/test_acl_listvm.py
+++ b/test/integration/component/test_acl_listvm.py
@@ -430,7 +430,7 @@ class TestVMList(cloudstackTestCase):
     def test_listVM_as_domainadmin_listall_true_rec_false(self):
         """
         # Test listing of Vms by passing listall="true" and isrecusriv="false" parameter as domain admin
-        # Validate that it returns all the Vms that is owned by accounts in this domain and all its subdomain
+        # Validate that it returns all the Vms that is owned by accounts in this domain.
         """
 
         self.apiclient.connection.apiKey = self.user_d1_apikey
@@ -438,7 +438,7 @@ class TestVMList(cloudstackTestCase):
         vmList = VirtualMachine.list(self.apiclient, listall="true", isrecursive="false")
         self.debug("List as Domain Admin  - listall=true,isrecursive=false %s" % vmList)
 
-        self.assertEqual(len(vmList) == 9,
+        self.assertEqual(len(vmList) == 3,
                          True,
                          "Number of items in list response check failed!!")
 
@@ -618,7 +618,8 @@ class TestVMList(cloudstackTestCase):
     def test_listVM_as_domainadmin_domainid_listall_true(self):
         """
         # Test listing of Vms by passing domainId and listall="true" parameter as domain admin
-        # Validate that it returns all the Vms in the domain passed
+        # Validate that it returns all the Vms in the domain passed and it's sub-domains (when
+        isrecursive isn't passed, it defaults to true)
         """
 
         self.apiclient.connection.apiKey = self.user_d1_apikey
@@ -626,7 +627,7 @@ class TestVMList(cloudstackTestCase):
         vmList = VirtualMachine.list(self.apiclient, domainid=self.domain_11.id, listall="true")
         self.debug("List as Domain Admin passing domainId  - listall=true %s" % vmList)
 
-        self.assertEqual(len(vmList) == 3,
+        self.assertEqual(len(vmList) == 4,
                          True,
                          "Number of items in list response check failed!!")
 
@@ -1364,7 +1365,7 @@ class TestVMList(cloudstackTestCase):
     def test_listVM_as_rootadmin_domainid_listall_true(self):
         """
         # Test listing of Vms by passing domainid and listall="true" parameter as admin
-        # Validate that it returns all the Vms in the domain passed
+        # Validate that it returns all the Vms in the domain passed and it's subdomains
         """
 
         self.apiclient.connection.apiKey = self.user_a_apikey
@@ -1372,7 +1373,7 @@ class TestVMList(cloudstackTestCase):
         vmList = VirtualMachine.list(self.apiclient, domainid=self.domain_11.id, listall="true")
         self.debug("List as ROOT Admin passing domainId  - listall=true %s" % vmList)
 
-        self.assertEqual(len(vmList) == 3,
+        self.assertEqual(len(vmList) == 4,
                          True,
                          "Number of items in list response check failed!!")
 

--- a/test/integration/component/test_acl_listvolume.py
+++ b/test/integration/component/test_acl_listvolume.py
@@ -443,7 +443,7 @@ class TestVolumeList(cloudstackTestCase):
     def test_listVolume_as_domainadmin_listall_true_rec_false(self):
         """
         # Test listing of Volumes by passing listall="true" and isrecusriv="false" parameter as domain admin
-        # Validate that it returns all the Volumes that is owned by accounts in this domain and all its subdomain
+        # Validate that it returns all the Volumes that is owned by accounts in this domain.
         """
 
         self.apiclient.connection.apiKey = self.user_d1_apikey
@@ -451,7 +451,7 @@ class TestVolumeList(cloudstackTestCase):
         volumeList = Volume.list(self.apiclient, listall="true", isrecursive="false")
         self.debug("List as Domain Admin  - listall=true,isrecursive=false %s" % volumeList)
 
-        self.assertEqual(len(volumeList) == 9,
+        self.assertEqual(len(volumeList) == 3,
                          True,
                          "Number of items in list response check failed!!")
 
@@ -631,7 +631,7 @@ class TestVolumeList(cloudstackTestCase):
     def test_listVolume_as_domainadmin_domainid_listall_true(self):
         """
         # Test listing of Volumes by passing domainId and listall="true" parameter as domain admin
-        # Validate that it returns all the Volumes in the domain passed
+        # Validate that it returns all the Volumes in the domain passed and all the subdomains
         """
 
         self.apiclient.connection.apiKey = self.user_d1_apikey
@@ -639,7 +639,7 @@ class TestVolumeList(cloudstackTestCase):
         volumeList = Volume.list(self.apiclient, domainid=self.domain_11.id, listall="true")
         self.debug("List as Domain Admin passing domainId  - listall=true %s" % volumeList)
 
-        self.assertEqual(len(volumeList) == 3,
+        self.assertEqual(len(volumeList) == 4,
                          True,
                          "Number of items in list response check failed!!")
 
@@ -1381,7 +1381,7 @@ class TestVolumeList(cloudstackTestCase):
         volumeList = Volume.list(self.apiclient, domainid=self.domain_11.id, listall="true")
         self.debug("List as ROOT Admin passing domainId  - listall=true %s" % volumeList)
 
-        self.assertEqual(len(volumeList) == 3,
+        self.assertEqual(len(volumeList) == 4,
                          True,
                          "Number of items in list response check failed!!")
 


### PR DESCRIPTION
### Description

This PR fixes issues in the number of resources returned (VMs/Snapshots) for the corresponding list commands. This pertains to the change in behavior with listall & isrecusive (https://github.com/apache/cloudstack/pull/6045).
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
```
nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=setup/dev/advanced.cfg  -s -a tags=xx --hypervisor=simulator test/integration/component/test_acl_listsnapshot.py 

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/Mar_15_2022_15_55_59_V8ZQH8. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_listSnapshot_as_domainadmin_domainid_listall_true | Status : SUCCESS ===

=== TestName: test_listSnapshot_as_domainadmin_listall_true_rec_false | Status : SUCCESS ===




[16:46:11] pearl@pearl-XPS-15-7590:~/lab/shapeblue/cloudstack$ nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=setup/dev/advanced.cfg  -s -a tags=xx --hypervisor=simulator test/integration/component/test_acl_listvm.py

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/Mar_15_2022_16_49_53_7T5J5R. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_listVM_as_domainadmin_domainid_listall_true | Status : SUCCESS ===

=== TestName: test_listVM_as_domainadmin_listall_true_rec_false | Status : SUCCESS ===

=== TestName: test_listVM_as_rootadmin_domainid_listall_true | Status : SUCCESS ===




$ nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=setup/dev/advanced.cfg  -s -a tags=xx --hypervisor=simulator test/integration/component/test_acl_listvolume.py 

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/Mar_16_2022_17_54_29_RSQTC1. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_listVolume_as_domainadmin_domainid_listall_true | Status : SUCCESS ===

=== TestName: test_listVolume_as_domainadmin_listall_true_rec_false | Status : SUCCESS ===

=== TestName: test_listVolume_as_rootadmin_domainid_listall_true | Status : SUCCESS ===

===final results are now copied to: /tmp/MarvinLogs/test_acl_listvolume_3J1DO0===


```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
