### PR TITLE
[KVM] Enable IOURING only when it is available on the host

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -286,5 +286,3 @@ iscsi.session.cleanup.enabled=false
 # Enable manually setting CPU's topology on KVM's VM.
 # enable.manually.setting.cpu.topology.on.kvm.vm=true
 
-# Enable/disable IO driver for Qemu / It's disabled by default on KVM agents
-# enable.io.uring=true

--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -286,3 +286,5 @@ iscsi.session.cleanup.enabled=false
 # Enable manually setting CPU's topology on KVM's VM.
 # enable.manually.setting.cpu.topology.on.kvm.vm=true
 
+# Enable/disable IO driver for Qemu (requires an io_uring supported qemu version)
+# enable.io.uring=true

--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -286,5 +286,5 @@ iscsi.session.cleanup.enabled=false
 # Enable manually setting CPU's topology on KVM's VM.
 # enable.manually.setting.cpu.topology.on.kvm.vm=true
 
-# Enable/disable IO driver for Qemu / It's enabled by default on KVM agents
+# Enable/disable IO driver for Qemu / It's disabled by default on KVM agents
 # enable.io.uring=true

--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -286,5 +286,5 @@ iscsi.session.cleanup.enabled=false
 # Enable manually setting CPU's topology on KVM's VM.
 # enable.manually.setting.cpu.topology.on.kvm.vm=true
 
