### PR TITLE
Fix: Cannot import Vmware instances

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4279,11 +4279,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     vm.details.putAll(details);
                 }
 
-                if (sshPublicKeys != "") {
+                if (StringUtils.isNotBlank(sshPublicKeys)) {
                     vm.setDetail(VmDetailConstants.SSH_PUBLIC_KEY, sshPublicKeys);
                 }
 
-                if (sshkeypairs != "") {
+                if (StringUtils.isNotBlank(sshkeypairs)) {
                     vm.setDetail(VmDetailConstants.SSH_KEY_PAIR_NAMES, sshkeypairs);
                 }
 


### PR DESCRIPTION
### Description

This PR fixes the Vmware import unmanaged instances process, was failing due to a null detail value for SSHPublicKey:
<img width="1382" alt="Screen Shot 2022-05-12 at 09 06 08" src="https://user-images.githubusercontent.com/5295080/168070922-600dfe13-32e6-4460-a4a6-943cab7f4209.png">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Verified fix by importing VM successfully