### PR TITLE
Fix #6263 Cannot scale VM with custom offering

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1703,6 +1703,12 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         boolean volumeMigrateRequired = false;
         boolean volumeResizeRequired = false;
 
+        // Skip the Disk offering change on Volume if Disk Offering is the same and is linked to a custom Service Offering
+        if(isNewDiskOfferingTheSameAndCustomServiceOffering(existingDiskOffering, newDiskOffering)) {
+            s_logger.debug(String.format("Scaling CPU and/or Memory of VM with custom service offering. New disk offering stills the same. Skipping the Disk offering change on Volume %s.", volume.getUuid()));
+            return volume;
+        }
+
         // VALIDATIONS
         Long[] updateNewSize = {newSize};
         Long[] updateNewMinIops = {newMinIops};
@@ -1792,6 +1798,19 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         return volume;
+    }
+
+    /**
+     * Returns true if the new disk offering is the same than current offering, and the respective Service offering is a custom (constraint or unconstraint) offering.
+     */
+    protected boolean isNewDiskOfferingTheSameAndCustomServiceOffering(DiskOfferingVO existingDiskOffering, DiskOfferingVO newDiskOffering) {
+        if (newDiskOffering.getId() == existingDiskOffering.getId()) {
+            ServiceOfferingVO serviceOffering = _serviceOfferingDao.findServiceOfferingByComputeOnlyDiskOffering(newDiskOffering.getId());
+            if (serviceOffering != null && serviceOffering.isCustomized()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private VolumeVO resizeVolumeInternal(VolumeVO volume, DiskOfferingVO newDiskOffering, Long currentSize, Long newSize, Long newMinIops, Long newMaxIops, Integer newHypervisorSnapshotReserve, boolean shrinkOk) throws ResourceAllocationException {
@@ -1894,11 +1913,11 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         if (newDiskOffering.getId() == existingDiskOffering.getId()) {
-            throw new InvalidParameterValueException(String.format("Volume %s already have the new disk offering %s provided", volume.getUuid(), existingDiskOffering.getUuid()));
+            throw new InvalidParameterValueException(String.format("Volume %s already have the new disk offering %s provided.", volume.getUuid(), existingDiskOffering.getUuid()));
         }
 
         if (existingDiskOffering.getDiskSizeStrictness() != newDiskOffering.getDiskSizeStrictness()) {
-            throw new InvalidParameterValueException("Disk offering size strictness does not match with new disk offering");
+            throw new InvalidParameterValueException("Disk offering size strictness does not match with new disk offering.");
         }
 
         if (MatchStoragePoolTagsWithDiskOffering.valueIn(volume.getDataCenterId())) {

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -1156,4 +1156,49 @@ public class VolumeApiServiceImplTest {
         boolean result = volumeApiServiceImpl.isNotPossibleToResize(volume, diskOffering);
         Assert.assertEquals(expectedIsNotPossibleToResize, result);
     }
+
+    @Test
+    public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestDifferentOfferings() {
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, false, false, false);
+    }
+
+    @Test
+    public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestDifferentOfferingsCustom() {
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, true, false, false);
+    }
+
+    @Test
+    public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestSameOfferingsCustom() {
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, true, false, true);
+    }
+
+    @Test
+    public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestSameOfferingsNotCustom() {
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, false, false, false);
+    }
+
+    @Test
+    public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestDifferentOfferingsAndNullOffering() {
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, true, true, false);
+    }
+    @Test
+    public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestSameOfferingsNullOffering() {
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, false, true, false);
+    }
+
+    private void prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(long existingDiskOfferingId, long newDiskOfferingId, boolean isCustomized,
+            boolean isNullServiceOffering, boolean expectedResult) {
+        DiskOfferingVO existingDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        when(existingDiskOffering.getId()).thenReturn(existingDiskOfferingId);
+        DiskOfferingVO newDiskOffering = Mockito.mock(DiskOfferingVO.class);
+        when(newDiskOffering.getId()).thenReturn(newDiskOfferingId);
+        ServiceOfferingVO serviceOfferingVO = null;
+        if(!isNullServiceOffering) {
+            serviceOfferingVO = Mockito.mock(ServiceOfferingVO.class);
+            when(serviceOfferingVO.isCustomized()).thenReturn(isCustomized);
+            when(serviceOfferingDao.findServiceOfferingByComputeOnlyDiskOffering(anyLong())).thenReturn(serviceOfferingVO);
+        }
+        boolean result = volumeApiServiceImpl.isNewDiskOfferingTheSameAndCustomServiceOffering(existingDiskOffering, newDiskOffering);
+        Assert.assertEquals(expectedResult, result);
+    }
 }

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -1159,42 +1159,41 @@ public class VolumeApiServiceImplTest {
 
     @Test
     public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestDifferentOfferings() {
-        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, false, false, false);
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, false, true, false);
     }
 
     @Test
     public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestDifferentOfferingsCustom() {
-        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, true, false, false);
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, true, true, false);
     }
 
     @Test
     public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestSameOfferingsCustom() {
-        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, true, false, true);
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, true, true, true);
     }
 
     @Test
     public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestSameOfferingsNotCustom() {
-        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, false, false, false);
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, false, true, false);
     }
 
     @Test
     public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestDifferentOfferingsAndNullOffering() {
-        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, true, true, false);
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 2l, true, false, false);
     }
     @Test
     public void isNewDiskOfferingTheSameAndCustomServiceOfferingTestSameOfferingsNullOffering() {
-        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, false, true, false);
+        prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(1l, 1l, false, false, false);
     }
 
     private void prepareAndRunIsNewDiskOfferingTheSameAndCustomServiceOffering(long existingDiskOfferingId, long newDiskOfferingId, boolean isCustomized,
-            boolean isNullServiceOffering, boolean expectedResult) {
+            boolean isNotNullServiceOffering, boolean expectedResult) {
         DiskOfferingVO existingDiskOffering = Mockito.mock(DiskOfferingVO.class);
         when(existingDiskOffering.getId()).thenReturn(existingDiskOfferingId);
         DiskOfferingVO newDiskOffering = Mockito.mock(DiskOfferingVO.class);
         when(newDiskOffering.getId()).thenReturn(newDiskOfferingId);
-        ServiceOfferingVO serviceOfferingVO = null;
-        if(!isNullServiceOffering) {
-            serviceOfferingVO = Mockito.mock(ServiceOfferingVO.class);
+        if(isNotNullServiceOffering) {
+            ServiceOfferingVO serviceOfferingVO = Mockito.mock(ServiceOfferingVO.class);
             when(serviceOfferingVO.isCustomized()).thenReturn(isCustomized);
             when(serviceOfferingDao.findServiceOfferingByComputeOnlyDiskOffering(anyLong())).thenReturn(serviceOfferingVO);
         }


### PR DESCRIPTION


### Description

This PR fixes #6263.
The issue is that an Exception is thrown when scaling a customized offering, changing the CPU/Memory but keeping the same disk offering.

This PR proposes a fix for this issue by skipping the volume "upgrade" process in such situations, avoiding any operations and also the thrown exception.

Considering that the disk offering is the same, there is no need to run all actions of the respective method.
The skipped actions are, in summary:
1. run DB updates matching the "new offering";
2. publish EVENT_VOLUME_RESIZE;
3. if volume migration is required (and allowed), find a suitable pool to migrate volume in case the current pool does not match the new offering needs;
4. return a "Volume" object containing all the changes.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Scale (via UI or API) a VM with the custom offering, keeping the same offering but updating the Memory and/or CPU.
- After skipping the validation, all worked out fine.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
