### PR TITLE
Set UefiCapabilty for all hypervisors in hostresponse

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -533,13 +533,6 @@ public class HostResponse extends BaseResponseWithAnnotations {
         detailsCopy.remove("username");
         detailsCopy.remove("password");
 
-        if (detailsCopy.containsKey(Host.HOST_UEFI_ENABLE)) {
-            this.setUefiCapabilty(Boolean.parseBoolean((String) detailsCopy.get(Host.HOST_UEFI_ENABLE)));
-            detailsCopy.remove(Host.HOST_UEFI_ENABLE);
-        } else {
-            this.setUefiCapabilty(new Boolean(false)); // in case of existing host which is not scanned for UEFI capability
-        }
-
         this.details = detailsCopy;
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -230,10 +231,18 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 }
             }
 
+            Map<String, String> hostDetails = hostDetailsDao.findDetails(host.getId());
+            if (hostDetails != null) {
+                if (hostDetails.containsKey(Host.HOST_UEFI_ENABLE)) {
+                    hostResponse.setUefiCapabilty(Boolean.parseBoolean((String) hostDetails.get(Host.HOST_UEFI_ENABLE)));
+                } else {
+                    hostResponse.setUefiCapabilty(new Boolean(false));
+                }
+            }
             if (details.contains(HostDetails.all) && host.getHypervisorType() == Hypervisor.HypervisorType.KVM) {
                 //only kvm has the requirement to return host details
                 try {
-                    hostResponse.setDetails(hostDetailsDao.findDetails(host.getId()));
+                    hostResponse.setDetails(hostDetails);
                 } catch (Exception e) {
                     s_logger.debug("failed to get host details", e);
                 }


### PR DESCRIPTION
### Description

Sets the ueficapability flag for all hypervisor types, not just KVM

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### How Has This Been Tested?

#### Before :
```
(localhost) 🐱 > list hosts filter=name,ueficapability,
{
  "count": 5,
  "host": [
    {
      "name": "s-2-VM"
    },
    {
      "name": "SimulatedAgent.92502eaf-4bd2-4f79-a16b-ef71b7283a51"
    },
    {
      "name": "SimulatedAgent.ce1e03f7-7240-4655-9a7a-6fa81286c289"
    },
    {
      "name": "SimulatedAgent.225c478e-9777-450f-ac80-c4657b0beeb3"
    },
    {
      "name": "SimulatedAgent.9c33d117-7fef-46aa-a806-0ff58a81d7c7"
    }
  ]
}
```

#### After :
```
(localhost) 🐱 > list hosts filter=name,ueficapability,
{
  "count": 5,
  "host": [
    {
      "name": "s-2-VM"
    },
    {
      "name": "SimulatedAgent.92502eaf-4bd2-4f79-a16b-ef71b7283a51",
      "ueficapability": false
    },
    {
      "name": "SimulatedAgent.ce1e03f7-7240-4655-9a7a-6fa81286c289",
      "ueficapability": false
    },
    {
      "name": "SimulatedAgent.225c478e-9777-450f-ac80-c4657b0beeb3",
      "ueficapability": true
    },
    {
      "name": "SimulatedAgent.9c33d117-7fef-46aa-a806-0ff58a81d7c7",
      "ueficapability": true
    }
  ]
}
```

