### PR TITLE
Fix volume snapshot in a VM with an ISO attached

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParser.java
@@ -121,7 +121,7 @@ public class LibvirtDomainXMLParser {
                             }
                             def.defFileBasedDisk(diskFile, diskLabel, DiskDef.DiskBus.valueOf(bus.toUpperCase()), fmt);
                         } else if (device.equalsIgnoreCase("cdrom")) {
-                            def.defISODisk(diskFile , i+1);
+                            def.defISODisk(diskFile, i+1, diskLabel);
                         }
                     } else if (type.equalsIgnoreCase("block")) {
                         def.defBlockBasedDisk(diskDev, diskLabel,

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -860,17 +860,31 @@ public class LibvirtVMDef {
         }
 
         public void defISODisk(String volPath, Integer devId) {
-            if (devId == null) {
+            defISODisk(volPath, devId, null);
+        }
+
+        public void defISODisk(String volPath, Integer devId, String diskLabel) {
+            if (devId == null && StringUtils.isBlank(diskLabel)) {
+                s_logger.debug(String.format("No ID or label informed for volume [%s].", volPath));
                 defISODisk(volPath);
-            } else {
-                _diskType = DiskType.FILE;
-                _deviceType = DeviceType.CDROM;
-                _sourcePath = volPath;
-                _diskLabel = getDevLabel(devId, DiskBus.IDE, true);
-                _diskFmtType = DiskFmtType.RAW;
-                _diskCacheMode = DiskCacheMode.NONE;
-                _bus = DiskBus.IDE;
+                return;
             }
+
+            _diskType = DiskType.FILE;
+            _deviceType = DeviceType.CDROM;
+            _sourcePath = volPath;
+
+            if (StringUtils.isNotBlank(diskLabel)) {
+                s_logger.debug(String.format("Using informed label [%s] for volume [%s].", diskLabel, volPath));
+                _diskLabel = diskLabel;
+            } else {
+                _diskLabel = getDevLabel(devId, DiskBus.IDE, true);
+                s_logger.debug(String.format("Using device ID [%s] to define the label [%s] for volume [%s].", devId, _diskLabel, volPath));
+            }
+
+            _diskFmtType = DiskFmtType.RAW;
+            _diskCacheMode = DiskCacheMode.NONE;
+            _bus = DiskBus.IDE;
         }
 
         public void defISODisk(String volPath, Integer devId,boolean isSecure) {


### PR DESCRIPTION
### Description

When taking a snapshot of a volume in a VM with an ISO attached, ACS attempts to define the label of the target associated with the ISO by its ID. However, this ID may not be correctly mapped to the label, which causes the snapshot to fail.

This PR fixes this by using the defined label, instead of defining it during the snapshot process by its ID.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### How Has This Been Tested?

In a local lab, I created 3 VMs with ISOs attached: VM1, VM2 and VM3. VM1 had 1 volume, VM2 had 2 volumes, and VM3 had 3 volumes.  The label of the target associated to the ISO was `hdc` for all of them. 

When taking a snapshot for the volume in VM1, the label was incorrectly generated as `hdb`, which caused the snapshot to fail.
When taking snapshots for the volumes in VM2, the label was correctly generated as `hdc`, and the snapshots succeeded.
When taking snapshots for the volumes in VM3, the label was incorrectly generated as `hdd`, which caused the snapshots to fail.

After applying the changes, I took snapshots for every volume of the VMs. In all of them the label was correctly passed as `hdc`, and all snapshots succeeded.