### PR TITLE
schema: Add upgrade path from 4.17.2.0 same as 4.17.1.0

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -211,6 +211,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.17.0.0", new Upgrade41700to41710())
                 .next("4.17.0.1", new Upgrade41700to41710())
                 .next("4.17.1.0", new Upgrade41710to41800())
+                .next("4.17.2.0", new Upgrade41710to41800())
                 .build();
     }
 


### PR DESCRIPTION
There's no DB upgrade path b/w 4.17.1.0 and 4.17.2.0, this adds the same upgrade path of 4.17.1.0 when source version is 4.17.2.0.