### PR TITLE
UI: Add missing tooltips on service offering creation

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -899,6 +899,7 @@
 "label.diskofferingstrictness": "Disk offering strictness",
 "label.disksizestrictness": "Disk size strictness",
 "label.computeonly.offering": "Compute only disk offering",
+"label.computeonly.offering.tooltip": "Option to specify root disk related information in the compute offering or to link a disk offering to the compute offering",
 "label.edit": "Edit",
 "label.edit.acl.list": "Edit ACL list",
 "label.edit.acl.rule": "Edit ACL rule",

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -899,7 +899,7 @@
 "label.diskofferingstrictness": "Disk offering strictness",
 "label.disksizestrictness": "Disk size strictness",
 "label.computeonly.offering": "Compute only disk offering",
-"label.computeonly.offering.tooltip": "Option to specify root disk related information in the compute offering or to link a disk offering to the compute offering",
+"label.computeonly.offering.tooltip": "Option to specify root disk related information in the compute offering or to directly link a disk offering to the compute offering",
 "label.edit": "Edit",
 "label.edit.acl.list": "Edit ACL list",
 "label.edit.acl.rule": "Edit ACL rule",

--- a/ui/src/views/offering/AddComputeOffering.vue
+++ b/ui/src/views/offering/AddComputeOffering.vue
@@ -340,7 +340,7 @@
         </a-form-item>
         <a-form-item name="computeonly" ref="computeonly">
           <template #label>
-            <tooltip-label :title="$t('label.computeonly.offering')" tooltip="Option to specify root disk related information in the compute offering or to link a disk offering to the compute offering"/>
+            <tooltip-label :title="$t('label.computeonly.offering')" :tooltip="$t('label.computeonly.offering.tooltip')"/>
           </template>
           <a-switch v-model:checked="form.computeonly" :checked="computeonly" @change="val => { computeonly = val }"/>
         </a-form-item>

--- a/ui/src/views/offering/AddComputeOffering.vue
+++ b/ui/src/views/offering/AddComputeOffering.vue
@@ -340,7 +340,7 @@
         </a-form-item>
         <a-form-item name="computeonly" ref="computeonly">
           <template #label>
-            {{ $t('label.computeonly.offering') }}
+            <tooltip-label :title="$t('label.computeonly.offering')" tooltip="Option to specify root disk related information in the compute offering or to link a disk offering to the compute offering"/>
           </template>
           <a-switch v-model:checked="form.computeonly" :checked="computeonly" @change="val => { computeonly = val }"/>
         </a-form-item>
@@ -562,7 +562,7 @@
           </span>
           <a-form-item>
             <template #label>
-              <tooltip-label :title="$t('label.diskofferingstrictness')"/>
+              <tooltip-label :title="$t('label.diskofferingstrictness')" :tooltip="apiParams.diskofferingstrictness.description"/>
             </template>
             <a-switch v-model:checked="form.diskofferingstrictness" :checked="diskofferingstrictness" @change="val => { diskofferingstrictness = val }"/>
           </a-form-item>


### PR DESCRIPTION
### Description

This PR adds the missing tooltips helpers to fields in the service offering creation: 'Compute only disk offering' and 'Disk offering stricteness'

<img width="552" alt="Screen Shot 2022-05-11 at 09 12 04" src="https://user-images.githubusercontent.com/5295080/167846799-b99d8c9e-e029-4130-b7f5-9fb5bf8f96c3.png">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

