### PR TITLE
removed the use of SharedMountPoint storage type for the StorPool plugin

### DIFF
--- a/api/src/main/java/com/cloud/storage/Storage.java
+++ b/api/src/main/java/com/cloud/storage/Storage.java
@@ -149,7 +149,7 @@ public class Storage {
         ManagedNFS(true, false),
         Linstor(true, true),
         DatastoreCluster(true, true), // for VMware, to abstract pool of clusters
-        StorPool(true, false);
+        StorPool(true, true);
 
         private final boolean shared;
         private final boolean overprovisioning;

--- a/api/src/main/java/com/cloud/storage/Storage.java
+++ b/api/src/main/java/com/cloud/storage/Storage.java
@@ -148,7 +148,8 @@ public class Storage {
         PowerFlex(true, true), // Dell EMC PowerFlex/ScaleIO (formerly VxFlexOS)
         ManagedNFS(true, false),
         Linstor(true, true),
-        DatastoreCluster(true, true); // for VMware, to abstract pool of clusters
+        DatastoreCluster(true, true), // for VMware, to abstract pool of clusters
+        StorPool(true, false);
 
         private final boolean shared;
         private final boolean overprovisioning;

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41700to41710.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41700to41710.java
@@ -16,17 +16,29 @@
 // under the License.
 package com.cloud.upgrade.dao;
 
-import com.cloud.upgrade.SystemVmTemplateRegistration;
-import com.cloud.utils.exception.CloudRuntimeException;
-import org.apache.log4j.Logger;
-
 import java.io.InputStream;
 import java.sql.Connection;
+import java.util.List;
+
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDaoImpl;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.log4j.Logger;
+
+import com.cloud.storage.Storage.StoragePoolType;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
+import com.cloud.storage.dao.VolumeDaoImpl;
+import com.cloud.upgrade.SystemVmTemplateRegistration;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 public class Upgrade41700to41710 implements DbUpgrade, DbUpgradeSystemVmTemplate {
 
     final static Logger LOG = Logger.getLogger(Upgrade41610to41700.class);
     private SystemVmTemplateRegistration systemVmTemplateRegistration;
+
+    private PrimaryDataStoreDao storageDao;
+    private VolumeDao volumeDao;
 
     @Override
     public String[] getUpgradableVersionRange() {
@@ -56,6 +68,7 @@ public class Upgrade41700to41710 implements DbUpgrade, DbUpgradeSystemVmTemplate
 
     @Override
     public void performDataMigration(Connection conn) {
+        updateStorageType();
     }
 
     @Override
@@ -81,6 +94,27 @@ public class Upgrade41700to41710 implements DbUpgrade, DbUpgradeSystemVmTemplate
             systemVmTemplateRegistration.updateSystemVmTemplates(conn);
         } catch (Exception e) {
             throw new CloudRuntimeException("Failed to find / register SystemVM template(s)");
+        }
+    }
+
+    private void updateStorageType() {
+        storageDao = new PrimaryDataStoreDaoImpl();
+        List<StoragePoolVO> storPoolPools = storageDao.findPoolsByProvider("StorPool");
+        for (StoragePoolVO storagePoolVO : storPoolPools) {
+            if (StoragePoolType.SharedMountPoint == storagePoolVO.getPoolType()) {
+                storagePoolVO.setPoolType(StoragePoolType.StorPool);
+                storageDao.update(storagePoolVO.getId(), storagePoolVO);
+            }
+            updateStorPoolVolumesToStorPoolType(storagePoolVO.getId());
+        }
+    }
+
+    private void updateStorPoolVolumesToStorPoolType(long storagePoolId) {
+        volumeDao = new VolumeDaoImpl();
+        List<VolumeVO> volumes = volumeDao.findByPoolId(storagePoolId, null);
+        for (VolumeVO volumeVO : volumes) {
+            volumeVO.setPoolType(StoragePoolType.StorPool);
+            volumeDao.update(volumeVO.getId(), volumeVO);
         }
     }
 }

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41700to41710.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41700to41710.java
@@ -68,7 +68,7 @@ public class Upgrade41700to41710 implements DbUpgrade, DbUpgradeSystemVmTemplate
 
     @Override
     public void performDataMigration(Connection conn) {
-        updateStorageType();
+        updateStorPoolStorageType();
     }
 
     @Override
@@ -97,7 +97,7 @@ public class Upgrade41700to41710 implements DbUpgrade, DbUpgradeSystemVmTemplate
         }
     }
 
-    private void updateStorageType() {
+    private void updateStorPoolStorageType() {
         storageDao = new PrimaryDataStoreDaoImpl();
         List<StoragePoolVO> storPoolPools = storageDao.findPoolsByProvider("StorPool");
         for (StoragePoolVO storagePoolVO : storPoolPools) {
@@ -105,11 +105,11 @@ public class Upgrade41700to41710 implements DbUpgrade, DbUpgradeSystemVmTemplate
                 storagePoolVO.setPoolType(StoragePoolType.StorPool);
                 storageDao.update(storagePoolVO.getId(), storagePoolVO);
             }
-            updateStorPoolVolumesToStorPoolType(storagePoolVO.getId());
+            updateStorageTypeForStorPoolVolumes(storagePoolVO.getId());
         }
     }
 
