### PR TITLE
gha(python): fix `W391` blank line at end of file

### DIFF
--- a/test/integration/component/test_network_vpc_custom_dns.py
+++ b/test/integration/component/test_network_vpc_custom_dns.py
@@ -729,4 +729,3 @@ class TestVpcCustomDns(cloudstackTestCase):
         self.deployNetworkTierVm()
         self.checkVpcBasic()
         self.checkVpcRouter()
-

--- a/test/integration/smoke/test_register_userdata.py
+++ b/test/integration/smoke/test_register_userdata.py
@@ -762,5 +762,3 @@ class TestRegisteredUserdata(cloudstackTestCase):
             self.apiclient,
             templateid=self.template.id
         )
-
-


### PR DESCRIPTION
flake8 --select=W291,W292,W293,W391 .

./test/integration/smoke/test_register_userdata.py:766:1: W391 blank line at end of file

./test/integration/component/test_network_vpc_custom_dns.py:732:1: W391 blank line at end of file

### Description

This PR fixes the `flake8` test
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
