### PR TITLE
Allow expunging a VM on a deleted host when using host cache and ConfigDrive userdata service

### DIFF
--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.cloud.host.HostVO;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
@@ -563,6 +564,11 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         LOG.debug("Deleting config drive ISO for vm: " + vm.getInstanceName() + " on host: " + hostId);
         final String isoPath = ConfigDrive.createConfigDrivePath(vm.getInstanceName());
         final HandleConfigDriveIsoCommand configDriveIsoCommand = new HandleConfigDriveIsoCommand(isoPath, null, null, false, true, false);
+        HostVO hostVO = _hostDao.findById(hostId);
+        if (hostVO == null) {
+            LOG.warn(String.format("Host %s appears to be unavailable, skipping deletion of config-drive ISO on host cache", hostId));
+            return false;
+        }
 
         final HandleConfigDriveIsoAnswer answer = (HandleConfigDriveIsoAnswer) agentManager.easySend(hostId, configDriveIsoCommand);
         if (answer == null) {


### PR DESCRIPTION
### Description

This PR fixes an issue observed during expunging a VM deployed on a network using COnfigDrive userdata service and host cache
```
2022-04-08 07:24:14,834 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-8:ctx-e4d333b0 job-78) (logid:a6b8b1aa) Unexpected exception while executing org.apache.cloudstack.api.command.admin.vm.DestroyVMCmdByAdmin
com.cloud.utils.exception.CloudRuntimeException: Unable to get an answer to handle config drive deletion for vm: i-2-8-VM on host: 1
        at com.cloud.network.element.ConfigDriveNetworkElement.deleteConfigDriveIsoOnHostCache(ConfigDriveNetworkElement.java:569)
        at com.cloud.network.element.ConfigDriveNetworkElement.deleteConfigDriveIso(ConfigDriveNetworkElement.java:638)
        at com.cloud.network.element.ConfigDriveNetworkElement.postStateTransitionEvent(ConfigDriveNetworkElement.java:321)
        at com.cloud.network.element.ConfigDriveNetworkElement.postStateTransitionEvent(ConfigDriveNetworkElement.java:89)
        at com.cloud.utils.fsm.StateMachine2.transitTo(StateMachine2.java:142)
        at com.cloud.vm.VirtualMachineManagerImpl.stateTransitTo(VirtualMachineManagerImpl.java:2129)
        at com.cloud.vm.VirtualMachineManagerImpl$5.doInTransactionWithoutResult(VirtualMachineManagerImpl.java:2160)
        at com.cloud.utils.db.TransactionCallbackWithExceptionNoReturn.doInTransaction(TransactionCallbackWithExceptionNoReturn.java:25)
        at com.cloud.utils.db.TransactionCallbackWithExceptionNoReturn.doInTransaction(TransactionCallbackWithExceptionNoReturn.java:21)
        at com.cloud.utils.db.Transaction.execute(Transaction.java:40)
        at com.cloud.vm.VirtualMachineManagerImpl.destroy(VirtualMachineManagerImpl.java:2150)

```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Post Fix:
Successfully expunges the VM
```
022-04-08 08:22:29,583 DEBUG [o.a.c.e.o.NetworkOrchestrator] (API-Job-Executor-2:ctx-d3f0bdc8 job-94 ctx-6bcc9fd2) (logid:4d070eb7) Asking ConfigDrive to release NicProfile {"broadcastUri":null,"iPv4Address":"10.1.1.226","id":18,"reservationId":"9b5d5de0-a880-4ee4-b906-6fa086b19010","vmId":8}
2022-04-08 08:22:29,584 DEBUG [c.c.n.e.ConfigDriveNetworkElement] (API-Job-Executor-2:ctx-d3f0bdc8 job-94 ctx-6bcc9fd2) (logid:4d070eb7) Deleting config drive ISO for vm: i-2-8-VM on host: 1
2022-04-08 08:22:29,587 WARN  [c.c.n.e.ConfigDriveNetworkElement] (API-Job-Executor-2:ctx-d3f0bdc8 job-94 ctx-6bcc9fd2) (logid:4d070eb7) Host 1 appears to be unavailable, skipping deletion of config-drive ISO on host cache
2022-04-08 08:22:29,595 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (API-Job-Executor-2:ctx-d3f0bdc8 job-94 ctx-6bcc9fd2) (logid:4d070eb7) Sync job-96 execution on object VmWorkJobQueue.8
2022-04-08 08:22:31,498 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (AsyncJobMgr-Heartbeat-1:ctx-dd836c4c) (logid:00038e1f) Execute sync-queue item: SyncQueueItemVO {id:34, queueId: 9, contentType: AsyncJob, contentId: 96, lastProcessMsid: 32986976224091, lastprocessNumber: 10, lastProcessTime: Fri Apr 08 08:22:31 UTC 2022, created: Fri Apr 08 08:22:29 UTC 2022}
2022-04-08 08:22:31,500 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (AsyncJobMgr-Heartbeat-1:ctx-dd836c4c) (logid:00038e1f) Schedule queued job-96
2022-04-08 08:22:31,508 INFO  [o.a.c.f.j.i.AsyncJobMonitor] (Work-Job-Executor-5:ctx-a7f3e64f job-94/job-96) (logid:030ae26c) Add job-96 into job monitoring
2022-04-08 08:22:31,511 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (Work-Job-Executor-5:ctx-a7f3e64f job-94/job-96) (logid:4d070eb7) Executing AsyncJobVO: {id:96, userId: 2, accountId: 2, instanceType: null, instanceId: null, cmd: com.cloud.vm.VmWorkStop, cmdInfo: rO0ABXNyABdjb20uY2xvdWQudm0uVm1Xb3JrU3RvcALQ4GymiWjjAgABWgAHY2xlYW51cHhyABNjb20uY2xvdWQudm0uVm1Xb3Jrn5m2VvAlZ2sCAARKAAlhY2NvdW50SWRKAAZ1c2VySWRKAAR2bUlkTAALaGFuZGxlck5hbWV0ABJMamF2YS9sYW5nL1N0cmluZzt4cAAAAAAAAAACAAAAAAAAAAIAAAAAAAAACHQAGVZpcnR1YWxNYWNoaW5lTWFuYWdlckltcGwA, cmdVersion: 0, status: IN_PROGRESS, processStatus: 0, resultCode: 0, result: null, initMsid: 32986976224091, completeMsid: null, lastUpdated: null, lastPolled: null, created: Fri Apr 08 08:22:29 UTC 2022, removed: null}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
