### PR TITLE
Shows quotaSummary in API documentation

### DIFF
--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -221,7 +221,7 @@ for f in sys.argv:
     dirname, fn = os.path.split(f)
     if not fn.endswith('.xml'):
         continue
-    if fn.endswith('Summary.xml'):
+    if fn.endswith('Summary.xml') and fn != 'quotaSummary.xml':
         continue
     if fn.endswith('SummarySorted.xml'):
         continue


### PR DESCRIPTION
### Description

Through analysis, it was found that the Cloudstack API documentation (https://cloudstack.apache.org/api/apidocs-4.17) does not present the document for the quotaSummary API. This error has been present since the creation of this API.
The present patch corrects this behavior, exposing the documentation for this API to the user.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Screenshots:
![image](https://user-images.githubusercontent.com/19981369/182229173-ec236052-9b12-4894-a357-8b7b8e5117ce.png)


### How Has This Been Tested?
To generate the documentation and verify the correction, you can run `mvn clean install` inside the `tools/apidoc` project and check the content of the page present in `tools/apidoc/target/xmldoc/html/index.html`. Or run the `build-apidoc.sh` script:
```
`./build-apidoc.sh 4.17.0.0 ../../client/target//cloud-client-ui-4.17.0.0.jar ../../client/target//cloud-client-ui-4.17.00.jar ./myout
```
and check the page content available in myout/xmldoc/html/index.html