### PR TITLE
Support for parameter `cidrlist` added to the UI

### DIFF
--- a/ui/src/components/view/BulkActionProgress.vue
+++ b/ui/src/components/view/BulkActionProgress.vue
@@ -80,6 +80,9 @@
         <template #vm="{record}">
           <div><desktop-outlined /> {{ record.virtualmachinename }} ({{ record.vmguestip }})</div>
         </template>
+        <template #cidrlist="{ record }">
+          <span style="white-space: pre-line"> {{ record.cidrlist.replaceAll(" ", "\n") }}</span>
+        </template>
       </a-table>
       <br/>
     </div>

--- a/ui/src/components/view/BulkActionView.vue
+++ b/ui/src/components/view/BulkActionView.vue
@@ -82,6 +82,9 @@
           <template #endport="{record}">
             {{ record.icmpcode || record.endport >= 0 ? record.icmpcode || record.endport : $t('label.all') }}
           </template>
+          <template #cidrlist="{record}">
+            <span style="white-space: pre-line"> {{ record.cidrlist.replaceAll(" ", "\n") }}</span>
+          </template>
         </a-table>
         <a-divider />
         <br/>
@@ -149,12 +152,6 @@ export default {
       default: () => {}
     }
   },
-  filters: {
-    capitalise: val => {
-      if (val === 'all') return 'All'
-      return val.toUpperCase()
-    }
-  },
   inject: ['parentFetchData'],
   data () {
     return {
@@ -164,6 +161,10 @@ export default {
     }
   },
   methods: {
+    capitalise (val) {
+      if (val === 'all') return 'All'
+      return val.toUpperCase()
+    },
     handleCancel () {
       this.$emit('handle-cancel')
     },

--- a/ui/src/components/widgets/TooltipLabel.vue
+++ b/ui/src/components/widgets/TooltipLabel.vue
@@ -17,7 +17,12 @@
 
 <template>
   <span>
-    {{ title }}
+    <b v-if="bold">
+      {{ title }}
+    </b>
+    <span v-else>
+      {{ title }}
+    </span>
     <a-tooltip v-if="tooltip" :title="tooltip" :placement="tooltipPlacement">
       <info-circle-outlined class="tooltip-icon" />
     </a-tooltip>
@@ -40,7 +45,8 @@ export default {
     tooltipPlacement: {
       type: String,
       default: 'top'
-    }
+    },
+    bold: Boolean
   }
 }
 </script>

--- a/ui/src/views/network/LoadBalancing.vue
+++ b/ui/src/views/network/LoadBalancing.vue
@@ -36,6 +36,10 @@
         </div>
       </div>
       <div class="form">
+        <div class="form__item" ref="newCidrList">
+          <tooltip-label :title="$t('label.cidrlist')" bold :tooltip="createLoadBalancerRuleParams.cidrlist.description" :tooltip-placement="'right'"/>
+          <a-input v-model:value="newRule.cidrlist"></a-input>
+        </div>
         <div class="form__item">
           <div class="form__label">{{ $t('label.algorithm') }}</div>
           <a-select
@@ -93,6 +97,9 @@
       :pagination="false"
       :rowSelection="{selectedRowKeys: selectedRowKeys, onChange: onSelectChange}"
       :rowKey="record => record.id">
+      <template #cidrlist="{ record }">
+        <span style="white-space: pre-line"> {{ record.cidrlist.replaceAll(" ", "\n") }}</span>
+      </template>
       <template #algorithm="{ record }">
         {{ returnAlgorithmName(record.algorithm) }}
       </template>
@@ -500,6 +507,7 @@ import Status from '@/components/widgets/Status'
 import TooltipButton from '@/components/widgets/TooltipButton'
 import BulkActionView from '@/components/view/BulkActionView'
 import eventBus from '@/config/eventBus'
+import TooltipLabel from '@/components/widgets/TooltipLabel'
 
 export default {
   name: 'LoadBalancing',
@@ -507,7 +515,8 @@ export default {
   components: {
     Status,
     TooltipButton,
-    BulkActionView
+    BulkActionView,
+    TooltipLabel
   },
   props: {
     resource: {
@@ -554,7 +563,8 @@ export default {
         publicport: '',
         protocol: 'tcp',
         virtualmachineid: [],
-        vmguestip: []
+        vmguestip: [],
+        cidrlist: ''
       },
       addVmModalVisible: false,
       addVmModalLoading: false,
@@ -576,6 +586,10 @@ export default {
         {
           title: this.$t('label.privateport'),
           dataIndex: 'privateport'
+        },
+        {
+          title: this.$t('label.cidrlist'),
+          slots: { customRender: 'cidrlist' }
         },
         {
           title: this.$t('label.algorithm'),
@@ -647,6 +661,9 @@ export default {
     hasSelected () {
       return this.selectedRowKeys.length > 0
     }
+  },
+  beforeCreate () {
+    this.createLoadBalancerRuleParams = this.$getApiParams('createLoadBalancerRule')
   },
   created () {
     this.initForm()
@@ -1321,7 +1338,8 @@ export default {
         name: this.newRule.name,
         privateport: this.newRule.privateport,
         protocol: this.newRule.protocol,
-        publicport: this.newRule.publicport
+        publicport: this.newRule.publicport,
+        cidrlist: this.newRule.cidrlist
       }).then(response => {
         this.addVmModalVisible = false
         this.handleAssignToLBRule(response.createloadbalancerruleresponse.id)


### PR DESCRIPTION
### Description

PR #6460 reimplemented the `cidrlist` in API `createLoadBalancerRule`; However, this parameter was not implemented in the UI. This PRs intends to implement the `cidrlist` field in the create load balancer rule form.

This PR also fixes the `BulkActionView.vue`, which currently throws an exception when used.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/48719461/199739305-d9de9460-3a63-40fa-9336-3f9a4034c473.png)


### How Has This Been Tested?
This was tested in a local lab, by running `npm run serve` and creating/deleting load balancer rules with `cidrlists`. The BulkActionView was also tested: before this change it was throwing an exception and was not opening the form. After the changes, it worked fine.