### PR TITLE
fix description of configuration `max.data.migration.wait.time`

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
+++ b/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
@@ -147,7 +147,7 @@ public interface StorageManager extends StorageService {
             "Setting this to 'true' will auto scale down SSVMs", true, ConfigKey.Scope.Global);
 
     ConfigKey<Integer> MaxDataMigrationWaitTime = new ConfigKey<Integer>("Advanced", Integer.class, "max.data.migration.wait.time", "15",
-            "Maximum wait time for a data migration task before spawning a new SSVM", false, ConfigKey.Scope.Global);
+            "Maximum wait time (in minutes) for a data migration task before spawning a new SSVM", false, ConfigKey.Scope.Global);
     ConfigKey<Boolean> DiskProvisioningStrictness = new ConfigKey<Boolean>("Storage", Boolean.class, "disk.provisioning.type.strictness", "false",
             "If set to true, the disk is created only when there is a suitable storage pool that supports the disk provisioning type specified by the service/disk offering. " +
                     "If set to false, the disk is created with a disk provisioning type supported by the pool. Default value is false, and this is currently supported for VMware only.",


### PR DESCRIPTION
### Description

Currently the description of the configuration `max.data.migration.wait.time` does not specify which time unity is used (minutes). The goal of this PR is to add this information to the description.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### How Has This Been Tested?

I built the code with the changes and applied it in a local lab. After starting cloudstack-management.service, the configuration description changed to the new one.