### PR TITLE
Simplify Test Case ApplicationLoadBalancerTest.searchForNonExistingLoadBalancer

### DIFF
--- a/server/src/test/java/org/apache/cloudstack/network/lb/ApplicationLoadBalancerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/network/lb/ApplicationLoadBalancerTest.java
@@ -186,22 +186,11 @@ public class ApplicationLoadBalancerTest extends TestCase {
         assertNotNull("Couldn't find existing application load balancer", rule);
     }
 
-    @Test
+    @Test(expected = InvalidParameterValueException.class)
     //Negative test - try to retrieve non-existing lb
         public
-        void searchForNonExistingLoadBalancer() {
-        boolean notFound = false;
-        ApplicationLoadBalancerRule rule = null;
-        try {
-            rule = _appLbSvc.getApplicationLoadBalancer(nonExistingLbId);
-            if (rule != null) {
-                notFound = false;
-            }
-        } catch (InvalidParameterValueException ex) {
-            notFound = true;
-        }
-
-        assertTrue("Found non-existing load balancer; no invalid parameter value exception was thrown", notFound);
+        void searchForNonExistingLoadBalancer() throws InvalidParameterValueException {
+        _appLbSvc.getApplicationLoadBalancer(nonExistingLbId);
     }
 
     /**


### PR DESCRIPTION
### Description

Fix: #6660 

This PR Simplify the test case [`ApplicationLoadBalancerTest.searchForNonExistingLoadBalancer`](https://github.com/apache/cloudstack/blob/ddb11b1b966cc2b3443ef4d2eeb55c1d64ff3fb9/server/src/test/java/org/apache/cloudstack/network/lb/ApplicationLoadBalancerTest.java#L189-L205) and try to imporve its readability.

The test case checks that when retrieving a non-existing lb, an InvalidParameterValueException should be raised. However, the intention is not explicit in the current implementation of the test case. See below the current implementation:

**Before Refactoring**
```java
    @Test
    //Negative test - try to retrieve non-existing lb
    public void searchForNonExistingLoadBalancer() {
        boolean notFound = false;
        ApplicationLoadBalancerRule rule = null;
        try {
            rule = _appLbSvc.getApplicationLoadBalancer(nonExistingLbId);
            if (rule != null) {
                notFound = false;
            }
        } catch (InvalidParameterValueException ex) {
            notFound = true;
        }
        assertTrue("Found non-existing load balancer; no invalid parameter value exception was thrown", notFound);
    }
```
The test case relies on a parameter named notFound, being asserted in line [204](https://github.com/apache/cloudstack/blob/ddb11b1b966cc2b3443ef4d2eeb55c1d64ff3fb9/server/src/test/java/org/apache/cloudstack/network/lb/ApplicationLoadBalancerTest.java#L204), and a try-catch block with if condition between lines [195 to 204](https://github.com/apache/cloudstack/blob/ddb11b1b966cc2b3443ef4d2eeb55c1d64ff3fb9/server/src/test/java/org/apache/cloudstack/network/lb/ApplicationLoadBalancerTest.java#L195-#L204) to achieve the testing goal. It can be simplified to 4 lines with a more explicit intention for easy understanding, as follows:

**After refactoring**
```java
@Test(expected=InvalidParameterValueException.class)
 //Negative test - try to retrieve non-existing lb
public void searchForNonExistingLoadBalancer() throws InvalidParameterValueException {
   _appLbSvc.getApplicationLoadBalancer(nonExistingLbId));
  }
```
For more description details, please refer to the issue #6660.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
The local cluster environment (KVM, UBUNTU 18.04) runs the test suite.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
