### PR TITLE
mvn: bump version ahead of next major release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <cs.clover-maven-plugin.version>4.4.1</cs.clover-maven-plugin.version>
 
         <!-- Logging versions -->
-        <cs.reload4j.version>1.2.21</cs.reload4j.version>
+        <cs.reload4j.version>1.2.22</cs.reload4j.version>
         <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
         <cs.logging.version>1.1.1</cs.logging.version>
 
@@ -108,7 +108,7 @@
         <!-- do not forget to also upgrade hamcrest library with junit -->
         <cs.dbunit.version>2.5.4</cs.dbunit.version>
         <cs.hamcrest.version>1.3</cs.hamcrest.version>
-        <cs.junit.version>4.13</cs.junit.version>
+        <cs.junit.version>4.13.2</cs.junit.version>
         <cs.junit.dataprovider.version>1.13.1</cs.junit.dataprovider.version>
         <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
         <cs.mockito.version>3.2.4</cs.mockito.version>
@@ -121,10 +121,10 @@
         <cs.assertj.version>3.23.1</cs.assertj.version>
 
         <!-- Dependencies versions -->
-        <cs.amqp-client.version>5.10.0</cs.amqp-client.version>
+        <cs.amqp-client.version>5.16.0</cs.amqp-client.version>
         <cs.apache-cloudstack-java-client.version>1.0.9</cs.apache-cloudstack-java-client.version>
-        <cs.aspectjrt.version>1.9.6</cs.aspectjrt.version>
-        <cs.aws.sdk.version>1.12.255</cs.aws.sdk.version>
+        <cs.aspectjrt.version>1.9.9.1</cs.aspectjrt.version>
+        <cs.aws.sdk.version>1.12.310</cs.aws.sdk.version>
         <cs.axiom.version>1.2.8</cs.axiom.version>
         <cs.axis2.version>1.6.4</cs.axis2.version>
         <cs.batik.version>1.14</cs.batik.version>
@@ -134,7 +134,7 @@
         <cs.cxf.version>3.2.14</cs.cxf.version>
         <cs.ehcache.version>2.6.11</cs.ehcache.version>
         <cs.globodns-client.version>0.0.27</cs.globodns-client.version>
-        <cs.google-http-client>1.42.1</cs.google-http-client>
+        <cs.google-http-client>1.42.2</cs.google-http-client>
         <cs.groovy.version>2.4.17</cs.groovy.version>
         <cs.gson.version>1.7.2</cs.gson.version>
         <cs.guava.version>31.1-jre</cs.guava.version>
@@ -150,10 +150,10 @@
         <cs.jaxb.version>2.3.0</cs.jaxb.version>
         <cs.jaxws.version>2.3.2-1</cs.jaxws.version>
         <cs.jersey-client.version>2.26</cs.jersey-client.version>
-        <cs.jetty.version>9.4.48.v20220622</cs.jetty.version>
+        <cs.jetty.version>9.4.49.v20220914</cs.jetty.version>
         <cs.jetty-maven-plugin.version>9.4.27.v20200227</cs.jetty-maven-plugin.version>
         <cs.jna.version>5.5.0</cs.jna.version>
-        <cs.joda-time.version>2.10.14</cs.joda-time.version>
+        <cs.joda-time.version>2.11.2</cs.joda-time.version>
         <cs.jpa.version>2.2.1</cs.jpa.version>
         <cs.jsch.version>0.1.55</cs.jsch.version>
         <cs.json.version>20090211</cs.json.version>
@@ -177,7 +177,7 @@
         <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
         <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
         <cs.xstream.version>1.4.19</cs.xstream.version>
-        <org.springframework.version>5.3.21</org.springframework.version>
+        <org.springframework.version>5.3.23</org.springframework.version>
         <cs.ini.version>0.5.4</cs.ini.version>
         <cs.gmaven.version>1.12.0</cs.gmaven.version>
     </properties>


### PR DESCRIPTION
Bumps version of specific dependency to latest ahead of the next major release 4.18.