### PR TITLE
ui: fix hypervisortrafficlabel for phy nw traffic

### DIFF
--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -248,7 +248,7 @@ export default {
             if (trafficLabel.length > 0) {
               trafficLabel += ','
             }
-            trafficLabel += trafficConfig.vlanId
+            trafficLabel += trafficConfig.vlanId || ''
           }
           if ('vSwitchType' in trafficConfig) {
             if (trafficLabel.length > 0) {


### PR DESCRIPTION
### Description

Fixes: #6593

Before fix UI was setting vlan to 'null' when no value was passed. Now it just leaves the vlan value empty in the trafficlabel.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
