### PR TITLE
[Veeam] Fix escape powershell comand when listing Veeam repository names

### DIFF
--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
@@ -369,7 +369,7 @@ public class VeeamClient {
     protected String getRepositoryNameFromJob(String backupName) {
         final List<String> cmds = Arrays.asList(
                 String.format("$Job = Get-VBRJob -name \"%s\"", backupName),
-                "$Job.GetBackupTargetRepository() ^| select Name | Format-List"
+                "$Job.GetBackupTargetRepository() ^| select Name ^| Format-List"
         );
         Pair<Boolean, String> result = executePowerShellCommands(cmds);
         if (result == null || !result.first()) {


### PR DESCRIPTION
PR #5774 introduced a functionality to allow operators to choose in which Veeam's repository, if more than one is configured, ACS' clone job will be executed. However, a change was missing in the PR and caused the errors reported in #6599. 

This PR addresses the fix for #6599.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![205299189-cb62a8c6-9a75-4086-a77e-b7842fd0ce75](https://user-images.githubusercontent.com/31869303/205303051-1b1df656-acb7-451d-bb56-a1a73e0d1dda.png)

### How Has This Been Tested?

It was tested in a local laboratory:  
- I assigned three VMs to three Backup Offerings;
- Before, the assign fails, with the same message reported in issue #6599;
- Now the assign works.