### PR TITLE
Add support for vSphere 8.0

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
@@ -19,6 +19,10 @@
 -- Schema upgrade from 4.17.2.0 to 4.18.0.0
 --;
 
+-- Add support for VMware 8.0
+INSERT IGNORE INTO `cloud`.`hypervisor_capabilities` (uuid, hypervisor_type, hypervisor_version, max_guests_limit, security_group_enabled, max_data_volumes_limit, max_hosts_per_cluster, storage_motion_supported, vm_snapshot_enabled) values (UUID(), 'VMware', '8.0', 1024, 0, 59, 64, 1, 1);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'VMware', '8.0', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='VMware' AND hypervisor_version='7.0.3.0';
+
 -- Enable CPU cap for default system offerings;
 UPDATE `cloud`.`service_offering` so
 SET so.limit_cpu_use = 1

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <cs.servlet.version>4.0.1</cs.servlet.version>
         <cs.tomcat-embed-core.version>10.0.22</cs.tomcat-embed-core.version>
         <cs.trilead.version>build-217-jenkins-27</cs.trilead.version>
-        <cs.vmware.api.version>7.0</cs.vmware.api.version>
+        <cs.vmware.api.version>8.0</cs.vmware.api.version>
         <cs.winrm4j.version>0.5.0</cs.winrm4j.version>
         <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
         <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualStorageObjectManagerMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualStorageObjectManagerMO.java
@@ -58,7 +58,7 @@ public class VirtualStorageObjectManagerMO extends BaseMO {
     }
 
     public VStorageObject retrieveVirtualDisk (ID id, ManagedObjectReference morDS) throws Exception {
-        return _context.getService().retrieveVStorageObject(_mor, id, morDS);
+        return _context.getService().retrieveVStorageObject(_mor, id, morDS, null);
     }
 
     public VStorageObject createDisk(ManagedObjectReference morDS, Storage.ProvisioningType diskProvisioningType, long currentSizeInBytes, String datastoreFilepath, String filename) throws Exception {


### PR DESCRIPTION
Adds basic support to bump VMware vim sdk to 8.0, enable in hypervisor capabilties and copy guest mappings from the previous version.

May be a quick one to accept this, to have early access/support for 8.0 in ACS. Later any integration that requires changes in ACS for support in Trillian/BO can be done as separate PR.
