### PR TITLE
agent: Detect existing hosts with UEFI support

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/ReadyAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/ReadyAnswer.java
@@ -19,7 +19,12 @@
 
 package com.cloud.agent.api;
 
+import java.util.Map;
+
 public class ReadyAnswer extends Answer {
+
+    private Map<String, String> detailsMap;
+
     protected ReadyAnswer() {
     }
 
@@ -30,5 +35,15 @@ public class ReadyAnswer extends Answer {
     public ReadyAnswer(ReadyCommand cmd, String details) {
         super(cmd, false, details);
     }
+
+    public ReadyAnswer(ReadyCommand cmd, Map<String, String> detailsMap) {
+        super(cmd, true, null);
+        this.detailsMap = detailsMap;
+    }
+
+    public Map<String, String> getDetailsMap() {
+        return detailsMap;
+    }
+
 
 }

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -600,6 +600,20 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
             // return the attache instead of null, even it is disconnectede
             handleDisconnectWithoutInvestigation(attache, Event.AgentDisconnected, true, true);
         }
+        if (answer instanceof ReadyAnswer) {
+            ReadyAnswer readyAnswer = (ReadyAnswer)answer;
+            Map<String, String> detailsMap = readyAnswer.getDetailsMap();
+            s_logger.info("Got details map : " + detailsMap);
+            if (detailsMap != null) {
+                String uefiEnabled = detailsMap.get(Host.HOST_UEFI_ENABLE);
+                s_logger.info("Got HOST_UEFI_ENABLE : " + uefiEnabled);
+                if (uefiEnabled != null) {
+                    _hostDao.loadDetails(host);
+                    host.getDetails().put(Host.HOST_UEFI_ENABLE, uefiEnabled);
+                    _hostDao.saveDetails(host);
+                }
+            }
+        }
 
         agentStatusTransitTo(host, Event.Ready, _nodeId);
         attache.ready();

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -603,10 +603,9 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
         if (answer instanceof ReadyAnswer) {
             ReadyAnswer readyAnswer = (ReadyAnswer)answer;
             Map<String, String> detailsMap = readyAnswer.getDetailsMap();
-            s_logger.info("Got details map : " + detailsMap);
             if (detailsMap != null) {
                 String uefiEnabled = detailsMap.get(Host.HOST_UEFI_ENABLE);
-                s_logger.info("Got HOST_UEFI_ENABLE : " + uefiEnabled);
+                s_logger.debug(String.format("Got HOST_UEFI_ENABLE [%s] for hostId [%s]:", uefiEnabled, host.getUuid()));
                 if (uefiEnabled != null) {
                     _hostDao.loadDetails(host);
                     host.getDetails().put(Host.HOST_UEFI_ENABLE, uefiEnabled);

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -608,8 +608,10 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 s_logger.debug(String.format("Got HOST_UEFI_ENABLE [%s] for hostId [%s]:", uefiEnabled, host.getUuid()));
                 if (uefiEnabled != null) {
                     _hostDao.loadDetails(host);
-                    host.getDetails().put(Host.HOST_UEFI_ENABLE, uefiEnabled);
-                    _hostDao.saveDetails(host);
+                    if (!uefiEnabled.equals(host.getDetails().get(Host.HOST_UEFI_ENABLE))) {
+                        host.getDetails().put(Host.HOST_UEFI_ENABLE, uefiEnabled);
+                        _hostDao.saveDetails(host);
+                    }
                 }
             }
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -42,14 +42,18 @@ public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyComman
     public Answer execute(final ReadyCommand command, final LibvirtComputingResource libvirtComputingResource) {
         Map<String, String> hostDetails = new HashMap<String, String>();
 
+        if (hostSupportsUefi()) {
+            hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
+        }
+
+        return new ReadyAnswer(command, hostDetails);
+    }
+
+    private boolean hostSupportsUefi() {
         String cmd = "rpm -qa | grep -i ovmf";
         s_logger.debug("Running command : " + cmd);
         int result = Script.runSimpleBashScriptForExitValue(cmd);
         s_logger.debug("Got result : " + result);
-        if (result == 0) {
-            hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.toString(true));
-        }
-
-        return new ReadyAnswer(command, hostDetails);
+        return result == 0;
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -19,18 +19,37 @@
 
 package com.cloud.hypervisor.kvm.resource.wrapper;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.ReadyAnswer;
 import com.cloud.agent.api.ReadyCommand;
+import com.cloud.host.Host;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
+import com.cloud.utils.script.Script;
+
+import org.apache.log4j.Logger;
 
 @ResourceWrapper(handles =  ReadyCommand.class)
 public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyCommand, Answer, LibvirtComputingResource> {
 
+    private static final Logger s_logger = Logger.getLogger(LibvirtReadyCommandWrapper.class);
+
     @Override
     public Answer execute(final ReadyCommand command, final LibvirtComputingResource libvirtComputingResource) {
-        return new ReadyAnswer(command);
+        Map<String, String> hostDetails = new HashMap<String, String>();
+
+        String cmd = "rpm -qa | grep -i ovmf";
+        s_logger.debug("Running command : " + cmd);
+        int result = Script.runSimpleBashScriptForExitValue(cmd);
+        s_logger.debug("Got result : " + result);
+        if (result == 0) {
+            hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.toString(true));
+        }
+
+        return new ReadyAnswer(command, hostDetails);
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -367,10 +367,6 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
                 details.put("url", hostMo.getHostName());
                 details.put("username", username);
                 details.put("password", password);
-                boolean uefiLegacySupported = hostMo.isUefiLegacySupported();
-                if (uefiLegacySupported) {
-                    details.put(Host.HOST_UEFI_ENABLE, "true");
-                }
                 String guid = morHost.getType() + ":" + morHost.getValue() + "@" + url.getHost();
                 details.put("guid", guid);
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -42,7 +42,6 @@ import com.cloud.exception.DiscoveredWithErrorException;
 import com.cloud.exception.DiscoveryException;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.ResourceInUseException;
-import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -211,6 +211,7 @@ import com.cloud.configuration.Resource.ResourceType;
 import com.cloud.dc.Vlan;
 import com.cloud.exception.CloudException;
 import com.cloud.exception.InternalErrorException;
+import com.cloud.host.Host;
 import com.cloud.host.Host.Type;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.guru.VMwareGuru;
@@ -3930,8 +3931,17 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         try {
             VmwareContext context = getServiceContext();
             VmwareHypervisorHost hyperHost = getHyperHost(context);
+
+            Map<String, String> hostDetails = new HashMap<String, String>();
+            ManagedObjectReference morHost = hyperHost.getMor();
+            HostMO hostMo = new HostMO(context, morHost);
+            boolean uefiLegacySupported = hostMo.isUefiLegacySupported();
+            if (uefiLegacySupported) {
+                hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
+            }
+
             if (hyperHost.isHyperHostConnected()) {
-                return new ReadyAnswer(cmd);
+                return new ReadyAnswer(cmd, hostDetails);
             } else {
                 return new ReadyAnswer(cmd, "Host is not in connect state");
             }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -321,9 +321,6 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 details.put("username", username);
                 params.put("username", username);
                 details.put("password", password);
-                if (isUefiSupported(prodVersion)) {
-                    details.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
-                }
                 params.put("password", password);
                 params.put("zone", Long.toString(dcId));
                 params.put("guid", record.uuid);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import static com.cloud.hypervisor.xenserver.discoverer.XcpServerDiscoverer.isUefiSupported;
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 import java.io.BufferedReader;

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1779,9 +1779,6 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             }
             details.put("product_brand", productBrand);
             details.put("product_version", _host.getProductVersion());
-            if (isUefiSupported(_host.getProductVersion())) {
-                details.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
-            }
             if (hr.softwareVersion.get("product_version_text_short") != null) {
                 details.put("product_version_text_short", hr.softwareVersion.get("product_version_text_short"));
                 cmd.setHypervisorVersion(hr.softwareVersion.get("product_version_text_short"));

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixReadyCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixReadyCommandWrapper.java
@@ -19,14 +19,19 @@
 
 package com.cloud.hypervisor.xenserver.resource.wrapper.xenbase;
 
+import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
+import static com.cloud.hypervisor.xenserver.discoverer.XcpServerDiscoverer.isUefiSupported;
+
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.ReadyAnswer;
 import com.cloud.agent.api.ReadyCommand;
+import com.cloud.hypervisor.xenserver.resource.CitrixHelper;
 import com.cloud.hypervisor.xenserver.resource.CitrixResourceBase;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -44,6 +49,7 @@ public final class CitrixReadyCommandWrapper extends CommandWrapper<ReadyCommand
     public Answer execute(final ReadyCommand command, final CitrixResourceBase citrixResourceBase) {
         final Connection conn = citrixResourceBase.getConnection();
         final Long dcId = command.getDataCenterId();
+        Map<String, String> hostDetails = new HashMap<String, String>();
         // Ignore the result of the callHostPlugin. Even if unmounting the
         // snapshots dir fails, let Ready command
         // succeed.
@@ -55,6 +61,11 @@ public final class CitrixReadyCommandWrapper extends CommandWrapper<ReadyCommand
             final Host host = Host.getByUuid(conn, citrixResourceBase.getHost().getUuid());
             final Set<VM> vms = host.getResidentVMs(conn);
             citrixResourceBase.destroyPatchVbd(conn, vms);
+
+            final Host.Record hr = host.getRecord(conn);
+            if (isUefiSupported(CitrixHelper.getProductVersion(hr))) {
+                hostDetails.put(com.cloud.host.Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
+            }
         } catch (final Exception e) {
         }
         try {
@@ -70,6 +81,6 @@ public final class CitrixReadyCommandWrapper extends CommandWrapper<ReadyCommand
             return new ReadyAnswer(command, "Unable to cleanup halted vms");
         }
 
-        return new ReadyAnswer(command);
+        return new ReadyAnswer(command, hostDetails);
     }
 }

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -214,8 +214,6 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
     @Override
     public Map<? extends ServerResource, Map<String, String>>
         find(long dcId, Long podId, Long clusterId, URI uri, String username, String password, List<String> hostTags) throws DiscoveryException {
-        boolean isUefiSupported = false;
-
         ClusterVO cluster = _clusterDao.findById(clusterId);
         if (cluster == null || cluster.getHypervisorType() != getHypervisorType()) {
             if (s_logger.isInfoEnabled())
@@ -278,11 +276,6 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
                     s_logger.debug(errorMsg);
                 }
                 throw new DiscoveredWithErrorException(errorMsg);
-            }
-
-            if (SSHCmdHelper.sshExecuteCmd(sshConnection, "rpm -qa | grep -i ovmf", 3)) {
-                s_logger.debug("It's UEFI enabled KVM machine");
-                isUefiSupported = true;
             }
 
             List<PhysicalNetworkSetupInfo> netInfos = _networkMgr.getPhysicalNetworkInfo(dcId, getHypervisorType());
@@ -368,7 +361,6 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
             Map<String, String> hostDetails = connectedHost.getDetails();
             hostDetails.put("password", password);
             hostDetails.put("username", username);
-            hostDetails.put(Host.HOST_UEFI_ENABLE, isUefiSupported == true ? Boolean.toString(true) : Boolean.toString(false));
             _hostDao.saveDetails(connectedHost);
             return resources;
         } catch (DiscoveredWithErrorException e) {


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/6087
Adds support to detect existing hosts with UEFI capability

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

- Bring up a 4.13 env with VMware 6.5 (anything that supports UEFI)
- Upgrade to latest main 
- Try to deploy a VM with UEFI
- Deployment now passes Previously failed to find a suitable host as none were UEFI compatible


#### Before :
```
MariaDB [cloud]> select * from host_details where name = 'host.uefi.enable' \G
Empty set (0.00 sec)

```

#### After :
```
MariaDB [cloud]> select * from host_details where name = 'host.uefi.enable' \G
*************************** 1. row ***************************
     id: 34
host_id: 1
   name: host.uefi.enable
  value: true
*************************** 2. row ***************************
     id: 40
host_id: 2
   name: host.uefi.enable
  value: true
2 rows in set (0.00 sec)

```