### PR TITLE
systemvm,vr: disable radvd for non-applicable VRs

### DIFF
--- a/systemvm/debian/opt/cloud/bin/setup/dhcpsrvr.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/dhcpsrvr.sh
@@ -39,6 +39,10 @@ setup_dhcpsrvr() {
   sed -i "s/-A INPUT -i eth0 -p udp -m udp --dport 53 -j ACCEPT/-A INPUT -i eth0 -p udp -m udp --dport 53 -s $DHCP_RANGE\/$CIDR_SIZE -j ACCEPT/g" /etc/iptables/rules.v4
   sed -i "s/-A INPUT -i eth0 -p tcp -m tcp --dport 53 -j ACCEPT/-A INPUT -i eth0 -p tcp -m tcp --dport 53 -s $DHCP_RANGE\/$CIDR_SIZE -j ACCEPT/g" /etc/iptables/rules.v4
 
+  log_it "Disable radvd for dhcp server system vm"
+  rm -rf /etc/radvd.conf
+  systemctl stop radvd
+  systemctl disable radvd
 }
 
 dhcpsrvr_svcs


### PR DESCRIPTION
### Description

Fixes #6700

When VR is a DHCP server system VM type then stop radvd.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Tested IPv6 shared network VR.

_List an IPv6 shared network and its VR which is already rebooted:_
```
(localcloud) 🐱 > list networks id=4dcaae55-80b7-4a41-8d52-c6971d34959c 
{
  "count": 1,
  "network": [
    {
      "acltype": "Domain",
      "broadcastdomaintype": "Vlan",
      "broadcasturi": "vlan://1245",
      "canusefordeploy": true,
      "cidr": "10.9.9.0/24",
      "created": "2022-09-06T10:20:13+0000",
      "details": {},
      "displaynetwork": true,
      "displaytext": "sh",
      "dns1": "10.1.32.1",
      "dns2": "8.8.8.8",
      "domain": "ROOT",
      "domainid": "a2f1cc09-2dc0-11ed-b0f7-1e00d6000ca0",
      "gateway": "10.9.9.1",
      "hasannotations": false,
      "id": "4dcaae55-80b7-4a41-8d52-c6971d34959c",
      "ip6cidr": "fd17:ac56:1234:2000::/64",
      "ip6gateway": "fd17:ac56:1234:2000::1",
      "ispersistent": false,
      "issystem": false,
      "name": "sh",
      "netmask": "255.255.255.0",
      "networkdomain": "cs1cloud.internal",
      "networkofferingavailability": "Optional",
      "networkofferingconservemode": true,
      "networkofferingdisplaytext": "Offering for Shared networks",
      "networkofferingid": "2c986a4f-5f04-4956-9454-6ff1ebc07cab",
      "networkofferingname": "DefaultSharedNetworkOffering",
      "physicalnetworkid": "28d2b2ca-e484-4c63-bdf7-f638f6057593",
      "receivedbytes": 0,
      "redundantrouter": false,
      "related": "4dcaae55-80b7-4a41-8d52-c6971d34959c",
      "restartrequired": false,
      "sentbytes": 0,
      "service": [
        {
          "capability": [
            {
              "canchooseservicecapability": false,
              "name": "AllowDnsSuffixModification",
              "value": "true"
            }
          ],
          "name": "Dns",
          "provider": [
            {
              "name": "VirtualRouter"
            }
          ]
        },
        {
          "capability": [],
          "name": "UserData",
          "provider": [
            {
              "name": "VirtualRouter"
            }
          ]
        },
        {
          "capability": [
            {
              "canchooseservicecapability": false,
              "name": "DhcpAccrossMultipleSubnets",
              "value": "true"
            }
          ],
          "name": "Dhcp",
          "provider": [
            {
              "name": "VirtualRouter"
            }
          ]
        }
      ],
      "specifyipranges": true,
      "state": "Setup",
      "strechedl2subnet": false,
      "subdomainaccess": true,
      "tags": [],
      "traffictype": "Guest",
      "type": "Shared",
      "vlan": "1245",
      "zoneid": "569ae229-1d20-4deb-94cb-194c55b6a131",
      "zonename": "pr6696-t3-kvm-centos7"
    }
  ]
}
(localcloud) 🐱 > list routers id=a99923c5-c300-410f-8d7d-ebe6f3e840a4 
{
  "count": 1,
  "router": [
    {
      "account": "system",
      "created": "2022-09-06T10:20:56+0000",
      "dns1": "10.1.32.1",
      "dns2": "8.8.8.8",
      "domain": "ROOT",
      "domainid": "a2f1cc09-2dc0-11ed-b0f7-1e00d6000ca0",
      "guestipaddress": "10.9.9.10",
      "guestmacaddress": "1e:00:73:00:00:53",
      "guestnetmask": "255.255.255.0",
      "guestnetworkid": "4dcaae55-80b7-4a41-8d52-c6971d34959c",
      "guestnetworkname": "sh",
      "hasannotations": false,
      "healthchecksfailed": true,
      "hostid": "5ef18260-ec42-4a90-ad48-1af79f0407fe",
      "hostname": "pr6696-t3-kvm-centos7-kvm1",
      "hypervisor": "KVM",
      "id": "a99923c5-c300-410f-8d7d-ebe6f3e840a4",
      "ip6dns1": "2001:4860:4860::8888",
      "ip6dns2": "2001:4860:4860::8844",
      "isredundantrouter": false,
      "linklocalip": "169.254.53.68",
      "linklocalmacaddress": "0e:00:a9:fe:35:44",
      "linklocalnetmask": "255.255.0.0",
      "linklocalnetworkid": "15bdc1bf-2c96-46da-b64d-6e5f458e3461",
      "name": "r-10-VM",
      "networkdomain": "cs1cloud.internal",
      "nic": [
        {
          "broadcasturi": "vlan://1245",
          "gateway": "10.9.9.1",
          "id": "5934474c-7db2-482b-8e6f-d3bd44a4a7ce",
          "ip6address": "fd17:ac56:1234:2000:1c00:73ff:fe00:53",
          "ip6cidr": "fd17:ac56:1234:2000::/64",
          "ip6gateway": "fd17:ac56:1234:2000::1",
          "ipaddress": "10.9.9.10",
          "isdefault": true,
          "isolationuri": "vlan://1245",
          "macaddress": "1e:00:73:00:00:53",
          "netmask": "255.255.255.0",
          "networkid": "4dcaae55-80b7-4a41-8d52-c6971d34959c",
          "networkname": "sh",
          "traffictype": "Guest",
          "type": "Shared"
        },
        {
          "gateway": "169.254.0.1",
          "id": "901c313a-3a20-446c-9904-6ec9d72d9058",
          "ipaddress": "169.254.53.68",
          "isdefault": false,
          "macaddress": "0e:00:a9:fe:35:44",
          "netmask": "255.255.0.0",
          "networkid": "15bdc1bf-2c96-46da-b64d-6e5f458e3461",
          "traffictype": "Control"
        }
      ],
      "podid": "fa34487d-6aee-4afa-8b4e-dfb293247afb",
      "podname": "Pod1",
      "redundantstate": "UNKNOWN",
      "requiresupgrade": false,
      "role": "VIRTUAL_ROUTER",
      "scriptsversion": "f10f30d1d9e8d59f4cec2f4c83d0f8cd\n",
      "serviceofferingid": "3d74539b-456d-445a-b4ca-3678bba25d56",
      "serviceofferingname": "System Offering For Software Router",
      "softwareversion": "4.17.1.0",
      "state": "Running",
      "templateid": "cda9433a-7d13-41aa-97f7-65453d001c08",
      "templatename": "SystemVM Template (KVM)",
      "version": "4.17.0",
      "zoneid": "569ae229-1d20-4deb-94cb-194c55b6a131",
      "zonename": "pr6696-t3-kvm-centos7"
    }
  ]
}
```