-    private void updateStorPoolVolumesToStorPoolType(long storagePoolId) {
+    private void updateStorageTypeForStorPoolVolumes(long storagePoolId) {
         volumeDao = new VolumeDaoImpl();
         List<VolumeVO> volumes = volumeDao.findByPoolId(storagePoolId, null);
         for (VolumeVO volumeVO : volumes) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2848,7 +2848,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                         dataStoreUrl = "nfs://" + psHost + File.separator + psPath;
                         physicalDisk = getPhysicalDiskFromNfsStore(dataStoreUrl, data);
                     } else if (primaryDataStoreTO.getPoolType().equals(StoragePoolType.SharedMountPoint) ||
-                            primaryDataStoreTO.getPoolType().equals(StoragePoolType.Filesystem)) {
+                            primaryDataStoreTO.getPoolType().equals(StoragePoolType.Filesystem) ||
+                            primaryDataStoreTO.getPoolType().equals(StoragePoolType.StorPool)) {
                         physicalDisk = getPhysicalDiskPrimaryStore(primaryDataStoreTO, data);
                     }
                 }
@@ -2868,7 +2869,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                     && (pool.getType() == StoragePoolType.NetworkFilesystem
                     || pool.getType() == StoragePoolType.SharedMountPoint
                     || pool.getType() == StoragePoolType.Filesystem
-                    || pool.getType() == StoragePoolType.Gluster)) {
+                    || pool.getType() == StoragePoolType.Gluster
+                    || pool.getType() == StoragePoolType.StorPool)) {
                 setBackingFileFormat(physicalDisk.getPath());
             }
 

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/storage/StorPoolStorageAdaptor.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/storage/StorPoolStorageAdaptor.java
@@ -39,7 +39,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.Script;
 
-@StorageAdaptorInfo(storagePoolType=StoragePoolType.SharedMountPoint)
+@StorageAdaptorInfo(storagePoolType=StoragePoolType.StorPool)
 public class StorPoolStorageAdaptor implements StorageAdaptor {
     public static void SP_LOG(String fmt, Object... args) {
         try (PrintWriter spLogFile = new PrintWriter(new BufferedWriter(new FileWriter("/var/log/cloudstack/agent/storpool-agent.log", true)))) {

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -233,7 +233,6 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
                     VolumeVO volume = volumeDao.findById(vinfo.getId());
                     volume.setPoolId(dataStore.getId());
-                    volume.setPoolType(StoragePoolType.SharedMountPoint);
                     volume.setPath(path);
                     volumeDao.update(volume.getId(), volume);
 
@@ -716,7 +715,7 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
                     final String name = StorPoolStorageAdaptor.getVolumeNameFromPath(srcTO.getPath(), true);
                     StorPoolUtil.spLog("StorpoolPrimaryDataStoreDriverImpl.copyAsnc DST tmpSnapName=%s ,srcUUID=%s", name, srcTO.getUuid());
 
-                    if (checkStoragePool != null && checkStoragePool.getPoolType().equals(StoragePoolType.SharedMountPoint)) {
+                    if (checkStoragePool != null && checkStoragePool.getPoolType().equals(StoragePoolType.StorPool)) {
                         SpConnectionDesc conn = StorPoolUtil.getSpConnection(dstData.getDataStore().getUuid(), dstData.getDataStore().getId(), storagePoolDetailsDao, primaryStoreDao);
                         String baseOn = StorPoolStorageAdaptor.getVolumeNameFromPath(srcTO.getPath(), true);
                         //uuid tag will be the same as srcData.uuid

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/StorPoolPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/StorPoolPrimaryDataStoreLifeCycle.java
@@ -164,7 +164,7 @@ public class StorPoolPrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeCy
         parameters.setUuid(conn.getTemplateName() + ";" + UUID.randomUUID().toString());
         parameters.setZoneId(zoneId);
         parameters.setProviderName(providerName);
-        parameters.setType(StoragePoolType.SharedMountPoint);
+        parameters.setType(StoragePoolType.StorPool);
         parameters.setHypervisorType(HypervisorType.KVM);
         parameters.setManaged(false);
         parameters.setHost("n/a");


### PR DESCRIPTION
### Description

This PR fixes #6455 

The default storage adaptor - `LibvirtStorageAdaptor` - is used by different storage types and doesn't use the annotation `@StorageAdaptorInfo`. In this case, a storage plugin that wants to adopt one of the predefined storage pool types will override the default behaviour. If fixing the issue in general (for new storage plugins or current ones that want to reuse the existing storage pool types) would affect all volume/snapshot/VM cases. This will lead to the need of extensive testing for each storage plugin for which we don't have the resources to do it. That's why this patch fixes the old behaviour for the SharedMountPoint by adding a new storage pool type for the StorPool plugin.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested with the upgrade from CS 4.17.0.0 to 4.17.1.0
Manually tested test cases with created instances before the upgrade
executed smoke tests for the StorPool plugin