### PR TITLE
Fix UEFI detection on KVM and prevent deployments on non UEFI enabled hosts

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1414,13 +1414,13 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         s_logger.debug("agent.hooks.libvirt_vm_on_stop.method is " + _agentHooksVmOnStopMethod);
     }
 
-    public boolean isUefiPropertiesFileSet() {
-        return PropertiesUtil.findConfigFile("uefi.properties") != null;
+    public boolean isUefiPropertiesFileLoaded() {
+        return _uefiProperties != null && _uefiProperties.getProperty("guest.loader.legacy") != null;
     }
 
     private void loadUefiProperties() throws FileNotFoundException {
 
-        if (_uefiProperties != null && _uefiProperties.getProperty("guest.loader.legacy") != null) {
+        if (isUefiPropertiesFileLoaded()) {
             return;
         }
         final File file = PropertiesUtil.findConfigFile("uefi.properties");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1414,6 +1414,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         s_logger.debug("agent.hooks.libvirt_vm_on_stop.method is " + _agentHooksVmOnStopMethod);
     }
 
+    public boolean isUefiPropertiesFileSet() {
+        return PropertiesUtil.findConfigFile("uefi.properties") != null;
+    }
+
     private void loadUefiProperties() throws FileNotFoundException {
 
         if (_uefiProperties != null && _uefiProperties.getProperty("guest.loader.legacy") != null) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1415,7 +1415,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     public boolean isUefiPropertiesFileLoaded() {
-        return _uefiProperties != null && _uefiProperties.getProperty("guest.loader.legacy") != null;
+        return !_uefiProperties.isEmpty();
     }
 
     private void loadUefiProperties() throws FileNotFoundException {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -42,7 +42,7 @@ public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyComman
     public Answer execute(final ReadyCommand command, final LibvirtComputingResource libvirtComputingResource) {
         Map<String, String> hostDetails = new HashMap<String, String>();
 
-        if (hostSupportsUefi() && libvirtComputingResource.isUefiPropertiesFileSet()) {
+        if (hostSupportsUefi() && libvirtComputingResource.isUefiPropertiesFileLoaded()) {
             hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -42,7 +42,7 @@ public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyComman
     public Answer execute(final ReadyCommand command, final LibvirtComputingResource libvirtComputingResource) {
         Map<String, String> hostDetails = new HashMap<String, String>();
 
-        if (hostSupportsUefi()) {
+        if (hostSupportsUefi() && libvirtComputingResource.isUefiPropertiesFileSet()) {
             hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
         }
 

--- a/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -42,7 +42,6 @@ import com.cloud.utils.fsm.StateMachine2;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.affinity.AffinityGroupProcessor;
@@ -301,8 +300,8 @@ StateListener<State, VirtualMachine.Event, VirtualMachine>, Configurable {
             }
             HostVO host = _hostDao.findById(hostIdSpecified);
             if (host != null && StringUtils.isNotBlank(uefiFlag) && "yes".equalsIgnoreCase(uefiFlag)) {
-                _hostDao.loadDetails(host);
-                if (MapUtils.isNotEmpty(host.getDetails()) && host.getDetails().containsKey(Host.HOST_UEFI_ENABLE) && "false".equalsIgnoreCase(host.getDetails().get(Host.HOST_UEFI_ENABLE))) {
+                DetailVO uefiHostDetail = _hostDetailsDao.findDetail(host.getId(), Host.HOST_UEFI_ENABLE);
+                if (uefiHostDetail == null || "false".equalsIgnoreCase(uefiHostDetail.getValue())) {
                     s_logger.debug("Cannot deploy to specified host as host does n't support uefi vm deployment, returning.");
                     return null;
 


### PR DESCRIPTION
### Description

This PR fixes 2 issues:
- Prevent UEFI deployments on non UEFI enabled hosts (do not assume the host detail will always be present in case of not enabled)
- Fix the UEFI detection on KVM (uefi.properties file check was missing)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested on KVM - one UEFI enabled host, one disabled