### PR TITLE
UI: Fix navigation after delete template job is finished

### DIFF
--- a/ui/src/views/image/TemplateZones.vue
+++ b/ui/src/views/image/TemplateZones.vue
@@ -453,10 +453,9 @@ export default {
           successMethod: result => {
             if (singleZone) {
               const isResourcePage = (this.$route.params && this.$route.params.id)
-              if (isResourcePage) {
-                if (this.selectedItems.length === 0 && !this.showGroupActionModal) {
-                  this.$router.push({ path: '/template' })
-                }
+              const isSameResource = isResourcePage && this.$route.params.id === result.jobinstanceid
+              if (isResourcePage && isSameResource && this.selectedItems.length === 0 && !this.showGroupActionModal) {
+                this.$router.push({ path: '/template' })
               }
             } else {
               if (this.selectedItems.length === 0) {


### PR DESCRIPTION
### Description

This PR fixes the redirection to the templates view after a delete template job succeeds only if the user/admin stays on the same page.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

