### PR TITLE
Close restore and attach form right after receiving the job id

### DIFF
--- a/ui/src/views/storage/RestoreAttachBackupVolume.vue
+++ b/ui/src/views/storage/RestoreAttachBackupVolume.vue
@@ -162,12 +162,10 @@ export default {
               jobId,
               title,
               description: values.volumeid,
-              successMethod: result => {
-                this.closeAction()
-              },
               loadingMessage: `${title} ${this.$t('label.in.progress.for')} ${this.resource.id}`,
               catchMessage: this.$t('error.fetching.async.job.result')
             })
+            this.closeAction()
           }
         }).catch(error => {
           this.$notifyError(error)


### PR DESCRIPTION
### Description

When restoring and attaching a backup volume, the UI waits for the successfful response of the API to close the formulary. However, letting the form open after sending the command can confuse users, that might try to send the command again.

Note: other formularies (like volume or snapshot creation) always are closed after sending the command to the backend.

With this PR, we intend to close the formulary right after sending the command, as done with others.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

It was tested in a local lab.

Before the changes, I tried to restore and attach a backup volume. After clicking the button `Ok`, the command was sent, but the formulary was kept open. After the changes, when clicking the button `Ok`, the command is sent and the formulary is closed.