### PR TITLE
api,server,metrics: fix listVirtuaMachinesMetrics API for user

### DIFF
--- a/plugins/metrics/src/main/java/org/apache/cloudstack/api/ListVMsMetricsCmd.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/api/ListVMsMetricsCmd.java
@@ -43,7 +43,7 @@ import org.apache.cloudstack.response.VmMetricsResponse;
  * </ul>
  */
 @APICommand(name = ListVMsMetricsCmd.APINAME, description = "Lists VM metrics", responseObject = VmMetricsResponse.class,
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,  responseView = ResponseObject.ResponseView.Full,
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,  responseView = ResponseObject.ResponseView.Restricted,
         since = "4.9.3", authorized = {RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
 public class ListVMsMetricsCmd extends ListVMsCmd implements UserCmd {
     public static final String APINAME = "listVirtualMachinesMetrics";


### PR DESCRIPTION
### Description

Fixes #6983

In case of multiple command classes for an API, ApiServer returns an API command class for User role only when ResponseView is set to Restricted in the annotation. This PR set Restricted ResponseView for ListVMsMetrics class. It also adds a smoke test for User role account for the listVirtualMachinesMetrics API.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![Screenshot from 2022-12-14 00-35-34](https://user-images.githubusercontent.com/153340/207422956-9ed09a2b-aaab-4481-9f82-f36d706605b4.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

```
⇒  nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./setup/dev/advanced.cfg -s -a tags=advanced --hypervisor=Simulator test/integration/smoke/test_metrics_api.py 

==== Marvin Init Started ====


=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/Dec_14_2022_00_24_06_9HK9RV All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====

...

=== TestName: test_list_vms_metrics_admin | Status : SUCCESS ===

=== TestName: test_list_vms_metrics_user | Status : SUCCESS ===
...
```
