### PR TITLE
 synchronise VM creation to guard resource limit

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManager.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManager.java
@@ -48,12 +48,19 @@ import com.cloud.utils.Pair;
 public interface UserVmManager extends UserVmService {
     String EnableDynamicallyScaleVmCK = "enable.dynamic.scale.vm";
     String AllowUserExpungeRecoverVmCK ="allow.user.expunge.recover.vm";
-    ConfigKey<Boolean> EnableDynamicallyScaleVm = new ConfigKey<Boolean>("Advanced", Boolean.class, EnableDynamicallyScaleVmCK, "false",
+    ConfigKey<Boolean> EnableDynamicallyScaleVm = new ConfigKey<>("Advanced", Boolean.class, EnableDynamicallyScaleVmCK, "false",
         "Enables/Disables dynamically scaling a vm", true, ConfigKey.Scope.Zone);
-    ConfigKey<Boolean> AllowUserExpungeRecoverVm = new ConfigKey<Boolean>("Advanced", Boolean.class, AllowUserExpungeRecoverVmCK, "false",
+    ConfigKey<Boolean> AllowUserExpungeRecoverVm = new ConfigKey<>("Advanced", Boolean.class, AllowUserExpungeRecoverVmCK, "false",
         "Determines whether users can expunge or recover their vm", true, ConfigKey.Scope.Account);
-    ConfigKey<Boolean> DisplayVMOVFProperties = new ConfigKey<Boolean>("Advanced", Boolean.class, "vm.display.ovf.properties", "false",
+    ConfigKey<Boolean> DisplayVMOVFProperties = new ConfigKey<>("Advanced", Boolean.class, "vm.display.ovf.properties", "false",
             "Set display of VMs OVF properties as part of VM details", true);
+    ConfigKey<Boolean> AllowParallelVmCreation = new ConfigKey<>("Advanced"
+            , Boolean.class
+            , "allow.user.parallel.vm.creation"
+            , "true"
+            , "Determines whether users can create multiple VMs in parallel. Setting this to true could lead to overflow of quota limits"
+            , true
+            , ConfigKey.Scope.Account);
 
     static final int MAX_USER_DATA_LENGTH_BYTES = 2048;
 

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -374,6 +374,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private static final int ACQUIRE_GLOBAL_LOCK_TIMEOUT_FOR_COOPERATION = 3;
 
     private static final long GiB_TO_BYTES = 1024 * 1024 * 1024;
+    private static final int TRY_TO_GET_LOCK_TIME = 600;
 
     @Inject
     private EntityManager _entityMgr;
@@ -3870,301 +3871,311 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     }
 
     private synchronized UserVmVO getPermittedVmResource(DataCenter zone, String hostName, String displayName, Account owner, Long diskOfferingId, Long diskSize, List<NetworkVO> networkList, List<Long> securityGroupIdList, String group, HTTPMethod httpmethod, String userData, List<String> sshKeyPairs, Account caller, Map<Long, IpAddresses> requestedIps, IpAddresses defaultIps, Boolean isDisplayVm, String keyboard, List<Long> affinityGroupIdList, Map<String, String> customParameters, String customId, Map<String, Map<Integer, String>> dhcpOptionMap, Map<Long, DiskOffering> datadiskTemplateToDiskOfferringMap, Map<String, String> userVmOVFPropertiesMap, boolean dynamicScalingEnabled, String vmType, VMTemplateVO template, HypervisorType hypervisorType, long accountId, ServiceOfferingVO offering, boolean isIso, Long rootDiskOfferingId, long volumesSize) throws ResourceAllocationException, StorageUnavailableException, InsufficientCapacityException {
-        if (! VirtualMachineManager.ResourceCountRunningVMsonly.value()) {
-            resourceLimitCheck(owner, isDisplayVm, new Long(offering.getCpu()), new Long(offering.getRamSize()));
-        }
+        String lockName = String.format("VM.CREATE for %s/%d", owner.getAccountName(), owner.getDomainId());
+        GlobalLock quotaLimitLock = GlobalLock.getInternLock(lockName);
+        if(quotaLimitLock.lock(TRY_TO_GET_LOCK_TIME)) {
+            try {
+                if (!VirtualMachineManager.ResourceCountRunningVMsonly.value()) {
+                    resourceLimitCheck(owner, isDisplayVm, new Long(offering.getCpu()), new Long(offering.getRamSize()));
+                }
 
-        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, (isIso || diskOfferingId == null ? 1 : 2));
-        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, volumesSize);
+                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, (isIso || diskOfferingId == null ? 1 : 2));
+                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, volumesSize);
 
-        // verify security group ids
-        if (securityGroupIdList != null) {
-            for (Long securityGroupId : securityGroupIdList) {
-                SecurityGroup sg = _securityGroupDao.findById(securityGroupId);
-                if (sg == null) {
-                    throw new InvalidParameterValueException("Unable to find security group by id " + securityGroupId);
-                } else {
-                    // verify permissions
-                    _accountMgr.checkAccess(caller, null, true, owner, sg);
+                // verify security group ids
+                if (securityGroupIdList != null) {
+                    for (Long securityGroupId : securityGroupIdList) {
+                        SecurityGroup sg = _securityGroupDao.findById(securityGroupId);
+                        if (sg == null) {
+                            throw new InvalidParameterValueException("Unable to find security group by id " + securityGroupId);
+                        } else {
+                            // verify permissions
+                            _accountMgr.checkAccess(caller, null, true, owner, sg);
+                        }
+                    }
                 }
-            }
-        }
 
-        if (datadiskTemplateToDiskOfferringMap != null && !datadiskTemplateToDiskOfferringMap.isEmpty()) {
-            for (Entry<Long, DiskOffering> datadiskTemplateToDiskOffering : datadiskTemplateToDiskOfferringMap.entrySet()) {
-                VMTemplateVO dataDiskTemplate = _templateDao.findById(datadiskTemplateToDiskOffering.getKey());
-                DiskOffering dataDiskOffering = datadiskTemplateToDiskOffering.getValue();
+                if (datadiskTemplateToDiskOfferringMap != null && !datadiskTemplateToDiskOfferringMap.isEmpty()) {
+                    for (Entry<Long, DiskOffering> datadiskTemplateToDiskOffering : datadiskTemplateToDiskOfferringMap.entrySet()) {
+                        VMTemplateVO dataDiskTemplate = _templateDao.findById(datadiskTemplateToDiskOffering.getKey());
+                        DiskOffering dataDiskOffering = datadiskTemplateToDiskOffering.getValue();
 
-                if (dataDiskTemplate == null
-                        || (!dataDiskTemplate.getTemplateType().equals(TemplateType.DATADISK)) && (dataDiskTemplate.getState().equals(VirtualMachineTemplate.State.Active))) {
-                    throw new InvalidParameterValueException("Invalid template id specified for Datadisk template" + datadiskTemplateToDiskOffering.getKey());
+                        if (dataDiskTemplate == null
+                                || (!dataDiskTemplate.getTemplateType().equals(TemplateType.DATADISK)) && (dataDiskTemplate.getState().equals(VirtualMachineTemplate.State.Active))) {
+                            throw new InvalidParameterValueException("Invalid template id specified for Datadisk template" + datadiskTemplateToDiskOffering.getKey());
+                        }
+                        long dataDiskTemplateId = datadiskTemplateToDiskOffering.getKey();
+                        if (!dataDiskTemplate.getParentTemplateId().equals(template.getId())) {
+                            throw new InvalidParameterValueException("Invalid Datadisk template. Specified Datadisk template" + dataDiskTemplateId
+                                    + " doesn't belong to template " + template.getId());
+                        }
+                        if (dataDiskOffering == null) {
+                            throw new InvalidParameterValueException("Invalid disk offering id " + datadiskTemplateToDiskOffering.getValue().getId() +
+                                    " specified for datadisk template " + dataDiskTemplateId);
+                        }
+                        if (dataDiskOffering.isCustomized()) {
+                            throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
+                                    dataDiskTemplateId + ". Custom Disk offerings are not supported for Datadisk templates");
+                        }
+                        if (dataDiskOffering.getDiskSize() < dataDiskTemplate.getSize()) {
+                            throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
+                                    dataDiskTemplateId + ". Disk offering size should be greater than or equal to the template size");
+                        }
+                        _templateDao.loadDetails(dataDiskTemplate);
+                        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, 1);
+                        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, dataDiskOffering.getDiskSize());
+                    }
                 }
-                long dataDiskTemplateId = datadiskTemplateToDiskOffering.getKey();
-                if (!dataDiskTemplate.getParentTemplateId().equals(template.getId())) {
-                    throw new InvalidParameterValueException("Invalid Datadisk template. Specified Datadisk template" + dataDiskTemplateId
-                            + " doesn't belong to template " + template.getId());
-                }
-                if (dataDiskOffering == null) {
-                    throw new InvalidParameterValueException("Invalid disk offering id " + datadiskTemplateToDiskOffering.getValue().getId() +
-                            " specified for datadisk template " + dataDiskTemplateId);
-                }
-                if (dataDiskOffering.isCustomized()) {
-                    throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
-                            dataDiskTemplateId + ". Custom Disk offerings are not supported for Datadisk templates");
-                }
-                if (dataDiskOffering.getDiskSize() < dataDiskTemplate.getSize()) {
-                    throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
-                            dataDiskTemplateId + ". Disk offering size should be greater than or equal to the template size");
-                }
-                _templateDao.loadDetails(dataDiskTemplate);
-                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, 1);
-                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, dataDiskOffering.getDiskSize());
-            }
-        }
 
