### PR TITLE
KVM: Enable SSL if keystore exists

### DIFF
--- a/agent/src/main/java/com/cloud/agent/AgentShell.java
+++ b/agent/src/main/java/com/cloud/agent/AgentShell.java
@@ -27,6 +27,7 @@ import com.cloud.utils.PropertiesUtil;
 import com.cloud.utils.backoff.BackoffAlgorithm;
 import com.cloud.utils.backoff.impl.ConstantTimeBackoff;
 import com.cloud.utils.exception.CloudRuntimeException;
+import org.apache.cloudstack.utils.security.KeyStoreUtils;
 import org.apache.commons.daemon.Daemon;
 import org.apache.commons.daemon.DaemonContext;
 import org.apache.commons.daemon.DaemonInitException;
@@ -374,6 +375,7 @@ public class AgentShell implements IAgentShell, Daemon {
 
         loadProperties();
         parseCommand(args);
+        enableSSL();
 
         if (s_logger.isDebugEnabled()) {
             List<String> properties = Collections.list((Enumeration<String>)_properties.propertyNames());
@@ -395,6 +397,24 @@ public class AgentShell implements IAgentShell, Daemon {
         s_logger.info("Defaulting to the constant time backoff algorithm");
         _backoff = new ConstantTimeBackoff();
         _backoff.configure("ConstantTimeBackoff", new HashMap<String, Object>());
+    }
+
+    private void enableSSL() {
+        final File agentFile = PropertiesUtil.findConfigFile("agent.properties");
+        if (agentFile == null) {
+            s_logger.info("Failed to find agent.properties file");
+            return;
+        }
+        String keystorePass = getProperty(null, "keystore.passphrase");
+        if (StringUtils.isBlank(keystorePass)) {
+            return;
+        }
+        final String keyStoreFile = agentFile.getParent() + "/" + KeyStoreUtils.KS_FILENAME;
+        File f = new File(keyStoreFile);
+        if (f.exists() && !f.isDirectory()) {
+            System.setProperty("javax.net.ssl.trustStore", keyStoreFile);
+            System.setProperty("javax.net.ssl.trustStorePassword", keystorePass);
+        }
     }
 
     private void launchAgent() throws ConfigurationException {

--- a/agent/src/main/java/com/cloud/agent/AgentShell.java
+++ b/agent/src/main/java/com/cloud/agent/AgentShell.java
@@ -407,6 +407,7 @@ public class AgentShell implements IAgentShell, Daemon {
         }
         String keystorePass = getProperty(null, "keystore.passphrase");
         if (StringUtils.isBlank(keystorePass)) {
+            s_logger.info("Failed to find passphrase for keystore: " + KeyStoreUtils.KS_FILENAME);
             return;
         }
         final String keyStoreFile = agentFile.getParent() + "/" + KeyStoreUtils.KS_FILENAME;
@@ -414,6 +415,8 @@ public class AgentShell implements IAgentShell, Daemon {
         if (f.exists() && !f.isDirectory()) {
             System.setProperty("javax.net.ssl.trustStore", keyStoreFile);
             System.setProperty("javax.net.ssl.trustStorePassword", keystorePass);
+        } else {
+            s_logger.info("Failed to find keystore file: " + keyStoreFile);
         }
     }
 


### PR DESCRIPTION
### Description

This PR enables SSL in kvm agent if keystore exists.

This fixes the issue in URL check of direct-download templates

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
