### PR TITLE
UI: Build Dockerfile with Node v14

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,7 +17,7 @@
 
 # Build example: docker build -t <name> .
 
-FROM node:lts-stretch AS build
+FROM node:14-bullseye AS build
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 LABEL Description="Apache CloudStack UI; Modern role-base progressive UI for Apache CloudStack"


### PR DESCRIPTION
### Description
Node versions >14 throw errors when building and thus do not allow to build the UI.

Pinning to v14 allows us to build and run the UI Docker container.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Minor


Fixes:  #6709 
