### PR TITLE
test,xcp-ng: fix tests for VM PV driver issue

### DIFF
--- a/test/integration/component/test_network_permissions.py
+++ b/test/integration/component/test_network_permissions.py
@@ -44,7 +44,7 @@ from marvin.lib.base import (Account,
 
 from marvin.lib.common import (get_domain,
                                get_zone,
-                               get_template)
+                               get_suitable_test_template)
 
 NETWORK_FILTER_ACCOUNT = 'account'
 NETWORK_FILTER_DOMAIN = 'domain'
@@ -66,7 +66,12 @@ class TestNetworkPermissions(cloudstackTestCase):
 
         zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
         cls.zone = Zone(zone.__dict__)
-        cls.template = get_template(cls.apiclient, cls.zone.id)
+        cls.hypervisor = testClient.getHypervisorInfo()
+        cls.template = get_suitable_test_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"],
+            cls.hypervisor)
         cls._cleanup = []
 
         cls.logger = logging.getLogger("TestNetworkPermissions")

--- a/test/integration/smoke/test_attach_multiple_volumes.py
+++ b/test/integration/smoke/test_attach_multiple_volumes.py
@@ -28,9 +28,9 @@ from marvin.lib.base import (ServiceOffering,
                              DiskOffering,
                              )
 from marvin.lib.common import (get_domain,
-                                get_zone,
-                                get_template,
-                                find_storage_pool_type)
+                               get_zone,
+                               get_suitable_test_template,
+                               find_storage_pool_type)
 from marvin.codes import (
     PASS,
     FAILED,
@@ -69,13 +69,13 @@ class TestMultipleVolumeAttach(cloudstackTestCase):
                                     )
         cls._cleanup.append(cls.disk_offering)
 
-        template = get_template(
-                            cls.apiclient,
-                            cls.zone.id,
-                            cls.services["ostype"]
-                            )
+        template = get_suitable_test_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"],
+            cls.hypervisor)
         if template == FAILED:
-            assert False, "get_template() failed to return template with description %s" % cls.services["ostype"]
+            assert False, "get_suitable_test_template() failed to return template with description %s" % cls.services["ostype"]
 
         cls.services["domainid"] = cls.domain.id
         cls.services["zoneid"] = cls.zone.id

--- a/test/integration/smoke/test_network_permissions.py
+++ b/test/integration/smoke/test_network_permissions.py
@@ -66,7 +66,7 @@ class TestNetworkPermissions(cloudstackTestCase):
 
         zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
         cls.zone = Zone(zone.__dict__)
