### PR TITLE
server: fix listnetworkofferings with domain, refactor listvpofferings

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListVPCOfferingsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListVPCOfferingsCmd.java
@@ -23,6 +23,7 @@ import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseListCmd;
 import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.VpcOfferingResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
@@ -60,10 +61,17 @@ public class ListVPCOfferingsCmd extends BaseListCmd {
     @Parameter(name = ApiConstants.STATE, type = CommandType.STRING, description = "list VPC offerings by state")
     private String state;
 
+    @Parameter(name = ApiConstants.DOMAIN_ID,
+            type = CommandType.UUID,
+            entityType = DomainResponse.class,
+            description = "list VPC offerings available for VPC creation in specific domain",
+            since = "4.18")
+    private Long domainId;
+
     @Parameter(name = ApiConstants.ZONE_ID,
             type = CommandType.UUID,
             entityType = ZoneResponse.class,
-            description = "id of zone disk offering is associated with",
+            description = "id of zone VPC offering is associated with",
             since = "4.13")
     private Long zoneId;
 
@@ -92,6 +100,10 @@ public class ListVPCOfferingsCmd extends BaseListCmd {
 
     public String getState() {
         return state;
+    }
+
+    public Long getDomainId() {
+        return domainId;
     }
 
     public Long getZoneId() {

--- a/engine/schema/src/main/java/com/cloud/domain/dao/DomainDao.java
+++ b/engine/schema/src/main/java/com/cloud/domain/dao/DomainDao.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.cloud.domain.DomainVO;
+import com.cloud.user.Account;
 import com.cloud.utils.db.GenericDao;
 
 public interface DomainDao extends GenericDao<DomainVO, Long> {
@@ -40,4 +41,6 @@ public interface DomainDao extends GenericDao<DomainVO, Long> {
     Set<Long> getDomainParentIds(long domainId);
 
     List<Long> getDomainChildrenIds(String path);
+
+    boolean domainIdListContainsAccessibleDomain(String domainIdList, Account caller, Long domainId);
 }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -6709,24 +6709,25 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             ListIterator<NetworkOfferingJoinVO> it = offerings.listIterator();
             while (it.hasNext()) {
                 NetworkOfferingJoinVO offering = it.next();
-                if (StringUtils.isNotEmpty(offering.getDomainId())) {
-                    boolean toRemove = false;
-                    String[] domainIdsArray = offering.getDomainId().split(",");
-                    for (String domainIdString : domainIdsArray) {
-                        Long dId = Long.valueOf(domainIdString.trim());
-                        if (caller.getType() != Account.Type.ADMIN &&
-                                !_domainDao.isChildDomain(dId, caller.getDomainId())) {
-                            toRemove = true;
-                            break;
-                        }
-                        if (domainId != null && !_domainDao.isChildDomain(dId, domainId)) {
-                            toRemove = true;
-                            break;
-                        }
+                if (StringUtils.isEmpty(offering.getDomainId())) {
+                    continue;
+                }
+                boolean toRemove = true;
+                String[] domainIdsArray = offering.getDomainId().split(",");
+                for (String domainIdString : domainIdsArray) {
+                    Long dId = Long.valueOf(domainIdString.trim());
+                    if (caller.getType() != Account.Type.ADMIN &&
+                            _domainDao.isChildDomain(dId, caller.getDomainId())) {
+                        toRemove = false;
+                        break;
                     }
-                    if (toRemove) {
-                        it.remove();
+                    if (domainId != null && _domainDao.isChildDomain(dId, domainId)) {
+                        toRemove = false;
+                        break;
                     }
+                }
+                if (toRemove) {
+                    it.remove();
                 }
             }
         }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -6705,25 +6705,15 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         final List<NetworkOfferingJoinVO> offerings = networkOfferingJoinDao.search(sc, searchFilter);
         // Remove offerings that are not associated with caller's domain or domainId passed
-        if ((caller.getType() != Account.Type.ADMIN || domainId != null) && CollectionUtils.isNotEmpty(offerings)) {
+        if ((!Account.Type.ADMIN.equals(caller.getType()) || domainId != null) && CollectionUtils.isNotEmpty(offerings)) {
             ListIterator<NetworkOfferingJoinVO> it = offerings.listIterator();
             while (it.hasNext()) {
                 NetworkOfferingJoinVO offering = it.next();
                 if (StringUtils.isEmpty(offering.getDomainId())) {
                     continue;
                 }
-                String[] domainIdsArray = offering.getDomainId().split(",");
-                for (String domainIdString : domainIdsArray) {
-                    Long dId = Long.valueOf(domainIdString.trim());
-                    if (caller.getType() != Account.Type.ADMIN &&
-                            !_domainDao.isChildDomain(dId, caller.getDomainId())) {
-                        it.remove();
-                        break;
-                    }
-                    if (domainId != null && !_domainDao.isChildDomain(dId, domainId)) {
-                        it.remove();
-                        break;
-                    }
+                if (!_domainDao.domainIdListContainsAccessibleDomain(offering.getDomainId(), caller, domainId)) {
+                    it.remove();
                 }
             }
         }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -6712,22 +6712,18 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 if (StringUtils.isEmpty(offering.getDomainId())) {
                     continue;
                 }
-                boolean toRemove = true;
                 String[] domainIdsArray = offering.getDomainId().split(",");
                 for (String domainIdString : domainIdsArray) {
                     Long dId = Long.valueOf(domainIdString.trim());
                     if (caller.getType() != Account.Type.ADMIN &&
-                            _domainDao.isChildDomain(dId, caller.getDomainId())) {
-                        toRemove = false;
+                            !_domainDao.isChildDomain(dId, caller.getDomainId())) {
+                        it.remove();
                         break;
                     }
-                    if (domainId != null && _domainDao.isChildDomain(dId, domainId)) {
-                        toRemove = false;
+                    if (domainId != null && !_domainDao.isChildDomain(dId, domainId)) {
+                        it.remove();
                         break;
                     }
-                }
-                if (toRemove) {
-                    it.remove();
                 }
             }
         }

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -766,19 +766,20 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             ListIterator<VpcOfferingJoinVO> it = offerings.listIterator();
             while (it.hasNext()) {
                 VpcOfferingJoinVO offering = it.next();
-                if(org.apache.commons.lang3.StringUtils.isNotEmpty(offering.getDomainId())) {
-                    boolean toRemove = true;
-                    String[] domainIdsArray = offering.getDomainId().split(",");
-                    for (String domainIdString : domainIdsArray) {
-                        Long dId = Long.valueOf(domainIdString.trim());
-                        if (domainDao.isChildDomain(dId, caller.getDomainId())) {
-                            toRemove = false;
-                            break;
-                        }
+                if(org.apache.commons.lang3.StringUtils.isEmpty(offering.getDomainId())) {
+                    continue;
+                }
+                boolean toRemove = true;
+                String[] domainIdsArray = offering.getDomainId().split(",");
+                for (String domainIdString : domainIdsArray) {
+                    Long dId = Long.valueOf(domainIdString.trim());
+                    if (domainDao.isChildDomain(dId, caller.getDomainId())) {
+                        toRemove = false;
+                        break;
                     }
-                    if (toRemove) {
-                        it.remove();
-                    }
+                }
+                if (toRemove) {
+                    it.remove();
                 }
             }
         }

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -766,20 +766,16 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             ListIterator<VpcOfferingJoinVO> it = offerings.listIterator();
             while (it.hasNext()) {
                 VpcOfferingJoinVO offering = it.next();
-                if(org.apache.commons.lang3.StringUtils.isEmpty(offering.getDomainId())) {
+                if (org.apache.commons.lang3.StringUtils.isEmpty(offering.getDomainId())) {
                     continue;
                 }
-                boolean toRemove = true;
                 String[] domainIdsArray = offering.getDomainId().split(",");
                 for (String domainIdString : domainIdsArray) {
                     Long dId = Long.valueOf(domainIdString.trim());
-                    if (domainDao.isChildDomain(dId, caller.getDomainId())) {
-                        toRemove = false;
+                    if (!domainDao.isChildDomain(dId, caller.getDomainId())) {
+                        it.remove();
                         break;
                     }
-                }
-                if (toRemove) {
-                    it.remove();
                 }
             }
         }


### PR DESCRIPTION
### Description

Fixes #6745

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Using API with cmk,

```
(local) 🍂 > create domain name=d1
{
  "domain": {
    "haschild": false,
    "id": "afd89eeb-da02-4701-8b87-df0701d8c4a8",
    "level": 1,
    "name": "d1",
    "parentdomainid": "fcb3da55-37e0-11ed-b99e-645d8651f45a",
    "parentdomainname": "ROOT",
    "path": "ROOT/d1",
    "secondarystoragetotal": 0
  }
}
(local) 🐷 > create domain name=d2
{
  "domain": {
    "haschild": false,
    "id": "e52fe7a9-0f29-4463-84c4-21bcadf0b99f",
    "level": 1,
    "name": "d2",
    "parentdomainid": "fcb3da55-37e0-11ed-b99e-645d8651f45a",
    "parentdomainname": "ROOT",
    "path": "ROOT/d2",
    "secondarystoragetotal": 0
  }
}
(local) 🙉 > create networkoffering name=n1 displaytext=n1 domainid=fcb3da55-37e0-11ed-b99e-645d8651f45a,fcb3da55-37e0-11ed-b99e-645d8651f45a guestiptype=Isolated traffictype=Guest
{
  "networkoffering": {
    "availability": "Optional",
    "conservemode": true,
    "created": "2022-09-19T12:07:33+0530",
    "displaytext": "n1",
    "domain": "/",
    "domainid": "fcb3da55-37e0-11ed-b99e-645d8651f45a",
    "egressdefaultpolicy": true,
    "forvpc": false,
    "guestiptype": "Isolated",
    "hasannotations": false,
    "id": "391ae3f6-a931-44d7-9ed4-5e24b8bbffe4",
    "internetprotocol": "IPv4",
    "isdefault": false,
    "ispersistent": false,
    "name": "n1",
    "networkrate": 200,
    "service": [],
    "serviceofferingid": "08886d07-11eb-48e1-ac7f-f0f92fbfe085",
    "specifyipranges": false,
    "specifyvlan": false,
    "state": "Disabled",
    "supportspublicaccess": false,
    "supportsstrechedl2subnet": false,
    "traffictype": "Guest"
  }
}
(local) 🍄 > list networkofferings domainid=afd89eeb-da02-4701-8b87-df0701d8c4a8 filter=id,name,state
{
  "count": 15,
  "networkoffering": [
    {
      "id": "32c33040-c64b-4f2a-aa4e-fefd72e5e4d4",
      "name": "DefaultSharedNetworkOfferingWithSGService",
      "state": "Enabled"
    },
    ...
    {
      "id": "391ae3f6-a931-44d7-9ed4-5e24b8bbffe4",
      "name": "n1",
      "state": "Disabled"
    }
  ]
}
(local) 🐞 > list networkofferings domainid=e52fe7a9-0f29-4463-84c4-21bcadf0b99f  filter=id,name,state
{
  "count": 15,
  "networkoffering": [
    {
      "id": "32c33040-c64b-4f2a-aa4e-fefd72e5e4d4",
      "name": "DefaultSharedNetworkOfferingWithSGService",
      "state": "Enabled"
    },
    ...
    {
      "id": "391ae3f6-a931-44d7-9ed4-5e24b8bbffe4",
      "name": "n1",
      "state": "Disabled"
    }
  ]
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
