### PR TITLE
Log load bean exception

### DIFF
--- a/utils/src/main/java/com/cloud/utils/component/ComponentContext.java
+++ b/utils/src/main/java/com/cloud/utils/component/ComponentContext.java
@@ -72,8 +72,14 @@ public class ComponentContext implements ApplicationContextAware {
 
         Map<String, ComponentMethodInterceptable> interceptableComponents = getApplicationContext().getBeansOfType(ComponentMethodInterceptable.class);
         for (Map.Entry<String, ComponentMethodInterceptable> entry : interceptableComponents.entrySet()) {
-            Object bean = getTargetObject(entry.getValue());
-            beanFactory.configureBean(bean, entry.getKey());
+            try {
+                Object bean = getTargetObject(entry.getValue());
+                beanFactory.configureBean(bean, entry.getKey());
+            } catch (Throwable e){
+                s_logger.error(String.format("Could not load bean due to: [%s]. The service will be stopped. Please investigate the cause of the error or contact your support team.", e.getMessage(), e));
+                System.exit(1);
+            }
+
         }
 
         Map<String, ComponentLifecycle> lifecycleComponents = getApplicationContext().getBeansOfType(ComponentLifecycle.class);

--- a/utils/src/main/java/com/cloud/utils/component/ComponentContext.java
+++ b/utils/src/main/java/com/cloud/utils/component/ComponentContext.java
@@ -75,8 +75,8 @@ public class ComponentContext implements ApplicationContextAware {
             try {
                 Object bean = getTargetObject(entry.getValue());
                 beanFactory.configureBean(bean, entry.getKey());
-            } catch (Throwable e){
-                s_logger.error(String.format("Could not load bean due to: [%s]. The service will be stopped. Please investigate the cause of the error or contact your support team.", e.getMessage(), e));
+            } catch (BeansException e){
+                s_logger.error(String.format("Could not load bean due to: [%s]. The service will be stopped. Please investigate the cause of the error or contact your support team.", e.getMessage()), e);
                 System.exit(1);
             }
 

--- a/utils/src/main/java/com/cloud/utils/component/ComponentContext.java
+++ b/utils/src/main/java/com/cloud/utils/component/ComponentContext.java
@@ -31,6 +31,7 @@ import javax.naming.ConfigurationException;
 
 import org.apache.log4j.Logger;
 import org.springframework.aop.framework.Advised;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;


### PR DESCRIPTION
### Description

Currently when ACS fails to load the beans for some component, such as cloud-usage, an exception will be thrown but it is not logged, making the system restart indefinitely. Without any logs, it can be hard to figure out what is happening; to fix that, a try-catch block and a new log were added in the bootstrap of the agent.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab, by injecting a class into `UsageManagerImpl` without mapping its bean and checking if the log would appear and if the component would stop.
