### PR TITLE
ui: Display associated VPC network name against vpc tiers - deploy VM form

### DIFF
--- a/ui/src/views/compute/wizard/NetworkSelection.vue
+++ b/ui/src/views/compute/wizard/NetworkSelection.vue
@@ -271,9 +271,12 @@ export default {
   created () {
     this.vpcs = []
     const projectId = store?.getters?.project?.id || null
-    if (!projectId) return
+    var params = {}
+    if (projectId) {
+      params.projectid = projectId
+    }
     api('listVPCs', {
-      projectid: projectId
+      params
     }).then((response) => {
       this.vpcs = _.get(response, 'listvpcsresponse.vpc')
     })


### PR DESCRIPTION
### Description

This PR prints the vpc name to which the isolated network is associated 
before fix:
![image](https://user-images.githubusercontent.com/10495417/171012370-75ecde74-b415-4b1b-9b04-5225bfcdff91.png)

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
After fix:
![image](https://user-images.githubusercontent.com/10495417/171012554-d474324e-bdf4-45c2-9226-359a39c970bb.png)

Also tested in project view


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
