### PR TITLE
Prevent NPE on reboot stopped VM and startVM output with null displayname

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/UserVmVO.java
+++ b/engine/schema/src/main/java/com/cloud/vm/UserVmVO.java
@@ -28,6 +28,7 @@ import javax.persistence.Table;
 
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.uservm.UserVm;
+import org.apache.commons.lang3.StringUtils;
 
 @Entity
 @Table(name = "user_vm")
@@ -140,5 +141,9 @@ public class UserVmVO extends VMInstanceVO implements UserVm {
     @Override
     public String getName() {
         return instanceName;
+    }
+
+    public String getDisplayNameOrHostName() {
+        return StringUtils.isNotBlank(displayName) ? displayName : getHostName();
     }
 }

--- a/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -127,7 +127,7 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
         userVmResponse.setName(userVm.getName());
 
         if (userVm.getDisplayName() != null) {
-        userVmResponse.setDisplayName(userVm.getDisplayName());
+            userVmResponse.setDisplayName(userVm.getDisplayName());
         } else {
             userVmResponse.setDisplayName(userVm.getName());
         }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3130,10 +3130,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Unable to find a virtual machine with id " + vmId);
         }
 
-        if (!State.Running.equals(vmInstance.getState())) {
-            throw new InvalidParameterValueException(String.format("The VM %s is not in %s state",
-                    StringUtils.firstNonBlank(vmInstance.getDisplayName(), vmInstance.getName(),
-                            vmInstance.getUuid()), State.Running));
+        if (vmInstance.getState() != State.Running) {
+            throw new InvalidParameterValueException(String.format("The VM %s (%s) is not running, unable to reboot it",
+                    vmInstance.getUuid(), vmInstance.getDisplayNameOrHostName()));
         }
 
         _accountMgr.checkAccess(caller, null, true, vmInstance);
@@ -5125,8 +5124,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("unable to find a virtual machine with id " + vmId);
         }
 
-        if (vm.getState()== State.Running) {
-            throw new InvalidParameterValueException("The virtual machine "+ vm.getUuid()+ " ("+ vm.getDisplayName()+ ") is already running");
+        if (vm.getState() == State.Running) {
+            throw new InvalidParameterValueException("The virtual machine " + vm.getUuid() +
+                    " (" + vm.getDisplayNameOrHostName() + ") is already running");
         }
 
         _accountMgr.checkAccess(callerAccount, null, true, vm);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3130,6 +3130,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Unable to find a virtual machine with id " + vmId);
         }
 
+        if (!vmInstance.getState().equals(State.Running)) {
+            throw new InvalidParameterValueException("The VM with id " + vmId + " is not in Running state");
+        }
+
         _accountMgr.checkAccess(caller, null, true, vmInstance);
 
         checkIfHostOfVMIsInPrepareForMaintenanceState(vmInstance.getHostId(), vmId, "Reboot");

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -5125,8 +5125,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         if (vm.getState() == State.Running) {
-            throw new InvalidParameterValueException("The virtual machine " + vm.getUuid() +
-                    " (" + vm.getDisplayNameOrHostName() + ") is already running");
+            throw new InvalidParameterValueException(String.format("The virtual machine %s (%s) is already running",
+                    vm.getUuid(), vm.getDisplayNameOrHostName()));
         }
 
         _accountMgr.checkAccess(callerAccount, null, true, vm);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3131,7 +3131,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         if (!vmInstance.getState().equals(State.Running)) {
-            throw new InvalidParameterValueException("The VM with id " + vmId + " is not in Running state");
+            throw new InvalidParameterValueException("The VM with id " + vmInstance.getUuid() + " is not in Running state");
         }
 
         _accountMgr.checkAccess(caller, null, true, vmInstance);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3130,8 +3130,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Unable to find a virtual machine with id " + vmId);
         }
 
-        if (!vmInstance.getState().equals(State.Running)) {
-            throw new InvalidParameterValueException("The VM with id " + vmInstance.getUuid() + " is not in Running state");
+        if (!State.Running.equals(vmInstance.getState())) {
+            throw new InvalidParameterValueException(String.format("The VM %s is not in %s state",
+                    StringUtils.firstNonBlank(vmInstance.getDisplayName(), vmInstance.getName(),
+                            vmInstance.getUuid()), State.Running));
         }
 
         _accountMgr.checkAccess(caller, null, true, vmInstance);


### PR DESCRIPTION
### Description

This PR prevents an NPE on VM reboot when the VM is not in Running state.

Also addresses the output of the startVirtualMachine API with null displayname:

````
(isc-uat) 🐱 > start virtualmachine id=5e549d97-f6c6-4109-9416-ed6eb7c8b912
{
  "accountid": "53c6e98d-bc37-11ec-ba86-02000252074f",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.StartVMCmdByAdmin",
  "completed": "2022-05-17T21:50:25+0000",
  "created": "2022-05-17T21:50:24+0000",
  "jobid": "0ea90ce5-2af2-4268-baed-e189134aad78",
  "jobinstanceid": "5e549d97-f6c6-4109-9416-ed6eb7c8b912",
  "jobinstancetype": "VirtualMachine",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 431,
    "errortext": "The virtual machine 5e549d97-f6c6-4109-9416-ed6eb7c8b912 (null) is already running"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "9013ef87-e072-492f-a609-32c1f4c18383"
}
````

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?