### PR TITLE
server: do not deploy or upgrade vm with inactive service offering

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3742,7 +3742,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         }
 
         if (ServiceOffering.State.Inactive.equals(newServiceOffering.getState())) {
-            throw new InvalidParameterValueException("New service offering is Inactive: " + newServiceOffering.getUuid());
+            throw new InvalidParameterValueException(String.format("New service offering is inactive: [%s].", newServiceOffering.getUuid()));
         }
 
         if (!(vmInstance.getState().equals(State.Stopped) || vmInstance.getState().equals(State.Running))) {

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3741,6 +3741,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             throw new InvalidParameterValueException("Invalid parameter, newServiceOffering can't be null");
         }
 
+        if (ServiceOffering.State.Inactive.equals(newServiceOffering.getState())) {
+            throw new InvalidParameterValueException("New service offering is Inactive: " + newServiceOffering.getUuid());
+        }
+
         if (!(vmInstance.getState().equals(State.Stopped) || vmInstance.getState().equals(State.Running))) {
             s_logger.warn("Unable to upgrade virtual machine " + vmInstance.toString() + " in state " + vmInstance.getState());
             throw new InvalidParameterValueException("Unable to upgrade virtual machine " + vmInstance.toString() + " " + " in state " + vmInstance.getState() +

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -57,6 +57,7 @@ import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.HypervisorGuru;
+import com.cloud.offering.ServiceOffering;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.DiskOfferingVO;
@@ -230,6 +231,13 @@ public class VirtualMachineManagerImplTest {
         when(serviceOfferingMock.isSystemUse()).thenReturn(true);
         when(mockCurrentDiskOffering.getTags()).thenReturn("x,y");
         when(diskOfferingMock.getTags()).thenReturn("z,x,y");
+
+        virtualMachineManagerImpl.checkIfCanUpgrade(vmInstanceMock, serviceOfferingMock);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testCheckIfCanUpgradeFail() {
+        when(serviceOfferingMock.getState()).thenReturn(ServiceOffering.State.Inactive);
 
         virtualMachineManagerImpl.checkIfCanUpgrade(vmInstanceMock, serviceOfferingMock);
     }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -5664,7 +5664,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         if (ServiceOffering.State.Inactive.equals(serviceOffering.getState())) {
-            throw new InvalidParameterValueException("service offering is Inactive: " + serviceOffering.getUuid());
+            throw new InvalidParameterValueException(String.format("Service offering is inactive: [%s].", serviceOffering.getUuid()));
         }
 
         if (serviceOffering.getDiskOfferingStrictness() && overrideDiskOfferingId != null) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -5663,6 +5663,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Unable to find service offering: " + serviceOfferingId);
         }
 
+        if (ServiceOffering.State.Inactive.equals(serviceOffering.getState())) {
+            throw new InvalidParameterValueException("service offering is Inactive: " + serviceOffering.getUuid());
+        }
+
         if (serviceOffering.getDiskOfferingStrictness() && overrideDiskOfferingId != null) {
             throw new InvalidParameterValueException(String.format("Cannot override disk offering id %d since provided service offering is strictly mapped to its disk offering", overrideDiskOfferingId));
         }

--- a/server/src/main/java/org/apache/cloudstack/network/router/deployment/RouterDeploymentDefinition.java
+++ b/server/src/main/java/org/apache/cloudstack/network/router/deployment/RouterDeploymentDefinition.java
@@ -407,7 +407,7 @@ public class RouterDeploymentDefinition {
     private void verifyServiceOfferingByUuid(String offeringUuid) {
         logger.debug("Verifying router service offering with uuid : " + offeringUuid);
         ServiceOfferingVO serviceOffering = serviceOfferingDao.findByUuid(offeringUuid);
-        if (serviceOffering != null && serviceOffering.isSystemUse()) {
+        if (serviceOffering != null && serviceOffering.isSystemUse() && ServiceOffering.State.Active.equals(serviceOffering.getState())) {
             DiskOfferingVO diskOffering = diskOfferingDao.findById(serviceOffering.getDiskOfferingId());
             boolean isLocalStorage = ConfigurationManagerImpl.SystemVMUseLocalStorage.valueIn(dest.getDataCenter().getId());
             if (isLocalStorage == diskOffering.isUseLocalStorage()) {


### PR DESCRIPTION
### Description

This PR fixes #6740 

The deleted service offering is not removed , but changed to Inactive state.
Therefore the state needs to be checked when deploy/create new vm or upgrade vm.
Similar check is added to router service offering as well.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):



### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

```
    (localcloud) 🐱 > deploy virtualmachine zoneid=7c9769a1-ba70-4f3a-a976-5a6ae7d946bb templateid=936f5eda-6be2-11ed-a030-1e0066000350 networkids=e7d3308c-03fc-4411-998d-ff45a2c1fccc  serviceofferingid=c1ebd091-57a6-427a-99a9-6c482de84a4f
    {
      "virtualmachine": {
        "account": "admin",
    ...
      }
    }

    (localcloud) 🐱 > delete serviceoffering id=c1ebd091-57a6-427a-99a9-6c482de84a4f
    {
      "success": true
    }

    (localcloud) 🐱 > deploy virtualmachine zoneid=7c9769a1-ba70-4f3a-a976-5a6ae7d946bb templateid=936f5eda-6be2-11ed-a030-1e0066000350 networkids=e7d3308c-03fc-4411-998d-ff45a2c1fccc  serviceofferingid=c1ebd091-57a6-427a-99a9-6c482de84a4f
    🙈 Error: (HTTP 431, error code 4350) service offering is Inactive: c1ebd091-57a6-427a-99a9-6c482de84a4f
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