-        // check that the affinity groups exist
-        if (affinityGroupIdList != null) {
-            for (Long affinityGroupId : affinityGroupIdList) {
-                AffinityGroupVO ag = _affinityGroupDao.findById(affinityGroupId);
-                if (ag == null) {
-                    throw new InvalidParameterValueException("Unable to find affinity group " + ag);
-                } else if (!_affinityGroupService.isAffinityGroupProcessorAvailable(ag.getType())) {
-                    throw new InvalidParameterValueException("Affinity group type is not supported for group: " + ag + " ,type: " + ag.getType()
-                    + " , Please try again after removing the affinity group");
-                } else {
-                    // verify permissions
-                    if (ag.getAclType() == ACLType.Domain) {
-                        _accountMgr.checkAccess(caller, null, false, owner, ag);
-                        // Root admin has access to both VM and AG by default,
-                        // but
-                        // make sure the owner of these entities is same
-                        if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                            if (!_affinityGroupService.isAffinityGroupAvailableInDomain(ag.getId(), owner.getDomainId())) {
-                                throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's domain");
+                // check that the affinity groups exist
+                if (affinityGroupIdList != null) {
+                    for (Long affinityGroupId : affinityGroupIdList) {
+                        AffinityGroupVO ag = _affinityGroupDao.findById(affinityGroupId);
+                        if (ag == null) {
+                            throw new InvalidParameterValueException("Unable to find affinity group " + ag);
+                        } else if (!_affinityGroupService.isAffinityGroupProcessorAvailable(ag.getType())) {
+                            throw new InvalidParameterValueException("Affinity group type is not supported for group: " + ag + " ,type: " + ag.getType()
+                                    + " , Please try again after removing the affinity group");
+                        } else {
+                            // verify permissions
+                            if (ag.getAclType() == ACLType.Domain) {
+                                _accountMgr.checkAccess(caller, null, false, owner, ag);
+                                // Root admin has access to both VM and AG by default,
+                                // but
+                                // make sure the owner of these entities is same
+                                if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
+                                    if (!_affinityGroupService.isAffinityGroupAvailableInDomain(ag.getId(), owner.getDomainId())) {
+                                        throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's domain");
+                                    }
+                                }
+                            } else {
+                                _accountMgr.checkAccess(caller, null, true, owner, ag);
+                                // Root admin has access to both VM and AG by default,
+                                // but
+                                // make sure the owner of these entities is same
+                                if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
+                                    if (ag.getAccountId() != owner.getAccountId()) {
+                                        throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
+                                    }
+                                }
                             }
                         }
+                    }
+                }
+
+                if (hypervisorType != HypervisorType.BareMetal) {
+                    // check if we have available pools for vm deployment
+                    long availablePools = _storagePoolDao.countPoolsByStatus(StoragePoolStatus.Up);
+                    if (availablePools < 1) {
+                        throw new StorageUnavailableException("There are no available pools in the UP state for vm deployment", -1);
+                    }
+                }
+
+                if (template.getTemplateType().equals(TemplateType.SYSTEM) && !CKS_NODE.equals(vmType)) {
+                    throw new InvalidParameterValueException("Unable to use system template " + template.getId() + " to deploy a user vm");
+                }
+                List<VMTemplateZoneVO> listZoneTemplate = _templateZoneDao.listByZoneTemplate(zone.getId(), template.getId());
+                if (listZoneTemplate == null || listZoneTemplate.isEmpty()) {
+                    throw new InvalidParameterValueException("The template " + template.getId() + " is not available for use");
+                }
+
+                if (isIso && !template.isBootable()) {
+                    throw new InvalidParameterValueException("Installing from ISO requires an ISO that is bootable: " + template.getId());
+                }
+
+                // Check templates permissions
+                _accountMgr.checkAccess(owner, AccessType.UseEntry, false, template);
+
+                // check if the user data is correct
+                userData = validateUserData(userData, httpmethod);
+
+                // Find an SSH public key corresponding to the key pair name, if one is
+                // given
+                String sshPublicKeys = "";
+                String keypairnames = "";
+                if (!sshKeyPairs.isEmpty()) {
+                    List<SSHKeyPairVO> pairs = _sshKeyPairDao.findByNames(owner.getAccountId(), owner.getDomainId(), sshKeyPairs);
+                    if (pairs == null || pairs.size() != sshKeyPairs.size()) {
+                        throw new InvalidParameterValueException("Not all specified keyparis exist");
+                    }
+
+                    sshPublicKeys = pairs.stream().map(p -> p.getPublicKey()).collect(Collectors.joining("\n"));
+                    keypairnames = String.join(",", sshKeyPairs);
+                }
+
+                LinkedHashMap<String, List<NicProfile>> networkNicMap = new LinkedHashMap<>();
+
+                short defaultNetworkNumber = 0;
+                boolean securityGroupEnabled = false;
+                int networkIndex = 0;
+                for (NetworkVO network : networkList) {
+                    if ((network.getDataCenterId() != zone.getId())) {
+                        if (!network.isStrechedL2Network()) {
+                            throw new InvalidParameterValueException("Network id=" + network.getId() +
+                                    " doesn't belong to zone " + zone.getId());
+                        }
+
+                        NetworkOffering ntwkOffering = _networkOfferingDao.findById(network.getNetworkOfferingId());
+                        Long physicalNetworkId = _networkModel.findPhysicalNetworkId(zone.getId(), ntwkOffering.getTags(), ntwkOffering.getTrafficType());
+
+                        String provider = _ntwkSrvcDao.getProviderForServiceInNetwork(network.getId(), Service.Connectivity);
+                        if (!_networkModel.isProviderEnabledInPhysicalNetwork(physicalNetworkId, provider)) {
+                            throw new InvalidParameterValueException("Network in which is VM getting deployed could not be" +
+                                    " streched to the zone, as we could not find a valid physical network");
+                        }
+                    }
+
+                    _accountMgr.checkAccess(owner, AccessType.UseEntry, false, network);
+
+                    IpAddresses requestedIpPair = null;
+                    if (requestedIps != null && !requestedIps.isEmpty()) {
+                        requestedIpPair = requestedIps.get(network.getId());
+                    }
+
+                    if (requestedIpPair == null) {
+                        requestedIpPair = new IpAddresses(null, null);
                     } else {
-                        _accountMgr.checkAccess(caller, null, true, owner, ag);
-                        // Root admin has access to both VM and AG by default,
-                        // but
-                        // make sure the owner of these entities is same
-                        if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                            if (ag.getAccountId() != owner.getAccountId()) {
-                                throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
+                        _networkModel.checkRequestedIpAddresses(network.getId(), requestedIpPair);
+                    }
+
+                    NicProfile profile = new NicProfile(requestedIpPair.getIp4Address(), requestedIpPair.getIp6Address(), requestedIpPair.getMacAddress());
+                    profile.setOrderIndex(networkIndex);
+                    if (defaultNetworkNumber == 0) {
+                        defaultNetworkNumber++;
+                        // if user requested specific ip for default network, add it
+                        if (defaultIps.getIp4Address() != null || defaultIps.getIp6Address() != null) {
+                            _networkModel.checkRequestedIpAddresses(network.getId(), defaultIps);
+                            profile = new NicProfile(defaultIps.getIp4Address(), defaultIps.getIp6Address());
+                        } else if (defaultIps.getMacAddress() != null) {
+                            profile = new NicProfile(null, null, defaultIps.getMacAddress());
+                        }
+
+                        profile.setDefaultNic(true);
+                        if (!_networkModel.areServicesSupportedInNetwork(network.getId(), new Service[]{Service.UserData})) {
+                            if ((userData != null) && (!userData.isEmpty())) {
+                                throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as UserData is provided while deploying the VM");
+                            }
+
+                            if ((sshPublicKeys != null) && (!sshPublicKeys.isEmpty())) {
+                                throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as SSH keypair is provided while deploying the VM");
+                            }
+
+                            if (template.isEnablePassword()) {
+                                throwInvalidParemeterExceptionForNet(network, String.format("Unable to deploy VM as template %d is password enabled", template.getId()));
                             }
                         }
                     }
-                }
-            }
-        }
 
-        if (hypervisorType != HypervisorType.BareMetal) {
-            // check if we have available pools for vm deployment
-            long availablePools = _storagePoolDao.countPoolsByStatus(StoragePoolStatus.Up);
-            if (availablePools < 1) {
-                throw new StorageUnavailableException("There are no available pools in the UP state for vm deployment", -1);
-            }
-        }
-
-        if (template.getTemplateType().equals(TemplateType.SYSTEM) && !CKS_NODE.equals(vmType)) {
-            throw new InvalidParameterValueException("Unable to use system template " + template.getId() + " to deploy a user vm");
-        }
-        List<VMTemplateZoneVO> listZoneTemplate = _templateZoneDao.listByZoneTemplate(zone.getId(), template.getId());
-        if (listZoneTemplate == null || listZoneTemplate.isEmpty()) {
-            throw new InvalidParameterValueException("The template " + template.getId() + " is not available for use");
-        }
-
-        if (isIso && !template.isBootable()) {
-            throw new InvalidParameterValueException("Installing from ISO requires an ISO that is bootable: " + template.getId());
-        }
-
-        // Check templates permissions
-        _accountMgr.checkAccess(owner, AccessType.UseEntry, false, template);
-
-        // check if the user data is correct
-        userData = validateUserData(userData, httpmethod);
-
-        // Find an SSH public key corresponding to the key pair name, if one is
-        // given
-        String sshPublicKeys = "";
-        String keypairnames = "";
-        if (!sshKeyPairs.isEmpty()) {
-            List<SSHKeyPairVO> pairs = _sshKeyPairDao.findByNames(owner.getAccountId(), owner.getDomainId(), sshKeyPairs);
-            if (pairs == null || pairs.size() != sshKeyPairs.size()) {
-                throw new InvalidParameterValueException("Not all specified keyparis exist");
-            }
-
-            sshPublicKeys = pairs.stream().map(p -> p.getPublicKey()).collect(Collectors.joining("\n"));
-            keypairnames = String.join(",", sshKeyPairs);
-        }
-
-        LinkedHashMap<String, List<NicProfile>> networkNicMap = new LinkedHashMap<>();
-
-        short defaultNetworkNumber = 0;
-        boolean securityGroupEnabled = false;
-        int networkIndex = 0;
-        for (NetworkVO network : networkList) {
-            if ((network.getDataCenterId() != zone.getId())) {
-                if (!network.isStrechedL2Network()) {
-                    throw new InvalidParameterValueException("Network id=" + network.getId() +
-                            " doesn't belong to zone " + zone.getId());
-                }
-
-                NetworkOffering ntwkOffering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-                Long physicalNetworkId = _networkModel.findPhysicalNetworkId(zone.getId(), ntwkOffering.getTags(), ntwkOffering.getTrafficType());
-
-                String provider = _ntwkSrvcDao.getProviderForServiceInNetwork(network.getId(), Service.Connectivity);
-                if (!_networkModel.isProviderEnabledInPhysicalNetwork(physicalNetworkId, provider)) {
-                    throw new InvalidParameterValueException("Network in which is VM getting deployed could not be" +
-                            " streched to the zone, as we could not find a valid physical network");
-                }
-            }
-
-            _accountMgr.checkAccess(owner, AccessType.UseEntry, false, network);
-
-            IpAddresses requestedIpPair = null;
-            if (requestedIps != null && !requestedIps.isEmpty()) {
-                requestedIpPair = requestedIps.get(network.getId());
-            }
-
-            if (requestedIpPair == null) {
-                requestedIpPair = new IpAddresses(null, null);
-            } else {
-                _networkModel.checkRequestedIpAddresses(network.getId(), requestedIpPair);
-            }
-
-            NicProfile profile = new NicProfile(requestedIpPair.getIp4Address(), requestedIpPair.getIp6Address(), requestedIpPair.getMacAddress());
-            profile.setOrderIndex(networkIndex);
-            if (defaultNetworkNumber == 0) {
-                defaultNetworkNumber++;
-                // if user requested specific ip for default network, add it
-                if (defaultIps.getIp4Address() != null || defaultIps.getIp6Address() != null) {
-                    _networkModel.checkRequestedIpAddresses(network.getId(), defaultIps);
-                    profile = new NicProfile(defaultIps.getIp4Address(), defaultIps.getIp6Address());
-                } else if (defaultIps.getMacAddress() != null) {
-                    profile = new NicProfile(null, null, defaultIps.getMacAddress());
-                }
-
-                profile.setDefaultNic(true);
-                if (!_networkModel.areServicesSupportedInNetwork(network.getId(), new Service[]{Service.UserData})) {
-                    if ((userData != null) && (!userData.isEmpty())) {
-                        throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as UserData is provided while deploying the VM");
+                    if (_networkModel.isSecurityGroupSupportedInNetwork(network)) {
+                        securityGroupEnabled = true;
                     }
-
-                    if ((sshPublicKeys != null) && (!sshPublicKeys.isEmpty())) {
-                        throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as SSH keypair is provided while deploying the VM");
+                    List<NicProfile> profiles = networkNicMap.get(network.getUuid());
+                    if (CollectionUtils.isEmpty(profiles)) {
+                        profiles = new ArrayList<>();
                     }
-
-                    if (template.isEnablePassword()) {
-                        throwInvalidParemeterExceptionForNet(network, String.format("Unable to deploy VM as template %d is password enabled", template.getId()));
-                    }
+                    profiles.add(profile);
+                    networkNicMap.put(network.getUuid(), profiles);
+                    networkIndex++;
                 }
-            }
 
-            if (_networkModel.isSecurityGroupSupportedInNetwork(network)) {
-                securityGroupEnabled = true;
-            }
-            List<NicProfile> profiles = networkNicMap.get(network.getUuid());
-            if (CollectionUtils.isEmpty(profiles)) {
-                profiles = new ArrayList<>();
-            }
-            profiles.add(profile);
-            networkNicMap.put(network.getUuid(), profiles);
-            networkIndex++;
-        }
+                if (securityGroupIdList != null && !securityGroupIdList.isEmpty() && !securityGroupEnabled) {
+                    throw new InvalidParameterValueException("Unable to deploy vm with security groups as SecurityGroup service is not enabled for the vm's network");
+                }
 
-        if (securityGroupIdList != null && !securityGroupIdList.isEmpty() && !securityGroupEnabled) {
-            throw new InvalidParameterValueException("Unable to deploy vm with security groups as SecurityGroup service is not enabled for the vm's network");
-        }
+                // Verify network information - network default network has to be set;
+                // and vm can't have more than one default network
+                // This is a part of business logic because default network is required
+                // by Agent Manager in order to configure default
+                // gateway for the vm
+                if (defaultNetworkNumber == 0) {
+                    throw new InvalidParameterValueException("At least 1 default network has to be specified for the vm");
+                } else if (defaultNetworkNumber > 1) {
+                    throw new InvalidParameterValueException("Only 1 default network per vm is supported");
+                }
 
-        // Verify network information - network default network has to be set;
-        // and vm can't have more than one default network
-        // This is a part of business logic because default network is required
-        // by Agent Manager in order to configure default
-        // gateway for the vm
-        if (defaultNetworkNumber == 0) {
-            throw new InvalidParameterValueException("At least 1 default network has to be specified for the vm");
-        } else if (defaultNetworkNumber > 1) {
-            throw new InvalidParameterValueException("Only 1 default network per vm is supported");
-        }
+                long id = _vmDao.getNextInSequence(Long.class, "id");
 
-        long id = _vmDao.getNextInSequence(Long.class, "id");
+                if (hostName != null) {
+                    // Check is hostName is RFC compliant
+                    checkNameForRFCCompliance(hostName);
+                }
 
-        if (hostName != null) {
-            // Check is hostName is RFC compliant
-            checkNameForRFCCompliance(hostName);
-        }
-
-        String instanceName = null;
-        String instanceSuffix = _instance;
-        String uuidName = _uuidMgr.generateUuid(UserVm.class, customId);
-        if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType)) {
-            if (StringUtils.isNotEmpty(hostName)) {
-                instanceSuffix = hostName;
-            }
-            if (hostName == null) {
-                if (displayName != null) {
-                    hostName = displayName;
+                String instanceName = null;
+                String instanceSuffix = _instance;
+                String uuidName = _uuidMgr.generateUuid(UserVm.class, customId);
+                if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType)) {
+                    if (StringUtils.isNotEmpty(hostName)) {
+                        instanceSuffix = hostName;
+                    }
+                    if (hostName == null) {
+                        if (displayName != null) {
+                            hostName = displayName;
+                        } else {
+                            hostName = generateHostName(uuidName);
+                        }
+                    }
+                    // If global config vm.instancename.flag is set to true, then CS will set guest VM's name as it appears on the hypervisor, to its hostname.
+                    // In case of VMware since VM name must be unique within a DC, check if VM with the same hostname already exists in the zone.
+                    VMInstanceVO vmByHostName = _vmInstanceDao.findVMByHostNameInZone(hostName, zone.getId());
+                    if (vmByHostName != null && vmByHostName.getState() != State.Expunging) {
+                        throw new InvalidParameterValueException("There already exists a VM by the name: " + hostName + ".");
+                    }
                 } else {
-                    hostName = generateHostName(uuidName);
+                    if (hostName == null) {
+                        //Generate name using uuid and instance.name global config
+                        hostName = generateHostName(uuidName);
+                    }
                 }
-            }
-            // If global config vm.instancename.flag is set to true, then CS will set guest VM's name as it appears on the hypervisor, to its hostname.
-            // In case of VMware since VM name must be unique within a DC, check if VM with the same hostname already exists in the zone.
-            VMInstanceVO vmByHostName = _vmInstanceDao.findVMByHostNameInZone(hostName, zone.getId());
-            if (vmByHostName != null && vmByHostName.getState() != State.Expunging) {
-                throw new InvalidParameterValueException("There already exists a VM by the name: " + hostName + ".");
-            }
-        } else {
-            if (hostName == null) {
-                //Generate name using uuid and instance.name global config
-                hostName = generateHostName(uuidName);
-            }
-        }
 
-        if (hostName != null) {
-            // Check is hostName is RFC compliant
-            checkNameForRFCCompliance(hostName);
-        }
-        instanceName = VirtualMachineName.getVmName(id, owner.getId(), instanceSuffix);
-        if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType) && !instanceSuffix.equals(_instance)) {
-            customParameters.put(VmDetailConstants.NAME_ON_HYPERVISOR, instanceName);
-        }
+                if (hostName != null) {
+                    // Check is hostName is RFC compliant
+                    checkNameForRFCCompliance(hostName);
+                }
+                instanceName = VirtualMachineName.getVmName(id, owner.getId(), instanceSuffix);
+                if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType) && !instanceSuffix.equals(_instance)) {
+                    customParameters.put(VmDetailConstants.NAME_ON_HYPERVISOR, instanceName);
+                }
 
