### PR TITLE
Show name instead of description in the infocards and breadcrumbs

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -800,7 +800,7 @@ export default {
         'RemoteAccessVpn', 'User', 'SnapshotPolicy', 'VpcOffering']
     },
     name () {
-      return this.resource.displayname || this.resource.displaytext || this.resource.name || this.resource.username ||
+      return this.resource.displayname || this.resource.name || this.resource.displaytext || this.resource.username ||
         this.resource.ipaddress || this.resource.virtualmachinename || this.resource.templatetype
     },
     keypairs () {

--- a/ui/src/components/widgets/Breadcrumb.vue
+++ b/ui/src/components/widgets/Breadcrumb.vue
@@ -34,7 +34,7 @@
           </span>
         </label>
         <label v-else>
-          {{ resource.displayname || resource.displaytext || resource.name || resource.hostname || resource.username || resource.ipaddress || $route.params.id }}
+          {{ resource.displayname || resource.name || resource.displaytext || resource.hostname || resource.username || resource.ipaddress || $route.params.id }}
         </label>
       </span>
       <span v-else>


### PR DESCRIPTION
### Description
Currently on the infocards and breadcrumbs the object description is shown instead of the name. This PR updates de UI to use the name when possible, since the descriptions can be long to properly describe the object, and the name is shorter and intended to identify the object.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/48719461/192520323-4cdee00e-fc6a-4c03-b85e-8cb80301c6f2.png)

After:
![image](https://user-images.githubusercontent.com/48719461/192520361-2c621ed6-a70e-4db3-a7f6-86580f2d502a.png)


### How Has This Been Tested?
This was tested in a local lab, by browsing the UI and checking if the names would appear in the breadcrumbs and infocards.