### PR TITLE
ui: Fix create kubernetes cluster with ha enabled

### DIFF
--- a/ui/src/views/compute/CreateKubernetesCluster.vue
+++ b/ui/src/views/compute/CreateKubernetesCluster.vue
@@ -137,7 +137,7 @@
           </template>
           <a-switch v-model:checked="form.haenable" />
         </a-form-item>
-        <a-form-item v-if="form.haenable">
+        <a-form-item v-if="form.haenable" name="controlnodes" ref="controlnodes">
           <template #label>
             <tooltip-label :title="$t('label.controlnodes')" :tooltip="apiParams.controlnodes.description"/>
           </template>
@@ -145,7 +145,7 @@
             v-model:value="form.controlnodes"
             :placeholder="apiParams.controlnodes.description"/>
         </a-form-item>
-        <a-form-item v-if="form.haenable">
+        <a-form-item v-if="form.haenable" name="externalloadbalanceripaddress" ref="externalloadbalanceripaddress">
           <template #label>
             <tooltip-label :title="$t('label.externalloadbalanceripaddress')" :tooltip="apiParams.externalloadbalanceripaddress.description"/>
           </template>


### PR DESCRIPTION
### Description

Fixes the issue of ha kubernetes clusters not coming up with the specified control plane nodes

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

#### Before :

![Screenshot from 2022-05-30 16-01-22](https://user-images.githubusercontent.com/8244774/170974448-5fc889c5-42a9-429a-8e78-d473182a673a.png)


#### After :

![Screenshot from 2022-05-30 15-59-48](https://user-images.githubusercontent.com/8244774/170974386-341925c7-4590-42d7-ade9-fe3ad16ac319.png)

