### PR TITLE
UI: Fix detail settings

### DIFF
--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -56,8 +56,8 @@
             :options="detailValues"
             :placeholder="$t('label.value')"
             @change="e => onAddInputChange(e, 'newValue')" />
-          <tooltip-button :tooltip="$t('label.add.setting')" icon="check-outlined" @onClick="addDetail" buttonClass="detail-button" />
-          <tooltip-button :tooltip="$t('label.cancel')" icon="close-outlined" @onClick="closeDetail" buttonClass="detail-button" />
+          <tooltip-button :tooltip="$t('label.add.setting')" :shape="null" icon="check-outlined" @onClick="addDetail" buttonClass="detail-button" />
+          <tooltip-button :tooltip="$t('label.cancel')" :shape="null" icon="close-outlined" @onClick="closeDetail" buttonClass="detail-button" />
         </a-input-group>
         <p v-if="error" style="color: red"> {{ $t(error) }} </p>
       </div>

--- a/ui/src/components/widgets/TooltipButton.vue
+++ b/ui/src/components/widgets/TooltipButton.vue
@@ -20,10 +20,10 @@
     <template #title v-if="tooltip">
       {{ tooltip }}
     </template>
-    <span style="margin-right: 5px">
+    <span>
       <a-button
         v-if="copyResource"
-        shape="circle"
+        :shape="shape"
         :size="size"
         :type="type"
         :danger="danger"
@@ -39,7 +39,7 @@
       </a-button>
       <a-button
         v-else
-        shape="circle"
+        :shape="shape"
         :size="size"
         :type="type"
         :danger="danger"
@@ -108,6 +108,10 @@ export default {
     danger: {
       type: Boolean,
       default: false
+    },
+    shape: {
+      type: String,
+      default: 'circle'
     }
   },
   methods: {


### PR DESCRIPTION
### Description

This PR fixes the alignment of the details settings bar:

![image](https://user-images.githubusercontent.com/5295080/165778476-f23e7ac1-57ff-4cb0-9f84-51685abc8d31.png)
<img width="967" alt="Screen Shot 2022-04-28 at 11 42 32" src="https://user-images.githubusercontent.com/5295080/165778630-d0d1cb07-bd65-45e3-a5dd-b58a8ed13909.png">

After:
<img width="965" alt="Screen Shot 2022-04-28 at 11 43 01" src="https://user-images.githubusercontent.com/5295080/165778729-f1e3f69d-cc6e-497e-a9d4-f91b742906fc.png">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
