### PR TITLE
UI: Fix upload resource icon button

### DIFF
--- a/ui/src/components/view/UploadResourceIcon.vue
+++ b/ui/src/components/view/UploadResourceIcon.vue
@@ -81,7 +81,7 @@
           </a-button>
         </a-col>
         <a-col :xs="{span: 1, offset: 3}" :md="1">
-          <a-button type="primary" @click="uploadIcon('blob')"> {{ $t('label.upload') }} </a-button>
+          <a-button :disabled="options.img === ''" type="primary" @click="uploadIcon('blob')"> {{ $t('label.upload') }} </a-button>
         </a-col>
         <a-col :xs="{span: 2, offset: 5}" :md="2">
           <a-button


### PR DESCRIPTION
### Description

This PR fixes an issue on the upload resource icon dialog if no image is selected:
<img width="419" alt="Screen Shot 2022-04-23 at 02 43 52" src="https://user-images.githubusercontent.com/5295080/164879573-e8ff8d0d-e74e-495d-bb11-62b9d0db92ca.png">

The Upload button is disabled unless an image is selected
<img width="721" alt="Screen Shot 2022-04-23 at 02 47 41" src="https://user-images.githubusercontent.com/5295080/164879621-429ab4a3-7986-4d6d-918e-24e48de680cf.png">

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Upload resource icon -> try uploading without providing image -> select image -> upload