### PR TITLE
ui: fix vpc tier redirect to show details

### DIFF
--- a/ui/src/components/view/ResourceView.vue
+++ b/ui/src/components/view/ResourceView.vue
@@ -118,6 +118,11 @@ export default {
     },
     '$route.fullPath': function () {
       this.setActiveTab()
+    },
+    tabs: {
+      handler () {
+        this.setActiveTab()
+      }
     }
   },
   created () {

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -34,7 +34,7 @@
                 {{ $t('label.name') }}
               </div>
               <div>
-                <router-link :to="{ path: '/guestnetwork/' + network.id }">{{ network.name }} </router-link>
+                <router-link :to="{ path: '/guestnetwork/' + network.id, query: { tab: 'details' } }">{{ network.name }} </router-link>
                 <a-tag v-if="network.broadcasturi">{{ network.broadcasturi }}</a-tag>
               </div>
             </div>

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -34,7 +34,7 @@
                 {{ $t('label.name') }}
               </div>
               <div>
-                <router-link :to="{ path: '/guestnetwork/' + network.id, query: { tab: 'details' } }">{{ network.name }} </router-link>
+                <router-link :to="{ path: '/guestnetwork/' + network.id }">{{ network.name }} </router-link>
                 <a-tag v-if="network.broadcasturi">{{ network.broadcasturi }}</a-tag>
               </div>
             </div>


### PR DESCRIPTION
### Description

When redirecting to VPC tier from VPC view, details tab should be active by default

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before:
![Screenshot from 2022-03-30 13-31-08](https://user-images.githubusercontent.com/153340/160782125-b5c0fa9d-8c7a-4d05-ad9c-eb00ea55d058.png)


After:
![Screenshot from 2022-03-30 13-31-26](https://user-images.githubusercontent.com/153340/160782143-d336d814-8380-40cc-8793-f7bec7b301b5.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
