### PR TITLE
test: fix ipv6 network test for xenserver

### DIFF
--- a/test/integration/smoke/test_network_ipv6.py
+++ b/test/integration/smoke/test_network_ipv6.py
@@ -599,6 +599,12 @@ class TestIpv6Network(cloudstackTestCase):
                 cls.zone.id,
                 cls.services["ostype"]
             )
+            if cls.hypervisor.lower() in ('xenserver'):
+                # Default Xenserver template has IPv6 disabled
+                cls.template = get_test_template(
+                   cls.apiclient,
+                   cls.zone.id,
+                   cls.hypervisor)
         else:
             cls.debug("IPv6 is not supported, skipping tests!")
         return


### PR DESCRIPTION
### Description

Default ACS Xenserver template, CentOS 5.6, has IPv6 disabled.
/etc/modeprobe.conf shows "options ipv6 disable=1"
To run IPv6 network test successfully on Xenserver smoketest run get_test_template will be used instead of get_template while deploying guest VM in the IPv6 guest network.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
VM with default Xenserver CentOS 5.6 template
![Screenshot from 2022-04-28 12-13-01](https://user-images.githubusercontent.com/153340/165692980-fd6901af-6dca-4d71-ad61-75d6453a4bdf.png)
![Screenshot from 2022-04-28 12-12-51](https://user-images.githubusercontent.com/153340/165692992-8b696e04-c6bf-4708-bf79-5bb47e766dd7.png)


### How Has This Been Tested?
Ran test with changes in a Xenserver env:

```
[root@pr5811-t4060-xenserver-71-marvin ~]# cat /marvin/MarvinLogs/test_network_ipv6_2Z56GX/results.txt
Test to create network offering ... === TestName: test_01_create_ipv6_network_offering | Status : SUCCESS ===
ok
Test to create network offering ... === TestName: test_02_create_ipv6_network_offering_fail | Status : SUCCESS ===
ok
Test to create network offering ... === TestName: test_03_create_ipv6_vpc_offering | Status : SUCCESS ===
ok
Test to create VPC offering failure ... === TestName: test_04_create_ipv6_vpc_offering_fail | Status : SUCCESS ===
ok
Test to add IPv6 guest prefix ... === TestName: test_01_create_ipv6_guest_prefix | Status : SUCCESS ===
ok
Test to add IPv6 guest prefix failure ... === TestName: test_02_create_ipv6_guest_prefix_fail | Status : SUCCESS ===
ok
Test to verify IPv6 network ... === TestName: test_01_verify_ipv6_network | Status : SUCCESS ===
ok
Test to verify redundant IPv6 network ... === TestName: test_02_verify_ipv6_network_redundant | Status : SUCCESS ===
ok
Test to add IPv6 public IP range ... === TestName: test_01_create_ipv6_public_ip_range | Status : SUCCESS ===
ok
Test to add IPv6 public IP range failure ... === TestName: test_02_create_ipv6_public_ip_range_fail | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 10 tests in 1235.315s

OK

```