-        cls.hypervisor = testClient.getHypervisorInfo()
+        cls.hypervisor = cls.testClient.getHypervisorInfo()
         cls.template = get_suitable_test_template(
             cls.apiclient,
             cls.zone.id,

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -726,67 +726,6 @@ class TestVolumes(cloudstackTestCase):
             time.sleep(30)
         return
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
-    def test_12_resize_volume_with_only_size_parameter(self):
-        """Test resize a volume by providing only size parameter, disk offering id is not mandatory"""
-        # Verify the size is the new size is what we wanted it to be.
-        self.debug(
-            "Attaching volume (ID: %s) to VM (ID: %s)" % (
-                self.volume.id,
-                self.virtual_machine.id
-            ))
-
-        self.virtual_machine.attach_volume(self.apiClient, self.volume)
-        self.attached = True
-        hosts = Host.list(self.apiClient, id=self.virtual_machine.hostid)
-        self.assertTrue(isinstance(hosts, list))
-        self.assertTrue(len(hosts) > 0)
-        self.debug("Found %s host" % hosts[0].hypervisor)
-
-        if hosts[0].hypervisor == "XenServer":
-            self.virtual_machine.stop(self.apiClient)
-        elif hosts[0].hypervisor.lower() == "hyperv":
-            self.skipTest("Resize Volume is unsupported on Hyper-V")
-
-        # resize the data disk
-        self.debug("Resize Volume ID: %s" % self.volume.id)
-
-        cmd = resizeVolume.resizeVolumeCmd()
-        cmd.id = self.volume.id
-        cmd.size = 20
-
-        self.apiClient.resizeVolume(cmd)
-
-        count = 0
-        success = False
-        while count < 3:
-            list_volume_response = Volume.list(
-                self.apiClient,
-                id=self.volume.id,
-                type='DATADISK'
-            )
-            for vol in list_volume_response:
-                if vol.id == self.volume.id and int(vol.size) == (20 * (1024 ** 3)) and vol.state == 'Ready':
-                    success = True
-            if success:
-                break
-            else:
-                time.sleep(10)
-                count += 1
-
-        self.assertEqual(
-            success,
-            True,
-            "Check if the data volume resized appropriately"
-        )
-
-        # start the vm if it is on xenserver
-
-        if hosts[0].hypervisor == "XenServer":
-            self.virtual_machine.start(self.apiClient)
-            time.sleep(30)
-        return
-
     @attr(tags=["advanced", "advancedns", "smoke", "basic"], required_hardware="false")
     def test_09_delete_detached_volume(self):
         """Delete a Volume unattached to an VM
@@ -943,6 +882,67 @@ class TestVolumes(cloudstackTestCase):
 
         return
 
+    @attr(tags=["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    def test_12_resize_volume_with_only_size_parameter(self):
+        """Test resize a volume by providing only size parameter, disk offering id is not mandatory"""
+        # Verify the size is the new size is what we wanted it to be.
+        self.debug(
+            "Attaching volume (ID: %s) to VM (ID: %s)" % (
+                self.volume.id,
+                self.virtual_machine.id
+            ))
+
+        self.virtual_machine.attach_volume(self.apiClient, self.volume)
+        self.attached = True
+        hosts = Host.list(self.apiClient, id=self.virtual_machine.hostid)
+        self.assertTrue(isinstance(hosts, list))
+        self.assertTrue(len(hosts) > 0)
+        self.debug("Found %s host" % hosts[0].hypervisor)
+
+        if hosts[0].hypervisor == "XenServer":
+            self.virtual_machine.stop(self.apiClient)
+        elif hosts[0].hypervisor.lower() == "hyperv":
+            self.skipTest("Resize Volume is unsupported on Hyper-V")
+
+        # resize the data disk
+        self.debug("Resize Volume ID: %s" % self.volume.id)
+
+        cmd = resizeVolume.resizeVolumeCmd()
+        cmd.id = self.volume.id
+        cmd.size = 20
+
+        self.apiClient.resizeVolume(cmd)
+
+        count = 0
+        success = False
+        while count < 3:
+            list_volume_response = Volume.list(
+                self.apiClient,
+                id=self.volume.id,
+                type='DATADISK'
+            )
+            for vol in list_volume_response:
+                if vol.id == self.volume.id and int(vol.size) == (20 * (1024 ** 3)) and vol.state == 'Ready':
+                    success = True
+            if success:
+                break
+            else:
+                time.sleep(10)
+                count += 1
+
+        self.assertEqual(
+            success,
+            True,
+            "Check if the data volume resized appropriately"
+        )
+
+        # start the vm if it is on xenserver
+
+        if hosts[0].hypervisor == "XenServer":
+            self.virtual_machine.start(self.apiClient)
+            time.sleep(30)
+        return
+
     def wait_for_attributes_and_return_root_vol(self):
         def checkVolumeResponse():
             list_volume_response = Volume.list(
@@ -963,7 +963,7 @@ class TestVolumes(cloudstackTestCase):
         return response
 
     @attr(tags=["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
-    def test_11_migrate_volume_and_change_offering(self):
+    def test_13_migrate_volume_and_change_offering(self):
         """
         Validates the following
         1. Creates a new Volume with a small disk offering


### PR DESCRIPTION
### Description

Few of the smoke tests fail on XCP-ng8 with PV drivers not installed for the VM.
This PR makes changes to use get_suitable_test_template instead of get_template to use the appropriate template for the VM deployed during the test.
After volume migration VM becomes unusable for attach/detach volume action.
A new template could be used in future. For workaround right now, tests are ordered in a way that migrate volume test run at the end.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
