### PR TITLE
vmware: encode disk path for URL based access

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareContext.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareContext.java
@@ -16,29 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.vmware.util;
 
-import com.cloud.hypervisor.vmware.mo.DatacenterMO;
-import com.cloud.hypervisor.vmware.mo.DatastoreFile;
-import com.cloud.utils.ActionDelegate;
-import com.cloud.utils.StringUtils;
-import com.vmware.pbm.PbmPortType;
-import com.vmware.pbm.PbmServiceInstanceContent;
-import com.vmware.vim25.ManagedObjectReference;
-import com.vmware.vim25.ObjectContent;
-import com.vmware.vim25.ObjectSpec;
-import com.vmware.vim25.PropertyFilterSpec;
-import com.vmware.vim25.PropertySpec;
-import com.vmware.vim25.ServiceContent;
-import com.vmware.vim25.TaskInfo;
-import com.vmware.vim25.TraversalSpec;
-import com.vmware.vim25.VimPortType;
-import org.apache.cloudstack.utils.security.SSLUtils;
-import org.apache.cloudstack.utils.security.SecureSSLSocketFactory;
-import org.apache.log4j.Logger;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSession;
-import javax.xml.ws.soap.SOAPFaultException;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -58,6 +35,31 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
+import javax.xml.ws.soap.SOAPFaultException;
+
+import org.apache.cloudstack.utils.security.SSLUtils;
+import org.apache.cloudstack.utils.security.SecureSSLSocketFactory;
+import org.apache.log4j.Logger;
+
+import com.cloud.hypervisor.vmware.mo.DatacenterMO;
+import com.cloud.hypervisor.vmware.mo.DatastoreFile;
+import com.cloud.utils.ActionDelegate;
+import com.cloud.utils.StringUtils;
+import com.vmware.pbm.PbmPortType;
+import com.vmware.pbm.PbmServiceInstanceContent;
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.ObjectContent;
+import com.vmware.vim25.ObjectSpec;
+import com.vmware.vim25.PropertyFilterSpec;
+import com.vmware.vim25.PropertySpec;
+import com.vmware.vim25.ServiceContent;
+import com.vmware.vim25.TaskInfo;
+import com.vmware.vim25.TraversalSpec;
+import com.vmware.vim25.VimPortType;
 
 public class VmwareContext {
     private static final Logger s_logger = Logger.getLogger(VmwareContext.class);
@@ -631,12 +633,12 @@ public class VmwareContext {
         sb.append("https://");
         sb.append(_serverAddress);
         sb.append("/folder/");
-        sb.append(relativePath);
         try {
+            sb.append(URLEncoder.encode(relativePath, "UTF-8"));
             sb.append("?dcPath=").append(URLEncoder.encode(dcName, "UTF-8"));
             sb.append("&dsName=").append(URLEncoder.encode(datastoreName, "UTF-8"));
         } catch (UnsupportedEncodingException e) {
-            s_logger.error("Unable to encode URL. dcPath : " + dcName + ", dsName :" + datastoreName, e);
+            s_logger.error(String.format("Unable to encode URL. relativePath : %s, dcPath : %s, dsName : %s", relativePath, dcName, datastoreName), e);
         }
         return sb.toString();
     }


### PR DESCRIPTION
### Description

Fixes: #6992

During disk operations, the VMware plugin tries to connect to the VMware datacenter datastore using a URL based on the disk path and datastore name. This PR encodes the disk path to prevent any failure from the server due to a bad URL.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Without change,
```
2022-12-14 12:04:34,963 ERROR [c.c.s.r.VmwareStorageProcessor] (DirectAgent-482:ctx-38e8658a 10.0.34.64, job-169/job-170, cmd: DettachCommand) (logid:e6c5c585) Failed to detach volume!
java.io.IOException: Server returned HTTP response code: 400 for URL: https://10.0.33.178/folder/space test/space test_30.vmdk?dcPath=Trillian&dsName=fd54f3559fe43f60b8694fe4ccac777f
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1924)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
	at com.cloud.hypervisor.vmware.util.VmwareContext.getResourceContent(VmwareContext.java:514)
	at com.cloud.hypervisor.vmware.mo.VirtualMachineMO.getDiskDatastorePathChain(VirtualMachineMO.java:2853)
	at com.cloud.hypervisor.vmware.mo.VirtualMachineMO.detachDisk(VirtualMachineMO.java:1507)
	at com.cloud.storage.resource.VmwareStorageProcessor.attachVolume(VmwareStorageProcessor.java:2143)
	at com.cloud.storage.resource.VmwareStorageProcessor.dettachVolume(VmwareStorageProcessor.java:2407)
	at com.cloud.storage.resource.StorageSubsystemCommandHandlerBase.execute(StorageSubsystemCommandHandlerBase.java:172)
	at com.cloud.storage.resource.StorageSubsystemCommandHandlerBase.handleStorageCommands(StorageSubsystemCommandHandlerBase.java:69)
	at com.cloud.hypervisor.vmware.resource.VmwareResource.executeRequest(VmwareResource.java:583)

```

With change,
```
2022-12-14 12:42:27,497 INFO  [c.c.h.v.m.DatastoreMO] (DirectAgent-18:ctx-43ed63e2 10.0.34.64, job-184/job-185, cmd: DettachCommand) (logid:0f0b1695) File [fd54f3559fe43f60b8694fe4ccac777f] space test/space test_32-flat.vmdk exists on datastore
2022-12-14 12:42:27,592 INFO  [c.c.h.v.m.DatastoreMO] (DirectAgent-18:ctx-43ed63e2 10.0.34.64, job-184/job-185, cmd: DettachCommand) (logid:0f0b1695) Folder fcd exists on datastore
2022-12-14 12:42:27,593 INFO  [c.c.s.r.VmwareStorageLayoutHelper] (DirectAgent-18:ctx-43ed63e2 10.0.34.64, job-184/job-185, cmd: DettachCommand) (logid:0f0b1695) Fixup folder-synchronization. move [fd54f3559fe43f60b8694fe4ccac777f] space test/space test_32.vmdk -> [fd54f3559fe43f60b8694fe4ccac777f] fcd/space test_32.vmdk
2022-12-14 12:42:27,602 INFO  [c.c.h.v.m.DatastoreMO] (DirectAgent-18:ctx-43ed63e2 10.0.34.64, job-184/job-185, cmd: DettachCommand) (logid:0f0b1695) Search file space test_32.vmdk on [fd54f3559fe43f60b8694fe4ccac777f] space test
2022-12-14 12:42:27,617 INFO  [c.c.h.v.m.DatastoreMO] (DirectAgent-18:ctx-43ed63e2 10.0.34.64, job-184/job-185, cmd: DettachCommand) (logid:0f0b1695) File [fd54f3559fe43f60b8694fe4ccac777f] space test/space test_32.vmdk exists on datastore
2022-12-14 12:42:27,662 INFO  [c.c.h.v.u.VmwareContext] (DirectAgent-18:ctx-43ed63e2 10.0.34.64, job-184/job-185, cmd: DettachCommand) (logid:0f0b1695) Connected, conn: sun.net.www.protocol.https.DelegateHttpsURLConnection:https://10.0.33.178/folder/space+test?dcPath=Trillian&dsName=fd54f3559fe43f60b8694fe4ccac777f, retry: 0
2022-12-14 12:42:27,684 DEBUG [c.c.a.m.DirectAgentAttache] (DirectAgent-18:ctx-43ed63e2) (logid:0f0b1695) Seq 1-6176968363915345936: Response Received: 
```

Tested following:
- Import a VM with spaces in name/path
- Attach-detach data volume
- Migrate VM with storage

https://user-images.githubusercontent.com/153340/211802783-f7970692-4540-4b67-b916-fabca803f0f8.mp4

