### PR TITLE
Ensure Prometheus doesn't return values when the capacity_state is disabled

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -43,6 +43,7 @@ import com.cloud.api.query.vo.StoragePoolJoinVO;
 import com.cloud.capacity.Capacity;
 import com.cloud.capacity.CapacityManager;
 import com.cloud.capacity.CapacityVO;
+import com.cloud.capacity.CapacityState;
 import com.cloud.capacity.dao.CapacityDao;
 import com.cloud.capacity.dao.CapacityDaoImpl;
 import com.cloud.configuration.Resource;
@@ -156,7 +157,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
 
             final String cpuFactor = String.valueOf(CapacityManager.CpuOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO cpuCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU);
-            if (cpuCapacity != null) {
+            if (cpuCapacity != null && cpuCapacity.getCapacityState() == CapacityState.Enabled) {
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, cpuCapacity.getUsedCapacity(), isDedicated, hostTags));
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, cpuCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {
@@ -166,7 +167,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
 
             final String memoryFactor = String.valueOf(CapacityManager.MemOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO memCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_MEMORY);
-            if (memCapacity != null) {
+            if (memCapacity != null && memCapacity.getCapacityState() == CapacityState.Enabled) {
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, memCapacity.getUsedCapacity(), isDedicated, hostTags));
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, memCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {
@@ -177,7 +178,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             metricsList.add(new ItemHostVM(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), vmDao.listByHostId(host.getId()).size()));
 
             final CapacityVO coreCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU_CORE);
-            if (coreCapacity != null) {
+            if (coreCapacity != null && coreCapacity.getCapacityState() == CapacityState.Enabled) {
                 metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), USED, coreCapacity.getUsedCapacity(), isDedicated, hostTags));
                 metricsList.add(new ItemVMCore(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), TOTAL, coreCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {


### PR DESCRIPTION
### Description

This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
Fixes: #7000

It makes prometheus integration returns the same value ("0") when a capacity is explicitly "Disabled" or non-existent. 

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Set a host in maintenance.
Restart the cloudstack-management service.
Capacities are set to Disabled in table "op_host_capacity".

```
MariaDB [cloud]> SELECT id,host_id,used_capacity,reserved_capacity,total_capacity,capacity_type,capacity_state FROM op_host_capacity WHERE `host_id`=1;
+----+---------+---------------+-------------------+----------------+---------------+----------------+
| id | host_id | used_capacity | reserved_capacity | total_capacity | capacity_type | capacity_state |
+----+---------+---------------+-------------------+----------------+---------------+----------------+
| 11 |       1 |        196640 |                 0 |   105419636736 |             3 | Enabled        |
| 18 |       1 |             0 |                 0 |              2 |            90 | Disabled       |
| 19 |       1 |             0 |                 0 |     3048968192 |             0 | Disabled       |
| 20 |       1 |             0 |                 0 |           4394 |             1 | Disabled       |
+----+---------+---------------+-------------------+----------------+---------------+----------------+
4 rows in set (0.00 sec)
```

For the three disabled capacity types, Prometheus exporter returns a total capacity value of "0".
```
~# curl -s localhost:9595/metrics | grep node01 | grep "vms_cores_total\|cpu_usage_mhz\|memory_usage_mibs" | grep 'filter="total"'

cloudstack_host_cpu_usage_mhz_total{zone="testZone1",hostname="node01",ip="redacted",overprovisioningfactor="1.0",filter="total",tags=""} 0.00
cloudstack_host_memory_usage_mibs_total{zone="testZone1",hostname="node01",ip="redacted",overprovisioningfactor="1.0",filter="total",dedicated="0",tags=""} 0.00
cloudstack_host_vms_cores_total{zone="testZone1",hostname="node01",ip="redacted",filter="total",dedicated="0",tags=""} 0
```
 
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
