### PR TITLE
Fixes script that perform change password on hosts

### DIFF
--- a/scripts/vm/hypervisor/update_host_passwd.sh
+++ b/scripts/vm/hypervisor/update_host_passwd.sh
@@ -19,9 +19,9 @@
 username=$1
 new_passwd=$2
 expected="successfully."
-result=`echo -e "$new_passwd\n$new_passwd" | passwd --stdin $username | grep successfully | awk '{ print $6 }'`
+result=`echo -e "$new_passwd\n$new_passwd" | passwd $username | grep successfully | awk '{ print $6 }'`
 
-if [ $result = $expected ]; then
+if [[ $result == $expected ]]; then
    exit 0
 else
    exit 1

--- a/scripts/vm/hypervisor/update_host_passwd.sh
+++ b/scripts/vm/hypervisor/update_host_passwd.sh
@@ -17,7 +17,6 @@
 # under the License.
 username=$1
 new_passwd=$2
-expected="successfully."
 
 passwd ${username} << EOD
 ${new_passwd}

--- a/scripts/vm/hypervisor/update_host_passwd.sh
+++ b/scripts/vm/hypervisor/update_host_passwd.sh
@@ -15,13 +15,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 username=$1
 new_passwd=$2
-expected="successfully."
-result=`echo -e "$new_passwd\n$new_passwd" | passwd $username | grep successfully | awk '{ print $6 }'`
 
-if [[ $result == $expected ]]; then
+passwd ${username} << EOD
+${new_passwd}
+${new_passwd}
+EOD
+
+if [[ $(echo $?) ]]; then
    exit 0
 else
    exit 1

--- a/scripts/vm/hypervisor/update_host_passwd.sh
+++ b/scripts/vm/hypervisor/update_host_passwd.sh
@@ -17,13 +17,14 @@
 # under the License.
 username=$1
 new_passwd=$2
+expected="successfully."
 
 passwd ${username} << EOD
 ${new_passwd}
 ${new_passwd}
 EOD
 
-if [[ $(echo $?) ]]; then
+if [[ $(echo $?) -eq 0 ]]; then
    exit 0
 else
    exit 1


### PR DESCRIPTION
### Description
When adding a KVM host via ACS UI, it is necessary to provide a username and password for ACS to connect via SSH to the host. When using the `updateHostPassword` API, ACS updates the password in the metadata. When the update_passwd_on_host parameter is specified as true, ACS sends a command to the host that causes it to run a script to change the user's password on the host.

During some internal tests, it was observed that the script was not changing the password and returned an error. Adjustments were made to this script to make it work again.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
After executing the `updateHostPassword` API, an attempt was made to access the host via ssh using the user and the new password as a parameter. The expected result is that the password for that user has been updated, and this was the result observed during the tests.