### PR TITLE
UI: Fix protocol reset after changing provider on Add Primary Storage

### DIFF
--- a/ui/src/views/infra/AddPrimaryStorage.vue
+++ b/ui/src/views/infra/AddPrimaryStorage.vue
@@ -514,7 +514,9 @@ export default {
       } else {
         this.protocols = ['nfs']
       }
-      this.form.protocol = this.protocols[0]
+      if (!value) {
+        this.form.protocol = this.protocols[0]
+      }
     },
     nfsURL (server, path) {
       var url
@@ -642,7 +644,7 @@ export default {
         this.protocols = ['custom']
         this.form.protocol = 'custom'
       } else {
-        this.fetchHypervisor(null)
+        this.fetchHypervisor(value)
       }
     },
     closeModal () {


### PR DESCRIPTION
### Description

This PR fixes the Add primary storage wizard: protocol got reset to always 'NFS' after changing the provider

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested on KVM env - Add primary storage