-        // Check if VM with instanceName already exists.
-        VMInstanceVO vmObj = _vmInstanceDao.findVMByInstanceName(instanceName);
-        if (vmObj != null && vmObj.getState() != State.Expunging) {
-            throw new InvalidParameterValueException("There already exists a VM by the display name supplied");
-        }
+                // Check if VM with instanceName already exists.
+                VMInstanceVO vmObj = _vmInstanceDao.findVMByInstanceName(instanceName);
+                if (vmObj != null && vmObj.getState() != State.Expunging) {
+                    throw new InvalidParameterValueException("There already exists a VM by the display name supplied");
+                }
 
-        checkIfHostNameUniqueInNtwkDomain(hostName, networkList);
+                checkIfHostNameUniqueInNtwkDomain(hostName, networkList);
 
-        long userId = CallContext.current().getCallingUserId();
-        if (CallContext.current().getCallingAccount().getId() != owner.getId()) {
-            List<UserVO> userVOs = _userDao.listByAccount(owner.getAccountId());
-            if (!userVOs.isEmpty()) {
-                userId =  userVOs.get(0).getId();
-            }
-        }
+                long userId = CallContext.current().getCallingUserId();
+                if (CallContext.current().getCallingAccount().getId() != owner.getId()) {
+                    List<UserVO> userVOs = _userDao.listByAccount(owner.getAccountId());
+                    if (!userVOs.isEmpty()) {
+                        userId = userVOs.get(0).getId();
+                    }
+                }
 
