### PR TITLE
Ignore opensaml's slf4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,6 +622,20 @@
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml</artifactId>
                 <version>${cs.opensaml.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jul-to-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.owasp.esapi</groupId>


### PR DESCRIPTION
### Description
Commit f27de6364402569fd3c2d1286ed5c749b9bd6e12 introduced a new version of opensaml. That version brought `jcl-over-slf4j-1.7.5.jar`, `jul-to-slf4j-1.7.5.jar`, and `log4j-over-slf4j-1.7.5.jar` as dependencies, which causes Agents and Usages to not generate _logs_: 

![image](https://user-images.githubusercontent.com/38945620/187506004-75d5b635-c3df-4035-bd81-693c4b4d5b16.png)

In order to make the logs to work again, this PR intends to exclude these dependencies while building the packages.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

After applying the commit f27de6364402569fd3c2d1286ed5c749b9bd6e12, the logs on the Agents and Usages stopped being written. After applying this PR, the logs started to be written again.