### PR TITLE
Enable live volume migration for StorPool and small fixes

### DIFF
--- a/plugins/storage/volume/storpool/pom.xml
+++ b/plugins/storage/volume/storpool/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>commons-collections4</artifactId>
             <version>${cs.commons-collections.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.7.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.cloudstack.storage.command.CopyCmdAnswer;
+import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.utils.qemu.QemuImg;
 import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
 import org.apache.cloudstack.utils.qemu.QemuImgFile;
@@ -53,7 +54,7 @@ public final class StorPoolDownloadTemplateCommandWrapper extends CommandWrapper
         String dstPath = null;
         KVMStoragePool secondaryPool = null;
         DataTO src = cmd.getSourceTO();
-        DataTO dst = cmd.getDestinationTO();
+        TemplateObjectTO dst = (TemplateObjectTO) cmd.getDestinationTO();
 
         try {
             final KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
@@ -105,6 +106,7 @@ public final class StorPoolDownloadTemplateCommandWrapper extends CommandWrapper
 
             final QemuImg qemu = new QemuImg(cmd.getWaitInMillSeconds());
             StorPoolStorageAdaptor.resize( Long.toString(srcDisk.getVirtualSize()), dst.getPath());
+            dst.setSize(srcDisk.getVirtualSize());
 
             dstPath = dst.getPath();
             StorPoolStorageAdaptor.attachOrDetachVolume("attach", cmd.getObjectType(), dstPath);

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
@@ -54,7 +54,7 @@ public final class StorPoolDownloadTemplateCommandWrapper extends CommandWrapper
         String dstPath = null;
         KVMStoragePool secondaryPool = null;
         DataTO src = cmd.getSourceTO();
-        TemplateObjectTO dst = (TemplateObjectTO) cmd.getDestinationTO();
+        DataTO dst = cmd.getDestinationTO();
 
         try {
             final KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
@@ -106,7 +106,10 @@ public final class StorPoolDownloadTemplateCommandWrapper extends CommandWrapper
 
             final QemuImg qemu = new QemuImg(cmd.getWaitInMillSeconds());
             StorPoolStorageAdaptor.resize( Long.toString(srcDisk.getVirtualSize()), dst.getPath());
-            dst.setSize(srcDisk.getVirtualSize());
+
+            if (dst instanceof TemplateObjectTO) {
+                ((TemplateObjectTO) dst).setSize(srcDisk.getVirtualSize());
+            }
 
             dstPath = dst.getPath();
             StorPoolStorageAdaptor.attachOrDetachVolume("attach", cmd.getObjectType(), dstPath);

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolModifyStorageCommandWrapper.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolModifyStorageCommandWrapper.java
@@ -49,7 +49,7 @@ public final class StorPoolModifyStorageCommandWrapper extends CommandWrapper<St
     public Answer execute(final StorPoolModifyStoragePoolCommand command, final LibvirtComputingResource libvirtComputingResource) {
         String clusterId = getSpClusterId();
         if (clusterId == null) {
-            log.debug(String.format("Could not get StorPool cluster id for a command $s", command.getClass()));
+            log.debug(String.format("Could not get StorPool cluster id for a command [%s]", command.getClass()));
             return new Answer(command, false, "spNotFound");
         }
         try {
@@ -83,8 +83,6 @@ public final class StorPoolModifyStorageCommandWrapper extends CommandWrapper<St
         String SP_CLUSTER_ID = null;
         final String err = sc.execute(parser);
         if (err != null) {
-            final String errMsg = String.format("Could not execute storpool_confget. Error: %s", err);
-            log.warn(errMsg);
             StorPoolStorageAdaptor.SP_LOG("Could not execute storpool_confget. Error: %s", err);
             return SP_CLUSTER_ID;
         }

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/storage/StorPoolStorageAdaptor.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/storage/StorPoolStorageAdaptor.java
@@ -58,7 +58,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public KVMStoragePool createStoragePool(String uuid, String host, int port, String path, String userInfo, StoragePoolType storagePoolType, Map<String, String> details) {
-        SP_LOG("StorpooolStorageAdaptor.createStoragePool: uuid=%s, host=%s:%d, path=%s, userInfo=%s, type=%s", uuid, host, port, path, userInfo, storagePoolType);
+        SP_LOG("StorPoolStorageAdaptor.createStoragePool: uuid=%s, host=%s:%d, path=%s, userInfo=%s, type=%s", uuid, host, port, path, userInfo, storagePoolType);
 
         StorPoolStoragePool storagePool = new StorPoolStoragePool(uuid, host, port, storagePoolType, this);
         storageUuidToStoragePool.put(uuid, storagePool);
@@ -67,30 +67,30 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public KVMStoragePool getStoragePool(String uuid) {
-        SP_LOG("StorpooolStorageAdaptor.getStoragePool: uuid=%s", uuid);
+        SP_LOG("StorPoolStorageAdaptor.getStoragePool: uuid=%s", uuid);
         return storageUuidToStoragePool.get(uuid);
     }
 
     @Override
     public KVMStoragePool getStoragePool(String uuid, boolean refreshInfo) {
-        SP_LOG("StorpooolStorageAdaptor.getStoragePool: uuid=%s, refresh=%s", uuid, refreshInfo);
+        SP_LOG("StorPoolStorageAdaptor.getStoragePool: uuid=%s, refresh=%s", uuid, refreshInfo);
         return storageUuidToStoragePool.get(uuid);
     }
 
     @Override
     public boolean deleteStoragePool(String uuid) {
-        SP_LOG("StorpooolStorageAdaptor.deleteStoragePool: uuid=%s", uuid);
+        SP_LOG("StorPoolStorageAdaptor.deleteStoragePool: uuid=%s", uuid);
         return storageUuidToStoragePool.remove(uuid) != null;
     }
 
     @Override
     public boolean deleteStoragePool(KVMStoragePool pool) {
-        SP_LOG("StorpooolStorageAdaptor.deleteStoragePool: uuid=%s", pool.getUuid());
+        SP_LOG("StorPoolStorageAdaptor.deleteStoragePool: uuid=%s", pool.getUuid());
         return deleteStoragePool(pool.getUuid());
     }
 
     private static long getDeviceSize(final String devPath) {
-        SP_LOG("StorpooolStorageAdaptor.getDeviceSize: path=%s", devPath);
+        SP_LOG("StorPoolStorageAdaptor.getDeviceSize: path=%s", devPath);
 
         if (getVolumeNameFromPath(devPath, true) == null) {
             return 0;
@@ -149,7 +149,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
             return false;
         }
 
-        SP_LOG("StorpooolStorageAdaptor.attachOrDetachVolume: cmd=%s, type=%s, uuid=%s, name=%s", command, type, volumeUuid, name);
+        SP_LOG("StorPoolStorageAdaptor.attachOrDetachVolume: cmd=%s, type=%s, uuid=%s, name=%s", command, type, volumeUuid, name);
 
         final int numTries = 10;
         final int sleepTime = 1000;
@@ -205,7 +205,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
             return false;
         }
 
-        SP_LOG("StorpooolStorageAdaptor.resize: size=%s, uuid=%s, name=%s", newSize, volumeUuid, name);
+        SP_LOG("StorPoolStorageAdaptor.resize: size=%s, uuid=%s, name=%s", newSize, volumeUuid, name);
 
         Script sc = new Script("storpool", 0, log);
         sc.add("-M");
@@ -230,7 +230,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public KVMPhysicalDisk getPhysicalDisk(String volumeUuid, KVMStoragePool pool) {
-        SP_LOG("StorpooolStorageAdaptor.getPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool);
+        SP_LOG("StorPoolStorageAdaptor.getPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool);
 
         log.debug(String.format("getPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool));
 
@@ -245,7 +245,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public boolean connectPhysicalDisk(String volumeUuid, KVMStoragePool pool, Map<String, String> details) {
-        SP_LOG("StorpooolStorageAdaptor.connectPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool);
+        SP_LOG("StorPoolStorageAdaptor.connectPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool);
 
         log.debug(String.format("connectPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool));
 
@@ -254,7 +254,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public boolean disconnectPhysicalDisk(String volumeUuid, KVMStoragePool pool) {
-        SP_LOG("StorpooolStorageAdaptor.disconnectPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool);
+        SP_LOG("StorPoolStorageAdaptor.disconnectPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool);
 
         log.debug(String.format("disconnectPhysicalDisk: uuid=%s, pool=%s", volumeUuid, pool));
         return attachOrDetachVolume("detach", "volume", volumeUuid);
@@ -262,32 +262,23 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     public boolean disconnectPhysicalDisk(Map<String, String> volumeToDisconnect) {
         String volumeUuid = volumeToDisconnect.get(DiskTO.UUID);
-        SP_LOG("StorpooolStorageAdaptor.disconnectPhysicalDisk: map. uuid=%s", volumeUuid);
+        log.debug(String.format("StorPoolStorageAdaptor.disconnectPhysicalDisk: map. uuid=%s", volumeUuid));
         return attachOrDetachVolume("detach", "volume", volumeUuid);
     }
 
     @Override
     public boolean disconnectPhysicalDiskByPath(String localPath) {
-        SP_LOG("StorpooolStorageAdaptor.disconnectPhysicalDiskByPath: localPath=%s", localPath);
-
         log.debug(String.format("disconnectPhysicalDiskByPath: localPath=%s", localPath));
         return attachOrDetachVolume("detach", "volume", localPath);
-    }
-
-    // The following do not apply for StorpoolStorageAdaptor?
-    @Override
-    public KVMPhysicalDisk createPhysicalDisk(String volumeUuid, KVMStoragePool pool, PhysicalDiskFormat format, Storage.ProvisioningType provisioningType, long size, byte[] passphrase) {
-        SP_LOG("StorpooolStorageAdaptor.createPhysicalDisk: uuid=%s, pool=%s, format=%s, size=%d", volumeUuid, pool, format, size);
-        throw new UnsupportedOperationException("Creating a physical disk is not supported.");
     }
 
     @Override
     public boolean deletePhysicalDisk(String volumeUuid, KVMStoragePool pool, Storage.ImageFormat format) {
         // Should only come here when cleaning-up StorPool snapshots associated with CloudStack templates.
-        SP_LOG("StorpooolStorageAdaptor.deletePhysicalDisk: uuid=%s, pool=%s, format=%s", volumeUuid, pool, format);
+        SP_LOG("StorPoolStorageAdaptor.deletePhysicalDisk: uuid=%s, pool=%s, format=%s", volumeUuid, pool, format);
         final String name = getVolumeNameFromPath(volumeUuid, true);
         if (name == null) {
-            final String err = String.format("StorpooolStorageAdaptor.deletePhysicalDisk: '%s' is not a StorPool volume?", volumeUuid);
+            final String err = String.format("StorPoolStorageAdaptor.deletePhysicalDisk: '%s' is not a StorPool volume?", volumeUuid);
             SP_LOG(err);
             throw new UnsupportedOperationException(err);
         }
@@ -311,21 +302,13 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public List<KVMPhysicalDisk> listPhysicalDisks(String storagePoolUuid, KVMStoragePool pool) {
-        SP_LOG("StorpooolStorageAdaptor.listPhysicalDisks: uuid=%s, pool=%s", storagePoolUuid, pool);
+        SP_LOG("StorPoolStorageAdaptor.listPhysicalDisks: uuid=%s, pool=%s", storagePoolUuid, pool);
         throw new UnsupportedOperationException("Listing disks is not supported for this configuration.");
     }
 
     @Override
-    public KVMPhysicalDisk createDiskFromTemplate(KVMPhysicalDisk template, String name, PhysicalDiskFormat format,
-            ProvisioningType provisioningType, long size, KVMStoragePool destPool, int timeout, byte[] passphrase) {
-        SP_LOG("StorpooolStorageAdaptor.createDiskFromTemplate: template=%s, name=%s, fmt=%s, ptype=%s, size=%d, dst_pool=%s, to=%d",
-            template, name, format, provisioningType, size, destPool.getUuid(), timeout);
-        throw new UnsupportedOperationException("Creating a disk from a template is not yet supported for this configuration.");
-    }
-
-    @Override
     public KVMPhysicalDisk createTemplateFromDisk(KVMPhysicalDisk disk, String name, PhysicalDiskFormat format, long size, KVMStoragePool destPool) {
-        SP_LOG("StorpooolStorageAdaptor.createTemplateFromDisk: disk=%s, name=%s, fmt=%s, size=%d, dst_pool=%s", disk, name, format, size, destPool.getUuid());
+        SP_LOG("StorPoolStorageAdaptor.createTemplateFromDisk: disk=%s, name=%s, fmt=%s, size=%d, dst_pool=%s", disk, name, format, size, destPool.getUuid());
         throw new UnsupportedOperationException("Creating a template from a disk is not yet supported for this configuration.");
     }
 
@@ -336,38 +319,38 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     @Override
     public KVMPhysicalDisk copyPhysicalDisk(KVMPhysicalDisk disk, String name, KVMStoragePool destPool, int timeout) {
-        SP_LOG("StorpooolStorageAdaptor.copyPhysicalDisk: disk=%s, name=%s, dst_pool=%s, to=%d", disk, name, destPool.getUuid(), timeout);
+        SP_LOG("StorPoolStorageAdaptor.copyPhysicalDisk: disk=%s, name=%s, dst_pool=%s, to=%d", disk, name, destPool.getUuid(), timeout);
         throw new UnsupportedOperationException("Copying a disk is not supported in this configuration.");
     }
 
     public KVMPhysicalDisk createDiskFromSnapshot(KVMPhysicalDisk snapshot, String snapshotName, String name, KVMStoragePool destPool) {
-        SP_LOG("StorpooolStorageAdaptor.createDiskFromSnapshot: snap=%s, snap_name=%s, name=%s, dst_pool=%s", snapshot, snapshotName, name, destPool.getUuid());
+        SP_LOG("StorPoolStorageAdaptor.createDiskFromSnapshot: snap=%s, snap_name=%s, name=%s, dst_pool=%s", snapshot, snapshotName, name, destPool.getUuid());
         throw new UnsupportedOperationException("Creating a disk from a snapshot is not supported in this configuration.");
     }
 
     @Override
     public boolean refresh(KVMStoragePool pool) {
-        SP_LOG("StorpooolStorageAdaptor.refresh: pool=%s", pool);
+        SP_LOG("StorPoolStorageAdaptor.refresh: pool=%s", pool);
         return true;
     }
 
     @Override
     public boolean createFolder(String uuid, String path) {
-        SP_LOG("StorpooolStorageAdaptor.createFolder: uuid=%s, path=%s", uuid, path);
+        SP_LOG("StorPoolStorageAdaptor.createFolder: uuid=%s, path=%s", uuid, path);
         throw new UnsupportedOperationException("A folder cannot be created in this configuration.");
     }
 
     public KVMPhysicalDisk createDiskFromSnapshot(KVMPhysicalDisk snapshot, String snapshotName, String name,
             KVMStoragePool destPool, int timeout) {
-        SP_LOG("StorpooolStorageAdaptor.createDiskFromSnapshot: snap=%s, snap_name=%s, name=%s, dst_pool=%s", snapshot,
+        SP_LOG("StorPoolStorageAdaptor.createDiskFromSnapshot: snap=%s, snap_name=%s, name=%s, dst_pool=%s", snapshot,
                 snapshotName, name, destPool.getUuid());
         throw new UnsupportedOperationException(
                 "Creating a disk from a snapshot is not supported in this configuration.");
     }
 
     public KVMPhysicalDisk createDiskFromTemplateBacking(KVMPhysicalDisk template, String name,
-            PhysicalDiskFormat format, long size, KVMStoragePool destPool, int timeout, byte[] passphrase) {
-        SP_LOG("StorpooolStorageAdaptor.createDiskFromTemplateBacking: template=%s, name=%s, dst_pool=%s", template,
+            PhysicalDiskFormat format, long size, KVMStoragePool destPool, int timeout) {
+        SP_LOG("StorPoolStorageAdaptor.createDiskFromTemplateBacking: template=%s, name=%s, dst_pool=%s", template,
                 name, destPool.getUuid());
         throw new UnsupportedOperationException(
                 "Creating a disk from a template is not supported in this configuration.");
@@ -375,7 +358,7 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
 
     public KVMPhysicalDisk createTemplateFromDirectDownloadFile(String templateFilePath, KVMStoragePool destPool,
             boolean isIso) {
-        SP_LOG("StorpooolStorageAdaptor.createTemplateFromDirectDownloadFile: templateFilePath=%s, dst_pool=%s",
+        SP_LOG("StorPoolStorageAdaptor.createTemplateFromDirectDownloadFile: templateFilePath=%s, dst_pool=%s",
                 templateFilePath, destPool.getUuid());
         throw new UnsupportedOperationException(
                 "Creating a template from direct download is not supported in this configuration.");
@@ -389,5 +372,23 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
     @Override
     public boolean createFolder(String uuid, String path, String localPath) {
         return false;
+    }
+
+    @Override
+    public KVMPhysicalDisk createPhysicalDisk(String name, KVMStoragePool pool, PhysicalDiskFormat format,
+            ProvisioningType provisioningType, long size, byte[] passphrase) {
+        return null;
+    }
+
+    @Override
+    public KVMPhysicalDisk createDiskFromTemplate(KVMPhysicalDisk template, String name, PhysicalDiskFormat format,
+            ProvisioningType provisioningType, long size, KVMStoragePool destPool, int timeout, byte[] passphrase) {
+        return null;
+    }
+
+    @Override
+    public KVMPhysicalDisk createDiskFromTemplateBacking(KVMPhysicalDisk template, String name,
+            PhysicalDiskFormat format, long size, KVMStoragePool destPool, int timeout, byte[] passphrase) {
+        return null;
     }
 }

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/storage/StorPoolStorageAdaptor.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/storage/StorPoolStorageAdaptor.java
@@ -340,30 +340,6 @@ public class StorPoolStorageAdaptor implements StorageAdaptor {
         throw new UnsupportedOperationException("A folder cannot be created in this configuration.");
     }
 
-    public KVMPhysicalDisk createDiskFromSnapshot(KVMPhysicalDisk snapshot, String snapshotName, String name,
-            KVMStoragePool destPool, int timeout) {
-        SP_LOG("StorPoolStorageAdaptor.createDiskFromSnapshot: snap=%s, snap_name=%s, name=%s, dst_pool=%s", snapshot,
-                snapshotName, name, destPool.getUuid());
-        throw new UnsupportedOperationException(
-                "Creating a disk from a snapshot is not supported in this configuration.");
-    }
-
-    public KVMPhysicalDisk createDiskFromTemplateBacking(KVMPhysicalDisk template, String name,
-            PhysicalDiskFormat format, long size, KVMStoragePool destPool, int timeout) {
-        SP_LOG("StorPoolStorageAdaptor.createDiskFromTemplateBacking: template=%s, name=%s, dst_pool=%s", template,
-                name, destPool.getUuid());
-        throw new UnsupportedOperationException(
-                "Creating a disk from a template is not supported in this configuration.");
-    }
-
-    public KVMPhysicalDisk createTemplateFromDirectDownloadFile(String templateFilePath, KVMStoragePool destPool,
-            boolean isIso) {
-        SP_LOG("StorPoolStorageAdaptor.createTemplateFromDirectDownloadFile: templateFilePath=%s, dst_pool=%s",
-                templateFilePath, destPool.getUuid());
-        throw new UnsupportedOperationException(
-                "Creating a template from direct download is not supported in this configuration.");
-    }
-
     public KVMPhysicalDisk createTemplateFromDirectDownloadFile(String templateFilePath, String destTemplatePath,
             KVMStoragePool destPool, ImageFormat format, int timeout) {
         return null;

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -631,7 +631,7 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
                 Long snapshotSize = templStoragePoolVO.getTemplateSize();
                 long size = vinfo.getSize();
-                if (size < snapshotSize) {
+                if (snapshotSize != null && size < snapshotSize) {
                     StorPoolUtil.spLog(String.format("provided size is too small for snapshot. Provided %d, snapshot %d. Using snapshot size", size, snapshotSize));
                     size = snapshotSize;
                 }

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -47,8 +47,8 @@ import com.cloud.storage.VolumeDetailVO;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.SnapshotDetailsDao;
 import com.cloud.storage.dao.SnapshotDetailsVO;
+import com.cloud.storage.dao.StoragePoolHostDao;
 import com.cloud.storage.dao.VMTemplateDetailsDao;
-import com.cloud.storage.dao.VMTemplatePoolDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeDetailsDao;
 import com.cloud.tags.dao.ResourceTagDao;
@@ -133,7 +133,7 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     @Inject
     private StoragePoolDetailsDao storagePoolDetailsDao;
     @Inject
-    private VMTemplatePoolDao vmTemplatePoolDao;
+    private StoragePoolHostDao storagePoolHostDao;
 
     @Override
     public Map<String, String> getCapabilities() {
@@ -677,9 +677,9 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
                         EndPoint ep = selector.select(srcData, dstData);
 
-                        if( ep == null) {
-                            StorPoolUtil.spLog("select(srcData, dstData) returned NULL. trying srcOnly");
-                            ep = selector.select(srcData); // Storpool is zone
+                        if( ep == null || storagePoolHostDao.findByPoolHost(dstData.getId(), ep.getId()) == null) {
+                            StorPoolUtil.spLog("select(srcData, dstData) returned NULL or the destination pool is not connected to the selected host. Trying dstData");
+                            ep = selector.select(dstData); // Storpool is zone
                         }
                         if (ep == null) {
                             err = "No remote endpoint to send command, check if host or ssvm is down?";

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -677,7 +677,7 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
                         EndPoint ep = selector.select(srcData, dstData);
 
-                        if( ep == null || storagePoolHostDao.findByPoolHost(dstData.getId(), ep.getId()) == null) {
+                        if (ep == null || storagePoolHostDao.findByPoolHost(dstData.getId(), ep.getId()) == null) {
                             StorPoolUtil.spLog("select(srcData, dstData) returned NULL or the destination pool is not connected to the selected host. Trying dstData");
                             ep = selector.select(dstData); // Storpool is zone
                         }

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -814,7 +814,7 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
         }
         String newVolume = StorPoolUtil.getNameFromResponse(response, false);
 
-        StorPoolUtil.spLog("StorpoolPrimaryDataStoreDriverImpl.copyAsnc copy volume[%s] from pool[%s] to pool[%s] with a new name [%s]",
+        StorPoolUtil.spLog("StorpoolPrimaryDataStoreDriverImpl.copyAsnc copy volume[%s] from pool[%s] with a new name [%s]",
                 baseOn, srcInfo.getDataStore().getName(), newVolume);
 
         srcTO.setSize(srcInfo.getSize());

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/provider/StorPoolHostListener.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/provider/StorPoolHostListener.java
@@ -131,12 +131,9 @@ public class StorPoolHostListener implements HypervisorHostListener {
             StorPoolUtil.spLog("Storage pool [%s] is not connected to the host [%s]", poolVO.getName(), host.getName());
             removePoolOnHost(poolHost, isPoolConnectedToTheHost);
 
-            if (answer.getDetails() != null) {
-                if (answer.getDetails().equals("objectDoesNotExist") || answer.getDetails().equals("spNotFound")) {
-                    deleteVolumeWhenHostCannotConnectPool(conn, volumeOnPool);
-                    return false;
-                }
-
+            if (answer.getDetails() != null && isStorPoolVolumeOrStorageNotExistsOnHost(answer)) {
+                deleteVolumeWhenHostCannotConnectPool(conn, volumeOnPool);
+                return false;
             }
             String msg = "Unable to attach storage pool" + poolId + " to the host" + hostId;
             alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_HOST, pool.getDataCenterId(), pool.getPodId(), msg, msg);
@@ -168,6 +165,10 @@ public class StorPoolHostListener implements HypervisorHostListener {
 
         StorPoolUtil.spLog("Connection established between storage pool [%s] and host [%s]", poolVO.getName(), host.getName());
         return true;
+    }
+
+    private boolean isStorPoolVolumeOrStorageNotExistsOnHost(final Answer answer) {
+        return answer.getDetails().equals("objectDoesNotExist") || answer.getDetails().equals("spNotFound");
     }
 
     private void deleteVolumeWhenHostCannotConnectPool(SpConnectionDesc conn, StoragePoolDetailVO volumeOnPool) {

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/provider/StorPoolHostListener.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/provider/StorPoolHostListener.java
@@ -37,6 +37,7 @@ import org.apache.cloudstack.storage.datastore.util.StorPoolHelper;
 import org.apache.cloudstack.storage.datastore.util.StorPoolUtil;
 import org.apache.cloudstack.storage.datastore.util.StorPoolUtil.SpApiResponse;
 import org.apache.cloudstack.storage.datastore.util.StorPoolUtil.SpConnectionDesc;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
@@ -168,7 +169,7 @@ public class StorPoolHostListener implements HypervisorHostListener {
     }
 
     private boolean isStorPoolVolumeOrStorageNotExistsOnHost(final Answer answer) {
-        return answer.getDetails().equals("objectDoesNotExist") || answer.getDetails().equals("spNotFound");
+        return StringUtils.equalsAny(answer.getDetails(), "objectDoesNotExist", "spNotFound");
     }
 
     private void deleteVolumeWhenHostCannotConnectPool(SpConnectionDesc conn, StoragePoolDetailVO volumeOnPool) {

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
@@ -467,7 +467,7 @@ public class StorPoolUtil {
         return POST("MultiCluster/VolumeCreate", json, conn);
     }
 
-    public static SpApiResponse volumeCopy(final String name, final String baseOn, String csTag, Long iops,
+    public static SpApiResponse volumeCopy(final String name, final String baseOn, String csTag, Long iops, String cvmTag, String vcPolicyTag,
             SpConnectionDesc conn) {
         Map<String, Object> json = new HashMap<>();
         json.put("baseOn", baseOn);
@@ -475,7 +475,7 @@ public class StorPoolUtil {
             json.put("iops", iops);
         }
         json.put("template", conn.getTemplateName());
-        Map<String, String> tags = StorPoolHelper.addStorPoolTags(name, null, csTag, null);
+        Map<String, String> tags = StorPoolHelper.addStorPoolTags(name, cvmTag, csTag, vcPolicyTag);
         json.put("tags", tags);
         return POST("MultiCluster/VolumeCreate", json, conn);
     }
@@ -521,6 +521,12 @@ public class StorPoolUtil {
         Map<String, Object> json = new HashMap<>();
         Map<String, String> tags = StorPoolHelper.addStorPoolTags(null, null, null, vcPolicy);
         json.put("tags", tags);
+        return POST("MultiCluster/VolumeUpdate/" + name, json, conn);
+    }
+
+    public static SpApiResponse volumeUpadateTemplate(final String name, SpConnectionDesc conn) {
+        Map<String, Object> json = new HashMap<>();
+        json.put("template", conn.getTemplateName());
         return POST("MultiCluster/VolumeUpdate/" + name, json, conn);
     }
 

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
@@ -18,24 +18,16 @@
  */
 package org.apache.cloudstack.storage.datastore.util;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import com.cloud.hypervisor.kvm.storage.StorPoolStorageAdaptor;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.OutputInterpreter;
+import com.cloud.utils.script.Script;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailVO;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
@@ -54,16 +46,23 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.log4j.Logger;
 
-import com.cloud.hypervisor.kvm.storage.StorPoolStorageAdaptor;
-import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.script.OutputInterpreter;
-import com.cloud.utils.script.Script;
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class StorPoolUtil {
     private static final Logger log = Logger.getLogger(StorPoolUtil.class);
@@ -501,7 +500,7 @@ public class StorPoolUtil {
         return POST("MultiCluster/VolumeUpdate/" + name, json, conn);
     }
 
-    public static SpApiResponse volumeUpadateTags(final String name, final String uuid, Long iops,
+    public static SpApiResponse volumeUpdateTags(final String name, final String uuid, Long iops,
             SpConnectionDesc conn, String vcPolicy) {
         Map<String, Object> json = new HashMap<>();
         Map<String, String> tags = StorPoolHelper.addStorPoolTags(null, uuid, null, vcPolicy);
@@ -510,21 +509,21 @@ public class StorPoolUtil {
         return POST("MultiCluster/VolumeUpdate/" + name, json, conn);
     }
 
-    public static SpApiResponse volumeUpadateCvmTags(final String name, final String uuid, SpConnectionDesc conn) {
+    public static SpApiResponse volumeUpdateCvmTags(final String name, final String uuid, SpConnectionDesc conn) {
         Map<String, Object> json = new HashMap<>();
         Map<String, String> tags = StorPoolHelper.addStorPoolTags(null, uuid, null, null);
         json.put("tags", tags);
         return POST("MultiCluster/VolumeUpdate/" + name, json, conn);
     }
 
-    public static SpApiResponse volumeUpadateVCTags(final String name, SpConnectionDesc conn, String vcPolicy) {
+    public static SpApiResponse volumeUpdateVCTags(final String name, SpConnectionDesc conn, String vcPolicy) {
         Map<String, Object> json = new HashMap<>();
         Map<String, String> tags = StorPoolHelper.addStorPoolTags(null, null, null, vcPolicy);
         json.put("tags", tags);
         return POST("MultiCluster/VolumeUpdate/" + name, json, conn);
     }
 
-    public static SpApiResponse volumeUpadateTemplate(final String name, SpConnectionDesc conn) {
+    public static SpApiResponse volumeUpdateTemplate(final String name, SpConnectionDesc conn) {
         Map<String, Object> json = new HashMap<>();
         json.put("template", conn.getTemplateName());
         return POST("MultiCluster/VolumeUpdate/" + name, json, conn);

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/snapshot/StorPoolVMSnapshotStrategy.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/snapshot/StorPoolVMSnapshotStrategy.java
@@ -335,7 +335,7 @@ public class StorPoolVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
                 }
                 VolumeInfo vinfo = volFactory.getVolume(volumeObjectTO.getId());
                 if (vinfo.getMaxIops() != null) {
-                    resp = StorPoolUtil.volumeUpadateTags(volumeName, null, vinfo.getMaxIops(), conn, null);
+                    resp = StorPoolUtil.volumeUpdateTags(volumeName, null, vinfo.getMaxIops(), conn, null);
 
                     if (resp.getError() != null) {
                         StorPoolUtil.spLog("Volume was reverted successfully but max iops could not be set due to %s",

--- a/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
+++ b/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.cloudstack.storage.datastore.driver;
 
 import com.cloud.agent.api.to.DataObjectType;

--- a/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
+++ b/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
@@ -1,0 +1,137 @@
+package org.apache.cloudstack.storage.datastore.driver;
+
+import com.cloud.agent.api.to.DataObjectType;
+import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.Storage.StoragePoolType;
+import com.cloud.tags.dao.ResourceTagDao;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine.State;
+import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
+import org.apache.cloudstack.storage.datastore.util.StorPoolUtil;
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(StorPoolUtil.class)
+public class StorPoolPrimaryDataStoreDriverTest {
+
+    @Mock
+    private VMInstanceDao vmInstanceDao;
+
+    @Mock
+    private ResourceTagDao _resourceTagDao;
+
+    @Mock
+    private AsyncCompletionCallback<CopyCommandResult> callback;
+
+    @InjectMocks
+    private StorPoolPrimaryDataStoreDriver storPoolPrimaryDataStoreDriver;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(StorPoolUtil.class, RETURNS_MOCKS);
+    }
+
+    @Test
+    public void testMigrateVolume() {
+
+        DataStore srcStore = mock(DataStore.class);
+        DataStore destStore = mock(DataStore.class);
+
+        DataObject srcObj = mock(VolumeInfo.class);
+        DataObject destObj = mock(VolumeInfo.class);
+
+        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
+        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
+
+        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
+
+        VMInstanceVO vm = mock(VMInstanceVO.class);
+
+        setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
+        when(vm.getState()).thenReturn(State.Running);
+
+
+        storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+    }
+
+    @Test
+    public void testCopyVolumeAttachedToVm() {
+
+        DataStore srcStore = mock(DataStore.class);
+        DataStore destStore = mock(DataStore.class);
+
+        DataObject srcObj = mock(VolumeInfo.class);
+        DataObject destObj = mock(VolumeInfo.class);
+
+        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
+        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
+
+        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
+
+        VMInstanceVO vm = mock(VMInstanceVO.class);
+
+        setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
+        when(vm.getState()).thenReturn(State.Stopped);
+
+        storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+    }
+
+    @Test
+    public void testCopyVolumeNotAttachedToVm() {
+
+        DataStore srcStore = mock(DataStore.class);
+        DataStore destStore = mock(DataStore.class);
+
+        DataObject srcObj = mock(VolumeInfo.class);
+        DataObject destObj = mock(VolumeInfo.class);
+
+        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
+        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
+
+        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
+
+        setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, null);
+
+        storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+    }
+    private void setReturnsWhenSourceAndDestinationAreVolumes(DataStore srcStore, DataStore destStore, DataObject srcObj, DataObject destObj, VolumeObjectTO srcTO, VolumeObjectTO dstTO, PrimaryDataStoreTO dstPrimaryTo, VMInstanceVO vm) {
+        when(srcStore.getRole()).thenReturn(DataStoreRole.Primary);
+        when(destStore.getRole()).thenReturn(DataStoreRole.Primary);
+        when(srcObj.getDataStore()).thenReturn(srcStore);
+        when(destObj.getDataStore()).thenReturn(destStore);
+        when(srcObj.getType()).thenReturn(DataObjectType.VOLUME);
+        when(destObj.getType()).thenReturn(DataObjectType.VOLUME);
+        when(destObj.getTO()).thenReturn(dstTO);
+        when(srcObj.getTO()).thenReturn(srcTO);
+
+        when(srcObj.getDataStore().getDriver()).thenReturn(storPoolPrimaryDataStoreDriver);
+        when(destObj.getTO().getDataStore()).thenReturn(dstPrimaryTo);
+
+        when(srcTO.getPath()).thenReturn("/dev/storpool-byid/t.t.t");
+        when(srcTO.getUuid()).thenReturn(UUID.randomUUID().toString());
+        when(dstPrimaryTo.getPoolType()).thenReturn(StoragePoolType.StorPool);
+        when(vmInstanceDao.findById(anyLong())).thenReturn(vm);
+    }
+}

--- a/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
+++ b/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
@@ -76,6 +76,16 @@ public class StorPoolPrimaryDataStoreDriverTest {
     @Mock
     private VolumeDao volumeDao;
 
+    DataStore srcStore;
+    DataStore destStore;
+
+    DataObject srcObj;
+    DataObject destObj;
+
+    VolumeObjectTO srcTO;
+    VolumeObjectTO dstTO;
+
+    PrimaryDataStoreTO dstPrimaryTo;
     MockedStatic<StorPoolUtil> utilities;
     StorPoolUtil.SpConnectionDesc conn;
 
@@ -83,6 +93,17 @@ public class StorPoolPrimaryDataStoreDriverTest {
     public void setUp(){
         utilities = Mockito.mockStatic(StorPoolUtil.class);
         conn = new StorPoolUtil.SpConnectionDesc("1.1.1.1:81", "123", "tmp");
+
+        srcStore = mock(DataStore.class);
+        destStore = mock(DataStore.class);
+
+        srcObj = mock(VolumeInfo.class);
+        destObj = mock(VolumeInfo.class);
+
+        srcTO = mock(VolumeObjectTO.class);
+        dstTO = mock(VolumeObjectTO.class);
+
+        dstPrimaryTo = mock(PrimaryDataStoreTO.class);
     }
 
     @After
@@ -94,16 +115,7 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
     @Test
     public void testMigrateVolumePassed(){
-        DataStore srcStore = mock(DataStore.class);
-        DataStore destStore = mock(DataStore.class);
 
-        DataObject srcObj = mock(VolumeInfo.class);
-        DataObject destObj = mock(VolumeInfo.class);
-
-        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
-        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
-
-        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
 
         VMInstanceVO vm = mock(VMInstanceVO.class);
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
@@ -121,17 +133,6 @@ public class StorPoolPrimaryDataStoreDriverTest {
     @Test
     public void testMigrateVolumeNotPassed() {
 
-        DataStore srcStore = mock(DataStore.class);
-        DataStore destStore = mock(DataStore.class);
-
-        DataObject srcObj = mock(VolumeInfo.class);
-        DataObject destObj = mock(VolumeInfo.class);
-
-        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
-        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
-
-        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
-
         VMInstanceVO vm = mock(VMInstanceVO.class);
 
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
@@ -147,17 +148,6 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
     @Test
     public void testCopyVolumeAttachedToVmPassed() {
-
-        DataStore srcStore = mock(DataStore.class);
-        DataStore destStore = mock(DataStore.class);
-
-        DataObject srcObj = mock(VolumeInfo.class);
-        DataObject destObj = mock(VolumeInfo.class);
-
-        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
-        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
-
-        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
 
         VMInstanceVO vm = mock(VMInstanceVO.class);
 
@@ -179,17 +169,6 @@ public class StorPoolPrimaryDataStoreDriverTest {
     @Test
     public void testCopyVolumeAttachedToVmNotPassed() {
 
-        DataStore srcStore = mock(DataStore.class);
-        DataStore destStore = mock(DataStore.class);
-
-        DataObject srcObj = mock(VolumeInfo.class);
-        DataObject destObj = mock(VolumeInfo.class);
-
-        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
-        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
-
-        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
-
         VMInstanceVO vm = mock(VMInstanceVO.class);
 
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
@@ -208,18 +187,6 @@ public class StorPoolPrimaryDataStoreDriverTest {
     }
     @Test
     public void testCopyVolumeNotAttachedToVmNotPassed() {
-
-        DataStore srcStore = mock(DataStore.class);
-        DataStore destStore = mock(DataStore.class);
-
-        DataObject srcObj = mock(VolumeInfo.class);
-        DataObject destObj = mock(VolumeInfo.class);
-
-        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
-        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
-
-        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
-
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, null);
 
         when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
@@ -236,17 +203,6 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
     @Test
     public void testCopyVolumeNotAttachedToVmPassed() {
-
-        DataStore srcStore = mock(DataStore.class);
-        DataStore destStore = mock(DataStore.class);
-
-        DataObject srcObj = mock(VolumeInfo.class);
-        DataObject destObj = mock(VolumeInfo.class);
-
-        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
-        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
-
-        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
 
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, null);
 

--- a/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
+++ b/plugins/storage/volume/storpool/src/test/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriverTest.java
@@ -21,6 +21,8 @@ package org.apache.cloudstack.storage.datastore.driver;
 import com.cloud.agent.api.to.DataObjectType;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage.StoragePoolType;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
 import com.cloud.tags.dao.ResourceTagDao;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine.State;
@@ -30,27 +32,32 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
 import org.apache.cloudstack.storage.datastore.util.StorPoolUtil;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 @PrepareForTest(StorPoolUtil.class)
 public class StorPoolPrimaryDataStoreDriverTest {
 
@@ -62,17 +69,57 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
     @Mock
     private AsyncCompletionCallback<CopyCommandResult> callback;
+    @Mock
+    private PrimaryDataStoreDao storagePool;
+    @Mock
+    private StoragePoolDetailsDao detailsDao;
+    @Mock
+    private VolumeDao volumeDao;
 
+    MockedStatic<StorPoolUtil> utilities;
+    StorPoolUtil.SpConnectionDesc conn;
+
+    @Before
+    public void setUp(){
+        utilities = Mockito.mockStatic(StorPoolUtil.class);
+        conn = new StorPoolUtil.SpConnectionDesc("1.1.1.1:81", "123", "tmp");
+    }
+
+    @After
+    public void tearDown(){
+        utilities.close();
+    }
     @InjectMocks
     private StorPoolPrimaryDataStoreDriver storPoolPrimaryDataStoreDriver;
 
-    @Before
-    public void setUp() {
-        PowerMockito.mockStatic(StorPoolUtil.class, RETURNS_MOCKS);
-    }
-
     @Test
-    public void testMigrateVolume() {
+    public void testMigrateVolumePassed(){
+        DataStore srcStore = mock(DataStore.class);
+        DataStore destStore = mock(DataStore.class);
+
+        DataObject srcObj = mock(VolumeInfo.class);
+        DataObject destObj = mock(VolumeInfo.class);
+
+        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
+        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
+
+        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
+
+        VMInstanceVO vm = mock(VMInstanceVO.class);
+        setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
+        when(vm.getState()).thenReturn(State.Running);
+
+        when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
+        StorPoolUtil.SpApiResponse resp = new StorPoolUtil.SpApiResponse();
+        when(StorPoolUtil.volumeUpdateTemplate("~t.t.t", conn)).thenReturn(resp);
+
+        when(volumeDao.findById(srcObj.getId())).thenReturn(mock(VolumeVO.class));
+        storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+        utilities.verify(() -> StorPoolUtil.volumeUpdateTemplate("~t.t.t", conn), times(1));
+        Assert.assertNull(resp.getError());
+    }
+    @Test
+    public void testMigrateVolumeNotPassed() {
 
         DataStore srcStore = mock(DataStore.class);
         DataStore destStore = mock(DataStore.class);
@@ -90,12 +137,16 @@ public class StorPoolPrimaryDataStoreDriverTest {
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
         when(vm.getState()).thenReturn(State.Running);
 
-
+        when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
+        StorPoolUtil.SpApiResponse resp = new StorPoolUtil.SpApiResponse();
+        setResponseError(resp);
+        when(StorPoolUtil.volumeUpdateTemplate("~t.t.t", conn)).thenReturn(resp);
         storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+        Assert.assertNotNull(resp.getError());
     }
 
     @Test
-    public void testCopyVolumeAttachedToVm() {
+    public void testCopyVolumeAttachedToVmPassed() {
 
         DataStore srcStore = mock(DataStore.class);
         DataStore destStore = mock(DataStore.class);
@@ -112,12 +163,51 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
         when(vm.getState()).thenReturn(State.Stopped);
+        String vmUuid = UUID.randomUUID().toString();
+        when(vm.getUuid()).thenReturn(vmUuid);
 
+        when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
+
+        StorPoolUtil.SpApiResponse response = new StorPoolUtil.SpApiResponse();
+        String volumeUuid = UUID.randomUUID().toString();
+        when(srcObj.getUuid()).thenReturn(volumeUuid);
+        when(StorPoolUtil.volumeCopy(volumeUuid, "~t.t.t", "volume", null, vmUuid, "", conn)).thenReturn(response);
         storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+        Assert.assertNull(response.getError());
     }
 
     @Test
-    public void testCopyVolumeNotAttachedToVm() {
+    public void testCopyVolumeAttachedToVmNotPassed() {
+
+        DataStore srcStore = mock(DataStore.class);
+        DataStore destStore = mock(DataStore.class);
+
+        DataObject srcObj = mock(VolumeInfo.class);
+        DataObject destObj = mock(VolumeInfo.class);
+
+        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
+        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
+
+        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
+
+        VMInstanceVO vm = mock(VMInstanceVO.class);
+
+        setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, vm);
+        when(vm.getState()).thenReturn(State.Stopped);
+        String vmUuid = UUID.randomUUID().toString();
+        when(vm.getUuid()).thenReturn(vmUuid);
+
+        when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
+        StorPoolUtil.SpApiResponse response = new StorPoolUtil.SpApiResponse();
+        setResponseError(response);
+        String volumeUuid = UUID.randomUUID().toString();
+        when(srcObj.getUuid()).thenReturn(volumeUuid);
+        when(StorPoolUtil.volumeCopy(volumeUuid, "~t.t.t", "volume", null, vmUuid, "", conn)).thenReturn(response);
+        storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+        Assert.assertNotNull(response.getError());
+    }
+    @Test
+    public void testCopyVolumeNotAttachedToVmNotPassed() {
 
         DataStore srcStore = mock(DataStore.class);
         DataStore destStore = mock(DataStore.class);
@@ -132,8 +222,44 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
         setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, null);
 
+        when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
+        StorPoolUtil.SpApiResponse response = new StorPoolUtil.SpApiResponse();
+        setResponseError(response);
+        String volumeUuid = UUID.randomUUID().toString();
+        when(srcObj.getUuid()).thenReturn(volumeUuid);
+        when(StorPoolUtil.volumeCopy(volumeUuid, "~t.t.t", "volume", null, null, null, conn)).thenReturn(response);
         storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+        utilities.verify(() -> StorPoolUtil.volumeCopy(volumeUuid, "~t.t.t", "volume", null, null, null, conn), times(1));
+
+        Assert.assertNotNull(response.getError());
     }
+
+    @Test
+    public void testCopyVolumeNotAttachedToVmPassed() {
+
+        DataStore srcStore = mock(DataStore.class);
+        DataStore destStore = mock(DataStore.class);
+
+        DataObject srcObj = mock(VolumeInfo.class);
+        DataObject destObj = mock(VolumeInfo.class);
+
+        VolumeObjectTO srcTO = mock(VolumeObjectTO.class);
+        VolumeObjectTO dstTO = mock(VolumeObjectTO.class);
+
+        PrimaryDataStoreTO dstPrimaryTo = mock(PrimaryDataStoreTO.class);
+
+        setReturnsWhenSourceAndDestinationAreVolumes(srcStore, destStore, srcObj, destObj, srcTO, dstTO, dstPrimaryTo, null);
+
+        when(StorPoolUtil.getSpConnection(destObj.getDataStore().getUuid(), destObj.getDataStore().getId(), detailsDao, storagePool)).thenReturn(conn);
+        StorPoolUtil.SpApiResponse response = new StorPoolUtil.SpApiResponse();
+        String volumeUuid = UUID.randomUUID().toString();
+        when(srcObj.getUuid()).thenReturn(volumeUuid);
+        when(StorPoolUtil.volumeCopy(volumeUuid, "~t.t.t", "volume", null, null, null, conn)).thenReturn(response);
+        storPoolPrimaryDataStoreDriver.copyAsync(srcObj, destObj, callback);
+        utilities.verify(() -> StorPoolUtil.volumeCopy(volumeUuid, "~t.t.t", "volume", null, null, null, conn), times(1));
+        Assert.assertNull(response.getError());
+    }
+
     private void setReturnsWhenSourceAndDestinationAreVolumes(DataStore srcStore, DataStore destStore, DataObject srcObj, DataObject destObj, VolumeObjectTO srcTO, VolumeObjectTO dstTO, PrimaryDataStoreTO dstPrimaryTo, VMInstanceVO vm) {
         when(srcStore.getRole()).thenReturn(DataStoreRole.Primary);
         when(destStore.getRole()).thenReturn(DataStoreRole.Primary);
@@ -146,10 +272,18 @@ public class StorPoolPrimaryDataStoreDriverTest {
 
         when(srcObj.getDataStore().getDriver()).thenReturn(storPoolPrimaryDataStoreDriver);
         when(destObj.getTO().getDataStore()).thenReturn(dstPrimaryTo);
+        when(destObj.getDataStore().getUuid()).thenReturn("SP_API_HTTP=1.1.1.1:81;SP_AUTH_TOKEN=token;SP_TEMPLATE=template_name");
+        when(destObj.getDataStore().getId()).thenReturn(1L);
 
         when(srcTO.getPath()).thenReturn("/dev/storpool-byid/t.t.t");
-        when(srcTO.getUuid()).thenReturn(UUID.randomUUID().toString());
         when(dstPrimaryTo.getPoolType()).thenReturn(StoragePoolType.StorPool);
         when(vmInstanceDao.findById(anyLong())).thenReturn(vm);
+    }
+
+    private static void setResponseError(StorPoolUtil.SpApiResponse resp) {
+        StorPoolUtil.SpApiError respErr = new StorPoolUtil.SpApiError();
+        respErr.setName("error");
+        respErr.setDescr("Failed");
+        resp.setError(respErr);
     }
 }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2927,7 +2927,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new InvalidParameterValueException("Volume must be in ready state");
         }
 
-        if (vol.getPoolId() == storagePoolId) {
+        if (vol.getPoolId() == storagePoolId.longValue()) {
             throw new InvalidParameterValueException("Volume " + vol + " is already on the destination storage pool");
         }
 
@@ -2976,9 +2976,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 }
 
                 if (liveMigrateVolume && HypervisorType.KVM.equals(host.getHypervisorType())) {
-                    throw new InvalidParameterValueException("KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. " +
-                            "Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. " +
-                            "Use 'migrateVirtualMachineWithVolumes' instead.");
+                    StoragePoolVO destinationStoragePoolVo = _storagePoolDao.findById(storagePoolId);
+
+                    if (!(storagePoolVO.getPoolType() == Storage.StoragePoolType.StorPool && destinationStoragePoolVo.getPoolType() == Storage.StoragePoolType.StorPool)) {
+                        throw new InvalidParameterValueException("KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. " +
+                                "Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. " +
+                                "Use 'migrateVirtualMachineWithVolumes' instead.");
+                    }
                 }
             }
 

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2978,7 +2978,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 if (liveMigrateVolume && HypervisorType.KVM.equals(host.getHypervisorType())) {
                     StoragePoolVO destinationStoragePoolVo = _storagePoolDao.findById(storagePoolId);
 
-                    if (!(storagePoolVO.getPoolType() == Storage.StoragePoolType.StorPool && destinationStoragePoolVo.getPoolType() == Storage.StoragePoolType.StorPool)) {
+                    if (isSourceOrDestNotOnStorPool(storagePoolVO, destinationStoragePoolVo)) {
                         throw new InvalidParameterValueException("KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. " +
                                 "Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. " +
                                 "Use 'migrateVirtualMachineWithVolumes' instead.");
@@ -3127,6 +3127,11 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         return orchestrateMigrateVolume(vol, destPool, liveMigrateVolume, newDiskOffering);
+    }
+
+    private boolean isSourceOrDestNotOnStorPool(StoragePoolVO storagePoolVO, StoragePoolVO destinationStoragePoolVo) {
+        return storagePoolVO.getPoolType() != Storage.StoragePoolType.StorPool
+                || destinationStoragePoolVo.getPoolType() != Storage.StoragePoolType.StorPool;
     }
 
     /**

--- a/test/integration/plugins/storpool/MigrateVolumeToStorPool.py
+++ b/test/integration/plugins/storpool/MigrateVolumeToStorPool.py
@@ -194,9 +194,12 @@ class TestMigrateVolumeToAnotherPool(cloudstackTestCase):
         securitygroup = SecurityGroup.list(cls.apiclient, account = cls.account.name, domainid= cls.account.domainid)[0]
         cls.helper.set_securityGroups(cls.apiclient, account = cls.account.name, domainid= cls.account.domainid, id = securitygroup.id)
 
+        cls.clusters = cls.helper.getClustersWithStorPool(cls.apiclient, cls.zone.id,)
+
         cls.vm = VirtualMachine.create(cls.apiclient,
             {"name":"StorPool-%s" % uuid.uuid4() },
             zoneid=cls.zone.id,
+            clusterid=random.choice(cls.clusters),
             templateid=template.id,
             accountid=cls.account.name,
             domainid=cls.account.domainid,
@@ -207,6 +210,7 @@ class TestMigrateVolumeToAnotherPool(cloudstackTestCase):
         cls.vm2 = VirtualMachine.create(cls.apiclient,
             {"name":"StorPool-%s" % uuid.uuid4() },
             zoneid=cls.zone.id,
+            clusterid=random.choice(cls.clusters),
             templateid=template.id,
             accountid=cls.account.name,
             domainid=cls.account.domainid,
@@ -217,6 +221,7 @@ class TestMigrateVolumeToAnotherPool(cloudstackTestCase):
         cls.vm3 = VirtualMachine.create(cls.apiclient,
             {"name":"StorPool-%s" % uuid.uuid4() },
             zoneid=cls.zone.id,
+            clusterid=random.choice(cls.clusters),
             templateid=template.id,
             accountid=cls.account.name,
             domainid=cls.account.domainid,
@@ -227,6 +232,7 @@ class TestMigrateVolumeToAnotherPool(cloudstackTestCase):
         cls.vm4 = VirtualMachine.create(cls.apiclient,
             {"name":"StorPool-%s" % uuid.uuid4() },
             zoneid=cls.zone.id,
+            clusterid=random.choice(cls.clusters),
             templateid=template.id,
             accountid=cls.account.name,
             domainid=cls.account.domainid,
@@ -237,6 +243,7 @@ class TestMigrateVolumeToAnotherPool(cloudstackTestCase):
         cls.vm5 = VirtualMachine.create(cls.apiclient,
             {"name":"StorPool-%s" % uuid.uuid4() },
             zoneid=cls.zone.id,
+            clusterid=random.choice(cls.clusters),
             templateid=template.id,
             accountid=cls.account.name,
             domainid=cls.account.domainid,

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -518,7 +518,7 @@ class VirtualMachine:
                serviceofferingid=None, securitygroupids=None,
                projectid=None, startvm=None, diskofferingid=None,
                affinitygroupnames=None, affinitygroupids=None, group=None,
-               hostid=None, keypair=None, ipaddress=None, mode='default',
+               hostid=None, clusterid=None, keypair=None, ipaddress=None, mode='default',
                method='GET', hypervisor=None, customcpunumber=None,
                customcpuspeed=None, custommemory=None, rootdisksize=None,
                rootdiskcontroller=None, vpcid=None, macaddress=None, datadisktemplate_diskoffering_list={},
@@ -608,6 +608,9 @@ class VirtualMachine:
 
         if hostid:
             cmd.hostid = hostid
+
+        if clusterid:
+            cmd.clusterid = clusterid
 
         if "userdata" in services:
             cmd.userdata = base64.urlsafe_b64encode(services["userdata"].encode()).decode()


### PR DESCRIPTION
### Description

- Enable live volume migration between StorPool primary storage. Migrating volumes live between two StorPool's primary storages doesn't make changes in the XML of the domain. It only updates the information into StorPool
- removed unnecessary logging to storpool-agent.log when there isn't StorPool primary storage
- fix the first download of the system VM template

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### How Has This Been Tested?
CS version - main branch
hypervisors - KVM
primary storage - 2 Zone-wide StorPool's primary storages
