### PR TITLE
upgrade: update minreq.sysvmtemplate.version to the latest template version

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41610to41700.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41610to41700.java
@@ -70,7 +70,7 @@ public class Upgrade41610to41700 implements DbUpgrade, DbUpgradeSystemVmTemplate
     }
 
     private void initSystemVmTemplateRegistration() {
-        systemVmTemplateRegistration = new SystemVmTemplateRegistration("4.16.0");
+        systemVmTemplateRegistration = new SystemVmTemplateRegistration("");
     }
 
     @Override


### PR DESCRIPTION

### Description

This PR fixes the value set for `minreq.sysvmtemplate.version` when upgrading to 4.17. Because of the value being hard-coded to 4.16.0 at  https://github.com/apache/cloudstack/blob/main/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41610to41700.java#L73 it doesn't pick the right value, i.e., 4.16.1
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Upgrade from 4.16 to 4.17 and validate the global setting minreq.sysvmtemplate.version value

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
