### PR TITLE
Fix global setting reference for max secondary storage

### DIFF
--- a/api/src/main/java/com/cloud/user/ResourceLimitService.java
+++ b/api/src/main/java/com/cloud/user/ResourceLimitService.java
@@ -30,7 +30,7 @@ public interface ResourceLimitService {
     static final ConfigKey<Long> MaxAccountSecondaryStorage = new ConfigKey<Long>("Account Defaults", Long.class, "max.account.secondary.storage", "400",
             "The default maximum secondary storage space (in GiB) that can be used for an account", false);
     static final ConfigKey<Long> MaxProjectSecondaryStorage = new ConfigKey<Long>("Project Defaults", Long.class, "max.project.secondary.storage", "400",
-            "The default maximum secondary storage space (in GiB) that can be used for an project", false);
+            "The default maximum secondary storage space (in GiB) that can be used for a project", false);
     static final ConfigKey<Long> ResourceCountCheckInterval = new ConfigKey<Long>("Advanced", Long.class, "resourcecount.check.interval", "300",
             "Time (in seconds) to wait before running resource recalculation and fixing task. Default is 300 seconds, Setting this to 0 disables execution of the task", false);
 

--- a/api/src/main/java/com/cloud/user/ResourceLimitService.java
+++ b/api/src/main/java/com/cloud/user/ResourceLimitService.java
@@ -27,6 +27,10 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface ResourceLimitService {
 
+    static final ConfigKey<Long> MaxAccountSecondaryStorage = new ConfigKey<Long>("Account Defaults", Long.class, "max.account.secondary.storage", "400",
+            "The default maximum secondary storage space (in GiB) that can be used for an account", false);
+    static final ConfigKey<Long> MaxProjectSecondaryStorage = new ConfigKey<Long>("Project Defaults", Long.class, "max.project.secondary.storage", "400",
+            "The default maximum secondary storage space (in GiB) that can be used for an project", false);
     static final ConfigKey<Long> ResourceCountCheckInterval = new ConfigKey<Long>("Advanced", Long.class, "resourcecount.check.interval", "300",
             "Time (in seconds) to wait before running resource recalculation and fixing task. Default is 300 seconds, Setting this to 0 disables execution of the task", false);
 

--- a/api/src/main/java/com/cloud/user/ResourceLimitService.java
+++ b/api/src/main/java/com/cloud/user/ResourceLimitService.java
@@ -27,11 +27,11 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface ResourceLimitService {
 
-    static final ConfigKey<Long> MaxAccountSecondaryStorage = new ConfigKey<Long>("Account Defaults", Long.class, "max.account.secondary.storage", "400",
+    static final ConfigKey<Long> MaxAccountSecondaryStorage = new ConfigKey<>("Account Defaults", Long.class, "max.account.secondary.storage", "400",
             "The default maximum secondary storage space (in GiB) that can be used for an account", false);
-    static final ConfigKey<Long> MaxProjectSecondaryStorage = new ConfigKey<Long>("Project Defaults", Long.class, "max.project.secondary.storage", "400",
+    static final ConfigKey<Long> MaxProjectSecondaryStorage = new ConfigKey<>("Project Defaults", Long.class, "max.project.secondary.storage", "400",
             "The default maximum secondary storage space (in GiB) that can be used for a project", false);
-    static final ConfigKey<Long> ResourceCountCheckInterval = new ConfigKey<Long>("Advanced", Long.class, "resourcecount.check.interval", "300",
+    static final ConfigKey<Long> ResourceCountCheckInterval = new ConfigKey<>("Advanced", Long.class, "resourcecount.check.interval", "300",
             "Time (in seconds) to wait before running resource recalculation and fixing task. Default is 300 seconds, Setting this to 0 disables execution of the task", false);
 
     /**

--- a/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
@@ -49,7 +49,7 @@ public class TemplateOrVolumePostUploadCommand {
 
     String description;
 
-    private String defaultMaxSecondaryStorageInGB;
+    private long defaultMaxSecondaryStorageInGB;
 
     private long processTimeout;
 
@@ -185,11 +185,11 @@ public class TemplateOrVolumePostUploadCommand {
         this.description = description;
     }
 
-    public void setDefaultMaxSecondaryStorageInGB(String defaultMaxSecondaryStorageInGB) {
+    public void setDefaultMaxSecondaryStorageInGB(long defaultMaxSecondaryStorageInGB) {
         this.defaultMaxSecondaryStorageInGB = defaultMaxSecondaryStorageInGB;
     }
 
-    public String getDefaultMaxSecondaryStorageInGB() {
+    public long getDefaultMaxSecondaryStorageInGB() {
         return defaultMaxSecondaryStorageInGB;
     }
 

--- a/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
@@ -49,7 +49,7 @@ public class TemplateOrVolumePostUploadCommand {
 
     String description;
 
-    private String defaultMaxSecondaryStorage;
+    private String defaultMaxSecondaryStorageInGB;
 
     private long processTimeout;
 
@@ -185,12 +185,12 @@ public class TemplateOrVolumePostUploadCommand {
         this.description = description;
     }
 
-    public void setDefaultMaxSecondaryStorage(String defaultMaxSecondaryStorage) {
-        this.defaultMaxSecondaryStorage = defaultMaxSecondaryStorage;
+    public void setDefaultMaxSecondaryStorageInGB(String defaultMaxSecondaryStorageInGB) {
+        this.defaultMaxSecondaryStorageInGB = defaultMaxSecondaryStorageInGB;
     }
 
-    public String getDefaultMaxSecondaryStorage() {
-        return defaultMaxSecondaryStorage;
+    public String getDefaultMaxSecondaryStorageInGB() {
+        return defaultMaxSecondaryStorageInGB;
     }
 
     public void setAccountId(long accountId) {

--- a/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
@@ -49,7 +49,7 @@ public class TemplateOrVolumePostUploadCommand {
 
     String description;
 
-    private String defaultMaxAccountSecondaryStorage;
+    private String defaultMaxSecondaryStorage;
 
     private long processTimeout;
 
@@ -185,12 +185,12 @@ public class TemplateOrVolumePostUploadCommand {
         this.description = description;
     }
 
-    public void setDefaultMaxAccountSecondaryStorage(String defaultMaxAccountSecondaryStorage) {
-        this.defaultMaxAccountSecondaryStorage = defaultMaxAccountSecondaryStorage;
+    public void setDefaultMaxSecondaryStorage(String defaultMaxSecondaryStorage) {
+        this.defaultMaxSecondaryStorage = defaultMaxSecondaryStorage;
     }
 
-    public String getDefaultMaxAccountSecondaryStorage() {
-        return defaultMaxAccountSecondaryStorage;
+    public String getDefaultMaxSecondaryStorage() {
+        return defaultMaxSecondaryStorage;
     }
 
     public void setAccountId(long accountId) {

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -1361,14 +1361,6 @@ public enum Config {
             "200",
             "The default maximum primary storage space (in GiB) that can be used for an account",
             null),
-    DefaultMaxAccountSecondaryStorage(
-            "Account Defaults",
-            ManagementServer.class,
-            Long.class,
-            "max.account.secondary.storage",
-            "400",
-            "The default maximum secondary storage space (in GiB) that can be used for an account",
-            null),
 
     //disabling lb as cluster sync does not work with distributed cluster
     SubDomainNetworkAccess(
@@ -1496,14 +1488,6 @@ public enum Config {
             "max.project.primary.storage",
             "200",
             "The default maximum primary storage space (in GiB) that can be used for an project",
-            null),
-    DefaultMaxProjectSecondaryStorage(
-            "Project Defaults",
-            ManagementServer.class,
-            Long.class,
-            "max.project.secondary.storage",
-            "400",
-            "The default maximum secondary storage space (in GiB) that can be used for an project",
             null),
 
     ProjectInviteRequired(

--- a/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -226,7 +226,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
             projectResourceLimitMap.put(Resource.ResourceType.cpu, Long.parseLong(_configDao.getValue(Config.DefaultMaxProjectCpus.key())));
             projectResourceLimitMap.put(Resource.ResourceType.memory, Long.parseLong(_configDao.getValue(Config.DefaultMaxProjectMemory.key())));
             projectResourceLimitMap.put(Resource.ResourceType.primary_storage, Long.parseLong(_configDao.getValue(Config.DefaultMaxProjectPrimaryStorage.key())));
-            projectResourceLimitMap.put(Resource.ResourceType.secondary_storage, Long.parseLong(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key())));
+            projectResourceLimitMap.put(Resource.ResourceType.secondary_storage, MaxProjectSecondaryStorage.value());
 
             accountResourceLimitMap.put(Resource.ResourceType.public_ip, Long.parseLong(_configDao.getValue(Config.DefaultMaxAccountPublicIPs.key())));
             accountResourceLimitMap.put(Resource.ResourceType.snapshot, Long.parseLong(_configDao.getValue(Config.DefaultMaxAccountSnapshots.key())));
@@ -238,7 +238,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
             accountResourceLimitMap.put(Resource.ResourceType.cpu, Long.parseLong(_configDao.getValue(Config.DefaultMaxAccountCpus.key())));
             accountResourceLimitMap.put(Resource.ResourceType.memory, Long.parseLong(_configDao.getValue(Config.DefaultMaxAccountMemory.key())));
             accountResourceLimitMap.put(Resource.ResourceType.primary_storage, Long.parseLong(_configDao.getValue(Config.DefaultMaxAccountPrimaryStorage.key())));
-            accountResourceLimitMap.put(Resource.ResourceType.secondary_storage, Long.parseLong(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key())));
+            accountResourceLimitMap.put(Resource.ResourceType.secondary_storage, MaxAccountSecondaryStorage.value());
 
             domainResourceLimitMap.put(Resource.ResourceType.public_ip, Long.parseLong(_configDao.getValue(Config.DefaultMaxDomainPublicIPs.key())));
             domainResourceLimitMap.put(Resource.ResourceType.snapshot, Long.parseLong(_configDao.getValue(Config.DefaultMaxDomainSnapshots.key())));
@@ -1100,7 +1100,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ResourceCountCheckInterval};
+        return new ConfigKey<?>[] {ResourceCountCheckInterval, MaxAccountSecondaryStorage, MaxProjectSecondaryStorage};
     }
 
     protected class ResourceCountCheckTask extends ManagedContextRunnable {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -456,8 +456,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 //using the existing max upload size configuration
                 command.setProcessTimeout(NumbersUtil.parseLong(_configDao.getValue("vmware.package.ova.timeout"), 3600));
                 command.setMaxUploadSize(_configDao.getValue(Config.MaxUploadVolumeSize.key()));
-                command.setDefaultMaxAccountSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                 command.setAccountId(vol.getAccountId());
+                Account account = _accountDao.findById(vol.getAccountId());
+                if (account.getType().equals(Account.Type.PROJECT)) {
+                    command.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
+                } else {
+                    command.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                }
                 Gson gson = new GsonBuilder().create();
                 String metadata = EncryptionUtil.encodeData(gson.toJson(command), key);
                 response.setMetadata(metadata);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -459,9 +459,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 command.setAccountId(vol.getAccountId());
                 Account account = _accountDao.findById(vol.getAccountId());
                 if (account.getType().equals(Account.Type.PROJECT)) {
-                    command.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
+                    command.setDefaultMaxSecondaryStorageInGB(ResourceLimitService.MaxProjectSecondaryStorage.value());
                 } else {
-                    command.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                    command.setDefaultMaxSecondaryStorageInGB(ResourceLimitService.MaxAccountSecondaryStorage.value());
                 }
                 Gson gson = new GsonBuilder().create();
                 String metadata = EncryptionUtil.encodeData(gson.toJson(command), key);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -459,9 +459,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 command.setAccountId(vol.getAccountId());
                 Account account = _accountDao.findById(vol.getAccountId());
                 if (account.getType().equals(Account.Type.PROJECT)) {
-                    command.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
+                    command.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
                 } else {
-                    command.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                    command.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                 }
                 Gson gson = new GsonBuilder().create();
                 String metadata = EncryptionUtil.encodeData(gson.toJson(command), key);

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -93,6 +93,7 @@ import com.cloud.storage.dao.VMTemplateZoneDao;
 import com.cloud.storage.download.DownloadMonitor;
 import com.cloud.template.VirtualMachineTemplate.State;
 import com.cloud.user.Account;
+import com.cloud.user.ResourceLimitService;
 import com.cloud.utils.Pair;
 import com.cloud.utils.UriUtils;
 import com.cloud.utils.db.DB;
@@ -398,13 +399,12 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
                             templateOnStore.getDataStore().getRole().toString());
                     //using the existing max template size configuration
                     payload.setMaxUploadSize(_configDao.getValue(Config.MaxTemplateAndIsoSize.key()));
-                    payload.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                     payload.setAccountId(template.getAccountId());
                     Account account = _accountDao.findById(template.getAccountId());
                     if (account.getType().equals(Account.Type.PROJECT)) {
-                        payload.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
+                        payload.setDefaultMaxSecondaryStorageInGB(ResourceLimitService.MaxProjectSecondaryStorage.value());
                     } else {
-                        payload.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                        payload.setDefaultMaxSecondaryStorageInGB(ResourceLimitService.MaxAccountSecondaryStorage.value());
                     }
                     payload.setRemoteEndPoint(ep.getPublicAddr());
                     payload.setRequiresHvm(template.requiresHvm());

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -398,13 +398,13 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
                             templateOnStore.getDataStore().getRole().toString());
                     //using the existing max template size configuration
                     payload.setMaxUploadSize(_configDao.getValue(Config.MaxTemplateAndIsoSize.key()));
-                    payload.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                    payload.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                     payload.setAccountId(template.getAccountId());
                     Account account = _accountDao.findById(template.getAccountId());
                     if (account.getType().equals(Account.Type.PROJECT)) {
-                        payload.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
+                        payload.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
                     } else {
-                        payload.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                        payload.setDefaultMaxSecondaryStorageInGB(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                     }
                     payload.setRemoteEndPoint(ep.getPublicAddr());
                     payload.setRequiresHvm(template.requiresHvm());

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -398,8 +398,14 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
                             templateOnStore.getDataStore().getRole().toString());
                     //using the existing max template size configuration
                     payload.setMaxUploadSize(_configDao.getValue(Config.MaxTemplateAndIsoSize.key()));
-                    payload.setDefaultMaxAccountSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                    payload.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                     payload.setAccountId(template.getAccountId());
+                    Account account = _accountDao.findById(template.getAccountId());
+                    if (account.getType().equals(Account.Type.PROJECT)) {
+                        payload.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxProjectSecondaryStorage.key()));
+                    } else {
+                        payload.setDefaultMaxSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
+                    }
                     payload.setRemoteEndPoint(ep.getPublicAddr());
                     payload.setRequiresHvm(template.requiresHvm());
                     payload.setDescription(template.getDisplayText());

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -3275,7 +3275,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 "accountTemplateDirSize: " + accountTemplateDirSize + " accountSnapshotDirSize: " + accountSnapshotDirSize + " accountVolumeDirSize: " + accountVolumeDirSize);
 
         int accountDirSizeInGB = getSizeInGB(accountTemplateDirSize + accountSnapshotDirSize + accountVolumeDirSize);
-        int defaultMaxSecondaryStorageInGB = Integer.parseInt(cmd.getDefaultMaxSecondaryStorageInGB());
+        long defaultMaxSecondaryStorageInGB = cmd.getDefaultMaxSecondaryStorageInGB();
 
         if (defaultMaxSecondaryStorageInGB != Resource.RESOURCE_UNLIMITED && (accountDirSizeInGB + contentLengthInGB) > defaultMaxSecondaryStorageInGB) {
             s_logger.error("accountDirSizeInGb: " + accountDirSizeInGB + " defaultMaxSecondaryStorageInGB: " + defaultMaxSecondaryStorageInGB + " contentLengthInGB:"

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -3275,7 +3275,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 "accountTemplateDirSize: " + accountTemplateDirSize + " accountSnapshotDirSize: " + accountSnapshotDirSize + " accountVolumeDirSize: " + accountVolumeDirSize);
 
         int accountDirSizeInGB = getSizeInGB(accountTemplateDirSize + accountSnapshotDirSize + accountVolumeDirSize);
-        int defaultMaxSecondaryStorageInGB = Integer.parseInt(cmd.getDefaultMaxSecondaryStorage());
+        int defaultMaxSecondaryStorageInGB = Integer.parseInt(cmd.getDefaultMaxSecondaryStorageInGB());
 
         if (defaultMaxSecondaryStorageInGB != Resource.RESOURCE_UNLIMITED && (accountDirSizeInGB + contentLengthInGB) > defaultMaxSecondaryStorageInGB) {
             s_logger.error("accountDirSizeInGb: " + accountDirSizeInGB + " defaultMaxSecondaryStorageInGB: " + defaultMaxSecondaryStorageInGB + " contentLengthInGB:"

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -3275,12 +3275,12 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 "accountTemplateDirSize: " + accountTemplateDirSize + " accountSnapshotDirSize: " + accountSnapshotDirSize + " accountVolumeDirSize: " + accountVolumeDirSize);
 
         int accountDirSizeInGB = getSizeInGB(accountTemplateDirSize + accountSnapshotDirSize + accountVolumeDirSize);
-        int defaultMaxAccountSecondaryStorageInGB = Integer.parseInt(cmd.getDefaultMaxAccountSecondaryStorage());
+        int defaultMaxSecondaryStorageInGB = Integer.parseInt(cmd.getDefaultMaxSecondaryStorage());
 
-        if (defaultMaxAccountSecondaryStorageInGB != Resource.RESOURCE_UNLIMITED && (accountDirSizeInGB + contentLengthInGB) > defaultMaxAccountSecondaryStorageInGB) {
-            s_logger.error("accountDirSizeInGb: " + accountDirSizeInGB + " defaultMaxAccountSecondaryStorageInGB: " + defaultMaxAccountSecondaryStorageInGB + " contentLengthInGB:"
+        if (defaultMaxSecondaryStorageInGB != Resource.RESOURCE_UNLIMITED && (accountDirSizeInGB + contentLengthInGB) > defaultMaxSecondaryStorageInGB) {
+            s_logger.error("accountDirSizeInGb: " + accountDirSizeInGB + " defaultMaxSecondaryStorageInGB: " + defaultMaxSecondaryStorageInGB + " contentLengthInGB:"
                     + contentLengthInGB); // extra attention
-            String errorMessage = "Maximum number of resources of type secondary_storage for account has exceeded";
+            String errorMessage = "Maximum number of resources of type secondary_storage for account/project has exceeded";
             updateStateMapWithError(cmd.getEntityUUID(), errorMessage);
             throw new InvalidParameterValueException(errorMessage);
         }


### PR DESCRIPTION
This PR fixes issue #6411 

There are two global settings max.account.secondary.storage and max.project.secondary.storage to specify maximum secondary storage space (in GiB) that can be used for an account and project respectively.

But during upload template from project is not considering max.project.secondary.storage but uses max.account.secondary.storage.

We have fixed this here to use max.project.secondary.storage in case of project.

### Description
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Uploaded a template from both account and project and observed using appropriate global settings.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
