### PR TITLE
server: fix volume migration on user vm scale

### DIFF
--- a/api/src/main/java/com/cloud/server/ManagementService.java
+++ b/api/src/main/java/com/cloud/server/ManagementService.java
@@ -405,7 +405,7 @@ public interface ManagementService {
      */
     Pair<List<? extends StoragePool>, List<? extends StoragePool>> listStoragePoolsForMigrationOfVolume(Long volumeId);
 
-    Pair<List<? extends StoragePool>, List<? extends StoragePool>> listStoragePoolsForMigrationOfVolumeInternal(Long volumeId, Long newDiskOfferingId, Long newSize, Long newMinIops, Long newMaxIops, boolean keepSourceStoragePool, boolean bypassStorageTypeCheck);
+    Pair<List<? extends StoragePool>, List<? extends StoragePool>> listStoragePoolsForSystemMigrationOfVolume(Long volumeId, Long newDiskOfferingId, Long newSize, Long newMinIops, Long newMaxIops, boolean keepSourceStoragePool, boolean bypassStorageTypeCheck);
 
     String[] listEventTypes();
 

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1767,7 +1767,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             return volume;
         }
 
-        if (currentSize != newSize || newMaxIops != volume.getMaxIops() || newMinIops != volume.getMinIops()) {
+        if (currentSize != newSize || !compareEqualsIncludingNullOrZero(newMaxIops, volume.getMaxIops()) || !compareEqualsIncludingNullOrZero(newMinIops, volume.getMinIops())) {
             volumeResizeRequired = true;
             validateVolumeReadyStateAndHypervisorChecks(volume, currentSize, newSize);
         }
@@ -1821,6 +1821,26 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         return volume;
+    }
+
+    /**
+     * This method is to compare long values, in miniops and maxiops a or b can be null or 0.
+     * Use this method to treat 0 and null as same
+     *
+     * @param a
+     * @param b
+     * @return true if a and b are equal excluding 0 and null values.
+     */
+    private boolean compareEqualsIncludingNullOrZero(Long a, Long b) {
+        if ((a != null && a == 0 && b == null) || (a == null && b != null && b == 0)) {
+            return true;
+        }
+
+        if (a == b) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1774,7 +1774,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         StoragePoolVO existingStoragePool = _storagePoolDao.findById(volume.getPoolId());
 
-        Pair<List<? extends StoragePool>, List<? extends StoragePool>> poolsPair = managementService.listStoragePoolsForMigrationOfVolumeInternal(volume.getId(), newDiskOffering.getId(), newSize, newMinIops, newMaxIops, true, false);
+        Pair<List<? extends StoragePool>, List<? extends StoragePool>> poolsPair = managementService.listStoragePoolsForSystemMigrationOfVolume(volume.getId(), newDiskOffering.getId(), newSize, newMinIops, newMaxIops, true, false);
         List<? extends StoragePool> suitableStoragePools = poolsPair.second();
 
         if (!suitableStoragePools.stream().anyMatch(p -> (p.getId() == existingStoragePool.getId()))) {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1832,15 +1832,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
      * @return true if a and b are equal excluding 0 and null values.
      */
     private boolean compareEqualsIncludingNullOrZero(Long a, Long b) {
-        if ((a != null && a == 0 && b == null) || (a == null && b != null && b == 0)) {
-            return true;
-        }
+        a = ObjectUtils.defaultIfNull(a, 0L);
+        b = ObjectUtils.defaultIfNull(b, 0L);
 
-        if (a == b) {
-            return true;
-        }
-
-        return false;
+        return a.equals(b);
     }
 
     /**

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -96,6 +96,7 @@ import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToSt
 import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;

--- a/server/src/main/java/com/cloud/vm/UserVmManager.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManager.java
@@ -47,9 +47,12 @@ import com.cloud.utils.Pair;
  */
 public interface UserVmManager extends UserVmService {
     String EnableDynamicallyScaleVmCK = "enable.dynamic.scale.vm";
+    String AllowDiskOfferingChangeDuringScaleVmCK = "allow.diskOffering.change.during.scale.vm";
     String AllowUserExpungeRecoverVmCK ="allow.user.expunge.recover.vm";
     ConfigKey<Boolean> EnableDynamicallyScaleVm = new ConfigKey<Boolean>("Advanced", Boolean.class, EnableDynamicallyScaleVmCK, "false",
         "Enables/Disables dynamically scaling a vm", true, ConfigKey.Scope.Zone);
+    ConfigKey<Boolean> AllowDiskOfferingChangeDuringScaleVm = new ConfigKey<Boolean>("Advanced", Boolean.class, AllowDiskOfferingChangeDuringScaleVmCK, "false",
+            "Determines whether to allow or disallow disk offering change for root volume during scaling of a stopped or running vm", true, ConfigKey.Scope.Zone);
     ConfigKey<Boolean> AllowUserExpungeRecoverVm = new ConfigKey<Boolean>("Advanced", Boolean.class, AllowUserExpungeRecoverVmCK, "false",
         "Determines whether users can expunge or recover their vm", true, ConfigKey.Scope.Account);
     ConfigKey<Boolean> DisplayVMOVFProperties = new ConfigKey<Boolean>("Advanced", Boolean.class, "vm.display.ovf.properties", "false",

--- a/server/src/main/java/com/cloud/vm/UserVmManager.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManager.java
@@ -47,7 +47,7 @@ import com.cloud.utils.Pair;
  */
 public interface UserVmManager extends UserVmService {
     String EnableDynamicallyScaleVmCK = "enable.dynamic.scale.vm";
-    String AllowDiskOfferingChangeDuringScaleVmCK = "allow.diskOffering.change.during.scale.vm";
+    String AllowDiskOfferingChangeDuringScaleVmCK = "allow.diskoffering.change.during.scale.vm";
     String AllowUserExpungeRecoverVmCK ="allow.user.expunge.recover.vm";
     ConfigKey<Boolean> EnableDynamicallyScaleVm = new ConfigKey<Boolean>("Advanced", Boolean.class, EnableDynamicallyScaleVmCK, "false",
         "Enables/Disables dynamically scaling a vm", true, ConfigKey.Scope.Zone);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2040,7 +2040,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         if (!AllowDiskOfferingChangeDuringScaleVm.valueIn(zoneId)) {
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug(String.format("Disk Offering change for the root volume is disabled during the compute offering change operation. Please check the setting %s", AllowDiskOfferingChangeDuringScaleVm.key()));
+                s_logger.debug(String.format("Changing the disk offering of the root volume during the compute offering change operation is disabled. Please check the setting [%s].", AllowDiskOfferingChangeDuringScaleVm.key()));
             }
             return;
         }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1241,7 +1241,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         // resize and migrate the root volume if required
         DiskOfferingVO newDiskOffering = _diskOfferingDao.findById(newServiceOffering.getDiskOfferingId());
-        changeDiskOfferingForRootVolume(vmId, newDiskOffering, customParameters);
+        changeDiskOfferingForRootVolume(vmId, newDiskOffering, customParameters, vmInstance.getDataCenterId());
 
         _itMgr.upgradeVmDb(vmId, newServiceOffering, currentServiceOffering);
 
@@ -2000,7 +2000,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
                     // #3 resize or migrate the root volume if required
                     DiskOfferingVO newDiskOffering = _diskOfferingDao.findById(newServiceOffering.getDiskOfferingId());
-                    changeDiskOfferingForRootVolume(vmId, newDiskOffering, customParameters);
+                    changeDiskOfferingForRootVolume(vmId, newDiskOffering, customParameters, vmInstance.getDataCenterId());
 
                     // #4 scale the vm now
                     vmInstance = _vmInstanceDao.findById(vmId);
@@ -2036,7 +2036,14 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
     }
 
-    private void changeDiskOfferingForRootVolume(Long vmId, DiskOfferingVO newDiskOffering, Map<String, String> customParameters) throws ResourceAllocationException {
+    private void changeDiskOfferingForRootVolume(Long vmId, DiskOfferingVO newDiskOffering, Map<String, String> customParameters, Long zoneId) throws ResourceAllocationException {
+
+        if (!AllowDiskOfferingChangeDuringScaleVm.valueIn(zoneId)) {
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("Disk Offering change for the root volume is disabled during the compute offering change operation. Please check the setting %s", AllowDiskOfferingChangeDuringScaleVm.key()));
+            }
+            return;
+        }
 
         List<VolumeVO> vols = _volsDao.findReadyAndAllocatedRootVolumesByInstance(vmId);
 
@@ -7791,7 +7798,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {EnableDynamicallyScaleVm, AllowUserExpungeRecoverVm, VmIpFetchWaitInterval, VmIpFetchTrialMax,
+        return new ConfigKey<?>[] {EnableDynamicallyScaleVm, AllowDiskOfferingChangeDuringScaleVm, AllowUserExpungeRecoverVm, VmIpFetchWaitInterval, VmIpFetchTrialMax,
                 VmIpFetchThreadPoolMax, VmIpFetchTaskWorkers, AllowDeployVmIfGivenHostFails, EnableAdditionalVmConfig, DisplayVMOVFProperties,
                 KvmAdditionalConfigAllowList, XenServerAdditionalConfigAllowList, VmwareAdditionalConfigAllowList};
     }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -794,7 +794,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 continue;
             }
             LOGGER.debug(String.format("Volume %s needs to be migrated", volumeVO.getUuid()));
-            Pair<List<? extends StoragePool>, List<? extends StoragePool>> poolsPair = managementService.listStoragePoolsForMigrationOfVolumeInternal(profile.getVolumeId(), null, null, null, null, false, true);
+            Pair<List<? extends StoragePool>, List<? extends StoragePool>> poolsPair = managementService.listStoragePoolsForSystemMigrationOfVolume(profile.getVolumeId(), null, null, null, null, false, true);
             if (CollectionUtils.isEmpty(poolsPair.first()) && CollectionUtils.isEmpty(poolsPair.second())) {
                 cleanupFailedImportVM(vm);
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("VM import failed for unmanaged vm: %s during volume ID: %s migration as no suitable pool(s) found", userVm.getInstanceName(), volumeVO.getUuid()));

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -25,8 +25,10 @@ from marvin.lib.base import (Account,
                              Host,
                              VirtualMachine,
                              ServiceOffering,
+                             DiskOffering,
                              Template,
-                             Configurations)
+                             Configurations,
+                             Volume)
 from marvin.lib.common import (get_zone,
                                get_template,
                                get_domain)
@@ -54,7 +56,7 @@ class TestScaleVm(cloudstackTestCase):
             return
 
         # Get Zone, Domain and templates
-        domain = get_domain(cls.apiclient)
+        cls.domain = get_domain(cls.apiclient)
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.services['mode'] = cls.zone.networktype
 
@@ -90,7 +92,7 @@ class TestScaleVm(cloudstackTestCase):
         cls.account = Account.create(
             cls.apiclient,
             cls.services["account"],
-            domainid=domain.id
+            domainid=cls.domain.id
         )
         cls._cleanup.append(cls.account)
 
@@ -170,6 +172,11 @@ class TestScaleVm(cloudstackTestCase):
             name="enable.dynamic.scale.vm",
             value="false"
         )
