### PR TITLE
Introducing Hamcrest API to simplify assertion in ImplicitPlannerTest

### DIFF
--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -18,7 +18,9 @@ package org.apache.cloudstack.implicitplanner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -211,15 +213,7 @@ public class ImplicitPlannerTest {
         // Check cluster 2 and 3 are not in the cluster list.
         // Host 6 and 7 should also be in avoid list.
         assertFalse("Cluster list should not be null/empty", (clusterList == null || clusterList.isEmpty()));
-        boolean foundNeededCluster = false;
-        for (Long cluster : clusterList) {
-            if (cluster != 1) {
-                fail("Found a cluster that shouldn't have been present, cluster id : " + cluster);
-            } else {
-                foundNeededCluster = true;
-            }
-        }
-        assertTrue("Didn't find cluster 1 in the list. It should have been present", foundNeededCluster);
+        assertThat("Found cluster that shouldn't have been present, only cluster 1 should be present",clusterList, everyItem(equalTo(1L)));
 
         Set<Long> hostsInAvoidList = avoids.getHostsToAvoid();
         assertFalse("Host 5 shouldn't have be in the avoid list, but it is present", hostsInAvoidList.contains(5L));
@@ -248,15 +242,7 @@ public class ImplicitPlannerTest {
         // Check cluster 1 and 3 are not in the cluster list.
         // Host 5 and 7 should also be in avoid list.
         assertFalse("Cluster list should not be null/empty", (clusterList == null || clusterList.isEmpty()));
-        boolean foundNeededCluster = false;
-        for (Long cluster : clusterList) {
-            if (cluster != 2) {
-                fail("Found a cluster that shouldn't have been present, cluster id : " + cluster);
-            } else {
-                foundNeededCluster = true;
-            }
-        }
-        assertTrue("Didn't find cluster 2 in the list. It should have been present", foundNeededCluster);
+        assertThat("Found cluster that shouldn't have been present, only cluster 2 should be present",clusterList, everyItem(equalTo(2L)));
 
         Set<Long> hostsInAvoidList = avoids.getHostsToAvoid();
         assertFalse("Host 6 shouldn't have be in the avoid list, but it is present", hostsInAvoidList.contains(6L));
@@ -307,15 +293,7 @@ public class ImplicitPlannerTest {
         // Check cluster 1 and 2 are not in the cluster list.
         // Host 5 and 6 should also be in avoid list.
         assertFalse("Cluster list should not be null/empty", (clusterList == null || clusterList.isEmpty()));
-        boolean foundNeededCluster = false;
-        for (Long cluster : clusterList) {
-            if (cluster != 3) {
-                fail("Found a cluster that shouldn't have been present, cluster id : " + cluster);
-            } else {
-                foundNeededCluster = true;
-            }
-        }
-        assertTrue("Didn't find cluster 3 in the list. It should have been present", foundNeededCluster);
+        assertThat("Found cluster that shouldn't have been present, only cluster 3 should be present",clusterList, everyItem(equalTo(3L)));
 
         Set<Long> hostsInAvoidList = avoids.getHostsToAvoid();
         assertFalse("Host 7 shouldn't have be in the avoid list, but it is present", hostsInAvoidList.contains(7L));
@@ -382,8 +360,8 @@ public class ImplicitPlannerTest {
         clustersWithEnoughCapacity.add(2L);
         clustersWithEnoughCapacity.add(3L);
         when(
-            capacityDao.listClustersInZoneOrPodByHostCapacities(dataCenterId, 12L, noOfCpusInOffering * cpuSpeedInOffering, ramInOffering * 1024L * 1024L,
-                Capacity.CAPACITY_TYPE_CPU, true)).thenReturn(clustersWithEnoughCapacity);
+                capacityDao.listClustersInZoneOrPodByHostCapacities(dataCenterId, 12L, noOfCpusInOffering * cpuSpeedInOffering, ramInOffering * 1024L * 1024L,
+                        Capacity.CAPACITY_TYPE_CPU, true)).thenReturn(clustersWithEnoughCapacity);
 
         Map<Long, Double> clusterCapacityMap = new HashMap<Long, Double>();
         clusterCapacityMap.put(1L, 2048D);
@@ -465,8 +443,8 @@ public class ImplicitPlannerTest {
 
     @Configuration
     @ComponentScan(basePackageClasses = {ImplicitDedicationPlanner.class},
-                   includeFilters = {@Filter(value = TestConfiguration.Library.class, type = FilterType.CUSTOM)},
-                   useDefaultFilters = false)
+            includeFilters = {@Filter(value = TestConfiguration.Library.class, type = FilterType.CUSTOM)},
+            useDefaultFilters = false)
     public static class TestConfiguration extends SpringUtils.CloudStackTestConfiguration {
 
         @Bean

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -213,7 +213,7 @@ public class ImplicitPlannerTest {
         // Check cluster 2 and 3 are not in the cluster list.
         // Host 6 and 7 should also be in avoid list.
         assertFalse("Cluster list should not be null/empty", (clusterList == null || clusterList.isEmpty()));
-        assertThat("Found cluster that shouldn't have been present, only cluster 1 should be present",clusterList, everyItem(equalTo(1L)));
+        assertThat("Found cluster that shouldn't have been present, only cluster 1 should be present", clusterList, everyItem(equalTo(1L)));
 
         Set<Long> hostsInAvoidList = avoids.getHostsToAvoid();
         assertFalse("Host 5 shouldn't have be in the avoid list, but it is present", hostsInAvoidList.contains(5L));
@@ -242,7 +242,7 @@ public class ImplicitPlannerTest {
         // Check cluster 1 and 3 are not in the cluster list.
         // Host 5 and 7 should also be in avoid list.
         assertFalse("Cluster list should not be null/empty", (clusterList == null || clusterList.isEmpty()));
-        assertThat("Found cluster that shouldn't have been present, only cluster 2 should be present",clusterList, everyItem(equalTo(2L)));
+        assertThat("Found cluster that shouldn't have been present, only cluster 2 should be present", clusterList, everyItem(equalTo(2L)));
 
         Set<Long> hostsInAvoidList = avoids.getHostsToAvoid();
         assertFalse("Host 6 shouldn't have be in the avoid list, but it is present", hostsInAvoidList.contains(6L));
@@ -293,7 +293,7 @@ public class ImplicitPlannerTest {
         // Check cluster 1 and 2 are not in the cluster list.
         // Host 5 and 6 should also be in avoid list.
         assertFalse("Cluster list should not be null/empty", (clusterList == null || clusterList.isEmpty()));
-        assertThat("Found cluster that shouldn't have been present, only cluster 3 should be present",clusterList, everyItem(equalTo(3L)));
+        assertThat("Found cluster that shouldn't have been present, only cluster 3 should be present", clusterList, everyItem(equalTo(3L)));
 
         Set<Long> hostsInAvoidList = avoids.getHostsToAvoid();
         assertFalse("Host 7 shouldn't have be in the avoid list, but it is present", hostsInAvoidList.contains(7L));

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -360,8 +360,8 @@ public class ImplicitPlannerTest {
         clustersWithEnoughCapacity.add(2L);
         clustersWithEnoughCapacity.add(3L);
         when(
-                capacityDao.listClustersInZoneOrPodByHostCapacities(dataCenterId, 12L, noOfCpusInOffering * cpuSpeedInOffering, ramInOffering * 1024L * 1024L,
-                        Capacity.CAPACITY_TYPE_CPU, true)).thenReturn(clustersWithEnoughCapacity);
+            capacityDao.listClustersInZoneOrPodByHostCapacities(dataCenterId, 12L, noOfCpusInOffering * cpuSpeedInOffering, ramInOffering * 1024L * 1024L,
+                Capacity.CAPACITY_TYPE_CPU, true)).thenReturn(clustersWithEnoughCapacity);
 
         Map<Long, Double> clusterCapacityMap = new HashMap<Long, Double>();
         clusterCapacityMap.put(1L, 2048D);
@@ -443,8 +443,8 @@ public class ImplicitPlannerTest {
 
     @Configuration
     @ComponentScan(basePackageClasses = {ImplicitDedicationPlanner.class},
-            includeFilters = {@Filter(value = TestConfiguration.Library.class, type = FilterType.CUSTOM)},
-            useDefaultFilters = false)
+                   includeFilters = {@Filter(value = TestConfiguration.Library.class, type = FilterType.CUSTOM)},
+                   useDefaultFilters = false)
     public static class TestConfiguration extends SpringUtils.CloudStackTestConfiguration {
 
         @Bean


### PR DESCRIPTION
### Description
Fix #6659 

This PR introduces Hamcrest API to simplify assertion in [`ImplicitPlannerTest.checkStrictModeWithCurrentAccountVmsPresent`](https://github.com/Codegass/cloudstack/blob/71056191f2bdad4be1a7eaf9bb73a7dcee3516f2/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java#L199), [`ImplicitPlannerTest.checkStrictModeHostWithCurrentAccountVmsFull`](https://github.com/Codegass/cloudstack/blob/71056191f2bdad4be1a7eaf9bb73a7dcee3516f2/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java#L233), and [`ImplicitPlannerTest.checkPreferredModePreferredHostAvailable`](https://github.com/Codegass/cloudstack/blob/71056191f2bdad4be1a7eaf9bb73a7dcee3516f2/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java#L291).

Take `ImplicitPlannerTest.checkStrictModeWithCurrentAccountVmsPresent` as example:
Before Refactoring
```java
...
        boolean foundNeededCluster = false;
        for (Long cluster : clusterList) {
            if (cluster != 1) {
                fail("Found a cluster that shouldn't have been present, cluster id : " + cluster);
            } else {
                foundNeededCluster = true;
            }
        }
        assertTrue("Didn't find cluster 1 in the list. It should have been present", foundNeededCluster);
...
```
After Refactoring
```java
import static org.hamcrest.Matchers.everyItem;
import static org.hamcrest.Matchers.equalTo;
import static org.hamcrest.MatcherAssert.assertThat; // org.junit.Assert.assertThat has been deprecated
...
        assertThat("Found cluster that shouldn't have been present, only cluster 1 should have been present",
                            clusterList, everyItem(equalTo(1L)));
...
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Local cluster environment (KVM, UBUNTU 18.04) runs the test suite.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
