### PR TITLE
Fixes #6621 - Update host memory stats

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -536,6 +536,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     public MemStat getMemStat() {
+        _memStat.refresh();
         return _memStat;
     }
 


### PR DESCRIPTION
### Description

This PR ensures that when `getMemStat()` is called in KVM environments, the hosts actual used memory is returned, and not a static value that was retrieved when the cloudstack-agent was started.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):


### How Has This Been Tested?
We have applied this patch into our own environment, built the packages and installed them on the managers and hosts. We then migrated VMs between hosts and saw the host memory usage being updated, instead of remaining static until the cloudstack-agent was restarted.