### PR TITLE
Refactor test and change IP range

### DIFF
--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -49,165 +49,6 @@ from nose.plugins.attrib import attr
 import logging
 import time
 
-
-class Services:
-
-    """Test VPC VPN Services.
-    """
-
-    def __init__(self):
-        self.services = {
-            "account": {
-                "email": "test@test.com",
-                "firstname": "Test",
-                "lastname": "User",
-                "username": "test",
-                "password": "password",
-            },
-            "host1": None,
-            "host2": None,
-            "compute_offering": {
-                "name": "Tiny Instance",
-                "displaytext": "Tiny Instance",
-                "cpunumber": 1,
-                "cpuspeed": 100,
-                "memory": 128,
-            },
-            "network_offering": {
-                "name": 'VPC Network offering',
-                "displaytext": 'VPC Network',
-                "guestiptype": 'Isolated',
-                "supportedservices": 'Vpn,Dhcp,Dns,SourceNat,Lb,PortForwarding,UserData,StaticNat,NetworkACL',
-                "traffictype": 'GUEST',
-                "availability": 'Optional',
-                "useVpc": 'on',
-                "serviceProviderList": {
-                    "Vpn": 'VpcVirtualRouter',
-                    "Dhcp": 'VpcVirtualRouter',
-                    "Dns": 'VpcVirtualRouter',
-                    "SourceNat": 'VpcVirtualRouter',
-                    "Lb": 'VpcVirtualRouter',
-                    "PortForwarding": 'VpcVirtualRouter',
-                    "UserData": 'VpcVirtualRouter',
-                    "StaticNat": 'VpcVirtualRouter',
-                    "NetworkACL": 'VpcVirtualRouter'
-                },
-            },
-            "network_offering_internal_lb": {
-                "name": 'VPC Network Internal Lb offering',
-                "displaytext": 'VPC Network internal lb',
-                "guestiptype": 'Isolated',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,UserData,StaticNat,NetworkACL,Lb',
-                "traffictype": 'GUEST',
-                "availability": 'Optional',
-                "useVpc": 'on',
-                "serviceCapabilityList": {
-                    "Lb": {
-                        "SupportedLbIsolation": 'dedicated',
-                        "lbSchemes": 'internal'
-                    }
-                },
-                "serviceProviderList": {
-                    "Dhcp": 'VpcVirtualRouter',
-                    "Dns": 'VpcVirtualRouter',
-                    "SourceNat": 'VpcVirtualRouter',
-                    "PortForwarding": 'VpcVirtualRouter',
-                    "UserData": 'VpcVirtualRouter',
-                    "StaticNat": 'VpcVirtualRouter',
-                    "NetworkACL": 'VpcVirtualRouter',
-                    "Lb": 'InternalLbVm'
-                },
-                "egress_policy": "true",
-            },
-            "vpc_offering": {
-                "name": 'VPC off',
-                "displaytext": 'VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
-            },
-            "redundant_vpc_offering": {
-                "name": 'Redundant VPC off',
-                "displaytext": 'Redundant VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
-                "serviceProviderList": {
-                    "Vpn": 'VpcVirtualRouter',
-                    "Dhcp": 'VpcVirtualRouter',
-                    "Dns": 'VpcVirtualRouter',
-                    "SourceNat": 'VpcVirtualRouter',
-                    "PortForwarding": 'VpcVirtualRouter',
-                    "Lb": 'VpcVirtualRouter',
-                    "UserData": 'VpcVirtualRouter',
-                    "StaticNat": 'VpcVirtualRouter',
-                    "NetworkACL": 'VpcVirtualRouter'
-                },
-                "serviceCapabilityList": {
-                    "SourceNat": {
-                        "RedundantRouter": 'true'
-                    }
-                },
-            },
-            "vpc": {
-                "name": "TestVPC",
-                "displaytext": "TestVPC",
-                "cidr": '10.1.0.0/16'
-            },
-            "vpc1": {
-                "name": "TestVPC",
-                "displaytext": "VPC1",
-                "cidr": '10.1.0.0/16'
-            },
-            "vpc2": {
-                "name": "TestVPC",
-                "displaytext": "VPC2",
-                "cidr": '10.3.0.0/16'
-            },
-            "network_1": {
-                "name": "Test Network",
-                "displaytext": "Test Network",
-                "netmask": '255.255.255.0',
-                "gateway": "10.1.1.1"
-            },
-            "network_2": {
-                "name": "Test Network",
-                "displaytext": "Test Network",
-                "netmask": '255.255.255.0',
-                "gateway": "10.3.1.1"
-            },
-            "vpn": {
-                "vpn_user": "root",
-                "vpn_pass": "Md1sdc",
-                "vpn_pass_fail": "abc!123",  # too short
-                "iprange": "10.3.2.1-10.3.2.10",
-                "fordisplay": "true"
-            },
-            "vpncustomergateway": {
-                "esppolicy": "3des-md5;modp1536",
-                "ikepolicy": "3des-md5;modp1536",
-                "ipsecpsk": "ipsecpsk"
-            },
-            "natrule": {
-                "protocol": "TCP",
-                "cidrlist": '0.0.0.0/0',
-            },
-            "http_rule": {
-                "privateport": 80,
-                "publicport": 80,
-                "startport": 80,
-                "endport": 80,
-                "cidrlist": '0.0.0.0/0',
-                "protocol": "TCP"
-            },
-            "virtual_machine": {
-                "displayname": "Test VM",
-                "username": "root",
-                "password": "password",
-                "ssh_port": 22,
-                "privateport": 22,
-                "publicport": 22,
-                "protocol": 'TCP',
-            }
-        }
-
-
 class TestVpcRemoteAccessVpn(cloudstackTestCase):
 
     @classmethod
@@ -220,7 +61,7 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
 
         testClient = super(TestVpcRemoteAccessVpn, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
-        cls.services = Services().services
+        cls.services = testClient.getParsedTestDataConfig()
 
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.domain = get_domain(cls.apiclient)
@@ -229,11 +70,11 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
 
         cls.compute_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["compute_offering"]
+            cls.services["vpc_vpn"]["compute_offering"]
         )
         cls._cleanup.append(cls.compute_offering)
         cls.account = Account.create(
-            cls.apiclient, services=cls.services["account"])
+            cls.apiclient, services=cls.services["vpc_vpn"]["account"])
         cls._cleanup.append(cls.account)
 
         cls.hypervisor = testClient.getHypervisorInfo()
@@ -270,7 +111,7 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
         try:
             vpc = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc"],
+                services=self.services["vpc_vpn"]["vpc"],
                 networkDomain="vpc.vpn",
                 vpcofferingid=vpcOffering[0].id,
                 zoneid=self.zone.id,
@@ -288,7 +129,7 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
             # 2) Create network in VPC
             ntwk = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_1"],
+                services=self.services["vpc_vpn"]["network_1"],
                 accountid=self.account.name,
                 domainid=self.domain.id,
                 networkofferingid=networkOffering[0].id,
@@ -305,7 +146,7 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
 
         try:
             # 3) Deploy a vm
-            vm = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                        templateid=self.template.id,
                                        zoneid=self.zone.id,
                                        accountid=self.account.name,
@@ -345,8 +186,8 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
                              publicipid=ip.id,
                              account=self.account.name,
                              domainid=self.account.domainid,
-                             iprange=self.services["vpn"]["iprange"],
-                             fordisplay=self.services["vpn"]["fordisplay"]
+                             iprange=self.services["vpc_vpn"]["vpn"]["iprange"],
+                             fordisplay=self.services["vpc_vpn"]["vpn"]["fordisplay"]
                              )
         except Exception as e:
             self.fail(e)
@@ -360,8 +201,8 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
             vpnUser = VpnUser.create(self.apiclient,
                                      account=self.account.name,
                                      domainid=self.account.domainid,
-                                     username=self.services["vpn"]["vpn_user"],
-                                     password=self.services["vpn"]["vpn_pass"]
+                                     username=self.services["vpc_vpn"]["vpn"]["vpn_user"],
+                                     password=self.services["vpc_vpn"]["vpn"]["vpn_pass"]
                                      )
         except Exception as e:
             self.fail(e)
@@ -404,7 +245,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
 
         testClient = super(TestVpcSite2SiteVpn, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
-        cls.services = Services().services
+        cls.services = testClient.getParsedTestDataConfig()
 
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.domain = get_domain(cls.apiclient)
@@ -413,12 +254,12 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
 
         cls.compute_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["compute_offering"]
+            cls.services["vpc_vpn"]["compute_offering"]
         )
         cls._cleanup.append(cls.compute_offering)
 
         cls.account = Account.create(
-            cls.apiclient, services=cls.services["account"])
+            cls.apiclient, services=cls.services["vpc_vpn"]["account"])
         cls._cleanup.append(cls.account)
 
         cls.hypervisor = testClient.getHypervisorInfo()
@@ -444,9 +285,9 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         try:
             ssh_client = SshClient(
                 virtual_machine.public_ip,
-                services["virtual_machine"]["ssh_port"],
-                services["virtual_machine"]["username"],
-                services["virtual_machine"]["password"],
+                services["vpc_vpn"]["virtual_machine"]["ssh_port"],
+                services["vpc_vpn"]["virtual_machine"]["username"],
+                services["vpc_vpn"]["virtual_machine"]["password"],
                 retries)
 
         except Exception as e:
@@ -460,11 +301,11 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
     def _create_natrule(self, vpc, vm, public_port, private_port, public_ip, network, services=None):
         self.logger.debug("Creating NAT rule in network for vm with public IP")
         if not services:
