### PR TITLE
VOLUME.DETACH, created during VM removal has type VirtualMachine instead of Volume and has "Vm Id: XXX" in the description.

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -8062,8 +8062,22 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private void detachVolumesFromVm(List<VolumeVO> volumes) {
 
         for (VolumeVO volume : volumes) {
+            CallContext vmContext = CallContext.current();
+            // Create new context and inject correct event resource type, id and details,
+            // otherwise VOLUME.DETACH event will be associated with VirtualMachine and contain VM id and other information.
+            CallContext volumeContext = CallContext.register(vmContext.getCallingUserId(), vmContext.getCallingAccountId());
+            volumeContext.setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, volume.getId()) + " Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, volume.getInstanceId()));
+            volumeContext.setEventResourceType(ApiCommandResourceType.Volume);
+            volumeContext.setEventResourceId(volume.getId());
+            volumeContext.setStartEventId(vmContext.getStartEventId());
 
-            Volume detachResult = _volumeService.detachVolumeViaDestroyVM(volume.getInstanceId(), volume.getId());
+            Volume detachResult = null;
+            try {
+                detachResult = _volumeService.detachVolumeViaDestroyVM(volume.getInstanceId(), volume.getId());
+            } finally {
+                // Remove volumeContext and pop vmContext back
+                CallContext.unregister();
+            }
 
             if (detachResult == null) {
                 s_logger.error("DestroyVM remove volume - failed to detach and delete volume " + volume.getInstanceId() + " from instance " + volume.getId());


### PR DESCRIPTION
### Description

VOLUME.DETACH, created during VM removal, has type VirtualMachine instead of Volume and has "Vm Id: XXX" in the description.
Steps to reproduce:

1. Create Volume
2. Create VM
3. Attach Volume to VM
4. Delete VM
5. Check Volume events page, VOLUME.DETACH is missing there
6. Check Events page, VOLUME.DETACH available, but has description "Vm Id: XXX" and resource is VM instead of Volume

The root cause: @actionevent uses CallContext information for event details, and in this case CallContext contains VM information.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before this change (see VOLUME.DETACH event):
<img width="1506" alt="190269757-1b163476-88fd-47cb-8cb7-20a4cf629ab9" src="https://user-images.githubusercontent.com/742444/200919104-234f9821-e5a3-48ce-acba-e6c1cc256364.png">
After this change:
<img width="1514" alt="190269816-d91381b7-4a89-429b-9b38-8e9826e24562" src="https://user-images.githubusercontent.com/742444/200919179-6ab89237-0dcc-4d51-b57d-1f562f5ce60e.png">
<img width="1513" alt="190269867-bc9d069b-9c3d-4b1a-a4c7-d65f9961a8c1" src="https://user-images.githubusercontent.com/742444/200919263-c7dbd650-2fca-456b-b889-29eac14210dd.png">


### How Has This Been Tested?
Tested manually.
