### PR TITLE
Allow ssvm agent certs to contain host IP for NAT situations

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/ca/CAManager.java
+++ b/api/src/main/java/org/apache/cloudstack/ca/CAManager.java
@@ -62,6 +62,11 @@ public interface CAManager extends CAService, Configurable, PluggableService {
             "true",
             "Enable automatic renewal and provisioning of certificate to agents as supported by the configured CA plugin.", true, ConfigKey.Scope.Cluster);
 
+    ConfigKey<Boolean> AllowHostIPInSysVMAgentCert = new ConfigKey<>("Advanced", Boolean.class,
+            "ca.framework.cert.systemvm.allow.host.ip",
+            "false",
+            "Allow hypervisor host's IP to be a part of a system VM's agent cert", true, ConfigKey.Scope.Zone);
+
     ConfigKey<Long> CABackgroundJobDelay = new ConfigKey<>("Advanced", Long.class,
             "ca.framework.background.task.delay",
             "3600",

--- a/core/src/main/java/com/cloud/agent/api/routing/NetworkElementCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/routing/NetworkElementCommand.java
@@ -39,6 +39,7 @@ public abstract class NetworkElementCommand extends Command {
     public static final String VPC_PRIVATE_GATEWAY = "vpc.gateway.private";
     public static final String FIREWALL_EGRESS_DEFAULT = "firewall.egress.default";
     public static final String NETWORK_PUB_LAST_IP = "network.public.last.ip";
+    public static final String HYPERVISOR_HOST_PRIVATE_IP = "hypervisor.private.ip";
 
     private String routerAccessIp;
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -992,6 +992,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         if (org.apache.commons.lang3.StringUtils.isNotEmpty(csr)) {
             final Map<String, String> ipAddressDetails = new HashMap<>(sshAccessDetails);
             ipAddressDetails.remove(NetworkElementCommand.ROUTER_NAME);
+            addHostIpToCertDetailsIfConfigAllows(vmHost, ipAddressDetails, CAManager.AllowHostIPInSysVMAgentCert);
             final Certificate certificate = caManager.issueCertificate(csr, Arrays.asList(vm.getHostName(), vm.getInstanceName()),
                     new ArrayList<>(ipAddressDetails.values()), CAManager.CertValidityPeriod.value(), null);
             final boolean result = caManager.deployCertificate(vmHost, certificate, false, sshAccessDetails);
@@ -1000,6 +1001,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             }
         } else {
             s_logger.error("Failed to setup keystore and generate CSR for system vm: " + vm.getInstanceName());
+        }
+    }
+
+    protected void addHostIpToCertDetailsIfConfigAllows(Host vmHost, Map<String, String> ipAddressDetails, ConfigKey<Boolean> configKey) {
+        if (configKey.valueIn(vmHost.getDataCenterId())) {
+            ipAddressDetails.put(NetworkElementCommand.HYPERVISOR_HOST_PRIVATE_IP, vmHost.getPrivateIpAddress());
         }
     }
 

--- a/server/src/main/java/org/apache/cloudstack/ca/CAManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/ca/CAManagerImpl.java
@@ -432,6 +432,6 @@ public class CAManagerImpl extends ManagerBase implements CAManager {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {CAProviderPlugin, CertKeySize, CertSignatureAlgorithm, CertValidityPeriod, AutomaticCertRenewal, CABackgroundJobDelay, CertExpiryAlertPeriod};
+        return new ConfigKey<?>[] {CAProviderPlugin, CertKeySize, CertSignatureAlgorithm, CertValidityPeriod, AutomaticCertRenewal, AllowHostIPInSysVMAgentCert, CABackgroundJobDelay, CertExpiryAlertPeriod};
     }
 }


### PR DESCRIPTION
### Description

There are some networking setups where system VM communications are proxied off of the hypervisor host on which the system VM is running. For example, if the KVM management network is a NAT bridge, or the network plugin employs user mode network for system VM management interfaces, then system VM agent comms look as though they come form the hypervisor host. Admittedly, these configurations are bespoke, which is why a configuration is provided and it's disabled by default.

In such a setup, the certificate authentication for agents fails because the source IP is that of the host of the system VM, rather than the system VM itself, and this IP is not in the connecting certificate presented. This PR adds a configuration value that allows the system VM cert to contain the host IP that the system VM is scheduled on. This allows such setups to maintain auth strictness on agent auth.
### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### How Has This Been Tested?
Tested this via unit tests, and in our private integration environment. When ca.framework.cert.systemvm.allow.host.ip is set, agent auth succeeds from system VMs, when unset, it fails as it did prior to this change.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
