### PR TITLE
[KVM] Skip volumes on shared storage when live migrating VM with local volumes (root / datadisk)

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -573,7 +573,7 @@ public class LibvirtVMDef {
             }
         }
 
-        enum DiskType {
+        public enum DiskType {
             FILE("file"), BLOCK("block"), DIRECTROY("dir"), NETWORK("network");
             String _diskType;
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
@@ -37,7 +37,7 @@ public class MigrateKVMAsync implements Callable<Domain> {
     private String dxml = "";
     private String vmName = "";
     private String destIp = "";
-    private String rootDiskDiskDeviceLabel = null;
+    private String rootDiskDiskDevicesLabels = null;
     private boolean migrateStorage;
     private boolean migrateNonSharedInc;
     private boolean autoConvergence;
@@ -94,7 +94,7 @@ public class MigrateKVMAsync implements Callable<Domain> {
 
     public MigrateKVMAsync(final LibvirtComputingResource libvirtComputingResource, final Domain dm, final Connect dconn, final String dxml,
             final boolean migrateStorage, final boolean migrateNonSharedInc, final boolean autoConvergence, final String vmName, final String destIp,
-            final String rootDiskDiskDeviceLabel) {
+            final String rootDiskDiskDevicesLabels) {
         this.libvirtComputingResource = libvirtComputingResource;
 
         this.dm = dm;
@@ -105,7 +105,7 @@ public class MigrateKVMAsync implements Callable<Domain> {
         this.autoConvergence = autoConvergence;
         this.vmName = vmName;
         this.destIp = destIp;
-        this.rootDiskDiskDeviceLabel = rootDiskDiskDeviceLabel;
+        this.rootDiskDiskDevicesLabels = rootDiskDiskDevicesLabels;
     }
 
     @Override
@@ -130,8 +130,8 @@ public class MigrateKVMAsync implements Callable<Domain> {
             flags |= VIR_MIGRATE_AUTO_CONVERGE;
         }
 
-        if (StringUtils.isNotBlank(rootDiskDiskDeviceLabel) && migrateStorage && !migrateNonSharedInc) {
-            return migrateRootDisk(flags, rootDiskDiskDeviceLabel, destUri);
+        if (StringUtils.isNotBlank(rootDiskDiskDevicesLabels) && migrateStorage && !migrateNonSharedInc) {
+            return migrateRootDisk(flags, rootDiskDiskDevicesLabels, destUri);
         }
         return dm.migrate(dconn, flags, dxml, vmName, destUri, libvirtComputingResource.getMigrateSpeed());
     }
@@ -141,14 +141,14 @@ public class MigrateKVMAsync implements Callable<Domain> {
      * VIR_MIGRATE_NON_SHARED_DISK is analagous to "--copy-all" in "virsh".
      * Binding into: "virsh migrate i-2-13456-VM qemu://<DestHostAddr>/system --live --compressed --copy-storage-all --migrate-disks vda --xml i-2-13456-VM.xml"
      */
-    private Domain migrateRootDisk(long flags, String diskDeviceName, String uri) throws LibvirtException {
+    private Domain migrateRootDisk(long flags, String diskDevicesName, String uri) throws LibvirtException {
         int nParams = 5;
         TypedParameter[] params = new TypedParameter[nParams];
         params[0] = new TypedStringParameter(Domain.DomainMigrateParameters.VIR_MIGRATE_PARAM_DEST_XML, dxml);
         params[1] = new TypedStringParameter(Domain.DomainMigrateParameters.VIR_MIGRATE_PARAM_DEST_NAME, vmName);
         params[2] = new TypedStringParameter(Domain.DomainMigrateParameters.VIR_MIGRATE_PARAM_URI, uri);
         params[3] = new TypedUlongParameter(Domain.DomainMigrateParameters.VIR_MIGRATE_PARAM_BANDWIDTH, (long)libvirtComputingResource.getMigrateSpeed());
-        params[4] = new TypedStringParameter(Domain.DomainMigrateParameters.VIR_MIGRATE_PARAM_MIGRATE_DISKS, diskDeviceName);
+        params[4] = new TypedStringParameter(Domain.DomainMigrateParameters.VIR_MIGRATE_PARAM_MIGRATE_DISKS, diskDevicesName);
         return dm.migrate(dconn, params, flags);
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -794,40 +794,54 @@ public class LibvirtMigrateCommandWrapperTest {
 
     @Test
     public void discoverLocalRootDiskDeviceLabelTestRootDiskFile() {
-        String rootLabel = "vda";
-        DiskDef rootDisk = mockDisk(DiskDef.DiskType.FILE, DiskDef.DeviceType.DISK);
+        String rootLabel = "rootLabel";
+        DiskDef rootDisk = mockDisk(DiskDef.DiskType.FILE, DiskDef.DeviceType.DISK, rootLabel);
         Mockito.when(rootDisk.getDiskLabel()).thenReturn(rootLabel);
-        prepareAndTestDiscoverLocalRootDiskDeviceLabel(rootDisk, rootLabel);
+        List<DiskDef> disks = new ArrayList<>();
+        disks.add(rootDisk);
+        prepareAndTestDiscoverLocalRootDiskDeviceLabel(disks, rootLabel);
     }
 
     @Test
     public void discoverLocalRootDiskDeviceLabelTestRootDiskFileNotDisk() {
-        String rootLabel = "vda";
+        String rootLabel = "rootLabel";
         String expectedLabel = null;
         for (DiskDef.DeviceType deviceType : DiskDef.DeviceType.values()) {
             if (DiskDef.DeviceType.DISK != deviceType) {
                 List<DiskDef> disks = new ArrayList<>();
-                DiskDef rootDisk = mockDisk(DiskDef.DiskType.FILE, deviceType);
+                DiskDef rootDisk = mockDisk(DiskDef.DiskType.FILE, deviceType, rootLabel);
                 Mockito.when(rootDisk.getDiskLabel()).thenReturn(rootLabel);
-                prepareAndTestDiscoverLocalRootDiskDeviceLabel(rootDisk, expectedLabel);
+                disks.add(rootDisk);
+                prepareAndTestDiscoverLocalRootDiskDeviceLabel(disks, expectedLabel);
             }
         }
     }
 
-    private void prepareAndTestDiscoverLocalRootDiskDeviceLabel(DiskDef rootDisk, String expected) {
+    @Test
+    public void TestMultipleDeviceLabel() {
         List<DiskDef> disks = new ArrayList<>();
-        disks.add(rootDisk);
-        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK));
-        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK));
-        disks.add(mockDisk(DiskDef.DiskType.BLOCK, DiskDef.DeviceType.DISK));
-        String diskLabel = libvirtMigrateCmdWrapper.retrieveLocalRootDiskDeviceLabel(disks);
+        disks.add(mockDisk(DiskDef.DiskType.FILE, DiskDef.DeviceType.DISK, "label1"));
+        disks.add(mockDisk(DiskDef.DiskType.FILE, DiskDef.DeviceType.DISK, "label2"));
+        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK, "label3"));
+        disks.add(mockDisk(DiskDef.DiskType.BLOCK, DiskDef.DeviceType.DISK, "label4"));
+        String diskLabel = libvirtMigrateCmdWrapper.retrieveLocalDiskDevicesLabels(disks);
+        String expected = "label1,label2";
         Assert.assertEquals(expected, diskLabel);
     }
 
-    private DiskDef mockDisk(DiskDef.DiskType file, DiskDef.DeviceType diskType) {
+    private void prepareAndTestDiscoverLocalRootDiskDeviceLabel(List<DiskDef> disks, String expected) {
+        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK, "label1"));
+        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK, "label2"));
+        disks.add(mockDisk(DiskDef.DiskType.BLOCK, DiskDef.DeviceType.DISK,"label3"));
+        String diskLabel = libvirtMigrateCmdWrapper.retrieveLocalDiskDevicesLabels(disks);
+        Assert.assertEquals(expected, diskLabel);
+    }
+
+    private DiskDef mockDisk(DiskDef.DiskType file, DiskDef.DeviceType diskType, String label) {
         DiskDef mockedDisk = Mockito.mock(DiskDef.class);
         Mockito.when(mockedDisk.getDiskType()).thenReturn(file);
         Mockito.when(mockedDisk.getDeviceType()).thenReturn(diskType);
+        Mockito.when(mockedDisk.getDiskLabel()).thenReturn(label);
         return mockedDisk;
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -791,4 +791,43 @@ public class LibvirtMigrateCommandWrapperTest {
         Assert.assertTrue(replaced.contains("csdpdk-7"));
         Assert.assertFalse(replaced.contains("csdpdk-1"));
     }
+
+    @Test
+    public void discoverLocalRootDiskDeviceLabelTestRootDiskFile() {
+        String rootLabel = "vda";
+        DiskDef rootDisk = mockDisk(DiskDef.DiskType.FILE, DiskDef.DeviceType.DISK);
+        Mockito.when(rootDisk.getDiskLabel()).thenReturn(rootLabel);
+        prepareAndTestDiscoverLocalRootDiskDeviceLabel(rootDisk, rootLabel);
+    }
+
+    @Test
+    public void discoverLocalRootDiskDeviceLabelTestRootDiskFileNotDisk() {
+        String rootLabel = "vda";
+        String expectedLabel = null;
+        for (DiskDef.DeviceType deviceType : DiskDef.DeviceType.values()) {
+            if (DiskDef.DeviceType.DISK != deviceType) {
+                List<DiskDef> disks = new ArrayList<>();
+                DiskDef rootDisk = mockDisk(DiskDef.DiskType.FILE, deviceType);
+                Mockito.when(rootDisk.getDiskLabel()).thenReturn(rootLabel);
+                prepareAndTestDiscoverLocalRootDiskDeviceLabel(rootDisk, expectedLabel);
+            }
+        }
+    }
+
+    private void prepareAndTestDiscoverLocalRootDiskDeviceLabel(DiskDef rootDisk, String expected) {
+        List<DiskDef> disks = new ArrayList<>();
+        disks.add(rootDisk);
+        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK));
+        disks.add(mockDisk(DiskDef.DiskType.NETWORK, DiskDef.DeviceType.DISK));
+        disks.add(mockDisk(DiskDef.DiskType.BLOCK, DiskDef.DeviceType.DISK));
+        String diskLabel = libvirtMigrateCmdWrapper.retrieveLocalRootDiskDeviceLabel(disks);
+        Assert.assertEquals(expected, diskLabel);
+    }
+
+    private DiskDef mockDisk(DiskDef.DiskType file, DiskDef.DeviceType diskType) {
+        DiskDef mockedDisk = Mockito.mock(DiskDef.class);
+        Mockito.when(mockedDisk.getDiskType()).thenReturn(file);
+        Mockito.when(mockedDisk.getDeviceType()).thenReturn(diskType);
+        return mockedDisk;
+    }
 }


