### PR TITLE
Update usage when scaling vms

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -4569,11 +4569,11 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 throw new CloudRuntimeException("Unable to scale vm due to " + (reconfigureAnswer == null ? "" : reconfigureAnswer.getDetails()));
             }
 
+            upgradeVmDb(vm.getId(), newServiceOffering, oldServiceOffering);
+
             if (vm.getType().equals(VirtualMachine.Type.User)) {
                 _userVmMgr.generateUsageEvent(vm, vm.isDisplayVm(), EventTypes.EVENT_VM_DYNAMIC_SCALE);
             }
-
-            upgradeVmDb(vm.getId(), newServiceOffering, oldServiceOffering);
 
             if (reconfiguringOnExistingHost) {
                 vm.setServiceOfferingId(oldServiceOffering.getId());


### PR DESCRIPTION
### Description

When scaling a VM, the new details of the compute resources (memory, CPU speed, and CPU cores) are updated in the database after generating the usage event. This way, the usage events are generated with outdated details. Usage uses those events while generating entries in `cloud_usage.usage_vm_instance` and `cloud_usage.cloud_usage`, however, as in the scaling the details are updated after generating the events, the entries for the VM in `cloud_usage.usage_vm_instance` are always outdated after the scaling, as well the entries in `cloud_usage.cloud_usage`. In order to make Usage generate the proper entries, operators must stop and start the VM again (generating events of stop and start with the current VM compute resources' state).

This PR intends to fix this behavior by updating the details before generating the usage event, making the events synchronized with the current VM compute resources' state.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
I set the `usage.stats.job.aggregation.range` setting to 1 minute to speed up the testing process, then I created a new VM with a constrained offering, and started scaling it.

Before this change, the entries in `cloud_usage.usage_vm_instance` and `cloud_usage.cloud_usage` would contain the memory, CPU speed, and CPU cores of the VM from before the last scaling, e.g., after the first scaling, the entries would have the original details, after the second scaling, the entries would have the details from the first scaling, and so on.

After this change, when dynamic scaling a VM, the events and entries in `cloud_usage.usage_vm_instance` and `cloud_usage.cloud_usage` are generated properly.