### PR TITLE
Add check for update only name and/or description of disk offering

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1363,6 +1363,15 @@ export default {
           delete values.tags
         }
 
+        if (['updateServiceOffering'].includes(action.api)) {
+          if (values.hosttags === this.resource.hosttags) {
+            delete values.hosttags
+          }
+          if (values.storagetags === this.resource.storagetags) {
+            delete values.tags
+          }
+        }
+
         for (const key in values) {
           const input = values[key]
           for (const param of action.params) {

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1358,6 +1358,11 @@ export default {
         if ('id' in this.resource && action.params.map(i => { return i.name }).includes('id')) {
           params.id = this.resource.id
         }
+
+        if (['updateDiskOffering'].includes(action.api) && values.tags === this.resource.tags) {
+          delete values.tags
+        }
+
         for (const key in values) {
           const input = values[key]
           for (const param of action.params) {


### PR DESCRIPTION
### Description

While trying to update a disk offering through the UI, the tag fields are always sent, even when they are not changed. This causes a bug when active volumes are using a disk offering in storage pools with tags. As ACS would interpret this as an update on the tags as well. This PR aims to fix this problem, only sending the tags if they are different from the current tags, allowing the user to update the name and/or description of disk offerings, as it is already allowed through CloudMonkey.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

On a local lab, I tried updating the disk offering with the following use cases:
- updating only the name
- updating only the description
- updating only the name and description fields

All of the tests worked as expected, the UI only sent the the fields that were changed.

Then, while trying to update the name and/or description fields, and changing the tags as well, the API was sending the tags parameters, as expected.