### PR TITLE
Gateways after Nic update on Shared Network tests

### DIFF
--- a/test/integration/smoke/test_gateway_on_shared_networks.py
+++ b/test/integration/smoke/test_gateway_on_shared_networks.py
@@ -1,0 +1,207 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#Import Local Modules
+from marvin.cloudstackAPI import *
+from marvin.cloudstackTestCase import cloudstackTestCase
+import unittest
+from marvin.lib.base import (NetworkOffering,
+                             Network,
+                             ServiceOffering,
+                             VirtualMachine,
+                             Template,
+                             PublicIpRange,
+                             NIC
+                             )
+from marvin.lib.common import (get_domain,
+                               get_zone,
+                               get_template,
+                               find_storage_pool_type,
+                               get_builtin_template_info)
+from marvin.codes import (
+    PASS,
+    FAILED,
+    JOB_FAILED,
+    JOB_CANCELLED,
+    JOB_SUCCEEDED
+)
+from nose.plugins.attrib import attr
+import time
+
+
+class TestGatewayOnSharedNetwork(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            testClient = super(TestGatewayOnSharedNetwork, cls).getClsTestClient()
+            cls.apiclient = testClient.getApiClient()
+            cls.services = testClient.getParsedTestDataConfig()
+            cls._cleanup = []
+            # Get Zone, Domain and templates
+            cls.domain = get_domain(cls.apiclient)
+            cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
+            cls.services['mode'] = cls.zone.networktype
+            cls.hypervisor = testClient.getHypervisorInfo()
+
+            cls.service_offering = ServiceOffering.create(
+                cls.apiclient,
+                cls.services["service_offering"]
+            )
+            cls._cleanup.append(cls.service_offering)
+
+            builtin_info = get_builtin_template_info(cls.apiclient, cls.zone.id)
+            cls.services["template"]["url"] = builtin_info[0]
+            cls.services["template"]["hypervisor"] = builtin_info[1]
+            cls.services["template"]["format"] = builtin_info[2]
+
+            cls.template = get_template(
+                cls.apiclient,
+                cls.zone.id
+            )
+
+            # # Register new template
+            # cls.template = Template.register(
+            #     cls.apiclient,
+            #     cls.services["template"],
+            #     zoneid=cls.zone.id,
+            #     hypervisor=cls.hypervisor
+            # )
+            # cls._cleanup.append(cls.template)
+
+            cls.services["shared_network_offering"]["specifyVlan"] = "True"
+            cls.services["shared_network_offering"]["specifyIpRanges"] = "True"
+            cls.shared_network_offering = NetworkOffering.create(
+                cls.apiclient,
+                cls.services["shared_network_offering"],
+                conservemode=False
+            )
+            cls._cleanup.append(cls.shared_network_offering)
+            NetworkOffering.update(
+                cls.shared_network_offering,
+                cls.apiclient,
+                id=cls.shared_network_offering.id,
+                state="enabled"
+            )
+
+        except Exception as e:
+            cls.tearDownClass()
+            raise unittest.SkipTest("Exception in setUpClass: %s" % e)
+
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.debug(f"tearing down TestGatewayOnSharedNetwork")
+        super(TestGatewayOnSharedNetwork, cls).tearDownClass()
+
+    def setUp(self):
+        self.cleanup = []
+
+    def tearDown(self):
+        self.debug(f"tearing down test in TestGatewayOnSharedNetwork")
+        super(TestGatewayOnSharedNetwork, self).tearDown()
+
+    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    def test_updating_nics_on_two_shared_networks(self):
+        """
+        Test updating vm nics on two shared networks
+        Works as follows:
+        - Create two shared networks, with different IP ranges (eg network1, network2).
+        - Create two VMs on each shared network (eg vm1 on network1, vm2 on network2) and stop them.
+        - Add additional IP range to each shared network. The two additional IP ranges have same start IP and end IP,
+            but different gateway and netmask (eg network1-iprange2, network2-iprange2).
+        - Update IP address of the two vms, by specifying new IP address on additional IP ranges. The new gateway and
+            netmask should be updated correctly (eg vm1 on network1-iprange2, vm2 on network2-iprange2).
+        """
+        # - Create two shared networks, with different IP ranges (eg network1, network2).
+        self.services["shared_network"]["netmask"] = "255.255.255.0"
+        self.services["shared_network"]["gateway"] = "192.168.1.1"
+        self.services["shared_network"]["startip"] = "192.168.1.2"
+        self.services["shared_network"]["endip"] = "192.168.1.20"
+        self.services["shared_network"]["vlan"] = "111"
+        testnet = self.services["shared_network"]
+        self.debug(f"========= network 1 : {testnet}")
+
+        self.network1 = Network.create(
+            self.apiclient,
+            self.services["shared_network"],
+            networkofferingid=self.shared_network_offering.id,
+            zoneid=self.zone.id,
+        )
+        self._cleanup.append(self.network1)
+
+        self.services["shared_network"]["netmask"] = "255.255.255.0"
+        self.services["shared_network"]["gateway"] = "192.168.2.1"
+        self.services["shared_network"]["startip"] = "192.168.2.2"
+        self.services["shared_network"]["endip"] = "192.168.2.20"
+        self.services["shared_network"]["vlan"] = "222"
+        self.network2 = Network.create(
+            self.apiclient,
+            self.services["shared_network"],
+            networkofferingid=self.shared_network_offering.id,
+            zoneid=self.zone.id,
+        )
+        self._cleanup.append(self.network2)
+
+        # - Create two VMs on each shared network (eg vm1 on network1, vm2 on network2) and stop them.
+        vm_data = self.services["virtual_machine"]
+        self.debug(f"============virtual machine data : {vm_data}")
+        virtual_machine1 = VirtualMachine.create(
+            self.apiclient,
+            self.services["virtual_machine"],
+            templateid=self.template.id,
+            serviceofferingid=self.service_offering.id,
+            networkids=[self.network1.id],
+            zoneid=self.zone.id
+        )
+        self.cleanup.append(virtual_machine1)
+        virtual_machine1.stop(self.apiclient)
+        virtual_machine2 = VirtualMachine.create(
+            self.apiclient,
+            self.services["virtual_machine"],
+            templateid=self.template.id,
+            serviceofferingid=self.service_offering.id,
+            networkids=[self.network2.id],
+            zoneid=self.zone.id
+        )
+        self.cleanup.append(virtual_machine2)
+        virtual_machine2.stop(self.apiclient)
+        # - Add additional IP range to each shared network. The two additional IP ranges have same start IP and end IP,
+        #   but different gateway and netmask (eg network1-iprange2, network2-iprange2).
+        self.services["vlan_ip_range"]["netmask"] = "255.255.255.224"
+        self.services["vlan_ip_range"]["gateway"] = "192.168.3.1"
+        self.services["vlan_ip_range"]["startip"] = "192.168.3.2"
+        self.services["vlan_ip_range"]["endip"] = "192.168.3.20"
+        self.services["vlan_ip_range"]["vlan"] = "111"
+        PublicIpRange.create(self.apiclient, self.services["vlan_ip_range"], networkid=self.network1.id)
+
+        self.services["vlan_ip_range"]["netmask"] = "255.255.255.192"
+        self.services["vlan_ip_range"]["gateway"] = "192.168.3.21"
+        self.services["vlan_ip_range"]["startip"] = "192.168.3.2"
+        self.services["vlan_ip_range"]["endip"] = "192.168.3.20"
+        self.services["vlan_ip_range"]["vlan"] = "222"
+        PublicIpRange.create(self.apiclient, self.services["vlan_ip_range"], networkid=self.network2.id)
+
+        # - Update IP address of the two vms, by specifying new IP address on additional IP ranges. The new gateway and
+        #   netmask should be updated correctly (eg vm1 on network1-iprange2, vm2 on network2-iprange2).
+        nic1 = NIC.list(self.apiclient, virtualmachineid=virtual_machine1)[0]
+        nic1.updateIP(self.apiclient, id=nic1.id, ipaddress="192.168.3.2")
+
+        nic2 = NIC.list(self.apiclient, virtualmachineid=virtual_machine1)[0]
+        nic2.updateIP(self.apiclient, id=nic1.id, ipaddress="192.168.3.2")
+
+        return

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -3627,7 +3627,7 @@ class PublicIpRange:
         self.__dict__.update(items)
 
     @classmethod
-    def create(cls, apiclient, services, account=None, domainid=None, forsystemvms=None):
+    def create(cls, apiclient, services, account=None, domainid=None, forsystemvms=None, networkid=None):
         """Create VlanIpRange"""
 
         cmd = createVlanIpRange.createVlanIpRangeCmd()
@@ -3635,15 +3635,18 @@ class PublicIpRange:
             cmd.gateway = services["gateway"]
         if "netmask" in services:
             cmd.netmask = services["netmask"]
-        cmd.forvirtualnetwork = services["forvirtualnetwork"]
+        if "forvirtualnetwork" in services:
+            cmd.forvirtualnetwork = services["forvirtualnetwork"]
         if "startip" in services:
             cmd.startip = services["startip"]
         if "endip" in services:
             cmd.endip = services["endip"]
-        cmd.zoneid = services["zoneid"]
+        if "zoneid" in services:
+            cmd.zoneid = services["zoneid"]
         if "podid" in services:
             cmd.podid = services["podid"]
-        cmd.vlan = services["vlan"]
+        if "vlan" in services:
+            cmd.vlan = services["vlan"]
         if "ip6gateway" in services:
             cmd.ip6gateway = services["ip6gateway"]
         if "ip6cidr" in services:
@@ -3655,6 +3658,8 @@ class PublicIpRange:
             cmd.domainid = domainid
         if forsystemvms:
             cmd.forsystemvms = forsystemvms
+        if networkid:
+            cmd.networkid = networkid
 
         return PublicIpRange(apiclient.createVlanIpRange(cmd).__dict__)
 


### PR DESCRIPTION
### Description

This PR add a test to verify that the right gateways and netmasks are set on updates of IPs from a different range on shared networks. This was fixed in #5105

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
integration test only