-        dynamicScalingEnabled = dynamicScalingEnabled && checkIfDynamicScalingCanBeEnabled(null, offering, template, zone.getId());
+                dynamicScalingEnabled = dynamicScalingEnabled && checkIfDynamicScalingCanBeEnabled(null, offering, template, zone.getId());
 
-        UserVmVO vm = commitUserVm(zone, template, hostName, displayName, owner, diskOfferingId, diskSize, userData, caller, isDisplayVm, keyboard, accountId, userId, offering,
-                isIso, sshPublicKeys, networkNicMap, id, instanceName, uuidName, hypervisorType, customParameters, dhcpOptionMap,
-                datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, rootDiskOfferingId, keypairnames);
+                UserVmVO vm = commitUserVm(zone, template, hostName, displayName, owner, diskOfferingId, diskSize, userData, caller, isDisplayVm, keyboard, accountId, userId, offering,
+                        isIso, sshPublicKeys, networkNicMap, id, instanceName, uuidName, hypervisorType, customParameters, dhcpOptionMap,
+                        datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, rootDiskOfferingId, keypairnames);
 
-        // Assign instance to the group
-        try {
-            if (group != null) {
-                boolean addToGroup = addInstanceToGroup(Long.valueOf(id), group);
-                if (!addToGroup) {
+                // Assign instance to the group
+                try {
+                    if (group != null) {
+                        boolean addToGroup = addInstanceToGroup(Long.valueOf(id), group);
+                        if (!addToGroup) {
+                            throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
+                        }
+                    }
+                } catch (Exception ex) {
                     throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
                 }
+                return vm;
+            } finally {
+                quotaLimitLock.unlock();
             }
-        } catch (Exception ex) {
-            throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
+        } else {
+            throw new ResourceAllocationException(String.format("unable to acquire quota limit \"%s\"", lockName), ResourceType.user_vm);
         }
-        return vm;
     }
 
     private static void throwInvalidParemeterExceptionForNet(NetworkVO network, String reason) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4048,15 +4048,15 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 profile.setDefaultNic(true);
                 if (!_networkModel.areServicesSupportedInNetwork(network.getId(), new Service[]{Service.UserData})) {
                     if ((userData != null) && (!userData.isEmpty())) {
-                        throw new InvalidParameterValueException("Unable to deploy VM as UserData is provided while deploying the VM, but there is no support for " + Service.UserData.getName() + " service in the default network " + network.getId());
+                        throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as UserData is provided while deploying the VM");
                     }
 
                     if ((sshPublicKeys != null) && (!sshPublicKeys.isEmpty())) {
-                        throw new InvalidParameterValueException("Unable to deploy VM as SSH keypair is provided while deploying the VM, but there is no support for " + Service.UserData.getName() + " service in the default network " + network.getId());
+                        throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as SSH keypair is provided while deploying the VM");
                     }
 
                     if (template.isEnablePassword()) {
-                        throw new InvalidParameterValueException("Unable to deploy VM as template " + template.getId() + " is password enabled, but there is no support for " + Service.UserData.getName() + " service in the default network " + network.getId());
+                        throwInvalidParemeterExceptionForNet(network, String.format("Unable to deploy VM as template %d is password enabled", template.getId()));
                     }
                 }
             }
@@ -4165,6 +4165,14 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
         }
         return vm;
+    }
+
+    private static void throwInvalidParemeterExceptionForNet(NetworkVO network, String reason) {
+        String message = String.format("%s, but there is no support for %s service in the default network %d."
+                , reason
+                , Service.UserData.getName()
+                , network.getId());
+        throw new InvalidParameterValueException(message);
     }
 
     private long verifyAndGetDiskSize(DiskOfferingVO diskOffering, Long diskSize) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3869,313 +3869,324 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         CallContext.current().putContextParameter(VirtualMachine.class, vm.getUuid());
         return vm;
     }
+    private UserVmVO getPermittedVmResource(DataCenter zone, String hostName, String displayName, Account owner, Long diskOfferingId, Long diskSize, List<NetworkVO> networkList, List<Long> securityGroupIdList, String group, HTTPMethod httpmethod, String userData, List<String> sshKeyPairs, Account caller, Map<Long, IpAddresses> requestedIps, IpAddresses defaultIps, Boolean isDisplayVm, String keyboard, List<Long> affinityGroupIdList, Map<String, String> customParameters, String customId, Map<String, Map<Integer, String>> dhcpOptionMap, Map<Long, DiskOffering> datadiskTemplateToDiskOfferringMap, Map<String, String> userVmOVFPropertiesMap, boolean dynamicScalingEnabled, String vmType, VMTemplateVO template, HypervisorType hypervisorType, long accountId, ServiceOfferingVO offering, boolean isIso, Long rootDiskOfferingId, long volumesSize) throws ResourceAllocationException, StorageUnavailableException, InsufficientCapacityException {
+        if(Boolean.TRUE.equals(AllowParallelVmCreation.valueIn(owner.getAccountId()))) {
+            return getUserVmResource(zone, hostName, displayName, owner, diskOfferingId, diskSize, networkList, securityGroupIdList, group, httpmethod, userData, sshKeyPairs, caller, requestedIps, defaultIps, isDisplayVm, keyboard, affinityGroupIdList, customParameters, customId, dhcpOptionMap, datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, template, hypervisorType, accountId, offering, isIso, rootDiskOfferingId, volumesSize);
+        } else {
+            return getSynchronisedPermittedVmResource(zone, hostName, displayName, owner, diskOfferingId, diskSize, networkList, securityGroupIdList, group, httpmethod, userData, sshKeyPairs, caller, requestedIps, defaultIps, isDisplayVm, keyboard, affinityGroupIdList, customParameters, customId, dhcpOptionMap, datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, template, hypervisorType, accountId, offering, isIso, rootDiskOfferingId, volumesSize);
+        }
+    }
 
