### PR TITLE
server: fix scale vm with compute offering having same disk offering

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2042,13 +2042,25 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         for (final VolumeVO rootVolumeOfVm : vols) {
             DiskOfferingVO currentRootDiskOffering = _diskOfferingDao.findById(rootVolumeOfVm.getDiskOfferingId());
+            Long rootDiskSize= null;
+            Long rootDiskSizeBytes = null;
+            if (customParameters.containsKey(ApiConstants.ROOT_DISK_SIZE)) {
+                rootDiskSize = Long.parseLong(customParameters.get(ApiConstants.ROOT_DISK_SIZE));
+                rootDiskSizeBytes = rootDiskSize << 30;
+            }
+            if (currentRootDiskOffering.getId() == newDiskOffering.getId() &&
+                    (!newDiskOffering.isCustomized() || (newDiskOffering.isCustomized() && Objects.equals(rootVolumeOfVm.getSize(), rootDiskSizeBytes)))) {
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug(String.format("Volume %s is already having disk offering %s", rootVolumeOfVm, newDiskOffering.getUuid()));
+                }
+                continue;
+            }
             HypervisorType hypervisorType = _volsDao.getHypervisorType(rootVolumeOfVm.getId());
             if (HypervisorType.Simulator != hypervisorType) {
                 Long minIopsInNewDiskOffering = null;
                 Long maxIopsInNewDiskOffering = null;
                 boolean autoMigrate = false;
                 boolean shrinkOk = false;
-                Long rootDiskSize = null;
                 if (customParameters.containsKey(ApiConstants.MIN_IOPS)) {
                     minIopsInNewDiskOffering = Long.parseLong(customParameters.get(ApiConstants.MIN_IOPS));
                 }
@@ -2060,9 +2072,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 }
                 if (customParameters.containsKey(ApiConstants.SHRINK_OK)) {
                     shrinkOk = Boolean.parseBoolean(customParameters.get(ApiConstants.SHRINK_OK));
-                }
-                if (customParameters.containsKey(ApiConstants.ROOT_DISK_SIZE)) {
-                    rootDiskSize = Long.parseLong(customParameters.get(ApiConstants.ROOT_DISK_SIZE));
                 }
                 ChangeOfferingForVolumeCmd changeOfferingForVolumeCmd = new ChangeOfferingForVolumeCmd(rootVolumeOfVm.getId(), newDiskOffering.getId(), minIopsInNewDiskOffering, maxIopsInNewDiskOffering, autoMigrate, shrinkOk);
                 if (rootDiskSize != null) {


### PR DESCRIPTION
Fixes #6679

Fixes behaviour when the VM is scaled to a new compute offering which has the same disk offering associated as the earlier compute offering.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

**Service offering and VM**

```
(localcloud) 🐱 > list serviceofferings id=1892001d-1d4c-4467-937d-a35415bc1093 
{
  "count": 1,
  "serviceoffering": [
    {
      "cpunumber": 1,
      "cpuspeed": 1000,
      "created": "2022-08-31T10:35:00+0000",
      "defaultuse": false,
      "diskofferingdisplaytext": "Medium Disk, 20 GB",
      "diskofferingid": "0bae8790-1c97-43f6-b0d4-777023377ec8",
      "diskofferingname": "Medium",
      "diskofferingstrictness": false,
      "displaytext": "co1",
      "dynamicscalingenabled": true,
      "hasannotations": false,
      "id": "1892001d-1d4c-4467-937d-a35415bc1093",
      "iscustomized": false,
      "issystem": false,
      "isvolatile": false,
      "limitcpuuse": false,
      "memory": 512,
      "name": "co1",
      "offerha": false,
      "provisioningtype": "thin",
      "rootdisksize": 20,
      "storagetype": "shared"
    }
  ]
}
(localcloud) 🐱 > list serviceofferings id=125b186c-45cf-4a7c-9684-78378e7b327f 
{
  "count": 1,
  "serviceoffering": [
    {
      "cpunumber": 1,
      "cpuspeed": 1000,
      "created": "2022-08-31T10:35:13+0000",
      "defaultuse": false,
      "diskofferingdisplaytext": "Medium Disk, 20 GB",
      "diskofferingid": "0bae8790-1c97-43f6-b0d4-777023377ec8",
      "diskofferingname": "Medium",
      "diskofferingstrictness": false,
      "displaytext": "co2",
      "dynamicscalingenabled": true,
      "hasannotations": false,
      "id": "125b186c-45cf-4a7c-9684-78378e7b327f",
      "iscustomized": false,
      "issystem": false,
      "isvolatile": false,
      "limitcpuuse": false,
      "memory": 1024,
      "name": "co2",
      "offerha": false,
      "provisioningtype": "thin",
      "rootdisksize": 20,
      "storagetype": "shared"
    }
  ]
}
(localcloud) 🐱 > list virtualmachines id=e9bf1ab4-fe27-4c7e-837c-b296ab35e949 
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "admin",
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 1000,
      "created": "2022-08-31T10:41:55+0000",
      "details": {
        "Message.ReservedCapacityFreed.Flag": "false",
        "cpuOvercommitRatio": "2.0",
        "dataDiskController": "osdefault",
        "memoryOvercommitRatio": "1.0",
        "rootDiskController": "osdefault",
        "rootdisksize": "20"
      },
      "diskofferingid": "0bae8790-1c97-43f6-b0d4-777023377ec8",
      "diskofferingname": "Medium",
      "displayname": "test-vm",
      "displayvm": true,
      "domain": "ROOT",
      "domainid": "65609c23-2826-11ed-bf3a-1e00750002ea",
      "guestosid": "6582ae97-2826-11ed-bf3a-1e00750002ea",
      "haenable": false,
      "hasannotations": false,
      "hypervisor": "VMware",
      "id": "e9bf1ab4-fe27-4c7e-837c-b296ab35e949",
      "instancename": "i-2-5-VM",
      "isdynamicallyscalable": false,
      "lastupdated": "2022-08-31T10:42:31+0000",
      "memory": 512,
      "name": "test-vm",
      "nic": [
        {
          "deviceid": "0",
          "extradhcpoption": [],
          "id": "fa90c6c8-12c1-4a5a-b86b-c23fdf9453af",
          "isdefault": true,
          "macaddress": "02:00:18:37:00:03",
          "networkid": "6a8f495b-ef15-488b-ac78-fd83e913b69b",
          "networkname": "l2",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "L2"
        }
      ],
      "osdisplayname": "Other Linux (64-bit)",
      "ostypeid": "6582ae97-2826-11ed-bf3a-1e00750002ea",
      "passwordenabled": false,
      "pooltype": "NetworkFilesystem",
      "receivedbytes": 0,
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "sentbytes": 0,
      "serviceofferingid": "1892001d-1d4c-4467-937d-a35415bc1093",
      "serviceofferingname": "co1",
      "state": "Stopped",
      "tags": [],
      "templatedisplaytext": "ma",
      "templateid": "feb21788-29be-4fb0-8618-ec0f50921838",
      "templatename": "ma",
      "userid": "85491d90-2826-11ed-bf3a-1e00750002ea",
      "username": "admin",
      "zoneid": "fce252b8-5075-4077-80c0-4f027fea354d",
      "zonename": "ref-trl-3557-v-M7-abhishek-kumar"
    }
  ]
}
```

**Before fix**
```
(localcloud) 🐱 > scale virtualmachine id=e9bf1ab4-fe27-4c7e-837c-b296ab35e949 serviceofferingid=125b186c-45cf-4a7c-9684-78378e7b327f 
{
  "accountid": "8547ecfc-2826-11ed-bf3a-1e00750002ea",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ScaleVMCmdByAdmin",
  "completed": "2022-08-31T10:44:51+0000",
  "created": "2022-08-31T10:44:51+0000",
  "jobid": "ad8860f6-33d3-43b0-957f-8feca3db5c99",
  "jobinstanceid": "e9bf1ab4-fe27-4c7e-837c-b296ab35e949",
  "jobinstancetype": "VirtualMachine",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 431,
    "errortext": "Volume 59896710-9353-4e39-9017-e0f422c7b5c1 already have the new disk offering 0bae8790-1c97-43f6-b0d4-777023377ec8 provided."
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "85491d90-2826-11ed-bf3a-1e00750002ea"
}
```

**After fix**

```
(localcloud) 🐱 > scale virtualmachine id=e9bf1ab4-fe27-4c7e-837c-b296ab35e949 serviceofferingid=125b186c-45cf-4a7c-9684-78378e7b327f 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 1000,
    "created": "2022-08-31T10:41:55+0000",
    "details": {
      "Message.ReservedCapacityFreed.Flag": "false",
      "cpuOvercommitRatio": "2.0",
      "dataDiskController": "osdefault",
      "memoryOvercommitRatio": "1.0",
      "rootDiskController": "osdefault",
      "rootdisksize": "20"
    },
    "diskofferingid": "0bae8790-1c97-43f6-b0d4-777023377ec8",
    "diskofferingname": "Medium",
    "displayname": "test-vm",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "65609c23-2826-11ed-bf3a-1e00750002ea",
    "guestosid": "6582ae97-2826-11ed-bf3a-1e00750002ea",
    "haenable": false,
    "hasannotations": false,
    "hypervisor": "VMware",
    "id": "e9bf1ab4-fe27-4c7e-837c-b296ab35e949",
    "instancename": "i-2-5-VM",
    "isdynamicallyscalable": false,
    "jobid": "3e5ecbf9-b806-45dd-b7d1-3c0d190eb64e",
    "jobstatus": 0,
    "lastupdated": "2022-08-31T10:42:31+0000",
    "memory": 1024,
    "name": "test-vm",
    "nic": [
      {
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "fa90c6c8-12c1-4a5a-b86b-c23fdf9453af",
        "isdefault": true,
        "macaddress": "02:00:18:37:00:03",
        "networkid": "6a8f495b-ef15-488b-ac78-fd83e913b69b",
        "networkname": "l2",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "Other Linux (64-bit)",
    "ostypeid": "6582ae97-2826-11ed-bf3a-1e00750002ea",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "125b186c-45cf-4a7c-9684-78378e7b327f",
    "serviceofferingname": "co2",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "ma",
    "templateid": "feb21788-29be-4fb0-8618-ec0f50921838",
    "templatename": "ma",
    "userid": "85491d90-2826-11ed-bf3a-1e00750002ea",
    "username": "admin",
    "zoneid": "fce252b8-5075-4077-80c0-4f027fea354d",
    "zonename": "ref-trl-3557-v-M7-abhishek-kumar"
  }
}
```