### PR TITLE
Display proper gateway length in health check result

### DIFF
--- a/systemvm/debian/root/health_checks/gateways_check.py
+++ b/systemvm/debian/root/health_checks/gateways_check.py
@@ -44,7 +44,7 @@ def main():
             unreachableGateWays.append(gw)
 
     if len(unreachableGateWays) == 0:
-        print "All " + str(len(gws)) + " gateways are reachable via ping"
+        print "All " + str(len(gwsList)) + " gateways are reachable via ping"
         exit(0)
     else:
         print "Unreachable gateways found-"


### PR DESCRIPTION
### Description
The output always returns 1 since all gateways are present in one line
but the actual output should be the number of gateways present
in that line


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Before the fix

```
# python gateways_check.py basic
gw is [{u'gatewaysIps': u'10.135.126.254 169.254.0.1'}]
gwsList is [u'10.135.126.254', u'169.254.0.1']
All 1 gateways are reachable via ping
```


After the fix

```
# python gateways_check.py basic
gw is [{u'gatewaysIps': u'10.135.126.254 169.254.0.1'}]
gwsList is [u'10.135.126.254', u'169.254.0.1']
All 2 gateways are reachable via ping
```