### PR TITLE
Bring in the JUnit Assume Feature to `CABackgroundTaskTest`

### DIFF
--- a/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java
+++ b/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java
@@ -20,6 +20,7 @@
 package org.apache.cloudstack.ca;
 
 import static org.apache.cloudstack.ca.CAManager.AutomaticCertRenewal;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -36,6 +37,7 @@ import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.cloudstack.utils.security.CertUtils;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,7 +95,7 @@ public class CABackgroundTaskTest {
     @Test
     public void testNullCert() throws Exception {
         certMap.put(hostIp, null);
-        Assert.assertTrue(certMap.size() == 1);
+        Assume.assumeThat(certMap.size() == 1, is(true));
         task.runInContext();
         Assert.assertTrue(certMap.size() == 0);
     }
@@ -102,7 +104,7 @@ public class CABackgroundTaskTest {
     public void testNullHost() throws Exception {
         Mockito.when(hostDao.findByIp(Mockito.anyString())).thenReturn(null);
         certMap.put(hostIp, expiredCertificate);
-        Assert.assertTrue(certMap.size() == 1);
+        Assume.assumeThat(certMap.size() == 1, is(true));
         task.runInContext();
         Assert.assertTrue(certMap.size() == 0);
     }
@@ -112,7 +114,7 @@ public class CABackgroundTaskTest {
         overrideDefaultConfigValue(AutomaticCertRenewal, "_defaultValue", "true");
         host.setManagementServerId(ManagementServerNode.getManagementServerId());
         certMap.put(hostIp, expiredCertificate);
-        Assert.assertTrue(certMap.size() == 1);
+        Assume.assumeThat(certMap.size() == 1, is(true));
         task.runInContext();
         Mockito.verify(caManager, Mockito.times(1)).provisionCertificate(host, false, null);
         Mockito.verify(caManager, Mockito.times(0)).sendAlert(Mockito.any(Host.class), Mockito.anyString(), Mockito.anyString());
@@ -124,7 +126,7 @@ public class CABackgroundTaskTest {
         Mockito.when(caManager.provisionCertificate(any(Host.class), anyBoolean(), nullable(String.class))).thenThrow(new CloudRuntimeException("some error"));
         host.setManagementServerId(ManagementServerNode.getManagementServerId());
         certMap.put(hostIp, expiredCertificate);
-        Assert.assertTrue(certMap.size() == 1);
+        Assume.assumeThat(certMap.size() == 1, is(true));
         task.runInContext();
         Mockito.verify(caManager, Mockito.times(1)).provisionCertificate(host, false, null);
         Mockito.verify(caManager, Mockito.times(1)).sendAlert(Mockito.any(Host.class), Mockito.anyString(), Mockito.anyString());
@@ -134,7 +136,7 @@ public class CABackgroundTaskTest {
     public void testAutoRenewalDisabled() throws Exception {
         overrideDefaultConfigValue(AutomaticCertRenewal, "_defaultValue", "false");
         certMap.put(hostIp, expiredCertificate);
-        Assert.assertTrue(certMap.size() == 1);
+        Assume.assumeThat(certMap.size() == 1, is(true));
         // First round
         task.runInContext();
         Mockito.verify(caManager, Mockito.times(0)).provisionCertificate(Mockito.any(Host.class), anyBoolean(), Mockito.anyString());


### PR DESCRIPTION
### Description

Fix: #6203 

This PR introduces JUnit Assume API to the five test cases of `CABackgroundTaskTest`:
[`testNullCert`](https://github.com/apache/cloudstack/blob/4c5a2ba3a6eb6399390c2f8963cb26e0e35fc058/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java#L94-L99), [`testNullHost`](https://github.com/apache/cloudstack/blob/4c5a2ba3a6eb6399390c2f8963cb26e0e35fc058/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java#L102-L108), [`testAutoRenewalEnabledWithExceptionsOnProvisioning`](https://github.com/apache/cloudstack/blob/main/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java#L122), [`testAutoRenewalEnabledWithNoExceptionsOnProvisioning`](https://github.com/apache/cloudstack/blob/main/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java#L111) , and [`testAutoRenewalDisabled`](https://github.com/apache/cloudstack/blob/main/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java#L134).

Take [`testAutoRenewalDisabled`](https://github.com/apache/cloudstack/blob/main/server/src/test/java/org/apache/cloudstack/ca/CABackgroundTaskTest.java#L134) as a example:

Right now this case is asserting `certMap.size() == 1` before the actual testing target(`task.runInContext()`) is executed. 

```java
certMap.put(hostIp, expiredCertificate);
Assert.assertTrue(certMap.size() == 1);
```
Since the test case `testAutoRenewalDisabled` contains 2 assertions, it may fail due to 2 reasons:

  * The functions related to the `certMap` have bugs.(Here is the `Assert.assertTrue(certMap.size() == 1)`)
  * The function `task.runInContext()` have bugs.(What we actually want to check with this test)

Here I suggest replacing the `assertTrue` function with the `assumeThat` function, so when the precondition fails, JUnit can skip it instead of report a failurel.  This can help us to focus on failure that is raised by the target testing function.


**Before refactoring**
```java
certMap.put(hostIp, expiredCertificate);
Assert.assertTrue(certMap.size() == 1);
```

**After refactoring**
```java
certMap.put(hostIp, expiredCertificate);
Assume.assumeThat(icertMap.size() == 1, is(true));
```

#### Brief changelog
Replace `Assert.assertTrue(certMap.size() == 1);` with `Assume.assumeThat(icertMap.size() == 1, is(true));` for better code comprehension.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
The local cluster environment (KVM, UBUNTU 18.04) runs the test suite.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
