### PR TITLE
ui: Fix netowrkid not passed in deployvm

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -2154,6 +2154,7 @@ export default {
     },
     fetchTemplateNics (template) {
       var nics = []
+      this.nicToNetworkSelection = []
       if (template && template.deployasisdetails && Object.keys(template.deployasisdetails).length > 0) {
         var keys = Object.keys(template.deployasisdetails)
         keys = keys.filter(key => key.startsWith('network-'))
@@ -2165,7 +2166,6 @@ export default {
           return a.InstanceID - b.InstanceID
         })
         if (this.options.networks && this.options.networks.length > 0) {
-          this.nicToNetworkSelection = []
           for (var i = 0; i < nics.length; ++i) {
             var nic = nics[i]
             nic.id = nic.InstanceID


### PR DESCRIPTION
### Description

Fixes the issue of the networkid not being passed when deploying a VM
This is caused when the first template selected is a deploy-as-is one and the `nicToNetworkSelection` not being reset when selecting a new template

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
