### PR TITLE
VPC VR: fix /etc/network/interfaces is misconfigured

### DIFF
--- a/systemvm/debian/opt/cloud/bin/setup/init.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/init.sh
@@ -188,6 +188,7 @@ setup_interface_sshd() {
     setup_sshd $ETH1_IP "eth1"
 
   elif [ "$TYPE" == "vpcrouter" ]; then
+    init_interfaces "eth0"
     setup_interface "0" $ETH0_IP $ETH0_MASK $GW
     setup_sshd $ETH0_IP "eth0"
 

--- a/systemvm/debian/opt/cloud/bin/setup/vpcrouter.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/vpcrouter.sh
@@ -25,11 +25,6 @@ setup_vpcrouter() {
     grep -q $NAME /etc/hosts || echo "127.0.0.1 $NAME" >> /etc/hosts;
   fi
 
-    cat > /etc/network/interfaces << EOF
-auto lo eth0
-iface lo inet loopback
-EOF
-
   echo $NAME > /etc/hostname
   echo 'AVAHI_DAEMON_DETECT_LOCAL=0' > /etc/default/avahi-daemon
   hostnamectl set-hostname $NAME


### PR DESCRIPTION
### Description

This PR fixes that the /etc/network/interfaces is misconfigured in VPC VR startup, which causes VPC VR to be stuck for 1 minute and continue working.

The issue is because `ifup eth0` and `ifdown eth0` do not work when `/etc/network/interfaces` is not correct in VPC VR.

severity: to be discussed.
This requires a new systemvm template.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
