### PR TITLE
test: fix failure on non-VMware env

### DIFF
--- a/test/integration/smoke/test_vm_lifecycle_unmanage_import.py
+++ b/test/integration/smoke/test_vm_lifecycle_unmanage_import.py
@@ -60,6 +60,8 @@ class TestUnmanageVM(cloudstackTestCase):
             assert False, "get_suitable_test_template() failed to return template with description %s" % cls.services["ostype"]
 
         cls.hypervisorNotSupported = cls.hypervisor.lower() != "vmware"
+        if cls.hypervisorNotSupported:
+            return
 
         cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["small"]["template"] = cls.template.id
@@ -97,9 +99,14 @@ class TestUnmanageVM(cloudstackTestCase):
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
-        self.services["network"]["networkoffering"] = self.network_offering.id
         self.cleanup = []
         self.created_networks = []
+        self.virtual_machine = None
+        self.unmanaged_instance = None
+        self.imported_vm = None
+        if self.hypervisorNotSupported:
+            return
+        self.services["network"]["networkoffering"] = self.network_offering.id
         network_data = self.services["l2-network"]
         self.network = Network.create(
             self.apiclient,
@@ -127,8 +134,6 @@ class TestUnmanageVM(cloudstackTestCase):
         )
         self.cleanup.append(self.network2)
         self.created_networks.append(self.network2)
-        self.unmanaged_instance = None
-        self.imported_vm = None
 
     '''
     Fetch vmware datacenter login details


### PR DESCRIPTION
### Description

PR #6964 added some changes for VM import test which are causing exceptions on non-VMware environments. This PR fixes those error and correctly skips unmanage and import tests for non-VMware env.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
**On KVM** - tests are skipped without errors
```
[root@pr6803-t5409-kvm-centos7-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr6803-t5409-kvm-centos7-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_vm_lifecycle_unmanage_import.py 
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography and will be removed in a future release.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Dec_10_2022_06_46_11_GM8KGX All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== Final results are now copied to: /marvin//MarvinLogs/test_vm_lifecycle_unmanage_import_P2LYDF ===
```

**On VMware**
```
[root@pr6953-t5437-vmware-67u3-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr6953-t5437-vmware-67u3-advanced-cfg -s -a tags=advanced --hypervisor=VMware tests/smoke/test_vm_lifecycle_unmanage_import.py 
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography and will be removed in a future release.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Dec_10_2022_06_45_20_5G7EGE All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_01_unmanage_vm_cycle | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_vm_lifecycle_unmanage_import_MYS5OH ===
```
