### PR TITLE
Return object name in the listHypervisorCapabilities API

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/HypervisorCapabilitiesResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HypervisorCapabilitiesResponse.java
@@ -63,6 +63,10 @@ public class HypervisorCapabilitiesResponse extends BaseResponse {
     @Param(description = "true if VM snapshots are enabled for this hypervisor")
     private boolean isVmSnapshotEnabled;
 
+    public HypervisorCapabilitiesResponse(){
+        super("hypervisorcapabilities");
+    }
+
     public String getId() {
         return id;
     }


### PR DESCRIPTION
### Description

The `hypervisorCapabilitiesResponse` does not set an object name, returning a null object name instead. This PR adds an object name to the response. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab, by calling the API via CloudMonkey and checking the object name value.
Before:
```
{
  "null": {
    "hypervisor": "VMware",
    "hypervisorversion": "5.0",
    "id": "11",
    "maxdatavolumeslimit": 12,
    "maxguestslimit": 127,
    "maxhostspercluster": 31,
    "securitygroupenabled": true,
    "storagemotionenabled": true,
    "vmsnapshotenabled": false
  }
}
```
After:
```
{
  "hypervisorcapabilities": {
    "hypervisor": "VMware",
    "hypervisorversion": "5.0",
    "id": "11",
    "maxdatavolumeslimit": 12,
    "maxguestslimit": 127,
    "maxhostspercluster": 31,
    "securitygroupenabled": true,
    "storagemotionenabled": true,
    "vmsnapshotenabled": false
  }
}
```