### PR TITLE
Fix API deleteTrafficType not filtering physical network

### DIFF
--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
@@ -572,7 +572,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
     public List<NetworkVO> listByPhysicalNetworkTrafficType(final long physicalNetworkId, final TrafficType trafficType) {
         final SearchCriteria<NetworkVO> sc = AllFieldsSearch.create();
         sc.setParameters("trafficType", trafficType);
-        sc.setParameters("physicalNetworkId", physicalNetworkId);
+        sc.setParameters("physicalNetwork", physicalNetworkId);
         return listBy(sc);
     }
 

--- a/engine/schema/src/test/java/com/cloud/network/dao/NetworkDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/network/dao/NetworkDaoImplTest.java
@@ -1,0 +1,47 @@
+package com.cloud.network.dao;
+
+import com.cloud.network.Networks;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+public class NetworkDaoImplTest {
+
+    @Mock
+    SearchBuilder<NetworkVO> searchBuilderNetworkVoMock;
+
+    @Mock
+    SearchCriteria<NetworkVO> searchCriteriaNetworkVoMock;
+
+    @Mock
+    List<NetworkVO> listNetworkVoMock;
+
+    @Test
+    public void listByPhysicalNetworkTrafficTypeTestSetParametersValidation() throws Exception {
+        NetworkDaoImpl networkDaoImplSpy = PowerMockito.spy(new NetworkDaoImpl());
+
+        networkDaoImplSpy.AllFieldsSearch = searchBuilderNetworkVoMock;
+        Mockito.doReturn(searchCriteriaNetworkVoMock).when(searchBuilderNetworkVoMock).create();
+        Mockito.doNothing().when(searchCriteriaNetworkVoMock).setParameters(Mockito.anyString(), Mockito.any());
+        PowerMockito.doReturn(listNetworkVoMock).when(networkDaoImplSpy, "listBy", Mockito.any(SearchCriteria.class));
+
+        long expectedPhysicalNetwork = 2513l;
+
+        for (Networks.TrafficType trafficType : Networks.TrafficType.values()) {
+            List<NetworkVO> result = networkDaoImplSpy.listByPhysicalNetworkTrafficType(expectedPhysicalNetwork, trafficType);
+            Assert.assertEquals(listNetworkVoMock, result);
+            Mockito.verify(searchCriteriaNetworkVoMock).setParameters("trafficType", trafficType);
+        }
+
+        Mockito.verify(searchCriteriaNetworkVoMock, Mockito.times(Networks.TrafficType.values().length)).setParameters("physicalNetwork", expectedPhysicalNetwork);
+    }
+}

--- a/engine/schema/src/test/java/com/cloud/network/dao/NetworkDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/network/dao/NetworkDaoImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.cloud.network.dao;
 
 import com.cloud.network.Networks;


### PR DESCRIPTION
### Description

While deleting a traffic type, ACS validates if there is any VM related to it. However, if we have several physical networks containing a traffic type, ACS does not filter the physical network to do the validation. For instance, if we have two (2) physical networks containing the traffic type Guest, the first one having VMs related, and the second not having VMs related, if we try to remove the second traffic type, ACS give us the message `The Traffic Type is not deletable because there are existing networks with this traffic type:Guest`.

The API `deleteTrafficType` was designed to filter the physical network where the traffic type is, however, due to a typo this filtering was not been applied correctly. This PR intends to fix this typo to honor the API behavior.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

In an advanced zone I created 4 physical networks, one for each traffic type (Public, Guest, Management, Storage). I instantiated some VMs so they get guest IPs. In the Public physical network I added a Guest traffic type. I tried to remove the new Guest traffic type from Public physical network, which did not have any VMs related to it, and, before the changes, I was getting the message `The Traffic Type is not deletable because there are existing networks with this traffic type:Guest`. After the changes, I could remove successfully the new Guest traffic type via API deleteTrafficType. I also tried to remove the Guest traffic type which had VMs related to it, however, as expected, I received the `The Traffic Type is not deletable...` message.

I also created a unit test to validate the data retrieving.