### PR TITLE
Fixed reset configuration response, to return the updated config value.

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1043,7 +1043,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     s_logger.error("Failed to reset configuration option, name: " + name + ", defaultValue:" + defaultValue);
                     throw new CloudRuntimeException("Failed to reset configuration value. Please contact Cloud Support.");
                 }
-                optionalValue = Optional.ofNullable(configKey != null ? configKey.value() : config.getValue());
+                optionalValue = Optional.ofNullable(configKey != null ? configKey.value() : _configDao.findByName(name).getValue());
                 newValue = optionalValue.isPresent() ? optionalValue.get().toString() : defaultValue;
         }
 


### PR DESCRIPTION
### Description

This PR updates reset configuration, to return the updated config value in its initial response.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested reset configuration from UI / API (cmk).

**List config before reset =>**
```
(cloud) 🐱 > list configurations name="storage.pool.disk.wait"
{
  "configuration": [
    {
      "category": "Storage",
      "component": "StorageManager",
      "defaultvalue": "60",
      "description": "Timeout (in secs) for the storage pool disk (of managed pool) to become available in the host. Currently only supported for PowerFlex.",
      "displaytext": "Storage pool disk wait",
      "group": "Storage",
      "isdynamic": true,
      "name": "storage.pool.disk.wait",
      "subgroup": "Storage",
      "type": "Number",
      "value": "65"
    }
  ],
  "count": 1
}
```

**Before Fix =>**
```
(cloud) 🐱 > reset configuration name="storage.pool.disk.wait"
{
  "configuration": {
    "category": "Storage",
    "component": "StorageManager",
    "defaultvalue": "60",
    "description": "Timeout (in secs) for the storage pool disk (of managed pool) to become available in the host. Currently only supported for PowerFlex.",
    "displaytext": "Storage pool disk wait",
    "group": "Storage",
    "isdynamic": true,
    "name": "storage.pool.disk.wait",
    "subgroup": "Storage",
    "type": "Number",
    "value": "65"
  }
}
```

**After Fix =>**
```
(cloud) 🐱 > reset configuration name="storage.pool.disk.wait"
{
  "configuration": {
    "category": "Storage",
    "component": "StorageManager",
    "defaultvalue": "60",
    "description": "Timeout (in secs) for the storage pool disk (of managed pool) to become available in the host. Currently only supported for PowerFlex.",
    "displaytext": "Storage pool disk wait",
    "group": "Storage",
    "isdynamic": true,
    "name": "storage.pool.disk.wait",
    "subgroup": "Storage",
    "type": "Number",
    "value": "60"
  }
}
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