### PR DESCRIPTION
### Description

The new release [Libvirt-Java v0.5.3](https://gitlab.com/libvirt/libvirt-java/-/tags/v0.5.3) now supports `virDomainMigrate3`[[1]](https://gitlab.com/libvirt/libvirt-java/),[[2]](https://gitlab.com/libvirt/libvirt-java/-/commit/e45d3fb8bccab2d3048f902f0be74308afc923df), a powerful and flexible _domain migrate_ command in Libvirt. This command allows pointing just the Root volume to be migrated, saving a lot of compute resources, network bandwidth, and time. 

Likely, data disks hold TBs of data, while Root volumes hundreds of GBs. This allows saving crucial time, bandwidth, and processing.

It can easily save several hours to offload a KVM machine depending on the amount of VMs to be migrated and data disks attached to the respective VMs.

[[1] Libvirt-Java](https://gitlab.com/libvirt/libvirt-java/)
[[2] commit that added `virtDomainMigrate3` into the Libvirt-Java](https://gitlab.com/libvirt/libvirt-java/-/commit/e45d3fb8bccab2d3048f902f0be74308afc923df)
Fore reference, PR https://github.com/apache/cloudstack/pull/6472 added `libvirt-java v0.5.3` into CloudStack.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [X] Major
- [ ] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested migration of VM with local Root (50GB) + data-disk (100GB)
1. As an example, this is a scenario without this PR:
```
~# virsh domjobinfo i-2-345-VM
Job type:         Unbounded   
Operation:        Outgoing migration
Time elapsed:     17063        ms
Data processed:   2.938 GiB
Data remaining:   147.065 GiB
Data total:       150.004 GiB
File processed:   2.938 MiB
File remaining:   147.065 GiB
File total:       150.004 GiB
```
**Data total 150.004  GiB**

2. When testing the same migration but with the changes of the PR:
```
~# virsh domjobinfo i-2-345-VM
Job type:         Unbounded   
Operation:        Outgoing migration
Time elapsed:     10300        ms
Data processed:   952.000 MiB
Data remaining:   49.070 GiB
Data total:       50.000 GiB
File processed:   952.000 MiB
File remaining:   49.070 GiB
File total:       50.000 GiB
```
**Data total 50.000 GiB**

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
