### PR TITLE
[VMware] Remove unnecessary logs on VM deployments

### DIFF
--- a/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
+++ b/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
@@ -40,8 +40,10 @@ public class NiciraNvpApiVersion {
         return (compare < 0);
     }
 
-    public static synchronized void logNiciraApiVersion(){
-        s_logger.info("NSX API VERSION: " + ((niciraApiVersion != null) ? niciraApiVersion : " NOT PRESENT"));
+    public static synchronized void logNiciraApiVersion() {
+        if (niciraApiVersion != null) {
+            s_logger.info("NSX API VERSION: " + niciraApiVersion);
+        }
     }
 
 }

--- a/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
+++ b/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
@@ -42,7 +42,7 @@ public class NiciraNvpApiVersion {
 
     public static synchronized void logNiciraApiVersion() {
         if (niciraApiVersion != null) {
-            s_logger.info("NSX API VERSION: " + niciraApiVersion);
+            s_logger.info(String.format("NSX API VERSION: %s", niciraApiVersion));
         }
     }
 


### PR DESCRIPTION
### Description

This PR removes unnecessary logging on VMware deployments in which the NVP plugin is not enabled. On each StartCommand a similar line is logged even if the NVP plugin is not configured:

````
2022-12-14 15:05:33,375 INFO  [c.c.u.n.n.p.NiciraNvpApiVersion] (DirectAgent-434:ctx-979662ea esxi2.michikusa.local, job-2738/job-2739, cmd: StartCommand) (logid:5a621e44) NSX API VERSION:  NOT PRESENT
````

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
