### PR TITLE
KVM: Enhance CPU speed detection on hosts

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -285,3 +285,6 @@ iscsi.session.cleanup.enabled=false
 
 # Enable manually setting CPU's topology on KVM's VM.
 # enable.manually.setting.cpu.topology.on.kvm.vm=true
+
+# host.cpu.manual.speed.mhz = int
+# Manually set the host CPU MHz, in cases where CPU scaling support detected value is wrong

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -371,6 +371,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected String _rngPath = "/dev/random";
     protected int _rngRatePeriod = 1000;
     protected int _rngRateBytes = 2048;
+    protected int _manualCpuSpeed = 0;
     protected String _agentHooksBasedir = "/etc/cloudstack/agent/hooks";
 
     protected String _agentHooksLibvirtXmlScript = "libvirt-vm-xml-transformer.groovy";
@@ -1033,6 +1034,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (Boolean.parseBoolean(value)) {
             _noMemBalloon = true;
         }
+
+        value = (String)params.get("host.cpu.manual.speed.mhz");
+        _manualCpuSpeed = NumbersUtil.parseInt(value, 0);
 
         _videoHw = (String) params.get("vm.video.hardware");
         value = (String) params.get("vm.video.ram");
@@ -3294,7 +3298,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     @Override
     public StartupCommand[] initialize() {
 
-        final KVMHostInfo info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem);
+        final KVMHostInfo info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem, _manualCpuSpeed);
 
         String capabilities = String.join(",", info.getCapabilities());
         if (dpdkSupport) {

--- a/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/linux/KVMHostInfoTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/linux/KVMHostInfoTest.java
@@ -16,16 +16,26 @@
 // under the License.
 package org.apache.cloudstack.utils.linux;
 
+import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
 import org.apache.commons.lang.SystemUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.Assume;
 import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.libvirt.Connect;
 import org.mockito.Mockito;
 
 import org.libvirt.NodeInfo;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(value = {LibvirtConnection.class})
+@PowerMockIgnore({"javax.xml.*", "org.w3c.dom.*", "org.apache.xerces.*", "org.xml.*"})
 public class KVMHostInfoTest {
     @Test
     public void getCpuSpeed() {
@@ -33,5 +43,23 @@ public class KVMHostInfoTest {
         NodeInfo nodeInfo = Mockito.mock(NodeInfo.class);
         nodeInfo.mhz = 1000;
         Assert.assertThat(KVMHostInfo.getCpuSpeed(nodeInfo), Matchers.greaterThan(0l));
+    }
+
+    @Test
+    public void manualCpuSpeedTest() throws Exception {
+        PowerMockito.mockStatic(LibvirtConnection.class);
+        Connect conn = Mockito.mock(Connect.class);
+        NodeInfo nodeInfo = Mockito.mock(NodeInfo.class);
+        nodeInfo.mhz = 1000;
+        String capabilitiesXml = "<capabilities></capabilities>";
+
+        PowerMockito.doReturn(conn).when(LibvirtConnection.class, "getConnection");
+        PowerMockito.when(conn.nodeInfo()).thenReturn(nodeInfo);
+        PowerMockito.when(conn.getCapabilities()).thenReturn(capabilitiesXml);
+        PowerMockito.when(conn.close()).thenReturn(0);
+        int manualSpeed = 500;
+
+        KVMHostInfo kvmHostInfo = new KVMHostInfo(10, 10, manualSpeed);
+        Assert.assertEquals(kvmHostInfo.getCpuSpeed(), manualSpeed);
     }
 }


### PR DESCRIPTION
### Description

This PR does two things:

1. In a recent commit the way host CPU speed is detected was changed to use `lscpu`. This is a great enhancement, but it changed the detected speed from being the host's max turbo frequency to being the base clock. I agree this is the ideal speed to use since the max turbo frequency usually is not achieved by all cores at once. To ensure the fallback of using `cpufreq` files matches this behavior, we change the fallback to look at the `base_frequency` file rather than `cpuinfo_max_freq`.

2. Introduce agent.properties setting `host.cpu.manual.speed.mhz` to allow the admin to set the frequency in case all else fails.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?