-    private synchronized UserVmVO getPermittedVmResource(DataCenter zone, String hostName, String displayName, Account owner, Long diskOfferingId, Long diskSize, List<NetworkVO> networkList, List<Long> securityGroupIdList, String group, HTTPMethod httpmethod, String userData, List<String> sshKeyPairs, Account caller, Map<Long, IpAddresses> requestedIps, IpAddresses defaultIps, Boolean isDisplayVm, String keyboard, List<Long> affinityGroupIdList, Map<String, String> customParameters, String customId, Map<String, Map<Integer, String>> dhcpOptionMap, Map<Long, DiskOffering> datadiskTemplateToDiskOfferringMap, Map<String, String> userVmOVFPropertiesMap, boolean dynamicScalingEnabled, String vmType, VMTemplateVO template, HypervisorType hypervisorType, long accountId, ServiceOfferingVO offering, boolean isIso, Long rootDiskOfferingId, long volumesSize) throws ResourceAllocationException, StorageUnavailableException, InsufficientCapacityException {
+    private synchronized UserVmVO getSynchronisedPermittedVmResource(DataCenter zone, String hostName, String displayName, Account owner, Long diskOfferingId, Long diskSize, List<NetworkVO> networkList, List<Long> securityGroupIdList, String group, HTTPMethod httpmethod, String userData, List<String> sshKeyPairs, Account caller, Map<Long, IpAddresses> requestedIps, IpAddresses defaultIps, Boolean isDisplayVm, String keyboard, List<Long> affinityGroupIdList, Map<String, String> customParameters, String customId, Map<String, Map<Integer, String>> dhcpOptionMap, Map<Long, DiskOffering> datadiskTemplateToDiskOfferringMap, Map<String, String> userVmOVFPropertiesMap, boolean dynamicScalingEnabled, String vmType, VMTemplateVO template, HypervisorType hypervisorType, long accountId, ServiceOfferingVO offering, boolean isIso, Long rootDiskOfferingId, long volumesSize) throws ResourceAllocationException, StorageUnavailableException, InsufficientCapacityException {
         String lockName = String.format("VM.CREATE for %s/%d", owner.getAccountName(), owner.getDomainId());
         GlobalLock quotaLimitLock = GlobalLock.getInternLock(lockName);
         if(quotaLimitLock.lock(TRY_TO_GET_LOCK_TIME)) {
             try {
-                if (!VirtualMachineManager.ResourceCountRunningVMsonly.value()) {
-                    resourceLimitCheck(owner, isDisplayVm, new Long(offering.getCpu()), new Long(offering.getRamSize()));
-                }
-
-                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, (isIso || diskOfferingId == null ? 1 : 2));
-                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, volumesSize);
-
-                // verify security group ids
-                if (securityGroupIdList != null) {
-                    for (Long securityGroupId : securityGroupIdList) {
-                        SecurityGroup sg = _securityGroupDao.findById(securityGroupId);
-                        if (sg == null) {
-                            throw new InvalidParameterValueException("Unable to find security group by id " + securityGroupId);
-                        } else {
-                            // verify permissions
-                            _accountMgr.checkAccess(caller, null, true, owner, sg);
-                        }
-                    }
-                }
-
-                if (datadiskTemplateToDiskOfferringMap != null && !datadiskTemplateToDiskOfferringMap.isEmpty()) {
-                    for (Entry<Long, DiskOffering> datadiskTemplateToDiskOffering : datadiskTemplateToDiskOfferringMap.entrySet()) {
-                        VMTemplateVO dataDiskTemplate = _templateDao.findById(datadiskTemplateToDiskOffering.getKey());
-                        DiskOffering dataDiskOffering = datadiskTemplateToDiskOffering.getValue();
-
-                        if (dataDiskTemplate == null
-                                || (!dataDiskTemplate.getTemplateType().equals(TemplateType.DATADISK)) && (dataDiskTemplate.getState().equals(VirtualMachineTemplate.State.Active))) {
-                            throw new InvalidParameterValueException("Invalid template id specified for Datadisk template" + datadiskTemplateToDiskOffering.getKey());
-                        }
-                        long dataDiskTemplateId = datadiskTemplateToDiskOffering.getKey();
-                        if (!dataDiskTemplate.getParentTemplateId().equals(template.getId())) {
-                            throw new InvalidParameterValueException("Invalid Datadisk template. Specified Datadisk template" + dataDiskTemplateId
-                                    + " doesn't belong to template " + template.getId());
-                        }
-                        if (dataDiskOffering == null) {
-                            throw new InvalidParameterValueException("Invalid disk offering id " + datadiskTemplateToDiskOffering.getValue().getId() +
-                                    " specified for datadisk template " + dataDiskTemplateId);
-                        }
-                        if (dataDiskOffering.isCustomized()) {
-                            throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
-                                    dataDiskTemplateId + ". Custom Disk offerings are not supported for Datadisk templates");
-                        }
-                        if (dataDiskOffering.getDiskSize() < dataDiskTemplate.getSize()) {
-                            throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
-                                    dataDiskTemplateId + ". Disk offering size should be greater than or equal to the template size");
-                        }
-                        _templateDao.loadDetails(dataDiskTemplate);
-                        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, 1);
-                        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, dataDiskOffering.getDiskSize());
-                    }
-                }
-
-                // check that the affinity groups exist
-                if (affinityGroupIdList != null) {
-                    for (Long affinityGroupId : affinityGroupIdList) {
-                        AffinityGroupVO ag = _affinityGroupDao.findById(affinityGroupId);
-                        if (ag == null) {
-                            throw new InvalidParameterValueException("Unable to find affinity group " + ag);
-                        } else if (!_affinityGroupService.isAffinityGroupProcessorAvailable(ag.getType())) {
-                            throw new InvalidParameterValueException("Affinity group type is not supported for group: " + ag + " ,type: " + ag.getType()
-                                    + " , Please try again after removing the affinity group");
-                        } else {
-                            // verify permissions
-                            if (ag.getAclType() == ACLType.Domain) {
-                                _accountMgr.checkAccess(caller, null, false, owner, ag);
-                                // Root admin has access to both VM and AG by default,
-                                // but
-                                // make sure the owner of these entities is same
-                                if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                                    if (!_affinityGroupService.isAffinityGroupAvailableInDomain(ag.getId(), owner.getDomainId())) {
-                                        throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's domain");
-                                    }
-                                }
-                            } else {
-                                _accountMgr.checkAccess(caller, null, true, owner, ag);
-                                // Root admin has access to both VM and AG by default,
-                                // but
-                                // make sure the owner of these entities is same
-                                if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                                    if (ag.getAccountId() != owner.getAccountId()) {
-                                        throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (hypervisorType != HypervisorType.BareMetal) {
-                    // check if we have available pools for vm deployment
-                    long availablePools = _storagePoolDao.countPoolsByStatus(StoragePoolStatus.Up);
-                    if (availablePools < 1) {
-                        throw new StorageUnavailableException("There are no available pools in the UP state for vm deployment", -1);
-                    }
-                }
-
-                if (template.getTemplateType().equals(TemplateType.SYSTEM) && !CKS_NODE.equals(vmType)) {
-                    throw new InvalidParameterValueException("Unable to use system template " + template.getId() + " to deploy a user vm");
-                }
-                List<VMTemplateZoneVO> listZoneTemplate = _templateZoneDao.listByZoneTemplate(zone.getId(), template.getId());
-                if (listZoneTemplate == null || listZoneTemplate.isEmpty()) {
-                    throw new InvalidParameterValueException("The template " + template.getId() + " is not available for use");
-                }
-
-                if (isIso && !template.isBootable()) {
-                    throw new InvalidParameterValueException("Installing from ISO requires an ISO that is bootable: " + template.getId());
-                }
-
-                // Check templates permissions
-                _accountMgr.checkAccess(owner, AccessType.UseEntry, false, template);
-
-                // check if the user data is correct
-                userData = validateUserData(userData, httpmethod);
-
-                // Find an SSH public key corresponding to the key pair name, if one is
-                // given
-                String sshPublicKeys = "";
-                String keypairnames = "";
-                if (!sshKeyPairs.isEmpty()) {
-                    List<SSHKeyPairVO> pairs = _sshKeyPairDao.findByNames(owner.getAccountId(), owner.getDomainId(), sshKeyPairs);
-                    if (pairs == null || pairs.size() != sshKeyPairs.size()) {
-                        throw new InvalidParameterValueException("Not all specified keyparis exist");
-                    }
-
-                    sshPublicKeys = pairs.stream().map(p -> p.getPublicKey()).collect(Collectors.joining("\n"));
-                    keypairnames = String.join(",", sshKeyPairs);
-                }
-
-                LinkedHashMap<String, List<NicProfile>> networkNicMap = new LinkedHashMap<>();
-
-                short defaultNetworkNumber = 0;
-                boolean securityGroupEnabled = false;
-                int networkIndex = 0;
-                for (NetworkVO network : networkList) {
-                    if ((network.getDataCenterId() != zone.getId())) {
-                        if (!network.isStrechedL2Network()) {
-                            throw new InvalidParameterValueException("Network id=" + network.getId() +
-                                    " doesn't belong to zone " + zone.getId());
-                        }
-
-                        NetworkOffering ntwkOffering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-                        Long physicalNetworkId = _networkModel.findPhysicalNetworkId(zone.getId(), ntwkOffering.getTags(), ntwkOffering.getTrafficType());
-
-                        String provider = _ntwkSrvcDao.getProviderForServiceInNetwork(network.getId(), Service.Connectivity);
-                        if (!_networkModel.isProviderEnabledInPhysicalNetwork(physicalNetworkId, provider)) {
-                            throw new InvalidParameterValueException("Network in which is VM getting deployed could not be" +
-                                    " streched to the zone, as we could not find a valid physical network");
-                        }
-                    }
-
-                    _accountMgr.checkAccess(owner, AccessType.UseEntry, false, network);
-
-                    IpAddresses requestedIpPair = null;
-                    if (requestedIps != null && !requestedIps.isEmpty()) {
-                        requestedIpPair = requestedIps.get(network.getId());
-                    }
-
-                    if (requestedIpPair == null) {
-                        requestedIpPair = new IpAddresses(null, null);
-                    } else {
-                        _networkModel.checkRequestedIpAddresses(network.getId(), requestedIpPair);
-                    }
-
-                    NicProfile profile = new NicProfile(requestedIpPair.getIp4Address(), requestedIpPair.getIp6Address(), requestedIpPair.getMacAddress());
-                    profile.setOrderIndex(networkIndex);
-                    if (defaultNetworkNumber == 0) {
-                        defaultNetworkNumber++;
-                        // if user requested specific ip for default network, add it
-                        if (defaultIps.getIp4Address() != null || defaultIps.getIp6Address() != null) {
-                            _networkModel.checkRequestedIpAddresses(network.getId(), defaultIps);
-                            profile = new NicProfile(defaultIps.getIp4Address(), defaultIps.getIp6Address());
-                        } else if (defaultIps.getMacAddress() != null) {
-                            profile = new NicProfile(null, null, defaultIps.getMacAddress());
-                        }
-
-                        profile.setDefaultNic(true);
-                        if (!_networkModel.areServicesSupportedInNetwork(network.getId(), new Service[]{Service.UserData})) {
-                            if ((userData != null) && (!userData.isEmpty())) {
-                                throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as UserData is provided while deploying the VM");
-                            }
-
-                            if ((sshPublicKeys != null) && (!sshPublicKeys.isEmpty())) {
-                                throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as SSH keypair is provided while deploying the VM");
-                            }
-
-                            if (template.isEnablePassword()) {
-                                throwInvalidParemeterExceptionForNet(network, String.format("Unable to deploy VM as template %d is password enabled", template.getId()));
-                            }
-                        }
-                    }
-
-                    if (_networkModel.isSecurityGroupSupportedInNetwork(network)) {
-                        securityGroupEnabled = true;
-                    }
-                    List<NicProfile> profiles = networkNicMap.get(network.getUuid());
-                    if (CollectionUtils.isEmpty(profiles)) {
-                        profiles = new ArrayList<>();
-                    }
-                    profiles.add(profile);
-                    networkNicMap.put(network.getUuid(), profiles);
-                    networkIndex++;
-                }
-
-                if (securityGroupIdList != null && !securityGroupIdList.isEmpty() && !securityGroupEnabled) {
-                    throw new InvalidParameterValueException("Unable to deploy vm with security groups as SecurityGroup service is not enabled for the vm's network");
-                }
-
-                // Verify network information - network default network has to be set;
-                // and vm can't have more than one default network
-                // This is a part of business logic because default network is required
-                // by Agent Manager in order to configure default
-                // gateway for the vm
-                if (defaultNetworkNumber == 0) {
-                    throw new InvalidParameterValueException("At least 1 default network has to be specified for the vm");
-                } else if (defaultNetworkNumber > 1) {
-                    throw new InvalidParameterValueException("Only 1 default network per vm is supported");
-                }
-
-                long id = _vmDao.getNextInSequence(Long.class, "id");
-
-                if (hostName != null) {
-                    // Check is hostName is RFC compliant
-                    checkNameForRFCCompliance(hostName);
-                }
-
-                String instanceName = null;
-                String instanceSuffix = _instance;
-                String uuidName = _uuidMgr.generateUuid(UserVm.class, customId);
-                if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType)) {
-                    if (StringUtils.isNotEmpty(hostName)) {
-                        instanceSuffix = hostName;
-                    }
-                    if (hostName == null) {
-                        if (displayName != null) {
-                            hostName = displayName;
-                        } else {
-                            hostName = generateHostName(uuidName);
-                        }
-                    }
-                    // If global config vm.instancename.flag is set to true, then CS will set guest VM's name as it appears on the hypervisor, to its hostname.
-                    // In case of VMware since VM name must be unique within a DC, check if VM with the same hostname already exists in the zone.
-                    VMInstanceVO vmByHostName = _vmInstanceDao.findVMByHostNameInZone(hostName, zone.getId());
-                    if (vmByHostName != null && vmByHostName.getState() != State.Expunging) {
-                        throw new InvalidParameterValueException("There already exists a VM by the name: " + hostName + ".");
-                    }
-                } else {
-                    if (hostName == null) {
-                        //Generate name using uuid and instance.name global config
-                        hostName = generateHostName(uuidName);
-                    }
-                }
-
-                if (hostName != null) {
-                    // Check is hostName is RFC compliant
-                    checkNameForRFCCompliance(hostName);
-                }
-                instanceName = VirtualMachineName.getVmName(id, owner.getId(), instanceSuffix);
-                if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType) && !instanceSuffix.equals(_instance)) {
-                    customParameters.put(VmDetailConstants.NAME_ON_HYPERVISOR, instanceName);
-                }
-
-                // Check if VM with instanceName already exists.
-                VMInstanceVO vmObj = _vmInstanceDao.findVMByInstanceName(instanceName);
-                if (vmObj != null && vmObj.getState() != State.Expunging) {
-                    throw new InvalidParameterValueException("There already exists a VM by the display name supplied");
-                }
-
-                checkIfHostNameUniqueInNtwkDomain(hostName, networkList);
-
-                long userId = CallContext.current().getCallingUserId();
-                if (CallContext.current().getCallingAccount().getId() != owner.getId()) {
-                    List<UserVO> userVOs = _userDao.listByAccount(owner.getAccountId());
-                    if (!userVOs.isEmpty()) {
-                        userId = userVOs.get(0).getId();
-                    }
-                }
-
-                dynamicScalingEnabled = dynamicScalingEnabled && checkIfDynamicScalingCanBeEnabled(null, offering, template, zone.getId());
-
-                UserVmVO vm = commitUserVm(zone, template, hostName, displayName, owner, diskOfferingId, diskSize, userData, caller, isDisplayVm, keyboard, accountId, userId, offering,
-                        isIso, sshPublicKeys, networkNicMap, id, instanceName, uuidName, hypervisorType, customParameters, dhcpOptionMap,
-                        datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, rootDiskOfferingId, keypairnames);
-
-                // Assign instance to the group
-                try {
-                    if (group != null) {
-                        boolean addToGroup = addInstanceToGroup(Long.valueOf(id), group);
-                        if (!addToGroup) {
-                            throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
-                        }
-                    }
-                } catch (Exception ex) {
-                    throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
-                }
-                return vm;
+                return getUserVmResource(zone, hostName, displayName, owner, diskOfferingId, diskSize, networkList, securityGroupIdList, group, httpmethod, userData, sshKeyPairs, caller, requestedIps, defaultIps, isDisplayVm, keyboard, affinityGroupIdList, customParameters, customId, dhcpOptionMap, datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, template, hypervisorType, accountId, offering, isIso, rootDiskOfferingId, volumesSize);
             } finally {
                 quotaLimitLock.unlock();
             }
         } else {
             throw new ResourceAllocationException(String.format("unable to acquire quota limit \"%s\"", lockName), ResourceType.user_vm);
         }
