### PR TITLE
Extract the IO_URING configuration into the agent.properties

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -285,3 +285,6 @@ iscsi.session.cleanup.enabled=false
 
 # Enable manually setting CPU's topology on KVM's VM.
 # enable.manually.setting.cpu.topology.on.kvm.vm=true
+
+# Enable/disable IO driver for Qemu / It's enabled by default on KVM agents
+# enable.io.uring=true

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -54,6 +54,13 @@ public class AgentProperties{
      */
     public static final Property<Boolean> ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM = new Property<Boolean>("enable.manually.setting.cpu.topology.on.kvm.vm", true);
 
+    /**
+     * Enable manually IO driver on KVM's VM. <br>
+     * Data type: boolean.<br>
+     * Default value: true.
+     */
+    public static final Property<Boolean> ENABLE_IO_URING = new Property<Boolean>("enable.io.uring", true);
+
     public static class Property <T>{
         private final String name;
         private final T defaultValue;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2956,7 +2956,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      * (ii) Libvirt >= 6.3.0
      */
     protected void setDiskIoDriver(DiskDef disk) {
-        if (getHypervisorLibvirtVersion() >= HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IO_URING && getHypervisorQemuVersion() >= HYPERVISOR_QEMU_VERSION_SUPPORTS_IO_URING) {
+        if (getHypervisorLibvirtVersion() >= HYPERVISOR_LIBVIRT_VERSION_SUPPORTS_IO_URING
+                && getHypervisorQemuVersion() >= HYPERVISOR_QEMU_VERSION_SUPPORTS_IO_URING
+                && AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_IO_URING)) {
             disk.setIoDriver(DiskDef.IoDriver.IOURING);
         }
     }


### PR DESCRIPTION
### Description

This PR fixes #6252 
When using advanced virtualization, the IO Driver is not supported. The admins will decide if they want to enable/disable this configuration from `agent.properties` file. It's enabled by default

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

