### PR TITLE
Add message upon network offering creation to warn user of VR creation

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2627,6 +2627,8 @@
 "message.volume.state.uploadinprogress": "Volume upload is in progress.",
 "message.volume.state.uploadop": "The volume upload operation is in progress or in short the volume is on secondary storage.",
 "message.volume.state.primary.storage.suitability": "The suitability of a primary storage for a volume depends on the disk offering of the volume and on the virtual machine allocations if the volume is attached to a virtual machine.",
+"message.vr.alert.upon.network.offering.creation.l2": "As virtual routers are not created for L2 networks, the compute offering will not be used.",
+"message.vr.alert.upon.network.offering.creation.others": "As none of the obligatory services for creating a virtual router (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) are enabled, the virtual router will not be created and the compute offering will not be used.",
 "message.warn.filetype": "jpg, jpeg, png, bmp and svg are the only supported image formats.",
 "message.zone.creation.complete": "Zone creation complete.",
 "message.zone.detail.description": "Populate zone details.",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -2462,6 +2462,8 @@
 "message.volume.state.uploaderror": "O carregamento do volume encontrou um erro",
 "message.volume.state.uploadinprogress": "Carregamento do volume em progresso",
 "message.volume.state.uploadop": "A opera\u00e7\u00e3o de carregamento de volume est\u00e1 em andamento",
+"message.vr.alert.upon.network.offering.creation.l2": "Como VRs não são criados para redes do tipo L2, a oferta de computação não será utilizada.",
+"message.vr.alert.upon.network.offering.creation.others": "Como nenhum dos serviços obrigatórios para criação do VR (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) foram habilitados, o VR não será criado e a oferta de computação não será usada.",
 "message.warn.filetype": "jpg, jpeg, png, bmp e svg s\u00e3o os \u00fanicos formatos de imagem suportados",
 "message.zone.creation.complete": "Cria\u00e7\u00e3o de zona completa",
 "message.zone.detail.description": "Preencha os detalhes da zona",

--- a/ui/src/views/offering/AddNetworkOffering.vue
+++ b/ui/src/views/offering/AddNetworkOffering.vue
@@ -237,7 +237,13 @@
             </a-radio-button>
           </a-radio-group>
         </a-form-item>
-        <a-form-item v-if="isVirtualRouterForAtLeastOneService || isVpcVirtualRouterForAtLeastOneService">
+        <a-form-item>
+          <a-alert v-if="!isVirtualRouterForAtLeastOneService" type="warning" style="margin-bottom: 10px">
+            <template #message>
+              <span v-if="guestType === 'l2'" v-html="$t('message.vr.alert.upon.network.offering.creation.l2')" />
+              <span v-else v-html="$t('message.vr.alert.upon.network.offering.creation.others')" />
+            </template>
+          </a-alert>
           <template #label>
             <tooltip-label :title="$t('label.serviceofferingid')" :tooltip="apiParams.serviceofferingid.description"/>
           </template>


### PR DESCRIPTION
### Description

This PR aims to improve the user experience upon creation of Network Offerings warning the user of the scenarios in which a VR is created. For this, the service offering field is always shown in the form and a warning message is displayed if the user's configuration does not require the creation of a VR. These scenarios include a network offering with guest type L2, and a with a guest type Shared or Isolated when none of the following services are enabled: (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat and/or PortForwarding). Finally, the message for the Isolated and Shared networks disappear when one of the aforementioned services are selected.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Message if the guest type is **Isolated or Shared**:
![image](https://user-images.githubusercontent.com/42067040/187272985-65a3715e-36eb-406f-a8e6-ae0d89dc7eb4.png)
  
Message if the guest type is **L2**:
![image](https://user-images.githubusercontent.com/42067040/187273080-d6185ad5-46e1-49d0-afd0-25a5f2de3a71.png)


### How Has This Been Tested?
This was tested in a local lab using the networking offering form. The message for Shared/Isolated type was only displayed if the none of the following services (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat and/or PortForwarding) were not selected.
For the L2 message, it was always displayed, unless the guest type was changed.
