### PR TITLE
Fix rpfilter config values from integer to boolean on upgrade path

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41700to41710.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41700to41710.sql
@@ -18,3 +18,6 @@
 --;
 -- Schema upgrade from 4.17.0.0 to 4.17.1.0
 --;
+
+UPDATE `cloud`.`configuration` set `value` = 'false' where `name` = 'network.disable.rpfilter' and `value` != 'true';
+UPDATE `cloud`.`configuration` set `value` = 'false' where `name` = 'consoleproxy.disable.rpfilter' and `value` != 'true';

--- a/engine/schema/src/main/resources/META-INF/db/schema-41700to41710.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41700to41710.sql
@@ -20,4 +20,4 @@
 --;
 
 UPDATE `cloud`.`configuration` SET `value` = 'false' WHERE `name` = 'network.disable.rpfilter' AND `value` != 'true';
-UPDATE `cloud`.`configuration` set `value` = 'false' where `name` = 'consoleproxy.disable.rpfilter' and `value` != 'true';
+UPDATE `cloud`.`configuration` SET `value` = 'false' WHERE `name` = 'consoleproxy.disable.rpfilter' AND `value` != 'true';

--- a/engine/schema/src/main/resources/META-INF/db/schema-41700to41710.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41700to41710.sql
@@ -19,5 +19,5 @@
 -- Schema upgrade from 4.17.0.0 to 4.17.1.0
 --;
 
-UPDATE `cloud`.`configuration` set `value` = 'false' where `name` = 'network.disable.rpfilter' and `value` != 'true';
+UPDATE `cloud`.`configuration` SET `value` = 'false' WHERE `name` = 'network.disable.rpfilter' AND `value` != 'true';
 UPDATE `cloud`.`configuration` set `value` = 'false' where `name` = 'consoleproxy.disable.rpfilter' and `value` != 'true';


### PR DESCRIPTION
### Description

This PR updates the config values for `network.disable.rpfilter` and `consoleproxy.disable.rpfilter` to meet the boolean type set on #6380.
Fixes: #6390 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Upgrade from 4.16.1 successfully:

Before upgrade: Changed only one value, leave the other as default
````
MariaDB [cloud]> select name, value from configuration where name like '%rpfilter';
+-------------------------------+-------+
| name                          | value |
+-------------------------------+-------+
| consoleproxy.disable.rpfilter | 2     |
| network.disable.rpfilter      | true  |
+-------------------------------+-------+
2 rows in set (0.00 sec)

MariaDB [cloud]> select * from version order by id desc limit 1;
+----+----------+---------------------+----------+
| id | version  | updated             | step     |
+----+----------+---------------------+----------+
| 37 | 4.16.1.0 | 2022-06-20 11:49:40 | Complete |
+----+----------+---------------------+----------+
1 row in set (0.00 sec)
````

After the upgrade: only the integer value is properly updated, as expected
````
MariaDB [cloud]> select name, value from configuration where name like '%rpfilter';
+-------------------------------+-------+
| name                          | value |
+-------------------------------+-------+
| consoleproxy.disable.rpfilter | false |
| network.disable.rpfilter      | true  |
+-------------------------------+-------+
2 rows in set (0.00 sec)

MariaDB [cloud]> select * from version order by id desc limit 1;
+----+----------+---------------------+----------+
| id | version  | updated             | step     |
+----+----------+---------------------+----------+
| 39 | 4.17.1.0 | 2022-06-23 12:14:14 | Complete |
+----+----------+---------------------+----------+
1 row in set (0.00 sec)
````