### PR TITLE
vpc: prevent sourcenat ip disassociation for an active vpc

### DIFF
--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -1075,7 +1075,11 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
         if (networkId != null) {
             guestNetwork = getNetwork(networkId);
         }
-        if (ipVO.isSourceNat() && guestNetwork != null && guestNetwork.getState() != Network.State.Allocated) {
+        Vpc vpc = null;
+        if (ipVO.getVpcId() != null) {
+            vpc = _vpcMgr.getActiveVpc(ipVO.getVpcId());
+        }
+        if (ipVO.isSourceNat() && ((guestNetwork != null && guestNetwork.getState() != Network.State.Allocated) || vpc != null)) {
             throw new IllegalArgumentException("ip address is used for source nat purposes and can not be disassociated.");
         }
 


### PR DESCRIPTION
### Description

Fixes #6663

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

```
(localcloud) 🐱 > list vpcs id=d02c8c5b-6b29-4ea9-a54f-80ede983dc30 filter=id,name,state,
{
  "count": 1,
  "vpc": [
    {
      "id": "d02c8c5b-6b29-4ea9-a54f-80ede983dc30",
      "name": "testvpc",
      "state": "Enabled"
    }
  ]
}
(localcloud) 🐱 > list publicipaddresses vpcid=d02c8c5b-6b29-4ea9-a54f-80ede983dc30
{
  "count": 1,
  "publicipaddress": [
    {
      "account": "admin",
      "allocated": "2022-08-23T12:13:37+0000",
      "domain": "ROOT",
      "domainid": "096a1c2e-123b-11ed-994f-1e002e00010c",
      "fordisplay": true,
      "forvirtualnetwork": true,
      "hasannotations": false,
      "id": "e9f0591d-a089-4ce5-a1c6-89923405eee8",
      "ipaddress": "10.0.57.25",
      "isportable": false,
      "issourcenat": true,
      "isstaticnat": false,
      "issystem": false,
      "networkid": "3a41afc5-e204-4a1e-b679-e730600eca9b",
      "physicalnetworkid": "cbd66832-c67b-4b26-af82-b64d0c6c807d",
      "state": "Allocated",
      "tags": [],
      "vlanid": "7ec9ef91-692f-4e59-9b75-ec6cac3e96f1",
      "vlanname": "vlan://51",
      "vpcid": "d02c8c5b-6b29-4ea9-a54f-80ede983dc30",
      "vpcname": "testvpc",
      "zoneid": "c58c949d-78c3-4f02-babe-66d303ce30f1",
      "zonename": "pr6341-t4596-kvm-centos7"
    }
  ]
}
(localcloud) 🐱 > disassociate ipaddress id=e9f0591d-a089-4ce5-a1c6-89923405eee8
{
  "accountid": "24b1d31a-123b-11ed-994f-1e002e00010c",
  "cmd": "org.apache.cloudstack.api.command.user.address.DisassociateIPAddrCmd",
  "completed": "2022-08-23T12:14:25+0000",
  "created": "2022-08-23T12:14:25+0000",
  "jobid": "d5fd98de-297d-4edd-942b-56d8841758bb",
  "jobinstanceid": "e9f0591d-a089-4ce5-a1c6-89923405eee8",
  "jobinstancetype": "IpAddress",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "ip address is used for source nat purposes and can not be disassociated."
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "24b32cda-123b-11ed-994f-1e002e00010c"
}
🙈 Error: async API failed for job d5fd98de-297d-4edd-942b-56d8841758bb
```
