### PR TITLE
Externalize KVM HA heartbeat frequency

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -410,3 +410,12 @@ iscsi.session.cleanup.enabled=false
 
 # Time interval (in milliseconds) between KVM heartbeats.
 # kvm.heartbeat.update.frequency=60000
+
+# Number of maximum tries to KVM heartbeats.
+# kvm.heartbeat.update.max.tries=5
+
+# Time amount (in milliseconds) for the KVM heartbeat retry sleep.
+# kvm.heartbeat.update.retry.sleep=10000
+
+# Timeout (in milliseconds) of the KVM heartbeat checker.
+# kvm.heartbeat.checker.timeout=360000

--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -407,3 +407,6 @@ iscsi.session.cleanup.enabled=false
 # The path of an executable file/script for host health check for CloudStack to Auto Disable/Enable the host
 # depending on the return value of the file/script
 # agent.health.check.script.path=
+
+# Time interval (in milliseconds) between KVM heartbeats.
+# kvm.heartbeat.update.frequency=60000

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -746,7 +746,7 @@ public class AgentProperties{
      * Data type: Long.<br>
      * Default value: <code>60000l</code>
      */
-    public static final Property<Long> KVM_HEARTBEAT_UPDATE_FREQUENCY = new Property<Long>("kvm.heartbeat.update.frequency", 60000l);
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_FREQUENCY = new Property<>("kvm.heartbeat.update.frequency", 60000l);
 
     public static class Property <T>{
         private String name;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -539,10 +539,10 @@ public class AgentProperties{
     /**
      * Heartbeat update timeout (in ms).<br>
      * Depending on the use case, this timeout might need increasing/decreasing.<br>
-     * Data type: Integer.<br>
-     * Default value: <code>60000</code>
+     * Data type: Long.<br>
+     * Default value: <code>60000l</code>
      */
-    public static final Property<Integer> HEARTBEAT_UPDATE_TIMEOUT = new Property<>("heartbeat.update.timeout", 60000);
+    public static final Property<Long> HEARTBEAT_UPDATE_TIMEOUT = new Property<>("heartbeat.update.timeout", 60000l);
 
     /**
      * The timeout (in seconds) to retrieve the target's domain ID when migrating a VM with KVM. <br>
@@ -747,6 +747,30 @@ public class AgentProperties{
      * Default value: <code>60000l</code>
      */
     public static final Property<Long> KVM_HEARTBEAT_UPDATE_FREQUENCY = new Property<>("kvm.heartbeat.update.frequency", 60000l);
+
+    /**
+     * Number of maximum tries to KVM heartbeats. <br>
+     * This property is for KVM only.
+     * Data type: Long.<br>
+     * Default value: <code>5l</code>
+     */
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_MAX_TRIES = new Property<>("kvm.heartbeat.update.max.tries", 5l);
+
+    /**
+     * Time amount (in milliseconds) for the KVM heartbeat retry sleep. <br>
+     * This property is for KVM only.
+     * Data type: Long.<br>
+     * Default value: <code>10000l</code>
+     */
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_RETRY_SLEEP = new Property<>("kvm.heartbeat.update.retry.sleep", 10000l);
+
+    /**
+     * Timeout (in milliseconds) of the KVM heartbeat checker. <br>
+     * This property is for KVM only.
+     * Data type: Long.<br>
+     * Default value: <code>360000l</code>
+     */
+    public static final Property<Long> KVM_HEARTBEAT_CHECKER_TIMEOUT = new Property<>("kvm.heartbeat.checker.timeout", 360000l);
 
     public static class Property <T>{
         private String name;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -770,7 +770,7 @@ public class AgentProperties{
      * Data type: Long.<br>
      * Default value: <code>360000l</code>
      */
-    public static final Property<Long> KVM_HEARTBEAT_CHECKER_TIMEOUT = new Property<>("kvm.heartbeat.checker.timeout", 360000l);
+    public static final Property<Long> KVM_HEARTBEAT_CHECKER_TIMEOUT = new Property<>("kvm.heartbeat.checker.timeout", 360000L);
 
     public static class Property <T>{
         private String name;

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -540,9 +540,9 @@ public class AgentProperties{
      * Heartbeat update timeout (in ms).<br>
      * Depending on the use case, this timeout might need increasing/decreasing.<br>
      * Data type: Long.<br>
-     * Default value: <code>60000l</code>
+     * Default value: <code>60000L</code>
      */
-    public static final Property<Long> HEARTBEAT_UPDATE_TIMEOUT = new Property<>("heartbeat.update.timeout", 60000l);
+    public static final Property<Long> HEARTBEAT_UPDATE_TIMEOUT = new Property<>("heartbeat.update.timeout", 60000L);
 
     /**
      * The timeout (in seconds) to retrieve the target's domain ID when migrating a VM with KVM. <br>
@@ -746,7 +746,7 @@ public class AgentProperties{
      * Data type: Long.<br>
      * Default value: <code>60000l</code>
      */
-    public static final Property<Long> KVM_HEARTBEAT_UPDATE_FREQUENCY = new Property<>("kvm.heartbeat.update.frequency", 60000l);
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_FREQUENCY = new Property<>("kvm.heartbeat.update.frequency", 60000L);
 
     /**
      * Number of maximum tries to KVM heartbeats. <br>
@@ -754,7 +754,7 @@ public class AgentProperties{
      * Data type: Long.<br>
      * Default value: <code>5l</code>
      */
-    public static final Property<Long> KVM_HEARTBEAT_UPDATE_MAX_TRIES = new Property<>("kvm.heartbeat.update.max.tries", 5l);
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_MAX_TRIES = new Property<>("kvm.heartbeat.update.max.tries", 5L);
 
     /**
      * Time amount (in milliseconds) for the KVM heartbeat retry sleep. <br>
@@ -762,7 +762,7 @@ public class AgentProperties{
      * Data type: Long.<br>
      * Default value: <code>10000l</code>
      */
-    public static final Property<Long> KVM_HEARTBEAT_UPDATE_RETRY_SLEEP = new Property<>("kvm.heartbeat.update.retry.sleep", 10000l);
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_RETRY_SLEEP = new Property<>("kvm.heartbeat.update.retry.sleep", 10000L);
 
     /**
      * Timeout (in milliseconds) of the KVM heartbeat checker. <br>

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -740,6 +740,14 @@ public class AgentProperties{
      */
     public static final Property<String> CONTROL_CIDR = new Property<>("control.cidr", "169.254.0.0/16");
 
+    /**
+     * Time interval (in milliseconds) between KVM heartbeats. <br>
+     * This property is for KVM only.
+     * Data type: Long.<br>
+     * Default value: <code>60000l</code>
+     */
+    public static final Property<Long> KVM_HEARTBEAT_UPDATE_FREQUENCY = new Property<Long>("kvm.heartbeat.update.frequency", 60000l);
+
     public static class Property <T>{
         private String name;
         private T defaultValue;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHABase.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHABase.java
@@ -18,8 +18,6 @@ package com.cloud.hypervisor.kvm.resource;
 
 import java.io.File;
 
-import com.cloud.agent.properties.AgentProperties;
-import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import org.apache.log4j.Logger;
 import org.libvirt.LibvirtException;
 import org.libvirt.StoragePool;
@@ -30,6 +28,8 @@ import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
 import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.OutputInterpreter.AllLinesParser;
 import com.cloud.utils.script.Script;
+import com.cloud.agent.properties.AgentProperties;
+import com.cloud.agent.properties.AgentPropertiesFileHandler;
 
 public class KVMHABase {
     private static final Logger s_logger = Logger.getLogger(KVMHABase.class);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHABase.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHABase.java
@@ -18,6 +18,8 @@ package com.cloud.hypervisor.kvm.resource;
 
 import java.io.File;
 
+import com.cloud.agent.properties.AgentProperties;
+import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import org.apache.log4j.Logger;
 import org.libvirt.LibvirtException;
 import org.libvirt.StoragePool;
@@ -34,7 +36,7 @@ public class KVMHABase {
     private long _timeout = 60000; /* 1 minutes */
     protected static String s_heartBeatPath;
     protected long _heartBeatUpdateTimeout = 60000;
-    protected long _heartBeatUpdateFreq = 60000;
+    protected long _heartBeatUpdateFreq = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_FREQUENCY);
     protected long _heartBeatUpdateMaxTries = 5;
     protected long _heartBeatUpdateRetrySleep = 10000;
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHABase.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHABase.java
@@ -35,10 +35,10 @@ public class KVMHABase {
     private static final Logger s_logger = Logger.getLogger(KVMHABase.class);
     private long _timeout = 60000; /* 1 minutes */
     protected static String s_heartBeatPath;
-    protected long _heartBeatUpdateTimeout = 60000;
+    protected long _heartBeatUpdateTimeout = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.HEARTBEAT_UPDATE_TIMEOUT);
     protected long _heartBeatUpdateFreq = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_FREQUENCY);
-    protected long _heartBeatUpdateMaxTries = 5;
-    protected long _heartBeatUpdateRetrySleep = 10000;
+    protected long _heartBeatUpdateMaxTries = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_MAX_TRIES);
+    protected long _heartBeatUpdateRetrySleep = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_RETRY_SLEEP);
 
     public static enum PoolType {
         PrimaryStorage, SecondaryStorage

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHAMonitor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHAMonitor.java
@@ -48,7 +48,6 @@ public class KVMHAMonitor extends KVMHABase implements Runnable {
         hostPrivateIp = host;
         configureHeartBeatPath(scriptPath);
 
-        _heartBeatUpdateTimeout = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.HEARTBEAT_UPDATE_TIMEOUT);
         rebootHostAndAlertManagementOnHeartbeatTimeout = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.REBOOT_HOST_AND_ALERT_MANAGEMENT_ON_HEARTBEAT_TIMEOUT);
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePool.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePool.java
@@ -19,6 +19,8 @@ package com.cloud.hypervisor.kvm.storage;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.agent.properties.AgentProperties;
+import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
 import org.joda.time.Duration;
 
@@ -29,11 +31,11 @@ import com.cloud.storage.Storage.StoragePoolType;
 
 public interface KVMStoragePool {
 
-    public static final long HeartBeatUpdateTimeout = 60000;
-    public static final long HeartBeatUpdateFreq = 60000;
-    public static final long HeartBeatUpdateMaxTries = 5;
-    public static final long HeartBeatUpdateRetrySleep = 10000;
-    public static final long HeartBeatCheckerTimeout = 360000; // 6 minutes
+    public static final long HeartBeatUpdateTimeout = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.HEARTBEAT_UPDATE_TIMEOUT);
+    public static final long HeartBeatUpdateFreq = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_FREQUENCY);
+    public static final long HeartBeatUpdateMaxTries = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_MAX_TRIES);
+    public static final long HeartBeatUpdateRetrySleep = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_UPDATE_RETRY_SLEEP);
+    public static final long HeartBeatCheckerTimeout = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.KVM_HEARTBEAT_CHECKER_TIMEOUT);
 
 
     public KVMPhysicalDisk createPhysicalDisk(String volumeUuid, PhysicalDiskFormat format, Storage.ProvisioningType provisioningType, long size, byte[] passphrase);


### PR DESCRIPTION
### Description

Currently, the heartbeat frequency of the KVM HA is fixed at 60,000 milliseconds. This property was externalized as `kvm.heartbeat.update.frequency` in `agent.properties`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?
I applied the changes in a local lab, changed the frequency, and checked if heartbeats were occurring at the frequency I specified.