### PR TITLE
cks: Get caller user keys if cluster belongs to project

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -1137,8 +1137,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         startWorker = ComponentContext.inject(startWorker);
         if (onCreate) {
             // Start for Kubernetes cluster in 'Created' state
-            Account owner = getOwnerOrCaller(kubernetesCluster);
-            String[] keys = getServiceUserKeys(owner);
+            String[] keys = getServiceUserKeys(kubernetesCluster);
             startWorker.setKeys(keys);
             return startWorker.startKubernetesClusterOnCreate();
         } else {
@@ -1147,16 +1146,9 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         }
     }
 
-    private Account getOwnerOrCaller(KubernetesClusterVO kubernetesCluster) {
+    private String[] getServiceUserKeys(KubernetesClusterVO kubernetesCluster) {
         Account owner = accountService.getActiveAccountById(kubernetesCluster.getAccountId());
-        if (owner.getType() == Account.Type.PROJECT) {
-            owner = CallContext.current().getCallingAccount();
-        }
-        return owner;
-    }
-
-    private String[] getServiceUserKeys(Account owner) {
-        if (owner == null) {
+        if (owner == null || owner.getType() == Account.Type.PROJECT) {
             owner = CallContext.current().getCallingAccount();
         }
         String username = owner.getAccountName() + "-" + KUBEADMIN_ACCOUNT_NAME;
@@ -1307,8 +1299,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         validateKubernetesClusterScaleParameters(cmd);
 
         KubernetesClusterVO kubernetesCluster = kubernetesClusterDao.findById(cmd.getId());
-        Account owner = getOwnerOrCaller(kubernetesCluster);
-        String[] keys = getServiceUserKeys(owner);
+        String[] keys = getServiceUserKeys(kubernetesCluster);
         KubernetesClusterScaleWorker scaleWorker =
             new KubernetesClusterScaleWorker(kubernetesClusterDao.findById(cmd.getId()),
                 serviceOfferingDao.findById(cmd.getServiceOfferingId()),
@@ -1331,8 +1322,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
 
         validateKubernetesClusterUpgradeParameters(cmd);
         KubernetesClusterVO kubernetesCluster = kubernetesClusterDao.findById(cmd.getId());
-        Account owner = getOwnerOrCaller(kubernetesCluster);
-        String[] keys = getServiceUserKeys(owner);
+        String[] keys = getServiceUserKeys(kubernetesCluster);
         KubernetesClusterUpgradeWorker upgradeWorker =
             new KubernetesClusterUpgradeWorker(kubernetesClusterDao.findById(cmd.getId()),
                 kubernetesSupportedVersionDao.findById(cmd.getKubernetesVersionId()), this, keys);


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/6344
Passes the caller's API keys if the cluster is part of a project

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

autoscaler logs :

```
I0516 08:57:51.486442       1 static_autoscaler.go:235] Starting main loop
I0516 08:57:51.487030       1 client.go:169] NewAPIRequest API request URL:http://10.0.32.136:8080/client/api?apiKey=***&command=listKubernetesClusters&id=a5e617a3-6d95-410c-9d3a-306274ee8b11&response=json&signature=***
I0516 08:57:51.515655       1 client.go:175] NewAPIRequest response status code:200
I0516 08:57:51.518415       1 cloudstack_manager.go:88] Got cluster : &{a5e617a3-6d95-410c-9d3a-306274ee8b11 cluster 1 2 1 1 [0xc000716f90 0xc000716fc0] map[cluster-control-180cc02282f:0xc000716f90 cluster-node-180cc025111:0xc000716fc0]}

```
