### PR TITLE
server: fix network upgrade for IPv6

### DIFF
--- a/server/src/main/java/com/cloud/network/Ipv6ServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/Ipv6ServiceImpl.java
@@ -501,7 +501,7 @@ public class Ipv6ServiceImpl extends ComponentLifecycleBase implements Ipv6Servi
                 ipAddressDao.listByAssociatedVpc(network.getVpcId(), true);
         for (IPAddressVO address : addresses) {
             VlanVO vlan = vlanDao.findById(address.getVlanId());
-            final List<VlanVO> ranges = vlanDao.listIpv6RangeByZoneIdAndVlanId(network.getPhysicalNetworkId(), vlan.getVlanTag());
+            final List<VlanVO> ranges = vlanDao.listIpv6RangeByZoneIdAndVlanId(network.getDataCenterId(), vlan.getVlanTag());
             if (CollectionUtils.isEmpty(ranges)) {
                 s_logger.error(String.format("Unable to find IPv6 address for zone ID: %d, physical network ID: %d, VLAN: %s", network.getDataCenterId(), network.getPhysicalNetworkId(), vlan.getVlanTag()));
                 InsufficientAddressCapacityException ex = new InsufficientAddressCapacityException("Insufficient address capacity", DataCenter.class, network.getDataCenterId());

--- a/server/src/test/java/com/cloud/network/Ipv6ServiceImplTest.java
+++ b/server/src/test/java/com/cloud/network/Ipv6ServiceImplTest.java
@@ -592,10 +592,10 @@ public class Ipv6ServiceImplTest {
 
     @Test
     public void testCheckNetworkIpv6UpgradeForNoIpv6Vlan() {
-        final long physicalNetworkId = 1L;
+        final long zoneId = 1L;
         Mockito.when(dataCenterGuestIpv6PrefixDao.listByDataCenterId(Mockito.anyLong())).thenReturn(List.of(Mockito.mock(DataCenterGuestIpv6PrefixVO.class)));
         Network network = Mockito.mock(Network.class);
-        Mockito.when(network.getPhysicalNetworkId()).thenReturn(physicalNetworkId);
+        Mockito.when(network.getDataCenterId()).thenReturn(zoneId);
         Mockito.when(network.getVpcId()).thenReturn(null);
         Mockito.when(ipAddressDao.listByAssociatedNetwork(Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(IPAddressVO.class)));
         VlanVO vlanVO = Mockito.mock(VlanVO.class);
@@ -610,16 +610,16 @@ public class Ipv6ServiceImplTest {
 
     @Test
     public void testCheckNetworkIpv6UpgradeForNetwork() {
-        final long physicalNetworkId = 1L;
+        final long zoneId = 1L;
         Mockito.when(dataCenterGuestIpv6PrefixDao.listByDataCenterId(Mockito.anyLong())).thenReturn(List.of(Mockito.mock(DataCenterGuestIpv6PrefixVO.class)));
         Network network = Mockito.mock(Network.class);
-        Mockito.when(network.getPhysicalNetworkId()).thenReturn(physicalNetworkId);
+        Mockito.when(network.getDataCenterId()).thenReturn(zoneId);
         Mockito.when(network.getVpcId()).thenReturn(null);
         Mockito.when(ipAddressDao.listByAssociatedNetwork(Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(IPAddressVO.class)));
         VlanVO vlanVO = Mockito.mock(VlanVO.class);
         Mockito.when(vlanVO.getVlanTag()).thenReturn(vlan);
         Mockito.when(vlanDao.findById(Mockito.anyLong())).thenReturn(vlanVO);
-        Mockito.when(vlanDao.listIpv6RangeByZoneIdAndVlanId(physicalNetworkId, vlan)).thenReturn(List.of(vlanVO));
+        Mockito.when(vlanDao.listIpv6RangeByZoneIdAndVlanId(zoneId, vlan)).thenReturn(List.of(vlanVO));
         try {
             ipv6Service.checkNetworkIpv6Upgrade(network);
         } catch (InsufficientAddressCapacityException | ResourceAllocationException e) {


### PR DESCRIPTION
### Description

Fixes network update for IPv6 offering upgrade

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Before fix:
```
# cat /marvin//MarvinLogs/test_network_ipv6_W9ENW4/results.txt 
Test to verify IPv6 network ... === TestName: test_01_verify_ipv6_network | Status : SUCCESS ===
ok
Test to verify redundant IPv6 network ... === TestName: test_02_verify_ipv6_network_redundant | Status : SUCCESS ===
ok
Test to verify IPv4 network upgraded to IPv6 network ... === TestName: test_03_verify_upgraded_ipv6_network | Status : EXCEPTION ===
ERROR
Test to verify redundant IPv4 network upgraded to redundant IPv6 network ... === TestName: test_04_verify_upgraded_ipv6_network_redundant | Status : EXCEPTION ===
ERROR

# cat /marvin//MarvinLogs/test_network_ipv6_W9ENW4/failed_plus_exceptions.txt 
2022-09-12 09:02:13,776 - CRITICAL - EXCEPTION: test_03_verify_upgraded_ipv6_network: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/decoratorGenerators.py", line 30, in test_wrapper\n    return test(self, *args, **kwargs)\n', '  File "/marvin/tests/component/test_network_ipv6.py", line 888, in test_03_verify_upgraded_ipv6_network\n    self.updateNetworkWithOffering()\n', '  File "/marvin/tests/component/test_network_ipv6.py", line 548, in updateNetworkWithOffering\n    self.network.update(self.userapiclient, networkofferingid=self.network_offering_update.id)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 3275, in update\n    return (apiclient.updateNetwork(cmd))\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 2187, in updateNetwork\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 105, in __poll\n    % async_response)\n', 'Exception: Job failed: {accountid : \'2668148f-79d0-465b-924f-6c8d136315cb\', userid : \'48c0288b-bfc8-4b0f-8ea9-471f598ec4fd\', cmd : \'org.apache.cloudstack.api.command.user.network.UpdateNetworkCmd\', jobstatus : 2, jobprocstatus : 0, jobresultcode : 530, jobresulttype : \'object\', jobresult : {errorcode : 530, errortext : "Failed to upgrade network offering to \'Test Network offering-NF816G\' as unable to allocate IPv6 network"}, jobinstancetype : \'Network\', created : \'2022-09-12T09:01:14+0000\', completed : \'2022-09-12T09:01:14+0000\', jobid : \'915100ce-d7f9-4455-9725-f52ac6dfd3f3\'}\n']
2022-09-12 09:05:45,283 - CRITICAL - EXCEPTION: test_04_verify_upgraded_ipv6_network_redundant: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/decoratorGenerators.py", line 30, in test_wrapper\n    return test(self, *args, **kwargs)\n', '  File "/marvin/tests/component/test_network_ipv6.py", line 928, in test_04_verify_upgraded_ipv6_network_redundant\n    self.updateNetworkWithOffering()\n', '  File "/marvin/tests/component/test_network_ipv6.py", line 548, in updateNetworkWithOffering\n    self.network.update(self.userapiclient, networkofferingid=self.network_offering_update.id)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 3275, in update\n    return (apiclient.updateNetwork(cmd))\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 2187, in updateNetwork\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 105, in __poll\n    % async_response)\n', 'Exception: Job failed: {accountid : \'2668148f-79d0-465b-924f-6c8d136315cb\', userid : \'48c0288b-bfc8-4b0f-8ea9-471f598ec4fd\', cmd : \'org.apache.cloudstack.api.command.user.network.UpdateNetworkCmd\', jobstatus : 2, jobprocstatus : 0, jobresultcode : 530, jobresulttype : \'object\', jobresult : {errorcode : 530, errortext : "Failed to upgrade network offering to \'Network off-RVR services-0HRGO3\' as unable to allocate IPv6 network"}, jobinstancetype : \'Network\', created : \'2022-09-12T09:04:38+0000\', completed : \'2022-09-12T09:04:38+0000\', jobid : \'3a37d6d5-b841-493d-97dd-105316ea7787\'}\n']
```

After fix:
```
# cat /marvin//MarvinLogs/test_network_ipv6_ZJBQRM/results.txt 
Test to verify IPv6 network ... === TestName: test_01_verify_ipv6_network | Status : SUCCESS ===
ok
Test to verify redundant IPv6 network ... === TestName: test_02_verify_ipv6_network_redundant | Status : SUCCESS ===
ok
Test to verify IPv4 network upgraded to IPv6 network ... === TestName: test_03_verify_upgraded_ipv6_network | Status : SUCCESS ===
ok
Test to verify redundant IPv4 network upgraded to redundant IPv6 network ... === TestName: test_04_verify_upgraded_ipv6_network_redundant | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 2096.898s
```
