### PR TITLE
UI: user must specify the start of guest vlan range for advanced zone

### DIFF
--- a/ui/src/views/infra/zone/AdvancedGuestTrafficForm.vue
+++ b/ui/src/views/infra/zone/AdvancedGuestTrafficForm.vue
@@ -156,7 +156,7 @@ export default {
 
       this.formRef.value.validate().then(() => {
         const values = toRaw(this.form)
-        if (!this.checkFromTo(values.vlanRangeStart, values.vlanRangeEnd)) {
+        if (!values.vlanRangeStart || (values.vlanRangeEnd && !this.checkFromTo(values.vlanRangeStart, values.vlanRangeEnd))) {
           this.validStatus = 'error'
           this.validMessage = this.$t('message.error.vlan.range')
           return
@@ -185,7 +185,7 @@ export default {
         toVal = value
         fromVal = this.form[rule.compare]
       }
-      if (!this.checkFromTo(fromVal, toVal)) {
+      if (fromVal && toVal && !this.checkFromTo(fromVal, toVal)) {
         this.validStatus = 'error'
         this.validMessage = this.$t('message.error.vlan.range')
       }


### PR DESCRIPTION
### Description

This PR fixes #6727 

The start of guest vlan range is a must. 
if end is not set, the vlan range is start-start
otherwise, the vlan range is start-end

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Start and end are not set.
![image](https://user-images.githubusercontent.com/57355700/210246113-b7017385-7154-49be-8d86-7f08e51e8208.png)

Start is set
![image](https://user-images.githubusercontent.com/57355700/210246169-c11e6ba9-c61b-43a6-a892-e75991d5edcc.png)

wrong range
![image](https://user-images.githubusercontent.com/57355700/210246216-e05d558f-1dfc-48cf-a1a3-9e10847af89c.png)

correct range
![image](https://user-images.githubusercontent.com/57355700/210246244-25b0ef9d-434f-4fd6-8628-6c341dfd936f.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