+    }
+
+    private UserVmVO getUserVmResource(DataCenter zone, String hostName, String displayName, Account owner, Long diskOfferingId, Long diskSize, List<NetworkVO> networkList, List<Long> securityGroupIdList, String group, HTTPMethod httpmethod, String userData, List<String> sshKeyPairs, Account caller, Map<Long, IpAddresses> requestedIps, IpAddresses defaultIps, Boolean isDisplayVm, String keyboard, List<Long> affinityGroupIdList, Map<String, String> customParameters, String customId, Map<String, Map<Integer, String>> dhcpOptionMap, Map<Long, DiskOffering> datadiskTemplateToDiskOfferringMap, Map<String, String> userVmOVFPropertiesMap, boolean dynamicScalingEnabled, String vmType, VMTemplateVO template, HypervisorType hypervisorType, long accountId, ServiceOfferingVO offering, boolean isIso, Long rootDiskOfferingId, long volumesSize) throws ResourceAllocationException, StorageUnavailableException, InsufficientCapacityException {
+        if (!VirtualMachineManager.ResourceCountRunningVMsonly.value()) {
+            resourceLimitCheck(owner, isDisplayVm, new Long(offering.getCpu()), new Long(offering.getRamSize()));
+        }
+
+        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, (isIso || diskOfferingId == null ? 1 : 2));
+        _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, volumesSize);
+
+        // verify security group ids
+        if (securityGroupIdList != null) {
+            for (Long securityGroupId : securityGroupIdList) {
+                SecurityGroup sg = _securityGroupDao.findById(securityGroupId);
+                if (sg == null) {
+                    throw new InvalidParameterValueException("Unable to find security group by id " + securityGroupId);
+                } else {
+                    // verify permissions
+                    _accountMgr.checkAccess(caller, null, true, owner, sg);
+                }
+            }
+        }
+
+        if (datadiskTemplateToDiskOfferringMap != null && !datadiskTemplateToDiskOfferringMap.isEmpty()) {
+            for (Entry<Long, DiskOffering> datadiskTemplateToDiskOffering : datadiskTemplateToDiskOfferringMap.entrySet()) {
+                VMTemplateVO dataDiskTemplate = _templateDao.findById(datadiskTemplateToDiskOffering.getKey());
+                DiskOffering dataDiskOffering = datadiskTemplateToDiskOffering.getValue();
+
+                if (dataDiskTemplate == null
+                        || (!dataDiskTemplate.getTemplateType().equals(TemplateType.DATADISK)) && (dataDiskTemplate.getState().equals(VirtualMachineTemplate.State.Active))) {
+                    throw new InvalidParameterValueException("Invalid template id specified for Datadisk template" + datadiskTemplateToDiskOffering.getKey());
+                }
+                long dataDiskTemplateId = datadiskTemplateToDiskOffering.getKey();
+                if (!dataDiskTemplate.getParentTemplateId().equals(template.getId())) {
+                    throw new InvalidParameterValueException("Invalid Datadisk template. Specified Datadisk template" + dataDiskTemplateId
+                            + " doesn't belong to template " + template.getId());
+                }
+                if (dataDiskOffering == null) {
+                    throw new InvalidParameterValueException("Invalid disk offering id " + datadiskTemplateToDiskOffering.getValue().getId() +
+                            " specified for datadisk template " + dataDiskTemplateId);
+                }
+                if (dataDiskOffering.isCustomized()) {
+                    throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
+                            dataDiskTemplateId + ". Custom Disk offerings are not supported for Datadisk templates");
+                }
+                if (dataDiskOffering.getDiskSize() < dataDiskTemplate.getSize()) {
+                    throw new InvalidParameterValueException("Invalid disk offering id " + dataDiskOffering.getId() + " specified for datadisk template " +
+                            dataDiskTemplateId + ". Disk offering size should be greater than or equal to the template size");
+                }
+                _templateDao.loadDetails(dataDiskTemplate);
+                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.volume, 1);
+                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, dataDiskOffering.getDiskSize());
+            }
+        }
+
+        // check that the affinity groups exist
+        if (affinityGroupIdList != null) {
+            for (Long affinityGroupId : affinityGroupIdList) {
+                AffinityGroupVO ag = _affinityGroupDao.findById(affinityGroupId);
+                if (ag == null) {
+                    throw new InvalidParameterValueException("Unable to find affinity group " + ag);
+                } else if (!_affinityGroupService.isAffinityGroupProcessorAvailable(ag.getType())) {
+                    throw new InvalidParameterValueException("Affinity group type is not supported for group: " + ag + " ,type: " + ag.getType()
+                            + " , Please try again after removing the affinity group");
+                } else {
+                    // verify permissions
+                    if (ag.getAclType() == ACLType.Domain) {
+                        _accountMgr.checkAccess(caller, null, false, owner, ag);
+                        // Root admin has access to both VM and AG by default,
+                        // but
+                        // make sure the owner of these entities is same
+                        if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
+                            if (!_affinityGroupService.isAffinityGroupAvailableInDomain(ag.getId(), owner.getDomainId())) {
+                                throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's domain");
+                            }
+                        }
+                    } else {
+                        _accountMgr.checkAccess(caller, null, true, owner, ag);
+                        // Root admin has access to both VM and AG by default,
+                        // but
+                        // make sure the owner of these entities is same
+                        if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
+                            if (ag.getAccountId() != owner.getAccountId()) {
+                                throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (hypervisorType != HypervisorType.BareMetal) {
+            // check if we have available pools for vm deployment
+            long availablePools = _storagePoolDao.countPoolsByStatus(StoragePoolStatus.Up);
+            if (availablePools < 1) {
+                throw new StorageUnavailableException("There are no available pools in the UP state for vm deployment", -1);
+            }
+        }
+
+        if (template.getTemplateType().equals(TemplateType.SYSTEM) && !CKS_NODE.equals(vmType)) {
+            throw new InvalidParameterValueException("Unable to use system template " + template.getId() + " to deploy a user vm");
+        }
+        List<VMTemplateZoneVO> listZoneTemplate = _templateZoneDao.listByZoneTemplate(zone.getId(), template.getId());
+        if (listZoneTemplate == null || listZoneTemplate.isEmpty()) {
+            throw new InvalidParameterValueException("The template " + template.getId() + " is not available for use");
+        }
+
+        if (isIso && !template.isBootable()) {
+            throw new InvalidParameterValueException("Installing from ISO requires an ISO that is bootable: " + template.getId());
+        }
+
+        // Check templates permissions
+        _accountMgr.checkAccess(owner, AccessType.UseEntry, false, template);
+
+        // check if the user data is correct
+        userData = validateUserData(userData, httpmethod);
+
+        // Find an SSH public key corresponding to the key pair name, if one is
+        // given
+        String sshPublicKeys = "";
+        String keypairnames = "";
+        if (!sshKeyPairs.isEmpty()) {
+            List<SSHKeyPairVO> pairs = _sshKeyPairDao.findByNames(owner.getAccountId(), owner.getDomainId(), sshKeyPairs);
+            if (pairs == null || pairs.size() != sshKeyPairs.size()) {
+                throw new InvalidParameterValueException("Not all specified keyparis exist");
+            }
+
+            sshPublicKeys = pairs.stream().map(p -> p.getPublicKey()).collect(Collectors.joining("\n"));
+            keypairnames = String.join(",", sshKeyPairs);
+        }
+
+        LinkedHashMap<String, List<NicProfile>> networkNicMap = new LinkedHashMap<>();
+
+        short defaultNetworkNumber = 0;
+        boolean securityGroupEnabled = false;
+        int networkIndex = 0;
+        for (NetworkVO network : networkList) {
+            if ((network.getDataCenterId() != zone.getId())) {
+                if (!network.isStrechedL2Network()) {
+                    throw new InvalidParameterValueException("Network id=" + network.getId() +
+                            " doesn't belong to zone " + zone.getId());
+                }
+
+                NetworkOffering ntwkOffering = _networkOfferingDao.findById(network.getNetworkOfferingId());
+                Long physicalNetworkId = _networkModel.findPhysicalNetworkId(zone.getId(), ntwkOffering.getTags(), ntwkOffering.getTrafficType());
+
+                String provider = _ntwkSrvcDao.getProviderForServiceInNetwork(network.getId(), Service.Connectivity);
+                if (!_networkModel.isProviderEnabledInPhysicalNetwork(physicalNetworkId, provider)) {
+                    throw new InvalidParameterValueException("Network in which is VM getting deployed could not be" +
+                            " streched to the zone, as we could not find a valid physical network");
+                }
+            }
+
+            _accountMgr.checkAccess(owner, AccessType.UseEntry, false, network);
+
+            IpAddresses requestedIpPair = null;
+            if (requestedIps != null && !requestedIps.isEmpty()) {
+                requestedIpPair = requestedIps.get(network.getId());
+            }
+
+            if (requestedIpPair == null) {
+                requestedIpPair = new IpAddresses(null, null);
+            } else {
+                _networkModel.checkRequestedIpAddresses(network.getId(), requestedIpPair);
+            }
+
+            NicProfile profile = new NicProfile(requestedIpPair.getIp4Address(), requestedIpPair.getIp6Address(), requestedIpPair.getMacAddress());
+            profile.setOrderIndex(networkIndex);
+            if (defaultNetworkNumber == 0) {
+                defaultNetworkNumber++;
+                // if user requested specific ip for default network, add it
+                if (defaultIps.getIp4Address() != null || defaultIps.getIp6Address() != null) {
+                    _networkModel.checkRequestedIpAddresses(network.getId(), defaultIps);
+                    profile = new NicProfile(defaultIps.getIp4Address(), defaultIps.getIp6Address());
+                } else if (defaultIps.getMacAddress() != null) {
+                    profile = new NicProfile(null, null, defaultIps.getMacAddress());
+                }
+
+                profile.setDefaultNic(true);
+                if (!_networkModel.areServicesSupportedInNetwork(network.getId(), new Service[]{Service.UserData})) {
+                    if ((userData != null) && (!userData.isEmpty())) {
+                        throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as UserData is provided while deploying the VM");
+                    }
+
+                    if ((sshPublicKeys != null) && (!sshPublicKeys.isEmpty())) {
+                        throwInvalidParemeterExceptionForNet(network, "Unable to deploy VM as SSH keypair is provided while deploying the VM");
+                    }
+
+                    if (template.isEnablePassword()) {
+                        throwInvalidParemeterExceptionForNet(network, String.format("Unable to deploy VM as template %d is password enabled", template.getId()));
+                    }
+                }
+            }
+
+            if (_networkModel.isSecurityGroupSupportedInNetwork(network)) {
+                securityGroupEnabled = true;
+            }
+            List<NicProfile> profiles = networkNicMap.get(network.getUuid());
+            if (CollectionUtils.isEmpty(profiles)) {
+                profiles = new ArrayList<>();
+            }
+            profiles.add(profile);
+            networkNicMap.put(network.getUuid(), profiles);
+            networkIndex++;
+        }
+
+        if (securityGroupIdList != null && !securityGroupIdList.isEmpty() && !securityGroupEnabled) {
+            throw new InvalidParameterValueException("Unable to deploy vm with security groups as SecurityGroup service is not enabled for the vm's network");
+        }
+
+        // Verify network information - network default network has to be set;
+        // and vm can't have more than one default network
+        // This is a part of business logic because default network is required
+        // by Agent Manager in order to configure default
+        // gateway for the vm
+        if (defaultNetworkNumber == 0) {
+            throw new InvalidParameterValueException("At least 1 default network has to be specified for the vm");
+        } else if (defaultNetworkNumber > 1) {
+            throw new InvalidParameterValueException("Only 1 default network per vm is supported");
+        }
+
+        long id = _vmDao.getNextInSequence(Long.class, "id");
+
+        if (hostName != null) {
+            // Check is hostName is RFC compliant
+            checkNameForRFCCompliance(hostName);
+        }
+
+        String instanceName = null;
+        String instanceSuffix = _instance;
+        String uuidName = _uuidMgr.generateUuid(UserVm.class, customId);
+        if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType)) {
+            if (StringUtils.isNotEmpty(hostName)) {
+                instanceSuffix = hostName;
+            }
+            if (hostName == null) {
+                if (displayName != null) {
+                    hostName = displayName;
+                } else {
+                    hostName = generateHostName(uuidName);
+                }
+            }
+            // If global config vm.instancename.flag is set to true, then CS will set guest VM's name as it appears on the hypervisor, to its hostname.
+            // In case of VMware since VM name must be unique within a DC, check if VM with the same hostname already exists in the zone.
+            VMInstanceVO vmByHostName = _vmInstanceDao.findVMByHostNameInZone(hostName, zone.getId());
+            if (vmByHostName != null && vmByHostName.getState() != State.Expunging) {
+                throw new InvalidParameterValueException("There already exists a VM by the name: " + hostName + ".");
+            }
+        } else {
+            if (hostName == null) {
+                //Generate name using uuid and instance.name global config
+                hostName = generateHostName(uuidName);
+            }
+        }
+
+        if (hostName != null) {
+            // Check is hostName is RFC compliant
+            checkNameForRFCCompliance(hostName);
+        }
+        instanceName = VirtualMachineName.getVmName(id, owner.getId(), instanceSuffix);
+        if (_instanceNameFlag && HypervisorType.VMware.equals(hypervisorType) && !instanceSuffix.equals(_instance)) {
+            customParameters.put(VmDetailConstants.NAME_ON_HYPERVISOR, instanceName);
+        }
+
+        // Check if VM with instanceName already exists.
+        VMInstanceVO vmObj = _vmInstanceDao.findVMByInstanceName(instanceName);
+        if (vmObj != null && vmObj.getState() != State.Expunging) {
+            throw new InvalidParameterValueException("There already exists a VM by the display name supplied");
+        }
+
+        checkIfHostNameUniqueInNtwkDomain(hostName, networkList);
+
+        long userId = CallContext.current().getCallingUserId();
+        if (CallContext.current().getCallingAccount().getId() != owner.getId()) {
+            List<UserVO> userVOs = _userDao.listByAccount(owner.getAccountId());
+            if (!userVOs.isEmpty()) {
+                userId = userVOs.get(0).getId();
+            }
+        }
+
+        dynamicScalingEnabled = dynamicScalingEnabled && checkIfDynamicScalingCanBeEnabled(null, offering, template, zone.getId());
+
+        UserVmVO vm = commitUserVm(zone, template, hostName, displayName, owner, diskOfferingId, diskSize, userData, caller, isDisplayVm, keyboard, accountId, userId, offering,
+                isIso, sshPublicKeys, networkNicMap, id, instanceName, uuidName, hypervisorType, customParameters, dhcpOptionMap,
+                datadiskTemplateToDiskOfferringMap, userVmOVFPropertiesMap, dynamicScalingEnabled, vmType, rootDiskOfferingId, keypairnames);
+
+        // Assign instance to the group
+        try {
+            if (group != null) {
+                boolean addToGroup = addInstanceToGroup(Long.valueOf(id), group);
+                if (!addToGroup) {
+                    throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
+                }
+            }
+        } catch (Exception ex) {
+            throw new CloudRuntimeException("Unable to assign Vm to the group " + group);
+        }
+        return vm;
     }
 
     private static void throwInvalidParemeterExceptionForNet(NetworkVO network, String reason) {
@@ -7792,7 +7803,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {EnableDynamicallyScaleVm, AllowUserExpungeRecoverVm, VmIpFetchWaitInterval, VmIpFetchTrialMax,
                 VmIpFetchThreadPoolMax, VmIpFetchTaskWorkers, AllowDeployVmIfGivenHostFails, EnableAdditionalVmConfig, DisplayVMOVFProperties,
-                KvmAdditionalConfigAllowList, XenServerAdditionalConfigAllowList, VmwareAdditionalConfigAllowList};
+                KvmAdditionalConfigAllowList, XenServerAdditionalConfigAllowList, VmwareAdditionalConfigAllowList, AllowParallelVmCreation};
     }
 
     @Override

