### PR TITLE
UI: Fix hypervisor list after zone validation when registering a template

### DIFF
--- a/ui/src/views/image/RegisterOrUploadTemplate.vue
+++ b/ui/src/views/image/RegisterOrUploadTemplate.vue
@@ -722,10 +722,10 @@ export default {
       }
       this.hyperVisor.opts = []
 
-      if (this.zoneError !== '') {
+      const allZoneExists = value.filter(zone => zone === this.$t('label.all.zone'))
+      if (allZoneExists.length > 0 && value.length > 1) {
         return
       }
-
       const arrSelectReset = ['hypervisor', 'format', 'rootDiskControllerType', 'nicAdapterType', 'keyboardType']
       this.resetSelect(arrSelectReset)
 
@@ -876,10 +876,8 @@ export default {
         return Promise.resolve()
       }
       const allZoneExists = value.filter(zone => zone === this.$t('label.all.zone'))
-      this.zoneError = ''
 
       if (allZoneExists.length > 0 && value.length > 1) {
-        this.zoneError = 'error'
         return Promise.reject(this.$t('message.error.zone.combined'))
       }
 


### PR DESCRIPTION
### Description

This PR fixes an error on the hypervisor menu when registering a template and the zone validation triggers

![Screen Recording 2022-05-11 at 14 41 52](https://user-images.githubusercontent.com/5295080/167912955-2190dc9d-d9ac-44c6-9142-400b363e86d3.gif)


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
