### PR TITLE
Fix min balance for API quotaCredits to be optional

### DIFF
--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaCreditsCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaCreditsCmd.java
@@ -129,9 +129,6 @@ public class QuotaCreditsCmd extends BaseCmd {
         if (getMinBalance() != null) {
             _quotaService.setMinBalance(accountId, getMinBalance());
         }
-        else {
-            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Please set a value for min balance");
-        }
 
         final QuotaCreditsResponse response = _responseBuilder.addQuotaCredits(accountId, getDomainId(), getValue(), CallContext.current().getCallingUserId(), getQuotaEnforce());
         response.setResponseName(getCommandName());


### PR DESCRIPTION
### Description

This PR aims to fix the current behavior of the `min_balance` parameter of the `quotaCredits` API. This parameter is considered optional in the API documentation; however, when using the API, it is not possible to add credits without specifying the minimum balance for the account. Therefore, this behavior was fixed. If the minimum balance is not specified it is considered as 0.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab using the API `quotaCredits` without specifying the `min_balance` field. The API was executed with no errors.
