### PR TITLE
Fix C2S VPN in parallel to S2S VPN

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -999,7 +999,7 @@ class CsRemoteAccessVpn(CsDataBag):
 
         secret = CsFile(vpnsecretfilte)
         secret.empty()
-        secret.addeq("%s : PSK \"%s\"" % (left, psk))
+        secret.addeq(": PSK \"%s\"" % (psk))
         secret.commit()
 
         xl2tpdconf = CsFile(xl2tpdconffile)


### PR DESCRIPTION
### Description

PR #5375, introduced in version 4.15.2.0, removed parameter `%any` of VPNs client-to-site (C2S) IPSec secrets:
- structure before PR #5375:
  `<IP> %any : PSK "<PSK>"`
- structure after PR #5375:
  `<IP> : PSK "<PSK>"`


Because of that, when a VPN site-so-site (S2S) is created in parallel to a VPN C2S in the same network, the C2S will not handle any IP (`%any`) anymore and, as the network is being tunneled to the other VPN, the connection will be handled by the final peer. This way, when a VPN S2S is created in parallel to a VPN C2S in the same network, it is only possible to connect to the C2S with the S2S PSK.

As ACS is only able to implement a single C2S per network (ACS allows setting more than one IP of the network as VPN, however, only the first will be implemented) and every S2S has its own secret file, the secrets structure of C2S was changed to contain only the PSK:
```
: PSK "<PSK>"
```
 By doing that, StrongSwan will handle correctly C2S connections from any IP and still will use the correct PSK for S2S.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

I created 3 networks (A, B, and C) and a VM in each network. In networks B and C I enabled the VPN. From VM in network A, I configured both VPNs and successfully connected to them with their respective PSK. Then, from B to C I established a S2S VPN. Without this change, when I was trying to connect again to C2S B with B PSK, the connection was refused; however, when tried to connect to C2S B with C PSK, the connection was successful. After the changes, I tried to connect again to C2S B with B PSK and the connection was successful.