### PR TITLE
Reword KVM VM snapshot without memory error message

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/CreateVMSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/CreateVMSnapshotCmd.java
@@ -17,6 +17,7 @@
 
 package org.apache.cloudstack.api.command.user.vmsnapshot;
 
+import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.APICommand;
@@ -90,7 +91,13 @@ public class CreateVMSnapshotCmd extends BaseAsyncCreateCmd {
 
     @Override
     public void create() throws ResourceAllocationException {
-        VMSnapshot vmsnapshot = _vmSnapshotService.allocVMSnapshot(getVmId(), getDisplayName(), getDescription(), snapshotMemory());
+        VMSnapshot vmsnapshot;
+        try {
+            vmsnapshot = _vmSnapshotService.allocVMSnapshot(getVmId(), getDisplayName(), getDescription(), snapshotMemory());
+        } catch (CloudRuntimeException e) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to create vm snapshot: " + e.getMessage(), e);
+        }
+
         if (vmsnapshot != null) {
             setEntityId(vmsnapshot.getId());
         } else {

--- a/server/src/main/java/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
@@ -384,7 +384,9 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
             VMSnapshotStrategy snapshotStrategy = storageStrategyFactory.getVmSnapshotStrategy(userVmVo.getId(), rootVolumePool.getId(), snapshotMemory);
 
             if (snapshotStrategy == null) {
-                throw new CloudRuntimeException("Could not find snapshot strategy for VM snapshot");
+                String message = "KVM does not support the type of snapshot requested";
+                s_logger.debug(message);
+                throw new CloudRuntimeException(message);
             }
         }
 


### PR DESCRIPTION
### Description

This PR throws a more descriptive error on KVM in case the snapshot type is not supported (tested on KVM + snapshot memory = false):

Before:
<img width="425" alt="Screen Shot 2022-05-12 at 12 00 51" src="https://user-images.githubusercontent.com/5295080/168106092-933d0891-efc6-4b4e-800f-cafef370b14d.png">

After:
<img width="425" alt="Screen Shot 2022-05-12 at 12 14 09" src="https://user-images.githubusercontent.com/5295080/168108854-cbe4dced-ace2-429d-96bb-dc37187e3500.png">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
