### PR TITLE
Fix: Prevent NPE on disk offering search while listing VMs

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -1052,8 +1052,11 @@ public class ApiDBUtils {
     }
 
     public static DiskOfferingVO findDiskOfferingById(Long diskOfferingId) {
+        if (diskOfferingId == null) {
+            return null;
+        }
         DiskOfferingVO off = s_diskOfferingDao.findByIdIncludingRemoved(diskOfferingId);
-        if (!off.isComputeOnly()) {
+        if (off != null && !off.isComputeOnly()) {
             return off;
         }
         return null;


### PR DESCRIPTION
### Description

This PR fixes an NPE while listing VMs - has been found while testing detach ROOT volume from VM on PR #6201 (which simply adds a UI option for this operation, it can be replicated by the API)

````
2022-04-19 15:17:37,061 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-8:null) (logid:) SeqA 3-6270: Processing Seq 3-6270:  { Cmd , MgmtId: -1, via: 3, Ver: v1, Flags: 11, [{"com.cloud.agent.api.ConsoleProxyLoadReportCommand":{"_proxyVmId":"2","_loadInfo":"{
  "connections": []
}","wait":"0","bypassHostMaintenance":"false"}}] }
2022-04-19 15:17:37,064 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-8:null) (logid:) SeqA 3-6270: Sending Seq 3-6270:  { Ans: , MgmtId: 32988268069116, via: 3, Ver: v1, Flags: 100010, [{"com.cloud.agent.api.AgentControlAnswer":{"result":"true","wait":"0","bypassHostMaintenance":"false"}}] }
2022-04-19 15:17:37,498 DEBUG [o.a.c.h.HAManagerImpl] (BackgroundTaskPollManager-5:ctx-4f360eb6) (logid:80937b13) HA health check task is running...
2022-04-19 15:17:39,780 DEBUG [c.c.a.ApiServlet] (qtp793138072-17:ctx-5f7bb05e) (logid:dc99935d) ===START===  10.0.3.251 -- GET  listall=true&page=1&pagesize=20&showIcon=true&command=listVirtualMachinesMetrics&response=json
2022-04-19 15:17:39,784 DEBUG [c.c.a.ApiServer] (qtp793138072-17:ctx-5f7bb05e ctx-162916e3) (logid:dc99935d) CIDRs from which account 'Acct[d088e28f-bf84-11ec-b127-1e00ae0000fc-admin] -- Account {"id": 2, "name": "admin", "uuid": "d088e28f-bf84-11ec-b127-1e00ae0000fc"}' is allowed to perform API calls: 0.0.0.0/0,::/0
2022-04-19 15:17:39,802 ERROR [c.c.a.ApiServer] (qtp793138072-17:ctx-5f7bb05e ctx-162916e3) (logid:dc99935d) unhandled exception executing api command: [Ljava.lang.String;@6baff340
java.lang.NullPointerException
	at com.cloud.api.ApiDBUtils.findDiskOfferingById(ApiDBUtils.java:1056)
	at com.cloud.api.query.dao.UserVmJoinDaoImpl.newUserVmResponse(UserVmJoinDaoImpl.java:187)
	at jdk.internal.reflect.GeneratedMethodAccessor330.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at com.cloud.utils.db.TransactionContextInterceptor.invoke(TransactionContextInterceptor.java:34)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy158.newUserVmResponse(Unknown Source)
	at com.cloud.api.ApiDBUtils.newUserVmResponse(ApiDBUtils.java:1812)
	at com.cloud.api.query.ViewResponseHelper.createUserVmResponse(ViewResponseHelper.java:154)
	at com.cloud.api.query.QueryManagerImpl.searchForUserVMs(QueryManagerImpl.java:931)
	at org.apache.cloudstack.api.ListVMsMetricsCmd.execute(ListVMsMetricsCmd.java:60)
	at com.cloud.api.ApiDispatcher.dispatch(ApiDispatcher.java:156)
	at com.cloud.api.ApiServer.queueCommand(ApiServer.java:776)
	at com.cloud.api.ApiServer.handleRequest(ApiServer.java:600)
	at com.cloud.api.ApiServlet.processRequestInContext(ApiServlet.java:334)
````

![image](https://user-images.githubusercontent.com/5295080/164056847-0fa876f3-32a7-48ba-91b8-333d9dea6dbf.png)


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Detach VM's ROOT volume
- List virtual machines