_Check inside VR (radvd is running)_
```
[root@pr6696-t3-kvm-centos7-kvm1 ~]# ssh root@169.254.53.68 -i /root/.ssh/id_rsa.cloud -p 3922
Linux r-10-VM 5.10.0-13-amd64 #1 SMP Debian 5.10.106-1 (2022-03-17) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Tue Sep  6 10:32:21 2022

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@r-10-VM:~# systemctl status radvd
● radvd.service - Router advertisement daemon for IPv6
     Loaded: loaded (/lib/systemd/system/radvd.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2022-09-06 10:31:43 UTC; 1h 49min ago
       Docs: man:radvd(8)
   Main PID: 920 (radvd)
      Tasks: 2 (limit: 228)
     Memory: 496.0K
        CPU: 151ms
     CGroup: /system.slice/radvd.service
             ├─920 /usr/sbin/radvd --logmethod stderr_clean
             └─921 /usr/sbin/radvd --logmethod stderr_clean

Sep 06 10:31:43 r-10-VM systemd[1]: Starting Router advertisement daemon for IPv6...
Sep 06 10:31:43 r-10-VM radvd[899]: config file, /etc/radvd.conf, syntax ok
Sep 06 10:31:43 r-10-VM radvd[918]: version 2.18 started
Sep 06 10:31:43 r-10-VM systemd[1]: Started Router advertisement daemon for IPv6.
```

