### PR TITLE
server: fix ipv6 network deployment with separate guest nw

### DIFF
--- a/engine/schema/src/main/java/com/cloud/dc/dao/VlanDao.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/VlanDao.java
@@ -61,7 +61,7 @@ public interface VlanDao extends GenericDao<VlanVO, Long> {
 
     List<VlanVO> listDedicatedVlans(long accountId);
 
-    List<VlanVO> listIpv6RangeByPhysicalNetworkIdAndVlanId(long physicalNetworkId, String vlanId);
+    List<VlanVO> listIpv6RangeByZoneIdAndVlanId(long zoneId, String vlanId);
 
     List<VlanVO> listIpv6SupportingVlansByZone(long zoneId);
 }

--- a/engine/schema/src/main/java/com/cloud/dc/dao/VlanDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/VlanDaoImpl.java
@@ -64,7 +64,7 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
     protected SearchBuilder<VlanVO> ZoneWideNonDedicatedVlanSearch;
     protected SearchBuilder<VlanVO> VlanGatewaysearch;
     protected SearchBuilder<VlanVO> DedicatedVlanSearch;
-    protected SearchBuilder<VlanVO> PhysicalNetworkVlanIp6Search;
+    protected SearchBuilder<VlanVO> ZoneVlanIp6Search;
     protected SearchBuilder<VlanVO> ZoneIp6Search;
     protected SearchBuilder<VlanVO> ZoneVlansSearch;
 
@@ -260,12 +260,12 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
         DedicatedVlanSearch.done();
         AccountVlanMapSearch.done();
 
-        PhysicalNetworkVlanIp6Search = createSearchBuilder();
-        PhysicalNetworkVlanIp6Search.and("physicalNetworkId", PhysicalNetworkVlanIp6Search.entity().getPhysicalNetworkId(), SearchCriteria.Op.EQ);
-        PhysicalNetworkVlanIp6Search.and("vlanId", PhysicalNetworkVlanIp6Search.entity().getVlanTag(), SearchCriteria.Op.EQ);
-        PhysicalNetworkVlanIp6Search.and("ip6Gateway", PhysicalNetworkVlanIp6Search.entity().getIp6Gateway(), SearchCriteria.Op.NNULL);
-        PhysicalNetworkVlanIp6Search.and("ip6Cidr", PhysicalNetworkVlanIp6Search.entity().getIp6Cidr(), SearchCriteria.Op.NNULL);
-        PhysicalNetworkVlanIp6Search.done();
+        ZoneVlanIp6Search = createSearchBuilder();
+        ZoneVlanIp6Search.and("zoneId", ZoneVlanIp6Search.entity().getDataCenterId(), SearchCriteria.Op.EQ);
+        ZoneVlanIp6Search.and("vlanId", ZoneVlanIp6Search.entity().getVlanTag(), SearchCriteria.Op.EQ);
+        ZoneVlanIp6Search.and("ip6Gateway", ZoneVlanIp6Search.entity().getIp6Gateway(), SearchCriteria.Op.NNULL);
+        ZoneVlanIp6Search.and("ip6Cidr", ZoneVlanIp6Search.entity().getIp6Cidr(), SearchCriteria.Op.NNULL);
+        ZoneVlanIp6Search.done();
 
         ZoneIp6Search = createSearchBuilder();
         ZoneIp6Search.and("zoneId", ZoneIp6Search.entity().getDataCenterId(), SearchCriteria.Op.EQ);
@@ -410,9 +410,9 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
     }
 
     @Override
