### PR TITLE
server: fix domain shared public template check

### DIFF
--- a/server/src/main/java/com/cloud/acl/DomainChecker.java
+++ b/server/src/main/java/com/cloud/acl/DomainChecker.java
@@ -120,7 +120,7 @@ public class DomainChecker extends AdapterBase implements SecurityChecker {
      */
 
     private void checkPublicTemplateAccess(VirtualMachineTemplate template, Account owner, Account caller){
-        if (!QueryService.SharePublicTemplatesWithOtherDomains.valueIn(owner.getDomainId()) ||
+        if (QueryService.SharePublicTemplatesWithOtherDomains.valueIn(owner.getDomainId()) ||
                 caller.getDomainId() == owner.getDomainId() ||
                 _domainDao.isChildDomain(owner.getDomainId(), caller.getDomainId())) {
             return;


### PR DESCRIPTION
### Description

Fixes #6885

Fixes the incorrect inverted check.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Using API with two accounts in two different domains,

```
(local) 🕷 > list domains filter=id,name,path,
{
  "count": 3,
  "domain": [
    {
      "id": "02c03550-6a40-11ed-adb6-645d8651f45a",
      "name": "ROOT",
      "path": "ROOT"
    },
    {
      "id": "a6df78e8-d16f-4b75-b2a9-e7e21bf1458b",
      "name": "d1",
      "path": "ROOT/d1"
    },
    {
      "id": "9d7e43a1-4055-4de7-886f-bcf7b75a6509",
      "name": "d2",
      "path": "ROOT/d2"
    }
  ]
}
(local) 🐕 > list accounts id=c39c1bed-77a2-40e2-9574-3cc0099152d4 filter=id,name,roletype,domainid,domainpath,
{
  "account": [
    {
      "domainid": "a6df78e8-d16f-4b75-b2a9-e7e21bf1458b",
      "domainpath": "ROOT/d1",
      "id": "c39c1bed-77a2-40e2-9574-3cc0099152d4",
      "name": "d1user",
      "roletype": "User"
    }
  ],
  "count": 1
}
(local) 🍀 > list accounts id=515fb210-1cdd-4545-afec-326c98d0a37e  filter=id,name,roletype,domainid,domainpath,
{
  "account": [
    {
      "domainid": "9d7e43a1-4055-4de7-886f-bcf7b75a6509",
      "domainpath": "ROOT/d2",
      "id": "515fb210-1cdd-4545-afec-326c98d0a37e",
      "name": "d2user",
      "roletype": "User"
    }
  ],
  "count": 1
}
(local) 🦁 > list templates id=db68e383-c25d-4fe7-bbf6-aa5a03566e80 filter=id,name,accountid,account,domain,domainid templatefilter=all
{
  "count": 1,
  "template": [
    {
      "account": "d1user",
      "domain": "d1",
      "domainid": "a6df78e8-d16f-4b75-b2a9-e7e21bf1458b",
      "id": "db68e383-c25d-4fe7-bbf6-aa5a03566e80",
      "name": "publicma"
    }
  ]
}
(local) 🐜 > list configurations domainid=a6df78e8-d16f-4b75-b2a9-e7e21bf1458b name=share.public.templates.with.other.domains
{
  "configuration": [
    {
      "category": "Advanced",
      "description": "If false, templates of this domain will not show up in the list templates of other domains.",
      "isdynamic": true,
      "name": "share.public.templates.with.other.domains",
      "scope": "domain",
      "value": "true"
    }
  ],
  "count": 1
}
(local) 🐜 > set username d2user
(local) 🐌 > set domain d2
(local) 🐣 > sync
Discovered 294 APIs
(local) 🐌 > list templates id=db68e383-c25d-4fe7-bbf6-aa5a03566e80 templatefilter=community
{
  "count": 1,
  "template": [
    {
      "account": "d1user",
      "bits": 0,
      "created": "2022-11-22T18:34:04+0530",
      "crossZones": false,
      "deployasis": false,
      "details": {},
      "directdownload": false,
      "displaytext": "publicma",
      "domain": "d1",
      "domainid": "a6df78e8-d16f-4b75-b2a9-e7e21bf1458b",
      "downloaddetails": [
        {
          "datastore": "nfs://10.147.28.6:/export/home/sandbox/secondary",
          "downloadPercent": "100",
          "downloadState": "DOWNLOADED"
        }
      ],
      "format": "VHD",
      "hasannotations": false,
      "hypervisor": "Simulator",
      "id": "db68e383-c25d-4fe7-bbf6-aa5a03566e80",
      "isdynamicallyscalable": false,
      "isextractable": false,
      "isfeatured": false,
      "ispublic": true,
      "isready": true,
      "name": "publicma",
      "ostypeid": "02af909e-6a40-11ed-adb6-645d8651f45a",
      "ostypename": "Other Linux (64-bit)",
      "passwordenabled": false,
      "physicalsize": 5242880,
      "requireshvm": true,
      "size": 5242880,
      "sshkeyenabled": false,
      "tags": [],
      "templatetype": "USER",
      "zoneid": "7044a830-22e1-4671-8c61-0389b5e036ea",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```