-# Enable/disable IO driver for Qemu (requires an io_uring supported qemu version)
+# Enable/disable IO driver for Qemu (in case it is not set CloudStack can also detect if its supported by qemu)
 # enable.io.uring=true

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -54,13 +54,6 @@ public class AgentProperties{
      */
     public static final Property<Boolean> ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM = new Property<Boolean>("enable.manually.setting.cpu.topology.on.kvm.vm", true);
 
-    /**
-     * Enable manually IO driver on KVM's VM. If it is not manually enabled CloudStack can detect if its available<br>
-     * Data type: boolean.<br>
-     * Default value: null.
-     */
-    public static final Property<Boolean> ENABLE_IO_URING = new Property<>("enable.io.uring", null);
-
     public static class Property <T>{
         private final String name;
         private final T defaultValue;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -57,9 +57,9 @@ public class AgentProperties{
     /**
      * Enable manually IO driver on KVM's VM. <br>
      * Data type: boolean.<br>
-     * Default value: true.
+     * Default value: false.
      */
-    public static final Property<Boolean> ENABLE_IO_URING = new Property<Boolean>("enable.io.uring", true);
+    public static final Property<Boolean> ENABLE_IO_URING = new Property<>("enable.io.uring", false);
 
     public static class Property <T>{
         private final String name;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -55,11 +55,11 @@ public class AgentProperties{
     public static final Property<Boolean> ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM = new Property<Boolean>("enable.manually.setting.cpu.topology.on.kvm.vm", true);
 
     /**
-     * Enable manually IO driver on KVM's VM. To be applied it also requires qemu supports io_uring <br>
+     * Enable manually IO driver on KVM's VM. If it is not manually enabled CloudStack can detect if its available<br>
      * Data type: boolean.<br>
-     * Default value: true.
+     * Default value: null.
      */
-    public static final Property<Boolean> ENABLE_IO_URING = new Property<>("enable.io.uring", true);
+    public static final Property<Boolean> ENABLE_IO_URING = new Property<>("enable.io.uring", null);
 
     public static class Property <T>{
         private final String name;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -54,6 +54,13 @@ public class AgentProperties{
      */
     public static final Property<Boolean> ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM = new Property<Boolean>("enable.manually.setting.cpu.topology.on.kvm.vm", true);
 
+    /**
+     * Enable manually IO driver on KVM's VM. To be applied it also requires qemu supports io_uring <br>
+     * Data type: boolean.<br>
+     * Default value: true.
+     */
+    public static final Property<Boolean> ENABLE_IO_URING = new Property<>("enable.io.uring", true);
+
     public static class Property <T>{
         private final String name;
         private final T defaultValue;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -54,13 +54,6 @@ public class AgentProperties{
      */
     public static final Property<Boolean> ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM = new Property<Boolean>("enable.manually.setting.cpu.topology.on.kvm.vm", true);
 
-    /**
-     * Enable manually IO driver on KVM's VM. <br>
-     * Data type: boolean.<br>
-     * Default value: false.
-     */
-    public static final Property<Boolean> ENABLE_IO_URING = new Property<>("enable.io.uring", false);
-
     public static class Property <T>{
         private final String name;
         private final T defaultValue;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -820,6 +820,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
 
         // Enable/disable IO driver for Qemu (in case it is not set CloudStack can also detect if its supported by qemu)
+        // Do not remove - switching it to AgentProperties.Property may require accepting null values for the properties default value
         String enableIoUringConfig = (String) params.get(ENABLE_IO_URING_PROPERTY);
         enableIoUring = isIoUringEnabled(enableIoUringConfig);
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2954,23 +2954,18 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      */
     protected boolean isIoUringSupportedByQemu() {
         s_logger.debug("Checking if iouring is supported");
-        String hostOsKey = "Host.OS";
-        Map<String, String> versionStrings = getVersionStrings();
-        if (MapUtils.isEmpty(versionStrings) || !versionStrings.containsKey(hostOsKey)) {
-            return false;
-        }
-        String os = versionStrings.get(hostOsKey);
-        if (org.apache.commons.lang3.StringUtils.isBlank(os)) {
-            return false;
-        }
-        if (os.equalsIgnoreCase("ubuntu")) {
-            // Enabled by default on ubuntu
-            return true;
-        }
-        String qemuBinary = os.toLowerCase().contains("suse") ? "/usr/bin/qemu-kvm" : "/usr/libexec/qemu-kvm";
-        String command = String.format("ldd %s | grep -Eqe '[[:space:]]liburing\\.so'", qemuBinary);
+        String command = getIoUringCheckCommand();
         int exitValue = executeBashScriptAndRetrieveExitValue(command);
         return exitValue == 0;
+    }
+
+    protected String getIoUringCheckCommand() {
+        String qemuPath = "/usr/bin/qemu-system-x86_64";
+        File file = new File(qemuPath);
+        if (!file.exists()) {
+            qemuPath = "/usr/libexec/qemu-kvm";
+        }
+        return String.format("ldd %s | grep -Eqe '[[:space:]]liburing\\.so'", qemuPath);
     }
 
     /**

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2964,7 +2964,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     protected String getIoUringCheckCommand() {
-        String[] qemuPaths = {"/usr/bin/qemu-system-x86_64", "/usr/libexec/qemu-kvm", "/usr/bin/qemu-kvm" };
+        String[] qemuPaths = { "/usr/bin/qemu-system-x86_64", "/usr/libexec/qemu-kvm", "/usr/bin/qemu-kvm" };
         for (String qemuPath : qemuPaths) {
             File file = new File(qemuPath);
             if (file.exists()) {
@@ -2991,10 +2991,19 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     /**
-     * IO_URING supported if it is supported by qemu AND the property 'enable.io.uring' is set to true
+     * IO_URING supported if the property 'enable.io.uring' is set to true OR it is supported by qemu
      */
     private boolean isIoUringEnabled() {
-        return isIoUringSupportedByQemu() && AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_IO_URING);
+        Boolean propertyValue = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_IO_URING);
+        return BooleanUtils.isTrue(propertyValue) || isBaseOsUbuntu() || isIoUringSupportedByQemu();
+    }
+
+    private boolean isBaseOsUbuntu() {
+        Map<String, String> versionString = getVersionStrings();
+        if (MapUtils.isEmpty(versionString) || !versionString.containsKey("Host.OS") || versionString.get("Host.OS") == null) {
+            return false;
+        }
+        return versionString.get("Host.OS").equalsIgnoreCase("ubuntu");
     }
 
     private KVMPhysicalDisk getPhysicalDiskFromNfsStore(String dataStoreUrl, DataTO data) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2956,6 +2956,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         s_logger.debug("Checking if iouring is supported");
         String command = getIoUringCheckCommand();
         if (org.apache.commons.lang3.StringUtils.isBlank(command)) {
+            s_logger.debug("Could not check iouring support, disabling it");
             return false;
         }
         int exitValue = executeBashScriptAndRetrieveExitValue(command);
@@ -2963,11 +2964,13 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     protected String getIoUringCheckCommand() {
-        String[] qemuPaths = {"/usr/bin/qemu-system-x86_64", "/usr/libexec/qemu-kvm" };
+        String[] qemuPaths = {"/usr/bin/qemu-system-x86_64", "/usr/libexec/qemu-kvm", "/usr/bin/qemu-kvm" };
         for (String qemuPath : qemuPaths) {
             File file = new File(qemuPath);
             if (file.exists()) {
-                return String.format("ldd %s | grep -Eqe '[[:space:]]liburing\\.so'", qemuPath);
+                String cmd = String.format("ldd %s | grep -Eqe '[[:space:]]liburing\\.so'", qemuPath);
+                s_logger.debug("Using the check command: " + cmd);
+                return cmd;
             }
         }
         return null;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -819,6 +819,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             directDownloadTemporaryDownloadPath = getDefaultDirectDownloadTemporaryPath();
         }
 
+        // Enable/disable IO driver for Qemu (in case it is not set CloudStack can also detect if its supported by qemu)
         String enableIoUringConfig = (String) params.get(ENABLE_IO_URING_PROPERTY);
         enableIoUring = isIoUringEnabled(enableIoUringConfig);
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1138,6 +1138,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         // Do not remove - switching it to AgentProperties.Property may require accepting null values for the properties default value
         String enableIoUringConfig = (String) params.get(ENABLE_IO_URING_PROPERTY);
         enableIoUring = isIoUringEnabled(enableIoUringConfig);
+        s_logger.info("IO uring driver for Qemu: " + (enableIoUring ? "enabled" : "disabled"));
 
         final String cpuArchOverride = (String)params.get("guest.cpu.arch");
         if (!Strings.isNullOrEmpty(cpuArchOverride)) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2995,15 +2995,16 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      */
     private boolean isIoUringEnabled() {
         Boolean propertyValue = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_IO_URING);
-        return BooleanUtils.isTrue(propertyValue) || isBaseOsUbuntu() || isIoUringSupportedByQemu();
+        return propertyValue != null ? propertyValue: (isBaseOsUbuntu() || isIoUringSupportedByQemu());
     }
 
     private boolean isBaseOsUbuntu() {
         Map<String, String> versionString = getVersionStrings();
-        if (MapUtils.isEmpty(versionString) || !versionString.containsKey("Host.OS") || versionString.get("Host.OS") == null) {
+        String hostKey = "Host.OS";
+        if (MapUtils.isEmpty(versionString) || !versionString.containsKey(hostKey) || versionString.get(hostKey) == null) {
             return false;
         }
-        return versionString.get("Host.OS").equalsIgnoreCase("ubuntu");
+        return versionString.get(hostKey).equalsIgnoreCase("ubuntu");
     }
 
     private KVMPhysicalDisk getPhysicalDiskFromNfsStore(String dataStoreUrl, DataTO data) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -313,6 +313,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     public final static String HOST_CACHE_PATH_PARAMETER = "host.cache.location";
     public final static String CONFIG_DIR = "config";
+    private Boolean enableIoUring;
+    private final static String ENABLE_IO_URING_PROPERTY = "enable.io.uring";
 
     public static final String BASH_SCRIPT_PATH = "/bin/bash";
 
@@ -815,6 +817,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         directDownloadTemporaryDownloadPath = (String) params.get("direct.download.temporary.download.location");
         if (org.apache.commons.lang.StringUtils.isBlank(directDownloadTemporaryDownloadPath)) {
             directDownloadTemporaryDownloadPath = getDefaultDirectDownloadTemporaryPath();
+        }
+
+        String enableIoUringConfig = (String) params.get(ENABLE_IO_URING_PROPERTY);
+        if (enableIoUringConfig != null) {
+            enableIoUring = Boolean.parseBoolean(enableIoUringConfig);
         }
 
         cachePath = (String) params.get(HOST_CACHE_PATH_PARAMETER);
@@ -2994,8 +3001,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      * IO_URING supported if the property 'enable.io.uring' is set to true OR it is supported by qemu
      */
     private boolean isIoUringEnabled() {
-        Boolean propertyValue = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_IO_URING);
-        return propertyValue != null ? propertyValue: (isBaseOsUbuntu() || isIoUringSupportedByQemu());
+        return enableIoUring != null ? enableIoUring: (isBaseOsUbuntu() || isIoUringSupportedByQemu());
     }
 
     private boolean isBaseOsUbuntu() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2950,10 +2950,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     /**
-     * Check if IO_URING is available on the host
+     * Check if IO_URING is supported by qemu
      */
-    protected boolean isIoUringEnabled() {
-        s_logger.debug("Checking if iouring is enabled on the host");
+    protected boolean isIoUringSupportedByQemu() {
+        s_logger.debug("Checking if iouring is supported");
         String hostOsKey = "Host.OS";
         Map<String, String> versionStrings = getVersionStrings();
         if (MapUtils.isEmpty(versionStrings) || !versionStrings.containsKey(hostOsKey)) {
@@ -2978,6 +2978,13 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 && isIoUringEnabled()) {
             disk.setIoDriver(DiskDef.IoDriver.IOURING);
         }
+    }
+
+    /**
+     * IO_URING supported if it is supported by qemu AND the property 'enable.io.uring' is set to true
+     */
+    private boolean isIoUringEnabled() {
+        return isIoUringSupportedByQemu() && AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_IO_URING);
     }
 
     private KVMPhysicalDisk getPhysicalDiskFromNfsStore(String dataStoreUrl, DataTO data) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -819,11 +819,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             directDownloadTemporaryDownloadPath = getDefaultDirectDownloadTemporaryPath();
         }
 
-        // Enable/disable IO driver for Qemu (in case it is not set CloudStack can also detect if its supported by qemu)
-        // Do not remove - switching it to AgentProperties.Property may require accepting null values for the properties default value
-        String enableIoUringConfig = (String) params.get(ENABLE_IO_URING_PROPERTY);
-        enableIoUring = isIoUringEnabled(enableIoUringConfig);
-
         cachePath = (String) params.get(HOST_CACHE_PATH_PARAMETER);
         if (org.apache.commons.lang.StringUtils.isBlank(cachePath)) {
             cachePath = getDefaultCachePath();
@@ -1138,6 +1133,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } catch (final LibvirtException e) {
             s_logger.trace("Ignoring libvirt error.", e);
         }
+
+        // Enable/disable IO driver for Qemu (in case it is not set CloudStack can also detect if its supported by qemu)
+        // Do not remove - switching it to AgentProperties.Property may require accepting null values for the properties default value
+        String enableIoUringConfig = (String) params.get(ENABLE_IO_URING_PROPERTY);
+        enableIoUring = isIoUringEnabled(enableIoUringConfig);
 
         final String cpuArchOverride = (String)params.get("guest.cpu.arch");
         if (!Strings.isNullOrEmpty(cpuArchOverride)) {


### PR DESCRIPTION
### Description

This PR enables IO_URING only when it is available on the hosts, as being discussed on https://github.com/apache/cloudstack/pull/6253#issuecomment-1131216926

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
