### PR TITLE
ipv6: set default_egress_policy for ingress rules

### DIFF
--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -475,7 +475,7 @@ public class CommandSetupHelper {
                 _rulesDao.loadDestinationCidrs((FirewallRuleVO)rule);
                 final FirewallRule.TrafficType trafficType = rule.getTrafficType();
                 if (trafficType == FirewallRule.TrafficType.Ingress) {
-                    final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, null, Purpose.Ipv6Firewall, trafficType);
+                    final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, null, Purpose.Ipv6Firewall, trafficType, defaultEgressPolicy);
                     rulesTO.add(ruleTO);
                 } else if (rule.getTrafficType() == FirewallRule.TrafficType.Egress) {
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, "", Purpose.Ipv6Firewall, trafficType, defaultEgressPolicy);
@@ -560,7 +560,7 @@ public class CommandSetupHelper {
                 _rulesDao.loadDestinationCidrs((FirewallRuleVO)rule);
                 final FirewallRule.TrafficType traffictype = rule.getTrafficType();
                 if (traffictype == FirewallRule.TrafficType.Ingress) {
-                    final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, null, Purpose.Ipv6Firewall, traffictype);
+                    final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, null, Purpose.Ipv6Firewall, traffictype, defaultEgressPolicy);
                     rulesTO.add(ruleTO);
                 } else if (rule.getTrafficType() == FirewallRule.TrafficType.Egress) {
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, "", Purpose.Ipv6Firewall, traffictype, defaultEgressPolicy);


### PR DESCRIPTION
### Description

This PR fixes an issue we found in the smoke test `test/integration/smoke/test_network_ipv6.py`.
sometimes the test failed with error below
```
FAIL: Test to verify IPv6 network
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/marvin/lib/decoratorGenerators.py", line 30, in test_wrapper
    return test(self, *args, **kwargs)
  File "/marvin/test_network_ipv6.py", line 1215, in test_01_verify_ipv6_network
    self.checkNetworkRouting()
  File "/marvin/test_network_ipv6.py", line 1060, in checkNetworkRouting
    "Ping from VM %s of network %s to VM %s of network %s is unsuccessful" % (self.routing_test_vm.id, self.routing_test_network.id, self.virtual_machine.id, self.network.id))
AssertionError: False is not true : Ping from VM 0aa36a76-09c6-476f-97c5-b9cea27a5b7c of network 27a2b244-e319-46c5-a779-d6ae73eb9ac2 to VM ae13ea17-1f35-4ca7-83c1-e13126f8df79 of network 1f38a686-69f3-41ed-a75e-cd3f822497d8 is unsuccessful
```

After investigation, we found the egress traffic is dropped by `nft`.

a correct nft chain looks like
```
root@r-282-VM:~# nft list chain ip6 ip6_firewall fw_chain_egress
table ip6 ip6_firewall {
	chain fw_chain_egress {
		counter packets 0 bytes 0 accept
	}
}
```

However, some VRs have the following nft chain
```
root@r-280-VM:~# nft list chain ip6 ip6_firewall fw_chain_egress
table ip6 ip6_firewall {
	chain fw_chain_egress {
		counter packets 0 bytes 0 drop
	}
}
```

It is because the ingress rule does not have correct `default_egress_policy`
```
root@r-280-VM:~# cat /etc/cloudstack/ipv6firewallrules.json
{
  "0": {
    "already_added": false,
    "default_egress_policy": true,
    "dest_cidr_list": [],
    "guest_ip6_cidr": "fd17:ac56:1234:1a96::/64",
    "id": 0,
    "protocol": "all",
    "purpose": "Ipv6Firewall",
    "revoked": false,
    "source_cidr_list": [],
    "src_ip": "",
    "traffic_type": "Egress"
  },
  "1263": {
    "already_added": false,
    "default_egress_policy": false,
    "dest_cidr_list": [
      "::/0"
    ],
    "guest_ip6_cidr": "fd17:ac56:1234:1a96::/64",
    "icmp_code": -1,
    "icmp_type": -1,
    "id": 1263,
    "protocol": "icmp",
    "purpose": "Ipv6Firewall",
    "revoked": false,
    "source_cidr_list": [
      "::/0"
    ],
    "traffic_type": "Ingress"
  },
  "id": "ipv6firewallrules"
}
```

in mose time, the Egress rule is processed before Ingress rule.
But when the Ingress rule is processed at first, the nft chain will be wrong.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