-    public List<VlanVO> listIpv6RangeByPhysicalNetworkIdAndVlanId(long physicalNetworkId, String vlanId) {
-        SearchCriteria<VlanVO> sc = PhysicalNetworkVlanIp6Search.create();
-        sc.setParameters("physicalNetworkId", physicalNetworkId);
+    public List<VlanVO> listIpv6RangeByZoneIdAndVlanId(long zoneId, String vlanId) {
+        SearchCriteria<VlanVO> sc = ZoneVlanIp6Search.create();
+        sc.setParameters("zoneId", zoneId);
         if(StringUtils.isNotEmpty(vlanId)) {
             sc.setParameters("vlanId", vlanId);
         }

--- a/server/src/main/java/com/cloud/network/Ipv6ServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/Ipv6ServiceImpl.java
@@ -205,7 +205,7 @@ public class Ipv6ServiceImpl extends ComponentLifecycleBase implements Ipv6Servi
     }
 
     private Pair<String, ? extends Vlan> assignPublicIpv6ToNetworkInternal(Network network, String vlanId, String nicMacAddress) throws InsufficientAddressCapacityException {
-        final List<VlanVO> ranges = vlanDao.listIpv6RangeByPhysicalNetworkIdAndVlanId(network.getPhysicalNetworkId(), vlanId);
+        final List<VlanVO> ranges = vlanDao.listIpv6RangeByZoneIdAndVlanId(network.getDataCenterId(), vlanId);
         if (CollectionUtils.isEmpty(ranges)) {
             s_logger.error(String.format("Unable to find IPv6 address for zone ID: %d, physical network ID: %d, VLAN: %s", network.getDataCenterId(), network.getPhysicalNetworkId(), vlanId));
             InsufficientAddressCapacityException ex = new InsufficientAddressCapacityException("Insufficient address capacity", DataCenter.class, network.getDataCenterId());
@@ -501,7 +501,7 @@ public class Ipv6ServiceImpl extends ComponentLifecycleBase implements Ipv6Servi
                 ipAddressDao.listByAssociatedVpc(network.getVpcId(), true);
         for (IPAddressVO address : addresses) {
             VlanVO vlan = vlanDao.findById(address.getVlanId());
-            final List<VlanVO> ranges = vlanDao.listIpv6RangeByPhysicalNetworkIdAndVlanId(network.getPhysicalNetworkId(), vlan.getVlanTag());
+            final List<VlanVO> ranges = vlanDao.listIpv6RangeByZoneIdAndVlanId(network.getPhysicalNetworkId(), vlan.getVlanTag());
             if (CollectionUtils.isEmpty(ranges)) {
                 s_logger.error(String.format("Unable to find IPv6 address for zone ID: %d, physical network ID: %d, VLAN: %s", network.getDataCenterId(), network.getPhysicalNetworkId(), vlan.getVlanTag()));
                 InsufficientAddressCapacityException ex = new InsufficientAddressCapacityException("Insufficient address capacity", DataCenter.class, network.getDataCenterId());

--- a/server/src/test/java/com/cloud/network/Ipv6ServiceImplTest.java
+++ b/server/src/test/java/com/cloud/network/Ipv6ServiceImplTest.java
@@ -397,7 +397,7 @@ public class Ipv6ServiceImplTest {
         Nic nic = Mockito.mock(Nic.class);
         Mockito.when(nic.getIPv6Address()).thenReturn(null);
         Mockito.when(nic.getBroadcastUri()).thenReturn(URI.create(vlan));
-        Mockito.when(vlanDao.listIpv6RangeByPhysicalNetworkIdAndVlanId(1L, "vlan")).thenReturn(new ArrayList<>());
+        Mockito.when(vlanDao.listIpv6RangeByZoneIdAndVlanId(1L, "vlan")).thenReturn(new ArrayList<>());
         try (TransactionLegacy txn = TransactionLegacy.open("testNewErrorAssignPublicIpv6ToNetwork")) {
            ipv6Service.assignPublicIpv6ToNetwork(Mockito.mock(Network.class), nic);
         }
@@ -421,7 +421,7 @@ public class Ipv6ServiceImplTest {
         Mockito.when(vlanVO.getVlanType()).thenReturn(Vlan.VlanType.VirtualNetwork);
         List<VlanVO> vlans = new ArrayList<>();
         vlans.add(vlanVO);
-        Mockito.when(vlanDao.listIpv6RangeByPhysicalNetworkIdAndVlanId(Mockito.anyLong(), Mockito.anyString())).thenReturn(vlans);
+        Mockito.when(vlanDao.listIpv6RangeByZoneIdAndVlanId(Mockito.anyLong(), Mockito.anyString())).thenReturn(vlans);
         List<NicVO> placeholderNics = new ArrayList<>();
         if (fromPlaceholder) {
             placeholderNics = mockPlaceholderNics();
@@ -601,7 +601,7 @@ public class Ipv6ServiceImplTest {
         VlanVO vlanVO = Mockito.mock(VlanVO.class);
         Mockito.when(vlanVO.getVlanTag()).thenReturn(vlan);
         Mockito.when(vlanDao.findById(Mockito.anyLong())).thenReturn(vlanVO);
-        Mockito.when(vlanDao.listIpv6RangeByPhysicalNetworkIdAndVlanId(Mockito.anyLong(), Mockito.anyString())).thenReturn(new ArrayList<>());
+        Mockito.when(vlanDao.listIpv6RangeByZoneIdAndVlanId(Mockito.anyLong(), Mockito.anyString())).thenReturn(new ArrayList<>());
         try {
             ipv6Service.checkNetworkIpv6Upgrade(network);
             Assert.fail("No InsufficientAddressCapacityException");
@@ -619,7 +619,7 @@ public class Ipv6ServiceImplTest {
         VlanVO vlanVO = Mockito.mock(VlanVO.class);
         Mockito.when(vlanVO.getVlanTag()).thenReturn(vlan);
         Mockito.when(vlanDao.findById(Mockito.anyLong())).thenReturn(vlanVO);
-        Mockito.when(vlanDao.listIpv6RangeByPhysicalNetworkIdAndVlanId(physicalNetworkId, vlan)).thenReturn(List.of(vlanVO));
+        Mockito.when(vlanDao.listIpv6RangeByZoneIdAndVlanId(physicalNetworkId, vlan)).thenReturn(List.of(vlanVO));
         try {
             ipv6Service.checkNetworkIpv6Upgrade(network);
         } catch (InsufficientAddressCapacityException | ResourceAllocationException e) {


### PR DESCRIPTION
### Description

Fixes #6584

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Tested locally on a simulator env with separate physical network for guest traffic

```
(local) 🦂 > list physicalnetworks 
{
  "count": 2,
  "physicalnetwork": [
    {
      "broadcastdomainrange": "ZONE",
      "id": "4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173",
      "isolationmethods": "VLAN",
      "name": "Physical Network 1",
      "state": "Enabled",
      "vlan": "220-240",
      "zoneid": "78e1da67-04e5-4683-9d52-346ef6cd7472",
      "zonename": "z1"
    },
    {
      "broadcastdomainrange": "ZONE",
      "id": "78e3c74b-7def-40c2-b1d4-49e8d61fcc1b",
      "isolationmethods": "VLAN",
      "name": "Physical Network 2",
      "state": "Enabled",
      "vlan": "1220-1240",
      "zoneid": "78e1da67-04e5-4683-9d52-346ef6cd7472",
      "zonename": "z1"
    }
  ]
}
(local) 🍀 > list traffictypes 
💩 Missing required parameters:  physicalnetworkid
(local) 🐺 > list traffictypes physicalnetworkid=4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173 
{
  "count": 3,
  "traffictype": [
    {
      "id": "02bd3c75-dc66-4973-bb0e-a1a4c62dee95",
      "physicalnetworkid": "4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173",
      "traffictype": "Management"
    },
    {
      "id": "5006060a-616c-4ff8-90b0-3540e96039e9",
      "physicalnetworkid": "4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173",
      "traffictype": "Public"
    },
    {
      "id": "42afdc9e-867b-4a4e-9ed3-95e261e4cf5e",
      "physicalnetworkid": "4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173",
      "traffictype": "Storage"
    }
  ]
}
(local) 🦈 > list traffictypes physicalnetworkid=78e3c74b-7def-40c2-b1d4-49e8d61fcc1b 
{
  "count": 1,
  "traffictype": [
    {
      "id": "3268d521-c367-4693-b232-827d53d3bbd9",
      "physicalnetworkid": "78e3c74b-7def-40c2-b1d4-49e8d61fcc1b",
      "traffictype": "Guest"
    }
  ]
}
(local) 🐰 > list vlanipranges
{
  "count": 2,
  "vlaniprange": [
    {
      "account": "system",
      "cidr": "172.20.0.0/16",
      "domain": "ROOT",
      "domainid": "261e885f-0f19-11ed-8e7c-645d8651f45a",
      "endip": "172.20.20.200",
      "forsystemvms": false,
      "forvirtualnetwork": true,
      "gateway": "172.20.0.1",
      "id": "6f48b389-f9ef-44ca-95e4-84b046b7acb0",
      "netmask": "255.255.0.0",
      "networkid": "75e0cb27-d930-443a-923e-5906769aac52",
      "physicalnetworkid": "4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173",
      "startip": "172.20.20.10",
      "vlan": "vlan://50",
      "zoneid": "78e1da67-04e5-4683-9d52-346ef6cd7472"
    },
    {
      "account": "system",
      "domain": "ROOT",
      "domainid": "261e885f-0f19-11ed-8e7c-645d8651f45a",
      "forsystemvms": false,
      "forvirtualnetwork": true,
      "id": "2a17eaa9-c35d-4047-85da-a5c0072b1064",
      "ip6cidr": "2a00:1728:23:1140::/64",
      "ip6gateway": "2a00:1728:23:1140::1",
      "networkid": "75e0cb27-d930-443a-923e-5906769aac52",
      "physicalnetworkid": "4e3a8e0d-9d4e-4de5-bda0-17fb83b1b173",
      "vlan": "vlan://50",
      "zoneid": "78e1da67-04e5-4683-9d52-346ef6cd7472"
    }
  ]
}
(local) 🦑 > list networkofferings id=8af32012-878c-4ff3-a7fc-4763fbb82a92 filter=id,name,internetprotocol
{
  "count": 1,
  "networkoffering": [
    {
      "id": "8af32012-878c-4ff3-a7fc-4763fbb82a92",
      "internetprotocol": "DualStack",
      "name": "ip6"
    }
  ]
}
(local) 🐺 > create network zoneid=78e1da67-04e5-4683-9d52-346ef6cd7472 networkofferingid=8af32012-878c-4ff3-a7fc-4763fbb82a92 name=testnw displaytext=testnw
{
  "network": {
    "account": "admin",
    "acltype": "Account",
    "broadcastdomaintype": "Vlan",
    "canusefordeploy": true,
    "cidr": "10.1.1.0/24",
    "created": "2022-07-29T18:17:12+0530",
    "details": {},
    "displaynetwork": true,
    "displaytext": "testnw",
    "dns1": "8.8.8.8",
    "domain": "ROOT",
    "domainid": "261e885f-0f19-11ed-8e7c-645d8651f45a",
    "egressdefaultpolicy": false,
    "gateway": "10.1.1.1",
    "hasannotations": false,
    "id": "e5bb9951-b87e-4ac2-b18a-07f2f5044ed1",
    "internetprotocol": "DualStack",
    "ip6cidr": "2a00:1728:23:10d5::/64",
    "ip6gateway": "2a00:1728:23:10d5::1",
    "ip6routes": [],
    "ip6routing": "Static",
    "ispersistent": false,
    "issystem": false,
    "name": "testnw",
    "netmask": "255.255.255.0",
    "networkdomain": "cs2cloud.internal",
    "networkofferingavailability": "Optional",
    "networkofferingconservemode": true,
    "networkofferingdisplaytext": "ip6",
    "networkofferingid": "8af32012-878c-4ff3-a7fc-4763fbb82a92",
    "networkofferingname": "ip6",
    "physicalnetworkid": "78e3c74b-7def-40c2-b1d4-49e8d61fcc1b",
    "receivedbytes": 0,
    "redundantrouter": false,
    "related": "e5bb9951-b87e-4ac2-b18a-07f2f5044ed1",
    "restartrequired": false,
    "sentbytes": 0,
    "service": [
      {
        "capability": [
          {
            "canchooseservicecapability": true,
            "name": "SupportedSourceNatTypes",
            "value": "peraccount"
          },
          {
            "canchooseservicecapability": true,
            "name": "RedundantRouter",
            "value": "false"
          }
        ],
        "name": "SourceNat",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [],
        "name": "UserData",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "AllowDnsSuffixModification",
            "value": "true"
          }
        ],
        "name": "Dns",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "SupportedStickinessMethods",
            "value": "[{\"methodname\":\"LbCookie\",\"paramlist\":[{\"paramname\":\"cookie-name\",\"required\":false,\"isflag\":false,\"description\":\" \"},{\"paramname\":\"mode\",\"required\":false,\"isflag\":false,\"description\":\" \"},{\"paramname\":\"nocache\",\"required\":false,\"isflag\":true,\"description\":\" \"},{\"paramname\":\"indirect\",\"required\":false,\"isflag\":true,\"description\":\" \"},{\"paramname\":\"postonly\",\"required\":false,\"isflag\":true,\"description\":\" \"},{\"paramname\":\"domain\",\"required\":false,\"isflag\":false,\"description\":\" \"}],\"description\":\"This is loadbalancer cookie based stickiness method.\"},{\"methodname\":\"AppCookie\",\"paramlist\":[{\"paramname\":\"cookie-name\",\"required\":false,\"isflag\":false,\"description\":\" \"},{\"paramname\":\"length\",\"required\":false,\"isflag\":false,\"description\":\" \"},{\"paramname\":\"holdtime\",\"required\":false,\"isflag\":false,\"description\":\" \"},{\"paramname\":\"request-learn\",\"required\":false,\"isflag\":true,\"description\":\" \"},{\"paramname\":\"prefix\",\"required\":false,\"isflag\":true,\"description\":\" \"},{\"paramname\":\"mode\",\"required\":false,\"isflag\":false,\"description\":\" \"}],\"description\":\"This is App session based sticky method. Define session stickiness on an existing application cookie. It can be used only for a specific http traffic\"},{\"methodname\":\"SourceBased\",\"paramlist\":[{\"paramname\":\"tablesize\",\"required\":false,\"isflag\":false,\"description\":\" \"},{\"paramname\":\"expire\",\"required\":false,\"isflag\":false,\"description\":\" \"}],\"description\":\"This is source based Stickiness method, it can be used for any type of protocol.\"}]"
          },
          {
            "canchooseservicecapability": false,
            "name": "LbSchemes",
            "value": "Public"
          },
          {
            "canchooseservicecapability": true,
            "name": "SupportedLBIsolation",
            "value": "dedicated"
          },
          {
            "canchooseservicecapability": false,
            "name": "AutoScaleCounters",
            "value": "[{\"methodname\":\"cpu\",\"paramlist\":[]},{\"methodname\":\"memory\",\"paramlist\":[]}]"
          },
          {
            "canchooseservicecapability": false,
            "name": "SupportedLbAlgorithms",
            "value": "roundrobin,leastconn,source"
          },
          {
            "canchooseservicecapability": false,
            "name": "SupportedProtocols",
            "value": "tcp, udp, tcp-proxy"
          },
          {
            "canchooseservicecapability": false,
            "name": "ElasticLb",
            "value": "false"
          },
          {
            "canchooseservicecapability": false,
            "name": "InlineMode",
            "value": "false"
          }
        ],
        "name": "Lb",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "SupportedEgressProtocols",
            "value": "tcp,udp,icmp, all"
          },
          {
            "canchooseservicecapability": false,
            "name": "SupportedTrafficDirection",
            "value": "ingress, egress"
          },
          {
            "canchooseservicecapability": false,
            "name": "MultipleIps",
            "value": "true"
          },
          {
            "canchooseservicecapability": false,
            "name": "TrafficStatistics",
            "value": "per public ip"
          },
          {
            "canchooseservicecapability": false,
            "name": "SupportedProtocols",
            "value": "tcp,udp,icmp"
          }
        ],
        "name": "Firewall",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "VpnTypes",
            "value": "removeaccessvpn"
          },
          {
            "canchooseservicecapability": false,
            "name": "SupportedVpnTypes",
            "value": "pptp,l2tp,ipsec"
          }
        ],
        "name": "Vpn",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "DhcpAccrossMultipleSubnets",
            "value": "true"
          }
        ],
        "name": "Dhcp",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "SupportedProtocols",
            "value": "tcp,udp"
          }
        ],
        "name": "PortForwarding",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      },
      {
        "capability": [
          {
            "canchooseservicecapability": false,
            "name": "ElasticIp",
            "value": "false"
          },
          {
            "canchooseservicecapability": false,
            "name": "AssociatePublicIP",
            "value": "false"
          }
        ],
        "name": "StaticNat",
        "provider": [
          {
            "name": "VirtualRouter"
          }
        ]
      }
    ],
    "specifyipranges": false,
    "state": "Allocated",
    "strechedl2subnet": false,
    "tags": [],
    "traffictype": "Guest",
    "type": "Isolated",
    "zoneid": "78e1da67-04e5-4683-9d52-346ef6cd7472",
    "zonename": "z1"
  }
}
(local) 🐻 > deploy virtualmachine zoneid=78e1da67-04e5-4683-9d52-346ef6cd7472 serviceofferingid=2aa6cb73-7448-4dff-b12f-e6000f639b44 templateid=3a182a15-0f1b-11ed-8e7c-645d8651f45a networkids=e5bb9951-b87e-4ac2-b18a-07f2f5044ed1 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2022-07-29T18:17:53+0530",
    "details": {},
    "displayname": "VM-8a7a512a-dd39-451a-8088-fb2f8cb5ffef",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "261e885f-0f19-11ed-8e7c-645d8651f45a",
    "guestosid": "260e5aab-0f19-11ed-8e7c-645d8651f45a",
    "haenable": false,
    "hasannotations": false,
    "hostid": "3463f7b3-82ef-4b45-bafb-860553c89ce1",
    "hostname": "SimulatedAgent.21a13f62-9eec-4bab-98ba-e0116b16a16a",
    "hypervisor": "Simulator",
    "id": "8a7a512a-dd39-451a-8088-fb2f8cb5ffef",
    "instancename": "i-2-23-VM",
    "isdynamicallyscalable": false,
    "jobid": "d964031c-6ee7-43e9-b157-c92dedd9889a",
    "jobstatus": 0,
    "lastupdated": "2022-07-29T18:17:56+0530",
    "memory": 512,
    "name": "VM-8a7a512a-dd39-451a-8088-fb2f8cb5ffef",
    "nic": [
      {
        "broadcasturi": "vlan://1240",
        "deviceid": "0",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "b9c02029-9ae6-4149-8684-3c19e3fe0af1",
        "ip6address": "2a00:1728:23:10d5:0:28ff:fe3c:1",
        "ip6cidr": "2a00:1728:23:10d5::/64",
        "ip6gateway": "2a00:1728:23:10d5::1",
        "ipaddress": "10.1.1.15",
        "isdefault": true,
        "isolationuri": "vlan://1240",
        "macaddress": "02:00:28:3c:00:01",
        "netmask": "255.255.255.0",
        "networkid": "e5bb9951-b87e-4ac2-b18a-07f2f5044ed1",
        "networkname": "testnw",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "260e5aab-0f19-11ed-8e7c-645d8651f45a",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "2aa6cb73-7448-4dff-b12f-e6000f639b44",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "templateid": "3a182a15-0f1b-11ed-8e7c-645d8651f45a",
    "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "userid": "261f0c07-0f19-11ed-8e7c-645d8651f45a",
    "username": "admin",
    "zoneid": "78e1da67-04e5-4683-9d52-346ef6cd7472",
    "zonename": "z1"
  }
}

```
