### PR TITLE
Fix flaky tests in SMTPMailSenderTest.java and ReflectionToStringBuilderUtilsTest.java

### DIFF
--- a/utils/src/test/java/org/apache/cloudstack/utils/mailing/SMTPMailSenderTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/mailing/SMTPMailSenderTest.java
@@ -22,6 +22,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -547,7 +548,7 @@ public class SMTPMailSenderTest extends TestCase {
     public void setMailRecipientsTest() throws UnsupportedEncodingException, MessagingException {
         SMTPMessage messageMock = new SMTPMessage(Mockito.mock(MimeMessage.class));
 
-        Set<MailAddress> recipients = new HashSet<>();
+        Set<MailAddress> recipients = new LinkedHashSet<>();
         recipients.add(new MailAddress(null));
         recipients.add(new MailAddress(""));
         recipients.add(new MailAddress("  "));

--- a/utils/src/test/java/org/apache/cloudstack/utils/reflectiontostringbuilderutils/ReflectionToStringBuilderUtilsTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/reflectiontostringbuilderutils/ReflectionToStringBuilderUtilsTest.java
@@ -175,8 +175,10 @@ public class ReflectionToStringBuilderUtilsTest extends TestCase {
     public void validateGetNonSelectedFieldsObjectIsNotACollectionAndValidSelectedFieldsMustReturnNonSelectedFields(){
         String fieldToRemove = classToReflectRemovedField;
         String[] expectedResult = classToReflectFieldsNamesArray;
+        Arrays.sort(expectedResult);
 
         String[] result = ReflectionToStringBuilderUtils.getNonSelectedFields("test", fieldToRemove);
+        Arrays.sort(result);
         Assert.assertArrayEquals(expectedResult, result);
     }
 
@@ -184,8 +186,10 @@ public class ReflectionToStringBuilderUtilsTest extends TestCase {
     public void validateGetNonSelectedFieldsObjectIsACollectionAndValidSelectedFieldsMustReturnNonSelectedFields(){
         String fieldToRemove = classToReflectRemovedField;
         String[] expectedResult = classToReflectFieldsNamesArray;
+        Arrays.sort(expectedResult);
 
         String[] result = ReflectionToStringBuilderUtils.getNonSelectedFields(Arrays.asList("test1", "test2"), fieldToRemove);
+        Arrays.sort(result);
         Assert.assertArrayEquals(expectedResult, result);
     }
 


### PR DESCRIPTION
### Description

The tests below in `ReflectionToStringBuilderUtilsTest.java` and `SMTPMailSenderTest.java` were found flaky because of the ordering of HashSet and result Arrays. The orders of elements in the HashSet and result Arrays are not the same every time the test being called. In this case, LinkedHashSet was applied and Arrays were sorted to ensure the orders do not cause the flakiness. This code change is trying to fix the [flaky tests](https://docs.gitlab.com/ee/development/testing_guide/flaky_tests.html) mentioned above, because they sometimes fail (as the picture showed) and sometimes pass. The failure could be reproduced by the commands below by using the tool of [NonDex](https://github.com/TestingResearchIllinois/NonDex). The code change is to make sure the tests will always pass in this case.

- `org.apache.cloudstack.utils.mailing.SMTPMailSenderTest.setMailRecipientsTest`
- `org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtilsTest.validateGetNonSelectedFieldsObjectIsACollectionAndValidSelectedFieldsMustReturnNonSelectedFields`
- `org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtilsTest.validateGetNonSelectedFieldsObjectIsNotACollectionAndValidSelectedFieldsMustReturnNonSelectedFields`

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
<img width="900" alt="4" src="https://user-images.githubusercontent.com/61256379/200501912-0f1ab8d9-12fc-4c3e-a61e-369d1fec22f6.png">

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

The test failures could be reproduced by

1. `mvn install -pl utils -am -DskipTests`
2.  run tests with NonDex 
    `mvn -pl utils edu.illinois:nondex-maven-plugin:2.1:nondex -Dtest=org.apache.cloudstack.utils.mailing.SMTPMailSenderTest#setMailRecipientsTest`


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->