### PR TITLE
ui: Toggle Theme to default(light) on login

### DIFF
--- a/ui/src/permission.js
+++ b/ui/src/permission.js
@@ -78,6 +78,7 @@ router.beforeEach((to, from, next) => {
               } else {
                 next({ path: redirect })
               }
+              store.dispatch('ToggleTheme', 'light')
             })
           })
           .catch(() => {


### PR DESCRIPTION
### Description

This PR toggle to default view when logging in after having logged out from project view.
1. Project View:
![image](https://user-images.githubusercontent.com/10495417/164613503-52f5c8d3-b056-4811-97c2-e414c2725651.png)

2. Logout when in project view and re-login:
Dark theme still persists
![image](https://user-images.githubusercontent.com/10495417/164613605-4f3b9a69-9618-449f-a0b0-7f2cddd1803b.png)

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Logout from project view & login again, and the UI loads with light theme 



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
