### PR TITLE
Allow for arbitrary disk offering details to be saved/displayed

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/DiskOfferingResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DiskOfferingResponse.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.api.response;
 
 import java.util.Date;
+import java.util.Map;
 
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponseWithAnnotations;
@@ -158,6 +159,10 @@ public class DiskOfferingResponse extends BaseResponseWithAnnotations {
     @SerializedName(ApiConstants.DISK_SIZE_STRICTNESS)
     @Param(description = "To allow or disallow the resize operation on the disks created from this disk offering, if the flag is true then resize is not allowed", since = "4.17")
     private Boolean diskSizeStrictness;
+
+    @SerializedName(ApiConstants.DETAILS)
+    @Param(description = "additional key/value details tied with this disk offering", since = "4.17")
+    private Map<String, String> details;
 
     public Boolean getDisplayOffering() {
         return displayOffering;
@@ -374,5 +379,9 @@ public class DiskOfferingResponse extends BaseResponseWithAnnotations {
 
     public void setDiskSizeStrictness(Boolean diskSizeStrictness) {
         this.diskSizeStrictness = diskSizeStrictness;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
     }
 }

--- a/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
@@ -131,6 +131,7 @@ public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, 
         diskOfferingResponse.setCacheMode(offering.getCacheMode());
         diskOfferingResponse.setObjectName("diskoffering");
         Map<String, String> offeringDetails = ApiDBUtils.getResourceDetails(offering.getId(), ResourceTag.ResourceObjectType.DiskOffering);
+        diskOfferingResponse.setDetails(offeringDetails);
         if (offeringDetails != null && !offeringDetails.isEmpty()) {
             String vsphereStoragePolicyId = offeringDetails.get(ApiConstants.STORAGE_POLICY);
             if (vsphereStoragePolicyId != null) {

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3537,7 +3537,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
             if (MapUtils.isNotEmpty(details)) {
                 details.forEach((key, value) -> {
-                    boolean displayDetail = !key.equals(Volume.BANDWIDTH_LIMIT_IN_MBPS) && !key.equals(Volume.IOPS_LIMIT);
+                    boolean displayDetail = !StringUtils.equalsAny(key, Volume.BANDWIDTH_LIMIT_IN_MBPS, Volume.IOPS_LIMIT);
                     detailsVO.add(new DiskOfferingDetailVO(offering.getId(), key, value, displayDetail));
                 });
             }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3535,14 +3535,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     detailsVO.add(new DiskOfferingDetailVO(offering.getId(), ApiConstants.ZONE_ID, String.valueOf(zoneId), false));
                 }
             }
-            if (details != null && !details.isEmpty()) {
-                // Support disk offering details for below parameters
-                if (details.containsKey(Volume.BANDWIDTH_LIMIT_IN_MBPS)) {
-                    detailsVO.add(new DiskOfferingDetailVO(offering.getId(), Volume.BANDWIDTH_LIMIT_IN_MBPS, details.get(Volume.BANDWIDTH_LIMIT_IN_MBPS), false));
-                }
-                if (details.containsKey(Volume.IOPS_LIMIT)) {
-                    detailsVO.add(new DiskOfferingDetailVO(offering.getId(), Volume.IOPS_LIMIT, details.get(Volume.IOPS_LIMIT), false));
-                }
+            if (MapUtils.isNotEmpty(details)) {
+                details.forEach((key, value) -> {
+                    boolean displayDetail = !key.equals(Volume.BANDWIDTH_LIMIT_IN_MBPS) && !key.equals(Volume.IOPS_LIMIT);
+                    detailsVO.add(new DiskOfferingDetailVO(offering.getId(), key, value, displayDetail));
+                });
             }
             if (storagePolicyID != null) {
                 detailsVO.add(new DiskOfferingDetailVO(offering.getId(), ApiConstants.STORAGE_POLICY, String.valueOf(storagePolicyID), false));


### PR DESCRIPTION
Similar to service offering details, allow details to be provided and
displayed. Can be used for classification of offerings, etc.

Signed-off-by: Marcus Sorensen <mls@apple.com>

### Description

This PR relaxes the disk offering details to match the way the service offering details work. With Service offering details, any arbitrary values provided can be saved and displayed, which can be used as metadata to tag, classify, or organize offerings by higher level consumers.  With disk offerings, any detail that isn't recognized is ignored, so this PR relaxes that and persists arbitrary details as well.

Note that with both disk offerings and service offerings, there are a few 'special' detail keys that are marked `display=false` when they are persisted, and this functionality remains intact.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally, properly displays arbitrary details and hides the special details that are marked `display=false` when queried as non-admin user.

```
(localhost) 🐱 > create diskoffering name=test displaytext=test disksize=1 details[0].foo=bar details[0].iopsLimit=200
{
  "diskoffering": {
    "created": "2022-06-15T16:29:17+0000",
    "details": {
      "foo": "bar",
      "iopsLimit": "200"
    },
    "disksize": 1,
    "displayoffering": true,
    "displaytext": "test",
    "hasannotations": false,
    "id": "a9787073-4704-4bdc-a03f-69e514b79926",
    "iscustomized": false,
    "name": "test",
    "provisioningtype": "thin",
    "storagetype": "shared"
  }
}
(localhost) 🐱 > set profile localhost-user
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
Loaded server profile: localhost-user
Url:         http://localhost:8080/client/api
Username:    user
Domain:      /
API Key:
Total APIs:  590

(localhost-user) 🐱 > list diskofferings id=a9787073-4704-4bdc-a03f-69e514b79926
{
  "count": 1,
  "diskoffering": [
    {
      "created": "2022-06-15T16:29:17+0000",
      "details": {
        "foo": "bar"
      },
      "disksize": 1,
      "displayoffering": true,
      "displaytext": "test",
      "hasannotations": false,
      "id": "a9787073-4704-4bdc-a03f-69e514b79926",
      "iscustomized": false,
      "name": "test",
      "provisioningtype": "thin",
      "storagetype": "shared"
    }
  ]
}
```


