### PR TITLE
Allow users to inform timezones on APIs that have the date parameter

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/BaseCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/BaseCmd.java
@@ -103,7 +103,7 @@ public abstract class BaseCmd {
         GET, POST, PUT, DELETE
     }
     public static enum CommandType {
-        BOOLEAN, DATE, FLOAT, DOUBLE, INTEGER, SHORT, LIST, LONG, OBJECT, MAP, STRING, TZDATE, UUID
+        BOOLEAN, DATE, FLOAT, DOUBLE, INTEGER, SHORT, LIST, LONG, OBJECT, MAP, STRING, UUID
     }
 
     private Object _responseObject;

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/job/ListAsyncJobsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/job/ListAsyncJobsCmd.java
@@ -34,7 +34,7 @@ public class ListAsyncJobsCmd extends BaseListAccountResourcesCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
 
-    @Parameter(name = ApiConstants.START_DATE, type = CommandType.TZDATE, description = "The start date of the async job (use format \"yyyy-MM-dd'T'HH:mm:ss'+'SSSS\")")
+    @Parameter(name = ApiConstants.START_DATE, type = CommandType.DATE, description = "The start date of the async job (use format \"yyyy-MM-dd'T'HH:mm:ss'+'SSSS\")")
     private Date startDate;
 
     /////////////////////////////////////////////////////

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -422,7 +422,6 @@ public class ParamProcessWorker implements DispatchWorker {
                     " is not accessible]");
         }
     }