--- a/test/integration/smoke/test_deploy_vms_in_parallel.py
+++ b/test/integration/smoke/test_deploy_vms_in_parallel.py
@@ -109,7 +109,6 @@ class TestDeployVMsInParallel(cloudstackTestCase):
             hypervisor=self.hypervisor
         )
         self.cleanup.append(virtual_machine)
-        print(f"==== network: {virtual_machine.__dict__}")
         self.networkids = virtual_machine.nic[0].networkid
         virtual_machine.delete(self.apiclient)
         self.cleanup.remove(virtual_machine)
@@ -143,7 +142,7 @@ class TestDeployVMsInParallel(cloudstackTestCase):
         self.test_limits(vm_limit=2)
 
     def test_limits(self, vm_limit=1):
-        print(f"==== limit: {vm_limit} ====")
+        self.info(f"==== limit: {vm_limit} ====")
 
         self.update_resource_limit(max=vm_limit)
 
@@ -161,13 +160,13 @@ class TestDeployVMsInParallel(cloudstackTestCase):
         failed = 0
         for i in range(vm_limit+3):
             try:
-                self.debug(f"==== deploying instance #{i}")
+                self.info(f"==== deploying instance #{i}")
                 response = self.userApiClient.deployVirtualMachine(cmd, method="GET")
                 responses.append(response)
             except Exception as e:
                 failed += 1
 
