### PR TITLE
.asf.yaml: dummy fix to re-kick asf-infra integration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,10 +43,10 @@ github:
     squash: true
     rebase: false
 
+  collaborators:
+    - acs-robot
+
   protected_branches:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 2
-
-  collaborators:
-    - acs-robot


### PR DESCRIPTION
This is to re-kick an integration issue, following Daniel's advice on asf-infra slack;

<img width="885" alt="Screenshot 2022-04-06 at 2 30 03 PM" src="https://user-images.githubusercontent.com/95203/161937809-8ed58b2f-4bd0-427c-9b59-093baa0f72d4.png">

