### PR TITLE
kvm: correctly set vm cpu topology

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2629,7 +2629,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (VirtualMachine.Type.User.equals(vmTO.getType())) {
             cmd.setFeatures(_cpuFeatures);
         }
-        setCpuTopology(cmd, vcpus, vmTO.getDetails());
+        int vCpusInDef = vmTO.getVcpuMaxLimit() == null ? vcpus : vmTO.getVcpuMaxLimit();
+        setCpuTopology(cmd, vCpusInDef, vmTO.getDetails());
         return cmd;
     }
 
@@ -4706,7 +4707,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return false;
     }
 
-    private void setCpuTopology(CpuModeDef cmd, int vcpus, Map<String, String> details) {
+    private void setCpuTopology(CpuModeDef cmd, int vCpusInDef, Map<String, String> details) {
         if (!enableManuallySettingCpuTopologyOnKvmVm) {
             s_logger.debug(String.format("Skipping manually setting CPU topology on VM's XML due to it is disabled in agent.properties {\"property\": \"%s\", \"value\": %s}.",
               AgentProperties.ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM.getName(), enableManuallySettingCpuTopologyOnKvmVm));
@@ -4717,19 +4718,19 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (details != null) {
             final String coresPerSocket = details.get(VmDetailConstants.CPU_CORE_PER_SOCKET);
             final int intCoresPerSocket = NumbersUtil.parseInt(coresPerSocket, numCoresPerSocket);
-            if (intCoresPerSocket > 0 && vcpus % intCoresPerSocket == 0) {
+            if (intCoresPerSocket > 0 && vCpusInDef % intCoresPerSocket == 0) {
                 numCoresPerSocket = intCoresPerSocket;
             }
         }
         if (numCoresPerSocket <= 0) {
-            if (vcpus % 6 == 0) {
+            if (vCpusInDef % 6 == 0) {
                 numCoresPerSocket = 6;
-            } else if (vcpus % 4 == 0) {
+            } else if (vCpusInDef % 4 == 0) {
                 numCoresPerSocket = 4;
             }
         }
         if (numCoresPerSocket > 0) {
-            cmd.setTopology(numCoresPerSocket, vcpus / numCoresPerSocket);
+            cmd.setTopology(numCoresPerSocket, vCpusInDef / numCoresPerSocket);
         }
     }
 


### PR DESCRIPTION
### Description

Fixes: #6807

When a custom offering is used max vCPU value may differ from the actual vCPU value therefore while applying CPU topology correct value must be used.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
Using a custom constrained offering with CPU range 1-6 and VM deployed with CPU=4
```
> list serviceofferings id=bbe6c987-b609-42ab-a6a6-9268d8bd35a7 
{
  "count": 1,
  "serviceoffering": [
    {
      "cacheMode": "none",
      "cpuspeed": 1000,
      "created": "2022-11-04T07:20:41+0000",
      "defaultuse": false,
      "diskofferingstrictness": false,
      "displaytext": "CustomConstrained",
      "dynamicscalingenabled": true,
      "hasannotations": false,
      "id": "bbe6c987-b609-42ab-a6a6-9268d8bd35a7",
      "iscustomized": true,
      "issystem": false,
      "isvolatile": false,
      "limitcpuuse": false,
      "name": "CustomConstrained",
      "offerha": false,
      "provisioningtype": "thin",
      "rootdisksize": 0,
      "serviceofferingdetails": {
        "maxcpunumber": "6",
        "maxmemory": "4096",
        "mincpunumber": "1",
        "minmemory": "512"
      },
      "storagetype": "shared"
    }
  ]
}
```

Without changes error is seen,
```
2022-11-04 08:47:16,533 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:816a51ed) Manually setting CPU topology on VM's XML, vcpu: 4
2022-11-04 08:47:16,533 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:816a51ed) Manually setting CPU topology on VM's XML, numCoresPerSocket: 4, sockets: 1
2022-11-04 08:47:16,541 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:816a51ed) Passed custom disk controller for ROOT disk osdefault
2022-11-04 08:47:16,541 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:816a51ed) Looking for libvirtd connection at: qemu:///system
2022-11-04 08:47:16,542 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Trying to fetch storage pool a02c01cc-8e7c-31cf-8f83-7859fedeb6cc from libvirt
2022-11-04 08:47:16,542 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:816a51ed) Looking for libvirtd connection at: qemu:///system
2022-11-04 08:47:16,546 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Successfully refreshed pool a02c01cc-8e7c-31cf-8f83-7859fedeb6cc Capacity: (1.9685 TB) 2164374110208 Used: (117.16 GB) 125803950080 Available: (1.8541 TB) 2038570160128
2022-11-04 08:47:16,547 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Could not find volume 1164448a-d91f-4b44-b30b-efffc92b9be6: Storage volume not found: no storage vol with matching name '1164448a-d91f-4b44-b30b-efffc92b9be6'
2022-11-04 08:47:16,548 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Refreshing storage pool a02c01cc-8e7c-31cf-8f83-7859fedeb6cc
2022-11-04 08:47:16,553 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Found volume 1164448a-d91f-4b44-b30b-efffc92b9be6 in storage pool a02c01cc-8e7c-31cf-8f83-7859fedeb6cc after refreshing the pool
2022-11-04 08:47:16,556 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:816a51ed) Looking for libvirtd connection at: qemu:///system
2022-11-04 08:47:16,557 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:816a51ed) Executing: qemu-img info -U /mnt/a02c01cc-8e7c-31cf-8f83-7859fedeb6cc/1164448a-d91f-4b44-b30b-efffc92b9be6 
2022-11-04 08:47:16,558 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:816a51ed) Executing while with timeout : 3600000
2022-11-04 08:47:16,562 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:816a51ed) Execution is successful.
2022-11-04 08:47:16,562 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:816a51ed) Passed custom disk controller for ROOT disk osdefault
2022-11-04 08:47:16,563 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:816a51ed) Passed custom disk controller for ROOT disk osdefault
2022-11-04 08:47:16,563 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Trying to fetch storage pool a02c01cc-8e7c-31cf-8f83-7859fedeb6cc from libvirt
2022-11-04 08:47:16,563 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:816a51ed) Looking for libvirtd connection at: qemu:///system
2022-11-04 08:47:16,567 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:816a51ed) Successfully refreshed pool a02c01cc-8e7c-31cf-8f83-7859fedeb6cc Capacity: (1.9685 TB) 2164374110208 Used: (117.19 GB) 125829120000 Available: (1.8540 TB) 2038544990208
2022-11-04 08:47:16,567 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-5:null) (logid:816a51ed) nic=[Nic:Guest-null-vlan://1338]
2022-11-04 08:47:16,567 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-5:null) (logid:816a51ed) creating a vNet dev and bridge for guest traffic per traffic label cloudbr1
2022-11-04 08:47:16,568 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-5:null) (logid:816a51ed) Executing: /usr/share/cloudstack-common/scripts/vm/network/vnet/modifyvlan.sh -v 1338 -p eth1 -b breth1-1338 -o add 
2022-11-04 08:47:16,568 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-5:null) (logid:816a51ed) Executing while with timeout : 1800000
2022-11-04 08:47:16,603 DEBUG [kvm.resource.BridgeVifDriver] (agentRequest-Handler-5:null) (logid:816a51ed) Execution is successful.
2022-11-04 08:47:16,614 DEBUG [resource.wrapper.LibvirtStartCommandWrapper] (agentRequest-Handler-5:null) (logid:816a51ed) starting i-2-7-VM: <domain type='kvm'>
<name>i-2-7-VM</name>
<uuid>4670a80a-9857-4104-8148-2348cd1fc8ba</uuid>
<description>Other Linux (64-bit)</description>
<cpu><topology sockets='1' cores='4' threads='1' /></cpu><sysinfo type='smbios'>
<system>
<entry name='manufacturer'>Apache Software Foundation</entry>
<entry name='product'>CloudStack KVM Hypervisor</entry>
<entry name='uuid'>4670a80a-9857-4104-8148-2348cd1fc8ba</entry>
</system>
</sysinfo>
<os>
<type  arch='x86_64' machine='pc'>hvm</type>
<boot dev='cdrom'/>
<boot dev='hd'/>
<smbios mode='sysinfo'/>
</os>
<on_reboot>restart</on_reboot>
<on_poweroff>destroy</on_poweroff>
<on_crash>destroy</on_crash>
<memory>2097152</memory>
<currentMemory>2097152</currentMemory>
<maxMemory slots='16' unit='KiB'>4194304</maxMemory>
<cpu> <numa> <cell id='0' cpus='0-5' memory='2097152' unit='KiB'/> </numa> </cpu>
<devices>
<memballoon model='virtio'/>
</devices>
<vcpu current="4">6</vcpu>
<features>
<pae/>
<apic/>
<acpi/>
</features>
<cputune>
<shares>2000</shares>
</cputune>
<clock offset='utc'>
</clock>
<devices>
<emulator></emulator>
<watchdog model='i6300esb' action='none'/>
<console type='pty'>
<target port='0'/>
</console>
<disk  device='disk' type='file'>
<driver name='qemu' type='qcow2' cache='none' />
<source file='/mnt/a02c01cc-8e7c-31cf-8f83-7859fedeb6cc/1164448a-d91f-4b44-b30b-efffc92b9be6'/>
<target dev='hda' bus='ide'/>
<serial>1164448ad91f4b44b30b</serial></disk>
<disk  device='cdrom' type='file'>
<driver name='qemu' type='raw' />
<source file=''/>
<target dev='hdc' bus='ide'/>
</disk>
<serial type='pty'>
<target port='0'/>
</serial>
<graphics type='vnc' autoport='yes' listen='10.1.35.156' passwd='AgnwUip3'/>
<channel type='unix'>
<source mode='bind' path='/var/lib/libvirt/qemu/i-2-7-VM.org.qemu.guest_agent.0'/>
<address type='virtio-serial'/>
<target type='virtio' name='org.qemu.guest_agent.0'/>
</channel>
<input type='tablet' bus='usb'/>
<interface type='bridge'>
<source bridge='breth1-1338'/>
<mac address='02:00:75:25:00:05'/>
<model type='e1000'/>
<bandwidth>
<inbound average='25600' peak='25600'/>
<outbound average='25600' peak='25600'/>
</bandwidth>
<link state='up'/>
</interface>
</devices>
</domain>

2022-11-04 08:47:16,616 WARN  [kvm.resource.LibvirtKvmAgentHook] (agentRequest-Handler-5:null) (logid:816a51ed) Groovy script '/etc/cloudstack/agent/hooks/libvirt-vm-xml-transformer.groovy' is not available. Transformations will not be applied.
2022-11-04 08:47:16,616 WARN  [kvm.resource.LibvirtKvmAgentHook] (agentRequest-Handler-5:null) (logid:816a51ed) Groovy scripting engine is not initialized. Data transformation skipped.
2022-11-04 08:47:16,618 WARN  [resource.wrapper.LibvirtStartCommandWrapper] (agentRequest-Handler-5:null) (logid:816a51ed) LibvirtException 
org.libvirt.LibvirtException: unsupported configuration: CPU topology doesn't match maximum vcpu count
	at org.libvirt.ErrorHandler.processError(Unknown Source)
	at org.libvirt.ErrorHandler.processError(Unknown Source)
	at org.libvirt.Connect.domainCreateXML(Unknown Source)
	at com.cloud.hypervisor.kvm.resource.LibvirtComputingResource.startVM(LibvirtComputingResource.java:1799)
	at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtStartCommandWrapper.execute(LibvirtStartCommandWrapper.java:89)
	at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtStartCommandWrapper.execute(LibvirtStartCommandWrapper.java:49)
	at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtRequestWrapper.execute(LibvirtRequestWrapper.java:78)
	at com.cloud.hypervisor.kvm.resource.LibvirtComputingResource.executeRequest(LibvirtComputingResource.java:1831)
	at com.cloud.agent.Agent.processRequest(Agent.java:660)
	at com.cloud.agent.Agent$AgentRequestHandler.doTask(Agent.java:1080)
	at com.cloud.utils.nio.Task.call(Task.java:83)
	at com.cloud.utils.nio.Task.call(Task.java:29)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

```

With changes, VM deployment work okay,
```
2022-11-04 09:18:19,418 DEBUG [resource.wrapper.LibvirtStartCommandWrapper] (agentRequest-Handler-3:null) (logid:755656be) starting i-2-8-VM: <domain type='kvm'>
<name>i-2-8-VM</name>
<uuid>c59796a0-5bc7-49f2-91a4-8bc88c8a42c5</uuid>
<description>Other Linux (64-bit)</description>
<cpu><topology sockets='1' cores='6' threads='1' /></cpu><sysinfo type='smbios'>
<system>
<entry name='manufacturer'>Apache Software Foundation</entry>
<entry name='product'>CloudStack KVM Hypervisor</entry>
<entry name='uuid'>c59796a0-5bc7-49f2-91a4-8bc88c8a42c5</entry>
</system>
</sysinfo>
<os>
<type  arch='x86_64' machine='pc'>hvm</type>
<boot dev='cdrom'/>
<boot dev='hd'/>
<smbios mode='sysinfo'/>
</os>
<on_reboot>restart</on_reboot>
<on_poweroff>destroy</on_poweroff>
<on_crash>destroy</on_crash>
<memory>2146304</memory>
<currentMemory>2146304</currentMemory>
<maxMemory slots='16' unit='KiB'>4194304</maxMemory>
<cpu> <numa> <cell id='0' cpus='0-5' memory='2146304' unit='KiB'/> </numa> </cpu>
<devices>
<memballoon model='virtio'/>
</devices>
<vcpu current="4">6</vcpu>
<features>
<pae/>
<apic/>
<acpi/>
</features>
<cputune>
<shares>2000</shares>
</cputune>
<clock offset='utc'>
</clock>
<devices>
<emulator></emulator>
<watchdog model='i6300esb' action='none'/>
<console type='pty'>
<target port='0'/>
</console>
<disk  device='disk' type='file'>
<driver name='qemu' type='qcow2' cache='none' />
<source file='/mnt/a02c01cc-8e7c-31cf-8f83-7859fedeb6cc/ddd05d24-63d9-4f77-8c3a-48f3175dc862'/>
<target dev='hda' bus='ide'/>
<serial>ddd05d2463d94f778c3a</serial></disk>
<disk  device='cdrom' type='file'>
<driver name='qemu' type='raw' />
<source file=''/>
<target dev='hdc' bus='ide'/>
</disk>
<serial type='pty'>
<target port='0'/>
</serial>
<graphics type='vnc' autoport='yes' listen='10.1.35.156' passwd='Rq1gXkBI'/>
<channel type='unix'>
<source mode='bind' path='/var/lib/libvirt/qemu/i-2-8-VM.org.qemu.guest_agent.0'/>
<address type='virtio-serial'/>
<target type='virtio' name='org.qemu.guest_agent.0'/>
</channel>
<input type='tablet' bus='usb'/>
<interface type='bridge'>
<source bridge='breth1-1338'/>
<mac address='02:00:28:1e:00:06'/>
<model type='e1000'/>
<bandwidth>
<inbound average='25600' peak='25600'/>
<outbound average='25600' peak='25600'/>
</bandwidth>
<link state='up'/>
</interface>
</devices>
</domain>

2022-11-04 09:18:19,565 WARN  [kvm.resource.LibvirtKvmAgentHook] (agentRequest-Handler-3:null) (logid:755656be) Groovy script '/etc/cloudstack/agent/hooks/libvirt-vm-xml-transformer.groovy' is not available. Transformations will not be applied.
2022-11-04 09:18:19,565 WARN  [kvm.resource.LibvirtKvmAgentHook] (agentRequest-Handler-3:null) (logid:755656be) Groovy scripting engine is not initialized. Data transformation skipped.
2022-11-04 09:18:20,113 WARN  [kvm.resource.LibvirtKvmAgentHook] (agentRequest-Handler-3:null) (logid:755656be) Groovy script '/etc/cloudstack/agent/hooks/libvirt-vm-state-change.groovy' is not available. Transformations will not be applied.
2022-11-04 09:18:20,113 WARN  [kvm.resource.LibvirtKvmAgentHook] (agentRequest-Handler-3:null) (logid:755656be) Groovy scripting engine is not initialized. Data transformation skipped.
2022-11-04 09:18:20,113 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-3:null) (logid:755656be) Checking default network rules for vm i-2-8-VM
2022-11-04 09:18:20,125 DEBUG [cloud.agent.Agent] (agentRequest-Handler-3:null) (logid:755656be) Seq 2-128634064356769805:  { Ans: , MgmtId: 32987060111733, via: 2, Ver: v1, Flags: 10, [{"com.cloud.agent.api.StartAnswer":{"vm":{"id":"8","name":"i-2-8-VM","state":"Starting","type":"User","cpus":"4","minSpeed":"500","maxSpeed":"1000","minRam":"(2.05 GB) 2197815296","maxRam":"(4.00 GB) 4294967296","arch":"x86_64","os":"Other Linux (64-bit)","platformEmulator":"Other Linux","bootArgs":"","enableHA":"false","limitCpuUse":"false","enableDynamicallyScaleVm":"true","vncPassword":"Rq1gXkBImi2baAC2zT9e8w","vncAddr":"10.1.35.156","params":{"cpuNumber":"4","deployvm":"true","memory":"2096","memoryOvercommitRatio":"1.0","Message.ReservedCapacityFreed.Flag":"false","cpuOvercommitRatio":"2.0","rootDiskController":"osdefault"},"uuid":"c59796a0-5bc7-49f2-91a4-8bc88c8a42c5","enterHardwareSetup":"false","disks":[{"data":{"org.apache.cloudstack.storage.to.VolumeObjectTO":{"uuid":"ddd05d24-63d9-4f77-8c3a-48f3175dc862","volumeType":"ROOT","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"a02c01cc-8e7c-31cf-8f83-7859fedeb6cc","name":"ref-trl-3660-k-M7-abhishek-kumar-kvm-pri1","id":"1","poolType":"NetworkFilesystem","host":"10.1.32.4","path":"/acs/primary/ref-trl-3660-k-M7-abhishek-kumar/ref-trl-3660-k-M7-abhishek-kumar-kvm-pri1","port":"2049","url":"NetworkFilesystem://10.1.32.4/acs/primary/ref-trl-3660-k-M7-abhishek-kumar/ref-trl-3660-k-M7-abhishek-kumar-kvm-pri1/?ROLE=Primary&STOREUUID=a02c01cc-8e7c-31cf-8f83-7859fedeb6cc","isManaged":"false"}},"name":"ROOT-8","size":"(50.00 MB) 52428800","path":"ddd05d24-63d9-4f77-8c3a-48f3175dc862","volumeId":"8","vmName":"i-2-8-VM","accountId":"2","format":"QCOW2","provisioningType":"THIN","poolId":"1","id":"8","deviceId":"0","bytesReadRate":"(0 bytes) 0","bytesWriteRate":"(0 bytes) 0","iopsReadRate":"(0 bytes) 0","iopsWriteRate":"(0 bytes) 0","cacheMode":"NONE","hypervisorType":"KVM","directDownload":"false","deployAsIs":"false"}},"diskSeq":"0","path":"ddd05d24-63d9-4f77-8c3a-48f3175dc862","type":"ROOT","_details":{"storageHost":"10.1.32.4","managed":"false","storagePort":"2049","storage.pool.disk.wait":"60","volumeSize":"(50.00 MB) 52428800"}},{"data":{"org.apache.cloudstack.storage.to.TemplateObjectTO":{"id":"0","format":"ISO","accountId":"0","hvm":"false","bootable":"false","directDownload":"false","deployAsIs":"false"}},"diskSeq":"3","type":"ISO"}],"nics":[{"deviceId":"0","networkRateMbps":"200","defaultNic":"true","pxeDisable":"false","nicUuid":"65f2a4aa-8e3f-4e18-9411-2d79abe016dd","details":{"MacAddressChanges":"true","ForgedTransmits":"true","PromiscuousMode":"false","MacLearning":"false"},"dpdkEnabled":"false","uuid":"09a0f9b8-b309-4875-ae7c-106125854224","mac":"02:00:28:1e:00:06","dns1":"10.1.32.1","dns2":"8.8.8.8","broadcastType":"Vlan","type":"Guest","broadcastUri":"vlan://1338","isolationUri":"vlan://1338","isSecurityGroupEnabled":"false","name":"cloudbr1"}],"vcpuMaxLimit":"6","configDriveLocation":"SECONDARY","guestOsDetails":{},"extraConfig":{}},"result":"true","wait":"0","bypassHostMaintenance":"false"}}] }

```

VM successfully deployed with the following XML def,
```
# virsh dumpxml i-2-8-VM
<domain type='kvm' id='3'>
  <name>i-2-8-VM</name>
  <uuid>c59796a0-5bc7-49f2-91a4-8bc88c8a42c5</uuid>
  <description>Other Linux (64-bit)</description>
  <maxMemory slots='16' unit='KiB'>4194304</maxMemory>
  <memory unit='KiB'>2146304</memory>
  <currentMemory unit='KiB'>2146304</currentMemory>
  <vcpu placement='static' current='4'>6</vcpu>
  <cputune>
    <shares>2000</shares>
  </cputune>
  <resource>
    <partition>/machine</partition>
  </resource>
  <sysinfo type='smbios'>
    <system>
      <entry name='manufacturer'>Apache Software Foundation</entry>
      <entry name='product'>CloudStack KVM Hypervisor</entry>
      <entry name='uuid'>c59796a0-5bc7-49f2-91a4-8bc88c8a42c5</entry>
    </system>
  </sysinfo>
  <os>
    <type arch='x86_64' machine='pc-i440fx-4.2'>hvm</type>
    <boot dev='cdrom'/>
    <boot dev='hd'/>
    <smbios mode='sysinfo'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <pae/>
  </features>
  <cpu mode='custom' match='exact' check='full'>
    <model fallback='forbid'>qemu64</model>
    <topology sockets='1' cores='6' threads='1'/>
...
```