### PR TITLE
Fix flaky tests in NeutronNetworkAdapterTest.java, NeutronNodeAdapterTest.java and NeutronPortAdapterTest.java

### DIFF
--- a/plugins/network-elements/opendaylight/src/test/java/org/apache/cloudstack/network/opendaylight/api/test/NeutronNetworkAdapterTest.java
+++ b/plugins/network-elements/opendaylight/src/test/java/org/apache/cloudstack/network/opendaylight/api/test/NeutronNetworkAdapterTest.java
@@ -27,6 +27,7 @@ import junit.framework.Assert;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.junit.Test;
 
+import com.google.gson.JsonParser;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -58,7 +59,8 @@ public class NeutronNetworkAdapterTest {
             entity = new StringRequestEntity(gsonNeutronNetwork.toJson(networkWrapper), "application/json", null);
 
             String actual = entity.getContent();
-            Assert.assertEquals(jsonString, actual);
+            JsonParser parser = new JsonParser();
+            Assert.assertEquals(parser.parse(jsonString), parser.parse(actual));
         } catch (UnsupportedEncodingException e) {
             Assert.fail(e.getMessage());
         }

--- a/plugins/network-elements/opendaylight/src/test/java/org/apache/cloudstack/network/opendaylight/api/test/NeutronNodeAdapterTest.java
+++ b/plugins/network-elements/opendaylight/src/test/java/org/apache/cloudstack/network/opendaylight/api/test/NeutronNodeAdapterTest.java
@@ -29,6 +29,7 @@ import org.apache.cloudstack.network.opendaylight.api.model.NeutronNodeWrapper;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.junit.Test;
 
+import com.google.gson.JsonParser;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -48,7 +49,8 @@ public class NeutronNodeAdapterTest {
             entity = new StringRequestEntity(gsonNeutronNode.toJson(nodeWrapper), "application/json", null);
 
             String actual = entity.getContent();
-            Assert.assertEquals(jsonString, actual);
+            JsonParser parser = new JsonParser();
+            Assert.assertEquals(parser.parse(jsonString), parser.parse(actual));
         } catch (UnsupportedEncodingException e) {
             Assert.fail(e.getMessage());
         }

--- a/plugins/network-elements/opendaylight/src/test/java/org/apache/cloudstack/network/opendaylight/api/test/NeutronPortAdapterTest.java
+++ b/plugins/network-elements/opendaylight/src/test/java/org/apache/cloudstack/network/opendaylight/api/test/NeutronPortAdapterTest.java
@@ -30,6 +30,7 @@ import org.apache.cloudstack.network.opendaylight.api.model.NeutronPortWrapper;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.junit.Test;
 
+import com.google.gson.JsonParser;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -61,7 +62,8 @@ public class NeutronPortAdapterTest {
 
             String actual = entity.getContent();
 
-            Assert.assertEquals(jsonString, actual);
+            JsonParser parser = new JsonParser();
+            Assert.assertEquals(parser.parse(jsonString), parser.parse(actual));
         } catch (UnsupportedEncodingException e) {
             Assert.fail(e.getMessage());
         }


### PR DESCRIPTION
### Description

The tests below in `NeutronNetworkAdapterTest.java`, `NeutronNodeAdapterTest.java` and `NeutronPortAdapterTest.java` were found flaky because of the ordering of JSON objects. The orders of elements in the JSON objects were not the same every time the test being called. In this case, JsonParser from Gson was applied to ensure the orders do not cause the flakiness. This code change is trying to fix the [flaky tests](https://docs.gitlab.com/ee/development/testing_guide/flaky_tests.html) mentioned above, because they sometimes fail (as the picture showed) and sometimes pass. The failure could be reproduced by the commands below by using the tool of [NonDex](https://github.com/TestingResearchIllinois/NonDex). The code change is to make sure the tests will always pass in this case.

- `org.apache.cloudstack.network.opendaylight.api.test.NeutronNetworkAdapterTest.gsonNeutronNetworkMarshalingTest`
- `org.apache.cloudstack.network.opendaylight.api.test.NeutronNodeAdapterTest.gsonNeutronPortMarshalingTest`
- `org.apache.cloudstack.network.opendaylight.api.test.NeutronNodeAdapterTest.gsonNeutronPortMarshalingTest`

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<img width="893" alt="1" src="https://user-images.githubusercontent.com/61256379/202354808-9587bc19-bdfb-4bc8-9af8-192f09ff665a.png">

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

The test failures could be reproduced by

1. `mvn install -pl plugins/network-elements/opendaylight -am -DskipTests`
2.  run tests with NonDex 
    `mvn -pl plugins/network-elements/opendaylight edu.illinois:nondex-maven-plugin:2.1:nondex -Dtest=org.apache.cloudstack.network.opendaylight.api.test.NeutronNodeAdapterTest#gsonNeutronPortMarshalingTest`


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->