### PR TITLE
server: fix check for ipv6 range overlap

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -4643,7 +4643,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 }
                 if (!StringUtils.isAllEmpty(ipv6Range, vlan.getIp6Range())) {
                     String r1 = StringUtils.isEmpty(ipv6Range) ? NetUtils.getIpv6RangeFromCidr(vlanIp6Cidr) : ipv6Range;
-                    String r2 = StringUtils.isEmpty(vlan.getIp6Range()) ? NetUtils.getIpv6RangeFromCidr(vlanIp6Cidr) : vlan.getIp6Range();
+                    String r2 = StringUtils.isEmpty(vlan.getIp6Range()) ? NetUtils.getIpv6RangeFromCidr(vlan.getIp6Cidr()) : vlan.getIp6Range();
                     if(NetUtils.isIp6RangeOverlap(r1, r2)) {
                         throw new InvalidParameterValueException(String.format("The IPv6 range with tag: %s already has IPs that overlap with the new range.",
                                 vlan.getVlanTag()));


### PR DESCRIPTION
### Description

Fixes incorrect check for verifying IPv6 ranges overlap. This causes the inability to add multiple IPv6 ranges.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Without change error is seen while creating shared networks when zone has an IPv6 public range added,

```
> list vlanipranges 
{
  "count": 2,
  "vlaniprange": [
    {
      "account": "system",
      "cidr": "10.1.48.0/20",
      "domain": "ROOT",
      "domainid": "6d9bb269-29c9-11ed-9e50-1e00a4000983",
      "endip": "10.1.54.220",
      "forsystemvms": false,
      "forvirtualnetwork": true,
      "gateway": "10.1.48.1",
      "id": "8c99a3eb-eb31-4de1-a7cf-aaba3754a5bf",
      "netmask": "255.255.240.0",
      "networkid": "8c89748a-ab07-4393-a669-87fd74072a87",
      "physicalnetworkid": "aced8f04-89af-460b-80b7-df08b249ae86",
      "startip": "10.1.54.201",
      "vlan": "vlan://51",
      "zoneid": "89386d1e-9e03-40f0-bb91-7190ea2a9b58"
    },
    {
      "account": "system",
      "domain": "ROOT",
      "domainid": "6d9bb269-29c9-11ed-9e50-1e00a4000983",
      "forsystemvms": false,
      "forvirtualnetwork": true,
      "id": "11a80dbf-e6be-4511-9804-dce6afd763b9",
      "ip6cidr": "fd17:ac56:1234:2000::/64",
      "ip6gateway": "fd17:ac56:1234:2000::1",
      "networkid": "8c89748a-ab07-4393-a669-87fd74072a87",
      "physicalnetworkid": "aced8f04-89af-460b-80b7-df08b249ae86",
      "vlan": "vlan://51",
      "zoneid": "89386d1e-9e03-40f0-bb91-7190ea2a9b58"
    }
  ]
}

```

```
2022-09-06 08:59:07,499 DEBUG [c.c.a.ApiServlet] (qtp793138072-21:ctx-25571319) (logid:b5cdca51) ===START===  10.1.3.251 -- GET  zoneId=89386d1e-9e03-40f0-bb91-7190ea2a9b58&name=sh&displayText=sh&networkOfferingId=bf76977a-2b83-4d00-92cc-672953e43d3e&physicalnetworkid=aced8f04-89af-460b-80b7-df08b249ae86&vlan=4321&acltype=domain&gateway=10.9.9.1&netmask=255.255.255.0&startip=10.9.9.10&endip=10.9.9.30&ip6gateway=2a00:1728:23:1140::1&ip6cidr=2a00:1728:23:1140::%2F64&startipv6=2a00:1728:23:1140::100&endipv6=2a00:1728:23:1140::200&command=createNetwork&response=json
2022-09-06 08:59:07,506 DEBUG [c.c.a.ApiServer] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) CIDRs from which account 'Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}]' is allowed to perform API calls: 0.0.0.0/0,::/0
2022-09-06 08:59:07,508 INFO  [o.a.c.a.DynamicRoleBasedAPIAccessChecker] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Account [Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}]] is Root Admin or Domain Admin, all APIs are allowed.
2022-09-06 08:59:07,509 WARN  [o.a.c.a.ProjectRoleBasedApiAccessChecker] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Project is null, ProjectRoleBasedApiAccessChecker only applies to projects, returning API [createNetwork] for user [User {"username":"admin","uuid":"8037004b-29c9-11ed-9e50-1e00a4000983"}.] as allowed.
2022-09-06 08:59:07,510 DEBUG [o.a.c.a.StaticRoleBasedAPIAccessChecker] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) RoleService is enabled. We will use it instead of StaticRoleBasedAPIAccessChecker.
2022-09-06 08:59:07,510 DEBUG [o.a.c.r.ApiRateLimitServiceImpl] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) API rate limiting is disabled. We will not use ApiRateLimitService.
2022-09-06 08:59:07,519 DEBUG [c.c.u.AccountManagerImpl] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Access granted to Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}] to [Network Offering [8-Guest-DefaultSharedNetworkOffering] by AffinityGroupAccessChecker
2022-09-06 08:59:07,530 DEBUG [c.c.n.g.BigSwitchBcfGuestNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network, the physical isolation type is not BCF_SEGMENT
2022-09-06 08:59:07,531 DEBUG [o.a.c.n.c.m.ContrailGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network
2022-09-06 08:59:07,532 DEBUG [c.c.n.g.NiciraNvpGuestNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network
2022-09-06 08:59:07,532 DEBUG [o.a.c.n.o.OpendaylightGuestNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network
2022-09-06 08:59:07,533 DEBUG [c.c.n.g.OvsGuestNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network
2022-09-06 08:59:07,534 DEBUG [c.c.n.g.DirectNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) VLAN: VLAN
2022-09-06 08:59:07,542 INFO  [c.c.n.g.DirectNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network
2022-09-06 08:59:07,543 DEBUG [o.a.c.n.g.SspGuestNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) SSP not configured to be active
2022-09-06 08:59:07,544 DEBUG [c.c.n.g.BrocadeVcsGuestNetworkGuru] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Refusing to design this network
2022-09-06 08:59:07,545 DEBUG [o.a.c.e.o.NetworkOrchestrator] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Releasing lock for Account [{"accountName":"system","id":1,"uuid":"80356fa8-29c9-11ed-9e50-1e00a4000983"}]
2022-09-06 08:59:07,547 DEBUG [c.c.c.ConfigurationManagerImpl] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Access granted to Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}] to zone:1 by AffinityGroupAccessChecker
2022-09-06 08:59:07,550 DEBUG [c.c.u.d.T.Transaction] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) Rolling back the transaction: Time = 27 Name =  qtp793138072-21; called by -TransactionLegacy.rollback:888-TransactionLegacy.removeUpTo:831-TransactionLegacy.close:655-Transaction.execute:38-NetworkServiceImpl.commitNetwork:1758-NetworkServiceImpl.createGuestNetwork:1612-NativeMethodAccessorImpl.invoke0:-2-NativeMethodAccessorImpl.invoke:62-DelegatingMethodAccessorImpl.invoke:43-Method.invoke:566-AopUtils.invokeJoinpointUsingReflection:344-ReflectiveMethodInvocation.invokeJoinpoint:198
2022-09-06 08:59:07,553 INFO  [c.c.a.ApiServer] (qtp793138072-21:ctx-25571319 ctx-c7d1a4e6) (logid:b5cdca51) The IPv6 range with tag: vlan://51 already has IPs that overlap with the new range.

```

Request works after changes:
```
2022-09-06 09:52:02,456 DEBUG [c.c.a.ApiServlet] (qtp793138072-22:ctx-418b0910) (logid:0e7b4ee9) ===START===  10.1.3.251 -- GET  zoneId=89386d1e-9e03-40f0-bb91-7190ea2a9b58&name=sh&displayText=sh&networkOfferingId=bf76977a-2b83-4d00-92cc-672953e43d3e&physicalnetworkid=aced8f04-89af-460b-80b7-df08b249ae86&vlan=4321&acltype=domain&gateway=10.9.9.1&netmask=255.255.255.0&startip=10.9.9.10&endip=10.9.9.30&ip6gateway=2a00:1728:23:1140::1&ip6cidr=2a00:1728:23:1140::%2F64&startipv6=2a00:1728:23:1140::100&endipv6=2a00:1728:23:1140::200&command=createNetwork&response=json
2022-09-06 09:52:02,461 DEBUG [c.c.a.ApiServer] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) CIDRs from which account 'Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}]' is allowed to perform API calls: 0.0.0.0/0,::/0
2022-09-06 09:52:02,462 INFO  [o.a.c.a.DynamicRoleBasedAPIAccessChecker] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Account [Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}]] is Root Admin or Domain Admin, all APIs are allowed.
2022-09-06 09:52:02,463 WARN  [o.a.c.a.ProjectRoleBasedApiAccessChecker] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Project is null, ProjectRoleBasedApiAccessChecker only applies to projects, returning API [createNetwork] for user [User {"username":"admin","uuid":"8037004b-29c9-11ed-9e50-1e00a4000983"}.] as allowed.
2022-09-06 09:52:02,463 DEBUG [o.a.c.a.StaticRoleBasedAPIAccessChecker] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) RoleService is enabled. We will use it instead of StaticRoleBasedAPIAccessChecker.
2022-09-06 09:52:02,463 DEBUG [o.a.c.r.ApiRateLimitServiceImpl] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) API rate limiting is disabled. We will not use ApiRateLimitService.
2022-09-06 09:52:02,483 DEBUG [c.c.u.AccountManagerImpl] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Access granted to Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}] to [Network Offering [8-Guest-DefaultSharedNetworkOffering] by AffinityGroupAccessChecker
2022-09-06 09:52:02,522 DEBUG [c.c.n.g.BigSwitchBcfGuestNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network, the physical isolation type is not BCF_SEGMENT
2022-09-06 09:52:02,522 DEBUG [o.a.c.n.c.m.ContrailGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network
2022-09-06 09:52:02,523 DEBUG [c.c.n.g.NiciraNvpGuestNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network
2022-09-06 09:52:02,524 DEBUG [o.a.c.n.o.OpendaylightGuestNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network
2022-09-06 09:52:02,530 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-19:null) (logid:) SeqA 4-54252: Processing Seq 4-54252:  { Cmd , MgmtId: -1, via: 4, Ver: v1, Flags: 11, [{"com.cloud.agent.api.ConsoleProxyLoadReportCommand":{"_proxyVmId":"2","_loadInfo":"{
  "connections": []
}","wait":"0","bypassHostMaintenance":"false"}}] }
2022-09-06 09:52:02,532 DEBUG [c.c.n.g.OvsGuestNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network
2022-09-06 09:52:02,533 INFO  [c.c.n.g.DirectNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network
2022-09-06 09:52:02,534 DEBUG [c.c.n.g.DirectNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) VLAN: VLAN
2022-09-06 09:52:02,534 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-19:null) (logid:) SeqA 4-54252: Sending Seq 4-54252:  { Ans: , MgmtId: 32988100299139, via: 4, Ver: v1, Flags: 100010, [{"com.cloud.agent.api.AgentControlAnswer":{"result":"true","wait":"0","bypassHostMaintenance":"false"}}] }
2022-09-06 09:52:02,551 DEBUG [o.a.c.n.g.SspGuestNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) SSP not configured to be active
2022-09-06 09:52:02,552 DEBUG [c.c.n.g.BrocadeVcsGuestNetworkGuru] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Refusing to design this network
2022-09-06 09:52:02,557 DEBUG [o.a.c.e.o.NetworkOrchestrator] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Releasing lock for Account [{"accountName":"system","id":1,"uuid":"80356fa8-29c9-11ed-9e50-1e00a4000983"}]
2022-09-06 09:52:02,561 DEBUG [c.c.c.ConfigurationManagerImpl] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Access granted to Account [{"accountName":"admin","id":2,"uuid":"8035bed2-29c9-11ed-9e50-1e00a4000983"}] to zone:1 by AffinityGroupAccessChecker
2022-09-06 09:52:02,573 DEBUG [c.c.c.ConfigurationManagerImpl] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) Saving vlan range Vlan[4321|10.9.9.1|255.255.255.0|2a00:1728:23:1140::1|2a00:1728:23:1140::/64|10.9.9.10-10.9.9.30|2a00:1728:23:1140::100-2a00:1728:23:1140::200|226]
2022-09-06 09:52:02,605 DEBUG [c.c.a.ApiServlet] (qtp793138072-22:ctx-418b0910 ctx-62516598) (logid:0e7b4ee9) ===END===  10.1.3.251 -- GET  zoneId=89386d1e-9e03-40f0-bb91-7190ea2a9b58&name=sh&displayText=sh&networkOfferingId=bf76977a-2b83-4d00-92cc-672953e43d3e&physicalnetworkid=aced8f04-89af-460b-80b7-df08b249ae86&vlan=4321&acltype=domain&gateway=10.9.9.1&netmask=255.255.255.0&startip=10.9.9.10&endip=10.9.9.30&ip6gateway=2a00:1728:23:1140::1&ip6cidr=2a00:1728:23:1140::%2F64&startipv6=2a00:1728:23:1140::100&endipv6=2a00:1728:23:1140::200&command=createNetwork&response=json
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
