### PR TITLE
api: fix ipv6 firewall apis default role permissions

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/CreateIpv6FirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/CreateIpv6FirewallRuleCmd.java
@@ -43,7 +43,12 @@ import com.cloud.network.rules.FirewallRule;
 import com.cloud.user.Account;
 import com.cloud.utils.net.NetUtils;
 
-@APICommand(name = CreateIpv6FirewallRuleCmd.APINAME, description = "Creates an Ipv6 firewall rule in the given network (the network has to belong to VPC)", responseObject = FirewallRuleResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = CreateIpv6FirewallRuleCmd.APINAME,
+        description = "Creates an Ipv6 firewall rule in the given network (the network has to belong to VPC)",
+        responseObject = FirewallRuleResponse.class,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = false,
+        authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
 public class CreateIpv6FirewallRuleCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = Logger.getLogger(CreateIpv6FirewallRuleCmd.class.getName());
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/DeleteIpv6FirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/DeleteIpv6FirewallRuleCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.ipv6;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
@@ -33,8 +34,12 @@ import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.user.Account;
 
-@APICommand(name = DeleteIpv6FirewallRuleCmd.APINAME, description = "Deletes a IPv6 firewall rule", responseObject = SuccessResponse.class,
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = DeleteIpv6FirewallRuleCmd.APINAME,
+        description = "Deletes a IPv6 firewall rule",
+        responseObject = SuccessResponse.class,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = false,
+        authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
 public class DeleteIpv6FirewallRuleCmd extends BaseAsyncCmd {
     public static final Logger s_logger = Logger.getLogger(DeleteIpv6FirewallRuleCmd.class.getName());
     public static final String APINAME = "deleteIpv6FirewallRule";

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/ListIpv6FirewallRulesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/ListIpv6FirewallRulesCmd.java
@@ -34,8 +34,12 @@ import org.apache.log4j.Logger;
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.utils.Pair;
 
-@APICommand(name = ListIpv6FirewallRulesCmd.APINAME, description = "Lists all IPv6 firewall rules", responseObject = FirewallRuleResponse.class,
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = ListIpv6FirewallRulesCmd.APINAME,
+        description = "Lists all IPv6 firewall rules",
+        responseObject = FirewallRuleResponse.class,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = false,
+        authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
 public class ListIpv6FirewallRulesCmd extends BaseListTaggedResourcesCmd implements IListFirewallRulesCmd {
     public static final Logger s_logger = Logger.getLogger(ListIpv6FirewallRulesCmd.class.getName());
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/UpdateIpv6FirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/ipv6/UpdateIpv6FirewallRuleCmd.java
@@ -34,7 +34,12 @@ import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.user.Account;
 
-@APICommand(name = UpdateIpv6FirewallRuleCmd.APINAME, description = "Updates Ipv6 firewall rule with specified ID", responseObject = FirewallRuleResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = UpdateIpv6FirewallRuleCmd.APINAME,
+        description = "Updates Ipv6 firewall rule with specified ID",
+        responseObject = FirewallRuleResponse.class,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = false,
+        authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
 public class UpdateIpv6FirewallRuleCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = Logger.getLogger(UpdateIpv6FirewallRuleCmd.class.getName());
 

--- a/test/integration/component/test_network_ipv6.py
+++ b/test/integration/component/test_network_ipv6.py
@@ -209,6 +209,10 @@ class TestIpv6Network(cloudstackTestCase):
     def setUp(self):
         self.services = self.testClient.getParsedTestDataConfig()
         self.apiclient = self.testClient.getApiClient()
+        self.userapiclient = self.testClient.getUserApiClient(
+            UserName=self.account.name,
+            DomainName=self.account.domain
+        )
         self.dbclient = self.testClient.getDbConnection()
         self.thread = None
         self.cleanup = []
@@ -567,7 +571,7 @@ class TestIpv6Network(cloudstackTestCase):
             cmd.icmptype = icmp_type
         if icmp_code is not None:
             cmd.icmpcode = icmp_code
-        fw_rule = self.apiclient.createIpv6FirewallRule(cmd)
+        fw_rule = self.userapiclient.createIpv6FirewallRule(cmd)
         return fw_rule
 
     def deployRoutingTestResources(self):
@@ -655,7 +659,7 @@ class TestIpv6Network(cloudstackTestCase):
 
         cmd = deleteIpv6FirewallRule.deleteIpv6FirewallRuleCmd()
         cmd.id = fw2.id
-        self.apiclient.deleteIpv6FirewallRule(cmd)
+        self.userapiclient.deleteIpv6FirewallRule(cmd)
 
     def createAndVerifyIpv6FirewallRule(self, traffic_type, source_cidr, dest_cidr, protocol,
         start_port, end_port, icmp_type, icmp_code, parsed_rule, delete=False):
@@ -664,7 +668,7 @@ class TestIpv6Network(cloudstackTestCase):
         start_port, end_port, icmp_type, icmp_code)
         cmd = listIpv6FirewallRules.listIpv6FirewallRulesCmd()
         cmd.id = fw_rule.id
-        rules = self.apiclient.listIpv6FirewallRules(cmd)
+        rules = self.userapiclient.listIpv6FirewallRules(cmd)
         self.assertTrue(
             isinstance(rules, list),
             "Check listIpv6FirewallRules response returns a valid list"
@@ -702,7 +706,7 @@ class TestIpv6Network(cloudstackTestCase):
         if delete == True:
             cmd = deleteIpv6FirewallRule.deleteIpv6FirewallRuleCmd()
             cmd.id = fw_rule.id
-            self.apiclient.deleteIpv6FirewallRule(cmd)
+            self.userapiclient.deleteIpv6FirewallRule(cmd)
             res = self.getRouterProcessStatus(self.getNetworkRouter(self.network), routerCmd)
             self.assertFalse(parsed_rule in res,
                 "Firewall rule present in nft list chain failure despite delete for rule: %s" % parsed_rule)

--- a/test/integration/component/test_network_ipv6.py
+++ b/test/integration/component/test_network_ipv6.py
@@ -270,10 +270,8 @@ class TestIpv6Network(cloudstackTestCase):
     def deployNetwork(self):
         self.services["network"]["networkoffering"] = self.network_offering.id
         self.network = Network.create(
-            self.apiclient,
+            self.userapiclient,
             self.services["network"],
-            self.account.name,
-            self.account.domainid,
             zoneid=self.zone.id
         )
         self.cleanup.append(self.network)
@@ -283,11 +281,9 @@ class TestIpv6Network(cloudstackTestCase):
             assert False, "get_test_template() failed to return template"
         self.services["virtual_machine"]["zoneid"] = self.zone.id
         self.virtual_machine = VirtualMachine.create(
-            self.apiclient,
+            self.userapiclient,
             self.services["virtual_machine"],
             templateid=self.template.id,
-            accountid=self.account.name,
-            domainid=self.account.domainid,
             networkids=self.network.id,
             serviceofferingid=self.service_offering.id
         )
@@ -545,11 +541,11 @@ class TestIpv6Network(cloudstackTestCase):
                     "IPv6 gateway for VM %s NIC is empty" % nic.traffictype)
 
     def restartNetworkWithCleanup(self):
-        self.network.restart(self.apiclient, cleanup=True)
+        self.network.restart(self.userapiclient, cleanup=True)
         time.sleep(SLEEP_BEFORE_VR_CHANGES)
 
     def updateNetworkWithOffering(self):
-        self.network.update(self.apiclient, networkofferingid=self.network_offering_update.id)
+        self.network.update(self.userapiclient, networkofferingid=self.network_offering_update.id)
         time.sleep(SLEEP_BEFORE_VR_CHANGES)
 
     def createIpv6FirewallRuleInNetwork(self, network_id, traffic_type, source_cidr, dest_cidr, protocol,

--- a/test/integration/smoke/test_network_ipv6.py
+++ b/test/integration/smoke/test_network_ipv6.py
@@ -209,6 +209,10 @@ class TestIpv6Network(cloudstackTestCase):
     def setUp(self):
         self.services = self.testClient.getParsedTestDataConfig()
         self.apiclient = self.testClient.getApiClient()
+        self.userapiclient = self.testClient.getUserApiClient(
+            UserName=self.account.name,
+            DomainName=self.account.domain
+        )
         self.dbclient = self.testClient.getDbConnection()
         self.thread = None
         self.cleanup = []
@@ -567,7 +571,7 @@ class TestIpv6Network(cloudstackTestCase):
             cmd.icmptype = icmp_type
         if icmp_code is not None:
             cmd.icmpcode = icmp_code
-        fw_rule = self.apiclient.createIpv6FirewallRule(cmd)
+        fw_rule = self.userapiclient.createIpv6FirewallRule(cmd)
         return fw_rule
 
     def deployRoutingTestResources(self):
@@ -655,7 +659,7 @@ class TestIpv6Network(cloudstackTestCase):
 
         cmd = deleteIpv6FirewallRule.deleteIpv6FirewallRuleCmd()
         cmd.id = fw2.id
-        self.apiclient.deleteIpv6FirewallRule(cmd)
+        self.userapiclient.deleteIpv6FirewallRule(cmd)
 
     def createAndVerifyIpv6FirewallRule(self, traffic_type, source_cidr, dest_cidr, protocol,
         start_port, end_port, icmp_type, icmp_code, parsed_rule, delete=False):
@@ -664,7 +668,7 @@ class TestIpv6Network(cloudstackTestCase):
         start_port, end_port, icmp_type, icmp_code)
         cmd = listIpv6FirewallRules.listIpv6FirewallRulesCmd()
         cmd.id = fw_rule.id
-        rules = self.apiclient.listIpv6FirewallRules(cmd)
+        rules = self.userapiclient.listIpv6FirewallRules(cmd)
         self.assertTrue(
             isinstance(rules, list),
             "Check listIpv6FirewallRules response returns a valid list"
@@ -702,7 +706,7 @@ class TestIpv6Network(cloudstackTestCase):
         if delete == True:
             cmd = deleteIpv6FirewallRule.deleteIpv6FirewallRuleCmd()
             cmd.id = fw_rule.id
-            self.apiclient.deleteIpv6FirewallRule(cmd)
+            self.userapiclient.deleteIpv6FirewallRule(cmd)
             res = self.getRouterProcessStatus(self.getNetworkRouter(self.network), routerCmd)
             self.assertFalse(parsed_rule in res,
                 "Firewall rule present in nft list chain failure despite delete for rule: %s" % parsed_rule)

--- a/test/integration/smoke/test_network_ipv6.py
+++ b/test/integration/smoke/test_network_ipv6.py
@@ -270,10 +270,8 @@ class TestIpv6Network(cloudstackTestCase):
     def deployNetwork(self):
         self.services["network"]["networkoffering"] = self.network_offering.id
         self.network = Network.create(
-            self.apiclient,
+            self.userapiclient,
             self.services["network"],
-            self.account.name,
-            self.account.domainid,
             zoneid=self.zone.id
         )
         self.cleanup.append(self.network)
@@ -283,11 +281,9 @@ class TestIpv6Network(cloudstackTestCase):
             assert False, "get_test_template() failed to return template"
         self.services["virtual_machine"]["zoneid"] = self.zone.id
         self.virtual_machine = VirtualMachine.create(
-            self.apiclient,
+            self.userapiclient,
             self.services["virtual_machine"],
             templateid=self.template.id,
-            accountid=self.account.name,
-            domainid=self.account.domainid,
             networkids=self.network.id,
             serviceofferingid=self.service_offering.id
         )
@@ -545,11 +541,11 @@ class TestIpv6Network(cloudstackTestCase):
                     "IPv6 gateway for VM %s NIC is empty" % nic.traffictype)
 
     def restartNetworkWithCleanup(self):
-        self.network.restart(self.apiclient, cleanup=True)
+        self.network.restart(self.userapiclient, cleanup=True)
         time.sleep(SLEEP_BEFORE_VR_CHANGES)
 
     def updateNetworkWithOffering(self):
-        self.network.update(self.apiclient, networkofferingid=self.network_offering_update.id)
+        self.network.update(self.userapiclient, networkofferingid=self.network_offering_update.id)
         time.sleep(SLEEP_BEFORE_VR_CHANGES)
 
     def createIpv6FirewallRuleInNetwork(self, network_id, traffic_type, source_cidr, dest_cidr, protocol,

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -62,7 +62,7 @@ export default {
       }, {
         name: 'ip.v6.firewall',
         component: shallowRef(defineAsyncComponent(() => import('@/views/network/Ipv6FirewallRulesTab.vue'))),
-        show: (record, route, user) => { return record.type === 'Isolated' && ['IPv6', 'DualStack'].includes(record.internetprotocol) && !('vpcid' in record) && 'listIpv6FirewallRules' in store.getters.apis && (['Admin', 'DomainAdmin'].includes(user.roletype) || record.account === user.account || record.projectid) }
+        show: (record) => { return record.type === 'Isolated' && ['IPv6', 'DualStack'].includes(record.internetprotocol) && !('vpcid' in record) && 'listIpv6FirewallRules' in store.getters.apis }
       }, {
         name: 'public.ip.addresses',
         component: shallowRef(defineAsyncComponent(() => import('@/views/network/IpAddressesTab.vue'))),

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -62,7 +62,7 @@ export default {
       }, {
         name: 'ip.v6.firewall',
         component: shallowRef(defineAsyncComponent(() => import('@/views/network/Ipv6FirewallRulesTab.vue'))),
-        show: (record) => { return record.type === 'Isolated' && ['IPv6', 'DualStack'].includes(record.internetprotocol) && !('vpcid' in record) && 'listIpv6FirewallRules' in store.getters.apis }
+        show: (record, route, user) => { return record.type === 'Isolated' && ['IPv6', 'DualStack'].includes(record.internetprotocol) && !('vpcid' in record) && 'listIpv6FirewallRules' in store.getters.apis && (['Admin', 'DomainAdmin'].includes(user.roletype) || record.account === user.account || record.projectid) }
       }, {
         name: 'public.ip.addresses',
         component: shallowRef(defineAsyncComponent(() => import('@/views/network/IpAddressesTab.vue'))),


### PR DESCRIPTION
### Description
Fixes default roles permissions for IPv6 firewall related APIs
Refactors related marvin tests to call deploy, update, restart network and VM APIs as user instead of the admin
Fixes #6575

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
