### PR TITLE
Change patch path during live patching of systemVMs 

### DIFF
--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -122,7 +122,8 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.cloudstack.org/systemvm/${cs.version}/md5sum.txt</url>
+<!--                            <url>https://download.cloudstack.org/systemvm/${cs.version}/md5sum.txt</url>-->
+                            <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/md5sum.txt</url>
                             <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                             <skipCache>true</skipCache>
                             <overwrite>true</overwrite>
@@ -181,7 +182,8 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>
+<!--                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>-->
+                                    <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${kvm.checksum}</md5>
                                 </configuration>
@@ -217,7 +219,8 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>
+<!--                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>-->
+                                    <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${vmware.checksum}</md5>
                                 </configuration>
@@ -253,7 +256,8 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>
+<!--                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>-->
+                                    <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${xen.checksum}</md5>
                                 </configuration>

--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -122,8 +122,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-<!--                            <url>https://download.cloudstack.org/systemvm/${cs.version}/md5sum.txt</url>-->
-                            <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/md5sum.txt</url>
+                            <url>https://download.cloudstack.org/systemvm/${cs.version}/md5sum.txt</url>
                             <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                             <skipCache>true</skipCache>
                             <overwrite>true</overwrite>
@@ -182,8 +181,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-<!--                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>-->
-                                    <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>
+                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${kvm.checksum}</md5>
                                 </configuration>
@@ -219,8 +217,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-<!--                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>-->
-                                    <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>
+                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${vmware.checksum}</md5>
                                 </configuration>
