### PR TITLE
UI: Fix delete ISO navigation after job is finished

### DIFF
--- a/ui/src/views/image/IsoZones.vue
+++ b/ui/src/views/image/IsoZones.vue
@@ -340,6 +340,13 @@ export default {
       this.selectedRowKeys = []
       this.fetchData()
       if (this.dataSource.length === 0) {
+        this.moveToPreviousView()
+      }
+    },
+    async moveToPreviousView () {
+      const lastPath = this.$router.currentRoute.value.fullPath
+      const navigationResult = await this.$router.go(-1)
+      if (navigationResult !== undefined || this.$router.currentRoute.value.fullPath === lastPath) {
         this.$router.go(-1)
       }
     },
@@ -379,7 +386,7 @@ export default {
           successMethod: result => {
             if (singleZone) {
               if (this.selectedItems.length === 0) {
-                this.$router.push({ path: '/iso' })
+                this.moveToPreviousView()
               }
             } else {
               if (this.selectedItems.length === 0) {
@@ -389,7 +396,7 @@ export default {
             if (this.selectedItems.length > 0) {
               eventBus.emit('update-resource-state', { selectedItems: this.selectedItems, resource: record.zoneid, state: 'success' })
               if (this.selectedItems.length === this.zones.length) {
-                this.$router.push({ path: '/iso' })
+                this.moveToPreviousView()
               }
             }
           },

--- a/ui/src/views/image/IsoZones.vue
+++ b/ui/src/views/image/IsoZones.vue
@@ -206,6 +206,7 @@ export default {
       selectedColumns: [],
       filterColumns: ['Status', 'Ready'],
       showConfirmationAction: false,
+      redirectOnFinish: true,
       message: {
         title: this.$t('label.action.bulk.delete.isos'),
         confirmMessage: this.$t('label.confirm.delete.isos')
@@ -341,6 +342,7 @@ export default {
       this.fetchData()
       if (this.dataSource.length === 0) {
         this.moveToPreviousView()
+        this.redirectOnFinish = false
       }
     },
     async moveToPreviousView () {
@@ -379,13 +381,14 @@ export default {
         const jobId = json.deleteisoresponse.jobid
         eventBus.emit('update-job-details', { jobId, resourceId: null })
         const singleZone = (this.dataSource.length === 1)
+        this.redirectOnFinish = true
         this.$pollJob({
           jobId,
           title: this.$t('label.action.delete.iso'),
           description: this.resource.name,
           successMethod: result => {
             if (singleZone) {
-              if (this.selectedItems.length === 0) {
+              if (this.selectedItems.length === 0 && this.redirectOnFinish) {
                 this.moveToPreviousView()
               }
             } else {
@@ -395,7 +398,7 @@ export default {
             }
             if (this.selectedItems.length > 0) {
               eventBus.emit('update-resource-state', { selectedItems: this.selectedItems, resource: record.zoneid, state: 'success' })
-              if (this.selectedItems.length === this.zones.length) {
+              if (this.selectedItems.length === this.zones.length && this.redirectOnFinish) {
                 this.moveToPreviousView()
               }
             }

--- a/ui/src/views/image/IsoZones.vue
+++ b/ui/src/views/image/IsoZones.vue
@@ -379,7 +379,7 @@ export default {
           successMethod: result => {
             if (singleZone) {
               if (this.selectedItems.length === 0) {
-                this.$router.go(-1)
+                this.$router.push({ path: '/iso' })
               }
             } else {
               if (this.selectedItems.length === 0) {
@@ -388,6 +388,9 @@ export default {
             }
             if (this.selectedItems.length > 0) {
               eventBus.emit('update-resource-state', { selectedItems: this.selectedItems, resource: record.zoneid, state: 'success' })
+              if (this.selectedItems.length === this.zones.length) {
+                this.$router.push({ path: '/iso' })
+              }
             }
           },
           errorMethod: () => {


### PR DESCRIPTION
### Description

This PR fixes the navigation for ISOs after deletion. The following issues are addressed:
- After removal of an ISO without bulk operation -> The view keeps displaying the data of the removed ISO
- After removal of an ISO selecting bulk operation -> The view redirects to the 404 exception view

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
The following scenarios were tested on a single zone:
- Delete ISO without selecting any zone -> After removal, the ISO view is displayed
- Delete ISO selecting the zone and clicking on 'Bulk operation' -> After removal, the ISO view is displayed