### PR TITLE
Added new field to updateBackupOffering API.

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
@@ -27,6 +27,7 @@ import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.BackupOfferingResponse;
 import org.apache.cloudstack.backup.BackupManager;
 import org.apache.cloudstack.backup.BackupOffering;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -55,6 +56,9 @@ public class UpdateBackupOfferingCmd extends BaseCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "The name of the Backup Offering to be updated")
     private String name;
 
+    @Parameter(name = ApiConstants.ALLOW_USER_DRIVEN_BACKUPS, type = CommandType.BOOLEAN, description = "Whether to allow user driven backups or not")
+    private Boolean allowUserDrivenBackups;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -70,20 +74,26 @@ public class UpdateBackupOfferingCmd extends BaseCmd {
         return description;
     }
 
+    public Boolean getAllowUserDrivenBackups() {
+        return allowUserDrivenBackups;
+    }
+
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////
     /////////////////////////////////////////////////////
     @Override
     public void execute() {
         try {
-            if (StringUtils.isAllEmpty(name, description)) {
-                throw new InvalidParameterValueException(String.format("Can't update Backup Offering [id: %s] because there is no change in name or description.", id));
+            if (StringUtils.isAllEmpty(name, description) && allowUserDrivenBackups == null) {
+                throw new InvalidParameterValueException(String.format("Can't update Backup Offering [id: %s] because there are no parameters to be updated, at least one of the",
+                        "following should be informed: name, description or allowUserDrivenBackups.", id));
             }
 
             BackupOffering result = backupManager.updateBackupOffering(this);
 
             if (result == null) {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to update backup offering [id: %s, name: %s, description: %s].", id, name, description));
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to update backup offering %s.",
+                        ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "id", "name", "description", "allowUserDrivenBackups")));
             }
             BackupOfferingResponse response = _responseGenerator.createBackupOfferingResponse(result);
             response.setResponseName(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/backup/UpdateBackupOfferingCmd.java
@@ -84,7 +84,7 @@ public class UpdateBackupOfferingCmd extends BaseCmd {
     @Override
     public void execute() {
         try {
-            if (StringUtils.isAllEmpty(name, description) && allowUserDrivenBackups == null) {
+            if (StringUtils.isAllEmpty(getName(), getDescription()) && getAllowUserDrivenBackups() == null) {
                 throw new InvalidParameterValueException(String.format("Can't update Backup Offering [id: %s] because there are no parameters to be updated, at least one of the",
                         "following should be informed: name, description or allowUserDrivenBackups.", id));
             }

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -1081,14 +1081,14 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         Long id = updateBackupOfferingCmd.getId();
         String name = updateBackupOfferingCmd.getName();
         String description = updateBackupOfferingCmd.getDescription();
+        Boolean allowUserDrivenBackups = updateBackupOfferingCmd.getAllowUserDrivenBackups();
 
         BackupOfferingVO backupOfferingVO = backupOfferingDao.findById(id);
         if (backupOfferingVO == null) {
             throw new InvalidParameterValueException(String.format("Unable to find Backup Offering with id: [%s].", id));
         }
-
-        LOG.debug(String.format("Trying to update Backup Offering [id: %s, name: %s, description: %s] to [name: %s, description: %s].",
-                backupOfferingVO.getUuid(), backupOfferingVO.getName(), backupOfferingVO.getDescription(), name, description));
+        LOG.debug(String.format("Trying to update Backup Offering %s to %s.", ReflectionToStringBuilderUtils.reflectOnlySelectedFields(backupOfferingVO,"uuid", "name",
+                        "description", "userDrivenBackupAllowed"), ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this,"name", "description", "allowUserDrivenBackups")));
 
         BackupOfferingVO offering = backupOfferingDao.createForUpdate(id);
         List<String> fields = new ArrayList<>();
@@ -1102,13 +1102,19 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
             fields.add("description: " + description);
         }
 
+
+        if (allowUserDrivenBackups != null){
+            offering.setUserDrivenBackupAllowed(allowUserDrivenBackups);
+            fields.add("allowUserDrivenBackups: " + allowUserDrivenBackups);
+        }
+
         if (!backupOfferingDao.update(id, offering)) {
             LOG.warn(String.format("Couldn't update Backup offering [id: %s] with [%s].", id, String.join(", ", fields)));
         }
 
         BackupOfferingVO response = backupOfferingDao.findById(id);
         CallContext.current().setEventDetails(String.format("Backup Offering updated [%s].",
-                ReflectionToStringBuilderUtils.reflectOnlySelectedFields(response, "id", "name", "description", "externalId")));
+                ReflectionToStringBuilderUtils.reflectOnlySelectedFields(response, "id", "name", "description", "userDrivenBackupAllowed", "externalId")));
         return response;
     }
 

