### PR TITLE
ui: Fix Internal LB LB rule column and missing translation

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2085,6 +2085,7 @@
 "label.source.nat.supported": "SourceNAT Supported",
 "label.sourcecidr": "Source CIDR",
 "label.sourceipaddress": "Source IP Address",
+"label.sourceipaddressnetworkid": "Network ID of Source IP Address",
 "label.sourcenat": "Source NAT",
 "label.sourcenatsupported": "Source NAT Supported",
 "label.sourcenattype": "Supported Source NAT type",

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -295,6 +295,9 @@
       <status :text="record.requiresupgrade ? 'warning' : ''" />
       {{ record.requiresupgrade ? 'Yes' : 'No' }}
     </template>
+    <template #loadbalancerrule="{ record }">
+      <span>  {{ record.loadbalancerrule }} </span>
+    </template>
     <template #autoscalingenabled="{ record }">
       <status :text="record.autoscalingenabled ? 'Enabled' : 'Disabled'" />
       {{ record.autoscalingenabled ? 'Enabled' : 'Disabled' }}


### PR DESCRIPTION
### Description

This PR displays the load balancer rule in the internal LB list view which appears as an empty column, while the details view shows it.
![image](https://user-images.githubusercontent.com/10495417/164168496-d136a5cf-7ec7-4913-ad5d-6479431be707.png)

vs 
![image](https://user-images.githubusercontent.com/10495417/164168589-1672de26-fae7-404c-b4e4-fdd99f86756c.png)

Also, there is a missing translation for a param field in the Add Internal LB form:
![image](https://user-images.githubusercontent.com/10495417/164168716-5df25285-0145-4af6-bd7f-23435f768592.png)

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Goto http://<IP>:8080/#/ilb
1. And view the list view - where the lb rule is displayed:
![image](https://user-images.githubusercontent.com/10495417/164168925-6a29cdaa-622c-4055-8137-6c1153ab42d8.png)

2. Missing translation added:
![image](https://user-images.githubusercontent.com/10495417/164169017-17b4ee91-df4d-4bb7-b26c-181b6dea2ba1.png)


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