-    
     private void parseAndSetDate(Field field, BaseCmd cmdObj, Object paramObj) throws IllegalAccessException, ParseException {
         try {
             field.set(cmdObj, DateUtil.parseTZDateString(paramObj.toString()));

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -63,10 +63,10 @@ import com.cloud.utils.exception.CloudRuntimeException;
 public class ParamProcessWorker implements DispatchWorker {
 
     private static final Logger s_logger = Logger.getLogger(ParamProcessWorker.class.getName());
-    private final String inputFormatString = "yyyy-MM-dd";
-    private final String newInputFormatString = "yyyy-MM-dd HH:mm:ss";
-    public final DateFormat inputFormat = new SimpleDateFormat(inputFormatString);
-    public final DateFormat newInputFormat = new SimpleDateFormat(newInputFormatString);
+    private static final String inputFormatString = "yyyy-MM-dd";
+    private static final String newInputFormatString = "yyyy-MM-dd HH:mm:ss";
+    public static final DateFormat inputFormat = new SimpleDateFormat(inputFormatString);
+    public static final DateFormat newInputFormat = new SimpleDateFormat(newInputFormatString);
 
     @Inject
     protected AccountManager _accountMgr;
@@ -335,33 +335,7 @@ public class ParamProcessWorker implements DispatchWorker {
                 field.set(cmdObj, Boolean.valueOf(paramObj.toString()));
                 break;
             case DATE:
-                // This piece of code is for maintaining backward compatibility
-                // and support both the date formats(Bug 9724)
-                try {
-                    field.set(cmdObj, DateUtil.parseTZDateString(paramObj.toString()));
-                    break;
-                } catch (ParseException parseException) {
-                    s_logger.debug(String.format("Could not parse date [%s] with timezone parser, trying to parse without timezone.", paramObj));
-                }
-                if (isObjInNewDateFormat(paramObj.toString())) {
-                    s_logger.debug(String.format("Parsing date [%s] using the [%s] format.", paramObj, newInputFormatString));
-                    final DateFormat newFormat = newInputFormat;
-                    synchronized (newFormat) {
-                        field.set(cmdObj, newFormat.parse(paramObj.toString()));
-                    }
-                } else {
-                    s_logger.debug(String.format("Parsing date [%s] using the [%s] format.", paramObj, inputFormatString));
-                    final DateFormat format = inputFormat;
-                    synchronized (format) {
-                        Date date = format.parse(paramObj.toString());
-                        if (field.getName().equals("startDate")) {
-                            date = messageDate(date, 0, 0, 0);
-                        } else if (field.getName().equals("endDate")) {
-                            date = messageDate(date, 23, 59, 59);
-                        }
-                        field.set(cmdObj, date);
-                    }
-                }
+                parseAndSetDate(field, cmdObj, paramObj);
                 break;
             case FLOAT:
                 // Assuming that the parameters have been checked for required before now,
@@ -446,6 +420,34 @@ public class ParamProcessWorker implements DispatchWorker {
             s_logger.error("Error initializing command " + cmdObj.getCommandName() + ", field " + field.getName() + " is not accessible.");
             throw new CloudRuntimeException("Internal error initializing parameters for command " + cmdObj.getCommandName() + " [field " + field.getName() +
                     " is not accessible]");
+        }
+    }
+    
+    private void parseAndSetDate(Field field, BaseCmd cmdObj, Object paramObj) throws IllegalAccessException, ParseException {
+        try {
+            field.set(cmdObj, DateUtil.parseTZDateString(paramObj.toString()));
+            return;
+        } catch (ParseException parseException) {
+            s_logger.debug(String.format("Could not parse date [%s] with timezone parser, trying to parse without timezone.", paramObj));
+        }
+        if (isObjInNewDateFormat(paramObj.toString())) {
+            s_logger.debug(String.format("Parsing date [%s] using the [%s] format.", paramObj, newInputFormatString));
+            final DateFormat newFormat = newInputFormat;
+            synchronized (newFormat) {
+                field.set(cmdObj, newFormat.parse(paramObj.toString()));
+            }
+        } else {
+            s_logger.debug(String.format("Parsing date [%s] using the [%s] format.", paramObj, inputFormatString));
+            final DateFormat format = inputFormat;
+            synchronized (format) {
+                Date date = format.parse(paramObj.toString());
+                if (field.getName().equals("startDate")) {
+                    date = messageDate(date, 0, 0, 0);
+                } else if (field.getName().equals("endDate")) {
+                    date = messageDate(date, 23, 59, 59);
+                }
+                field.set(cmdObj, date);
+            }
         }
     }
 

--- a/ui/src/components/view/StatsTab.vue
+++ b/ui/src/components/view/StatsTab.vue
@@ -289,24 +289,10 @@ export default {
   mounted () {
     this.fetchData()
   },
-  computed: {
-    usebrowsertimezone: function () {
-      return this.$store.getters.usebrowsertimezone
-    }
-  },
   watch: {
     resource: function (newItem) {
       if (!newItem || !newItem.id) {
         return
-      }
-      this.fetchData()
-    },
-    usebrowsertimezone: function () {
-      if (this.startDate) {
-        this.startDate = this.onToggleUseBrowserTimezone(new Date(this.startDate))
-      }
-      if (this.endDate) {
-        this.endDate = this.onToggleUseBrowserTimezone(new Date(this.endDate))
       }
       this.fetchData()
     }
@@ -355,25 +341,11 @@ export default {
     },
     getStartDate () {
       var now = new Date()
-      if (!this.$store.getters.usebrowsertimezone) {
-        var dateInUTC = new Date(now.getTime() + now.getTimezoneOffset() * 60000)
-        return dateInUTC.setHours(dateInUTC.getHours() - 1)
-      }
       now.setHours(now.getHours() - 1)
       return now
     },
     getEndDate () {
-      var now = new Date()
-      if (this.$store.getters.usebrowsertimezone) {
-        return now
-      }
-      return new Date(now.getTime() + now.getTimezoneOffset() * 60000)
-    },
-    onToggleUseBrowserTimezone (date) {
-      if (this.$store.getters.usebrowsertimezone) {
-        return this.$toLocalDate(date)
-      }
-      return new Date(date.getTime() + date.getTimezoneOffset() * 60000)
+      return new Date()
     },
     fetchData () {
       this.loaded = false

--- a/ui/src/components/view/StatsTab.vue
+++ b/ui/src/components/view/StatsTab.vue
@@ -375,23 +375,16 @@ export default {
       }
       return new Date(date.getTime() + date.getTimezoneOffset() * 60000)
     },
-    convertAndFormatDateAppropriately (date) {
-      if (this.$store.getters.usebrowsertimezone) {
-        var dateInUTC = new Date(date).toISOString().split('T')
-        return dateInUTC[0] + ' ' + dateInUTC[1].split('-')[0].split('.')[0]
-      }
-      return moment(date).format('YYYY-MM-DD HH:mm:ss')
-    },
     fetchData () {
       this.loaded = false
       this.showResourceInfoModal = false
       this.formatPeriod()
       var params = { id: this.resource.id }
       if (this.startDate) {
-        params.startDate = this.convertAndFormatDateAppropriately(this.startDate)
+        params.startDate = moment(this.startDate).format()
       }
       if (this.endDate) {
-        params.endDate = this.convertAndFormatDateAppropriately(this.endDate)
+        params.endDate = moment(this.endDate).format()
       }
       api('listVirtualMachinesUsageHistory', params).then(response => {
         this.handleStatsResponse(response)


### PR DESCRIPTION
Although ACS stores all dates in the DB with the UTC timezone, all APIs that have parameters of type date are handled according to the server's timezone. In this case, if the server's timezone is in UTC-3, for instance, and user is in UTC-2 and inform `yyyy-MM-dd 09:00:00` in the parameter, the Date object will be `yyyy-MM-dd 09:00:00` (UTC-3) and ACS will convert it to `yyyy-MM-dd 12:00:00` while querying the database. This way, if the final users want to retrieve data from date `09:00:00`, they must know the server's timezone in order to inform the correspondent date (in this example, `yyyy-MM-dd 06:00:00`).

This situation is very clear when calling the `listvirtualmachinesusagehistory` API. If the data was collected at `yyyy-MM-dd 12:00:00` (UTC), final user must know that the server is in UTC-3 and inform `yyyy-MM-dd 09:00:00`. Via UI, either using the local timezone or not, the informed timestamp is always converted to UTC. Then, the server would consider this converted timestamp as UTC-3, and would convert it to UTC again, adding 3 hours to the date and returning nothing. Example: user is in UTC-2 and informs `yyyy-MM-dd 10:00:00`; the UI converts it to UTC (`yyyy-MM-dd 12:00:00`); ACS interprets it as UTC-3 and converts again to UTC (`yyyy-MM-dd 15:00:00`).

To handle this situation, an extension was made to allow all APIs that have parameters of type date to also receive them in the format with timezone `yyyy-MM-dd'T'HH:mm:ssZ`, for example, `2022-12-20T14:33:42+0100`. This change only extends the date parameter, previous behavior still works normally. Thus the user will be able to send requests with the chosen timezone, and the ACS will carry out the conversion to the timezone it operates.

Furthermore, the VM stats listing in the UI has been updated to always send the date and time with the timezone of the user's machine.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

After setting the management server's timezone to UTC+1, and setting `vm.stats.max.retention.time` to 5, I did the following tests: 
| # | Test | Result | 
| ------ | ------ | ------ |
| 1 | I called the `listvirtualmachinesusagehistory` API with the `startdate` as 5 minutes prior to the tests time, passing my timezone (UTC-3) | The stats were correctly recovered | 
| 2 | I called the API with the same timestamp, but informing UTC-4 as the timezone | No records were returned|
| 3 | I called the API with the `startdate` as 5 minutes prior to the tests time, informing the date and time using the UTC+1 timezone, but without informing the timezone, e.g. `2022-12-28 15:10:00` | The stats were correctly recovered |
| 4 | I called the API with the `startdate` as 5 minutes prior to the tests time, informing the date and time using the UTC-3 timezone, but without informing the timezone | No stats were recovered |
| 5 | I called the listEvents API with the `startDate` in the `YYYY-MM-DD HH:mm:ss` format | the events were properly listed |