### PR TITLE
Return volume UUID in the `listRouters` and `listSystemVms` APIs

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/DomainRouterResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DomainRouterResponse.java
@@ -237,6 +237,10 @@ public class DomainRouterResponse extends BaseResponseWithAnnotations implements
     @Param(description = "the version of the code / software in the router")
     private String softwareVersion;
 
+    @SerializedName("rootvolumeid")
+    @Param(description = "the router's ROOT volume ID")
+    private String rootVolumeID;
+
     public DomainRouterResponse() {
         nics = new LinkedHashSet<NicResponse>();
     }
@@ -501,5 +505,13 @@ public class DomainRouterResponse extends BaseResponseWithAnnotations implements
 
     public void setSoftwareVersion(String softwareVersion) {
         this.softwareVersion = softwareVersion;
+    }
+
+    public String getRootVolumeID() {
+        return rootVolumeID;
+    }
+
+    public void setRootVolumeID(String rootVolumeID) {
+        this.rootVolumeID = rootVolumeID;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/SystemVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SystemVmResponse.java
@@ -174,6 +174,10 @@ public class SystemVmResponse extends BaseResponseWithAnnotations {
     @Param(description = "true if vm contains XS/VMWare tools inorder to support dynamic scaling of VM cpu/memory.")
     private Boolean isDynamicallyScalable;
 
+    @SerializedName("rootvolumeid")
+    @Param(description = "the system VM's ROOT volume ID")
+    private String rootVolumeID;
+
     @Override
     public String getObjectId() {
         return this.getId();
@@ -453,5 +457,13 @@ public class SystemVmResponse extends BaseResponseWithAnnotations {
 
     public void setDynamicallyScalable(Boolean dynamicallyScalable) {
         isDynamicallyScalable = dynamicallyScalable;
+    }
+
+    public String getRootVolumeID() {
+        return rootVolumeID;
+    }
+
+    public void setRootVolumeID(String rootVolumeID) {
+        this.rootVolumeID = rootVolumeID;
     }
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -96,6 +96,10 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> findReadyAndAllocatedRootVolumesByInstance(long instanceId);
 
+    List<VolumeVO> findRootVolumesByInstance(long instanceId);
+
+    VolumeVO getInstanceRootVolume(long instanceId, String instanceUuid);
+
     List<Long> listPoolIdsByVolumeCount(long dcId, Long podId, Long clusterId, long accountId);
 
     List<Long> listZoneWidePoolIdsByVolumeCount(long dcId, long accountId);

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -241,9 +241,8 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
         if (rootVolumeVoList.size() > 1) {
             logger.warn(String.format("More than one ROOT volume has been found for VM [%s], there is probably an inconsistency in the database.", instanceUuid));
         } else if (rootVolumeVoList.isEmpty()) {
-            CloudRuntimeException exception = new CloudRuntimeException(String.format("No ROOT volume has been found for VM [%s].", instanceUuid));
-            logger.error(exception.getMessage(), exception);
-            throw exception;
+            logger.debug(String.format("No ready ROOT volume has been found for VM [%s].", instanceUuid));
+            return null;
         }
         return rootVolumeVoList.get(0);
     }

--- a/engine/schema/src/test/java/com/cloud/storage/dao/VolumeDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/storage/dao/VolumeDaoImplTest.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.storage.dao;
+
+import com.cloud.storage.VolumeVO;
+import com.cloud.utils.exception.CloudRuntimeException;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VolumeDaoImplTest {
+
+    @Mock
+    VolumeVO volumeVoMock;
+
+    @Mock
+    VolumeVO alternateVolumeVoMock;
+
+    @Mock
+    Logger loggerMock;
+
+    @Spy
+    @InjectMocks
+    VolumeDaoImpl volumeDaoSpy;
+
+    @Test
+    public void getInstanceRootVolumeTestReturningOneVolume() {
+        List<VolumeVO> volumeVOList = Collections.singletonList(volumeVoMock);
+        Mockito.doReturn(volumeVOList).when(volumeDaoSpy).findRootVolumesByInstance(1234);
+        VolumeVO actualVo = volumeDaoSpy.getInstanceRootVolume(1234, "test-uuid");
+        Assert.assertEquals(volumeVoMock, actualVo);
+    }
+
+    @Test
+    public void getInstanceRootVolumeTestReturningMoreThanOneVolume() {
+        List<VolumeVO> volumeVOList = Arrays.asList(volumeVoMock, alternateVolumeVoMock);
+        Mockito.doReturn(volumeVOList).when(volumeDaoSpy).findRootVolumesByInstance(1234);
+        VolumeVO actualVo = volumeDaoSpy.getInstanceRootVolume(1234, "test-uuid");
+        Mockito.verify(loggerMock).warn("More than one ROOT volume has been found for VM [test-uuid], there is probably an inconsistency in the database.");
+        Assert.assertEquals(volumeVoMock, actualVo);
+    }
+
+    @Test (expected = CloudRuntimeException.class)
+    public void getInstanceRootVolumeTestReturningNoVolumes() {
+        List<VolumeVO> volumeVOList = new ArrayList<>();
+        Mockito.doReturn(volumeVOList).when(volumeDaoSpy).findRootVolumesByInstance(1234);
+        volumeDaoSpy.getInstanceRootVolume(1234, "test-uuid");
+    }
+}

--- a/engine/schema/src/test/java/com/cloud/storage/dao/VolumeDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/storage/dao/VolumeDaoImplTest.java
@@ -17,7 +17,6 @@
 package com.cloud.storage.dao;
 
 import com.cloud.storage.VolumeVO;
-import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
@@ -66,10 +65,10 @@ public class VolumeDaoImplTest {
         Assert.assertEquals(volumeVoMock, actualVo);
     }
 
-    @Test (expected = CloudRuntimeException.class)
+    @Test
     public void getInstanceRootVolumeTestReturningNoVolumes() {
         List<VolumeVO> volumeVOList = new ArrayList<>();
         Mockito.doReturn(volumeVOList).when(volumeDaoSpy).findRootVolumesByInstance(1234);
-        volumeDaoSpy.getInstanceRootVolume(1234, "test-uuid");
+        Assert.assertNull(volumeDaoSpy.getInstanceRootVolume(1234, "test-uuid"));
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1624,6 +1624,11 @@ public class ApiResponseHelper implements ResponseGenerator {
                 }
             }
         }
+
+        VolumeVO rootVolumeVo = _volumeDao.getInstanceRootVolume(vm.getId(), vm.getUuid());
+
+        vmResponse.setRootVolumeID(rootVolumeVo.getUuid());
+
         vmResponse.setObjectName("systemvm");
         return vmResponse;
     }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1627,7 +1627,9 @@ public class ApiResponseHelper implements ResponseGenerator {
 
         VolumeVO rootVolumeVo = _volumeDao.getInstanceRootVolume(vm.getId(), vm.getUuid());
 
-        vmResponse.setRootVolumeID(rootVolumeVo.getUuid());
+        if (rootVolumeVo != null) {
+            vmResponse.setRootVolumeID(rootVolumeVo.getUuid());
+        }
 
         vmResponse.setObjectName("systemvm");
         return vmResponse;

--- a/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
 import org.apache.cloudstack.annotation.AnnotationService;
 import org.apache.cloudstack.annotation.dao.AnnotationDao;
 import org.apache.cloudstack.context.CallContext;
@@ -58,6 +60,9 @@ public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, 
     public AccountManager _accountMgr;
     @Inject
     private AnnotationDao annotationDao;
+
+    @Inject
+    private VolumeDao volumeDao;
 
     private final SearchBuilder<DomainRouterJoinVO> vrSearch;
 
@@ -221,6 +226,11 @@ public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, 
         } else {
             routerResponse.setObjectName("router");
         }
+
+        VolumeVO rootVolumeVo = volumeDao.getInstanceRootVolume(router.getId(), router.getUuid());
+
+        routerResponse.setRootVolumeID(rootVolumeVo.getUuid());
+
 
         return routerResponse;
     }

--- a/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
@@ -229,8 +229,9 @@ public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, 
 
         VolumeVO rootVolumeVo = volumeDao.getInstanceRootVolume(router.getId(), router.getUuid());
 
-        routerResponse.setRootVolumeID(rootVolumeVo.getUuid());
-
+        if (rootVolumeVo != null) {
+            routerResponse.setRootVolumeID(rootVolumeVo.getUuid());
+        }
 
         return routerResponse;
     }


### PR DESCRIPTION
### Description

This PR extends the `listRouters` and `listSystemVms` APIs to make them return the VM's root volume ID. So that in the future the UI may be extended to use the `findStoragePoolsForMigration` to migrate VRs and System VMs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab, by calling the APIs through Cloudmonkey and checking if the VM's root volume ID was being correctly returned.
Some unit tests were also added.