-            self.services["natrule"]["privateport"] = private_port
-            self.services["natrule"]["publicport"] = public_port
-            self.services["natrule"]["startport"] = public_port
-            self.services["natrule"]["endport"] = public_port
-            services = self.services["natrule"]
+            self.services["vpc_vpn"]["natrule"]["privateport"] = private_port
+            self.services["vpc_vpn"]["natrule"]["publicport"] = public_port
+            self.services["vpc_vpn"]["natrule"]["startport"] = public_port
+            self.services["vpc_vpn"]["natrule"]["endport"] = public_port
+            services = self.services["vpc_vpn"]["natrule"]
 
         nat_rule = NATRule.create(
             apiclient=self.apiclient,
@@ -513,7 +354,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
             self.logger.debug("Creating VPC offering: %s", offering_name)
             vpc_off = VpcOffering.create(
                 self.apiclient,
-                self.services[offering_name]
+                self.services["vpc_vpn"][offering_name]
             )
 
             self._validate_vpc_offering(vpc_off)
@@ -541,7 +382,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         try:
             vpc1 = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc"],
+                services=self.services["vpc_vpn"]["vpc"],
                 networkDomain="vpc1.vpn",
                 vpcofferingid=vpc_offering.id,
                 zoneid=self.zone.id,
@@ -560,7 +401,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         try:
             vpc2 = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc2"],
+                services=self.services["vpc_vpn"]["vpc2"],
                 networkDomain="vpc2.vpn",
                 vpcofferingid=vpc_offering.id,
                 zoneid=self.zone.id,
@@ -582,7 +423,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         try:
             ntwk1 = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_1"],
+                services=self.services["vpc_vpn"]["network_1"],
                 accountid=self.account.name,
                 domainid=self.account.domainid,
                 networkofferingid=networkOffering[0].id,
@@ -602,7 +443,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         try:
             ntwk2 = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_2"],
+                services=self.services["vpc_vpn"]["network_2"],
                 accountid=self.account.name,
                 domainid=self.account.domainid,
                 networkofferingid=networkOffering[0].id,
@@ -620,7 +461,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         vm1 = None
         # Deploy a vm in network 1
         try:
-            vm1 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm1 = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                         templateid=self.template.id,
                                         zoneid=self.zone.id,
                                         accountid=self.account.name,
@@ -640,7 +481,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         vm2 = None
         # Deploy a vm in network 2
         try:
-            vm2 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm2 = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                         templateid=self.template.id,
                                         zoneid=self.zone.id,
                                         accountid=self.account.name,
@@ -688,7 +529,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         )
         ip2 = src_nat_list[0]
 
-        services = self.services["vpncustomergateway"]
+        services = self.services["vpc_vpn"]["vpncustomergateway"]
         customer1_response = VpnCustomerGateway.create(
             self.apiclient, services, "Peer VPC1", ip1.ipaddress, vpc1.cidr, self.account.name, self.domain.id)
         self.debug("VPN customer gateway added for VPC %s enabled" % vpc1.id)
@@ -780,7 +621,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
 
         testClient = super(TestRVPCSite2SiteVpn, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
-        cls.services = Services().services
+        cls.services = testClient.getParsedTestDataConfig()
 
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.domain = get_domain(cls.apiclient)
@@ -788,12 +629,12 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
 
         cls.compute_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["compute_offering"]
+            cls.services["vpc_vpn"]["compute_offering"]
         )
         cls._cleanup.append(cls.compute_offering)
 
         cls.account = Account.create(
-            cls.apiclient, services=cls.services["account"])
+            cls.apiclient, services=cls.services["vpc_vpn"]["account"])
         cls._cleanup.append(cls.account)
 
         cls.hypervisor = testClient.getHypervisorInfo()
@@ -837,7 +678,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
             self.logger.debug("Creating VPC offering: %s", offering_name)
             vpc_off = VpcOffering.create(
                 self.apiclient,
-                self.services[offering_name]
+                self.services["vpc_vpn"][offering_name]
             )
 
             self._validate_vpc_offering(vpc_off)
@@ -852,9 +693,9 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         try:
             ssh_client = SshClient(
                 virtual_machine.public_ip,
-                services["virtual_machine"]["ssh_port"],
-                services["virtual_machine"]["username"],
-                services["virtual_machine"]["password"],
+                services["vpc_vpn"]["virtual_machine"]["ssh_port"],
+                services["vpc_vpn"]["virtual_machine"]["username"],
+                services["vpc_vpn"]["virtual_machine"]["password"],
                 retries)
 
         except Exception as e:
@@ -868,11 +709,11 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
     def _create_natrule(self, vpc, vm, public_port, private_port, public_ip, network, services=None):
         self.logger.debug("Creating NAT rule in network for vm with public IP")
         if not services:
-            self.services["natrule"]["privateport"] = private_port
-            self.services["natrule"]["publicport"] = public_port
-            self.services["natrule"]["startport"] = public_port
-            self.services["natrule"]["endport"] = public_port
-            services = self.services["natrule"]
+            self.services["vpc_vpn"]["natrule"]["privateport"] = private_port
+            self.services["vpc_vpn"]["natrule"]["publicport"] = public_port
+            self.services["vpc_vpn"]["natrule"]["startport"] = public_port
+            self.services["vpc_vpn"]["natrule"]["endport"] = public_port
+            services = self.services["vpc_vpn"]["natrule"]
 
         nat_rule = NATRule.create(
             apiclient=self.apiclient,
@@ -914,7 +755,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         try:
             vpc1 = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc"],
+                services=self.services["vpc_vpn"]["vpc"],
                 networkDomain="vpc1.vpn",
                 vpcofferingid=redundant_vpc_offering.id,
                 zoneid=self.zone.id,
@@ -933,7 +774,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         try:
             vpc2 = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc2"],
+                services=self.services["vpc_vpn"]["vpc2"],
                 networkDomain="vpc2.vpn",
                 vpcofferingid=redundant_vpc_offering.id,
                 zoneid=self.zone.id,
@@ -955,7 +796,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         try:
             ntwk1 = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_1"],
+                services=self.services["vpc_vpn"]["network_1"],
                 accountid=self.account.name,
                 domainid=self.account.domainid,
                 networkofferingid=networkOffering[0].id,
@@ -975,7 +816,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         try:
             ntwk2 = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_2"],
+                services=self.services["vpc_vpn"]["network_2"],
                 accountid=self.account.name,
                 domainid=self.account.domainid,
                 networkofferingid=networkOffering[0].id,
@@ -993,7 +834,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         # Deploy a vm in network 1
         vm1 = None
         try:
-            vm1 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm1 = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                         templateid=self.template.id,
                                         zoneid=self.zone.id,
                                         accountid=self.account.name,
@@ -1013,7 +854,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         # Deploy a vm in network 2
         vm2 = None
         try:
-            vm2 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm2 = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                         templateid=self.template.id,
                                         zoneid=self.zone.id,
                                         accountid=self.account.name,
@@ -1061,7 +902,7 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         )
         ip2 = src_nat_list[0]
 
-        services = self.services["vpncustomergateway"]
+        services = self.services["vpc_vpn"]["vpncustomergateway"]
         customer1_response = VpnCustomerGateway.create(
             self.apiclient, services, "Peer VPC1", ip1.ipaddress, vpc1.cidr, self.account.name, self.domain.id)
         self.debug("VPN customer gateway added for VPC %s enabled" % vpc1.id)
@@ -1156,7 +997,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
 
         testClient = super(TestVPCSite2SiteVPNMultipleOptions, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
-        cls.services = Services().services
+        cls.services = testClient.getParsedTestDataConfig()
 
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.domain = get_domain(cls.apiclient)
@@ -1165,12 +1006,12 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
 
         cls.compute_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["compute_offering"]
+            cls.services["vpc_vpn"]["compute_offering"]
         )
         cls._cleanup.append(cls.compute_offering)
 
         cls.account = Account.create(
-            cls.apiclient, services=cls.services["account"])
+            cls.apiclient, services=cls.services["vpc_vpn"]["account"])
         cls._cleanup.append(cls.account)
 
         cls.hypervisor = testClient.getHypervisorInfo()
@@ -1196,9 +1037,9 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         try:
             ssh_client = SshClient(
                 virtual_machine.public_ip,
-                services["virtual_machine"]["ssh_port"],
-                services["virtual_machine"]["username"],
-                services["virtual_machine"]["password"],
+                services["vpc_vpn"]["virtual_machine"]["ssh_port"],
+                services["vpc_vpn"]["virtual_machine"]["username"],
+                services["vpc_vpn"]["virtual_machine"]["password"],
                 retries)
 
         except Exception as e:
@@ -1212,11 +1053,11 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
     def _create_natrule(self, vpc, vm, public_port, private_port, public_ip, network, services=None):
         self.logger.debug("Creating NAT rule in network for vm with public IP")
         if not services:
