### PR TITLE
configDrive: Fix failure to delete (unstarted) VM

### DIFF
--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -639,7 +639,10 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
         if (location == Location.SECONDARY) {
             dataStore = _dataStoreMgr.getImageStoreWithFreeCapacity(vm.getDataCenterId());
-            agentId = findAgentIdForImageStore(dataStore);
+            if (!VirtualMachineManager.VmConfigDriveOnPrimaryPool.valueIn(vm.getDataCenterId()) &&
+                    !VirtualMachineManager.VmConfigDriveForceHostCacheUse.valueIn(vm.getDataCenterId()) && dataStore != null) {
+                agentId = findAgentIdForImageStore(dataStore);
+            }
         } else if (location == Location.PRIMARY) {
             List<VolumeVO> volumes = _volumeDao.findByInstanceAndType(vm.getId(), Volume.Type.ROOT);
             if (volumes != null && volumes.size() > 0) {


### PR DESCRIPTION
### Description

This PR fixes the issue observed when trying to expunge a VM created using config drive userdata service (with startVM=false) and the env has no secondary stores.  
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
1. On an env with no secondary store, set the global setting: `vm.configdrive.primarypool.enabled` to true
2. Deploy a VM with a network offering with configDrive userdata service, but do not start it
3. Attempt deleting(expunge) the VM - the VM deletes successfully without NPE 

Performed the above test with  `vm.configdrive.primarypool.enabled` set to false and was also able to expunge the VM


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
