### PR TITLE
UI fix message.add.vpn.customer.gateway.failed when catched error

### DIFF
--- a/ui/src/views/network/CreateVpnCustomerGateway.vue
+++ b/ui/src/views/network/CreateVpnCustomerGateway.vue
@@ -341,7 +341,7 @@ export default {
           this.formRef.value.resetFields()
         }).catch(error => {
           console.error(error)
-          this.$message.error(this.$t('message.success.add.vpn.customer.gateway'))
+          this.$message.error(this.$t('message.add.vpn.customer.gateway.failed'))
           this.isSubmitted = false
         })
       }).catch(error => {

--- a/ui/src/views/network/VpcTab.vue
+++ b/ui/src/views/network/VpcTab.vue
@@ -822,7 +822,6 @@ export default {
     handleNetworkAclFormSubmit () {
       if (this.fetchLoading) return
       this.fetchLoading = true
-      //this.modals.networkAcl = false
 
       this.formRef.value.validate().then(() => {
         const values = toRaw(this.form)

--- a/ui/src/views/network/VpcTab.vue
+++ b/ui/src/views/network/VpcTab.vue
@@ -822,7 +822,7 @@ export default {
     handleNetworkAclFormSubmit () {
       if (this.fetchLoading) return
       this.fetchLoading = true
-      this.modals.networkAcl = false
+      //this.modals.networkAcl = false
 
       this.formRef.value.validate().then(() => {
         const values = toRaw(this.form)
@@ -852,6 +852,7 @@ export default {
         }).catch(error => {
           this.$notifyError(error)
         }).finally(() => {
+          this.modals.networkAcl = false
           this.fetchLoading = false
           this.fetchAclList()
         })


### PR DESCRIPTION
### Description

As 4.17.0.0,when catched error, we changed message.success.add.vpn.customer.gateway to
message.add.vpn.customer.gateway.failed.

fix UI VPC add ACL without required input close ui
Without any input, click ok button then close the ui . We need display ui to confirm all required input.

changed the base branch of the PR to 4.17 and rebase your PR branch to the 4.17 branch
link  #6489

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

