### PR TITLE
Set root volume as destroyed when destroying a VM

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -146,4 +146,5 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
      * @return the list of volumes that uses that disk offering.
      */
     List<VolumeVO> findByDiskOfferingId(long diskOfferingId);
+    VolumeVO getInstanceRootVolume(long instanceId, String instanceUuid);
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -146,5 +146,5 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
      * @return the list of volumes that uses that disk offering.
      */
     List<VolumeVO> findByDiskOfferingId(long diskOfferingId);
-    VolumeVO getInstanceRootVolume(long instanceId, String instanceUuid);
+    VolumeVO getInstanceRootVolume(long instanceId);
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -759,4 +759,11 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
             throw new CloudRuntimeException(e);
         }
     }
+    @Override
+    public VolumeVO getInstanceRootVolume(long instanceId, String instanceUuid) {
+        SearchCriteria<VolumeVO> sc = RootDiskStateSearch.create();
+        sc.setParameters("instanceId", instanceId);
+        sc.setParameters("vType", Volume.Type.ROOT);
+        return findOneBy(sc);
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -760,7 +760,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
         }
     }
     @Override
-    public VolumeVO getInstanceRootVolume(long instanceId, String instanceUuid) {
+    public VolumeVO getInstanceRootVolume(long instanceId) {
         SearchCriteria<VolumeVO> sc = RootDiskStateSearch.create();
         sc.setParameters("instanceId", instanceId);
         sc.setParameters("vType", Volume.Type.ROOT);

--- a/server/src/main/java/com/cloud/vm/UserVmManager.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManager.java
@@ -56,7 +56,7 @@ public interface UserVmManager extends UserVmService {
             "Set display of VMs OVF properties as part of VM details", true);
 
     ConfigKey<Boolean> DestroyRootVolumeOnVmDestruction = new ConfigKey<Boolean>("Advanced", Boolean.class, "destroy.root.volume.on.vm.destruction", "false",
-            "Destroys the VM's root volume when the VM is destroyed. When set to true, volume cleanup task will not expunge destroyed volumes, but the VM cleanup task will.",
+            "Destroys the VM's root volume when the VM is destroyed.",
             true, ConfigKey.Scope.Domain);
 
     static final int MAX_USER_DATA_LENGTH_BYTES = 2048;

--- a/server/src/main/java/com/cloud/vm/UserVmManager.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManager.java
@@ -55,6 +55,10 @@ public interface UserVmManager extends UserVmService {
     ConfigKey<Boolean> DisplayVMOVFProperties = new ConfigKey<Boolean>("Advanced", Boolean.class, "vm.display.ovf.properties", "false",
             "Set display of VMs OVF properties as part of VM details", true);
 
+    ConfigKey<Boolean> DestroyRootVolumeOnVmDestruction = new ConfigKey<Boolean>("Advanced", Boolean.class, "destroy.root.volume.on.vm.destruction", "false",
+            "Destroys the VM's root volume when the VM is destroyed. When set to true, volume cleanup task will not expunge destroyed volumes, but the VM cleanup task will.",
+            true, ConfigKey.Scope.Domain);
+
     static final int MAX_USER_DATA_LENGTH_BYTES = 2048;
 
     public  static  final String CKS_NODE = "cksnode";
@@ -133,5 +137,7 @@ public interface UserVmManager extends UserVmService {
     HashMap<Long, List<VmNetworkStatsEntry>> getVmNetworkStatistics(long hostId, String hostName, List<Long> vmIds);
 
     boolean checkIfDynamicScalingCanBeEnabled(VirtualMachine vm, ServiceOffering offering, VirtualMachineTemplate template, Long zoneId);
+
+    Boolean getDestroyRootVolumeOnVmDestruction(Long domainId);
 
 }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3326,7 +3326,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         deleteVolumesFromVm(volumesToBeDeleted, expunge);
 
         if (getDestroyRootVolumeOnVmDestruction(vm.getDomainId())) {
-            VolumeVO rootVolume = _volsDao.getInstanceRootVolume(vm.getId(), vm.getUuid());
+            VolumeVO rootVolume = _volsDao.getInstanceRootVolume(vm.getId());
             if (rootVolume != null) {
                 _volService.destroyVolume(rootVolume.getId());
             } else {

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.vm;
 
+import com.cloud.storage.Volume;
+import com.cloud.storage.dao.VolumeDao;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -165,6 +167,12 @@ public class UserVmManagerImplTest {
 
     @Mock
     UserDataDao userDataDao;
+
+    @Mock
+    private VolumeVO volumeVOMock;
+
+    @Mock
+    private VolumeDao volumeDaoMock;
 
     private long vmId = 1l;
 
@@ -855,5 +863,15 @@ public class UserVmManagerImplTest {
 
         Assert.assertEquals("testUserdata", userVmVO.getUserData());
         Assert.assertEquals(1L, (long)userVmVO.getUserDataId());
+    }
+
+    @Test
+    public void recoverRootVolumeTestDestroyState() {
+        Mockito.doReturn(Volume.State.Destroy).when(volumeVOMock).getState();
+
+        userVmManagerImpl.recoverRootVolume(volumeVOMock, vmId);
+
+        Mockito.verify(volumeApiService).recoverVolume(volumeVOMock.getId());
+        Mockito.verify(volumeDaoMock).attachVolume(volumeVOMock.getId(), vmId, UserVmManagerImpl.ROOT_DEVICE_ID);
     }
 }


### PR DESCRIPTION
### Description

When a user removes a VM, ACS puts it in a `Destroy` state and stops counting it towards the user resource limit. However, the VM root volume remains in `Ready` state and consuming resources until the VM cleanup task runs on ACS. 

The `destroy.root.volume.on.vm.destruction` setting was created so that when it is set to true, when destroying a VM its root volume will also be placed in the `Destroy` state, no longer counting towards the user resource limit.

Also, while this setting is active, root volumes in the destroy state will not be removed by the ACS volume cleanup task, so that it is possible to restore the VM again. However, the VM cleanup task will still remove the VMs along with their respective volumes.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab.
| Nº | Test | Result |
| ------ | ------ | ------ |
|1| With the setting disabled, a VM was destroyed | the VM was in `Destroy` state and its root volume in `Ready` |
|2| With the setting enabled, a VM was destroyed | the VM was in `Destroy` state and its root volume in `Destroy` too |
|3| With the setting enabled, the test 2 VM was restored | The VM was correctly restored along with its root volume |
|4| Test 1 VM was restored | The VM was correctly restored |
|5| With the setting enabled, the test 3 VM was destroyed, its volume restored, and then the VM restored | When the volume was restored, it became `DATADISK` type (since it is detached when being recovered), then the VM was restored, the volume was reattached and the VM worked correctly |
|6| With the setting enabled, a VM was destroyed, and the cleanup task had its interval shortened | The cleanup task did not purge ROOT volume from VM |
|7| With the setting disabled, and with a ROOT volume in `Destroy` state the cleanup task had its interval shortened | ROOT volume was purged |
