### PR TITLE
Add option to define password during password reset

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
@@ -16,7 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.vm;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.vm;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -56,8 +57,7 @@ public class ResetVMPasswordCmd extends BaseAsyncCmd implements UserCmd {
             required=true, description="The ID of the virtual machine")
     private Long id;
 
-    // unexposed parameter needed for serializing/deserializing the command
-    @Parameter(name=ApiConstants.PASSWORD, type=CommandType.STRING, expose=false)
+    @Parameter(name=ApiConstants.PASSWORD, type=CommandType.STRING, description="The new password of the virtual machine. If null, a random password will be generated for the VM.")
     protected String password;
 
 
@@ -118,7 +118,14 @@ public class ResetVMPasswordCmd extends BaseAsyncCmd implements UserCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException {
-        password = _mgr.generateRandomPassword();
+        password = getPassword();
+        UserVm vm = _responseGenerator.findUserVmById(getId());
+        if (StringUtils.isBlank(password)) {
+            password = _mgr.generateRandomPassword();
+            s_logger.debug(String.format("Resetting VM [%s] password to a randomly generated password.", vm.getUuid()));
+        } else {
+            s_logger.debug(String.format("Resetting VM [%s] password to password defined by user.", vm.getUuid()));
+        }
         CallContext.current().setEventDetails("Vm Id: " + getId());
         UserVm result = _userVmService.resetVMPassword(this, password);
         if (result != null){

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
@@ -57,7 +57,7 @@ public class ResetVMPasswordCmd extends BaseAsyncCmd implements UserCmd {
             required=true, description="The ID of the virtual machine")
     private Long id;
 
-    @Parameter(name=ApiConstants.PASSWORD, type=CommandType.STRING, description="The new password of the virtual machine. If null, a random password will be generated for the VM.")
+    @Parameter(name=ApiConstants.PASSWORD, type=CommandType.STRING, description="The new password of the virtual machine. If null, a random password will be generated for the VM.", since="4.19.0")
     protected String password;
 
 

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -369,12 +369,29 @@ export default {
           label: 'label.action.reset.password',
           message: 'message.action.instance.reset.password',
           dataView: true,
+          args: ['id', 'password'],
           show: (record) => { return ['Stopped'].includes(record.state) && record.passwordenabled },
           response: (result) => {
             return {
               message: result.virtualmachine && result.virtualmachine.password ? `The password of VM <b>${result.virtualmachine.displayname}</b> is <b>${result.virtualmachine.password}</b>` : null,
               copybuttontext: result.virtualmachine.password ? 'label.copy.password' : null,
               copytext: result.virtualmachine.password ? result.virtualmachine.password : null
+            }
+          }
+          mapping: {
+            id: {
+              value: (record) => { return record.id }
+            }
+          },
+          successMethod: (obj, result) => {
+            const vm = result.jobresult.virtualmachine || {}
+            if (result.jobstatus === 1 && vm.password) {
+              const name = vm.displayname || vm.name || vm.id
+              obj.$notification.success({
+                message: `${obj.$t('label.action.reset.password')}`,
+                description: `The password of VM ${name} is ${vm.password}`,
+                duration: 0
+              })
             }
           }
         },

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -369,29 +369,13 @@ export default {
           label: 'label.action.reset.password',
           message: 'message.action.instance.reset.password',
           dataView: true,
-          args: ['id', 'password'],
+          args: ['password'],
           show: (record) => { return ['Stopped'].includes(record.state) && record.passwordenabled },
           response: (result) => {
             return {
               message: result.virtualmachine && result.virtualmachine.password ? `The password of VM <b>${result.virtualmachine.displayname}</b> is <b>${result.virtualmachine.password}</b>` : null,
               copybuttontext: result.virtualmachine.password ? 'label.copy.password' : null,
               copytext: result.virtualmachine.password ? result.virtualmachine.password : null
-            }
-          }
-          mapping: {
-            id: {
-              value: (record) => { return record.id }
-            }
-          },
-          successMethod: (obj, result) => {
-            const vm = result.jobresult.virtualmachine || {}
-            if (result.jobstatus === 1 && vm.password) {
-              const name = vm.displayname || vm.name || vm.id
-              obj.$notification.success({
-                message: `${obj.$t('label.action.reset.password')}`,
-                description: `The password of VM ${name} is ${vm.password}`,
-                duration: 0
-              })
             }
           }
         },


### PR DESCRIPTION
### Description

This PR allows users to define the password of a virtual machine when redefining the VM password (`resetPasswordForVirtualMachine` API). If no password is informed, current ACS behavior is maintained: a random password is generated, injected into the VM, and returned to the user. 


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots:
![screenshot](https://user-images.githubusercontent.com/82549714/199344313-204a11a3-59cf-49a4-b766-28dd4bc363ff.png)



### How Has This Been Tested?
I applied the changes in a local lab, called the `resetPasswordForVirtualMachine` API defining a password, and successfully accessed the VM with the password I have defined. Additionally, I called the `resetPasswordForVirtualMachine` API without defining a password, and successfully accessed the VM with the random password generated.