### PR TITLE
Allow template names upto 255 chars

### DIFF
--- a/api/src/main/java/com/cloud/template/VirtualMachineTemplate.java
+++ b/api/src/main/java/com/cloud/template/VirtualMachineTemplate.java
@@ -30,6 +30,8 @@ import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.utils.fsm.StateObject;
 
 public interface VirtualMachineTemplate extends ControlledEntity, Identity, InternalIdentity, StateObject<VirtualMachineTemplate.State> {
+    int MAXIMUM_TEMPLATE_NAME_LENGTH = 255;
+
     enum State {
         Active,
         Inactive,

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1748,7 +1748,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
 
         String name = cmd.getTemplateName();
         if ((org.apache.commons.lang3.StringUtils.isBlank(name)
-                || (name.length() > VirtualMachineTemplate.MAXIMUM_TEMPLATE_NAME_LENGTH)) {
+                || (name.length() > VirtualMachineTemplate.MAXIMUM_TEMPLATE_NAME_LENGTH))) {
             throw new InvalidParameterValueException(String.format("Template name cannot be null and cannot be more %s characters", VirtualMachineTemplate.MAXIMUM_TEMPLATE_NAME_LENGTH));
         }
 

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1747,7 +1747,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         _accountMgr.checkAccess(caller, null, true, templateOwner);
 
         String name = cmd.getTemplateName();
-        if ((name == null) || (name.length() > 32)) {
+        if ((name == null) || (name.length() > 255)) {
             throw new InvalidParameterValueException("Template name cannot be null and should be less than 32 characters");
         }
 

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1748,7 +1748,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
 
         String name = cmd.getTemplateName();
         if ((name == null) || (name.length() > 255)) {
-            throw new InvalidParameterValueException("Template name cannot be null and should be less than 32 characters");
+            throw new InvalidParameterValueException("Template name cannot be null and should be less than 255 characters");
         }
 
         if (cmd.getTemplateTag() != null) {

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1747,8 +1747,9 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         _accountMgr.checkAccess(caller, null, true, templateOwner);
 
         String name = cmd.getTemplateName();
-        if ((name == null) || (name.length() > 255)) {
-            throw new InvalidParameterValueException("Template name cannot be null and should be less than 255 characters");
+        if ((org.apache.commons.lang3.StringUtils.isBlank(name)
+                || (name.length() > VirtualMachineTemplate.MAXIMUM_TEMPLATE_NAME_LENGTH)) {
+            throw new InvalidParameterValueException(String.format("Template name cannot be null and cannot be more %s characters", VirtualMachineTemplate.MAXIMUM_TEMPLATE_NAME_LENGTH));
         }
 
         if (cmd.getTemplateTag() != null) {


### PR DESCRIPTION
### Description

This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #6766

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
registere a template with the name `thisIsAVerySmallTemplateWithAnExtremelyLongNameThatIsExcesiveInGivingInformationThatIsEitherUsefulOrUtterlyUselessAboutTheTemplateWhichIsReallyNotBigEnoughToSpendTheNameMiniOn` and deployed it.
When deployed stop it
From the Root Volume create a template with the name
`thisIsAVerySmallTemplateWithAnExtremelyLongNameThatIsExcesiveInGivingInformationThatIsEitherUsefulOrUtterlyUselessAboutTheTemplateWhichIsReallyNotBigEnoughToSpendTheNameMiniOnEither`

The last step would fail in without this fix.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