+        Configurations.update(
+            cls.apiclient,
+            name="allow.diskOffering.change.during.scale.vm",
+            value="false"
+        )
         super(TestScaleVm,cls).tearDownClass()
         return
 
@@ -177,6 +184,7 @@ class TestScaleVm(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
+        self.services["disk_offering"]["disksize"] = 8
 
         if self.unsupportedHypervisor:
             self.skipTest("Skipping test because unsupported hypervisor\
@@ -479,5 +487,356 @@ class TestScaleVm(cloudstackTestCase):
                 pass
         else:
             self.fail("Expected an exception to be thrown, failing")
+
+        return
+
+    @attr(hypervisor="xenserver")
+    @attr(tags=["advanced", "basic"], required_hardware="false")
+    def test_04_scale_vm_with_user_account(self):
+        """Test scale virtual machine under useraccount
+        """
+        # Validate the following
+        # Create a user Account and create a VM in it.
+        # Scale up the vm and see if it scales to the new svc offering
+
+        # Create an user account
+        self.userAccount = Account.create(
+            self.apiclient,
+            self.services["account"],
+            admin=False,
+            domainid=self.domain.id
+        )
+
+        self.cleanup.append(self.userAccount)
+        # Create user api client of the user account
+        self.userapiclient = self.testClient.getUserApiClient(
+            UserName=self.userAccount.name,
+            DomainName=self.userAccount.domain
+        )
+
+        # create a virtual machine
+        self.virtual_machine_in_user_account = VirtualMachine.create(
+            self.userapiclient,
+            self.services["small"],
+            accountid=self.userAccount.name,
+            domainid=self.userAccount.domainid,
+            serviceofferingid=self.small_offering.id,
+            mode=self.services["mode"]
+        )
+
+        if self.hypervisor.lower() == "vmware":
+            sshClient = self.virtual_machine_in_user_account.get_ssh_client()
+            result = str(
+                sshClient.execute("service vmware-tools status")).lower()
+            self.debug("and result is: %s" % result)
+            if not "running" in result:
+                self.skipTest("Skipping scale VM operation because\
+                    VMware tools are not installed on the VM")
+        if self.hypervisor.lower() != 'simulator':
+            list_vm_response = VirtualMachine.list(
+                self.apiclient,
+                id=self.virtual_machine_in_user_account.id
+            )[0]
+            hostid = list_vm_response.hostid
+            host = Host.list(
+                       self.apiclient,
+                       zoneid=self.zone.id,
+                       hostid=hostid,
+                       type='Routing'
+                   )[0]
+
+            try:
+                username = self.hostConfig["username"]
+                password = self.hostConfig["password"]
+                ssh_client = self.get_ssh_client(host.ipaddress, username, password)
+                res = ssh_client.execute("hostnamectl | grep 'Operating System' | cut -d':' -f2")
+            except Exception as e:
+                pass
+
+            if 'XenServer' in res[0]:
+                self.skipTest("Skipping test for XenServer as it's License does not allow scaling")
+
+        self.virtual_machine_in_user_account.update(
+            self.userapiclient,
+            isdynamicallyscalable='true')
+
+        self.debug("Scaling VM-ID: %s to service offering: %s and state %s" % (
+            self.virtual_machine_in_user_account.id,
+            self.big_offering.id,
+            self.virtual_machine_in_user_account.state
+        ))
+
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
+        cmd.serviceofferingid = self.big_offering.id
+        cmd.id = self.virtual_machine_in_user_account.id
+
+        try:
+            self.userapiclient.scaleVirtualMachine(cmd)
+        except Exception as e:
+            if "LicenceRestriction" in str(e):
+                self.skipTest("Your XenServer License does not allow scaling")
+            else:
+                self.fail("Scaling failed with the following exception: " + str(e))
+
+        list_vm_response = VirtualMachine.list(
+            self.userapiclient,
+            id=self.virtual_machine_in_user_account.id
+        )
+
+        vm_response = list_vm_response[0]
+
+        self.debug(
+            "Scaling VM-ID: %s from service offering: %s to new service\
+                    offering %s and the response says %s" %
+            (self.virtual_machine_in_user_account.id,
+             self.virtual_machine_in_user_account.serviceofferingid,
+             self.big_offering.id,
+             vm_response.serviceofferingid))
+        self.assertEqual(
+            vm_response.serviceofferingid,
+            self.big_offering.id,
+            "Check service offering of the VM"
+        )
+
+        self.assertEqual(
+            vm_response.state,
+            'Running',
+            "Check the state of VM"
+        )
+        return
+
+    @attr(hypervisor="xenserver")
+    @attr(tags=["advanced", "basic"], required_hardware="false")
+    def test_05_scale_vm_dont_allow_disk_offering_change(self):
+        """Test scale virtual machine with disk offering changes
+        """
+        # Validate the following two cases
+
+        # 1
+        # create serviceoffering1 with diskoffering1
+        # create serviceoffering2 with diskoffering2
+        # create a VM with serviceoffering1
+        # Scale up the vm to serviceoffering2
+        # Check disk offering of root volume to be diskoffering1 since setting allow.diskOffering.change.during.scale.vm is false
+
+        # 2
+        # create serviceoffering3 with diskoffering3
+        # update setting allow.diskOffering.change.during.scale.vm to true
+        # scale up the VM to serviceoffering3
+        # Check disk offering of root volume to be diskoffering3 since setting allow.diskOffering.change.during.scale.vm is true
+
+        self.disk_offering1 = DiskOffering.create(
+                                    self.apiclient,
+                                    self.services["disk_offering"],
+                                    )
+        self._cleanup.append(self.disk_offering1)
+        offering_data = {
+            'displaytext': 'ServiceOffering1WithDiskOffering1',
+            'cpuspeed': 500,
+            'cpunumber': 1,
+            'name': 'ServiceOffering1WithDiskOffering1',
+            'memory': 512,
+            'diskofferingid': self.disk_offering1.id
+        }
+
+        self.ServiceOffering1WithDiskOffering1 = ServiceOffering.create(
+            self.apiclient,
+            offering_data,
+        )
+        self._cleanup.append(self.ServiceOffering1WithDiskOffering1)
+
+        # create a virtual machine
+        self.virtual_machine_test = VirtualMachine.create(
+            self.apiclient,
+            self.services["small"],
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            serviceofferingid=self.ServiceOffering1WithDiskOffering1.id,
+            mode=self.services["mode"]
+        )
+
+        if self.hypervisor.lower() == "vmware":
+            sshClient = self.virtual_machine_test.get_ssh_client()
+            result = str(
+                sshClient.execute("service vmware-tools status")).lower()
+            self.debug("and result is: %s" % result)
+            if not "running" in result:
+                self.skipTest("Skipping scale VM operation because\
+                    VMware tools are not installed on the VM")
+        if self.hypervisor.lower() != 'simulator':
+            hostid = self.virtual_machine_test.hostid
+            host = Host.list(
+                       self.apiclient,
+                       zoneid=self.zone.id,
+                       hostid=hostid,
+                       type='Routing'
+                   )[0]
+
+            try:
+                username = self.hostConfig["username"]
+                password = self.hostConfig["password"]
+                ssh_client = self.get_ssh_client(host.ipaddress, username, password)
+                res = ssh_client.execute("hostnamectl | grep 'Operating System' | cut -d':' -f2")
+            except Exception as e:
+                pass
+
+            if 'XenServer' in res[0]:
+                self.skipTest("Skipping test for XenServer as it's License does not allow scaling")
+
+        self.virtual_machine_test.update(
+            self.apiclient,
+            isdynamicallyscalable='true')
+
+        self.disk_offering2 = DiskOffering.create(
+                                    self.apiclient,
+                                    self.services["disk_offering"],
+                                    )
+        self._cleanup.append(self.disk_offering2)
+        offering_data = {
+            'displaytext': 'ServiceOffering2WithDiskOffering2',
+            'cpuspeed': 1000,
+            'cpunumber': 2,
+            'name': 'ServiceOffering2WithDiskOffering2',
+            'memory': 1024,
+            'diskofferingid': self.disk_offering2.id
+        }
+
+        self.ServiceOffering2WithDiskOffering2 = ServiceOffering.create(
+            self.apiclient,
+            offering_data,
+        )
+        self._cleanup.append(self.ServiceOffering2WithDiskOffering2)
+
+        self.debug("Scaling VM-ID: %s to service offering: %s and state %s" % (
+            self.virtual_machine_test.id,
+            self.ServiceOffering2WithDiskOffering2.id,
+            self.virtual_machine_test.state
+        ))
+
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
+        cmd.serviceofferingid = self.ServiceOffering2WithDiskOffering2.id
+        cmd.id = self.virtual_machine_test.id
+
+        try:
+            self.apiclient.scaleVirtualMachine(cmd)
+        except Exception as e:
+            if "LicenceRestriction" in str(e):
+                self.skipTest("Your XenServer License does not allow scaling")
+            else:
+                self.fail("Scaling failed with the following exception: " + str(e))
+
+        list_vm_response = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine_test.id
+        )
+
+        vm_response = list_vm_response[0]
+
+        self.debug(
+            "Scaling VM-ID: %s from service offering: %s to new service\
+                    offering %s and the response says %s" %
+            (self.virtual_machine_test.id,
+             self.virtual_machine_test.serviceofferingid,
+             self.ServiceOffering2WithDiskOffering2.id,
+             vm_response.serviceofferingid))
+
+        vm_response = list_vm_response[0]
+
+        self.assertEqual(
+            vm_response.serviceofferingid,
+            self.ServiceOffering2WithDiskOffering2.id,
+            "Check service offering of the VM"
+        )
+
+        volume_response = Volume.list(
+            self.apiclient,
+            virtualmachineid=self.virtual_machine_test.id,
+            listall=True
+        )[0]
+
+        self.assertEqual(
+            volume_response.diskofferingid,
+            self.disk_offering1.id,
+            "Check disk offering of the VM, this should not change since allow.diskOffering.change.during.scale.vm is false"
+        )
+
+        # Do same scale vm operation with allow.diskOffering.change.during.scale.vm value to true
+
+        self.disk_offering3 = DiskOffering.create(
+                                    self.apiclient,
+                                    self.services["disk_offering"],
+                                    )
+        self._cleanup.append(self.disk_offering3)
+        offering_data = {
+            'displaytext': 'ServiceOffering3WithDiskOffering3',
+            'cpuspeed': 1500,
+            'cpunumber': 2,
+            'name': 'ServiceOffering3WithDiskOffering3',
+            'memory': 1024,
+            'diskofferingid': self.disk_offering3.id
+        }
+
+        self.ServiceOffering3WithDiskOffering3 = ServiceOffering.create(
+            self.apiclient,
+            offering_data,
+        )
+        self._cleanup.append(self.ServiceOffering3WithDiskOffering3)
+
+        Configurations.update(
+            self.apiclient,
+            name="allow.diskOffering.change.during.scale.vm",
+            value="true"
+        )
+
+        self.debug("Scaling VM-ID: %s to service offering: %s and state %s" % (
+            self.virtual_machine_test.id,
+            self.ServiceOffering3WithDiskOffering3.id,
+            self.virtual_machine_test.state
+        ))
+
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
+        cmd.serviceofferingid = self.ServiceOffering3WithDiskOffering3.id
+        cmd.id = self.virtual_machine_test.id
+
+        try:
+            self.apiclient.scaleVirtualMachine(cmd)
+        except Exception as e:
+            if "LicenceRestriction" in str(e):
+                self.skipTest("Your XenServer License does not allow scaling")
+            else:
+                self.fail("Scaling failed with the following exception: " + str(e))
+
+        list_vm_response = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine_test.id
+        )
+
+        vm_response = list_vm_response[0]
+
+        self.debug(
+            "Scaling VM-ID: %s from service offering: %s to new service\
+                    offering %s and the response says %s" %
+            (self.virtual_machine_test.id,
+             self.virtual_machine_test.serviceofferingid,
+             self.ServiceOffering3WithDiskOffering3.id,
+             vm_response.serviceofferingid))
+
+        self.assertEqual(
+            vm_response.serviceofferingid,
+            self.ServiceOffering3WithDiskOffering3.id,
+            "Check service offering of the VM"
+        )
+
+        volume_response = Volume.list(
+            self.apiclient,
+            virtualmachineid=self.virtual_machine_test.id,
+            listall=True
+        )[0]
+
+        self.assertEqual(
+            volume_response.diskofferingid,
+            self.disk_offering3.id,
+            "Check disk offering of the VM, this should change since allow.diskOffering.change.during.scale.vm is true"
+        )
 
         return

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -184,7 +184,7 @@ class TestScaleVm(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
-        self.services["disk_offering"]["disksize"] = 8
+        self.services["disk_offering"]["disksize"] = 2
 
         if self.unsupportedHypervisor:
             self.skipTest("Skipping test because unsupported hypervisor\


### PR DESCRIPTION
### Description

Fixes #6701

When volume migration is initiated by system, account check is not needed.

Introduces a new global setting - `allow.diskOffering.change.during.scale.vm`
Determines whether to allow or disallow disk offering change for root volume during scaling of a stopped or running VM. Default value is `true`

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
