### PR TITLE
Allow download of System VM templates through the  UI

### DIFF
--- a/ui/src/config/section/image.js
+++ b/ui/src/config/section/image.js
@@ -141,11 +141,11 @@ export default {
           dataView: true,
           show: (record, store) => {
             return (['Admin'].includes(store.userInfo.roletype) || // If admin or owner or belongs to current project
-              (record.domainid === store.userInfo.domainid && record.account === store.userInfo.account) ||
+              ((record.domainid === store.userInfo.domainid && record.account === store.userInfo.account) ||
               (record.domainid === store.userInfo.domainid && record.projectid && store.project && store.project.id && record.projectid === store.project.id)) &&
               record.templatetype !== 'SYSTEM' &&
-              record.isready &&
-              record.isextractable
+              record.isextractable) &&
+              record.isready
           },
           args: ['zoneid', 'mode'],
           mapping: {


### PR DESCRIPTION
### Description

The [PR#6750](https://github.com/apache/cloudstack/pull/6750) allowed Root Admins to download system VM templates through the API. This function was extended to the UI.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/49285692/210371056-febd5559-fee7-460b-8ad5-59aa1e730b9e.png)

After:
![image](https://user-images.githubusercontent.com/49285692/210371131-2205b6f0-f1ce-4517-8a80-0b24cd83d05d.png)


### How Has This Been Tested?

Before applying the changes:

1. I opened the instance menu and checked that I was unable to download the template.


After applying the changes:

1. I opened the instance menu with a Root Admin account and checked that the download button was available.

2. I opened the instance menu with a non-Root Admin account and checked that the download button was not available.
