### PR TITLE
Improve login time

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/acl/APIChecker.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/APIChecker.java
@@ -21,7 +21,11 @@ import com.cloud.user.Account;
 import com.cloud.user.User;
 import com.cloud.utils.component.Adapter;
 
-// APIChecker checks the ownership and access control to API requests
+import java.util.List;
+
+/**
+ * APICheckers is designed to verify the ownership of resources and to control the access to APIs.
+ */
 public interface APIChecker extends Adapter {
     // Interface for checking access for a role using apiname
     // If true, apiChecker has checked the operation
@@ -29,5 +33,14 @@ public interface APIChecker extends Adapter {
     // On exception, checkAccess failed don't allow
     boolean checkAccess(User user, String apiCommandName) throws PermissionDeniedException;
     boolean checkAccess(Account account, String apiCommandName) throws PermissionDeniedException;
+    /**
+     * Verifies if the account has permission for the given list of APIs and returns only the allowed ones.
+     *
+     * @param role of the user to be verified
+     * @param user to be verified
+     * @param apiNames the list of apis to be verified
+     * @return the list of allowed apis for the given user
+     */
+    List<String> getApisAllowedToUser(Role role, User user, List<String> apiNames) throws PermissionDeniedException;
     boolean isEnabled();
 }

--- a/engine/schema/src/main/java/com/cloud/projects/ProjectVO.java
+++ b/engine/schema/src/main/java/com/cloud/projects/ProjectVO.java
@@ -30,6 +30,7 @@ import javax.persistence.Table;
 
 import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 import com.cloud.utils.NumbersUtil;
 import com.cloud.utils.db.GenericDao;
@@ -116,9 +117,7 @@ public class ProjectVO implements Project, Identity, InternalIdentity {
 
     @Override
     public String toString() {
-        StringBuilder buf = new StringBuilder("Project[");
-        buf.append(id).append("|name=").append(name).append("|domainid=").append(domainId).append("]");
-        return buf.toString();
+        return String.format("Project %s.", ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "name", "uuid", "domainId"));
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/user/AccountVO.java
+++ b/engine/schema/src/main/java/com/cloud/user/AccountVO.java
@@ -18,6 +18,7 @@ package com.cloud.user;
 
 import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -189,7 +190,7 @@ public class AccountVO implements Account {
 
     @Override
     public String toString() {
-        return String.format("Acct[%s-%s] -- Account {\"id\": %s, \"name\": \"%s\", \"uuid\": \"%s\"}", uuid, accountName, id, accountName, uuid);
+        return String.format("Account [%s]", ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "uuid","accountName", "id"));
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/user/UserVO.java
+++ b/engine/schema/src/main/java/com/cloud/user/UserVO.java
@@ -30,6 +30,7 @@ import javax.persistence.Table;
 
 import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 import com.cloud.user.Account.State;
 import com.cloud.utils.db.Encrypt;
@@ -283,7 +284,7 @@ public class UserVO implements User, Identity, InternalIdentity {
 
     @Override
     public String toString() {
-        return new StringBuilder("User[").append(id).append("-").append(username).append("]").toString();
+        return String.format("User %s.", ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "username", "uuid"));
     }
 
     @Override

--- a/engine/schema/src/main/java/org/apache/cloudstack/acl/RoleVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/acl/RoleVO.java
@@ -18,6 +18,7 @@
 package org.apache.cloudstack.acl;
 
 import com.cloud.utils.db.GenericDao;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -113,5 +114,10 @@ public class RoleVO implements Role {
 
     public boolean isDefault() {
         return isDefault;
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "name", "uuid", "roleType");
     }
 }

--- a/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
@@ -84,15 +84,18 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
      */
     public boolean checkApiPermissionByRole(Role role, String apiName, List<RolePermission> allPermissions) {
         for (final RolePermission permission : allPermissions) {
-            if (permission.getRule().matches(apiName)) {
-                if (Permission.ALLOW.equals(permission.getPermission())) {
-                    if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace(String.format("The API [%s] is allowed for the role %s by the permission [%s].", apiName, role, permission.getRule().toString()));
-                    }
-                    return true;
-                }
+            if (!permission.getRule().matches(apiName)) {
+                continue;
+            }
+
+            if (!Permission.ALLOW.equals(permission.getPermission())) {
                 return false;
             }
+
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(String.format("The API [%s] is allowed for the role %s by the permission [%s].", apiName, role, permission.getRule().toString()));
+            }
+            return true;
         }
         return annotationRoleBasedApisMap.get(role.getRoleType()) != null &&
                 annotationRoleBasedApisMap.get(role.getRoleType()).contains(apiName);

--- a/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/dynamic-role-based/src/main/java/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.acl;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +27,7 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.acl.RolePermissionEntity.Permission;
 
@@ -48,7 +50,7 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
     private List<PluggableService> services;
     private Map<RoleType, Set<String>> annotationRoleBasedApisMap = new HashMap<RoleType, Set<String>>();
 
-    private static final Logger logger = Logger.getLogger(DynamicRoleBasedAPIAccessChecker.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(DynamicRoleBasedAPIAccessChecker.class.getName());
 
     protected DynamicRoleBasedAPIAccessChecker() {
         super();
@@ -57,22 +59,54 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
         }
     }
 
-    private void denyApiAccess(final String commandName) throws PermissionDeniedException {
-        throw new PermissionDeniedException("The API " + commandName + " is denied for the account's role.");
+    @Override
+    public List<String> getApisAllowedToUser(Role role, User user, List<String> apiNames) throws PermissionDeniedException {
+        if (!isEnabled()) {
+            return apiNames;
+        }
+
+        List<RolePermission> allPermissions = roleService.findAllPermissionsBy(role.getId());
+        List<String> allowedApis = new ArrayList<>();
+        for (String api : apiNames) {
+            if (checkApiPermissionByRole(role, api, allPermissions)) {
+                allowedApis.add(api);
+            }
+        }
+        return allowedApis;
     }
 
-    public boolean isDisabled() {
-        return !roleService.isEnabled();
+    /**
+     * Checks if the given Role of an Account has the allowed permission for the given API.
+     *
+     * @param role to be used on the verification
+     * @param apiName to be verified
+     * @param allPermissions list of role permissions for the given role
+     * @return if the role has the permission for the API
+     */
+    public boolean checkApiPermissionByRole(Role role, String apiName, List<RolePermission> allPermissions) {
+        for (final RolePermission permission : allPermissions) {
+            if (permission.getRule().matches(apiName)) {
+                if (Permission.ALLOW.equals(permission.getPermission())) {
+                    LOGGER.trace(String.format("The API [%s] is allowed for the role %s by the permission [%s].", apiName,
+                            ReflectionToStringBuilderUtils.reflectOnlySelectedFields(role, "name", "uuid"), permission.getRule().toString()));
+                    return true;
+                }
+                return false;
+            }
+        }
+        return annotationRoleBasedApisMap.get(role.getRoleType()) != null &&
+                annotationRoleBasedApisMap.get(role.getRoleType()).contains(apiName);
     }
 
     @Override
     public boolean checkAccess(User user, String commandName) throws PermissionDeniedException {
-        if (isDisabled()) {
+        if (!isEnabled()) {
             return true;
         }
+
         Account account = accountService.getAccount(user.getAccountId());
         if (account == null) {
-            throw new PermissionDeniedException("The account id=" + user.getAccountId() + "for user id=" + user.getId() + "is null");
+            throw new PermissionDeniedException(String.format("The account id [%s] for user id [%s] is null.", user.getAccountId(), user.getUuid()));
         }
 
         return checkAccess(account, commandName);
@@ -81,37 +115,35 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
     public boolean checkAccess(Account account, String commandName) {
         final Role accountRole = roleService.findRole(account.getRoleId());
         if (accountRole == null || accountRole.getId() < 1L) {
-            denyApiAccess(commandName);
+            throw new PermissionDeniedException(String.format("The account [%s] has role null or unknown.",
+                ReflectionToStringBuilderUtils.reflectOnlySelectedFields(account, "accountName", "uuid")));
         }
 
-        // Allow all APIs for root admins
         if (accountRole.getRoleType() == RoleType.Admin && accountRole.getId() == RoleType.Admin.getId()) {
+            LOGGER.info(String.format("Account [%s] is Root Admin or Domain Admin, all APIs are allowed.",
+                ReflectionToStringBuilderUtils.reflectOnlySelectedFields(account, "accountName", "uuid")));
             return true;
         }
 
-        // Check against current list of permissions
-        for (final RolePermission permission : roleService.findAllPermissionsBy(accountRole.getId())) {
-            if (permission.getRule().matches(commandName)) {
-                if (Permission.ALLOW.equals(permission.getPermission())) {
-                    return true;
-                } else {
-                    denyApiAccess(commandName);
-                }
-            }
-        }
-
-        // Check annotations
-        if (annotationRoleBasedApisMap.get(accountRole.getRoleType()) != null
-                && annotationRoleBasedApisMap.get(accountRole.getRoleType()).contains(commandName)) {
+        List<RolePermission> allPermissions = roleService.findAllPermissionsBy(accountRole.getId());
+        if (checkApiPermissionByRole(accountRole, commandName, allPermissions)) {
             return true;
         }
-
-        // Default deny all
-        throw new UnavailableCommandException("The API " + commandName + " does not exist or is not available for this account.");
+        throw new UnavailableCommandException(String.format("The API [%s] does not exist or is not available for the account %s.", commandName,
+            ReflectionToStringBuilderUtils.reflectOnlySelectedFields(account, "accountName", "uuid")));
     }
 
+    /**
+     * Only one strategy should be used between StaticRoleBasedAPIAccessChecker and DynamicRoleBasedAPIAccessChecker
+     * Default behavior is to use the Dynamic version. The StaticRoleBasedAPIAccessChecker is the legacy version.
+     * If roleService is enabled, then it uses the DynamicRoleBasedAPIAccessChecker, otherwise, it will use the
+     * StaticRoleBasedAPIAccessChecker.
+     */
     @Override
     public boolean isEnabled() {
+        if (!roleService.isEnabled()) {
+            LOGGER.trace("RoleService is disabled. We will not use DynamicRoleBasedAPIAccessChecker.");
+        }
         return roleService.isEnabled();
     }
 

--- a/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
+++ b/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
@@ -61,7 +61,7 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
     @Override
     public boolean isEnabled() {
         if (!roleService.isEnabled()) {
-            LOGGER.debug("RoleService is disabled. We will not use ProjectRoleBasedApiAccessChecker.");
+            LOGGER.trace("RoleService is disabled. We will not use ProjectRoleBasedApiAccessChecker.");
         }
         return roleService.isEnabled();
     }

--- a/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
+++ b/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
@@ -84,7 +84,9 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
             if (projectUser.getAccountRole() != ProjectAccount.Role.Admin) {
                 apiNames.removeIf(apiName -> !isPermitted(project, projectUser, apiName));
             }
-            LOGGER.trace(String.format("Returning APIs [%s] as allowed for user [%s].", apiNames, user));
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(String.format("Returning APIs [%s] as allowed for user [%s].", apiNames, user));
+            }
             return apiNames;
         }
 
@@ -96,7 +98,9 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
         if (projectAccount.getAccountRole() != ProjectAccount.Role.Admin) {
             apiNames.removeIf(apiName -> !isPermitted(project, projectAccount, apiName));
         }
-        LOGGER.trace(String.format("Returning APIs [%s] as allowed for user [%s].", apiNames, user));
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace(String.format("Returning APIs [%s] as allowed for user [%s].", apiNames, user));
+        }
         return apiNames;
     }
 

--- a/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
+++ b/plugins/acl/project-role-based/src/main/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessChecker.java
@@ -60,51 +60,87 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
 
     @Override
     public boolean isEnabled() {
+        if (!roleService.isEnabled()) {
+            LOGGER.debug("RoleService is disabled. We will not use ProjectRoleBasedApiAccessChecker.");
+        }
         return roleService.isEnabled();
     }
 
-    public boolean isDisabled() {
-        return !isEnabled();
+    @Override
+    public List<String> getApisAllowedToUser(Role role, User user, List<String> apiNames) throws PermissionDeniedException {
+        if (!isEnabled()) {
+            return apiNames;
+        }
+
+        Project project = CallContext.current().getProject();
+        if (project == null) {
+            LOGGER.warn(String.format("Project is null, ProjectRoleBasedApiAccessChecker only applies to projects, returning APIs [%s] for user [%s] as allowed.", apiNames, user));
+            return apiNames;
+        }
+
+        long accountID = user.getAccountId();
+        ProjectAccount projectUser = projectAccountDao.findByProjectIdUserId(project.getId(), accountID, user.getId());
+        if (projectUser != null) {
+            if (projectUser.getAccountRole() != ProjectAccount.Role.Admin) {
+                apiNames.removeIf(apiName -> !isPermitted(project, projectUser, apiName));
+            }
+            LOGGER.trace(String.format("Returning APIs [%s] as allowed for user [%s].", apiNames, user));
+            return apiNames;
+        }
+
+        ProjectAccount projectAccount = projectAccountDao.findByProjectIdAccountId(project.getId(), accountID);
+        if (projectAccount == null) {
+            throw new PermissionDeniedException(String.format("The user [%s] does not belong to the project [%s].", user, project));
+        }
+
+        if (projectAccount.getAccountRole() != ProjectAccount.Role.Admin) {
+            apiNames.removeIf(apiName -> !isPermitted(project, projectAccount, apiName));
+        }
+        LOGGER.trace(String.format("Returning APIs [%s] as allowed for user [%s].", apiNames, user));
+        return apiNames;
     }
 
     @Override
     public boolean checkAccess(User user, String apiCommandName) throws PermissionDeniedException {
-        if (isDisabled()) {
+        if (!isEnabled()) {
+            return true;
+        }
+
+        Project project = CallContext.current().getProject();
+        if (project == null) {
+            LOGGER.warn(String.format("Project is null, ProjectRoleBasedApiAccessChecker only applies to projects, returning API [%s] for user [%s] as allowed.", apiCommandName,
+                user));
             return true;
         }
 
         Account userAccount = accountService.getAccount(user.getAccountId());
-        Project project = CallContext.current().getProject();
-        if (project == null) {
-            return true;
-        }
-
         if (accountService.isRootAdmin(userAccount.getId()) || accountService.isDomainAdmin(userAccount.getAccountId())) {
+            LOGGER.info(String.format("Account [%s] is Root Admin or Domain Admin, all APIs are allowed.", userAccount.getAccountName()));
             return true;
         }
 
         ProjectAccount projectUser = projectAccountDao.findByProjectIdUserId(project.getId(), userAccount.getAccountId(), user.getId());
         if (projectUser != null) {
-            if (projectUser.getAccountRole() == ProjectAccount.Role.Admin) {
+            if (projectUser.getAccountRole() == ProjectAccount.Role.Admin || isPermitted(project, projectUser, apiCommandName)) {
                 return true;
-            } else {
-                return isPermitted(project, projectUser, apiCommandName);
             }
+            denyApiAccess(apiCommandName);
         }
 
         ProjectAccount projectAccount = projectAccountDao.findByProjectIdAccountId(project.getId(), userAccount.getAccountId());
         if (projectAccount != null) {
-            if (projectAccount.getAccountRole() == ProjectAccount.Role.Admin) {
+            if (projectAccount.getAccountRole() == ProjectAccount.Role.Admin || isPermitted(project, projectAccount, apiCommandName)) {
                 return true;
-            } else {
-                return isPermitted(project, projectAccount, apiCommandName);
             }
+            denyApiAccess(apiCommandName);
         }
+
         // Default deny all
         if ("updateProjectInvitation".equals(apiCommandName)) {
             return true;
         }
-        throw new UnavailableCommandException("The API " + apiCommandName + " does not exist or is not available for this account/user in project "+project.getUuid());
+
+        throw new UnavailableCommandException(String.format("The API [%s] does not exist or is not available for this account/user in project [%s].", apiCommandName, project.getUuid()));
     }
 
     @Override
@@ -112,7 +148,7 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
         return true;
     }
 
-    private boolean isPermitted(Project project, ProjectAccount projectUser, String apiCommandName) {
+    public boolean isPermitted(Project project, ProjectAccount projectUser, String ... apiCommandNames) {
         ProjectRole projectRole = null;
         if(projectUser.getProjectRoleId() != null) {
             projectRole = projectRoleService.findProjectRole(projectUser.getProjectRoleId(), project.getId());
@@ -122,12 +158,11 @@ public class ProjectRoleBasedApiAccessChecker  extends AdapterBase implements AP
             return true;
         }
 
-        for (ProjectRolePermission permission : projectRoleService.findAllProjectRolePermissions(project.getId(), projectRole.getId())) {
-            if (permission.getRule().matches(apiCommandName)) {
-                if (Permission.ALLOW.equals(permission.getPermission())) {
-                    return true;
-                } else {
-                    denyApiAccess(apiCommandName);
+        List<ProjectRolePermission> allProjectRolePermissions = projectRoleService.findAllProjectRolePermissions(project.getId(), projectRole.getId());
+        for (String api : apiCommandNames) {
+            for (ProjectRolePermission permission : allProjectRolePermissions) {
+                if (permission.getRule().matches(api)) {
+                    return Permission.ALLOW.equals(permission.getPermission());
                 }
             }
         }

--- a/plugins/acl/project-role-based/src/main/test/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessCheckerTest.java
+++ b/plugins/acl/project-role-based/src/main/test/java/org/apache/cloudstack/acl/ProjectRoleBasedApiAccessCheckerTest.java
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.acl;
+
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.projects.Project;
+import com.cloud.projects.ProjectAccount;
+import com.cloud.projects.ProjectAccountVO;
+import com.cloud.projects.ProjectVO;
+import com.cloud.projects.dao.ProjectAccountDao;
+import com.cloud.user.User;
+import com.cloud.user.UserVO;
+
+import org.apache.cloudstack.context.CallContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(CallContext.class)
+public class ProjectRoleBasedApiAccessCheckerTest extends TestCase {
+    @Mock
+    ProjectAccountDao projectAccountDaoMock;
+
+    @Mock
+    RoleService roleServiceMock;
+
+    @Mock
+    ProjectAccountVO projectAccountVOMock;
+
+    @Mock
+    CallContext callContextMock;
+
+    @InjectMocks
+    ProjectRoleBasedApiAccessChecker projectRoleBasedApiAccessCheckerSpy = Mockito.spy(ProjectRoleBasedApiAccessChecker.class);
+
+    List<String> apiNames = new ArrayList<>(Arrays.asList("apiName"));
+
+    @Before
+    public void setup() {
+
+        Mockito.doReturn(true).when(roleServiceMock).isEnabled();
+    }
+
+    public Project getTestProject() {
+        return new ProjectVO("Teste", "Teste", 1L, 1L);
+    }
+
+    private User getTestUser() {
+        return new UserVO(12L, "some user", "password", "firstName", "lastName",
+                "email@gmail.com", "GMT", "uuid", User.Source.UNKNOWN);
+    }
+
+    @Test
+    public void getApisAllowedToUserTestRoleServiceIsDisabledShouldReturnUnchangedApiList() {
+        Mockito.doReturn(false).when(roleServiceMock).isEnabled();
+
+        List<String> apisReceived = projectRoleBasedApiAccessCheckerSpy.getApisAllowedToUser(null, getTestUser(), apiNames);
+        Assert.assertEquals(1, apisReceived.size());
+    }
+
+    @Test
+    public void getApisAllowedToUserTestProjectIsNullShouldReturnUnchangedApiList() {
+        PowerMockito.mockStatic(CallContext.class);
+        PowerMockito.when(CallContext.current()).thenReturn(callContextMock);
+
+        Mockito.doReturn(null).when(callContextMock).getProject();
+
+        List<String> apisReceived = projectRoleBasedApiAccessCheckerSpy.getApisAllowedToUser(null, getTestUser(), apiNames);
+        Assert.assertEquals(1, apisReceived.size());
+    }
+
+    @Test (expected = PermissionDeniedException.class)
+    public void getApisAllowedToUserTestProjectAccountIsNullThrowPermissionDeniedException() {
+        PowerMockito.mockStatic(CallContext.class);
+        PowerMockito.when(CallContext.current()).thenReturn(callContextMock);
+
+        Mockito.when(callContextMock.getProject()).thenReturn(getTestProject());
+        Mockito.when(projectAccountDaoMock.findByProjectIdAccountId(Mockito.anyLong(), Mockito.anyLong())).thenReturn(null);
+        Mockito.when(projectAccountDaoMock.findByProjectIdUserId(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong())).thenReturn(null);
+
+        projectRoleBasedApiAccessCheckerSpy.getApisAllowedToUser(null, getTestUser(), apiNames);
+    }
+
+    @Test
+    public void getApisAllowedToUserTestProjectAccountHasAdminRoleReturnsUnchangedApiList() {
+        PowerMockito.mockStatic(CallContext.class);
+        PowerMockito.when(CallContext.current()).thenReturn(callContextMock);
+
+        Mockito.doReturn(getTestProject()).when(callContextMock).getProject();
+        Mockito.doReturn(projectAccountVOMock).when(projectAccountDaoMock).findByProjectIdUserId(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+        Mockito.doReturn(ProjectAccount.Role.Admin).when(projectAccountVOMock).getAccountRole();
+
+        List<String> apisReceived = projectRoleBasedApiAccessCheckerSpy.getApisAllowedToUser(null, getTestUser(), apiNames);
+        Assert.assertEquals(1, apisReceived.size());
+    }
+
+    @Test
+    public void getApisAllowedToUserTestProjectAccountNotPermittedForTheApiListShouldReturnEmptyList() {
+        PowerMockito.mockStatic(CallContext.class);
+        PowerMockito.when(CallContext.current()).thenReturn(callContextMock);
+
+        Mockito.doReturn(getTestProject()).when(callContextMock).getProject();
+        Mockito.doReturn(projectAccountVOMock).when(projectAccountDaoMock).findByProjectIdUserId(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+        Mockito.doReturn(ProjectAccount.Role.Regular).when(projectAccountVOMock).getAccountRole();
+        Mockito.doReturn(false).when(projectRoleBasedApiAccessCheckerSpy).isPermitted(Mockito.any(Project.class), Mockito.any(ProjectAccount.class), Mockito.anyString());
+
+
+        List<String> apisReceived = projectRoleBasedApiAccessCheckerSpy.getApisAllowedToUser(null, getTestUser(), apiNames);
+        Assert.assertTrue(apisReceived.isEmpty());
+    }
+
+    @Test
+    public void getApisAllowedToUserTestProjectAccountPermittedForTheApiListShouldReturnTheSameList() {
+        PowerMockito.mockStatic(CallContext.class);
+        PowerMockito.when(CallContext.current()).thenReturn(callContextMock);
+
+        Mockito.doReturn(getTestProject()).when(callContextMock).getProject();
+        Mockito.doReturn(projectAccountVOMock).when(projectAccountDaoMock).findByProjectIdUserId(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+        Mockito.doReturn(ProjectAccount.Role.Regular).when(projectAccountVOMock).getAccountRole();
+        Mockito.doReturn(true).when(projectRoleBasedApiAccessCheckerSpy).isPermitted(Mockito.any(Project.class), Mockito.any(ProjectAccount.class), Mockito.anyString());
+
+
+        List<String> apisReceived = projectRoleBasedApiAccessCheckerSpy.getApisAllowedToUser(null, getTestUser(), apiNames);
+        Assert.assertEquals(1, apisReceived.size());
+    }
+}

--- a/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -65,43 +65,72 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
         }
     }
 
+    /**
+     * Only one strategy should be used between StaticRoleBasedAPIAccessChecker and DynamicRoleBasedAPIAccessChecker
+     * Default behavior is to use the Dynamic version. The StaticRoleBasedAPIAccessChecker is the legacy version.
+     * If roleService is enabled, then it uses the DynamicRoleBasedAPIAccessChecker, otherwise, it will use the
+     * StaticRoleBasedAPIAccessChecker.
+     */
     @Override
     public boolean isEnabled() {
-        return !isDisabled();
-    }
-    public boolean isDisabled() {
+        if (roleService.isEnabled()) {
+            LOGGER.debug("RoleService is enabled. We will use it instead of StaticRoleBasedAPIAccessChecker.");
+        }
         return roleService.isEnabled();
     }
 
     @Override
+    public List<String> getApisAllowedToUser(Role role, User user, List<String> apiNames) throws PermissionDeniedException {
+        if (isEnabled()) {
+            return apiNames;
+        }
+
+        RoleType roleType = role.getRoleType();
+        apiNames.removeIf(apiName -> !isApiAllowed(apiName, roleType));
+
+        return apiNames;
+    }
+
+    @Override
     public boolean checkAccess(User user, String commandName) throws PermissionDeniedException {
-        if (isDisabled()) {
+        if (isEnabled()) {
             return true;
         }
 
         Account account = accountService.getAccount(user.getAccountId());
         if (account == null) {
-            throw new PermissionDeniedException("The account id=" + user.getAccountId() + "for user id=" + user.getId() + "is null");
+            throw new PermissionDeniedException(String.format("The account with id [%s] for user with uuid [%s] is null.", user.getAccountId(), user.getUuid()));
         }
 
         return checkAccess(account, commandName);
     }
 
+    @Override
     public boolean checkAccess(Account account, String commandName) {
         RoleType roleType = accountService.getRoleType(account);
-        boolean isAllowed =
-            commandsPropertiesOverrides.contains(commandName) ? commandsPropertiesRoleBasedApisMap.get(roleType).contains(commandName) : annotationRoleBasedApisMap.get(
-                roleType).contains(commandName);
-
-        if (isAllowed) {
+        if (isApiAllowed(commandName, roleType)) {
             return true;
         }
 
         if (commandNames.contains(commandName)) {
-            throw new PermissionDeniedException("The API is denied. Role type=" + roleType.toString() + " is not allowed to request the api: " + commandName);
+            throw new PermissionDeniedException(String.format("Request to API [%s] was denied. The role type [%s] is not allowed to request it.", commandName, roleType.toString()));
         } else {
-            throw new UnavailableCommandException("The API " + commandName + " does not exist or is not available for this account.");
+            throw new UnavailableCommandException(String.format("The API [%s] does not exist or is not available for this account.", commandName));
         }
+    }
+
+    /**
+     * Verifies if the API is allowed for the given RoleType.
+     *
+     * @param apiName API command to be verified
+     * @param roleType to be verified
+     * @return 'true' if the API is allowed for the given RoleType, otherwise, 'false'.
+     */
+    public boolean isApiAllowed(String apiName, RoleType roleType) {
+        if (commandsPropertiesOverrides.contains(apiName)) {
+            return commandsPropertiesRoleBasedApisMap.get(roleType).contains(apiName);
+        }
+        return annotationRoleBasedApisMap.get(roleType).contains(apiName);
     }
 
     @Override
@@ -147,7 +176,7 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
                         commandsPropertiesRoleBasedApisMap.get(roleType).add(apiName);
                 }
             } catch (NumberFormatException nfe) {
-                LOGGER.info("Malformed key=value pair for entry: " + entry.toString());
+                LOGGER.error(String.format("Malformed key=value pair for entry: [%s].", entry));
             }
         }
     }

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.cloud.user.Account;
 import org.apache.cloudstack.acl.APIChecker;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.BaseAsyncCmd;
@@ -35,17 +34,24 @@ import org.apache.cloudstack.api.BaseAsyncCreateCmd;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RoleService;
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.command.user.discovery.ListApisCmd;
 import org.apache.cloudstack.api.response.ApiDiscoveryResponse;
 import org.apache.cloudstack.api.response.ApiParameterResponse;
 import org.apache.cloudstack.api.response.ApiResponseResponse;
 import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.reflections.ReflectionUtils;
 import org.springframework.stereotype.Component;
 
+import com.cloud.exception.PermissionDeniedException;
 import com.cloud.serializer.Param;
+import com.cloud.user.Account;
+import com.cloud.user.AccountService;
 import com.cloud.user.User;
 import com.cloud.utils.ReflectUtil;
 import com.cloud.utils.component.ComponentLifecycleBase;
@@ -58,7 +64,13 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
 
     List<APIChecker> _apiAccessCheckers = null;
     List<PluggableService> _services = null;
-    private static Map<String, ApiDiscoveryResponse> s_apiNameDiscoveryResponseMap = null;
+    protected static Map<String, ApiDiscoveryResponse> s_apiNameDiscoveryResponseMap = null;
+
+    @Inject
+    AccountService accountService;
+
+    @Inject
+    RoleService roleService;
 
     protected ApiDiscoveryServiceImpl() {
         super();
@@ -231,8 +243,9 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
 
     @Override
     public ListResponse<? extends BaseResponse> listApis(User user, String name) {
-        ListResponse<ApiDiscoveryResponse> response = new ListResponse<ApiDiscoveryResponse>();
-        List<ApiDiscoveryResponse> responseList = new ArrayList<ApiDiscoveryResponse>();
+        ListResponse<ApiDiscoveryResponse> response = new ListResponse<>();
+        List<ApiDiscoveryResponse> responseList = new ArrayList<>();
+        List<String> apisAllowed = new ArrayList<>(s_apiNameDiscoveryResponseMap.keySet());
 
         if (user == null)
             return null;
@@ -245,24 +258,35 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
                 try {
                     apiChecker.checkAccess(user, name);
                 } catch (Exception ex) {
-                    s_logger.debug("API discovery access check failed for " + name + " with " + ex.getMessage());
+                    s_logger.error(String.format("API discovery access check failed for [%s] with error [%s].", name, ex.getMessage()), ex);
                     return null;
                 }
             }
             responseList.add(s_apiNameDiscoveryResponseMap.get(name));
 
         } else {
-            for (String apiName : s_apiNameDiscoveryResponseMap.keySet()) {
-                boolean isAllowed = true;
+            Account account = accountService.getAccount(user.getAccountId());
+            if (account == null) {
+                throw new PermissionDeniedException(String.format("The account with id [%s] for user [%s] is null.", user.getAccountId(), user));
+            }
+
+            final Role role = roleService.findRole(account.getRoleId());
+            if (role == null || role.getId() < 1L) {
+                throw new PermissionDeniedException(String.format("The account [%s] has role null or unknown.",
+                        ReflectionToStringBuilderUtils.reflectOnlySelectedFields(account, "accountName", "uuid")));
+            }
+
+            if (role.getRoleType() == RoleType.Admin && role.getId() == RoleType.Admin.getId()) {
+                s_logger.info(String.format("Account [%s] is Root Admin, all APIs are allowed.",
+                        ReflectionToStringBuilderUtils.reflectOnlySelectedFields(account, "accountName", "uuid")));
+            } else {
                 for (APIChecker apiChecker : _apiAccessCheckers) {
-                    try {
-                        apiChecker.checkAccess(user, apiName);
-                    } catch (Exception ex) {
-                        isAllowed = false;
-                    }
+                    apisAllowed = apiChecker.getApisAllowedToUser(role, user, apisAllowed);
                 }
-                if (isAllowed)
-                    responseList.add(s_apiNameDiscoveryResponseMap.get(apiName));
+            }
+
+            for (String apiName: apisAllowed) {
+                responseList.add(s_apiNameDiscoveryResponseMap.get(apiName));
             }
         }
         response.setResponses(responseList);


### PR DESCRIPTION
### Description

The API `listApis` currently has too many redundant calls to the DB, which causes slowness on the ACS login. This PR aims to improve the time of login on ACS by refactoring the classes that implement the `APIChecker` interface. In my local lab, the login usually took 13 seconds, without login cache. With this new version, the login took around 2 seconds, with no login cache as well.


Fixes: #5266

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created multiple accounts with the roles based on the following table. I compared this PR with a version with the unmodified `APIChecker`. And the number of APIs were returned as expected, as the table shows.

| Role Type | 4.16.0.6 version | PR version |
| ------ | ------ | ------ | 
| Root Admin | 624 | 624 |
| Domain Admin | 180 | 180 |
| Read-Only Admin | 312 | 312 |
| Support Admin | 202| 202 |
| User | 268 | 268 |

Furthermore, I tried multiple functions through the UI with these accounts, and the APIs allowed were working correctly.