### PR TITLE
alter ordering of backup offerings

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1161,7 +1161,7 @@ export default {
         param.loading = false
         for (const obj in json) {
           if (obj.includes('response')) {
-            if (possibleApi === 'listBackupOfferings') {
+            if (possibleApi === 'listBackupOfferings' && json[obj].backupoffering) {
               json[obj].backupoffering.sort((a, b) => {
                 return a.name > b.name
               })

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1161,6 +1161,11 @@ export default {
         param.loading = false
         for (const obj in json) {
           if (obj.includes('response')) {
+            if (possibleApi === 'listBackupOfferings') {
+              json[obj].backupoffering.sort((a, b) => {
+                return a.name > b.name
+              })
+            }
             for (const res in json[obj]) {
               if (res === 'count') {
                 continue


### PR DESCRIPTION
### Description

Currently the ordering of backup offerings is done based on their IDs. This ordering was altered to be made based on their names, in order to enhance its organization.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/49285692/210385699-def041bf-1b39-4235-9c9b-61d2845a71c6.png)

After:

![image](https://user-images.githubusercontent.com/49285692/210385746-9fc94365-c568-4221-9b81-d66f6d2ea47b.png)

### How Has This Been Tested?

1. Before applying the changes I opened the 'assign VM to backup offering' window and checked that the offerings where ordered based on their ID.

2. After applying the changes I reopened the same window and verified that now the offerings were ordered alphabetically.
