### PR TITLE
Log exception on keystore build for custom certificate

### DIFF
--- a/framework/security/src/main/java/org/apache/cloudstack/framework/security/keystore/KeystoreManagerImpl.java
+++ b/framework/security/src/main/java/org/apache/cloudstack/framework/security/keystore/KeystoreManagerImpl.java
@@ -109,15 +109,15 @@ public class KeystoreManagerImpl extends ManagerBase implements KeystoreManager 
         try {
             return CertificateHelper.buildAndSaveKeystore(certs, storePassword);
         } catch (KeyStoreException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to KeyStoreException");
+            s_logger.warn("Unable to build keystore for " + name + " due to KeyStoreException", e);
         } catch (CertificateException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to CertificateException");
+            s_logger.warn("Unable to build keystore for " + name + " due to CertificateException", e);
         } catch (NoSuchAlgorithmException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to NoSuchAlgorithmException");
+            s_logger.warn("Unable to build keystore for " + name + " due to NoSuchAlgorithmException", e);
         } catch (InvalidKeySpecException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to InvalidKeySpecException");
+            s_logger.warn("Unable to build keystore for " + name + " due to InvalidKeySpecException", e);
         } catch (IOException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to IOException");
+            s_logger.warn("Unable to build keystore for " + name + " due to IOException", e);
         }
         return null;
     }


### PR DESCRIPTION
### Description

If CloudStack fails to build and save keystore using the keystone certificate then it silently fails with just the following line:
````
2022-05-17 15:09:02,859 WARN  [o.a.c.f.s.k.KeystoreManagerImpl] (AgentConnectTaskPool-21:ctx-6795fce2) (logid:d7b1fab5) Unable to build keystore for CPVMCertificate due to CertificateException
````

This PR adds the exception to the logger

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
