### PR TITLE
Disable creating StorPool logs when there isn't StorPool primary storage

### DIFF
--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/collector/StorPoolAbandonObjectsCollector.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/collector/StorPoolAbandonObjectsCollector.java
@@ -89,9 +89,13 @@ public class StorPoolAbandonObjectsCollector extends ManagerBase implements Conf
     }
 
     private void init() {
+        List<StoragePoolVO> spPools = storagePoolDao.findPoolsByProvider(StorPoolUtil.SP_PROVIDER_NAME);
+        if (CollectionUtils.isNotEmpty(spPools)) {
+            StorPoolHelper.appendLogger(log, ABANDON_LOG, "abandon");
+        }
         _volumeTagsUpdateExecutor = Executors.newScheduledThreadPool(2,
                 new NamedThreadFactory("StorPoolAbandonObjectsCollector"));
-        StorPoolHelper.appendLogger(log, ABANDON_LOG, "abandon");
+
         if (volumeCheckupTagsInterval.value() > 0) {
             _volumeTagsUpdateExecutor.scheduleAtFixedRate(new StorPoolVolumesTagsUpdate(),
                     volumeCheckupTagsInterval.value(), volumeCheckupTagsInterval.value(), TimeUnit.SECONDS);

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -898,7 +898,7 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     }
 
     public void handleQualityOfServiceForVolumeMigration(VolumeInfo arg0, QualityOfServiceState arg1) {
-        StorPoolUtil.spLog("handleQualityOfServiceForVolumeMigration with volume name=%s", arg0.getName());
+        log.debug(String.format("handleQualityOfServiceForVolumeMigration with volume name=%s is not supported", arg0.getName()));
     }
 
 

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/snapshot/StorPoolSnapshotStrategy.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/snapshot/StorPoolSnapshotStrategy.java
@@ -81,11 +81,11 @@ public class StorPoolSnapshotStrategy implements SnapshotStrategy {
             snapshotObj.processEvent(Snapshot.Event.BackupToSecondary);
             snapshotObj.processEvent(Snapshot.Event.OperationSucceeded);
         } catch (NoTransitionException ex) {
-            StorPoolUtil.spLog("Failed to change state: " + ex.toString());
+            log.debug("Failed to change state: " + ex.toString());
             try {
                 snapshotObj.processEvent(Snapshot.Event.OperationFailed);
             } catch (NoTransitionException ex2) {
-                StorPoolUtil.spLog("Failed to change state: " + ex2.toString());
+                log.debug("Failed to change state: " + ex2.toString());
             }
         }
         return snapshotInfo;
@@ -126,7 +126,7 @@ public class StorPoolSnapshotStrategy implements SnapshotStrategy {
 
     @Override
     public StrategyPriority canHandle(Snapshot snapshot, SnapshotOperation op) {
-        StorPoolUtil.spLog("StorpoolSnapshotStrategy.canHandle: snapshot=%s, uuid=%s, op=%s", snapshot.getName(), snapshot.getUuid(), op);
+        log.debug(String.format("StorpoolSnapshotStrategy.canHandle: snapshot=%s, uuid=%s, op=%s", snapshot.getName(), snapshot.getUuid(), op));
 
         if (op != SnapshotOperation.DELETE) {
             return StrategyPriority.CANT_HANDLE;


### PR DESCRIPTION
### Description

There is no need to create log files for the StorPool driver when there
isn't a StorPool primary storage


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