@@ -256,8 +253,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-<!--                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>-->
-                                    <url>https://download.cloudstack.org/testing/systemvmtemplate/${cs.version}/newPath/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>
+                                    <url>https://download.cloudstack.org/systemvm/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${xen.checksum}</md5>
                                 </configuration>

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPatchSystemVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPatchSystemVmCommandWrapper.java
@@ -69,9 +69,9 @@ public class LibvirtPatchSystemVmCommandWrapper extends CommandWrapper<PatchSyst
 
         Pair<Boolean, String> patchResult = null;
         try {
-            FileUtil.scpPatchFiles(controlIp, "/tmp/", sshPort, pemFile, serverResource.systemVmPatchFiles, LibvirtComputingResource.BASEPATH);
+            FileUtil.scpPatchFiles(controlIp, VRScripts.CONFIG_CACHE_LOCATION, sshPort, pemFile, serverResource.systemVmPatchFiles, LibvirtComputingResource.BASEPATH);
             patchResult = SshHelper.sshExecute(controlIp, sshPort, "root",
-                    pemFile, null, "/tmp/patch-sysvms.sh", 10000, 10000, 600000);
+                    pemFile, null, "/var/cache/cloud/patch-sysvms.sh", 10000, 10000, 600000);
         } catch (Exception e) {
             return new PatchSystemVmAnswer(cmd, e.getMessage());
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
@@ -22,6 +22,7 @@ package com.cloud.hypervisor.kvm.resource.wrapper;
 import java.io.File;
 import java.net.URISyntaxException;
 
+import com.cloud.agent.resource.virtualnetwork.VRScripts;
 import com.cloud.utils.FileUtil;
 import org.apache.log4j.Logger;
 import org.libvirt.Connect;
@@ -120,7 +121,7 @@ public final class LibvirtStartCommandWrapper extends CommandWrapper<StartComman
 
                     try {
                         File pemFile = new File(LibvirtComputingResource.SSHPRVKEYPATH);
-                        FileUtil.scpPatchFiles(controlIp, "/tmp/", Integer.parseInt(LibvirtComputingResource.DEFAULTDOMRSSHPORT), pemFile, LibvirtComputingResource.systemVmPatchFiles, LibvirtComputingResource.BASEPATH);
+                        FileUtil.scpPatchFiles(controlIp, VRScripts.CONFIG_CACHE_LOCATION, Integer.parseInt(LibvirtComputingResource.DEFAULTDOMRSSHPORT), pemFile, LibvirtComputingResource.systemVmPatchFiles, LibvirtComputingResource.BASEPATH);
                         if (!virtRouterResource.isSystemVMSetup(vmName, controlIp)) {
                             String errMsg = "Failed to patch systemVM";
                             s_logger.error(errMsg);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -664,7 +664,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
         ExecutionResult result;
         try {
             result = getSystemVmVersionAndChecksum(controlIp);
-            FileUtil.scpPatchFiles(controlIp, "/tmp/", DefaultDomRSshPort, pemFile, systemVmPatchFiles, BASEPATH);
+            FileUtil.scpPatchFiles(controlIp, VRScripts.CONFIG_CACHE_LOCATION, DefaultDomRSshPort, pemFile, systemVmPatchFiles, BASEPATH);
         } catch (CloudRuntimeException e) {
             return new PatchSystemVmAnswer(cmd, e.getMessage());
         }
@@ -687,7 +687,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
         Pair<Boolean, String> patchResult = null;
         try {
             patchResult = SshHelper.sshExecute(controlIp, DefaultDomRSshPort, "root",
-                    pemFile, null, "/tmp/patch-sysvms.sh", 10000, 10000, 600000);
+                    pemFile, null, "/var/cache/cloud/patch-sysvms.sh", 10000, 10000, 600000);
         } catch (Exception e) {
             return new PatchSystemVmAnswer(cmd, e.getMessage());
         }
@@ -2578,7 +2578,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 try {
                     String homeDir = System.getProperty("user.home");
                     File pemFile = new File(homeDir + "/.ssh/id_rsa");
-                    FileUtil.scpPatchFiles(controlIp, "/tmp/", DefaultDomRSshPort, pemFile, systemVmPatchFiles, BASEPATH);
+                    FileUtil.scpPatchFiles(controlIp, VRScripts.CONFIG_CACHE_LOCATION, DefaultDomRSshPort, pemFile, systemVmPatchFiles, BASEPATH);
                     if (!_vrResource.isSystemVMSetup(vmInternalCSName, controlIp)) {
                         String errMsg = "Failed to patch systemVM";
                         s_logger.error(errMsg);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixPatchSystemVmCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixPatchSystemVmCommandWrapper.java
@@ -68,7 +68,7 @@ public class CitrixPatchSystemVmCommandWrapper extends CommandWrapper<PatchSyste
 
         String patchResult = null;
         try {
-            serverResource.copyPatchFilesToVR(controlIp, "/tmp/");
+            serverResource.copyPatchFilesToVR(controlIp, VRScripts.CONFIG_CACHE_LOCATION);
             patchResult = serverResource.callHostPlugin(conn, "vmops", "runPatchScriptInDomr", "domrip", controlIp);
         } catch (Exception e) {
             return new PatchSystemVmAnswer(command, e.getMessage());

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.cloud.agent.resource.virtualnetwork.VRScripts;
 import com.cloud.agent.resource.virtualnetwork.VirtualRoutingResource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -197,7 +198,7 @@ public final class CitrixStartCommandWrapper extends CommandWrapper<StartCommand
                 }
 
                 try {
-                    citrixResourceBase.copyPatchFilesToVR(controlIp, "/tmp/");
+                    citrixResourceBase.copyPatchFilesToVR(controlIp, VRScripts.CONFIG_CACHE_LOCATION);
                     VirtualRoutingResource vrResource = citrixResourceBase.getVirtualRoutingResource();
                     if (!vrResource.isSystemVMSetup(vmName, controlIp)) {
                         String errMsg = "Failed to patch systemVM";

--- a/scripts/vm/hypervisor/xenserver/vmops
+++ b/scripts/vm/hypervisor/xenserver/vmops
@@ -254,7 +254,7 @@ def runPatchScriptInDomr(session, args):
     txt=""
     try:
         target = "root@" + domrip
-        txt = util.pread2(['ssh','-p','3922','-i','/root/.ssh/id_rsa.cloud', target, "/bin/bash","/tmp/patch-sysvms.sh"])
+        txt = util.pread2(['ssh','-p','3922','-i','/root/.ssh/id_rsa.cloud', target, "/bin/bash","/var/cache/cloud/patch-sysvms.sh"])
         txt = 'succ#' + txt
     except:
         logging.debug("failed to run patch script in systemVM with IP:  " + domrip)

--- a/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
@@ -55,7 +55,7 @@ patch_systemvm() {
 }
 
 patch() {
-  local PATCH_MOUNT=/tmp/
+  local PATCH_MOUNT=/var/cache/cloud/
   local logfile="/var/log/patchsystemvm.log"
 
   if [ "$TYPE" == "consoleproxy" ] || [ "$TYPE" == "secstorage" ]  && [ -f ${PATCH_MOUNT}/agent.zip ] && [ -f /var/cache/cloud/patch.required ]

--- a/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
+++ b/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
@@ -41,7 +41,7 @@ validate_checksums() {
 }
 
 patch() {
-  local PATCH_MOUNT=/tmp
+  local PATCH_MOUNT=/var/cache/cloud
   local PATCH_SCRIPTS=cloud-scripts.tgz
   local oldpatchfile=/usr/share/cloud/$PATCH_SCRIPTS
   local patchfile=$PATCH_MOUNT/$PATCH_SCRIPTS
@@ -97,8 +97,8 @@ patch() {
 }
 
 cleanup() {
-  rm -rf /tmp/agent.zip
-  mv /tmp/cloud-scripts.tgz /usr/share/cloud/cloud-scripts.tgz
+  rm -rf /var/cache/cloud/agent.zip
+  mv /var/cache/cloud/cloud-scripts.tgz /usr/share/cloud/cloud-scripts.tgz
 }
 
 start() {

--- a/systemvm/patch-sysvms.sh
+++ b/systemvm/patch-sysvms.sh
@@ -17,9 +17,9 @@
 # under the License.
 
 PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
-backupfolder=/tmp/bkpup_live_patch
+backupfolder=/var/cache/cloud/bkpup_live_patch
 logfile="/var/log/livepatchsystemvm.log"
-newpath="/tmp/"
+newpath="/var/cache/cloud/"
 CMDLINE=/var/cache/cloud/cmdline
 md5file=/var/cache/cloud/cloud-scripts-signature
 svcfile=/var/cache/cloud/enabled_svcs

--- a/systemvm/patch-sysvms.sh
+++ b/systemvm/patch-sysvms.sh
@@ -89,6 +89,9 @@ restart_services() {
         return
       fi
     done < "$svcfile"
+    if [ "$TYPE" == "consoleproxy" ]; then
+      iptables -A INPUT -i eth2 -p tcp -m state --state NEW -m tcp --dport 8080 -j ACCEPT
+    fi
 }
 
 cleanup_systemVM() {

--- a/utils/src/main/java/com/cloud/utils/FileUtil.java
+++ b/utils/src/main/java/com/cloud/utils/FileUtil.java
@@ -38,7 +38,7 @@ public class FileUtil {
     }
 
     public static void scpPatchFiles(String controlIp, String destPath, int sshPort, File pemFile, String[] files, String basePath) {
-        String errMsg = "Failed to scp files to system VM";
+        String finalErrMsg = "";
         List<String> srcFiles = Arrays.asList(files);
         srcFiles = srcFiles.stream()
                 .map(file -> basePath + file) // Using Lambda notation to update the entries
@@ -50,10 +50,11 @@ public class FileUtil {
                         destPath, newSrcFiles, "0755");
                 return;
             } catch (Exception e) {
-                errMsg += ", retrying";
-                s_logger.error(errMsg);
+                finalErrMsg = String.format("Failed to scp files to system VM due to, %s",
+                        e.getCause() != null ? e.getCause().getLocalizedMessage() : e.getLocalizedMessage());
+                s_logger.error(finalErrMsg);
             }
         }
-        throw new CloudRuntimeException(errMsg);
+        throw new CloudRuntimeException(finalErrMsg);
     }
 }


### PR DESCRIPTION
### Description

This PR updates the location where the new software packages are temporarily copied during live patching.
This will allow livePatching of ACS 4.14, however versions <= 4.13 will not be supported for live patching due to the change in JDK version

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
