### PR TITLE
kvm: skip test that can't run and pass on M1 mac

### DIFF
--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -5590,6 +5590,9 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void getMemoryFreeInKBsTestDomainReturningIncompleteArray() throws LibvirtException {
+        if (!System.getProperty("os.name").equals("Linux")) {
+            return;
+        }
         LibvirtComputingResource libvirtComputingResource = new LibvirtComputingResource();
 
         MemoryStatistic[] mem = createMemoryStatisticFreeMemory100();


### PR DESCRIPTION
This fixes the build issue on M1 mac/osx.