### PR TITLE
Fixed NPE on volume creation from snapshot

### DIFF
--- a/api/src/main/java/com/cloud/deploy/DataCenterDeployment.java
+++ b/api/src/main/java/com/cloud/deploy/DataCenterDeployment.java
@@ -18,6 +18,7 @@ package com.cloud.deploy;
 
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.vm.ReservationContext;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -115,6 +116,12 @@ public class DataCenterDeployment implements DeploymentPlan {
     @Override
     public boolean isMigrationPlan() {
         return migrationPlan;
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "_dcId", "_podId", "_clusterId", "_poolId", "_hostid", "_physicalNetworkId",
+                "migrationPlan");
     }
 
 }

--- a/engine/components-api/src/main/java/com/cloud/vm/VirtualMachineProfileImpl.java
+++ b/engine/components-api/src/main/java/com/cloud/vm/VirtualMachineProfileImpl.java
@@ -86,7 +86,10 @@ public class VirtualMachineProfileImpl implements VirtualMachineProfile {
 
     @Override
     public String toString() {
-        return _vm.toString();
+        if (_vm != null) {
+            return _vm.toString();
+        }
+        return null;
     }
 
     @Override

--- a/engine/components-api/src/main/java/com/cloud/vm/VirtualMachineProfileImpl.java
+++ b/engine/components-api/src/main/java/com/cloud/vm/VirtualMachineProfileImpl.java
@@ -89,7 +89,7 @@ public class VirtualMachineProfileImpl implements VirtualMachineProfile {
         if (_vm != null) {
             return _vm.toString();
         }
-        return null;
+        return "";
     }
 
     @Override

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -374,15 +374,15 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
                 if (storagePool.isPresent()) {
                     storage = (StoragePool)this.dataStoreMgr.getDataStore(storagePool.get().getId(), DataStoreRole.Primary);
                     s_logger.debug(String.format("VM [%s] has a preferred storage pool [%s]. Volume Orchestrator found this storage using Storage Pool Allocator [%s] and will"
-                            + " use it.", vm, storage, allocator));
+                            + " use it.", vm, storage, allocator.getClass().getSimpleName()));
                 } else {
                     storage = (StoragePool)dataStoreMgr.getDataStore(poolList.get(0).getId(), DataStoreRole.Primary);
                     s_logger.debug(String.format("VM [%s] does not have a preferred storage pool or it cannot be used. Volume Orchestrator will use the available Storage Pool"
-                            + " [%s], which was discovered using Storage Pool Allocator [%s].", vm, storage, allocator));
+                            + " [%s], which was discovered using Storage Pool Allocator [%s].", vm, storage, allocator.getClass().getSimpleName()));
                 }
                 return storage;
             }
-            s_logger.debug(String.format("Could not find any available Storage Pool using Storage Pool Allocator [%s].", allocator));
+            s_logger.debug(String.format("Could not find any available Storage Pool using Storage Pool Allocator [%s].", allocator.getClass().getSimpleName()));
         }
         s_logger.info("Volume Orchestrator could not find any available Storage Pool.");
         return null;

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.storage.allocator;
 import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -387,6 +388,11 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
             boolean bypassStorageTypeCheck){
         s_logger.trace(String.format("%s is looking for storage pools that match the VM's disk profile [%s], virtual machine profile [%s] and "
                 + "deployment plan [%s]. Returning up to [%d] and bypassStorageTypeCheck [%s].", this.getClass().getSimpleName(), dskCh, vmProfile, plan, returnUpTo, bypassStorageTypeCheck));
+    }
+
+    protected void logEndOfSearch(List<StoragePool> storagePoolList) {
+        s_logger.debug(String.format("%s is returning [%s] suitable storage pools [%s].", this.getClass().getSimpleName(), storagePoolList.size(),
+                Arrays.toString(storagePoolList.toArray())));
     }
 
 }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ClusterScopeStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ClusterScopeStoragePoolAllocator.java
@@ -107,7 +107,7 @@ public class ClusterScopeStoragePoolAllocator extends AbstractStoragePoolAllocat
             }
         }
 
-        s_logger.debug(String.format("ClusterScopeStoragePoolAllocator is returning [%s] suitable storage pools [%s].", suitablePools.size(), suitablePools));
+        logEndOfSearch(suitablePools);
 
         return suitablePools;
     }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/LocalStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/LocalStoragePoolAllocator.java
@@ -120,7 +120,7 @@ public class LocalStoragePoolAllocator extends AbstractStoragePoolAllocator {
                 avoid.addPool(pool.getId());
             }
         }
-        s_logger.debug(String.format("LocalStoragePoolAllocator returning [%s] suitable storage pools [%s].", suitablePools.size(), suitablePools));
+        logEndOfSearch(suitablePools);
 
         return suitablePools;
     }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ZoneWideStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/ZoneWideStoragePoolAllocator.java
@@ -102,7 +102,7 @@ public class ZoneWideStoragePoolAllocator extends AbstractStoragePoolAllocator {
                 }
             }
         }
-        LOGGER.debug(String.format("ZoneWideStoragePoolAllocator is returning [%s] suitable storage pools [%s].", suitablePools.size(), suitablePools));
+        logEndOfSearch(suitablePools);
 
         return suitablePools;
     }

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/PrimaryDataStoreImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/PrimaryDataStoreImpl.java
@@ -46,6 +46,7 @@ import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.volume.VolumeObject;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.to.DataObjectType;
@@ -463,5 +464,10 @@ public class PrimaryDataStoreImpl implements PrimaryDataStore {
             return this.parentStoragePool.getPoolType();
         }
         return null;
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "name", "uuid");
     }
 }

--- a/plugins/storage-allocators/random/src/main/java/org/apache/cloudstack/storage/allocator/RandomStoragePoolAllocator.java
+++ b/plugins/storage-allocators/random/src/main/java/org/apache/cloudstack/storage/allocator/RandomStoragePoolAllocator.java
@@ -73,7 +73,7 @@ public class RandomStoragePoolAllocator extends AbstractStoragePoolAllocator {
             }
         }
 
-        s_logger.debug(String.format("RandomStoragePoolAllocator is returning [%s] suitable storage pools [%s].", suitablePools.size(), suitablePools));
+        logEndOfSearch(suitablePools);
 
         return suitablePools;
     }


### PR DESCRIPTION
### Description

This PR fixes a NPE that occurs when trying to create a volume from a snapshot. This happens because when trying to log the `virtualMachineProfile` in the `AbstractStoragePoolAllocator#logStartOfSearch` method, its `toString()` method will throw a NPE since the `_vm` attribute is null.

Some `toString()`s were also created in classes that had objects being logged during the volume creation process, as they were being logged as memory addresses since they had no `toString()` implementation.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab, before this patch every time I tried to create a volume from a snapshot, a NPE was thrown. After the patch the volume creation from snapshot was fixed.
