### PR TITLE
Fix extract snapshot from vm snapshot on kvm

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -930,7 +930,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         final String secondaryStoragePoolUrl = nfsImageStore.getUrl();
         // NOTE: snapshot name is encoded in snapshot path
         final int index = snapshot.getPath().lastIndexOf("/");
-        final boolean isCreatedFromVmSnapshot = (index == -1) ? true: false; // -1 means the snapshot is created from existing vm snapshot
+        final boolean isCreatedFromVmSnapshot = index == -1; // -1 means the snapshot is created from existing vm snapshot
 
         final String snapshotName = snapshot.getPath().substring(index + 1);
         String descName = snapshotName;
@@ -1002,7 +1002,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
             } else {
                 final Script command = new Script(_manageSnapshotPath, cmd.getWaitInMillSeconds(), s_logger);
-                command.add("-b", snapshot.getPath());
+                command.add("-b", isCreatedFromVmSnapshot ? snapshotDisk.getPath() : snapshot.getPath());
                 command.add(NAME_OPTION, snapshotName);
                 command.add("-p", snapshotDestPath);
                 if (isCreatedFromVmSnapshot) {

--- a/scripts/storage/qcow2/managesnapshot.sh
+++ b/scripts/storage/qcow2/managesnapshot.sh
@@ -226,7 +226,7 @@ backup_snapshot() {
       return 2
     fi
   elif [ -f ${disk} ]; then
-    if [[ $disk == *"\/snapshots\/"* ]]; then
+    if [[ $disk == *"/snapshots/"* ]]; then
       #Backup volume snapshot
       cp "$disk" "${destPath}/${destName}"
       ret_code=$?

--- a/scripts/storage/qcow2/managesnapshot.sh
+++ b/scripts/storage/qcow2/managesnapshot.sh
@@ -226,14 +226,48 @@ backup_snapshot() {
       return 2
     fi
   elif [ -f ${disk} ]; then
+    if [[ $disk == *"\/snapshots\/"* ]]; then
+      #Backup volume snapshot
+      cp "$disk" "${destPath}/${destName}"
+      ret_code=$?
 
-    cp "$disk" "${destPath}/${destName}"
-    ret_code=$?
+      if [ $ret_code -gt 0 ]
+      then
+        printf "Failed to backup $snapshotname for disk $disk to $destPath\n" >&2
+        return 2
+      fi
+    else
+      # Backup VM snapshot
+      qemuimg_ret=$($qemu_img snapshot $forceShareFlag -l $disk 2>&1)
+      ret_code=$?
+      if [ $ret_code -gt 0 ] && [[ $qemuimg_ret == *"snapshot: invalid option -- 'U'"* ]]; then
+        forceShareFlag=""
+        qemuimg_ret=$($qemu_img snapshot $forceShareFlag -l $disk)
+        ret_code=$?
+      fi
 
-    if [ $ret_code -gt 0 ]
-    then
-      printf "Failed to backup $snapshotname for disk $disk to $destPath\n" >&2
-      return 2
+      if [ $ret_code -gt 0 ] || [[ ! $qemuimg_ret == *"$snapshotname"* ]]; then
+        printf "there is no $snapshotname on disk $disk\n" >&2
+        return 1
+      fi
+
+      qemuimg_ret=$($qemu_img convert $forceShareFlag -f qcow2 -O qcow2 -l snapshot.name=$snapshotname $disk $destPath/$destName 2>&1 > /dev/null)
+      ret_code=$?
+      if [ $ret_code -gt 0 ] && [[ $qemuimg_ret == *"convert: invalid option -- 'U'"* ]]; then
+        forceShareFlag=""
+        qemuimg_ret=$($qemu_img convert $forceShareFlag -f qcow2 -O qcow2 -l snapshot.name=$snapshotname $disk $destPath/$destName 2>&1 > /dev/null)
+        ret_code=$?
+      fi
+
+      if [ $ret_code -gt 0 ] && [[ $qemuimg_ret == *"convert: invalid option -- 'l'"* ]]; then
+        $qemu_img convert $forceShareFlag -f qcow2 -O qcow2 -s $snapshotname $disk $destPath/$destName >& /dev/null
+        ret_code=$?
+      fi
+
+      if [ $ret_code -gt 0 ]; then
+        printf "Failed to backup $snapshotname for disk $disk to $destPath\n" >&2
+        return 2
+      fi
     fi
   else
     printf "***Failed to backup snapshot $snapshotname, undefined type $disk\n" >&2


### PR DESCRIPTION
### Description

PR #5297 introduced the disk-only snapshot feature for KVM, which changed the whole snapshot workflow for KVM. While taking a volume snapshot and the global setting `snapshot.backup.to.secondary` is `true`, ACS will backup the snapshot from the primary storage to the secondary storage. As the disk-only snapshot process generates an external file, the backup process only copies it to the secondary storage.
The extract snapshot from VM snapshot feature uses the same backup workflow to extract the snapshot from the VM directly to the secondary storage. However, as the process was changed to only copy the file, the following error occurs when trying to extract a snapshot from a VM snapshot:


```
2022-05-30 11:55:19,152 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-2:null) (logid:565d35b1) Executing: /usr/share/cloudstack-common/scripts/storage/qcow2/managesnapshot.sh -b i-2-5-VM_VS_20220530114135 -n i-2-5-VM_VS_20220530114135 -p /mnt/3ac1f06a-3f50-3e03-b53e-92faead36a85/snapshots/2/5 -t 248e458e-f2c5-48c3-86bc-5201104a5832 
2022-05-30 11:55:19,155 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-2:null) (logid:565d35b1) Executing while with timeout : 21600000
2022-05-30 11:55:19,167 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-2:null) (logid:565d35b1) Exit value is 3
2022-05-30 11:55:19,168 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-2:null) (logid:565d35b1) ***Failed to backup snapshot i-2-5-VM_VS_20220530114135, undefined type i-2-5-VM_VS_20220530114135
```

As the VM snapshot is internal, the backup workflow has to be different. This PR address the fix for the situation, by using the previous backup workflow when a snapshot is being extracted from a VM snapshot.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### How Has This Been Tested?

In a local lab I created a VM and took a VM snapshot. With the changes I could extract the VM snapshot and do other operations with it (create volume, create template and so on).
I also took a volume snapshot and tested the operations (create volume, create template and so on).