### PR TITLE
Rename validateUUID method to isUuid

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiArgValidator.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiArgValidator.java
@@ -29,7 +29,7 @@ public enum ApiArgValidator {
     PositiveNumber,
 
     /**
-     * Validates if the parameter is an UUID with the method {@link UuidUtils#validateUUID(String)}.
+     * Validates if the parameter is an UUID with the method {@link UuidUtils#isUuid(String)}.
      */
     UuidString,
 }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2616,7 +2616,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 throw new InvalidParameterValueException("The VLAN tag for isolated PVLAN " + isolatedPvlan + " is already being used for dynamic vlan allocation for the guest network in zone "
                         + zone.getName());
             }
-            if (!UuidUtils.validateUUID(vlanId)) {
+            if (!UuidUtils.isUuid(vlanId)) {
                 // For Isolated and L2 networks, don't allow to create network with vlan that already exists in the zone
                 if (!hasGuestBypassVlanOverlapCheck(bypassVlanOverlapCheck, ntwkOff, isPrivateNetwork)) {
                     if (_networksDao.listByZoneAndUriAndGuestType(zoneId, uri.toString(), null).size() > 0) {
@@ -2779,7 +2779,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (vlanIdFinal != null) {
                     if (isolatedPvlan == null) {
                         URI uri = null;
-                        if (UuidUtils.validateUUID(vlanIdFinal)) {
+                        if (UuidUtils.isUuid(vlanIdFinal)) {
                             //Logical router's UUID provided as VLAN_ID
                             userNetwork.setVlanIdAsUUID(vlanIdFinal); //Set transient field
                         } else {

--- a/plugins/event-bus/inmemory/src/test/java/org/apache/cloudstack/mom/inmemory/InMemoryEventBusTest.java
+++ b/plugins/event-bus/inmemory/src/test/java/org/apache/cloudstack/mom/inmemory/InMemoryEventBusTest.java
@@ -59,7 +59,7 @@ public class InMemoryEventBusTest {
         assertNotNull(uuid);
 
         String uuidStr = uuid.toString();
-        assertTrue(UuidUtils.validateUUID(uuidStr));
+        assertTrue(UuidUtils.isUuid(uuidStr));
         assertTrue(bus.totalSubscribers() == 1);
 
         bus.unsubscribe(uuid, subscriber);
@@ -96,7 +96,7 @@ public class InMemoryEventBusTest {
 
         String uuidStr = uuid.toString();
 
-        assertTrue(UuidUtils.validateUUID(uuidStr));
+        assertTrue(UuidUtils.isUuid(uuidStr));
         assertTrue(bus.totalSubscribers() == 1);
         //
         bus.unsubscribe(uuid, subscriber);
@@ -138,7 +138,7 @@ public class InMemoryEventBusTest {
         assertNotNull(uuid);
 
         String uuidStr = uuid.toString();
-        assertTrue(UuidUtils.validateUUID(uuidStr));
+        assertTrue(UuidUtils.isUuid(uuidStr));
         assertTrue(bus.totalSubscribers() == 1);
 
         bus.publish(event);

--- a/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/model/VirtualMachineModel.java
+++ b/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/model/VirtualMachineModel.java
@@ -95,7 +95,7 @@ public class VirtualMachineModel extends ModelObjectBase {
                  *
                  * In other fix I added the validate UUID method to the UuidUtil classes.
                  */
-                if (UuidUtils.validateUUID(serviceUuid)) {
+                if (UuidUtils.isUuid(serviceUuid)) {
                     /* link the object with the service instance */
                     buildServiceInstance(controller, serviceUuid);
                 } else {

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -131,7 +131,7 @@ public class ScaleIOUtil {
             return null;
         }
 
-        if (!UuidUtils.validateUUID(result)) {
+        if (!UuidUtils.isUuid(result)) {
             LOGGER.warn("Invalid SDC guid: " + result);
             return null;
         }

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -109,7 +109,7 @@ public class ParamProcessWorker implements DispatchWorker {
     private void validateUuidString(final Object param, final String argName) {
         String value = String.valueOf(param);
 
-        if (!UuidUtils.validateUUID(value)) {
+        if (!UuidUtils.isUuid(value)) {
             throwInvalidParameterValueException(argName);
         }
     }
@@ -467,7 +467,7 @@ public class ParamProcessWorker implements DispatchWorker {
         // If annotation's empty, the cmd existed before 3.x try conversion to long
         final boolean isPre3x = annotation.since().isEmpty();
         // Match against Java's UUID regex to check if input is uuid string
-        final boolean isUuid = UuidUtils.validateUUID(uuid);
+        final boolean isUuid = UuidUtils.isUuid(uuid);
         // Enforce that it's uuid for newly added apis from version 3.x
         if (!isPre3x && !isUuid)
             return null;

--- a/server/src/test/java/com/cloud/user/DomainManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/DomainManagerImplTest.java
@@ -357,19 +357,19 @@ public class DomainManagerImplTest {
     @Test
     public void createDomainVoTestCreateValidUuidIfEmptyString(){
         DomainVO domainVo = domainManager.createDomainVo("test",1L,2L,"NetworkTest","");
-        Assert.assertTrue(UuidUtils.validateUUID(domainVo.getUuid()));
+        Assert.assertTrue(UuidUtils.isUuid(domainVo.getUuid()));
     }
 
     @Test
     public void createDomainVoTestCreateValidUuidIfWhiteSpace(){
         DomainVO domainVo = domainManager.createDomainVo("test",1L,2L,"NetworkTest","  ");
-        Assert.assertTrue(UuidUtils.validateUUID(domainVo.getUuid()));
+        Assert.assertTrue(UuidUtils.isUuid(domainVo.getUuid()));
     }
 
     @Test
     public void createDomainVoTestCreateValidUuidIfNull(){
         DomainVO domainVo = domainManager.createDomainVo("test",1L,2L,"NetworkTest",null);
-        Assert.assertTrue(UuidUtils.validateUUID(domainVo.getUuid()));
+        Assert.assertTrue(UuidUtils.isUuid(domainVo.getUuid()));
     }
 
     @Test

--- a/utils/src/main/java/com/cloud/utils/UuidUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UuidUtils.java
@@ -30,7 +30,7 @@ public class UuidUtils {
         return uuid.substring(0, uuid.indexOf('-'));
     }
 
-    public static boolean validateUUID(String uuid) {
+    public static boolean isUuid(String uuid) {
         return uuidRegex.matches(uuid);
     }
 
@@ -49,7 +49,7 @@ public class UuidUtils {
                 .append(noHyphen.substring(16, 20)).append("-")
                 .append(noHyphen.substring(20, 32));
         String uuid = stringBuilder.toString();
-        if (!validateUUID(uuid)) {
+        if (!isUuid(uuid)) {
             throw new CloudRuntimeException("Error generating UUID");
         }
         return uuid;

--- a/utils/src/main/java/com/cloud/utils/UuidUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UuidUtils.java
@@ -30,6 +30,12 @@ public class UuidUtils {
         return uuid.substring(0, uuid.indexOf('-'));
     }
 
+    /**
+     * Checks if the parameter is a valid UUID (based on {@link UuidUtils#uuidRegex}).
+     * <br/>
+     * Example: 24abcb8f-4211-374f-a2e1-e5c0b7e88a2d -> true
+     *          24abcb8f4211374fa2e1e5c0b7e88a2dda23 -> false
+     */
     public static boolean isUuid(String uuid) {
         return uuidRegex.matches(uuid);
     }

--- a/utils/src/test/java/com/cloud/utils/UuidUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/UuidUtilsTest.java
@@ -27,16 +27,16 @@ import org.junit.Test;
 public class UuidUtilsTest {
 
     @Test
-    public void testValidateUUIDPass() throws Exception {
+    public void isUuidTestPass() throws Exception {
         String serviceUuid = "f81a9aa3-1f7d-466f-b04b-f2b101486bae";
 
-        assertTrue(UuidUtils.validateUUID(serviceUuid));
+        assertTrue(UuidUtils.isUuid(serviceUuid));
     }
 
     @Test
-    public void testValidateUUIDFail() throws Exception {
+    public void isUuidTestFail() throws Exception {
         String serviceUuid = "6fc6ce7-d503-4f95-9e68-c9cd281b13df";
 
-        assertFalse(UuidUtils.validateUUID(serviceUuid));
+        assertFalse(UuidUtils.isUuid(serviceUuid));
     }
 }


### PR DESCRIPTION
### Description

This PR renames the method `validateUUID` to `isUuid` and everywhere it's called.

The current name of the method (`validateUUID`) gives the impression that if the validation fails, an exception will be thrown, when in fact it just returns a boolean value, and that's why I think that `isUuid` is more appropriate.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
As the PR only renames the method, I tested it (the PR) building it locally: 
![project-build](https://user-images.githubusercontent.com/48932878/193342132-73d612e3-20cf-4448-9803-1ef0e4cf4ec7.png)