### PR TITLE
UI: Fix Usage Server stats date display

### DIFF
--- a/ui/src/views/infra/Metrics.vue
+++ b/ui/src/views/infra/Metrics.vue
@@ -158,7 +158,7 @@ export default {
           metric.name = 'uptime in seconds'
           metric.value = map[key]
           array.push(metric)
-        } else if (key === 'collectiontime' || key === 'lastheartbeat' || key === 'lastsuccesfuljob') {
+        } else if (key === 'collectiontime' || key === 'lastheartbeat' || key === 'lastsuccessfuljob') {
           metric = {}
           metric.name = key
           metric.value = this.$toLocaleDate(map[key]) // needs a conversion


### PR DESCRIPTION
### Description

This PR fixes the display format for the last successful job for the usage statistics:

Before:
<img width="449" alt="Screen Shot 2022-04-23 at 02 20 33" src="https://user-images.githubusercontent.com/5295080/164878951-44064426-e7de-4014-aaa8-dd42d0914e22.png">


After:
<img width="449" alt="Screen Shot 2022-04-23 at 02 21 23" src="https://user-images.githubusercontent.com/5295080/164878983-b97fcc7d-5eef-49ef-b5f1-07b994a76e2e.png">


<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
List DB/Usage stats