-            self.services["natrule"]["privateport"] = private_port
-            self.services["natrule"]["publicport"] = public_port
-            self.services["natrule"]["startport"] = public_port
-            self.services["natrule"]["endport"] = public_port
-            services = self.services["natrule"]
+            self.services["vpc_vpn"]["natrule"]["privateport"] = private_port
+            self.services["vpc_vpn"]["natrule"]["publicport"] = public_port
+            self.services["vpc_vpn"]["natrule"]["startport"] = public_port
+            self.services["vpc_vpn"]["natrule"]["endport"] = public_port
+            services = self.services["vpc_vpn"]["natrule"]
 
         nat_rule = NATRule.create(
             apiclient=self.apiclient,
@@ -1265,7 +1106,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
             self.logger.debug("Creating VPC offering: %s", offering_name)
             vpc_off = VpcOffering.create(
                 self.apiclient,
-                self.services[offering_name]
+                self.services["vpc_vpn"][offering_name]
             )
 
             self._validate_vpc_offering(vpc_off)
@@ -1293,7 +1134,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         try:
             vpc1 = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc"],
+                services=self.services["vpc_vpn"]["vpc"],
                 networkDomain="vpc1.vpn",
                 vpcofferingid=vpc_offering.id,
                 zoneid=self.zone.id,
@@ -1312,7 +1153,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         try:
             vpc2 = VPC.create(
                 apiclient=self.apiclient,
-                services=self.services["vpc2"],
+                services=self.services["vpc_vpn"]["vpc2"],
                 networkDomain="vpc2.vpn",
                 vpcofferingid=vpc_offering.id,
                 zoneid=self.zone.id,
@@ -1334,7 +1175,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         try:
             ntwk1 = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_1"],
+                services=self.services["vpc_vpn"]["network_1"],
                 accountid=self.account.name,
                 domainid=self.account.domainid,
                 networkofferingid=networkOffering[0].id,
@@ -1354,7 +1195,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         try:
             ntwk2 = Network.create(
                 apiclient=self.apiclient,
-                services=self.services["network_2"],
+                services=self.services["vpc_vpn"]["network_2"],
                 accountid=self.account.name,
                 domainid=self.account.domainid,
                 networkofferingid=networkOffering[0].id,
@@ -1372,7 +1213,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         vm1 = None
         # Deploy a vm in network 1
         try:
-            vm1 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm1 = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                         templateid=self.template.id,
                                         zoneid=self.zone.id,
                                         accountid=self.account.name,
@@ -1392,7 +1233,7 @@ class TestVPCSite2SiteVPNMultipleOptions(cloudstackTestCase):
         vm2 = None
         # Deploy a vm in network 2
         try:
-            vm2 = VirtualMachine.create(self.apiclient, services=self.services["virtual_machine"],
+            vm2 = VirtualMachine.create(self.apiclient, services=self.services["vpc_vpn"]["virtual_machine"],
                                         templateid=self.template.id,
                                         zoneid=self.zone.id,
                                         accountid=self.account.name,

--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -136,11 +136,11 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
                 zoneid=self.zone.id,
                 vpcid=vpc.id
             )
+            self.cleanup.append(ntwk)
         except Exception as e:
             self.fail(e)
         finally:
             self.assertIsNotNone(ntwk, "Network failed to create")
-            self.cleanup.append(ntwk)
             self.logger.debug(
                 "Network %s created in VPC %s" % (ntwk.id, vpc.id))
 
@@ -155,13 +155,13 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
                                        networkids=ntwk.id,
                                        hypervisor=self.hypervisor
                                        )
-            self.assertTrue(vm is not None, "VM failed to deploy")
             self.cleanup.append(vm)
-            self.assertTrue(vm.state == 'Running', "VM is not running")
             self.debug("VM %s deployed in VPC %s" % (vm.id, vpc.id))
         except Exception as e:
             self.fail(e)
         finally:
+            self.assertTrue(vm is not None, "VM failed to deploy")
+            self.assertTrue(vm.state == 'Running', "VM is not running")
             self.logger.debug("Deployed virtual machine: OK")
 
         try:

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -1998,35 +1998,35 @@ test_data = {
         "vpc": {
             "name": "TestVPC",
             "displaytext": "TestVPC",
-            "cidr": '10.2.0.0/16'
+            "cidr": '10.254.0.0/16'
         },
         "vpc1": {
             "name": "TestVPC",
             "displaytext": "VPC1",
-            "cidr": '10.2.0.0/16'
+            "cidr": '10.254.0.0/16'
         },
         "vpc2": {
             "name": "TestVPC",
             "displaytext": "VPC2",
-            "cidr": '10.3.0.0/16'
+            "cidr": '10.253.0.0/16'
         },
         "network_1": {
             "name": "Test Network",
             "displaytext": "Test Network",
             "netmask": '255.255.255.0',
-            "gateway": "10.2.1.1"
+            "gateway": "10.254.1.1"
         },
         "network_2": {
             "name": "Test Network",
             "displaytext": "Test Network",
             "netmask": '255.255.255.0',
-            "gateway": "10.3.1.1"
+            "gateway": "10.253.1.1"
         },
         "vpn": {
             "vpn_user": "root",
             "vpn_pass": "Md1sdc",
             "vpn_pass_fail": "abc!123",  # too short
-            "iprange": "10.3.2.1-10.3.2.10",
+            "iprange": "10.253.2.1-10.253.2.10",
             "fordisplay": "true"
         },
         "vpncustomergateway": {

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -1906,6 +1906,156 @@ test_data = {
             "disksize": 3,
         }
     },
+    "vpc_vpn": {
+        "account": {
+            "email": "test@test.com",
+            "firstname": "Test",
+            "lastname": "User",
+            "username": "test",
+            "password": "password",
+        },
+        "host1": None,
+        "host2": None,
+        "compute_offering": {
+            "name": "Tiny Instance",
+            "displaytext": "Tiny Instance",
+            "cpunumber": 1,
+            "cpuspeed": 100,
+            "memory": 128,
+        },
+        "network_offering": {
+            "name": 'VPC Network offering',
+            "displaytext": 'VPC Network',
+            "guestiptype": 'Isolated',
+            "supportedservices": 'Vpn,Dhcp,Dns,SourceNat,Lb,PortForwarding,UserData,StaticNat,NetworkACL',
+            "traffictype": 'GUEST',
+            "availability": 'Optional',
+            "useVpc": 'on',
+            "serviceProviderList": {
+                "Vpn": 'VpcVirtualRouter',
+                "Dhcp": 'VpcVirtualRouter',
+                "Dns": 'VpcVirtualRouter',
+                "SourceNat": 'VpcVirtualRouter',
+                "Lb": 'VpcVirtualRouter',
+                "PortForwarding": 'VpcVirtualRouter',
+                "UserData": 'VpcVirtualRouter',
+                "StaticNat": 'VpcVirtualRouter',
+                "NetworkACL": 'VpcVirtualRouter'
+            },
+        },
+        "network_offering_internal_lb": {
+            "name": 'VPC Network Internal Lb offering',
+            "displaytext": 'VPC Network internal lb',
+            "guestiptype": 'Isolated',
+            "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,UserData,StaticNat,NetworkACL,Lb',
+            "traffictype": 'GUEST',
+            "availability": 'Optional',
+            "useVpc": 'on',
+            "serviceCapabilityList": {
+                "Lb": {
+                    "SupportedLbIsolation": 'dedicated',
+                    "lbSchemes": 'internal'
+                }
+            },
+            "serviceProviderList": {
+                "Dhcp": 'VpcVirtualRouter',
+                "Dns": 'VpcVirtualRouter',
+                "SourceNat": 'VpcVirtualRouter',
+                "PortForwarding": 'VpcVirtualRouter',
+                "UserData": 'VpcVirtualRouter',
+                "StaticNat": 'VpcVirtualRouter',
+                "NetworkACL": 'VpcVirtualRouter',
+                "Lb": 'InternalLbVm'
+            },
+            "egress_policy": "true",
+        },
+        "vpc_offering": {
+            "name": 'VPC off',
+            "displaytext": 'VPC off',
+            "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+        },
+        "redundant_vpc_offering": {
+            "name": 'Redundant VPC off',
+            "displaytext": 'Redundant VPC off',
+            "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+            "serviceProviderList": {
+                "Vpn": 'VpcVirtualRouter',
+                "Dhcp": 'VpcVirtualRouter',
+                "Dns": 'VpcVirtualRouter',
+                "SourceNat": 'VpcVirtualRouter',
+                "PortForwarding": 'VpcVirtualRouter',
+                "Lb": 'VpcVirtualRouter',
+                "UserData": 'VpcVirtualRouter',
+                "StaticNat": 'VpcVirtualRouter',
+                "NetworkACL": 'VpcVirtualRouter'
+            },
+            "serviceCapabilityList": {
+                "SourceNat": {
+                    "RedundantRouter": 'true'
+                }
+            },
+        },
+        "vpc": {
+            "name": "TestVPC",
+            "displaytext": "TestVPC",
+            "cidr": '10.2.0.0/16'
+        },
+        "vpc1": {
+            "name": "TestVPC",
+            "displaytext": "VPC1",
+            "cidr": '10.2.0.0/16'
+        },
+        "vpc2": {
+            "name": "TestVPC",
+            "displaytext": "VPC2",
+            "cidr": '10.3.0.0/16'
+        },
+        "network_1": {
+            "name": "Test Network",
+            "displaytext": "Test Network",
+            "netmask": '255.255.255.0',
+            "gateway": "10.2.1.1"
+        },
+        "network_2": {
+            "name": "Test Network",
+            "displaytext": "Test Network",
+            "netmask": '255.255.255.0',
+            "gateway": "10.3.1.1"
+        },
+        "vpn": {
+            "vpn_user": "root",
+            "vpn_pass": "Md1sdc",
+            "vpn_pass_fail": "abc!123",  # too short
+            "iprange": "10.3.2.1-10.3.2.10",
+            "fordisplay": "true"
+        },
+        "vpncustomergateway": {
+            "esppolicy": "3des-md5;modp1536",
+            "ikepolicy": "3des-md5;modp1536",
+            "ipsecpsk": "ipsecpsk"
+        },
+        "natrule": {
+            "protocol": "TCP",
+            "cidrlist": '0.0.0.0/0',
+        },
+        "http_rule": {
+            "privateport": 80,
+            "publicport": 80,
+            "startport": 80,
+            "endport": 80,
+            "cidrlist": '0.0.0.0/0',
+            "protocol": "TCP"
+        },
+        "virtual_machine": {
+            "displayname": "Test VM",
+            "username": "root",
+            "password": "password",
+            "ssh_port": 22,
+            "privateport": 22,
+            "publicport": 22,
+            "protocol": 'TCP',
+        }
+    },
     "browser_upload_template": {
         "VHD": {
             "templatename": "XenUploadtemplate",

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -49,6 +49,15 @@ test_data = {
         "forvirtualnetwork": "true",
         "vlan": "300"
     },
+    "publicip6range": {
+        "ip6gateway": "fd17:ac56:1234:2000::1",
+        "ip6cidr": "fd17:ac56:1234:2000::/64",
+        "vlan": 301,
+        "forvirtualnetwork": "true"
+    },
+    "guestip6prefix": {
+        "prefix": "fd17:ac56:1234:1000::/52"
+    },
     "private_gateway": {
         "ipaddress": "172.16.1.2",
         "gateway": "172.16.1.1",
@@ -87,21 +96,21 @@ test_data = {
         "hypervisor": "XenServer",
         "privateport": 22,
         "publicport": 22,
-        "protocol": 'TCP',
+        "protocol": "TCP"
     },
     "service_offering": {
         "name": "Tiny Instance",
         "displaytext": "Tiny Instance",
         "cpunumber": 1,
         "cpuspeed": 256,  # in MHz
-        "memory": 256,  # In MBs
+        "memory": 256     # In MBs
     },
     "service_offering_multiple_cores": {
         "name": "Tiny Instance",
         "displaytext": "Tiny Instance",
         "cpunumber": 4,
         "cpuspeed": 100,    # in MHz
-        "memory": 128,    # In MBs
+        "memory": 128       # In MBs
     },
     "service_offerings": {
         "tiny": {
@@ -109,7 +118,7 @@ test_data = {
             "displaytext": "Tiny Instance",
             "cpunumber": 1,
             "cpuspeed": 100,
-            "memory": 128,
+            "memory": 128
         },
         "small": {
             "name": "Small Instance",
@@ -123,14 +132,14 @@ test_data = {
             "displaytext": "Medium Instance",
             "cpunumber": 1,
             "cpuspeed": 100,
-            "memory": 256,
+            "memory": 256
         },
         "big": {
             "name": "BigInstance",
             "displaytext": "BigInstance",
             "cpunumber": 1,
             "cpuspeed": 100,
-            "memory": 512,
+            "memory": 512
         },
         "large": {
             "name": "LargeInstance",
@@ -146,7 +155,7 @@ test_data = {
             "cpuspeed": 100,
             "memory": 256,
             "hosttags": "ha",
-            "offerha": True,
+            "offerha": True
         },
         "taggedsmall": {
             "name": "Tagged Small Instance",
@@ -154,8 +163,8 @@ test_data = {
             "cpunumber": 1,
             "cpuspeed": 100,
             "memory": 256,
-            "hosttags": "vmsync",
-        },
+            "hosttags": "vmsync"
+        }
     },
     "service_offering_h1": {
         "name": "Tagged h1 Small Instance",
@@ -178,17 +187,17 @@ test_data = {
         "displaytext": "Disk offering",
         "disksize": 1
     },
-    'resized_disk_offering': {
+    "resized_disk_offering": {
         "displaytext": "Resized",
         "name": "Resized",
         "disksize": 3
     },
-    'disk_offering_shared_5GB': {
+    "disk_offering_shared_5GB": {
         "displaytext": "disk_offering_shared_5GB",
         "name": "disk_offering_shared_5GB",
         "disksize": 5
     },
-    'disk_offering_shared_15GB': {
+    "disk_offering_shared_15GB": {
         "displaytext": "disk_offering_shared_5GB",
         "name": "disk_offering_shared_5GB",
         "disksize": 15
@@ -196,7 +205,7 @@ test_data = {
     "network": {
         "name": "Test Network",
         "displaytext": "Test Network",
-        "acltype": "Account",
+        "acltype": "Account"
     },
     "l2-network": {
         "name": "Test L2 Network",
@@ -210,90 +219,90 @@ test_data = {
         "netmask": "255.255.255.0",
         "startip": "172.16.15.21",
         "endip": "172.16.15.41",
-        "acltype": "Account",
+        "acltype": "Account"
     },
     "l2-network_offering": {
-        "name": 'Test L2 - Network offering',
-        "displaytext": 'Test L2 - Network offering',
-        "guestiptype": 'L2',
-        "supportedservices": '',
-        "traffictype": 'GUEST',
-        "availability": 'Optional'
+        "name": "Test L2 - Network offering",
+        "displaytext": "Test L2 - Network offering",
+        "guestiptype": "L2",
+        "supportedservices": "",
+        "traffictype": "GUEST",
+        "availability": "Optional"
     },
     "network_offering": {
-        "name": 'Test Network offering',
-        "displaytext": 'Test Network offering',
-        "guestiptype": 'Isolated',
-        "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding',
-        "traffictype": 'GUEST',
-        "availability": 'Optional',
+        "name": "Test Network offering",
+        "displaytext": "Test Network offering",
+        "guestiptype": "Isolated",
+        "supportedservices": "Dhcp,Dns,SourceNat,PortForwarding",
+        "traffictype": "GUEST",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter"
+        }
     },
     "nw_off_no_services": {
-        "name": 'Test Network offering without services',
-        "displaytext": 'Test Network offering without services',
-        "guestiptype": 'Isolated',
-        "supportedservices": '',
-        "traffictype": 'GUEST',
-        "availability": 'Optional',
+        "name": "Test Network offering without services",
+        "displaytext": "Test Network offering without services",
+        "guestiptype": "Isolated",
+        "supportedservices": "",
+        "traffictype": "GUEST",
+        "availability": "Optional",
         "serviceProviderList": {
         },
     },
     "nw_off_isolated_netscaler": {
-        "name": 'Netscaler',
-        "displaytext": 'Netscaler',
-        "guestiptype": 'Isolated',
-        "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Firewall,Lb,UserData,StaticNat',
-        "traffictype": 'GUEST',
-        "availability": 'Optional',
+        "name": "Netscaler",
+        "displaytext": "Netscaler",
+        "guestiptype": "Isolated",
+        "supportedservices": "Dhcp,Dns,SourceNat,PortForwarding,Vpn,Firewall,Lb,UserData,StaticNat",
+        "traffictype": "GUEST",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
-            "Vpn": 'VirtualRouter',
-            "Firewall": 'VirtualRouter',
-            "Lb": 'Netscaler',
-            "UserData": 'VirtualRouter',
-            "StaticNat": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter",
+            "Vpn": "VirtualRouter",
+            "Firewall": "VirtualRouter",
+            "Lb": "Netscaler",
+            "UserData": "VirtualRouter",
+            "StaticNat": "VirtualRouter"
+        }
     },
     "nw_off_isolated_persistent": {
-        "name": 'Test Nw off isolated persistent',
-        "displaytext": 'Test Nw off isolated persistent',
-        "guestiptype": 'Isolated',
-        "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding',
-        "traffictype": 'GUEST',
-        "ispersistent": 'True',
-        "availability": 'Optional',
-        "tags": 'native',
+        "name": "Test Nw off isolated persistent",
+        "displaytext": "Test Nw off isolated persistent",
+        "guestiptype": "Isolated",
+        "supportedservices": "Dhcp,Dns,SourceNat,PortForwarding",
+        "traffictype": "GUEST",
+        "ispersistent": "True",
+        "availability": "Optional",
+        "tags": "native",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter"
+        }
     },
     "nw_off_isolated_persistent_lb": {
-        "name": 'Test Nw off isolated persistent',
-        "displaytext": 'Test Nw off isolated persistent',
-        "guestiptype": 'Isolated',
-        "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Lb',
-        "traffictype": 'GUEST',
-        "ispersistent": 'True',
-        "availability": 'Optional',
+        "name": "Test Nw off isolated persistent",
+        "displaytext": "Test Nw off isolated persistent",
+        "guestiptype": "Isolated",
+        "supportedservices": "Dhcp,Dns,SourceNat,PortForwarding,Lb",
+        "traffictype": "GUEST",
+        "ispersistent": "True",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter",
             "Lb": "VirtualRouter"
-        },
+        }
     },
     "isolated_network_offering": {
         "name": "Network offering-DA services",
@@ -302,7 +311,7 @@ test_data = {
         "supportedservices":
             "Dhcp,Dns,SourceNat,PortForwarding,Vpn,Firewall,Lb,UserData,StaticNat",
         "traffictype": "GUEST",
-        "availability": "Optional'",
+        "availability": "Optional",
         "tags": "native",
         "serviceProviderList": {
             "Dhcp": "VirtualRouter",
@@ -325,32 +334,32 @@ test_data = {
         "specifyVlan": 'True'
     },
     "network_offering_vlan": {
-        "name": 'Test Network offering',
-        "displaytext": 'Test Network offering',
-        "guestiptype": 'Isolated',
-        "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding',
-        "traffictype": 'GUEST',
-        "specifyVlan": 'False',
-        "availability": 'Optional',
+        "name": "Test Network offering",
+        "displaytext": "Test Network offering",
+        "guestiptype": "Isolated",
+        "supportedservices": "Dhcp,Dns,SourceNat,PortForwarding",
+        "traffictype": "GUEST",
+        "specifyVlan": "False",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter"
+        }
     },
     "network_offering_without_sourcenat": {
-        "name": 'Test Network offering',
-        "displaytext": 'Test Network offering',
-        "guestiptype": 'Isolated',
-        "supportedservices": 'Dhcp,Dns,UserData',
-        "traffictype": 'GUEST',
-        "availability": 'Optional',
+        "name": "Test Network offering",
+        "displaytext": "Test Network offering",
+        "guestiptype": "Isolated",
+        "supportedservices": "Dhcp,Dns,UserData",
+        "traffictype": "GUEST",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "UserData": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "UserData": "VirtualRouter"
+        }
     },
     "isolated_network": {
         "name": "Isolated Network",
@@ -374,11 +383,11 @@ test_data = {
     },
     "netscaler_network": {
         "name": "Netscaler",
-        "displaytext": "Netscaler",
+        "displaytext": "Netscaler"
     },
     "network_without_acl": {
         "name": "TestNetwork",
-        "displaytext": "TestNetwork",
+        "displaytext": "TestNetwork"
     },
     "virtual_machine": {
         "displayname": "Test VM",
@@ -390,7 +399,7 @@ test_data = {
         "protocol": "TCP",
         "affinity": {
             "name": "webvms",
-            "type": "host anti-affinity",
+            "type": "host anti-affinity"
         }
     },
     "virtual_machine_userdata": {
@@ -403,17 +412,17 @@ test_data = {
         "protocol": "TCP",
         "affinity": {
             "name": "webvms",
-            "type": "host anti-affinity",
+            "type": "host anti-affinity"
         },
         "userdata": "This is sample data"
     },
     "virtual_machine2": {
         "name": "testvm2",
-        "displayname": "Test VM2",
+        "displayname": "Test VM2"
     },
     "virtual_machine3": {
         "name": "testvm3",
-        "displayname": "Test VM3",
+        "displayname": "Test VM3"
     },
     "shared_network": {
         "name": "MySharedNetwork - Test",
@@ -477,6 +486,20 @@ test_data = {
             "SecurityGroup": "SecurityGroupProvider"
         }
     },
+    "shared_network_config_drive_offering": {
+        "name": 'shared_network_config_drive_offering',
+        "displaytext": 'shared_network_config_drive_offering',
+        "guestiptype": 'shared',
+        "supportedservices": 'Dhcp,UserData',
+        "traffictype": 'GUEST',
+        "specifyVlan": "True",
+        "specifyIpRanges": "True",
+        "availability": 'Optional',
+        "serviceProviderList": {
+            "Dhcp": "VirtualRouter",
+            "UserData": 'ConfigDrive'
+        }
+    },
     "shared_network_sg": {
         "name": "Shared-Network-SG-Test",
         "displaytext": "Shared-Network_SG-Test",
@@ -506,15 +529,15 @@ test_data = {
         "displaytext": "VPC offering with multiple Lb service providers",
         "supportedservices": "Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat,NetworkACL",
         "serviceProviderList": {
-            "Vpn": 'VpcVirtualRouter',
-            "Dhcp": 'VpcVirtualRouter',
-            "Dns": 'VpcVirtualRouter',
-            "SourceNat": 'VpcVirtualRouter',
+            "Vpn": "VpcVirtualRouter",
+            "Dhcp": "VpcVirtualRouter",
+            "Dns": "VpcVirtualRouter",
+            "SourceNat": "VpcVirtualRouter",
             "Lb": ["InternalLbVm", "VpcVirtualRouter"],
-            "PortForwarding": 'VpcVirtualRouter',
-            "UserData": 'VpcVirtualRouter',
-            "StaticNat": 'VpcVirtualRouter',
-            "NetworkACL": 'VpcVirtualRouter'
+            "PortForwarding": "VpcVirtualRouter",
+            "UserData": "VpcVirtualRouter",
+            "StaticNat": "VpcVirtualRouter",
+            "NetworkACL": "VpcVirtualRouter"
         }
     },
     "vpc": {
@@ -525,65 +548,65 @@ test_data = {
     "vpc_network_domain": {
         "name": "TestVPC",
         "displaytext": "TestVPC",
-        "cidr": '10.0.0.1/24',
+        "cidr": "10.0.0.1/24",
         "network_domain": "TestVPC"
     },
     "clusters": {
         0: {
             "clustername": "Xen Cluster",
             "clustertype": "CloudManaged",
-            "hypervisor": "XenServer",
+            "hypervisor": "XenServer"
         },
         1: {
             "clustername": "KVM Cluster",
             "clustertype": "CloudManaged",
-            "hypervisor": "KVM",
+            "hypervisor": "KVM"
         },
         2: {
-            "hypervisor": 'VMware',
-            "clustertype": 'ExternalManaged',
-            "username": 'administrator',
-            "password": 'fr3sca',
-            "url": 'http://192.168.100.17/CloudStack-Clogeny-Pune/Pune-1',
-            "clustername": 'VMWare Cluster',
-        },
+            "hypervisor": "VMware",
+            "clustertype": "ExternalManaged",
+            "username": "administrator",
+            "password": "fr3sca",
+            "url": "http://192.168.100.17/CloudStack-Clogeny-Pune/Pune-1",
+            "clustername": "VMWare Cluster"
+        }
     },
     "hosts": {
         "xenserver": {
-            "hypervisor": 'XenServer',
-            "clustertype": 'CloudManaged',
-            "url": 'http://192.168.100.211',
+            "hypervisor": "XenServer",
+            "clustertype": "CloudManaged",
+            "url": "http://192.168.100.211",
             "username": "root",
-            "password": "fr3sca",
+            "password": "fr3sca"
         },
         "kvm": {
-            "hypervisor": 'KVM',
-            "clustertype": 'CloudManaged',
-            "url": 'http://192.168.100.212',
+            "hypervisor": "KVM",
+            "clustertype": "CloudManaged",
+            "url": "http://192.168.100.212",
             "username": "root",
-            "password": "fr3sca",
+            "password": "fr3sca"
         },
         "vmware": {
-            "hypervisor": 'VMware',
-            "clustertype": 'ExternalManaged',
-            "url": 'http://192.168.100.203',
+            "hypervisor": "VMware",
+            "clustertype": "ExternalManaged",
+            "url": "http://192.168.100.203",
             "username": "administrator",
-            "password": "fr3sca",
-        },
+            "password": "fr3sca"
+        }
     },
     "network_offering_shared": {
-        "name": 'Test Network offering shared',
-        "displaytext": 'Test Network offering Shared',
-        "guestiptype": 'Shared',
-        "supportedservices": 'Dhcp,Dns,UserData',
-        "traffictype": 'GUEST',
+        "name": "Test Network offering shared",
+        "displaytext": "Test Network offering Shared",
+        "guestiptype": "Shared",
+        "supportedservices": "Dhcp,Dns,UserData",
+        "traffictype": "GUEST",
         "specifyVlan": "True",
         "specifyIpRanges": "True",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "UserData": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "UserData": "VirtualRouter"
+        }
     },
     "nw_off_isolated_RVR": {
         "name": "Network offering-RVR services",
@@ -615,34 +638,34 @@ test_data = {
         }
     },
     "nw_off_persistent_RVR": {
-        "name": 'Network offering-RVR services',
-        "displaytext": 'Network off-RVR services',
-        "guestiptype": 'Isolated',
+        "name": "Network offering-RVR services",
+        "displaytext": "Network off-RVR services",
+        "guestiptype": "Isolated",
         "supportedservices":
-            'Vpn,Dhcp,Dns,SourceNat,PortForwarding,Firewall,Lb,UserData,StaticNat',
-        "traffictype": 'GUEST',
-        "ispersistent": 'True',
-        "availability": 'Optional',
+            "Vpn,Dhcp,Dns,SourceNat,PortForwarding,Firewall,Lb,UserData,StaticNat",
+        "traffictype": "GUEST",
+        "ispersistent": "True",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Vpn": 'VirtualRouter',
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
-            "Firewall": 'VirtualRouter',
-            "Lb": 'VirtualRouter',
-            "UserData": 'VirtualRouter',
-            "StaticNat": 'VirtualRouter',
+            "Vpn": "VirtualRouter",
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter",
+            "Firewall": "VirtualRouter",
+            "Lb": "VirtualRouter",
+            "UserData": "VirtualRouter",
+            "StaticNat": "VirtualRouter"
         },
         "serviceCapabilityList": {
             "SourceNat": {
                 "SupportedSourceNatTypes": "peraccount",
-                "RedundantRouter": "true",
+                "RedundantRouter": "true"
             },
             "lb": {
                 "SupportedLbIsolation": "dedicated"
-            },
-        },
+            }
+        }
     },
     "nw_offering_isolated_vpc": {
         "name": "Isolated Network for VPC",
@@ -653,7 +676,7 @@ test_data = {
         "availability": "Optional",
         "ispersistent": "False",
         "useVpc": "on",
-        "tags": 'native',
+        "tags": "native",
         "serviceProviderList": {
             "Dhcp": "VpcVirtualRouter",
             "Dns": "VpcVirtualRouter",
@@ -802,25 +825,25 @@ test_data = {
     },
 
     "nw_off_isolated_persistent_netscaler": {
-        "name": 'Netscaler',
-        "displaytext": 'Netscaler',
-        "guestiptype": 'Isolated',
+        "name": "Netscaler",
+        "displaytext": "Netscaler",
+        "guestiptype": "Isolated",
         "supportedservices":
-            'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Firewall,Lb,UserData,StaticNat',
-        "traffictype": 'GUEST',
-        "ispersistent": 'True',
-        "availability": 'Optional',
+            "Dhcp,Dns,SourceNat,PortForwarding,Vpn,Firewall,Lb,UserData,StaticNat",
+        "traffictype": "GUEST",
+        "ispersistent": "True",
+        "availability": "Optional",
         "serviceProviderList": {
-            "Dhcp": 'VirtualRouter',
-            "Dns": 'VirtualRouter',
-            "SourceNat": 'VirtualRouter',
-            "PortForwarding": 'VirtualRouter',
-            "Vpn": 'VirtualRouter',
-            "Firewall": 'VirtualRouter',
-            "Lb": 'Netscaler',
-            "UserData": 'VirtualRouter',
-            "StaticNat": 'VirtualRouter',
-        },
+            "Dhcp": "VirtualRouter",
+            "Dns": "VirtualRouter",
+            "SourceNat": "VirtualRouter",
+            "PortForwarding": "VirtualRouter",
+            "Vpn": "VirtualRouter",
+            "Firewall": "VirtualRouter",
+            "Lb": "Netscaler",
+            "UserData": "VirtualRouter",
+            "StaticNat": "VirtualRouter"
+        }
 
     },
     "network_acl_rule": {
@@ -846,7 +869,7 @@ test_data = {
             "SourceNat": "VpcVirtualRouter",
             "StaticNat": "VpcVirtualRouter",
             "PortForwarding": "VpcVirtualRouter",
-            "NetworkACL": "VpcVirtualRouter",
+            "NetworkACL": "VpcVirtualRouter"
         },
         "serviceCapabilityList": {
             "SourceNat": {"SupportedSourceNatTypes": "peraccount"},
@@ -880,14 +903,14 @@ test_data = {
         "alg": "roundrobin",
         "privateport": 22,
         "publicport": 2222,
-        "protocol": 'TCP'
+        "protocol": "TCP"
     },
     "vpclbrule": {
         "name": "SSH",
         "alg": "roundrobin",
         "privateport": 22,
         "publicport": 22,
-        "protocol": 'TCP'
+        "protocol": "TCP"
     },
     "internal_lbrule": {
         "name": "SSH",
@@ -897,7 +920,7 @@ test_data = {
         "instanceport": 22,
         "scheme": "internal",
         "protocol": "TCP",
-        "cidrlist": '0.0.0.0/0',
+        "cidrlist": "0.0.0.0/0"
     },
     "internal_lbrule_http": {
         "name": "HTTP",
@@ -907,7 +930,7 @@ test_data = {
         "instanceport": 80,
         "scheme": "internal",
         "protocol": "TCP",
-        "cidrlist": '0.0.0.0/0',
+        "cidrlist": "0.0.0.0/0"
     },
     "http_rule": {
         "privateport": 80,
@@ -915,7 +938,15 @@ test_data = {
         "startport": 80,
         "endport": 80,
         "protocol": "TCP",
-        "cidrlist": '0.0.0.0/0',
+        "cidrlist": "0.0.0.0/0"
+    },
+    "dns_rule": {
+        "privateport": 53,
+        "publicport": 53,
+        "startport": 53,
+        "endport": 53,
+        "protocol": "UDP",
+        "cidrlist": "0.0.0.0/0"
     },
     "icmprule": {
         "icmptype": -1,
@@ -929,7 +960,7 @@ test_data = {
         "url": "http://people.apache.org/~tsp/dummy.iso",
         "bootable": False,
         "ispublic": False,
-        "ostype": "Other (64-bit)",
+        "ostype": "Other (64-bit)"
     },
     "iso1": {
         "displaytext": "Test ISO 1",
@@ -938,7 +969,7 @@ test_data = {
         "isextractable": True,
         "isfeatured": True,
         "ispublic": True,
-        "ostype": "CentOS 5.6 (64-bit)",
+        "ostype": "CentOS 5.6 (64-bit)"
     },
     "iso2": {
         "displaytext": "Test ISO 2",
@@ -948,7 +979,7 @@ test_data = {
         "isfeatured": True,
         "ispublic": True,
         "ostype": "CentOS 5.6 (64-bit)",
-        "mode": 'HTTP_DOWNLOAD',
+        "mode": "HTTP_DOWNLOAD"
     },
     "iso3": {
         "displaytext": "Test ISO 3",
@@ -1149,16 +1180,16 @@ test_data = {
         "templatefilter": "self"
     },
     "volume_from_snapshot": {
-        "diskname": 'Volume from snapshot',
+        "diskname": "Volume from snapshot",
         "size": "1",
         "zoneid": ""
     },
-    "templatefilter": 'self',
+    "templatefilter": "self",
     "templates": {
-        "displaytext": 'Template',
-        "name": 'Template',
+        "displaytext": "Template",
+        "name": "Template",
         "ostype": "CentOS 5.3 (64-bit)",
-        "templatefilter": 'self',
+        "templatefilter": "self"
     },
     "win2012template": {
         "displaytext": "win2012",
@@ -1166,7 +1197,7 @@ test_data = {
         "passwordenabled": False,
         "url": "http://people.apache.org/~sanjeev/new-test-win.ova",
         "format": "OVA",
-        "ostype": "Windows 8 (64-bit)",
+        "ostype": "Windows 8 (64-bit)"
     },
     "rhel60template": {
         "displaytext": "Rhel60",
@@ -1184,16 +1215,19 @@ test_data = {
         "cidrlist": "0.0.0.0/0"
     },
     "ingress_rule_ICMP": {
-        "name": 'ICMP',
-        "protocol": 'ICMP',
+        "name": "ICMP",
+        "protocol": "ICMP",
         "startport": -1,
         "endport": -1,
-        "cidrlist": '0.0.0.0/0',
+        "cidrlist": "0.0.0.0/0"
     },
     "vpncustomergateway": {
-        "esppolicy": "3des-md5;modp1536",
-        "ikepolicy": "3des-md5;modp1536",
-        "ipsecpsk": "ipsecpsk"
+        "ipsecpsk": "secreatKey",
+        "ikepolicy": "aes128-sha1",
+        "ikelifetime": "86400",
+        "esppolicy": "aes128-sha1",
+        "epslifetime": "3600",
+        "dpd": "false"
     },
     "vlan_ip_range": {
         "startip": "",
@@ -1201,14 +1235,14 @@ test_data = {
         "netmask": "",
         "gateway": "",
         "forvirtualnetwork": "false",
-        "vlan": "untagged",
+        "vlan": "untagged"
     },
     "ostype": "CentOS 5.6 (64-bit)",
     "sleep": 90,
     "timeout": 10,
     "page": 1,
     "pagesize": 2,
-    "listall": 'true',
+    "listall": "true",
     "advanced_sg": {
         "zone": {
             "name": "",
@@ -1233,39 +1267,38 @@ test_data = {
         "name": "Primary XEN 2"
     },
     "iscsi": {
-        "url":
-            "iscsi://192.168.100.21/iqn.2012-01.localdomain.clo-cstack-cos6:iser/1",
+        "url": "iscsi://192.168.100.21/iqn.2012-01.localdomain.clo-cstack-cos6:iser/1",
         "name": "Primary iSCSI"
     },
     "volume": {"diskname": "Test Volume",
                "size": 1
-               },
+    },
     "volume_write_path": {
         "diskname": "APP Data Volume",
         "size": 1,   # in GBs
         "xenserver": {"rootdiskdevice":"/dev/xvda",
-                      "datadiskdevice_1": '/dev/xvdb',
-                      "datadiskdevice_2": '/dev/xvdc',   # Data Disk
-                      },
+                      "datadiskdevice_1": "/dev/xvdb",
+                      "datadiskdevice_2": "/dev/xvdc"  # Data Disk
+                     },
         "kvm":       {"rootdiskdevice": "/dev/vda",
                       "datadiskdevice_1": "/dev/vdb",
                       "datadiskdevice_2": "/dev/vdc"
-                      },
+                     },
         "vmware":    {"rootdiskdevice": "/dev/hda",
                       "datadiskdevice_1": "/dev/hdb",
                       "datadiskdevice_2": "/dev/hdc"
-                      }
+                     }
     },
     "data_write_paths": {
         "mount_dir": "/mnt/tmp",
         "sub_dir": "test",
         "sub_lvl_dir1": "test1",
         "sub_lvl_dir2": "test2",
-        "random_data": "random.data",
+        "random_data": "random.data"
     },
     "custom_volume": {
         "customdisksize": 1,
-        "diskname": "Custom disk",
+        "diskname": "Custom disk"
     },
     "recurring_snapshot": {
         "maxsnaps": 2,
@@ -1273,17 +1306,17 @@ test_data = {
         "schedule": 1
     },
     "volume_offerings": {
-        0: {"diskname": "TestDiskServ"},
+        0: {"diskname": "TestDiskServ"}
     },
-    "diskdevice": ['/dev/vdc', '/dev/vdb', '/dev/hdb', '/dev/hdc',
-                   '/dev/xvdd', '/dev/cdrom', '/dev/sr0', '/dev/cdrom1'],
+    "diskdevice": ["/dev/vdc", "/dev/vdb", "/dev/hdb", "/dev/hdc",
+                   "/dev/xvdd", "/dev/cdrom", "/dev/sr0", "/dev/cdrom1"],
 
     # test_vpc_vpn.py
     "vpn_user": {
         "username": "test",
-        "password": "password",
+        "password": "password"
     },
-    "vpc": {
+    "vpntest_vpc": {
         "name": "vpc_vpn",
         "displaytext": "vpc-vpn",
         "cidr": "10.1.1.0/24"
@@ -1307,14 +1340,13 @@ test_data = {
     },
     "privateport": 22,
     "publicport": 22,
-    "protocol": 'TCP',
+    "protocol": "TCP",
     "forvirtualnetwork": "true",
     "customdisksize": 1,
     "diskname": "Test Volume",
     "sparse": {
         "name": "Sparse Type Disk offering",
-        "displaytext":
-            "Sparse Type Disk offering",
+        "displaytext": "Sparse Type Disk offering",
         "disksize": 1,  # in GB
         "provisioningtype": "sparse"
     },
@@ -1351,7 +1383,7 @@ test_data = {
     },
     "host_anti_affinity": {
         "name": "hostantiaffinity",
-        "type": "host anti-affinity",
+        "type": "host anti-affinity"
     },
     "vgpu": {
         "disk_offering": {
@@ -1417,12 +1449,12 @@ test_data = {
         },
         "hosts": {
             "nonvgpuxenserver": {
-                "hypervisor": 'XenServer',
-                "clustertype": 'CloudManaged',
-                "url": 'http://10.102.192.57',
+                "hypervisor": "XenServer",
+                "clustertype": "CloudManaged",
+                "url": "http://10.102.192.57",
                 "username": "root",
-                "password": "freebsd",
-            },
+                "password": "freebsd"
+            }
         },
         "account": {
             "email": "test@test.com",
@@ -1431,7 +1463,7 @@ test_data = {
             "username": "test",
             # Random characters are appended in create account to
             # ensure unique username generated each time
-            "password": "password",
+            "password": "password"
         },
         "service_offerings":
             {
@@ -1441,7 +1473,7 @@ test_data = {
                         "displaytext": "vGPU260Q",
                         "cpunumber": 2,
                         "cpuspeed": 1600,  # in MHz
-                        "memory": 3072,  # In MBs
+                        "memory": 3072  # In MBs
                     },
                 "GRID K240Q":
                     {
@@ -1449,7 +1481,7 @@ test_data = {
                         "displaytext": "vGPU240Q",
                         "cpunumber": 2,
                         "cpuspeed": 1600,  # in MHz
-                        "memory": 3072,  # In MBs
+                        "memory": 3072  # In MBs
                     },
                 "GRID K220Q":
                     {
@@ -1457,7 +1489,7 @@ test_data = {
                         "displaytext": "vGPU220Q",
                         "cpunumber": 2,
                         "cpuspeed": 1600,  # in MHz
-                        "memory": 3072,  # In MBs
+                        "memory": 3072  # In MBs
                     },
                 "GRID K200":
                     {
@@ -1465,7 +1497,7 @@ test_data = {
                         "displaytext": "vGPU200",
                         "cpunumber": 2,
                         "cpuspeed": 1600,  # in MHz
-                        "memory": 3072,  # In MBs
+                        "memory": 3072  # In MBs
                     },
                 "passthrough":
                     {
@@ -1473,7 +1505,7 @@ test_data = {
                         "displaytext": "vGPU passthrough",
                         "cpunumber": 2,
                         "cpuspeed": 1600,  # in MHz
-                        "memory": 3072,  # In MBs
+                        "memory": 3072  # In MBs
                     },
                 "GRID K140Q":
                     {
@@ -1483,7 +1515,7 @@ test_data = {
                         "displaytext": "vGPU140Q",
                         "cpunumber": 2,
                         "cpuspeed": 1600,
-                        "memory": 3072,
+                        "memory": 3072
                     },
                 "GRID K120Q":
                     {
@@ -1491,7 +1523,7 @@ test_data = {
                         "displaytext": "vGPU120Q",
                         "cpunumber": 2,
                         "cpuspeed": 1600,
-                        "memory": 3072,
+                        "memory": 3072
                     },
                 "GRID K100":
                     {
@@ -1499,7 +1531,7 @@ test_data = {
                         "displaytext": "vGPU100",
                         "cpunumber": 2,
                         "cpuspeed": 1600,
-                        "memory": 3072,
+                        "memory": 3072
                     },
                 "nonvgpuoffering":
                     {
@@ -1507,23 +1539,23 @@ test_data = {
                         "displaytext": "nonvgpuoffering",
                         "cpunumber": 2,
                         "cpuspeed": 1600,
-                        "memory": 3072,
+                        "memory": 3072
                     }
 
             },
-        "diskdevice": ['/dev/vdc', '/dev/vdb', '/dev/hdb', '/dev/hdc', '/dev/xvdd', '/dev/cdrom', '/dev/sr0',
-                       '/dev/cdrom1'],
+        "diskdevice": ["/dev/vdc", "/dev/vdb", "/dev/hdb", "/dev/hdc", "/dev/xvdd", "/dev/cdrom", "/dev/sr0",
+                       "/dev/cdrom1"],
         # Disk device where ISO is attached to instance
         "mount_dir": "/mnt/tmp",
         "sleep": 180,
         "timeout": 60,
-        "ostype": 'Windows 8 (64-bit)',
+        "ostype": "Windows 8 (64-bit)",
         "nongpu_host_ip": "10.102.192.57"
     },
     "acl": {
         #data for domains and accounts
         "domain1": {
-            "name": "D1",
+            "name": "D1"
         },
         "accountD1": {
             "email": "testD1@test.com",
@@ -1531,24 +1563,24 @@ test_data = {
             "lastname": "Admin",
             "username": "testD1",
             "password": "password",
-            "accounttype": "1",
+            "accounttype": "1"
         },
         "accountD1A": {
             "email": "testD1A@test.com",
             "firstname": "testD1A",
             "lastname": "User",
             "username": "testD1A",
-            "password": "password",
+            "password": "password"
         },
         "accountD1B": {
             "email": "testD1B@test.com",
             "firstname": "testD1B",
             "lastname": "User",
             "username": "testD1B",
-            "password": "password",
+            "password": "password"
         },
         "domain11": {
-            "name": "D11",
+            "name": "D11"
         },
         "accountD11": {
             "email": "testD11@test.com",
@@ -1556,65 +1588,65 @@ test_data = {
             "lastname": "Admin",
             "username": "testD11",
             "password": "password",
-            "accounttype": "1",
+            "accounttype": "1"
         },
         "accountD11A": {
             "email": "testD11A@test.com",
             "firstname": "testD11A",
             "lastname": "User",
             "username": "testD11A",
-            "password": "password",
+            "password": "password"
         },
         "accountD11B": {
             "email": "test11B@test.com",
             "firstname": "testD11B",
             "lastname": "User",
             "username": "testD11B",
-            "password": "password",
+            "password": "password"
         },
         "domain111": {
-            "name": "D111",
+            "name": "D111"
         },
         "accountD111": {
             "email": "testD111@test.com",
             "firstname": "testD111",
             "lastname": "Admin",
             "username": "testD111",
-            "password": "password",
+            "password": "password"
         },
         "accountD111A": {
             "email": "testD111A@test.com",
             "firstname": "testD111A",
             "lastname": "User",
             "username": "testD111A",
-            "password": "password",
+            "password": "password"
         },
         "accountD111B": {
             "email": "testD111B@test.com",
             "firstname": "testD111B",
             "lastname": "User",
             "username": "testD111B",
-            "password": "password",
+            "password": "password"
         },
         "domain12": {
-            "name": "D12",
+            "name": "D12"
         },
         "accountD12A": {
             "email": "testD12A@test.com",
             "firstname": "testD12A",
             "lastname": "User",
             "username": "testD12A",
-            "password": "password",
+            "password": "password"
         },
         "accountD12B": {
             "email": "testD12B@test.com",
             "firstname": "testD12B",
             "lastname": "User",
             "username": "testD12B",
-            "password": "password",
+            "password": "password"
         },
         "domain2": {
-            "name": "D2",
+            "name": "D2"
         },
         "accountD2": {
             "email": "testD2@test.com",
@@ -1622,21 +1654,21 @@ test_data = {
             "lastname": "User",
             "username": "testD2",
             "password": "password",
-            "accounttype": "1",
+            "accounttype": "1"
         },
         "accountD2A": {
             "email": "testD2A@test.com",
             "firstname": "testD2A",
             "lastname": "User",
             "username": "testD2A",
-            "password": "password",
+            "password": "password"
         },
         "accountROOTA": {
             "email": "testROOTA@test.com",
             "firstname": "testROOTA",
             "lastname": "User",
             "username": "testROOTA",
-            "password": "password",
+            "password": "password"
         },
 
         "accountROOT": {
@@ -1644,65 +1676,65 @@ test_data = {
             "firstname": "testROOT",
             "lastname": "admin",
             "username": "testROOT",
-            "password": "password",
+            "password": "password"
         },
         #data reqd for virtual machine creation
         "vmD1": {
             "name": "d1",
-            "displayname": "d1",
+            "displayname": "d1"
         },
         "vmD1A": {
             "name": "d1a",
-            "displayname": "d1a",
+            "displayname": "d1a"
         },
         "vmD1B": {
             "name": "d1b",
-            "displayname": "d1b",
+            "displayname": "d1b"
         },
         "vmD11": {
             "name": "d11",
-            "displayname": "d11",
+            "displayname": "d11"
         },
         "vmD11A": {
             "name": "d11a",
-            "displayname": "d11a",
+            "displayname": "d11a"
         },
         "vmD11B": {
             "name": "d11b",
-            "displayname": "d11b",
+            "displayname": "d11b"
         },
         "vmD111": {
             "name": "d111",
-            "displayname": "d111",
+            "displayname": "d111"
         },
         "vmD111A": {
             "name": "d111a",
-            "displayname": "d111a",
+            "displayname": "d111a"
         },
         "vmD111B": {
             "name": "d111b",
-            "displayname": "d111b",
+            "displayname": "d111b"
         },
         "vmD12A": {
             "name": "d12a",
-            "displayname": "d12a",
+            "displayname": "d12a"
         },
         "vmD12B": {
             "name": "d12b",
-            "displayname": "d12b",
+            "displayname": "d12b"
         },
         "vmD2A": {
             "name": "d2a",
-            "displayname": "d2a",
+            "displayname": "d2a"
         },
 
         "vmROOTA": {
             "name": "roota",
-            "displayname": "roota",
+            "displayname": "roota"
         },
         "vmROOT": {
             "name": "root",
-            "displayname": "root",
+            "displayname": "root"
         },
 
         #data reqd for Network creation
@@ -1777,14 +1809,14 @@ test_data = {
         "host": {
             "publicport": 22,
             "username": "root",
-            "password": "password",
+            "password": "password"
         },
         "ldap_account": {
             "email": "",
             "firstname": "",
             "lastname": "",
             "username": "",
-            "password": "",
+            "password": ""
         },
         "ldap_configuration": {
             "basedn": "",
@@ -1797,16 +1829,16 @@ test_data = {
             "ldapPassword": ""
         },
         "systemVmDelay": 120,
-        "setUsageConfigurationThroughTestCase": False,
-        "vmware_cluster" : {
-            "hypervisor": 'VMware',
-            "clustertype": 'ExternalManaged',
-            "username": '',
-            "password": '',
-            "url": '',
-            "clustername": 'VMWare Cluster with Space in DC name',
+	"setUsageConfigurationThroughTestCase": False,
+	"vmware_cluster" : {
+            "hypervisor": "VMware",
+            "clustertype": "ExternalManaged",
+            "username": "",
+            "password": "",
+            "url": "",
+            "clustername": "VMWare Cluster with Space in DC name",
             "startip": "10.223.1.2",
-            "endip": "10.223.1.100",
+            "endip": "10.223.1.100"
         },
         #small service offering
         "service_offering": {
@@ -1815,10 +1847,10 @@ test_data = {
                 "displaytext": "Small Instance",
                 "cpunumber": 1,
                 "cpuspeed": 100,
-                "memory": 128,
-            },
+                "memory": 128
+            }
         },
-        "ostype": 'CentOS 5.6 (64-bit)',
+        "ostype": "CentOS 5.6 (64-bit)"
     },
     "test_34_DeployVM_in_SecondSGNetwork": {
         "zone": "advsg",
@@ -1863,7 +1895,6 @@ test_data = {
                     "ostype": "Windows 8 (64-bit)",
                     "ispublic": "true",
                     "hypervisor": "XenServer"
-
                 },
             "OVA":
                 {
@@ -1881,29 +1912,31 @@ test_data = {
                 "name": "windowsxdtemplate",
                 "passwordenabled": False,
                 "ostype": "Windows 8 (64-bit)"
-            },
-        },
+            }
+        }
 
+    "configurableData":
+        {
     "browser_upload_volume":{
         "VHD": {
             "diskname": "XenUploadVol",
             "url": "http://people.apache.org/~sanjeev/rajani-thin-volume.vhd",
-            "checksum": "09b08b6abb1b903fca7711d3ac8d6598",
+            "checksum": "09b08b6abb1b903fca7711d3ac8d6598"
         },
         "OVA": {
             "diskname": "VMwareUploadVol",
             "url": "http://people.apache.org/~sanjeev/CentOS5.5(64bit)-vmware-autoscale.ova",
-            "checksum": "da997b697feaa2f1f6e0d4785b0cece2",
+            "checksum": "da997b697feaa2f1f6e0d4785b0cece2"
         },
         "QCOW2": {
             "diskname": "KVMUploadVol",
             "url": "http://people.apache.org/~sanjeev/rajani-thin-volume.qcow2",
-            "checksum": "02de0576dd3a61ab59c03fd795fc86ac",
+            "checksum": "02de0576dd3a61ab59c03fd795fc86ac"
         },
-        'browser_resized_disk_offering': {
+        "browser_resized_disk_offering": {
             "displaytext": "Resizeddisk",
             "name": "Resizeddisk",
-            "disksize": 3,
+            "disksize": 3
         }
     },
     "vpc_vpn": {
@@ -2080,10 +2113,8 @@ test_data = {
             "checksum": "ada77653dcf1e59495a9e1ac670ad95f",
             "hypervisor":"KVM",
             "ostypeid":"2e02e376-cdf3-11e4-beb3-8aa6272b57ef"
-        },
+        }
     },
-    "configurableData":
-    {
         "portableIpRange": {
             "gateway": "10.223.59.1",
             "netmask": "255.255.255.0",
@@ -2110,14 +2141,14 @@ test_data = {
         "host": {
             "publicport": 22,
             "username": "root",
-            "password": "password",
+            "password": "password"
         },
         "ldap_account": {
             "email": "",
             "firstname": "",
             "lastname": "",
             "username": "",
-            "password": "",
+            "password": ""
         },
         "link_ldap_details": {
             "domain_name": "",
@@ -2144,29 +2175,28 @@ test_data = {
         "systemVmDelay": 120,
         "setUsageConfigurationThroughTestCase": True,
         "vmware_cluster": {
-            "hypervisor": 'VMware',
-            "clustertype": 'ExternalManaged',
-            "username": '',
-            "password": '',
-            "url": '',
-            "clustername": 'VMWare Cluster with Space in DC name',
+            "hypervisor": "VMware",
+            "clustertype": "ExternalManaged",
+            "username": "",
+            "password": "",
+            "url": "",
+            "clustername": "VMWare Cluster with Space in DC name"
         },
         "upload_volume": {
             "diskname": "UploadVol",
             "format": "VHD",
             "url": "http://download.cloudstack.org/releases/2.0.0/UbuntuServer-10-04-64bit.vhd.bz2",
-            "checksum": "",
+            "checksum": ""
         },
-        "bootableIso":
-            {
-                "displaytext": "Test Bootable ISO",
-                "name": "testISO",
-                "bootable": True,
-                "ispublic": False,
-                "url": "http://dl.openvm.eu/cloudstack/iso/TinyCore-8.0.iso",
-                "ostype": 'Other Linux (64-bit)',
-                "mode": 'HTTP_DOWNLOAD'
-            },
+        "bootableIso": {
+            "displaytext": "Test Bootable ISO",
+            "name": "testISO",
+            "bootable": True,
+            "ispublic": False,
+            "url": "http://dl.openvm.eu/cloudstack/iso/TinyCore-8.0.iso",
+            "ostype": "Other Linux (64-bit)",
+            "mode": "HTTP_DOWNLOAD"
+        },
         "setHostConfigurationForIngressRule": False,
         "restartManagementServerThroughTestCase": False,
         "vmxnet3template": {
@@ -2192,10 +2222,10 @@ test_data = {
                 "url": ""
             },
             "hyperv": {
-                "url": ""
-            },
-            "ostype": 'CentOS 5.3 (64-bit)',
-            "mode": 'HTTP_DOWNLOAD'
+	        "url": ""
+	    },
+            "ostype": "CentOS 5.3 (64-bit)",
+            "mode": "HTTP_DOWNLOAD"
         }
     },
     "cks_kubernetes_versions": {
@@ -2214,6 +2244,18 @@ test_data = {
         "1.16.3": {
             "semanticversion": "1.16.3",
             "url": "http://download.cloudstack.org/cks/setup-1.16.3.iso",
+            "mincpunumber": 2,
+            "minmemory": 2048
+        },
+        "1.23.3": {
+            "semanticversion": "1.23.3",
+            "url": "http://download.cloudstack.org/cks/setup-1.23.3.iso",
+            "mincpunumber": 2,
+            "minmemory": 2048
+        },
+        "1.24.0": {
+            "semanticversion": "1.24.0",
+            "url": "http://download.cloudstack.org/cks/setup-1.24.0.iso",
             "mincpunumber": 2,
             "minmemory": 2048
         }


### PR DESCRIPTION
### Description

This PR moves the test_data from the specific test to the central location - test_data.py and also changes the network cidr from 10.1.0.0/16 to 10.2.0.0/16 as it conflicts with the IP range of the lab where trillian jobs runs - thus leading to failures, which could be confusing
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
```
est Site 2 Site VPN Across redundant VPCs ... === TestName: test_01_redundant_vpc_site2site_vpn | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across VPCs ... === TestName: test_01_vpc_site2site_vpn_multiple_options | Status : SUCCESS ===
ok
Test Remote Access VPN in VPC ... === TestName: test_01_vpc_remote_access_vpn | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across VPCs ... === TestName: test_01_vpc_site2site_vpn | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 1812.057s

OK

```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
