### PR TITLE
Improve log when live patching fails

### DIFF
--- a/utils/src/main/java/com/cloud/utils/FileUtil.java
+++ b/utils/src/main/java/com/cloud/utils/FileUtil.java
@@ -38,7 +38,7 @@ public class FileUtil {
     }
 
     public static void scpPatchFiles(String controlIp, String destPath, int sshPort, File pemFile, String[] files, String basePath) {
-        String errMsg = "Failed to scp files to system VM";
+        String finalErrMsg = "";
         List<String> srcFiles = Arrays.asList(files);
         srcFiles = srcFiles.stream()
                 .map(file -> basePath + file) // Using Lambda notation to update the entries
@@ -50,10 +50,11 @@ public class FileUtil {
                         destPath, newSrcFiles, "0755");
                 return;
             } catch (Exception e) {
-                errMsg += ", retrying";
-                s_logger.error(errMsg);
+                finalErrMsg = String.format("Failed to scp files to system VM due to, %s",
+                        e.getCause() != null ? e.getCause().getLocalizedMessage() : e.getLocalizedMessage());
+                s_logger.error(finalErrMsg);
             }
         }
-        throw new CloudRuntimeException(errMsg);
+        throw new CloudRuntimeException(finalErrMsg);
     }
 }


### PR DESCRIPTION
### Description

This PR improves error log message when scp fails during system VM live patching
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Before Fix:
```
2022-04-27 12:02:22,647 ERROR [c.c.s.ManagementServerImpl] (API-Job-Executor-1:ctx-f000200b job-40 ctx-161ff677) (logid:52d49a16) Failed to patch systemVM v-1-VM due to Failed to scp files to system VM, retrying, retrying, retrying
```

After Fix:
```
2022-04-27 13:15:16,189 ERROR [c.c.s.ManagementServerImpl] (API-Job-Executor-1:ctx-4cfd7ab1 job-62 ctx-23bea220) (logid:dffe10d7) Failed to patch systemVM s-2-VM due to Failed to scp files to system VM due to, Remote scp terminated with error (scp: /tmp//agent.zip: No space left on device).
```
![image](https://user-images.githubusercontent.com/10495417/165530378-8197f59d-c5b0-4c60-96c2-7fdc5da50509.png)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