**After fix**
_Reboot VR_
```
(localcloud) 🐱 > reboot router id=a99923c5-c300-410f-8d7d-ebe6f3e840a4 
{
  "router": {
    "account": "system",
    "created": "2022-09-06T10:20:56+0000",
    "dns1": "10.1.32.1",
    "dns2": "8.8.8.8",
    "domain": "ROOT",
    "domainid": "a2f1cc09-2dc0-11ed-b0f7-1e00d6000ca0",
    "guestipaddress": "10.9.9.10",
    "guestmacaddress": "1e:00:73:00:00:53",
    "guestnetmask": "255.255.255.0",
    "guestnetworkid": "4dcaae55-80b7-4a41-8d52-c6971d34959c",
    "guestnetworkname": "sh",
    "hasannotations": false,
    "healthchecksfailed": false,
    "hostid": "5ef18260-ec42-4a90-ad48-1af79f0407fe",
    "hostname": "pr6696-t3-kvm-centos7-kvm1",
    "hypervisor": "KVM",
    "id": "a99923c5-c300-410f-8d7d-ebe6f3e840a4",
    "ip6dns1": "2001:4860:4860::8888",
    "ip6dns2": "2001:4860:4860::8844",
    "isredundantrouter": false,
    "jobid": "8670993b-1e26-4d57-9253-e1143d86484e",
    "jobstatus": 0,
    "linklocalip": "169.254.170.88",
    "linklocalmacaddress": "0e:00:a9:fe:aa:58",
    "linklocalnetmask": "255.255.0.0",
    "linklocalnetworkid": "15bdc1bf-2c96-46da-b64d-6e5f458e3461",
    "name": "r-10-VM",
    "networkdomain": "cs1cloud.internal",
    "nic": [
      {
        "broadcasturi": "vlan://1245",
        "gateway": "10.9.9.1",
        "id": "5934474c-7db2-482b-8e6f-d3bd44a4a7ce",
        "ip6address": "fd17:ac56:1234:2000:1c00:73ff:fe00:53",
        "ip6cidr": "fd17:ac56:1234:2000::/64",
        "ip6gateway": "fd17:ac56:1234:2000::1",
        "ipaddress": "10.9.9.10",
        "isdefault": true,
        "isolationuri": "vlan://1245",
        "macaddress": "1e:00:73:00:00:53",
        "netmask": "255.255.255.0",
        "networkid": "4dcaae55-80b7-4a41-8d52-c6971d34959c",
        "networkname": "sh",
        "traffictype": "Guest",
        "type": "Shared"
      },
      {
        "gateway": "169.254.0.1",
        "id": "901c313a-3a20-446c-9904-6ec9d72d9058",
        "ipaddress": "169.254.170.88",
        "isdefault": false,
        "macaddress": "0e:00:a9:fe:aa:58",
        "netmask": "255.255.0.0",
        "networkid": "15bdc1bf-2c96-46da-b64d-6e5f458e3461",
        "traffictype": "Control"
      }
    ],
    "podid": "fa34487d-6aee-4afa-8b4e-dfb293247afb",
    "podname": "Pod1",
    "redundantstate": "UNKNOWN",
    "requiresupgrade": false,
    "role": "VIRTUAL_ROUTER",
    "scriptsversion": "459d674a29c3ae9682358d2171035d7c\n",
    "serviceofferingid": "3d74539b-456d-445a-b4ca-3678bba25d56",
    "serviceofferingname": "System Offering For Software Router",
    "softwareversion": "4.17.1.0",
    "state": "Running",
    "templateid": "cda9433a-7d13-41aa-97f7-65453d001c08",
    "templatename": "SystemVM Template (KVM)",
    "version": "4.17.0",
    "zoneid": "569ae229-1d20-4deb-94cb-194c55b6a131",
    "zonename": "pr6696-t3-kvm-centos7"
  }
}
```

_Check inside VR_
```
[root@pr6696-t3-kvm-centos7-kvm1 ~]# ssh root@169.254.170.88 -i /root/.ssh/id_rsa.cloud -p 3922
Linux r-10-VM 5.10.0-13-amd64 #1 SMP Debian 5.10.106-1 (2022-03-17) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Tue Sep  6 12:26:28 2022 from 169.254.0.1

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@r-10-VM:~# systemctl status radvd
● radvd.service - Router advertisement daemon for IPv6
     Loaded: loaded (/lib/systemd/system/radvd.service; disabled; vendor preset: enabled)
     Active: inactive (dead)
       Docs: man:radvd(8)

Sep 06 12:26:57 r-10-VM systemd[1]: Starting Router advertisement daemon for IPv6...
Sep 06 12:26:57 r-10-VM radvd[898]: config file, /etc/radvd.conf, syntax ok
Sep 06 12:26:57 r-10-VM radvd[920]: version 2.18 started
Sep 06 12:26:57 r-10-VM systemd[1]: Started Router advertisement daemon for IPv6.
Sep 06 12:27:00 r-10-VM systemd[1]: Stopping Router advertisement daemon for IPv6...
Sep 06 12:27:00 r-10-VM systemd[1]: radvd.service: Succeeded.
Sep 06 12:27:00 r-10-VM systemd[1]: Stopped Router advertisement daemon for IPv6.
root@r-10-VM:~# grep "radvd" /var/log/cloud.log 
Tue 06 Sep 2022 10:21:03 AM UTC Setting up radvd
Tue 06 Sep 2022 10:21:03 AM UTC Enabling radvd
Tue 06 Sep 2022 10:23:18 AM UTC Setting up radvd
Tue 06 Sep 2022 10:31:42 AM UTC Setting up radvd
Tue 06 Sep 2022 12:26:57 PM UTC Setting up radvd
Tue 06 Sep 2022 12:27:00 PM UTC Disable radvd for dhcp server system vm
```
