### PR TITLE
Minor console access refactor and improvements

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
+++ b/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
@@ -18,9 +18,8 @@ package org.apache.cloudstack.consoleproxy;
 
 import com.cloud.utils.component.Manager;
 import org.apache.cloudstack.api.command.user.consoleproxy.ConsoleEndpoint;
-import org.apache.cloudstack.framework.config.Configurable;
 
-public interface ConsoleAccessManager extends Manager, Configurable {
+public interface ConsoleAccessManager extends Manager {
 
     ConsoleEndpoint generateConsoleEndpoint(Long vmId, String extraSecurityToken, String clientAddress);
 

--- a/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
+++ b/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
@@ -18,14 +18,9 @@ package org.apache.cloudstack.consoleproxy;
 
 import com.cloud.utils.component.Manager;
 import org.apache.cloudstack.api.command.user.consoleproxy.ConsoleEndpoint;
-import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 
 public interface ConsoleAccessManager extends Manager, Configurable {
-
-    ConfigKey<Boolean> ConsoleProxyExtraSecurityValidationEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class,
-            "consoleproxy.extra.security.validation.enabled", "false",
-            "Enable/disable extra security validation for console proxy using an extra token.", true);
 
     ConsoleEndpoint generateConsoleEndpoint(Long vmId, String extraSecurityToken, String clientAddress);
 

--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -47,7 +47,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.cloudstack.api.command.user.consoleproxy.ConsoleEndpoint;
 import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.security.keys.KeysManager;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.ObjectUtils;
@@ -212,13 +211,14 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
             throw new CloudRuntimeException(msg);
         }
 
-        if (vm.getHostId() == null) {
+        Long hostId = vm.getState() != VirtualMachine.State.Migrating ? vm.getHostId() : vm.getLastHostId();
+        if (hostId == null) {
             msg = "VM " + vmUuid + " lost host info, sending blank response for console access request";
             s_logger.warn(msg);
             throw new CloudRuntimeException(msg);
         }
 
-        HostVO host = managementServer.getHostBy(vm.getHostId());
+        HostVO host = managementServer.getHostBy(hostId);
         if (host == null) {
             msg = "VM " + vmUuid + "'s host does not exist, sending blank response for console access request";
             s_logger.warn(msg);
@@ -487,13 +487,4 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
         }
     }
 
-    @Override
-    public String getConfigComponentName() {
-        return ConsoleAccessManagerImpl.class.getSimpleName();
-    }
-
-    @Override
-    public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey[] { };
-    }
 }

--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -59,8 +59,10 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -88,6 +90,10 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
     private final Gson gson = new GsonBuilder().create();
 
     public static final Logger s_logger = Logger.getLogger(ConsoleAccessManagerImpl.class.getName());
+
+    private static final List<VirtualMachine.State> unsupportedConsoleVMState = Arrays.asList(
+            VirtualMachine.State.Stopped, VirtualMachine.State.Error, VirtualMachine.State.Destroyed
+    );
 
     private static Set<String> allowedSessions;
 
@@ -200,8 +206,8 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
         }
 
         String vmUuid = vm.getUuid();
-        if (vm.getState() != VirtualMachine.State.Running) {
-            msg = "VM " + vmUuid + " must be Running to connect console, sending blank response for console access request";
+        if (unsupportedConsoleVMState.contains(vm.getState())) {
+            msg = "VM " + vmUuid + " must be running to connect console, sending blank response for console access request";
             s_logger.warn(msg);
             throw new CloudRuntimeException(msg);
         }

--- a/ui/src/components/widgets/Console.vue
+++ b/ui/src/components/widgets/Console.vue
@@ -28,7 +28,6 @@
 <script>
 import { SERVER_MANAGER } from '@/store/mutation-types'
 import { api } from '@/api'
-import { uuid } from 'vue-uuid'
 
 export default {
   name: 'Console',
@@ -44,24 +43,12 @@ export default {
   },
   data () {
     return {
-      url: '',
-      tokenValidationEnabled: false
+      url: ''
     }
   },
-  created () {
-    this.verifyExtraValidationEnabled()
-  },
   methods: {
-    verifyExtraValidationEnabled () {
-      api('listConfigurations', { name: 'consoleproxy.extra.security.validation.enabled' }).then(json => {
-        this.tokenValidationEnabled = json?.listconfigurationsresponse?.configuration && json?.listconfigurationsresponse?.configuration[0]?.value === 'true'
-      })
-    },
     consoleUrl () {
       const params = {}
-      if (this.tokenValidationEnabled) {
-        params.token = uuid.v4()
-      }
       params.virtualmachineid = this.resource.id
       api('createConsoleEndpoint', params).then(json => {
         this.url = (json && json.createconsoleendpointresponse) ? json.createconsoleendpointresponse.consoleendpoint.url : '#/exception/404'


### PR DESCRIPTION
### Description

This PR adds a few improvements on the console access, by:

- Removing the `consoleproxy.extra.security.validation.enabled` configuration introduced on the main branch (not yet on any release), in favour of the optional parameter `token` on the `createConsoleEndpoint`.
- Improving the error message when trying to access the console of a virtual machine that is not running

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Access console for virtual machines on the UI
- Using cmk, generate a console endpoint without the token parameter -> verify connection to the URL
- Using cmk, generate a console endpoint with the token parameter -> verify connection to the URL
- Using cmk, generate a console endpoint for a stopped VM -> check descriptive error message 