### PR TITLE
externalizes used protocol to upload isos, volumes and templates

### DIFF
--- a/api/src/main/java/com/cloud/storage/VolumeApiService.java
+++ b/api/src/main/java/com/cloud/storage/VolumeApiService.java
@@ -46,6 +46,14 @@ public interface VolumeApiService {
             , true // not sure if this is to be dynamic
             , ConfigKey.Scope.Global);
 
+    ConfigKey<Boolean> UseHttpsToUpload = new ConfigKey<Boolean>("Advanced",
+            Boolean.class,
+            "use.https.to.upload",
+            "true",
+            "Determines the protocol (HTTPS or HTTP) ACS will use to generate links to upload ISOs, volumes, and templates. When set as 'true', ACS will use protocol HTTPS, otherwise, it will use protocol HTTP. Default value is 'true'.",
+            true,
+            ConfigKey.Scope.StoragePool);
+
     /**
      * Creates the database object for a volume based on the given criteria
      *

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -429,8 +429,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 GetUploadParamsResponse response = new GetUploadParamsResponse();
 
                 String ssvmUrlDomain = _configDao.getValue(Config.SecStorageSecureCopyCert.key());
+                String protocol = UseHttpsToUpload.value() ? "https" : "http";
 
-                String url = ImageStoreUtil.generatePostUploadUrl(ssvmUrlDomain, ep.getPublicAddr(), vol.getUuid());
+                String url = ImageStoreUtil.generatePostUploadUrl(ssvmUrlDomain, ep.getPublicAddr(), vol.getUuid(),  protocol);
                 response.setPostURL(new URL(url));
 
                 // set the post url, this is used in the monitoring thread to determine the SSVM
@@ -4440,6 +4441,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ConcurrentMigrationsThresholdPerDatastore, AllowUserExpungeRecoverVolume, MatchStoragePoolTagsWithDiskOffering};
+        return new ConfigKey<?>[] {ConcurrentMigrationsThresholdPerDatastore, AllowUserExpungeRecoverVolume, MatchStoragePoolTagsWithDiskOffering, UseHttpsToUpload};
     }
 }

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.storage.VolumeApiService;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseListTemplateOrIsoPermissionsCmd;
@@ -379,8 +380,9 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             TemplateOrVolumePostUploadCommand firstCommand = payload.get(0);
 
             String ssvmUrlDomain = _configDao.getValue(Config.SecStorageSecureCopyCert.key());
+            String protocol = VolumeApiService.UseHttpsToUpload.value() ? "https" : "http";
 
-            String url = ImageStoreUtil.generatePostUploadUrl(ssvmUrlDomain, firstCommand.getRemoteEndPoint(), firstCommand.getEntityUUID());
+            String url = ImageStoreUtil.generatePostUploadUrl(ssvmUrlDomain, firstCommand.getRemoteEndPoint(), firstCommand.getEntityUUID(), protocol);
             response.setPostURL(new URL(url));
 
             // set the post url, this is used in the monitoring thread to determine the SSVM

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.storage.VolumeApiService;
 import com.cloud.utils.PasswordGenerator;
 import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.ca.CAManager;
@@ -1173,6 +1174,10 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         if (s_logger.isDebugEnabled()) {
             s_logger.debug(String.format("Boot args for machine profile [%s]: [%s].", profile.toString(), bootArgs));
         }
+
+        boolean useHttpsToUpload = BooleanUtils.toBooleanDefaultIfNull(VolumeApiService.UseHttpsToUpload.value(), true);
+        s_logger.debug(String.format("Setting UseHttpsToUpload config on cmdline with [%s] value.", useHttpsToUpload));
+        buf.append(" useHttpsToUpload=").append(useHttpsToUpload);
 
         return true;
     }

--- a/systemvm/debian/etc/apache2/vhost.template
+++ b/systemvm/debian/etc/apache2/vhost.template
@@ -39,6 +39,9 @@
         Allow from 127.0.0.0/255.0.0.0 ::1/128
     </Directory>
 
+    # Include HTTP configuration **IF SET**
+    IncludeOptional /etc/apache2/http.conf
+
 </VirtualHost>
 
 <IfModule mod_ssl.c>
@@ -83,8 +86,8 @@
 		Allow from 127.0.0.0/255.0.0.0 ::1/128
 	</Directory>
 
-	# Include CORS configuration **IF SET**
-	IncludeOptional /etc/apache2/[cC][oO][rR][sS].conf
+	# Include HTTPS configuration **IF SET**
+	IncludeOptional /etc/apache2/https.conf
 
 	#   SSL Engine Switch:
 	#   Enable/Disable SSL for this virtual host.

--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -882,6 +882,9 @@ parse_cmd_line() {
         privatekey)
           export PRIVATEKEY=$VALUE
           ;;
+        useHttpsToUpload)
+          export USEHTTPS=$VALUE
+          ;;
       esac
   done
   echo -e "\n\t}\n}" >> ${CHEF_TMP_FILE}

--- a/systemvm/debian/opt/cloud/bin/setup/secstorage.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/secstorage.sh
@@ -50,7 +50,11 @@ setup_secstorage() {
   a2enmod proxy_http
   a2enmod headers
 
-  cat >/etc/apache2/cors.conf <<CORS
+  if [ -z $USEHTTPS ] | $USEHTTPS ; then
+    if [ -f /etc/apache2/http.conf ]; then
+      rm -rf /etc/apache2/http.conf
+    fi
+      cat >/etc/apache2/https.conf <<HTTPS
 RewriteEngine On
 RewriteCond %{HTTPS} =on
 RewriteCond %{REQUEST_METHOD} =POST
@@ -58,7 +62,21 @@ RewriteRule ^/upload/(.*) http://127.0.0.1:8210/upload?uuid=\$1 [P,L]
 Header always set Access-Control-Allow-Origin "*"
 Header always set Access-Control-Allow-Methods "POST, OPTIONS"
 Header always set Access-Control-Allow-Headers "x-requested-with, Content-Type, origin, authorization, accept, client-security-token, x-signature, x-metadata, x-expires"
-CORS
+HTTPS
+  else
+    if [ -f /etc/apache2/https.conf ]; then
+      rm -rf /etc/apache2/https.conf
+    fi
+      cat >/etc/apache2/http.conf <<HTTP
+RewriteEngine On
+RewriteCond %{REQUEST_METHOD} =POST
+RewriteRule ^/upload/(.*) http://127.0.0.1:8210/upload?uuid=\$1 [P,L]
+Header always set Access-Control-Allow-Origin "*"
+Header always set Access-Control-Allow-Methods "POST, OPTIONS"
+Header always set Access-Control-Allow-Headers "x-requested-with, Content-Type, origin, authorization, accept, client-security-token, x-signature, x-metadata, x-expires"
+HTTP
+  fi
+
 
   disable_rpfilter
   enable_fwding 0

--- a/utils/src/main/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtil.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtil.java
@@ -26,7 +26,7 @@ import org.apache.log4j.Logger;
 public class ImageStoreUtil {
     public static final Logger s_logger = Logger.getLogger(ImageStoreUtil.class.getName());
 
-    public static String generatePostUploadUrl(String ssvmUrlDomain, String ipAddress, String uuid) {
+    public static String generatePostUploadUrl(String ssvmUrlDomain, String ipAddress, String uuid, String protocol) {
         String hostname = ipAddress;
 
         //if ssvm url domain is present, use it to construct hostname in the format 1-2-3-4.domain
@@ -39,7 +39,7 @@ public class ImageStoreUtil {
         }
 
         //only https works with postupload and url format is fixed
-        return "https://" + hostname + "/upload/" + uuid;
+        return String.format("%s://%s/upload/%s", protocol, hostname, uuid);
     }
 
     // given a path, returns empty if path is supported image, and the file type if unsupported

--- a/utils/src/test/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtilTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtilTest.java
@@ -26,29 +26,52 @@ import org.junit.Test;
 public class ImageStoreUtilTest {
 
     @Test
-    public void testgeneratePostUploadUrl() throws MalformedURLException {
+    public void testgenerateHttpsPostUploadUrl() throws MalformedURLException {
         String ssvmdomain = "*.realhostip.com";
         String ipAddress = "10.147.28.14";
         String uuid = UUID.randomUUID().toString();
+        String protocol = "https";
 
         //ssvm domain is not set
-        String url = ImageStoreUtil.generatePostUploadUrl(null, ipAddress, uuid);
-        assertPostUploadUrl(url, ipAddress, uuid);
+        String url = ImageStoreUtil.generatePostUploadUrl(null, ipAddress, uuid, protocol);
+        assertPostUploadUrl(url, ipAddress, uuid, protocol);
 
         //ssvm domain is set to empty value
-        url = ImageStoreUtil.generatePostUploadUrl("", ipAddress, uuid);
-        assertPostUploadUrl(url, ipAddress, uuid);
+        url = ImageStoreUtil.generatePostUploadUrl("", ipAddress, uuid, protocol);
+        assertPostUploadUrl(url, ipAddress, uuid, protocol);
 
         //ssvm domain is set to a valid value
-        url = ImageStoreUtil.generatePostUploadUrl(ssvmdomain, ipAddress, uuid);
-        assertPostUploadUrl(url, ipAddress.replace(".", "-") + ssvmdomain.substring(1), uuid);
+        url = ImageStoreUtil.generatePostUploadUrl(ssvmdomain, ipAddress, uuid, protocol);
+        assertPostUploadUrl(url, ipAddress.replace(".", "-") + ssvmdomain.substring(1), uuid, protocol);
     }
 
-    private void assertPostUploadUrl(String urlStr, String domain, String uuid) throws MalformedURLException {
+    @Test
+    public void testgenerateHttpPostUploadUrl() throws MalformedURLException {
+        String ssvmdomain = "*.realhostip.com";
+        String ipAddress = "10.147.28.14";
+        String uuid = UUID.randomUUID().toString();
+        String protocol = "http";
+
+        //ssvm domain is not set
+        String url = ImageStoreUtil.generatePostUploadUrl(null, ipAddress, uuid, protocol);
+        assertPostUploadUrl(url, ipAddress, uuid, protocol);
+
+        //ssvm domain is set to empty value
+        url = ImageStoreUtil.generatePostUploadUrl("", ipAddress, uuid, protocol);
+        assertPostUploadUrl(url, ipAddress, uuid, protocol);
+
+        //ssvm domain is set to a valid value
+        url = ImageStoreUtil.generatePostUploadUrl(ssvmdomain, ipAddress, uuid, protocol);
+        assertPostUploadUrl(url, ipAddress.replace(".", "-") + ssvmdomain.substring(1), uuid, protocol);
+    }
+
+    private void assertPostUploadUrl(String urlStr, String domain, String uuid, String protocol) throws MalformedURLException {
         URL url = new URL(urlStr);
         Assert.assertNotNull(url);
         Assert.assertEquals(url.getHost(), domain);
         Assert.assertEquals(url.getPath(), "/upload/" + uuid);
+        Assert.assertEquals(url.getProtocol(), protocol);
     }
+
 
 }


### PR DESCRIPTION
### Description

CloudStack has the functionality to upload volumes, templates, and local ISOs. To execute the process, ACS generates a link to the secondary storage (using its public IPs), where the resource must be sent. The *links* are always generated with the HTTPS protocol and the environment has to be configured to handle HTTPS, requiring us to have SSL certificates. However, for environments that do not need to use certificates (such as staging ones), via the UI, we need a workaround (get the URL generated by the API for generating upload links, open it in a new tab, and accept an insecure connection with the application).  

The ACS was changed so that it also handles HTTP to upload volumes/images/ISOs according to the global configuration `use.https.to.upload`; then operators can choose whether to use the HTTPS or HTTP protocol to generate upload links. By default (true) HTTPS will be used.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
In order to test the behavior, the value of the `use.https.to.upload` configuration was changed to `FALSE` and then checked if the upload of ISOs, volumes, and templates was carried out using the HTTP protocol.
