### PR TITLE
Fix typos and improve javadocs on ByteScaleUtils

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
@@ -469,7 +469,7 @@ public class PresetVariableHelper {
         }
 
         value.setTags(getPresetVariableValueResourceTags(volumeId, ResourceObjectType.Volume));
-        value.setSize(ByteScaleUtils.bytesToMib(volumeVo.getSize()));
+        value.setSize(ByteScaleUtils.bytesToMiB(volumeVo.getSize()));
     }
 
     protected GenericPresetVariable getPresetVariableValueDiskOffering(Long diskOfferingId) {
@@ -536,7 +536,7 @@ public class PresetVariableHelper {
         value.setName(vmTemplateVo.getName());
         value.setOsName(getPresetVariableValueOsName(vmTemplateVo.getGuestOSId()));
         value.setTags(getPresetVariableValueResourceTags(templateOrIsoId, usageType == UsageTypes.ISO ? ResourceObjectType.ISO : ResourceObjectType.Template));
-        value.setSize(ByteScaleUtils.bytesToMib(vmTemplateVo.getSize()));
+        value.setSize(ByteScaleUtils.bytesToMiB(vmTemplateVo.getSize()));
     }
 
     protected void loadPresetVariableValueForSnapshot(UsageVO usageRecord, Value value) {
@@ -554,7 +554,7 @@ public class PresetVariableHelper {
 
         value.setId(snapshotVo.getUuid());
         value.setName(snapshotVo.getName());
-        value.setSize(ByteScaleUtils.bytesToMib(snapshotVo.getSize()));
+        value.setSize(ByteScaleUtils.bytesToMiB(snapshotVo.getSize()));
         value.setSnapshotType(Snapshot.Type.values()[snapshotVo.getSnapshotType()]);
         value.setStorage(getPresetVariableValueStorage(getSnapshotDataStoreId(snapshotId), usageType));
         value.setTags(getPresetVariableValueResourceTags(snapshotId, ResourceObjectType.Snapshot));

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
@@ -469,7 +469,7 @@ public class PresetVariableHelper {
         }
 
         value.setTags(getPresetVariableValueResourceTags(volumeId, ResourceObjectType.Volume));
-        value.setSize(ByteScaleUtils.bytesToMiB(volumeVo.getSize()));
+        value.setSize(ByteScaleUtils.bytesToMebibytes(volumeVo.getSize()));
     }
 
     protected GenericPresetVariable getPresetVariableValueDiskOffering(Long diskOfferingId) {
@@ -536,7 +536,7 @@ public class PresetVariableHelper {
         value.setName(vmTemplateVo.getName());
         value.setOsName(getPresetVariableValueOsName(vmTemplateVo.getGuestOSId()));
         value.setTags(getPresetVariableValueResourceTags(templateOrIsoId, usageType == UsageTypes.ISO ? ResourceObjectType.ISO : ResourceObjectType.Template));
-        value.setSize(ByteScaleUtils.bytesToMiB(vmTemplateVo.getSize()));
+        value.setSize(ByteScaleUtils.bytesToMebibytes(vmTemplateVo.getSize()));
     }
 
     protected void loadPresetVariableValueForSnapshot(UsageVO usageRecord, Value value) {
@@ -554,7 +554,7 @@ public class PresetVariableHelper {
 
         value.setId(snapshotVo.getUuid());
         value.setName(snapshotVo.getName());
-        value.setSize(ByteScaleUtils.bytesToMiB(snapshotVo.getSize()));
+        value.setSize(ByteScaleUtils.bytesToMebibytes(snapshotVo.getSize()));
         value.setSnapshotType(Snapshot.Type.values()[snapshotVo.getSnapshotType()]);
         value.setStorage(getPresetVariableValueStorage(getSnapshotDataStoreId(snapshotId), usageType));
         value.setTags(getPresetVariableValueResourceTags(snapshotId, ResourceObjectType.Snapshot));

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelperTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelperTest.java
@@ -657,7 +657,7 @@ public class PresetVariableHelperTest {
         Value result = new Value();
         presetVariableHelperSpy.loadPresetVariableValueForVolume(usageVoMock, result);
 
-        Long expectedSize = ByteScaleUtils.bytesToMib(expected.getSize());
+        Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
 
         assertPresetVariableIdAndName(expected, result);
         Assert.assertEquals(expected.getDiskOffering(), result.getDiskOffering());
@@ -693,7 +693,7 @@ public class PresetVariableHelperTest {
         Value result = new Value();
         presetVariableHelperSpy.loadPresetVariableValueForVolume(usageVoMock, result);
 
-        Long expectedSize = ByteScaleUtils.bytesToMib(expected.getSize());
+        Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
 
         assertPresetVariableIdAndName(expected, result);
         Assert.assertEquals(expected.getDiskOffering(), result.getDiskOffering());
@@ -824,7 +824,7 @@ public class PresetVariableHelperTest {
             Value result = new Value();
             presetVariableHelperSpy.loadPresetVariableValueForTemplateAndIso(usageVoMock, result);
 
-            Long expectedSize = ByteScaleUtils.bytesToMib(expected.getSize());
+            Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
 
             assertPresetVariableIdAndName(expected, result);
             Assert.assertEquals(expected.getOsName(), result.getOsName());
@@ -872,7 +872,7 @@ public class PresetVariableHelperTest {
         Value result = new Value();
         presetVariableHelperSpy.loadPresetVariableValueForSnapshot(usageVoMock, result);
 
-        Long expectedSize = ByteScaleUtils.bytesToMib(expected.getSize());
+        Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
 
         assertPresetVariableIdAndName(expected, result);
         Assert.assertEquals(expected.getSnapshotType(), result.getSnapshotType());

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelperTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelperTest.java
@@ -657,7 +657,7 @@ public class PresetVariableHelperTest {
         Value result = new Value();
         presetVariableHelperSpy.loadPresetVariableValueForVolume(usageVoMock, result);
 
-        Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
+        Long expectedSize = ByteScaleUtils.bytesToMebibytes(expected.getSize());
 
         assertPresetVariableIdAndName(expected, result);
         Assert.assertEquals(expected.getDiskOffering(), result.getDiskOffering());
@@ -693,7 +693,7 @@ public class PresetVariableHelperTest {
         Value result = new Value();
         presetVariableHelperSpy.loadPresetVariableValueForVolume(usageVoMock, result);
 
-        Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
+        Long expectedSize = ByteScaleUtils.bytesToMebibytes(expected.getSize());
 
         assertPresetVariableIdAndName(expected, result);
         Assert.assertEquals(expected.getDiskOffering(), result.getDiskOffering());
@@ -824,7 +824,7 @@ public class PresetVariableHelperTest {
             Value result = new Value();
             presetVariableHelperSpy.loadPresetVariableValueForTemplateAndIso(usageVoMock, result);
 
-            Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
+            Long expectedSize = ByteScaleUtils.bytesToMebibytes(expected.getSize());
 
             assertPresetVariableIdAndName(expected, result);
             Assert.assertEquals(expected.getOsName(), result.getOsName());
@@ -872,7 +872,7 @@ public class PresetVariableHelperTest {
         Value result = new Value();
         presetVariableHelperSpy.loadPresetVariableValueForSnapshot(usageVoMock, result);
 
-        Long expectedSize = ByteScaleUtils.bytesToMiB(expected.getSize());
+        Long expectedSize = ByteScaleUtils.bytesToMebibytes(expected.getSize());
 
         assertPresetVariableIdAndName(expected, result);
         Assert.assertEquals(expected.getSnapshotType(), result.getSnapshotType());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2729,7 +2729,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         grd.setMemBalloning(!_noMemBalloon);
 
-        Long maxRam = ByteScaleUtils.bytesToKiB(vmTO.getMaxRam());
+        Long maxRam = ByteScaleUtils.bytesToKibibytes(vmTO.getMaxRam());
 
         grd.setMemorySize(maxRam);
         grd.setCurrentMem(getCurrentMemAccordingToMemBallooning(vmTO, maxRam));
@@ -2748,7 +2748,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             s_logger.warn(String.format("Setting VM's [%s] current memory as max memory [%s] due to memory ballooning is disabled. If you are using a custom service offering, verify if memory ballooning really should be disabled.", vmTO.toString(), maxRam));
             return maxRam;
         } else {
-            return ByteScaleUtils.bytesToKiB(vmTO.getMinRam());
+            return ByteScaleUtils.bytesToKibibytes(vmTO.getMinRam());
         }
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2729,7 +2729,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         grd.setMemBalloning(!_noMemBalloon);
 
-        Long maxRam = ByteScaleUtils.bytesToKib(vmTO.getMaxRam());
+        Long maxRam = ByteScaleUtils.bytesToKiB(vmTO.getMaxRam());
 
         grd.setMemorySize(maxRam);
         grd.setCurrentMem(getCurrentMemAccordingToMemBallooning(vmTO, maxRam));
@@ -2748,7 +2748,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             s_logger.warn(String.format("Setting VM's [%s] current memory as max memory [%s] due to memory ballooning is disabled. If you are using a custom service offering, verify if memory ballooning really should be disabled.", vmTO.toString(), maxRam));
             return maxRam;
         } else {
-            return ByteScaleUtils.bytesToKib(vmTO.getMinRam());
+            return ByteScaleUtils.bytesToKiB(vmTO.getMinRam());
         }
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
@@ -37,7 +37,7 @@ public class LibvirtScaleVmCommandWrapper extends CommandWrapper<ScaleVmCommand,
         String vmName = vmSpec.getName();
         Connect conn = null;
 
-        long newMemory = ByteScaleUtils.bytesToKib(vmSpec.getMaxRam());
+        long newMemory = ByteScaleUtils.bytesToKiB(vmSpec.getMaxRam());
         int newVcpus = vmSpec.getCpus();
         int newCpuSpeed = vmSpec.getMinSpeed() != null ? vmSpec.getMinSpeed() : vmSpec.getSpeed();
         int newCpuShares = newVcpus * newCpuSpeed;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
@@ -37,7 +37,7 @@ public class LibvirtScaleVmCommandWrapper extends CommandWrapper<ScaleVmCommand,
         String vmName = vmSpec.getName();
         Connect conn = null;
 
-        long newMemory = ByteScaleUtils.bytesToKiB(vmSpec.getMaxRam());
+        long newMemory = ByteScaleUtils.bytesToKibibytes(vmSpec.getMaxRam());
         int newVcpus = vmSpec.getCpus();
         int newCpuSpeed = vmSpec.getMinSpeed() != null ? vmSpec.getMinSpeed() : vmSpec.getSpeed();
         int newCpuShares = newVcpus * newCpuSpeed;

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -5748,7 +5748,7 @@ public class LibvirtComputingResourceTest {
         Mockito.when(vmTo.getMinRam()).thenReturn(minMemory);
 
         long currentMemory = libvirtComputingResource.getCurrentMemAccordingToMemBallooning(vmTo, maxMemory);
-        Assert.assertEquals(ByteScaleUtils.bytesToKib(minMemory), currentMemory);
+        Assert.assertEquals(ByteScaleUtils.bytesToKiB(minMemory), currentMemory);
         Mockito.verify(vmTo).getMinRam();
     }
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -5742,13 +5742,13 @@ public class LibvirtComputingResourceTest {
         libvirtComputingResource._noMemBalloon = false;
 
         long maxMemory = 2048;
-        long minMemory = ByteScaleUtils.mibToBytes(64);
+        long minMemory = ByteScaleUtils.mebibytesToBytes(64);
 
         VirtualMachineTO vmTo = Mockito.mock(VirtualMachineTO.class);
         Mockito.when(vmTo.getMinRam()).thenReturn(minMemory);
 
         long currentMemory = libvirtComputingResource.getCurrentMemAccordingToMemBallooning(vmTo, maxMemory);
-        Assert.assertEquals(ByteScaleUtils.bytesToKiB(minMemory), currentMemory);
+        Assert.assertEquals(ByteScaleUtils.bytesToKibibytes(minMemory), currentMemory);
         Mockito.verify(vmTo).getMinRam();
     }
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
@@ -76,7 +76,7 @@ public class LibvirtScaleVmCommandWrapperTest extends TestCase {
 
         vmTo = new VirtualMachineTO(1, "Test 1", VirtualMachine.Type.User, 2, 1000, 67108864, 67108864, VirtualMachineTemplate.BootloaderType.External, "Other Linux (64x)", true, true, "test123");
 
-        long memory = ByteScaleUtils.bytesToKib(vmTo.getMaxRam());
+        long memory = ByteScaleUtils.bytesToKiB(vmTo.getMaxRam());
         int vcpus = vmTo.getCpus();
         int cpuShares = vcpus * vmTo.getSpeed();
         scalingDetails = String.format("%s memory to [%s KiB], CPU cores to [%s] and cpu_shares to [%s]", vmTo.toString(), memory, vcpus, cpuShares);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
@@ -76,7 +76,7 @@ public class LibvirtScaleVmCommandWrapperTest extends TestCase {
 
         vmTo = new VirtualMachineTO(1, "Test 1", VirtualMachine.Type.User, 2, 1000, 67108864, 67108864, VirtualMachineTemplate.BootloaderType.External, "Other Linux (64x)", true, true, "test123");
 
-        long memory = ByteScaleUtils.bytesToKiB(vmTo.getMaxRam());
+        long memory = ByteScaleUtils.bytesToKibibytes(vmTo.getMaxRam());
         int vcpus = vmTo.getCpus();
         int cpuShares = vcpus * vmTo.getSpeed();
         scalingDetails = String.format("%s memory to [%s KiB], CPU cores to [%s] and cpu_shares to [%s]", vmTo.toString(), memory, vcpus, cpuShares);

--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -220,7 +220,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
         Integer maxMemoryConfig = ConfigurationManagerImpl.VM_SERVICE_OFFERING_MAX_RAM_SIZE.value();
         if (customOfferingMaxMemory != null) {
             s_logger.debug(String.format("Using 'Custom unconstrained' %s max memory value [%sMb] as %s memory.", serviceOfferingDescription, customOfferingMaxMemory, vmDescription));
-            maxMemory = ByteScaleUtils.mibToBytes(customOfferingMaxMemory);
+            maxMemory = ByteScaleUtils.mebibytesToBytes(customOfferingMaxMemory);
         } else {
             String maxMemoryConfigKey = ConfigurationManagerImpl.VM_SERVICE_OFFERING_MAX_RAM_SIZE.key();
 
@@ -228,7 +228,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
               serviceOfferingDescription, maxMemoryConfigKey, maxMemoryConfig, vmDescription));
 
             if (maxMemoryConfig > 0) {
-                maxMemory = ByteScaleUtils.mibToBytes(maxMemoryConfig);
+                maxMemory = ByteScaleUtils.mebibytesToBytes(maxMemoryConfig);
             } else {
                 s_logger.info(String.format("Config [%s] has value less or equal '0'. Using %s host or last host max memory [%s] as VM max memory in the hypervisor.", maxMemoryConfigKey, vmDescription, maxHostMemory));
                 maxMemory = maxHostMemory;

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2053,7 +2053,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     // #1 Check existing host has capacity
                     if (!excludes.shouldAvoid(ApiDBUtils.findHostById(vmInstance.getHostId()))) {
                         existingHostHasCapacity = _capacityMgr.checkIfHostHasCpuCapability(vmInstance.getHostId(), newCpu, newSpeed)
-                                && _capacityMgr.checkIfHostHasCapacity(vmInstance.getHostId(), cpuDiff, ByteScaleUtils.mibToBytes(memoryDiff), false,
+                                && _capacityMgr.checkIfHostHasCapacity(vmInstance.getHostId(), cpuDiff, ByteScaleUtils.mebibytesToBytes(memoryDiff), false,
                                         _capacityMgr.getClusterOverProvisioningFactor(host.getClusterId(), Capacity.CAPACITY_TYPE_CPU),
                                         _capacityMgr.getClusterOverProvisioningFactor(host.getClusterId(), Capacity.CAPACITY_TYPE_MEMORY), false);
                         excludes.addHost(vmInstance.getHostId());

--- a/server/src/test/java/com/cloud/hypervisor/KVMGuruTest.java
+++ b/server/src/test/java/com/cloud/hypervisor/KVMGuruTest.java
@@ -176,7 +176,7 @@ public class KVMGuruTest {
 
         long result = guru.getVmMaxMemory(serviceOfferingVoMock, "Vm description", 1l);
 
-        Assert.assertEquals(ByteScaleUtils.mibToBytes(maxCustomOfferingMemory), result);
+        Assert.assertEquals(ByteScaleUtils.mebibytesToBytes(maxCustomOfferingMemory), result);
     }
 
     @Test
@@ -190,12 +190,12 @@ public class KVMGuruTest {
         Mockito.when(vmServiceOfferingMaxRAMSize.value()).thenReturn(maxMemoryConfig);
         long result = guru.getVmMaxMemory(serviceOfferingVoMock, "Vm description", 1l);
 
-        Assert.assertEquals(ByteScaleUtils.mibToBytes(maxMemoryConfig), result);
+        Assert.assertEquals(ByteScaleUtils.mebibytesToBytes(maxMemoryConfig), result);
     }
 
     @Test
     public void validateGetVmMaxMemoryReturnMaxHostMemory(){
-        long maxHostMemory = ByteScaleUtils.mibToBytes(2000);
+        long maxHostMemory = ByteScaleUtils.mebibytesToBytes(2000);
         Mockito.when(serviceOfferingVoMock.getDetail(ApiConstants.MAX_MEMORY)).thenReturn(null);
 
         ConfigKey<Integer> vmServiceOfferingMaxRAMSize = Mockito.mock(ConfigKey.class);

--- a/utils/src/main/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtils.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtils.java
@@ -15,7 +15,7 @@
 package org.apache.cloudstack.utils.bytescale;
 
 /**
- * This class provides a facility to convert bytes through his scales (b, Kib, Kb, Mib, Mb...).
+ * This class provides a facility to convert bytes through the scales (B, KiB, KB, MiB, MB...).
  *
  */
 public class ByteScaleUtils {
@@ -27,32 +27,32 @@ public class ByteScaleUtils {
     private ByteScaleUtils() {}
 
     /**
-     * Converts mebibytes to bytes.
+     * Converts mebibyte to bytes.
      *
      * @param mib The value to convert to bytes (eq: 1, 2, 3, ..., 42,...).
-     * @return The parameter multiplied by 1048576 (1024 * 1024, 1 MiB).
+     * @return The parameter multiplied by 2²⁰ (1048576 | 1024 * 1024 | 1 MiB | ).
      */
     public static long mibToBytes(long mib) {
         return mib * MiB;
     }
 
     /**
-     * Converts bytes to kibibytes.
+     * Converts bytes to kibibyte.
      *
-     * @param b The value in bytes to convert to kibibytes.
-     * @return The parameter divided by 1024 (1 KiB).
+     * @param bytes The value in bytes to convert to kibibyte.
+     * @return The parameter divided by 2¹⁰ (1024 | 1 KiB).
      */
-    public static long bytesToKib(long b) {
-        return b / KiB;
+    public static long bytesToKiB(long bytes) {
+        return bytes / KiB;
     }
 
     /**
-     * Converts bytes to mebibytes.
+     * Converts bytes to mebibyte.
      *
-     * @param b The value in bytes to convert to mebibytes.
-     * @return The parameter divided by 1024 * 1024 (1 MiB).
+     * @param bytes The value in bytes to convert to mebibyte.
+     * @return The parameter divided by 2²⁰ (1048576 | 1024 * 1024 | 1 MiB).
      */
-    public static long bytesToMib(long b) {
-        return b / MiB;
+    public static long bytesToMiB(long bytes) {
+        return bytes / MiB;
     }
 }

--- a/utils/src/main/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtils.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtils.java
@@ -27,12 +27,12 @@ public class ByteScaleUtils {
     private ByteScaleUtils() {}
 
     /**
-     * Converts mebibyte to bytes.
+     * Converts mebibytes to bytes.
      *
      * @param mib The value to convert to bytes (eq: 1, 2, 3, ..., 42,...).
-     * @return The parameter multiplied by 2²⁰ (1048576 | 1024 * 1024 | 1 MiB | ).
+     * @return The parameter multiplied by 2²⁰ (1048576 | 1024 * 1024 | 1 mebibyte).
      */
-    public static long mibToBytes(long mib) {
+    public static long mebibytesToBytes(long mib) {
         return mib * MiB;
     }
 
@@ -40,19 +40,19 @@ public class ByteScaleUtils {
      * Converts bytes to kibibyte.
      *
      * @param bytes The value in bytes to convert to kibibyte.
-     * @return The parameter divided by 2¹⁰ (1024 | 1 KiB).
+     * @return The parameter divided by 2¹⁰ (1024 | 1 kibibyte).
      */
-    public static long bytesToKiB(long bytes) {
+    public static long bytesToKibibytes(long bytes) {
         return bytes / KiB;
     }
 
     /**
-     * Converts bytes to mebibyte.
+     * Converts bytes to mebibytes.
      *
-     * @param bytes The value in bytes to convert to mebibyte.
-     * @return The parameter divided by 2²⁰ (1048576 | 1024 * 1024 | 1 MiB).
+     * @param bytes The value in bytes to convert to mebibytes.
+     * @return The parameter divided by 2²⁰ (1048576 | 1024 * 1024 | 1 mebibyte).
      */
-    public static long bytesToMiB(long bytes) {
+    public static long bytesToMebibytes(long bytes) {
         return bytes / MiB;
     }
 }

--- a/utils/src/test/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtilsTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtilsTest.java
@@ -23,36 +23,36 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ByteScaleUtilsTest {
 
     @Test
-    public void validateMibToBytes() {
+    public void validateMebibytesToBytes() {
         long mib = 3000L;
         long bytes = 1024L * 1024L * mib;
-        Assert.assertEquals(bytes, ByteScaleUtils.mibToBytes(mib));
+        Assert.assertEquals(bytes, ByteScaleUtils.mebibytesToBytes(mib));
     }
 
     @Test
-    public void validateBytesToKiB() {
+    public void validateBytesToKibibytes() {
         long kib = 3000L;
         long bytes = 1024 * kib;
-        Assert.assertEquals(kib, ByteScaleUtils.bytesToKiB(bytes));
+        Assert.assertEquals(kib, ByteScaleUtils.bytesToKibibytes(bytes));
     }
 
     @Test
-    public void validateBytesToMiB() {
+    public void validateBytesToMebibytes() {
         long mib = 3000L;
         long bytes = 1024L * 1024L * mib;
-        Assert.assertEquals(mib, ByteScaleUtils.bytesToMiB(bytes));
+        Assert.assertEquals(mib, ByteScaleUtils.bytesToMebibytes(bytes));
     }
 
     @Test
-    public void validateMibToBytesIfIntTimesIntThenMustExtrapolateIntMaxValue() {
+    public void validateMebibytesToBytesIfIntTimesIntThenMustExtrapolateIntMaxValue() {
         int mib = 3000;
         long bytes = 1024L * 1024L * mib;
-        Assert.assertEquals(bytes, ByteScaleUtils.mibToBytes(mib));
+        Assert.assertEquals(bytes, ByteScaleUtils.mebibytesToBytes(mib));
     }
 
     @Test
-    public void validateBytesToKiBIfIntByIntThenMustExtrapolateIntMaxValue(){
+    public void validateBytesToKibibytesIfIntByIntThenMustExtrapolateIntMaxValue(){
         int bytes = Integer.MAX_VALUE;
-        Assert.assertEquals(bytes, ByteScaleUtils.bytesToKiB(bytes * 1024L));
+        Assert.assertEquals(bytes, ByteScaleUtils.bytesToKibibytes(bytes * 1024L));
     }
 }

--- a/utils/src/test/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtilsTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/bytescale/ByteScaleUtilsTest.java
@@ -14,45 +14,45 @@
 
 package org.apache.cloudstack.utils.bytescale;
 
-import junit.framework.TestCase;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ByteScaleUtilsTest extends TestCase {
+public class ByteScaleUtilsTest {
 
     @Test
     public void validateMibToBytes() {
         long mib = 3000L;
-        long b = 1024L * 1024L * mib;
-        assertEquals(b, ByteScaleUtils.mibToBytes(mib));
+        long bytes = 1024L * 1024L * mib;
+        Assert.assertEquals(bytes, ByteScaleUtils.mibToBytes(mib));
     }
 
     @Test
-    public void validateBytesToKib() {
+    public void validateBytesToKiB() {
         long kib = 3000L;
-        long b = 1024 * kib;
-        assertEquals(kib, ByteScaleUtils.bytesToKib(b));
+        long bytes = 1024 * kib;
+        Assert.assertEquals(kib, ByteScaleUtils.bytesToKiB(bytes));
     }
 
     @Test
-    public void validateBytesToMib() {
+    public void validateBytesToMiB() {
         long mib = 3000L;
-        long b = 1024L * 1024L * mib;
-        assertEquals(mib, ByteScaleUtils.bytesToMib(b));
+        long bytes = 1024L * 1024L * mib;
+        Assert.assertEquals(mib, ByteScaleUtils.bytesToMiB(bytes));
     }
 
     @Test
     public void validateMibToBytesIfIntTimesIntThenMustExtrapolateIntMaxValue() {
         int mib = 3000;
-        long b = 1024L * 1024L * mib;
-        assertEquals(b, ByteScaleUtils.mibToBytes(mib));
+        long bytes = 1024L * 1024L * mib;
+        Assert.assertEquals(bytes, ByteScaleUtils.mibToBytes(mib));
     }
 
     @Test
-    public void validateBytesToKibIfIntByIntThenMustExtrapolateIntMaxValue(){
-        int b = Integer.MAX_VALUE;
-        assertEquals(b, ByteScaleUtils.bytesToKib(b * 1024L));
+    public void validateBytesToKiBIfIntByIntThenMustExtrapolateIntMaxValue(){
+        int bytes = Integer.MAX_VALUE;
+        Assert.assertEquals(bytes, ByteScaleUtils.bytesToKiB(bytes * 1024L));
     }
 }


### PR DESCRIPTION
### Description

PR #5909 introduced a class to convert bytes through the scales (B, KiB, KB, MiB, MB...); however, there are some typos in the javadocs and method names. This PR intends to fix those typos and improve the javadocs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial
