### PR TITLE
utils: fix human-readable parsing failures

### DIFF
--- a/utils/src/main/java/com/cloud/utils/HumanReadableJson.java
+++ b/utils/src/main/java/com/cloud/utils/HumanReadableJson.java
@@ -23,6 +23,8 @@ import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import org.apache.log4j.Logger;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -30,9 +32,13 @@ import com.google.gson.JsonParser;
 
 public class HumanReadableJson {
 
+    static final Logger LOGGER = Logger.getLogger(HumanReadableJson.class);
+
     private boolean changeValue;
     private StringBuilder output = new StringBuilder();
     private boolean firstElement = true;
+
+    private String lastKey;
 
     private final String[] elementsToMatch = {
             "bytesSent","bytesReceived","BytesWrite","BytesRead","bytesReadRate","bytesWriteRate","iopsReadRate",
@@ -69,7 +75,9 @@ public class HumanReadableJson {
             if (changeValue) {
                 try {
                     changedValue = toHumanReadableSize(jsonElement.getAsLong());
-                } catch (NumberFormatException ignored) {}
+                } catch (NumberFormatException nfe) {
+                    LOGGER.debug(String.format("Unable to parse '%s' with value: %s to human readable number format. Returning as it is", lastKey, changedValue), nfe);
+                }
             }
             output.append("\"").append(changedValue).append("\"");
             firstElement = false;
@@ -84,6 +92,7 @@ public class HumanReadableJson {
         while(it.hasNext()) {
             Entry<String, JsonElement> value = it.next();
             String key = value.getKey();
+            lastKey = key;
             if (!firstElement){
                 output.append(",");
             }

--- a/utils/src/main/java/com/cloud/utils/HumanReadableJson.java
+++ b/utils/src/main/java/com/cloud/utils/HumanReadableJson.java
@@ -18,13 +18,14 @@
 //
 package com.cloud.utils;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 
 public class HumanReadableJson {
@@ -64,11 +65,13 @@ public class HumanReadableJson {
             firstElement = false;
         }
         if (jsonElement.isJsonPrimitive()) {
+            String changedValue = jsonElement.getAsString();
             if (changeValue) {
-                output.append("\"" + toHumanReadableSize(jsonElement.getAsLong()) + "\"");
-            } else {
-                output.append("\"" + jsonElement.getAsString() + "\"");
+                try {
+                    changedValue = toHumanReadableSize(jsonElement.getAsLong());
+                } catch (NumberFormatException ignored) {}
             }
+            output.append("\"").append(changedValue).append("\"");
             firstElement = false;
         }
     }

--- a/utils/src/test/java/com/cloud/utils/HumanReadableJsonTest.java
+++ b/utils/src/test/java/com/cloud/utils/HumanReadableJsonTest.java
@@ -18,11 +18,12 @@
 //
 package com.cloud.utils;
 
-import org.junit.Test;
+import static com.cloud.utils.HumanReadableJson.getHumanReadableBytesJson;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Locale;
-import static org.junit.Assert.assertEquals;
-import static com.cloud.utils.HumanReadableJson.getHumanReadableBytesJson;
+
+import org.junit.Test;
 
 public class HumanReadableJsonTest {
 
@@ -62,5 +63,10 @@ public class HumanReadableJsonTest {
         assertEquals("[{\"size\":\"(100.05 KB) 102456\"}]", getHumanReadableBytesJson("[{\"size\": \"102456\"}]"));
         Locale.setDefault(Locale.forLanguageTag("en-ZA")); // Other region test
         assertEquals("[{\"size\":\"(100,05 KB) 102456\"}]", getHumanReadableBytesJson("[{\"size\": \"102456\"}]"));
+    }
+
+    @Test
+    public void testNonNumberFieldParsing() {
+        assertEquals("{\"size\":\"SMALL\",\"newSize\":\"LARGE\"}", getHumanReadableBytesJson("{\"size\": \"SMALL\",\"newSize\": \"LARGE\"}"));
     }
 }


### PR DESCRIPTION
### Description

When an API response parameter which is expected by HumanReadableJson utility to return a number value is not returning a number value it results in API failure. This change makes API return the value as it is when there is a NumberFormatException with one of the API response param which is listed in HumanReadableJson.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Failure seen without change (A new API added which returns a param size as SMALL, BIG, HUGE),
```
(local) 🦑 > create something
{
  "accountid": "b009bced-803a-11ed-87cc-645d8651f45a",
  "cmd": "org.apache.cloudstack.api.command.CreateSomethingCmd",
  "completed": "2022-12-21T12:46:06+0530",
  "created": "2022-12-21T12:45:20+0530",
  "jobid": "c12b240b-bded-4c4e-bbd2-7c62959a8d60",
  "jobinstancetype": "None",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "For input string: \"SMALL\""
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "b00a01db-803a-11ed-87cc-645d8651f45a"
}
```