--- a/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
@@ -18,6 +18,7 @@ package org.apache.cloudstack.backup;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.command.admin.backup.UpdateBackupOfferingCmd;
 import org.apache.cloudstack.backup.dao.BackupOfferingDao;
 import org.junit.Before;
@@ -79,34 +80,26 @@ public class BackupManagerTest {
         }
     }
 
-    @Test
+    @Test (expected = InvalidParameterValueException.class)
     public void testExceptionWhenUpdateWithNonExistentId() {
-        try {
-            Long id = 123l;
+        Long id = 123l;
 
-            UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
-            when(cmd.getId()).thenReturn(id);
+        UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
+        when(cmd.getId()).thenReturn(id);
 
-            backupManager.updateBackupOffering(cmd);
-        } catch (InvalidParameterValueException e) {
-            assertEquals("Unable to find Backup Offering with id: [123].", e.getMessage());
-        }
+        backupManager.updateBackupOffering(cmd);
     }
 
-    @Test
+    @Test (expected = ServerApiException.class)
     public void testExceptionWhenUpdateWithoutChanges() {
-        try {
-            Long id = 1234l;
+        UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
+        when(cmd.getName()).thenReturn(null);
+        when(cmd.getDescription()).thenReturn(null);
+        when(cmd.getAllowUserDrivenBackups()).thenReturn(null);
 
-            UpdateBackupOfferingCmd cmd = Mockito.spy(UpdateBackupOfferingCmd.class);
-            when(cmd.getId()).thenReturn(id);
-            when(cmd.getName()).thenReturn(null);
-            when(cmd.getDescription()).thenReturn(null);
+        Mockito.doCallRealMethod().when(cmd).execute();
 
-            backupManager.updateBackupOffering(cmd);
-        } catch (InvalidParameterValueException e) {
-            assertEquals("Can't update Backup Offering [id: 1234] because there is no change in name or description.", e.getMessage());
-        }
+        cmd.execute();
     }
 
     @Test

--- a/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
@@ -48,6 +48,7 @@ public class BackupManagerTest {
         when(offering.getId()).thenReturn(1234l);
         when(offering.getName()).thenCallRealMethod();
         when(offering.getDescription()).thenCallRealMethod();
+        when(offering.isUserDrivenBackupAllowed()).thenCallRealMethod();
 
         BackupOfferingVO offeringUpdate = Mockito.spy(BackupOfferingVO.class);
         when(offeringUpdate.getId()).thenReturn(1234l);
@@ -59,6 +60,7 @@ public class BackupManagerTest {
         when(backupOfferingDao.update(1234l, offeringUpdate)).thenAnswer(answer -> {
             offering.setName("New name");
             offering.setDescription("New description");
+            offering.setUserDrivenBackupAllowed(true);
             return true;
         });
     }
@@ -115,9 +117,11 @@ public class BackupManagerTest {
         when(cmd.getId()).thenReturn(id);
         when(cmd.getName()).thenReturn("New name");
         when(cmd.getDescription()).thenReturn("New description");
+        when(cmd.getAllowUserDrivenBackups()).thenReturn(true);
 
         BackupOffering updated = backupManager.updateBackupOffering(cmd);
         assertEquals("New name", updated.getName());
         assertEquals("New description", updated.getDescription());
+        assertEquals(true, updated.isUserDrivenBackupAllowed());
     }
 }


### PR DESCRIPTION
### Description

This PR aims to add a new field to the `updateBackupOffering` API, allowing users to change the `allowuserdrivenbackups` parameter of a Backup Offering. Some unit tests were adapted/fixed as well.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab, by calling the `updateBackupOffering` API multiple times and changing a Backup Offering's parameters back and forth.
