### PR TITLE
network: fix event, acl, firewall for ipv6 nw

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/CreateIpv6FirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/CreateIpv6FirewallRuleCmd.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCreateCmd;
@@ -251,5 +252,15 @@ public class CreateIpv6FirewallRuleCmd extends BaseAsyncCreateCmd {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to create ipv6 firewall rule");
             }
         }
+    }
+
+    @Override
+    public Long getApiResourceId() {
+        return getNetworkId();
+    }
+
+    @Override
+    public ApiCommandResourceType getApiResourceType() {
+        return ApiCommandResourceType.Network;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/DeleteIpv6FirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/DeleteIpv6FirewallRuleCmd.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.api.command.user.ipv6;
 
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCmd;
@@ -94,4 +95,17 @@ public class DeleteIpv6FirewallRuleCmd extends BaseAsyncCmd {
         }
     }
 
+    @Override
+    public Long getApiResourceId() {
+        FirewallRule rule = _firewallService.getFirewallRule(id);
+        if (rule != null) {
+            return rule.getNetworkId();
+        }
+        return null;
+    }
+
+    @Override
+    public ApiCommandResourceType getApiResourceType() {
+        return ApiCommandResourceType.Network;
+    }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/UpdateIpv6FirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/UpdateIpv6FirewallRuleCmd.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseAsyncCustomIdCmd;
 import org.apache.cloudstack.api.Parameter;
@@ -172,4 +173,17 @@ public class UpdateIpv6FirewallRuleCmd extends BaseAsyncCustomIdCmd {
         }
     }
 
+    @Override
+    public Long getApiResourceId() {
+        FirewallRule rule = _firewallService.getFirewallRule(id);
+        if (rule != null) {
+            return rule.getNetworkId();
+        }
+        return null;
+    }
+
+    @Override
+    public ApiCommandResourceType getApiResourceType() {
+        return ApiCommandResourceType.Network;
+    }
 }

