### PR TITLE
Fixed list networks in projects after setting network permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ env:
              smoke/test_nested_virtualization
              smoke/test_network
              smoke/test_network_acl
+             smoke/test_network_permissions
              smoke/test_nic
              smoke/test_nic_adapter_type
              smoke/test_non_contigiousvlan
@@ -131,7 +132,6 @@ env:
 
     - TESTS="component/test_acl_sharednetwork
              component/test_acl_sharednetwork_deployVM-impersonation
-             component/test_network_permissions
              component/test_user_private_gateway
              component/test_user_shared_network"
 

--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -2022,7 +2022,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
                 if (Arrays.asList(Network.NetworkFilter.Shared, Network.NetworkFilter.All).contains(networkFilter)) {
                     // get shared networks
                     List<NetworkVO> sharedNetworks = listSharedNetworks(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, networkOfferingId,
-                            aclType, skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, permittedAccounts);
+                            aclType, true, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, permittedAccounts);
                     addNetworksToReturnIfNotExist(networksToReturn, sharedNetworks);
 
                 }
@@ -2035,23 +2035,23 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
                 if (Arrays.asList(Network.NetworkFilter.Domain, Network.NetworkFilter.AccountDomain, Network.NetworkFilter.All).contains(networkFilter)) {
                     //add domain specific networks of domain + parent domains
                     networksToReturn.addAll(listDomainSpecificNetworksByDomainPath(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, networkOfferingId,
-                            aclType, skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, path, isRecursive));
+                            aclType, true, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, path, isRecursive));
                     //add networks of subdomains
                     if (domainId == null) {
                         networksToReturn.addAll(listDomainLevelNetworks(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, networkOfferingId,
-                                aclType, true, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, caller.getDomainId(), true));
+                            aclType, true, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, caller.getDomainId(), true));
                     }
                 }
                 if (Arrays.asList(Network.NetworkFilter.Shared, Network.NetworkFilter.All).contains(networkFilter)) {
                     // get shared networks
                     List<NetworkVO> sharedNetworks = listSharedNetworksByDomainPath(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, networkOfferingId,
-                            aclType, skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, path, isRecursive);
+                            aclType, true, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter, path, isRecursive);
                     addNetworksToReturnIfNotExist(networksToReturn, sharedNetworks);
                 }
             }
         } else {
             networksToReturn = _networksDao.search(buildNetworkSearchCriteria(sb, keyword, id, isSystem, zoneId, guestIpType, trafficType, physicalNetworkId, networkOfferingId,
-                    null, skipProjectNetworks, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter);
+                    null, true, restartRequired, specifyIpRanges, vpcId, tags, display, vlanId, associatedNetworkId), searchFilter);
         }
 
         if (supportedServicesStr != null && !supportedServicesStr.isEmpty() && !networksToReturn.isEmpty()) {

--- a/test/integration/component/test_network_permissions.py
+++ b/test/integration/component/test_network_permissions.py
@@ -758,3 +758,24 @@ class TestNetworkPermissions(cloudstackTestCase):
         command = """self.reset_network_permission({apiclient}, self.user_network, expected=True)"""
         self.exec_command("self.otheruser_apiclient", command, expected=False)
         self.exec_command("self.user_apiclient", command, expected=True)
+
+    @attr(tags=["advanced"], required_hardware="false")
+    def test_05_list_networks_under_project(self):
+        """ Testing list networks under a project """
+        self.create_network_permission(self.apiclient, self.user_network, self.domain_admin, self.project, expected=True)
+        self.list_network(self.apiclient, self.domain_admin, self.user_network, self.project, None, expected=True)
+
+        self.remove_network_permission(self.apiclient, self.user_network, self.domain_admin, self.project, expected=True)
+        self.list_network(self.apiclient, self.domain_admin, self.user_network, self.project, None, expected=False)
+
+    @attr(tags=["advanced"], required_hardware="false")
+    def test_06_list_networks_under_account(self):
+        """ Testing list networks under an account """
+        self.create_network_permission(self.apiclient, self.user_network, self.domain_admin, None, expected=True)
+        self.list_network(self.apiclient, self.domain_admin, self.user_network, None, None, expected=True)
+        self.list_network(self.domainadmin_apiclient, self.domain_admin, self.user_network, None, None, expected=True)
+        self.list_network(self.user_apiclient, self.domain_admin, self.user_network, None, None, expected=False)
+
+        self.remove_network_permission(self.apiclient, self.user_network, self.domain_admin, None, expected=True)
+        self.list_network(self.apiclient, self.domain_admin, self.user_network, None, None, expected=False)
+        self.list_network(self.domainadmin_apiclient, self.domain_admin, self.user_network, None, None, expected=False)

--- a/test/integration/smoke/test_network_permissions.py
+++ b/test/integration/smoke/test_network_permissions.py
@@ -770,7 +770,7 @@ class TestNetworkPermissions(cloudstackTestCase):
 
     @attr(tags=["advanced"], required_hardware="false")
     def test_06_list_networks_under_account(self):
-        """ Testing list networks under an account """
+        """ Testing list networks under a domain admin account and user account """
         self.create_network_permission(self.apiclient, self.user_network, self.domain_admin, None, expected=True)
         self.list_network(self.apiclient, self.domain_admin, self.user_network, None, None, expected=True)
         self.list_network(self.domainadmin_apiclient, self.domain_admin, self.user_network, None, None, expected=True)
@@ -779,3 +779,11 @@ class TestNetworkPermissions(cloudstackTestCase):
         self.remove_network_permission(self.apiclient, self.user_network, self.domain_admin, None, expected=True)
         self.list_network(self.apiclient, self.domain_admin, self.user_network, None, None, expected=False)
         self.list_network(self.domainadmin_apiclient, self.domain_admin, self.user_network, None, None, expected=False)
+
+        self.create_network_permission(self.apiclient, self.user_network, self.other_user, None, expected=True)
+        self.list_network(self.apiclient, self.other_user, self.user_network, None, None, expected=True)
+        self.list_network(self.otheruser_apiclient, self.other_user, self.user_network, None, None, expected=True)
+
+        self.remove_network_permission(self.apiclient, self.user_network, self.other_user, None, expected=True)
+        self.list_network(self.apiclient, self.other_user, self.user_network, None, None, expected=False)
+        self.list_network(self.otheruser_apiclient, self.other_user, self.user_network, None, None, expected=False)


### PR DESCRIPTION
### Description

This PR fixes #6544 where it could not list networks in a project even after network permissions are set.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Created multiple networks N1, N2
2. Created a project P1
3. Created a user U1
4. Under network permissions in N1, added the project P1
5. Under network permissions in N2, added the user account U1
6. When switched to project view P1, I see only network N1
7. When logged in as U1, I see only N2


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
