### PR TITLE
ui: Fix groupaction for nw cleanup and Notify when groupaction fails

### DIFF
--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -114,9 +114,9 @@ export default {
           label: 'label.restart.network',
           message: 'message.restart.network',
           dataView: true,
-          args: (record) => {
+          args: (record, store, isGroupAction) => {
             var fields = []
-            if (record.vpcid == null) {
+            if (isGroupAction || record.vpcid == null) {
               fields.push('cleanup')
             }
             fields.push('livepatch')

--- a/ui/src/utils/plugins.js
+++ b/ui/src/utils/plugins.js
@@ -133,23 +133,25 @@ export const pollJobPlugin = {
           if (name) {
             desc = `(${name}) ${desc}`
           }
+          let onClose = () => {}
           if (!bulkAction) {
             let countNotify = store.getters.countNotify
             countNotify++
             store.commit('SET_COUNT_NOTIFY', countNotify)
-            notification.error({
-              top: '65px',
-              message: errMessage,
-              description: desc,
-              key: jobId,
-              duration: 0,
-              onClose: () => {
-                let countNotify = store.getters.countNotify
-                countNotify > 0 ? countNotify-- : countNotify = 0
-                store.commit('SET_COUNT_NOTIFY', countNotify)
-              }
-            })
+            onClose = () => {
+              let countNotify = store.getters.countNotify
+              countNotify > 0 ? countNotify-- : countNotify = 0
+              store.commit('SET_COUNT_NOTIFY', countNotify)
+            }
           }
+          notification.error({
+            top: '65px',
+            message: errMessage,
+            description: desc,
+            key: jobId,
+            duration: 0,
+            onClose: onClose
+          })
           store.dispatch('AddHeaderNotice', {
             key: jobId,
             title,


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/6330

Shows cleanup when restarting a network in group action irrespective of the type of network
Also throws an error notification when a group action fails

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![Screenshot from 2022-04-28 17-27-15](https://user-images.githubusercontent.com/8244774/165747238-0d177283-f42d-476c-8527-41baf310fcd3.png)

![Screenshot from 2022-04-28 17-30-34](https://user-images.githubusercontent.com/8244774/165747452-b69c75a4-0fa3-4ed0-a02f-44355897543c.png)