--- a/core/src/main/java/com/cloud/agent/api/routing/SetIpv6FirewallRulesCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/routing/SetIpv6FirewallRulesCommand.java
@@ -30,16 +30,22 @@ import com.cloud.agent.api.to.FirewallRuleTO;
  */
 public class SetIpv6FirewallRulesCommand extends NetworkElementCommand {
     FirewallRuleTO[] rules;
+    String guestIp6Cidr;
 
     protected SetIpv6FirewallRulesCommand() {
     }
 
-    public SetIpv6FirewallRulesCommand(List<FirewallRuleTO> rules) {
+    public SetIpv6FirewallRulesCommand(List<FirewallRuleTO> rules, String guestIp6Cidr) {
         this.rules = rules.toArray(new FirewallRuleTO[rules.size()]);
+        this.guestIp6Cidr = guestIp6Cidr;
     }
 
     public FirewallRuleTO[] getRules() {
         return rules;
+    }
+
+    public String getGuestIp6Cidr() {
+        return guestIp6Cidr;
     }
 
     @Override

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetIpv6FirewallRulesConfigItem.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetIpv6FirewallRulesConfigItem.java
@@ -42,6 +42,7 @@ public class SetIpv6FirewallRulesConfigItem extends AbstractConfigItemFacade{
             final FirewallRule fwRule = new FirewallRule(rule.getId(), rule.getSrcVlanTag(), rule.getSrcIp(), rule.getProtocol(), rule.getSrcPortRange(), rule.revoked(),
                     rule.isAlreadyAdded(), rule.getSourceCidrList(), rule.getDestCidrList(), rule.getPurpose().toString(), rule.getIcmpType(), rule.getIcmpCode(), rule.getTrafficType().toString(),
                     rule.getGuestCidr(), rule.isDefaultEgressPolicy());
+            fwRule.setGuestIp6Cidr(command.getGuestIp6Cidr());
             rules.add(fwRule);
         }
 

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/model/FirewallRule.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/model/FirewallRule.java
@@ -38,6 +38,7 @@ public class FirewallRule {
     private String guestCidr;
     private boolean defaultEgressPolicy;
     private String type;
+    private String guestIp6Cidr;
 
     public FirewallRule() {
         // Empty constructor for (de)serialization
@@ -174,4 +175,11 @@ public class FirewallRule {
         this.defaultEgressPolicy = defaultEgressPolicy;
     }
 
+    public String getGuestIp6Cidr() {
+        return guestIp6Cidr;
+    }
+
+    public void setGuestIp6Cidr(String guestIp6Cidr) {
+        this.guestIp6Cidr = guestIp6Cidr;
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/offerings/dao/NetworkOfferingDao.java
+++ b/engine/schema/src/main/java/com/cloud/offerings/dao/NetworkOfferingDao.java
@@ -73,5 +73,7 @@ public interface NetworkOfferingDao extends GenericDao<NetworkOfferingVO, Long> 
 
     NetUtils.InternetProtocol getNetworkOfferingInternetProtocol(long offeringId);
 
+    NetUtils.InternetProtocol getNetworkOfferingInternetProtocol(long offeringId, NetUtils.InternetProtocol defaultProtocol);
+
     boolean isIpv6Supported(long offeringId);
 }

--- a/engine/schema/src/main/java/com/cloud/offerings/dao/NetworkOfferingDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/offerings/dao/NetworkOfferingDaoImpl.java
@@ -279,6 +279,15 @@ public class NetworkOfferingDaoImpl extends GenericDaoBase<NetworkOfferingVO, Lo
     }
 
     @Override
+    public NetUtils.InternetProtocol getNetworkOfferingInternetProtocol(long offeringId,NetUtils.InternetProtocol defaultProtocol) {
+        NetUtils.InternetProtocol protocol = getNetworkOfferingInternetProtocol(offeringId);
+        if (protocol == null) {
+            return defaultProtocol;
+        }
+        return protocol;
+    }
+
+    @Override
     public boolean isIpv6Supported(long offeringId) {
         NetUtils.InternetProtocol internetProtocol = getNetworkOfferingInternetProtocol(offeringId);
         return NetUtils.InternetProtocol.isIpv6EnabledProtocol(internetProtocol);

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2533,7 +2533,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setBytesSent(bytesSent);
 
         if (networkOfferingDao.isIpv6Supported(network.getNetworkOfferingId())) {
-            response.setInternetProtocol(networkOfferingDao.getNetworkOfferingInternetProtocol(network.getNetworkOfferingId()).toString());
+            response.setInternetProtocol(networkOfferingDao.getNetworkOfferingInternetProtocol(network.getNetworkOfferingId(), NetUtils.InternetProtocol.IPv4).toString());
             response.setIpv6Routing(Network.Routing.Static.toString());
             response.setIpv6Routes(new LinkedHashSet<>());
             if (Network.GuestType.Isolated.equals(networkOffering.getGuestType())) {

--- a/server/src/main/java/com/cloud/api/query/dao/NetworkOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/NetworkOfferingJoinDaoImpl.java
@@ -19,6 +19,7 @@ package com.cloud.api.query.dao;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.cloudstack.api.response.NetworkOfferingResponse;
 import org.apache.log4j.Logger;
 
@@ -27,6 +28,7 @@ import com.cloud.offering.NetworkOffering;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.net.NetUtils;
 
 public class NetworkOfferingJoinDaoImpl extends GenericDaoBase<NetworkOfferingJoinVO, Long> implements NetworkOfferingJoinDao {
     public static final Logger s_logger = Logger.getLogger(NetworkOfferingJoinDaoImpl.class);
@@ -99,7 +101,11 @@ public class NetworkOfferingJoinDaoImpl extends GenericDaoBase<NetworkOfferingJo
             networkOfferingResponse.setDomain(networkOfferingJoinVO.getDomainPath());
             networkOfferingResponse.setZoneId(networkOfferingJoinVO.getZoneUuid());
             networkOfferingResponse.setZone(networkOfferingJoinVO.getZoneName());
-            networkOfferingResponse.setInternetProtocol(networkOfferingJoinVO.getInternetProtocol());
+            String protocol = networkOfferingJoinVO.getInternetProtocol();
+            if (StringUtils.isEmpty(protocol)) {
+                protocol = NetUtils.InternetProtocol.IPv4.toString();
+            }
+            networkOfferingResponse.setInternetProtocol(protocol);
         }
         networkOfferingResponse.setObjectName("networkoffering");
 

--- a/server/src/main/java/com/cloud/api/query/dao/VpcOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/VpcOfferingJoinDaoImpl.java
@@ -20,6 +20,7 @@ package com.cloud.api.query.dao;
 import java.util.List;
 
 import org.apache.cloudstack.api.response.VpcOfferingResponse;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.api.query.vo.VpcOfferingJoinVO;
@@ -27,6 +28,7 @@ import com.cloud.network.vpc.VpcOffering;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.net.NetUtils;
 
 public class VpcOfferingJoinDaoImpl extends GenericDaoBase<VpcOfferingJoinVO, Long> implements VpcOfferingJoinDao {
     public static final Logger s_logger = Logger.getLogger(VpcOfferingJoinDaoImpl.class);
@@ -70,7 +72,11 @@ public class VpcOfferingJoinDaoImpl extends GenericDaoBase<VpcOfferingJoinVO, Lo
             offeringResponse.setDomain(offeringJoinVO.getDomainPath());
             offeringResponse.setZoneId(offeringJoinVO.getZoneUuid());
             offeringResponse.setZone(offeringJoinVO.getZoneName());
-            offeringResponse.setInternetProtocol(offeringJoinVO.getInternetProtocol());
+            String protocol = offeringJoinVO.getInternetProtocol();
+            if (StringUtils.isEmpty(protocol)) {
+                protocol = NetUtils.InternetProtocol.IPv4.toString();
+            }
+            offeringResponse.setInternetProtocol(protocol);
         }
         offeringResponse.setObjectName("vpcoffering");
 

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -461,7 +461,9 @@ public class CommandSetupHelper {
     public void createApplyIpv6FirewallRulesCommands(final List<? extends FirewallRule> rules, final VirtualRouter router, final Commands cmds, final long guestNetworkId) {
         final List<FirewallRuleTO> rulesTO = new ArrayList<>();
         String systemRule = null;
-        Boolean defaultEgressPolicy = false;
+        final NetworkVO network = _networkDao.findById(guestNetworkId);
+        final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
+        Boolean defaultEgressPolicy = offering.isEgressDefaultPolicy();;
         if (rules != null) {
             if (rules.size() > 0) {
                 if (rules.get(0).getTrafficType() == FirewallRule.TrafficType.Egress && rules.get(0).getType() == FirewallRule.FirewallRuleType.System) {
@@ -476,16 +478,13 @@ public class CommandSetupHelper {
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, null, Purpose.Ipv6Firewall, trafficType);
                     rulesTO.add(ruleTO);
                 } else if (rule.getTrafficType() == FirewallRule.TrafficType.Egress) {
-                    final NetworkVO network = _networkDao.findById(guestNetworkId);
-                    final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-                    defaultEgressPolicy = offering.isEgressDefaultPolicy();
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, "", Purpose.Ipv6Firewall, trafficType, defaultEgressPolicy);
                     rulesTO.add(ruleTO);
                 }
             }
         }
 
-        final SetIpv6FirewallRulesCommand cmd = new SetIpv6FirewallRulesCommand(rulesTO);
+        final SetIpv6FirewallRulesCommand cmd = new SetIpv6FirewallRulesCommand(rulesTO, network.getIp6Cidr());
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_GUEST_IP, _routerControlHelper.getRouterIpInNetwork(guestNetworkId, router.getId()));
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, router.getInstanceName());
@@ -547,7 +546,9 @@ public class CommandSetupHelper {
     public void createIpv6FirewallRulesCommands(final List<? extends FirewallRule> rules, final VirtualRouter router, final Commands cmds, final long guestNetworkId) {
         final List<FirewallRuleTO> rulesTO = new ArrayList<>();
         String systemRule = null;
-        Boolean defaultEgressPolicy = false;
+        final NetworkVO network = _networkDao.findById(guestNetworkId);
+        final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
+        Boolean defaultEgressPolicy = offering.isEgressDefaultPolicy();
         if (rules != null) {
             if (rules.size() > 0) {
                 if (rules.get(0).getTrafficType() == FirewallRule.TrafficType.Egress && rules.get(0).getType() == FirewallRule.FirewallRuleType.System) {
@@ -562,16 +563,13 @@ public class CommandSetupHelper {
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, null, Purpose.Ipv6Firewall, traffictype);
                     rulesTO.add(ruleTO);
                 } else if (rule.getTrafficType() == FirewallRule.TrafficType.Egress) {
-                    final NetworkVO network = _networkDao.findById(guestNetworkId);
-                    final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-                    defaultEgressPolicy = offering.isEgressDefaultPolicy();
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, "", Purpose.Ipv6Firewall, traffictype, defaultEgressPolicy);
                     rulesTO.add(ruleTO);
                 }
             }
         }
 
-        final SetIpv6FirewallRulesCommand cmd = new SetIpv6FirewallRulesCommand(rulesTO);
+        final SetIpv6FirewallRulesCommand cmd = new SetIpv6FirewallRulesCommand(rulesTO, network.getIp6Cidr());
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_GUEST_IP, _routerControlHelper.getRouterIpInNetwork(guestNetworkId, router.getId()));
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, router.getInstanceName());

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -233,7 +233,6 @@ class CsNetfilters(object):
                 CsHelper.execute("nft add rule %s %s %s icmpv6 type { echo-request, echo-reply, nd-neighbor-solicit, nd-router-advert, nd-neighbor-advert } accept" % (address_family, table, chain))
 
     def apply_ip6_rules(self, rules, type):
-        logging.info("@pply--Add IPv6 rules: %s", rules)
         if len(rules) == 0:
             return
         address_family = 'ip6'

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -229,23 +229,24 @@ class CsNetfilters(object):
             if chain_policy and action:
                 chain_policy = "%s policy %s;" % (chain_policy, action)
             CsHelper.execute("nft add chain %s %s %s '{ %s }'" % (address_family, table, chain, chain_policy))
-            if chain_policy:
+            if hook == "input" or hook == "output":
                 CsHelper.execute("nft add rule %s %s %s icmpv6 type { echo-request, echo-reply, nd-neighbor-solicit, nd-router-advert, nd-neighbor-advert } accept" % (address_family, table, chain))
 
     def apply_ip6_rules(self, rules, type):
-        logging.debug("Add IPv6 rules: %s", rules)
+        logging.info("@pply--Add IPv6 rules: %s", rules)
         if len(rules) == 0:
             return
         address_family = 'ip6'
         table = 'ip6_firewall'
         default_chains = [
-            { "chain": "fw_chain_ingress", "hook": "input", "action": "drop"}
+            { "chain": "fw_input", "hook": "input", "action": "drop"},
+            { "chain": "fw_forward", "hook": "forward", "action": "accept"}
         ]
         if type == "acl":
             table = 'ip6_acl'
             default_chains = [
                 { "chain": "acl_input", "hook": "input", "action": "drop" },
-                { "chain": "acl_output", "hook": "output", "action": "accept" }
+                { "chain": "acl_forward", "hook": "forward", "action": "accept"}
             ]
         CsHelper.execute("nft add table %s %s" % (address_family, table))
         for chain in default_chains:
@@ -253,13 +254,15 @@ class CsNetfilters(object):
         for fw in rules:
             chain = fw['chain']
             type = fw['type']
-            rule = fw['rule']
+            rule = None
+            if 'rule' in fw:
+                rule = fw['rule']
             if type == "chain":
-                hook = "input"
-                if "egress" in chain:
+                hook = ""
+                if "output" in chain:
                     hook = "output"
-                if chain.startswith("eth"):
-                    hook = ""
+                elif "input" in chain:
+                    hook = "input"
                 self.add_ip6_chain(address_family, table, chain, hook, rule)
             else:
                 logging.info("Add: rule=%s in address_family=%s table=%s, chain=%s", rule, address_family, table, chain)

--- a/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
@@ -85,15 +85,6 @@ config_sysctl() {
       sed  -i "/^vm.vfs_cache_pressure/ c\vm.vfs_cache_pressure = 100" /etc/sysctl.conf
   fi
 
-  eth0_ip6=$(grep -Po 'eth0ip6=\K[0-9a-zA-Z:]*' $CMDLINE)
-  eth2_ip6=$(grep -Po 'eth2ip6=\K[0-9a-zA-Z:]*' $CMDLINE)
-  if [ -n "$eth0_ip6" ] || [ -n "$eth2_ip6" ]
-  then
-      sed  -i "s/net.ipv6.conf.all.disable_ipv6 =.*$/net.ipv6.conf.all.disable_ipv6 = 0/" /etc/sysctl.conf
-      sed  -i "s/net.ipv6.conf.all.forwarding =.*$/net.ipv6.conf.all.forwarding = 1/" /etc/sysctl.conf
-      sed  -i "s/net.ipv6.conf.all.accept_ra =.*$/net.ipv6.conf.all.accept_ra = 1/" /etc/sysctl.conf
-  fi
-
   sync
   sysctl -p
 }

--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -110,22 +110,29 @@ setup_interface() {
   fi
 }
 
-setup_interface_ipv6() {
+enable_interface_ipv6() {
   sysctl net.ipv6.conf.all.disable_ipv6=0
   sysctl net.ipv6.conf.all.forwarding=1
   sysctl net.ipv6.conf.all.accept_ra=1
-
   sed  -i "s/net.ipv6.conf.all.disable_ipv6 =.*$/net.ipv6.conf.all.disable_ipv6 = 0/" /etc/sysctl.conf
   sed  -i "s/net.ipv6.conf.all.forwarding =.*$/net.ipv6.conf.all.forwarding = 1/" /etc/sysctl.conf
   sed  -i "s/net.ipv6.conf.all.accept_ra =.*$/net.ipv6.conf.all.accept_ra = 1/" /etc/sysctl.conf
+  sysctl net.ipv6.conf.eth$1.accept_dad=0
+  sysctl net.ipv6.conf.eth$1.use_tempaddr=0
+  if [ "$2" = true ] ; then
+    local intf=eth${1}
+    ifdown $intf
+    ifup $intf
+  fi
+}
+
+setup_interface_ipv6() {
+  enable_interface_ipv6 $1 false
 
   local intfnum=$1
   local ipv6="$2"
   local prelen="$3"
   local intf=eth${intfnum}
-
-  sysctl net.ipv6.conf.$intf.accept_dad=0
-  sysctl net.ipv6.conf.$intf.use_tempaddr=0
 
   echo "iface $intf inet6 static" >> /etc/network/interfaces
   echo "  address $ipv6 " >> /etc/network/interfaces
@@ -266,31 +273,49 @@ enable_rpsrfs() {
   echo 256 > /sys/class/net/eth2/queues/rx-0/rps_flow_cnt
 }
 
+setup_ipv6() {
+  local enableradvd=false
+  if [ -n "$ETH0_IP6" ]
+  then
+    enableradvd=true
+    setup_interface_ipv6 "0" $ETH0_IP6 $ETH0_IP6_PRELEN
+  fi
+  if [ -n "$ETH0_IP6" ] || [ -n "$GUEST_GW6"  -a -n "$GUEST_CIDR6_SIZE" ]
+  then
+    rm -rf /etc/radvd.conf
+    setup_radvd "0" $GUEST_GW6 $GUEST_CIDR6_SIZE $enableradvd
+  fi
+  if [ -n "$ETH2_IP6" ]
+  then
+    setup_interface_ipv6 "2" $ETH2_IP6 $ETH2_IP6_PRELEN
+  fi
+}
+
+restore_ipv6() {
+  if [ -n "$ETH0_IP6" ]
+  then
+    enable_interface_ipv6 "0" true
+    enable_radvd
+  fi
+  if [ -n "$ETH2_IP6" ]
+  then
+    enable_interface_ipv6 "2" true
+  fi
+}
+
+
 setup_common() {
   init_interfaces $1 $2 $3
   if [ -n "$ETH0_IP" ]
   then
     setup_interface "0" $ETH0_IP $ETH0_MASK $GW
   fi
-  if [ -n "$ETH0_IP6" ]
-  then
-      setup_interface_ipv6 "0" $ETH0_IP6 $ETH0_IP6_PRELEN
-      rm -rf /etc/radvd.conf
-      setup_radvd "0" $ETH0_IP6 $ETH0_IP6_PRELEN true
-  elif [ -n "$GUEST_GW6"  -a -n "$GUEST_CIDR6_SIZE" ]
-  then
-      rm -rf /etc/radvd.conf
-      setup_radvd "0" $GUEST_GW6 $GUEST_CIDR6_SIZE false
-  fi
   setup_interface "1" $ETH1_IP $ETH1_MASK $GW
   if [ -n "$ETH2_IP" ]
   then
     setup_interface "2" $ETH2_IP $ETH2_MASK $GW
   fi
-  if [ -n "$ETH2_IP6" ]
-  then
-      setup_interface_ipv6 "2" $ETH2_IP6 $ETH2_IP6_PRELEN
-  fi
+  setup_ipv6
 
   echo $NAME > /etc/hostname
   echo 'AVAHI_DAEMON_DETECT_LOCAL=0' > /etc/default/avahi-daemon
@@ -370,6 +395,24 @@ setup_common() {
   fi
 }
 
+enable_radvd() {
+  systemctl -q is-enabled radvd
+  status=$?
+  if [ $status -ne 0 ]
+  then
+    log_it "Enabling radvd"
+    systemctl enable radvd
+    echo "radvd" >> /var/cache/cloud/enabled_svcs
+  fi
+  systemctl -q is-active radvd
+  status=$?
+  if [ $status -ne 0 ]
+  then
+    log_it "Starting radvd"
+    systemctl start radvd
+  fi
+}
+
 setup_radvd() {
   log_it "Setting up radvd"
 
@@ -394,8 +437,7 @@ setup_radvd() {
   sed -i "s,{{ RDNSS_CONFIG }},$RDNSS_CFG,g" /etc/radvd.conf.$intf
   cat /etc/radvd.conf.$intf >> /etc/radvd.conf
   if [ "$enable" = true ] ; then
-    systemctl enable radvd
-    echo "radvd" >> /var/cache/cloud/enabled_svcs
+    enable_radvd
   fi
 }
 

--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -111,18 +111,19 @@ setup_interface() {
 }
 
 enable_interface_ipv6() {
+  local intf=eth${1}
+  log_it "Enabling IPv6 on interface: ${intf}"
   sysctl net.ipv6.conf.all.disable_ipv6=0
   sysctl net.ipv6.conf.all.forwarding=1
   sysctl net.ipv6.conf.all.accept_ra=1
   sed  -i "s/net.ipv6.conf.all.disable_ipv6 =.*$/net.ipv6.conf.all.disable_ipv6 = 0/" /etc/sysctl.conf
   sed  -i "s/net.ipv6.conf.all.forwarding =.*$/net.ipv6.conf.all.forwarding = 1/" /etc/sysctl.conf
   sed  -i "s/net.ipv6.conf.all.accept_ra =.*$/net.ipv6.conf.all.accept_ra = 1/" /etc/sysctl.conf
-  sysctl net.ipv6.conf.eth$1.accept_dad=0
-  sysctl net.ipv6.conf.eth$1.use_tempaddr=0
+  sysctl net.ipv6.conf.${intf}.accept_dad=0
+  sysctl net.ipv6.conf.${intf}.use_tempaddr=0
   if [ "$2" = true ] ; then
-    local intf=eth${1}
-    ifdown $intf
-    ifup $intf
+    ifdown ${intf}
+    ifup ${intf}
   fi
 }
 
@@ -292,9 +293,12 @@ setup_ipv6() {
 }
 
 restore_ipv6() {
+  if [ -n "$ETH0_IP6" ] || [ -n "$GUEST_GW6"  -a -n "$GUEST_CIDR6_SIZE" ]
+    then
+    enable_interface_ipv6 "0" true
+  fi
   if [ -n "$ETH0_IP6" ]
   then
-    enable_interface_ipv6 "0" true
     enable_radvd
   fi
   if [ -n "$ETH2_IP6" ]

--- a/systemvm/debian/opt/cloud/bin/setup/router.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/router.sh
@@ -71,6 +71,7 @@ setup_router() {
   enable_fwding 1
   enable_rpsrfs 1
   enable_passive_ftp 1
+  restore_ipv6
 
   # Only allow DNS service for current network
   sed -i "s/-A INPUT -i eth0 -p udp -m udp --dport 53 -j ACCEPT/-A INPUT -i eth0 -p udp -m udp --dport 53 -s $DHCP_RANGE\/$CIDR_SIZE -j ACCEPT/g" /etc/iptables/rules.v4


### PR DESCRIPTION
### Description

Fixes following with IPv6 networks:
- Event resource for IPv6 firewall rules
- radvd not running in single VR isolated network
- IPv6 Firewall rules not added on the correct chain
- IPv6 VPC tier ACL rules not added on the correct chain

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
