### PR TITLE
Ignore calls to PowerFlex for host revocation when host is null

### DIFF
--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/driver/ScaleIOPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/driver/ScaleIOPrimaryDataStoreDriver.java
@@ -189,6 +189,11 @@ public class ScaleIOPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
     @Override
     public void revokeAccess(DataObject dataObject, Host host, DataStore dataStore) {
+        if (host == null) {
+            LOGGER.warn("Declining to revoke access to PowerFlex volume when a host is not provided");
+            return;
+        }
+
         try {
             if (DataObjectType.VOLUME.equals(dataObject.getType())) {
                 final VolumeVO volume = volumeDao.findById(dataObject.getId());

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/driver/ScaleIOPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/driver/ScaleIOPrimaryDataStoreDriver.java
@@ -190,7 +190,7 @@ public class ScaleIOPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     @Override
     public void revokeAccess(DataObject dataObject, Host host, DataStore dataStore) {
         if (host == null) {
-            LOGGER.warn("Declining to revoke access to PowerFlex volume when a host is not provided");
+            LOGGER.info("Declining to revoke access to PowerFlex volume when a host is not provided");
             return;
         }
 


### PR DESCRIPTION
Signed-off-by: Marcus Sorensen <mls@apple.com>

### Description

This PR Fixes #6739 (for PowerFlex/ScaleIO only, Datera still needs to be addressed), which can occur if the last host the VM ran on is deleted from CloudStack. At the point the VM is deleted, cloudstack attempts to make a final call to revoke access to volumes, passing the last host the VM ran on. If this host is gone, we get an error and are unable to delete the VM.

It's possible that there may be a more holistic fix to this by identifying all of the places where `revokeAccess()` is called and checking for null host. It's possible other storage plugins don't even need host information to revoke access to volumes and may need this call to revoke. Therefore I'm only applying this fix to the ScaleIOPrimaryDataStoreDriver to skip revoking access when there is no host to revoke access for, and this should protect us as well when a new part of the code tries to use `revokeAccess()` in the future.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested in a local branch against PowerFlex primary storage, and with internal testing environments. Repeated steps outlined in #6739. We also had quite a few VMs that would not delete before this change was put into place, which cleaned up successfully afterward.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
