### PR TITLE
[Veeam] Find VBRViDatastore and VBRServer by name

### DIFF
--- a/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.backup;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import org.apache.cloudstack.api.ServerApiException;
@@ -30,6 +31,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.utils.Pair;
 
 public class BackupManagerTest {
     @Spy
@@ -38,6 +40,12 @@ public class BackupManagerTest {
 
     @Mock
     BackupOfferingDao backupOfferingDao;
+
+    @Mock
+    BackupProvider backupProvider;
+
+    private String[] hostPossibleValues = {"127.0.0.1", "hostname"};
+    private String[] datastoresPossibleValues = {"e9804933-8609-4de3-bccc-6278072a496c", "datastore-name"};
 
     @Before
     public void setup() throws Exception {
@@ -116,5 +124,69 @@ public class BackupManagerTest {
         assertEquals("New name", updated.getName());
         assertEquals("New description", updated.getDescription());
         assertEquals(true, updated.isUserDrivenBackupAllowed());
+    }
+
+    @Test
+    public void restoreBackedUpVolumeTestHostIpAndDatastoreUuid() {
+        BackupVO backupVO = new BackupVO();
+        String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
+
+        Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
+                Mockito.eq("127.0.0.1"), Mockito.eq("e9804933-8609-4de3-bccc-6278072a496c"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+
+        assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
+        assertEquals("Success", restoreBackedUpVolume.second());
+
+        Mockito.verify(backupProvider, times(1)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void restoreBackedUpVolumeTestHostIpAndDatastoreName() {
+        BackupVO backupVO = new BackupVO();
+        String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
+
+        Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
+                Mockito.eq("127.0.0.1"), Mockito.eq("datastore-name"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success2"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+
+        assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
+        assertEquals("Success2", restoreBackedUpVolume.second());
+
+        Mockito.verify(backupProvider, times(2)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void restoreBackedUpVolumeTestHostNameAndDatastoreUuid() {
+        BackupVO backupVO = new BackupVO();
+        String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
+
+        Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
+                Mockito.eq("hostname"), Mockito.eq("e9804933-8609-4de3-bccc-6278072a496c"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success3"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+
+        assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
+        assertEquals("Success3", restoreBackedUpVolume.second());
+
+        Mockito.verify(backupProvider, times(3)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void restoreBackedUpVolumeTestHostAndDatastoreName() {
+        BackupVO backupVO = new BackupVO();
+        String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
+
+        Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
+                Mockito.eq("hostname"), Mockito.eq("datastore-name"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success4"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+
+        assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
+        assertEquals("Success4", restoreBackedUpVolume.second());
+
+        Mockito.verify(backupProvider, times(4)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString());
     }
 }


### PR DESCRIPTION
### Description

Using the VMWare hypervisor, with the Veeam plugin active, ACS tries to find, in Veeam, VBRViDatastore using the UUID of this storage in ACS, and VBRServer using the IP of the host in ACS. But, in some scenarios, the VBRViDatastore/VBRServer, in Veeam, can use the name of this component, which causes an exception in ACS. This PR aims to fix this behavior, improving the search of VBRViDatastore and VBRServer by using the name.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
It was tested in a local lab:

1. I added new storage and host in my lab, and make sure the component, in Veeam, are identified by their names;
2. I created a VM (the volume is in the new storage, and VM is in the new host) and added this VM to a backup offering;
3. I make some manual backups;
4. I tried to restore a backed-up volume of this VM;
5. Before, an exception occurs because ACS can't find both VBRViDatastore/VBRServer in Veeam;
6. Now, ACS can restore volume with no problem.