### PR TITLE
Deprecated changeServiceForVirtualMachine API and replaced all the oc…

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ScaleVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ScaleVMCmdByAdmin.java
@@ -25,6 +25,6 @@ import org.apache.cloudstack.api.response.SuccessResponse;
 import com.cloud.vm.VirtualMachine;
 
 
-@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering. This command also takes into account the Volume and it may resize the root disk size according to the service offering.", responseObject = SuccessResponse.class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
+@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering. This command also considers the volume size in the service offering or disk offering linked to the new service offering and apply all characteristics to the root volume.", responseObject = SuccessResponse.class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleVMCmdByAdmin extends ScaleVMCmd implements AdminCmd {}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpgradeVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpgradeVMCmdByAdmin.java
@@ -24,9 +24,10 @@ import org.apache.cloudstack.api.response.UserVmResponse;
 
 import com.cloud.vm.VirtualMachine;
 
-@APICommand(name = "changeServiceForVirtualMachine", responseObject=UserVmResponse.class, description="Changes the service offering for a virtual machine. " +
-                                            "The virtual machine must be in a \"Stopped\" state for " +
-        "this command to take effect. Note that it only changes the VM's compute offering and it does not update the root volume offering. "
-        + "If the Service Offering has a root disk size the volume will be resized only if using API command 'scaleVirtualMachine'.", responseView = ResponseView.Full, entityType = {VirtualMachine.class},
+@Deprecated(since = "4.18")
+@APICommand(name = "changeServiceForVirtualMachine", responseObject=UserVmResponse.class, description="(This API is deprecated, use scaleVirtualMachine API)" +
+        "Changes the service offering for a virtual machine. The virtual machine must be in a \"Stopped\" state for " +
+        "this command to take effect.",
+        responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class UpgradeVMCmdByAdmin extends UpgradeVMCmd implements AdminCmd {}

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
@@ -49,7 +49,7 @@ import com.cloud.uservm.UserVm;
 import com.cloud.vm.VirtualMachine;
 
 
-@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
+@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering. This command also considers the volume size in the service offering or disk offering linked to the new service offering and apply all characteristics to the root volume.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleVMCmd extends BaseAsyncCmd implements UserCmd {
     public static final Logger s_logger = Logger.getLogger(ScaleVMCmd.class.getName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
@@ -44,8 +44,9 @@ import com.cloud.user.Account;
 import com.cloud.uservm.UserVm;
 import com.cloud.vm.VirtualMachine;
 
-@APICommand(name = "changeServiceForVirtualMachine", responseObject=UserVmResponse.class, description="Changes the service offering for a virtual machine. " +
-                                            "The virtual machine must be in a \"Stopped\" state for " +
+@Deprecated(since = "4.18")
+@APICommand(name = "changeServiceForVirtualMachine", responseObject=UserVmResponse.class, description="(This API is deprecated, use scaleVirtualMachine API)" +
+        "Changes the service offering for a virtual machine. The virtual machine must be in a \"Stopped\" state for " +
         "this command to take effect.", responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class UpgradeVMCmd extends BaseCmd implements UserCmd {

--- a/test/integration/component/test_deploy_vgpu_vm.py
+++ b/test/integration/component/test_deploy_vgpu_vm.py
@@ -20,7 +20,7 @@
 # All tests inherit from cloudstackTestCase
 from marvin.cloudstackTestCase import cloudstackTestCase
 import unittest
-from marvin.cloudstackAPI import changeServiceForVirtualMachine, startVirtualMachine
+from marvin.cloudstackAPI import scaleVirtualMachine, startVirtualMachine
 
 # Import Integration Libraries
 
@@ -594,10 +594,10 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         self.destvgpuoffering = self.vgpu_serviceoffering_creation(
             desttype,
             destmodel)
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = vm.id
         cmd.serviceofferingid = self.destvgpuoffering.id
-        self.apiclient.changeServiceForVirtualMachine(cmd)
+        self.apiclient.scaleVirtualMachine(cmd)
 
         self.debug("Starting VM - ID: %s" % vm.id)
         self.start_vm()
@@ -644,10 +644,10 @@ class TestvGPUWindowsVm(cloudstackTestCase):
         self.destvgpuoffering = self.vgpu_serviceoffering_creation(
             desttype,
             destmodel)
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = vm.id
         cmd.serviceofferingid = self.destvgpuoffering.id
-        self.apiclient.changeServiceForVirtualMachine(cmd)
+        self.apiclient.scaleVirtualMachine(cmd)
 
         self.debug("Starting VM - ID: %s" % vm.id)
         self.start_vm()
@@ -1367,10 +1367,10 @@ class TestvGPUWindowsVm(cloudstackTestCase):
             desttype,
             destmodel)
         self.stop_life_cycle_vm(vmcard)
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = vmcard.id
         cmd.serviceofferingid = self.destvgpuoffering.id
-        self.apiclient.changeServiceForVirtualMachine(cmd)
+        self.apiclient.scaleVirtualMachine(cmd)
 
         self.debug("Starting VM - ID: %s" % vmcard.id)
         self.start_life_cycle_vm(vmcard)

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -19,7 +19,7 @@
 # Import Local Modules
 from marvin.codes import FAILED
 from marvin.cloudstackTestCase import cloudstackTestCase
-from marvin.cloudstackAPI import (changeServiceForVirtualMachine,
+from marvin.cloudstackAPI import (scaleVirtualMachine,
                                   updateServiceOffering)
 from marvin.lib.utils import (isAlmostEqual,
                               cleanup_resources,
@@ -546,10 +546,10 @@ class TestServiceOfferings(cloudstackTestCase):
         except Exception as e:
             self.fail("Failed to stop VM: %s" % e)
 
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = self.medium_virtual_machine.id
         cmd.serviceofferingid = self.small_offering.id
-        self.apiclient.changeServiceForVirtualMachine(cmd)
+        self.apiclient.scaleVirtualMachine(cmd)
 
         self.debug("Starting VM - ID: %s" % self.medium_virtual_machine.id)
         self.medium_virtual_machine.start(self.apiclient)
@@ -695,12 +695,12 @@ class TestServiceOfferings(cloudstackTestCase):
             offering_data,
         )
         self._cleanup.append(self.serviceOfferingWithDiskOfferingStrictnessTrue2)
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = self.virtual_machine_with_diskoffering_strictness_true.id
         cmd.serviceofferingid = self.serviceOfferingWithDiskOfferingStrictnessTrue2.id
 
         with self.assertRaises(Exception) as e:
-            self.apiclient.changeServiceForVirtualMachine(cmd)
+            self.apiclient.scaleVirtualMachine(cmd)
             self.debug("Upgrade VM with new service offering having different disk offering operation failed as expected with exception: %s" %
                        e.exception)
         return
@@ -800,10 +800,10 @@ class TestServiceOfferings(cloudstackTestCase):
             offering_data,
         )
         self._cleanup.append(self.serviceOfferingWithDiskOfferingStrictnessFalse2)
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = self.virtual_machine_with_diskoffering_strictness_false.id
         cmd.serviceofferingid = self.serviceOfferingWithDiskOfferingStrictnessFalse2.id
-        self.apiclient.changeServiceForVirtualMachine(cmd)
+        self.apiclient.scaleVirtualMachine(cmd)
 
         list_vm_response = VirtualMachine.list(
             self.apiclient,

--- a/tools/marvin/marvin/sandbox/demo/simulator/testcase/test_vm_life_cycle.py
+++ b/tools/marvin/marvin/sandbox/demo/simulator/testcase/test_vm_life_cycle.py
@@ -414,10 +414,10 @@ class TestVMLifeCycle(cloudstackTestCase):
         self.debug("Change Service offering VM - ID: %s" %
                                     self.medium_virtual_machine.id)
 
-        cmd = changeServiceForVirtualMachine.changeServiceForVirtualMachineCmd()
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
         cmd.id = self.medium_virtual_machine.id
         cmd.serviceofferingid = self.small_offering.id
-        self.apiclient.changeServiceForVirtualMachine(cmd)
+        self.apiclient.scaleVirtualMachine(cmd)
 
         self.debug("Starting VM - ID: %s" % self.medium_virtual_machine.id)
         self.medium_virtual_machine.start(self.apiclient)


### PR DESCRIPTION
### Description

This PR fixes issue #6150 to deprecate changeServiceForVirtualMachine API. Going forward the idea is to use scaleVirtualMachine API for both stopped and running VMs which we are already doing from UI.

I've also changed the API in all the tests to use scaleVirtualMachine API.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
