### PR TITLE
UI: fix netmask is not passed to api when create share network

### DIFF
--- a/ui/src/views/network/CreateSharedNetworkForm.vue
+++ b/ui/src/views/network/CreateSharedNetworkForm.vue
@@ -267,18 +267,18 @@
           </a-form-item>
           <a-form-item name="ip4gateway" ref="ip4gateway">
             <template #label>
-              <tooltip-label :title="$t('label.ip4gateway')" :tooltip="apiParams.netmask.description"/>
+              <tooltip-label :title="$t('label.ip4gateway')" :tooltip="apiParams.gateway.description"/>
             </template>
             <a-input
               v-model:value="form.ip4gateway"
-              :placeholder="apiParams.netmask.description"/>
+              :placeholder="apiParams.gateway.description"/>
           </a-form-item>
           <a-form-item name="ip4netmask" ref="ip4netmask">
             <template #label>
-              <tooltip-label :title="$t('label.netmask')" :tooltip="apiParams.netmask.description"/>
+              <tooltip-label :title="$t('label.ip4netmask')" :tooltip="apiParams.netmask.description"/>
             </template>
             <a-input
-              v-model:value="form.netmask"
+              v-model:value="form.ip4netmask"
               :placeholder="apiParams.netmask.description"/>
           </a-form-item>
           <a-form-item name="startipv4" ref="startipv4">
@@ -296,6 +296,14 @@
             <a-input
               v-model:value="form.endipv4"
               :placeholder="apiParams.endip.description"/>
+          </a-form-item>
+          <a-form-item v-if="isVirtualRouterForAtLeastOneService" name="routerip" ref="routerip">
+            <template #label>
+              <tooltip-label :title="$t('label.routerip')" :tooltip="apiParams.routerip.description"/>
+            </template>
+            <a-input
+              v-model:value="form.routerip"
+              :placeholder="apiParams.routerip.description"/>
           </a-form-item>
           <a-form-item name="ip6gateway" ref="ip6gateway">
             <template #label>
@@ -865,7 +873,7 @@ export default {
         const formRaw = toRaw(this.form)
         const values = this.handleRemoveFields(formRaw)
         if (
-          (!this.isValidTextValueForKey(values, 'ip4gateway') && !this.isValidTextValueForKey(values, 'netmask') &&
+          (!this.isValidTextValueForKey(values, 'ip4gateway') && !this.isValidTextValueForKey(values, 'ip4netmask') &&
             !this.isValidTextValueForKey(values, 'startipv4') && !this.isValidTextValueForKey(values, 'endipv4') &&
             !this.isValidTextValueForKey(values, 'ip6gateway') && !this.isValidTextValueForKey(values, 'ip6cidr') &&
             !this.isValidTextValueForKey(values, 'startipv6') && !this.isValidTextValueForKey(values, 'endipv6'))
@@ -923,8 +931,8 @@ export default {
         if (this.isValidTextValueForKey(values, 'ip4gateway')) {
           params.gateway = values.ip4gateway
         }
-        if (this.isValidTextValueForKey(values, 'netmask')) {
-          params.netmask = values.netmask
+        if (this.isValidTextValueForKey(values, 'ip4netmask')) {
+          params.netmask = values.ip4netmask
         }
         if (this.isValidTextValueForKey(values, 'startipv4')) {
           params.startip = values.startipv4
@@ -932,14 +940,14 @@ export default {
         if (this.isValidTextValueForKey(values, 'endipv4')) {
           params.endip = values.endipv4
         }
+        if (this.isValidTextValueForKey(values, 'routerip')) {
+          params.routerip = values.routerip
+        }
         // IPv4 (end)
 
         // IPv6 (begin)
-        if (this.isValidTextValueForKey(values, 'ip4gateway')) {
+        if (this.isValidTextValueForKey(values, 'ip6gateway')) {
           params.ip6gateway = values.ip6gateway
-        }
-        if (this.isValidTextValueForKey(values, 'routerip')) {
-          params.routerip = values.routerip
         }
         if (this.isValidTextValueForKey(values, 'ip6cidr')) {
           params.ip6cidr = values.ip6cidr


### PR DESCRIPTION
### Description

This PR fixes the issue that ip4 netmask is not passed to cloudstack api when create a shared network.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
