### PR TITLE
UI primarystorage linstor fixes

### DIFF
--- a/ui/src/views/infra/AddPrimaryStorage.vue
+++ b/ui/src/views/infra/AddPrimaryStorage.vue
@@ -209,24 +209,26 @@
             <a-input v-model:value="form.vCenterDataStore" :placeholder="$t('message.datastore.description')"/>
           </a-form-item>
         </div>
-        <a-form-item name="provider" ref="provider">
-          <template #label>
-            <tooltip-label :title="$t('label.providername')" :tooltip="apiParams.provider.description"/>
-          </template>
-          <a-select
-            v-model:value="form.provider"
-            @change="updateProviderAndProtocol"
-            showSearch
-            optionFilterProp="label"
-            :filterOption="(input, option) => {
-              return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
-            }"
-            :placeholder="apiParams.provider.description">
-            <a-select-option :value="provider" v-for="(provider,idx) in providers" :key="idx">
-              {{ provider }}
-            </a-select-option>
-          </a-select>
-        </a-form-item>
+        <div v-if="form.protocol !== 'Linstor'">
+          <a-form-item name="provider" ref="provider">
+            <template #label>
+              <tooltip-label :title="$t('label.providername')" :tooltip="apiParams.provider.description"/>
+            </template>
+            <a-select
+              v-model:value="form.provider"
+              @change="updateProviderAndProtocol"
+              showSearch
+              optionFilterProp="label"
+              :filterOption="(input, option) => {
+                return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+              }"
+              :placeholder="apiParams.provider.description">
+              <a-select-option :value="provider" v-for="(provider,idx) in providers" :key="idx">
+                {{ provider }}
+              </a-select-option>
+            </a-select>
+          </a-form-item>
+        </div>
         <div v-if="form.provider !== 'DefaultPrimary' && form.provider !== 'PowerFlex' && form.provider !== 'Linstor'">
           <a-form-item name="managed" ref="managed">
             <template #label>

--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -1343,6 +1343,7 @@ export default {
         url = this.rbdURL(rbdmonitor, rbdpool, rbdid, rbdsecret)
       } else if (protocol === 'Linstor') {
         url = this.linstorURL(server)
+        params.provider = 'Linstor'
         params['details[0].resourceGroup'] = this.prefillContent.primaryStorageLinstorResourceGroup
       } else if (protocol === 'vmfs' || protocol === 'datastorecluster') {
         let path = this.prefillContent.primaryStorageVmfsDatacenter


### PR DESCRIPTION
### Description
If Linstor protocol is selected it makes no sense to show other
providers as Linstor only works with the Linstor provider.
And also the install wizard doesn't use the correct provider for linstor.

This changes were already merged for 4.16.1.0 see: https://github.com/apache/cloudstack/pull/5672
But I don't know why they weren't merged to `main` back than, maybe I don't know how cloudstack's
merge/PR's work.
But this should be definitely merged to 4.17.* and main

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Clicked through local served vui ui -> add primary storage


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
