### PR TITLE
Filter removed nics while listing LB vm instances

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/UserVmDaoImpl.java
@@ -195,6 +195,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
         SearchBuilder<NicVO> nicSearch = _nicDao.createSearchBuilder();
         nicSearch.and("networkId", nicSearch.entity().getNetworkId(), SearchCriteria.Op.EQ);
         nicSearch.and("ip4Address", nicSearch.entity().getIPv4Address(), SearchCriteria.Op.NNULL);
+        nicSearch.and("removed", nicSearch.entity().getRemoved(), SearchCriteria.Op.NULL);
 
         AccountDataCenterVirtualSearch = createSearchBuilder();
         AccountDataCenterVirtualSearch.and("account", AccountDataCenterVirtualSearch.entity().getAccountId(), SearchCriteria.Op.EQ);


### PR DESCRIPTION
### Description

When we remove the NIC of a network from a VM and add a new NIC of the same network, we will have two registers in the database for the same VM and network, one of them being marked as `removed`. In API `listLoadBalancerRuleInstances`, specifically in the method `LoadBalancingRulesManagerImpl#listLoadBalancerInstances`, ACS retrieves the instances according to the user's account and the network where the LB is being created; however, it lists all the NICs, even the marked as `removed`, which causes the following error while listing the VMs:

```
2022-05-16 14:06:32,859 ERROR [c.c.a.ApiServer] (qtp365590665-27:ctx-5ce79f30 ctx-9de90969) (logid:a3518976) unhandled exception executing api command: [Ljava.lang.String;@55d45499
java.lang.IndexOutOfBoundsException: Index 2 out of bounds for length 2
```

This PR intends to fix this error by filtering the removed NICs while listing the LB intances.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ x] Minor
- [ ] Trivial

### How Has This Been Tested?
In a local lab, I created a VM with a random network. I added a NIC for a specific network (`test`) to the VM. I removed the NIC of network `test` and then added it again. I created a LB rule with this VM. Before the changes, while listing the LB rule instances I got `Index 1 out of bounds for length 1`. After the changes, the instance was listed.