### PR TITLE
Fix ping NFS server on ssvm-check.sh

### DIFF
--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -50,6 +50,7 @@ import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
@@ -1087,12 +1088,13 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         buf.append(" template=domP type=secstorage");
         buf.append(" host=").append(com.cloud.utils.StringUtils.toCSVList(indirectAgentLB.getManagementServerList(dest.getHost().getId(), dest.getDataCenter().getId(), null)));
         buf.append(" port=").append(_mgmtPort);
-        buf.append(" name=").append(profile.getVirtualMachine().getHostName());
+        String vmName = profile.getVirtualMachine().getHostName();
+        buf.append(" name=").append(vmName);
 
         buf.append(" zone=").append(dest.getDataCenter().getId());
         buf.append(" pod=").append(dest.getPod().getId());
 
-        buf.append(" guid=").append(profile.getVirtualMachine().getHostName());
+        buf.append(" guid=").append(vmName);
 
         buf.append(" workers=").append(_configDao.getValue("workers"));
         String msPublicKey = _configDao.getValue("ssh.publickey");
@@ -1180,7 +1182,27 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         s_logger.debug(String.format("Setting UseHttpsToUpload config on cmdline with [%s] value.", useHttpsToUpload));
         buf.append(" useHttpsToUpload=").append(useHttpsToUpload);
 
+        addSecondaryStorageServerAddressToBuffer(buf, secStore, vmName);
+
         return true;
+    }
+
+    /**
+     * Adds the secondary storage address to the buffer if it is in the following pattern: <protocol>//<address>/...
+     */
+    protected void addSecondaryStorageServerAddressToBuffer(StringBuilder buffer, DataStore dataStore, String vmName) {
+        String url = dataStore.getTO().getUrl();
+        String[] urlArray = url.split("/");
+
+        s_logger.debug(String.format("Found [%s] as secondary storage's URL for SSVM [%s].", url, vmName));
+        if (ArrayUtils.getLength(urlArray) < 3) {
+            s_logger.debug(String.format("Could not retrieve secondary storage address from URL [%s] of SSVM [%s].", url, vmName));
+            return;
+        }
+
+        String address = urlArray[2];
+        s_logger.info(String.format("Using [%s] as address of secondary storage of SSVM [%s].", address, vmName));
+            buffer.append(" secondaryStorageServerAddress=").append(address);
     }
 
     @Override


### PR DESCRIPTION
### Description

Part of script `ssvm-check.sh` checks if the secondary storage is mounted on the SSVM. If it is not mounted, it tries to ping the "NFS server"; This process infers that the "NFS server" is the seventeenth element of file `/var/cache/cloud/cmdline`; however, the index of the elements can vary according to some configurations (vide `SecondaryStorageManagerImpl#finalizeVirtualMachineProfile`). For instance, in https://github.com/apache/cloudstack/pull/6348#issuecomment-1310020312 it is trying to ping the netmask. Futhermore, we do not have the information of the NSF server in the `/var/cache/cloud/cmdline` file.

This PR intends to fix the check by adding the secondary storage server address to the file and retrieving it by the name. If the property is not in the file, it tries to validate the storage gateway to mitigate the "storage not mounted" situation.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?
...

