### PR TITLE
Added allowuserdrivenbackups toggle to the edit backup offering button

### DIFF
--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -228,7 +228,7 @@ export default {
         dataView: true,
         popup: true,
         groupMap: (selection) => { return selection.map(x => { return { id: x } }) },
-        args: ['name', 'description']
+        args: ['name', 'description', 'allowuserdrivenbackups']
       }, {
         api: 'deleteBackupOffering',
         icon: 'delete-outlined',


### PR DESCRIPTION
### Description

This PR aims to complement PR #6190, by adding a toggle to the edit backup offering button on the UI.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/48719461/165517367-5aac9a1f-378a-4ee8-98dc-f2be630545d9.png)

### How Has This Been Tested?
This has been tested in a local lab, by using the UI to edit the `allowuserdrivenbackups` parameter of a backup offering.