-        print(f"==== failed deploys: {failed} ====")
+        self.info(f"==== failed deploys: {failed} ====")
 
         self.assertEqual(failed, 3)
         self.assertEqual(len(responses), vm_limit) # we don´t care if the deploy succeed or failed for some other reason

--- a/test/integration/smoke/test_deploy_vms_in_parallel.py
+++ b/test/integration/smoke/test_deploy_vms_in_parallel.py
@@ -1,0 +1,169 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" P1 for Deploy VM from ISO
+"""
+# Import Local Modules
+from nose.plugins.attrib import attr
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.lib.base import (Account,
+                             DiskOffering,
+                             Domain,
+                             Resources,
+                             ServiceOffering,
+                             VirtualMachine)
+from marvin.lib.common import (get_zone,
+                               get_domain,
+                               get_test_template)
+from marvin.codes import PASS
+
+
+class TestDeployVMsInParallel(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.testClient = super(TestDeployVMsInParallel, cls).getClsTestClient()
+        cls.api_client = cls.testClient.getApiClient()
+
+        cls.testdata = cls.testClient.getParsedTestDataConfig()
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.api_client)
+        cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
+        cls.hypervisor = cls.testClient.getHypervisorInfo()
+
+        cls._cleanup = []
+
+        cls.template = get_test_template(
+            cls.api_client,
+            cls.zone.id,
+            cls.hypervisor
+        )
+
+        # Create service, disk offerings  etc
+        cls.service_offering = ServiceOffering.create(
+            cls.api_client,
+            cls.testdata["service_offering"]
+        )
+        cls._cleanup.append(cls.service_offering)
+
+        cls.disk_offering = DiskOffering.create(
+            cls.api_client,
+            cls.testdata["disk_offering"]
+        )
+        cls._cleanup.append(cls.disk_offering)
+
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestDeployVMsInParallel, cls).tearDownClass()
+
+    def setUp(self):
+
+        self.apiclient = self.testClient.getApiClient()
+        self.dbclient = self.testClient.getDbConnection()
+        self.cleanup = []
+        self.hypervisor = self.testClient.getHypervisorInfo()
+        self.testdata["virtual_machine"]["zoneid"] = self.zone.id
+        self.testdata["virtual_machine"]["template"] = self.template.id
+        self.testdata["iso"]["zoneid"] = self.zone.id
+        self.domain = Domain.create(
+            self.apiclient,
+            self.testdata["domain"]
+        )
+        self.cleanup.append(self.domain)
+        self.update_resource_limit()
+        self.account = Account.create(
+            self.apiclient,
+            self.testdata["account"],
+            domainid=self.domain.id
+        )
+        self.cleanup.append(self.account)
+        virtual_machine = VirtualMachine.create(
+            self.apiclient,
+            self.testdata["virtual_machine"],
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            templateid=self.template.id,
+            serviceofferingid=self.service_offering.id,
+            diskofferingid=self.disk_offering.id,
+            hypervisor=self.hypervisor
+        )
+        self.cleanup.append(virtual_machine)
+        virtual_machine.delete(self.apiclient)
+        self.cleanup.remove(virtual_machine)
+        return
+
+    def update_resource_limit(self):
+        Resources.updateLimit(
+            self.apiclient,
+            domainid=self.domain.id,
+            resourcetype=0,
+            max=1
+        )
+
+    def tearDown(self):
+        super(TestDeployVMsInParallel, self).tearDown()
+
+    @attr(
+        tags=[
+            "advanced",
+            "basic",
+            "sg"],
+        required_hardware="false")
+    def test_deploy_vms(self):
+        """
+        Test Deploy Virtual Machines in parallel
+
+        Validate the following:
+        1. set limits
+        2. deploy multiple VMs
+        """
+
+        self.debug("Deploying instance in the account: %s" %
+                   self.account.name)
+        self.virtual_machines = []
+        for i in range(4):
+            vm = VirtualMachine.create(
+                self.apiclient,
+                self.testdata["virtual_machine"],
+                accountid=self.account.name,
+                domainid=self.account.domainid,
+                templateid=self.template.id,
+                serviceofferingid=self.service_offering.id,
+                diskofferingid=self.disk_offering.id,
+                hypervisor=self.hypervisor
+            )
+            self.cleanup.append(vm)
+            self.virtual_machines.append(vm)
+
+        deployed = 0
+        failed = 0
+        for vm in self.virtual_machines:
+            response = vm.getState(self.apiclient, VirtualMachine.RUNNING)
+            if response[0] == PASS:
+                deployed += 1
+            else:
+                failed += 1
+        self.assertEqual(deployed, 1)
+        self.assertEqual(failed, 3)
+        # response = self.virtual_machine.getState(
+        #     self.apiclient,
+        #     VirtualMachine.RUNNING)
+        # self.assertEqual(response[0], PASS, response[1])
+        return


### PR DESCRIPTION
### Description

This PR makes sure a user can not create multiple VMs at once thus going passed their resource limit. For this purpose the part between the resource limit check and the commit of the VM has been put in a synchronized method. Also a GlobalLock is created. The problem with this is that
1. a lot of regression tests fail
2. users may rely on massive parallel creation of VMs
To guarantee backwards compatability, a setting has been introduced, `allow.user.parallel.vm.creation`, the defauklt is true to allow for the old behaviour, but this is deemed harmful from a quota point of view. If set to false the initial creation of a VM is not done in parallel and the limits are observed.
NOTE: this only affects the creation of the VM object including any needed resources. It is not synchronising the actual deployment.
NOTE: the test included in the code only tests the case where all VM creations are atempted on one MS. the multiple MS test is manual for now.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

prereqs:
- env with three MSs
- a domain with a limit of 2 user VMs
- an account in that domain with `allow.user.parallel.vm.creation` set to `false`
- a cmk install with preofiles `first`, `second` and `thiird` pointing to the different MSs
- 
test script:
```
for i in 1 2 3
  do
    cmk -p first deploy virtualmachine templateid=aed902af-0d71-4fd3-b767-32bdb0edc7f2 zoneid=33c25232-a25b-459b-812f-0e81ff8eded0 serviceofferingid=24dd5f48-4ee2-4ebb-9375-3cf882fa1b00 &
  done
for i in 1 2 3
  do
    cmk -p second deploy virtualmachine templateid=aed902af-0d71-4fd3-b767-32bdb0edc7f2 zoneid=33c25232-a25b-459b-812f-0e81ff8eded0 serviceofferingid=24dd5f48-4ee2-4ebb-9375-3cf882fa1b00 &  done ; for i in 1 2 3 ; do cmk -p third deploy virtualmachine templateid=aed902af-0d71-4fd3-b767-32bdb0edc7f2 zoneid=33c25232-a25b-459b-812f-0e81ff8eded0 serviceofferingid=24dd5f48-4ee2-4ebb-9375-3cf882fa1b00 & done


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
