### PR TITLE
vmware: fix vmware vm snapshot operations for datastorecluster

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
@@ -1282,7 +1282,9 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
                 syncVolume(hostService, vmMo, context, hyperHost, volumeTO);
                 path = volumeTO.getPath();
                 baseName = VmwareHelper.trimSnapshotDeltaPostfix(volumeTO.getPath());
-                datastoreUuid = volumeTO.getDataStoreUuid();
+                if (volumeTO.getDataStoreUuid() != null) {
+                    datastoreUuid = volumeTO.getDataStoreUuid();
+                }
             } else {
                 Map<String, String> mapNewDisk = getNewDiskMap(vmMo);
                 // if this is managed storage

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
@@ -1270,7 +1271,7 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
         return mapNewDisk;
     }
 
-    private void setVolumeToPathAndSize(List<VolumeObjectTO> volumeTOs, VirtualMachineMO vmMo, VmwareHostService hostService, VmwareContext context, VmwareHypervisorHost hyperHost)
+    protected void setVolumeToPathAndSize(List<VolumeObjectTO> volumeTOs, VirtualMachineMO vmMo, VmwareHostService hostService, VmwareContext context, VmwareHypervisorHost hyperHost)
             throws Exception {
         String vmName = vmMo.getVmName();
         for (VolumeObjectTO volumeTO : volumeTOs) {
@@ -1282,7 +1283,7 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
                 syncVolume(hostService, vmMo, context, hyperHost, volumeTO);
                 path = volumeTO.getPath();
                 baseName = VmwareHelper.trimSnapshotDeltaPostfix(volumeTO.getPath());
-                if (volumeTO.getDataStoreUuid() != null) {
+                if (StringUtils.isNotEmpty(volumeTO.getDataStoreUuid())) {
                     datastoreUuid = volumeTO.getDataStoreUuid();
                 }
             } else {

--- a/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImplTest.java
+++ b/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImplTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.hypervisor.vmware.manager;
 
 import java.util.ArrayList;

--- a/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImplTest.java
+++ b/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImplTest.java
@@ -100,5 +100,4 @@ public class VmwareStorageManagerImplTest {
     public void testSetVolumeToPathAndSizeDatastoreClusterDifferentChildStore() {
         testCommon(Storage.StoragePoolType.PreSetup, Storage.StoragePoolType.DatastoreCluster, true);
     }
-
 }

--- a/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImplTest.java
+++ b/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImplTest.java
@@ -1,0 +1,104 @@
+package com.cloud.hypervisor.vmware.manager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+
+import com.cloud.hypervisor.vmware.mo.VirtualMachineMO;
+import com.cloud.hypervisor.vmware.mo.VmwareHypervisorHost;
+import com.cloud.hypervisor.vmware.util.VmwareClient;
+import com.cloud.hypervisor.vmware.util.VmwareContext;
+import com.cloud.storage.Storage;
+import com.vmware.vim25.HostDatastoreBrowserSearchResults;
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.VimPortType;
+import com.vmware.vim25.VirtualDisk;
+
+public class VmwareStorageManagerImplTest {
+
+    @InjectMocks
+    private VmwareStorageManagerImpl storageManager;
+
+    @Before
+    public void init() {
+        VmwareStorageMount mountService = Mockito.mock(VmwareStorageMount.class);
+
+        storageManager = new VmwareStorageManagerImpl(mountService);
+    }
+
+    private void testCommon(Storage.StoragePoolType poolType, Storage.StoragePoolType parentPoolType, boolean dsChange) {
+        VirtualMachineMO vmMo = Mockito.mock(VirtualMachineMO.class);
+        VmwareContext context = Mockito.mock(VmwareContext.class);
+        VmwareHypervisorHost hyperHost = Mockito.mock(VmwareHypervisorHost.class);
+        final String volumePath = "somepath";
+        final String uuid1 = UUID.randomUUID().toString();
+        final String uuid2 = UUID.randomUUID().toString();
+        VolumeObjectTO volumeTO = new VolumeObjectTO();
+        volumeTO.setPath(volumePath);
+        PrimaryDataStoreTO primaryDataStoreTO = Mockito.mock(PrimaryDataStoreTO.class);
+        Mockito.when(primaryDataStoreTO.getPoolType()).thenReturn(poolType);
+        Mockito.when(primaryDataStoreTO.getParentPoolType()).thenReturn(parentPoolType);
+        Mockito.when(primaryDataStoreTO.getUuid()).thenReturn(uuid1);
+        volumeTO.setDataStore(primaryDataStoreTO);
+        boolean isVolumeOnDatastoreCluster = Storage.StoragePoolType.DatastoreCluster.equals(poolType) || Storage.StoragePoolType.DatastoreCluster.equals(parentPoolType);
+        if (isVolumeOnDatastoreCluster && dsChange) {
+            volumeTO.setDataStoreUuid(uuid2);
+        }
+        VmwareClient vmwareClient = Mockito.mock(VmwareClient.class);
+        VimPortType service = Mockito.mock(VimPortType.class);
+        ManagedObjectReference mor = Mockito.mock(ManagedObjectReference.class);
+        ArrayList<HostDatastoreBrowserSearchResults> arr = new ArrayList<>();
+        Mockito.when(context.getVimClient()).thenReturn(vmwareClient);
+        Mockito.when(context.getService()).thenReturn(service);
+        List<VolumeObjectTO> volumes = List.of(volumeTO);
+        try {
+            Mockito.when(vmMo.getVmName()).thenReturn("dummy-vm");
+            String key = "browser";
+            Mockito.when(vmwareClient.getDynamicProperty(null, key)).thenReturn(null);
+            Mockito.when(vmwareClient.getDynamicProperty(mor, key)).thenReturn(mor);
+            Mockito.when(vmwareClient.waitForTask(Mockito.any())).thenReturn(true);
+            Mockito.doNothing().when(context).waitForTaskProgressDone(Mockito.any(ManagedObjectReference.class));
+            key = "info.result";
+            Mockito.when(vmwareClient.getDynamicProperty(null, key)).thenReturn(arr);
+            Mockito.doThrow(RuntimeException.class).when(service).searchDatastoreSubFoldersTask(Mockito.eq(null), Mockito.anyString(), Mockito.any());
+            Mockito.when(vmMo.getAllDiskDevice()).thenReturn(new VirtualDisk[0]);
+            if (isVolumeOnDatastoreCluster) {
+                if (dsChange) {
+                    Mockito.when(hyperHost.findDatastore(uuid2)).thenReturn(mor);
+                } else {
+                    Mockito.when(hyperHost.findDatastore(uuid1)).thenReturn(mor);
+                }
+            } else {
+                Mockito.when(hyperHost.findDatastoreByName(volumePath)).thenReturn(mor);
+            }
+            storageManager.setVolumeToPathAndSize(volumes, vmMo, Mockito.mock(VmwareHostService.class), context, hyperHost);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        Assert.assertEquals(0L, (long) volumes.get(0).getSize());
+    }
+
+    @Test
+    public void testSetVolumeToPathAndSizeNotDatastoreCluster() {
+        testCommon(Storage.StoragePoolType.VMFS, null, false);
+    }
+
+    @Test
+    public void testSetVolumeToPathAndSizeDatastoreClusterSameChildStore() {
+        testCommon(Storage.StoragePoolType.PreSetup, Storage.StoragePoolType.DatastoreCluster, false);
+    }
+
+    @Test
+    public void testSetVolumeToPathAndSizeDatastoreClusterDifferentChildStore() {
+        testCommon(Storage.StoragePoolType.PreSetup, Storage.StoragePoolType.DatastoreCluster, true);
+    }
+
+}


### PR DESCRIPTION
### Description

Fixes #6894

Fixes NPE observed when VM volume is present on the same child datastore.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
