### PR TITLE
kvm: add libvirt host capabilities method for cpu speed retrieval

### DIFF
--- a/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/linux/KVMHostInfoTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/linux/KVMHostInfoTest.java
@@ -16,22 +16,21 @@
 // under the License.
 package org.apache.cloudstack.utils.linux;
 
-import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
 import org.apache.commons.lang.SystemUtils;
-
 import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.Assume;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.libvirt.Connect;
-import org.mockito.Mockito;
-
 import org.libvirt.NodeInfo;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(value = {LibvirtConnection.class})
@@ -45,7 +44,21 @@ public class KVMHostInfoTest {
         Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
         NodeInfo nodeInfo = Mockito.mock(NodeInfo.class);
         nodeInfo.mhz = 1000;
-        Assert.assertThat(KVMHostInfo.getCpuSpeed(nodeInfo), Matchers.greaterThan(0l));
+        Assert.assertThat(KVMHostInfo.getCpuSpeed(null, nodeInfo), Matchers.greaterThan(0l));
+    }
+
+    @Test
+    public void getCpuSpeedFromHostCapabilities() {
+        String capabilities = "<host>\n" +
+                "<uuid>8a330742-345f-b0df-7954-c9960b88116c</uuid>\n" +
+                "  <cpu>\n" +
+                "    <arch>x86_64</arch>\n" +
+                "    <model>Opteron_G2</model>\n" +
+                "    <vendor>AMD</vendor>\n" +
+                "    <counter name='tsc' frequency='2350000000' scaling='no'/>\n" +
+                "  </cpu>\n" +
+                "</host>\n";;
+        Assert.assertEquals(2350L, KVMHostInfo.getCpuSpeedFromHostCapabilities(capabilities));
     }
 
     @Test


### PR DESCRIPTION
### Description

Fixes #6680

While finding CPU speed for KVM host following methods will be used in the same order:
1. lscpu
2. value in /sys/devices/system/cpu/cpu0/cpufreq/base_frequency
3. libvirt host capabilities
4. libvirt nodeinfo

This will allow the correct value for AMD-based hosts when the first two methods don't give a value

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
Tested with an AMD-based KVM host,

```
2022-09-05 18:02:17,633 INFO  [utils.linux.KVMHostInfo] (Agent-Handler-1:null) (logid:) Fetching CPU speed from command "lscpu".
2022-09-05 18:02:17,633 DEBUG [utils.script.Script] (Agent-Handler-1:null) (logid:) Executing: /bin/bash -c lscpu | grep -i 'Model name' | head -n 1 | egrep -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g' 
2022-09-05 18:02:17,636 DEBUG [utils.script.Script] (Agent-Handler-1:null) (logid:) Executing while with timeout : 3600000
2022-09-05 18:02:17,641 DEBUG [utils.script.Script] (Agent-Handler-1:null) (logid:) Execution is successful.
2022-09-05 18:02:17,646 ERROR [utils.linux.KVMHostInfo] (Agent-Handler-1:null) (logid:) Unable to retrieve the CPU speed from lscpu.
java.lang.NullPointerException
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1838)
	at java.base/jdk.internal.math.FloatingDecimal.parseFloat(FloatingDecimal.java:122)
	at java.base/java.lang.Float.parseFloat(Float.java:455)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.getCpuSpeedFromCommandLscpu(KVMHostInfo.java:124)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.getCpuSpeed(KVMHostInfo.java:99)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.getHostInfoFromLibvirt(KVMHostInfo.java:179)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.<init>(KVMHostInfo.java:65)
	at com.cloud.hypervisor.kvm.resource.LibvirtComputingResource.initialize(LibvirtComputingResource.java:3376)
	at com.cloud.agent.Agent.sendStartup(Agent.java:441)
	at com.cloud.agent.Agent$ServerHandler.doTask(Agent.java:1099)
	at com.cloud.utils.nio.Task.call(Task.java:83)
	at com.cloud.utils.nio.Task.call(Task.java:29)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
2022-09-05 18:02:17,647 INFO  [utils.linux.KVMHostInfo] (Agent-Handler-1:null) (logid:) Fetching CPU speed from file [/sys/devices/system/cpu/cpu0/cpufreq/base_frequency].
2022-09-05 18:02:17,648 ERROR [utils.linux.KVMHostInfo] (Agent-Handler-1:null) (logid:) Unable to retrieve the CPU speed from file [/sys/devices/system/cpu/cpu0/cpufreq/base_frequency]
java.io.FileNotFoundException: /sys/devices/system/cpu/cpu0/cpufreq/base_frequency (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:112)
	at java.base/java.io.FileReader.<init>(FileReader.java:60)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.getCpuSpeedFromFile(KVMHostInfo.java:135)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.getCpuSpeed(KVMHostInfo.java:104)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.getHostInfoFromLibvirt(KVMHostInfo.java:179)
	at org.apache.cloudstack.utils.linux.KVMHostInfo.<init>(KVMHostInfo.java:65)
	at com.cloud.hypervisor.kvm.resource.LibvirtComputingResource.initialize(LibvirtComputingResource.java:3376)
	at com.cloud.agent.Agent.sendStartup(Agent.java:441)
	at com.cloud.agent.Agent$ServerHandler.doTask(Agent.java:1099)
	at com.cloud.utils.nio.Task.call(Task.java:83)
	at com.cloud.utils.nio.Task.call(Task.java:29)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
2022-09-05 18:02:17,648 INFO  [utils.linux.KVMHostInfo] (Agent-Handler-1:null) (logid:) Fetching CPU speed from "host capabilities"
2022-09-05 18:02:17,655 INFO  [utils.linux.KVMHostInfo] (Agent-Handler-1:null) (logid:) Retrieved value [2350000000] from "host capabilities". This corresponds to a CPU speed of [2350] MHz.

```