### PR TITLE
[KVM] Fix VM migration error due to VNC password on libvirt limiting versions

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -356,7 +356,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
                     if ("graphics".equals(deviceChildNode.getNodeName())) {
                         NamedNodeMap graphicAttributes = deviceChildNode.getAttributes();
                         Node passwdNode = graphicAttributes.getNamedItem("passwd");
-                        String vncPasswordValue = String.format("'%s'", vncPassword);
+                        String vncPasswordValue = String.format("%s", vncPassword);
                         if (passwdNode == null) {
                             Attr passwd = doc.createAttribute("passwd");
                             passwd.setValue(vncPasswordValue);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -793,7 +793,7 @@ public class LibvirtMigrateCommandWrapperTest {
     private void testReplaceVNCPassworBaseCase(String xml, String password) throws ParserConfigurationException, IOException, SAXException, TransformerException {
         final LibvirtMigrateCommandWrapper lw = new LibvirtMigrateCommandWrapper();
         String replaced = lw.replaceVncPassword(xml, password);
-        String expectedAttr = String.format("passwd=\"'%s'\"", password);
+        String expectedAttr = String.format("passwd=\"%s\"", password);
         Assert.assertTrue(replaced.contains(expectedAttr));
     }
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -571,16 +571,16 @@ public class LibvirtMigrateCommandWrapperTest {
     @Test
     public void testReplaceIpForVNCInDescFile() {
         final String targetIp = "192.168.22.21";
-        final String result = libvirtMigrateCmdWrapper.replaceIpForVNCInDescFile(fullfile, targetIp);
+        final String result = libvirtMigrateCmdWrapper.replaceIpForVNCInDescFileAndNormalizePassword(fullfile, targetIp, null);
         assertTrue("transformation does not live up to expectation:\n" + result, targetfile.equals(result));
     }
 
     @Test
-    public void testReplaceIpForVNCInDesc() {
+    public void testReplaceIpAndPasswordForVNCInDesc() {
         final String xmlDesc =
                 "<domain type='kvm' id='3'>" +
                 "  <devices>" +
-                "    <graphics type='vnc' port='5900' autoport='yes' listen='10.10.10.1'>" +
+                "    <graphics type='vnc' port='5900' autoport='yes' listen='10.10.10.1' passwd='123456789012345'>" +
                 "      <listen type='address' address='10.10.10.1'/>" +
                 "    </graphics>" +
                 "  </devices>" +
@@ -588,22 +588,23 @@ public class LibvirtMigrateCommandWrapperTest {
         final String expectedXmlDesc =
                 "<domain type='kvm' id='3'>" +
                 "  <devices>" +
-                "    <graphics type='vnc' port='5900' autoport='yes' listen='10.10.10.10'>" +
+                "    <graphics type='vnc' port='5900' autoport='yes' listen='10.10.10.10' passwd='12345678'>" +
                 "      <listen type='address' address='10.10.10.10'/>" +
                 "    </graphics>" +
                 "  </devices>" +
                 "</domain>";
         final String targetIp = "10.10.10.10";
-        final String result = libvirtMigrateCmdWrapper.replaceIpForVNCInDescFile(xmlDesc, targetIp);
+        final String password = "12345678";
+        final String result = libvirtMigrateCmdWrapper.replaceIpForVNCInDescFileAndNormalizePassword(xmlDesc, targetIp, password);
         assertTrue("transformation does not live up to expectation:\n" + result, expectedXmlDesc.equals(result));
     }
 
     @Test
-    public void testReplaceFqdnForVNCInDesc() {
+    public void testReplaceFqdnAndPasswordForVNCInDesc() {
         final String xmlDesc =
                 "<domain type='kvm' id='3'>" +
                 "  <devices>" +
-                "    <graphics type='vnc' port='5900' autoport='yes' listen='localhost.local'>" +
+                "    <graphics type='vnc' port='5900' autoport='yes' listen='localhost.local' passwd='123456789012345'>" +
                 "      <listen type='address' address='localhost.local'/>" +
                 "    </graphics>" +
                 "  </devices>" +
@@ -611,13 +612,14 @@ public class LibvirtMigrateCommandWrapperTest {
         final String expectedXmlDesc =
                 "<domain type='kvm' id='3'>" +
                 "  <devices>" +
-                "    <graphics type='vnc' port='5900' autoport='yes' listen='localhost.localdomain'>" +
+                "    <graphics type='vnc' port='5900' autoport='yes' listen='localhost.localdomain' passwd='12345678'>" +
                 "      <listen type='address' address='localhost.localdomain'/>" +
                 "    </graphics>" +
                 "  </devices>" +
                 "</domain>";
         final String targetIp = "localhost.localdomain";
-        final String result = libvirtMigrateCmdWrapper.replaceIpForVNCInDescFile(xmlDesc, targetIp);
+        final String password = "12345678";
+        final String result = libvirtMigrateCmdWrapper.replaceIpForVNCInDescFileAndNormalizePassword(xmlDesc, targetIp, password);
         assertTrue("transformation does not live up to expectation:\n" + result, expectedXmlDesc.equals(result));
     }
 
@@ -788,22 +790,5 @@ public class LibvirtMigrateCommandWrapperTest {
         String replaced = lw.replaceDpdkInterfaces(sourceDPDKVMToMigrate, dpdkPortMapping);
         Assert.assertTrue(replaced.contains("csdpdk-7"));
         Assert.assertFalse(replaced.contains("csdpdk-1"));
-    }
-
-    private void testReplaceVNCPassworBaseCase(String xml, String password) throws ParserConfigurationException, IOException, SAXException, TransformerException {
-        final LibvirtMigrateCommandWrapper lw = new LibvirtMigrateCommandWrapper();
-        String replaced = lw.replaceVncPassword(xml, password);
-        String expectedAttr = String.format("passwd=\"%s\"", password);
-        Assert.assertTrue(replaced.contains(expectedAttr));
-    }
-
-    @Test
-    public void testReplaceVNCPasswordAttributeNotPresent() throws ParserConfigurationException, IOException, SAXException, TransformerException {
-        testReplaceVNCPassworBaseCase(sourceDPDKVMToMigrate, "ABCD1234");
-    }
-
-    @Test
-    public void testReplaceVNCPasswordAttributePresent() throws ParserConfigurationException, IOException, SAXException, TransformerException {
-        testReplaceVNCPassworBaseCase(sourceMultidiskDomainXml, "ABCD1234");
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -790,4 +790,20 @@ public class LibvirtMigrateCommandWrapperTest {
         Assert.assertFalse(replaced.contains("csdpdk-1"));
     }
 
+    private void testReplaceVNCPassworBaseCase(String xml, String password) throws ParserConfigurationException, IOException, SAXException, TransformerException {
+        final LibvirtMigrateCommandWrapper lw = new LibvirtMigrateCommandWrapper();
+        String replaced = lw.replaceVncPassword(xml, password);
+        String expectedAttr = String.format("passwd=\"'%s'\"", password);
+        Assert.assertTrue(replaced.contains(expectedAttr));
+    }
+
+    @Test
+    public void testReplaceVNCPasswordAttributeNotPresent() throws ParserConfigurationException, IOException, SAXException, TransformerException {
+        testReplaceVNCPassworBaseCase(sourceDPDKVMToMigrate, "ABCD1234");
+    }
+
+    @Test
+    public void testReplaceVNCPasswordAttributePresent() throws ParserConfigurationException, IOException, SAXException, TransformerException {
+        testReplaceVNCPassworBaseCase(sourceMultidiskDomainXml, "ABCD1234");
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes a VM migration issue described on https://github.com/apache/cloudstack/pull/6402#issuecomment-1133602561

![image](https://user-images.githubusercontent.com/5295080/169676611-fde4e189-ddb6-491b-8fd1-8c785d1bf145.png)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Initial state: CS 4.16.1 / 2 KVM hosts running OpenSUSE 15.3 - libvirt 7.1.0 and QEMU 5.2.0
- Create 3 VMs
- Put host 2 on maintenance
- Upgrade host packages from: https://software.opensuse.org/download/package?package=libvirt&project=Virtualization to libvirt 8.3.0 and QEMU 6.2.0
- Cancel maintenance on host 2
- Attempt migrating any VM to host 2 -> FAILURE:
````
2022-05-22 03:56:07,297 DEBUG [c.c.c.CapacityManagerImpl] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) VM instance {id: "5", name: "i-2-5-VM", uuid: 
"6a2339af-5236-49aa-b9a0-65a2c9ce3952", type="User"} state transited from [Migrating] to [Running] with event [OperationFailed]. VM's original host: Host {"id": "1", "name": "ref-trl-
3127-k-M7-nicolas-vazquez-kvm1", "uuid": "9c851ff3-06f5-46e0-a822-f029a375748a", "type"="Routing"}, new host: Host {"id": "1", "name": "ref-trl-3127-k-M7-nicolas-vazquez-kvm1", "uuid"
: "9c851ff3-06f5-46e0-a822-f029a375748a", "type"="Routing"}, host before state transition: Host {"id": "4", "name": "ref-trl-3141-k-M7-nicolas-vazquez-kvm1", "uuid": "90107936-3a2d-48
06-b5af-561e97620664", "type"="Routing"}
2022-05-22 03:56:07,300 DEBUG [c.c.c.CapacityManagerImpl] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) Hosts's actual total CPU: 6300 and CPU after a
pplying overprovisioning: 12600
2022-05-22 03:56:07,301 DEBUG [c.c.c.CapacityManagerImpl] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) Hosts's actual total RAM: (6.77 GB) 7264485376
 and RAM after applying overprovisioning: (6.77 GB) 7264485376
2022-05-22 03:56:07,301 DEBUG [c.c.c.CapacityManagerImpl] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) release cpu from host: 4, old used: 500,reserv
ed: 0, actual total: 6300, total with overprovisioning: 12600; new used: 0,reserved:0; movedfromreserved: false,moveToReserveredfalse
2022-05-22 03:56:07,301 DEBUG [c.c.c.CapacityManagerImpl] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) release mem from host: 4, old used: (512.00 MB
) 536870912,reserved: (0 bytes) 0, total: (6.77 GB) 7264485376; new used: (0 bytes) 0,reserved:(0 bytes) 0; movedfromreserved: false,moveToReserveredfalse
2022-05-22 03:56:07,305 ERROR [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) Invocation exception, caused by: com.cloud.u
tils.exception.CloudRuntimeException: Exception during migrate: org.libvirt.LibvirtException: unsupported configuration: VNC password is 22 characters long, only 8 permitted
2022-05-22 03:56:07,305 INFO  [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-8:ctx-77987975 job-41/job-42 ctx-91220c68) (logid:c4ad92ef) Rethrow exception com.cloud.utils.exception.
CloudRuntimeException: Exception during migrate: org.libvirt.LibvirtException: unsupported configuration: VNC password is 22 characters long, only 8 permitted
2022-05-22 03:56:07,309 DEBUG [c.c.v.VmWorkJobDispatcher] (Work-Job-Executor-8:ctx-77987975 job-41/job-42) (logid:c4ad92ef) Done with run of VM work job: com.cloud.vm.VmWorkMigrate fo
r VM 5, job origin: 41
2022-05-22 03:56:07,310 ERROR [c.c.v.VmWorkJobDispatcher] (Work-Job-Executor-8:ctx-77987975 job-41/job-42) (logid:c4ad92ef) Unable to complete AsyncJobVO: {id:42, userId: 2, accountId
: 2, instanceType: null, instanceId: null, cmd: com.cloud.vm.VmWorkMigrate, cmdInfo: rO0ABXNyABpjb20uY2xvdWQudm0uVm1Xb3JrTWlncmF0ZRdxQXtPtzYqAgAGSgAJc3JjSG9zdElkTAAJY2x1c3RlcklkdAAQTG
phdmEvbGFuZy9Mb25nO0wABmhvc3RJZHEAfgABTAAFcG9kSWRxAH4AAUwAB3N0b3JhZ2V0AA9MamF2YS91dGlsL01hcDtMAAZ6b25lSWRxAH4AAXhyABNjb20uY2xvdWQudm0uVm1Xb3Jrn5m2VvAlZ2sCAARKAAlhY2NvdW50SWRKAAZ1c2VyS
WRKAAR2bUlkTAALaGFuZGxlck5hbWV0ABJMamF2YS9sYW5nL1N0cmluZzt4cAAAAAAAAAACAAAAAAAAAAIAAAAAAAAABXQAGVZpcnR1YWxNYWNoaW5lTWFuYWdlckltcGwAAAAAAAAAAXNyAA5qYXZhLmxhbmcuTG9uZzuL5JDMjyPfAgABSgAF
dmFsdWV4cgAQamF2YS5sYW5nLk51bWJlcoaslR0LlOCLAgAAeHAAAAAAAAAAAXNxAH4ABwAAAAAAAAAEcQB-AAlwcQB-AAk, cmdVersion: 0, status: IN_PROGRESS, processStatus: 0, resultCode: 0, result: null, ini
tMsid: 32986154140800, completeMsid: null, lastUpdated: null, lastPolled: null, created: Sun May 22 03:56:06 UTC 2022, removed: null}, job origin:41
com.cloud.utils.exception.CloudRuntimeException: Exception during migrate: org.libvirt.LibvirtException: unsupported configuration: VNC password is 22 characters long, only 8 permitte
d
        at com.cloud.vm.VirtualMachineManagerImpl.migrate(VirtualMachineManagerImpl.java:2795)
        at com.cloud.vm.VirtualMachineManagerImpl.orchestrateMigrate(VirtualMachineManagerImpl.java:2658)
        at com.cloud.vm.VirtualMachineManagerImpl.orchestrateMigrate(VirtualMachineManagerImpl.java:5883)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
````
- Upgrade cloudstack-agent packages on host 1, containing this fix -> then upgrade host 1
- Attempt migrations to host 2 -> SUCCESS
