### PR TITLE
xen: Fix volume snapshot deletion when it has child snapshots

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
@@ -127,7 +127,7 @@ public class SnapshotObject implements SnapshotInfo {
         if (vo == null) {
             return null;
         }
-        return snapshotFactory.getSnapshot(vo.getId(), store);
+        return snapshotFactory.getSnapshot(vo.getSnapshotId(), store);
     }
 
     @Override

--- a/test/integration/smoke/test_list_ids_parameter.py
+++ b/test/integration/smoke/test_list_ids_parameter.py
@@ -192,9 +192,9 @@ class TestListIdsParams(cloudstackTestCase):
                                          )
 
         cls._cleanup = [
-                        cls.snapshot_1,
-                        cls.snapshot_2,
                         cls.snapshot_3,
+                        cls.snapshot_2,
+                        cls.snapshot_1,
                         cls.account,
                         cls.disk_offering,
                         cls.service_offering


### PR DESCRIPTION
### Description

This PR fixes the constant test failure noticed on test_list_ids_parameter.py on xenserver :
https://github.com/apache/cloudstack/pull/5811#issuecomment-1104053583
The reason for the failure is that on 4.17, when attempting to delete a snapshot that has child snapshots, it fails deletion of the snapshot altogether. In addition to this, an NPE occurs when displaying the details of the child snapshot due to incorrect snapshot id used to get the details.

```
2022-04-21 04:47:42,145 DEBUG [o.a.c.s.s.DefaultSnapshotStrategy] (API-Job-Executor-47:ctx-ef3948e6 job-63 ctx-144c6c26) (logid:a43f2bcd) Deleting SnapshotTO[datastore=com.cloud.agent.api.to.NfsTO@75866c9d|volume=volumeTO[uuid=c1aaba2a-396e-4979-9793-8d54b906ecf5|path=7e848981-a142-4b6f-8ed8-ec8ab4f84f26|datastore=PrimaryDataStoreTO[uuid=637af10e-5a12-32a8-a2cb-47d34d1e710a|name=ref-trl-2887-x-M7-pearl-dsilva-xs-pri2|id=2|pooltype=NetworkFilesystem]]|pathsnapshots/5/5/7136e5ad-971e-41c3-8166-cddebdf7554a.vhd] chain of snapshots.
2022-04-21 04:47:42,147 ERROR [o.a.c.s.s.DefaultSnapshotStrategy] (API-Job-Executor-47:ctx-ef3948e6 job-63 ctx-144c6c26) (logid:a43f2bcd) Failed to delete snapshot [SnapshotTO[datastore=com.cloud.agent.api.to.NfsTO@75866c9d|volume=volumeTO[uuid=c1aaba2a-396e-4979-9793-8d54b906ecf5|path=7e848981-a142-4b6f-8ed8-ec8ab4f84f26|datastore=PrimaryDataStoreTO[uuid=637af10e-5a12-32a8-a2cb-47d34d1e710a|name=ref-trl-2887-x-M7-pearl-dsilva-xs-pri2|id=2|pooltype=NetworkFilesystem]]|pathsnapshots/5/5/7136e5ad-971e-41c3-8166-cddebdf7554a.vhd]] on storage [secondary storage {uuid: "5b3f46d0-4185-4144-9d3d-0ca6f4232d39", name: "NFS://10.0.32.4/acs/secondary/ref-trl-2887-x-M7-pearl-dsilva/ref-trl-2887-x-M7-pearl-dsilva-sec1"}] due to [null].
java.lang.NullPointerException
        at org.apache.cloudstack.storage.snapshot.SnapshotObject.getId(SnapshotObject.java:192)
        at org.apache.cloudstack.storage.datastore.ObjectInDataStoreManagerImpl.findObject(ObjectInDataStoreManagerImpl.java:354)
        at org.apache.cloudstack.storage.snapshot.SnapshotObject.getPath(SnapshotObject.java:251)
        at org.apache.cloudstack.storage.to.SnapshotObjectTO.<init>(SnapshotObjectTO.java:52)
        at org.apache.cloudstack.storage.snapshot.SnapshotObject.getTO(SnapshotObject.java:327)
        at org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy.deleteSnapshotChain(DefaultSnapshotStrategy.java:193)
        at org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy.deleteSnapshotInfo(DefaultSnapshotStrategy.java:331)
        at org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy.deleteSnapshotInfos(DefaultSnapshotStrategy.java:306)
        at org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy.destroySnapshotEntriesAndFiles(DefaultSnapshotStrategy.java:285)
        at org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy.deleteSnapshot(DefaultSnapshotStrategy.java:277)
        at com.cloud.storage.snapshot.SnapshotManagerImpl.deleteSnapshot(SnapshotManagerImpl.java:606)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)

```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
1. Successfully run the smoke test - test_list_ids_parameter.py
2. Created 2 snapshots from the same volume, and attempted to delete the parent snapshot, while it fails (as expected) - it no longer throws an NPE.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
