### PR TITLE
cleanups as suggested by errorprone

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@ This PR...
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Enhancement (improves an existing feature and functionality)
 - [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
+- [ ] build/CI
 
 ### Feature/Enhancement Scale or Bug Severity
 

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -149,7 +149,7 @@ public class ConfigKey<T> {
 
     public ConfigKey(Class<T> type, String name, String category, String defaultValue, String description, boolean isDynamic, Scope scope, T multiplier,
                      String displayText, String parent, Ternary<String, String, Long> group, Pair<String, Long> subGroup) {
-        this(type, name, category, defaultValue, description, isDynamic, scope, multiplier, null, parent, null, null, null, null);
+        this(type, name, category, defaultValue, description, isDynamic, scope, multiplier, displayText, parent, group, subGroup, null, null);
     }
 
     public ConfigKey(Class<T> type, String name, String category, String defaultValue, String description, boolean isDynamic, Scope scope, T multiplier,

--- a/framework/config/src/test/java/org/apache/cloudstack/framework/config/impl/ConfigDepotAdminTest.java
+++ b/framework/config/src/test/java/org/apache/cloudstack/framework/config/impl/ConfigDepotAdminTest.java
@@ -98,6 +98,8 @@ public class ConfigDepotAdminTest extends TestCase {
         ConfigurationVO staticIntCV = new ConfigurationVO("UnitTestComponent", StaticIntCK);
         dynamicIntCV.setValue("200");
         ConfigurationVO testCV = new ConfigurationVO("UnitTestComponent", TestCK);
+        ConfigurationGroupVO groupVO = new ConfigurationGroupVO();
+        ConfigurationSubGroupVO subGroupVO = new ConfigurationSubGroupVO();
 
         when(_configurable.getConfigComponentName()).thenReturn("UnitTestComponent");
         when(_configurable.getConfigKeys()).thenReturn(new ConfigKey<?>[] {DynamicIntCK, StaticIntCK, TestCK});
@@ -105,6 +107,8 @@ public class ConfigDepotAdminTest extends TestCase {
         when(_configDao.findById(DynamicIntCK.key())).thenReturn(dynamicIntCV);
         when(_configDao.findById(TestCK.key())).thenReturn(testCV);
         when(_configDao.persist(any(ConfigurationVO.class))).thenReturn(dynamicIntCV);
+        when(_configGroupDao.persist(any(ConfigurationGroupVO.class))).thenReturn(groupVO);
+        when(_configSubGroupDao.persist(any(ConfigurationSubGroupVO.class))).thenReturn(subGroupVO);
         _depotAdmin.populateConfigurations();
 
         // This is once because DynamicIntCK is returned.

--- a/framework/db/src/main/java/com/cloud/dao/EntityManagerImpl.java
+++ b/framework/db/src/main/java/com/cloud/dao/EntityManagerImpl.java
@@ -86,7 +86,7 @@ public class EntityManagerImpl extends ManagerBase implements EntityManager {
 
     public <T, K> GenericSearchBuilder<T, K> createGenericSearchBuilder(Class<T> entityType, Class<K> resultType) {
         GenericDao<T, ? extends Serializable> dao = (GenericDao<T, ? extends Serializable>)GenericDaoBase.getDao(entityType);
-        return dao.createSearchBuilder((Class<K>)resultType.getClass());
+        return dao.createSearchBuilder((Class<K>)resultType);
     }
 
     @Override

--- a/framework/db/src/main/java/com/cloud/utils/db/DbUtil.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/DbUtil.java
@@ -124,7 +124,7 @@ public class DbUtil {
     public static Field findField(Class<?> clazz, String columnName) {
         for (Field field : clazz.getDeclaredFields()) {
             if (field.getAnnotation(Embedded.class) != null || field.getAnnotation(EmbeddedId.class) != null) {
-                findField(field.getClass(), columnName);
+                findField(field.getType(), columnName);
             } else {
                 if (columnName.equals(DbUtil.getColumnName(field))) {
                     return field;
@@ -170,7 +170,7 @@ public class DbUtil {
         }
 
         if (field.getAnnotation(EmbeddedId.class) != null) {
-            assert (field.getClass().getAnnotation(Embeddable.class) != null) : "Class " + field.getClass().getName() + " must be Embeddable to be used as Embedded Id";
+            assert (field.getType().getAnnotation(Embeddable.class) != null) : "Class " + field.getType().getName() + " must be Embeddable to be used as Embedded Id";
             return true;
         }
 

--- a/framework/db/src/main/java/com/cloud/utils/db/DriverLoader.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/DriverLoader.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.utils.db;
 
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -56,12 +58,13 @@ public class DriverLoader {
         }
 
         try {
-            Class.forName(driverClass).newInstance();
+            Class<Driver> klazz = (Class<Driver>) Class.forName(driverClass);
+            klazz.getDeclaredConstructor().newInstance();
             LOADED_DRIVERS.add(dbDriver);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Successfully loaded DB driver " + driverClass);
             }
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             LOGGER.error("Failed to load DB driver " + driverClass);
             throw new CloudRuntimeException("Failed to load DB driver " + driverClass, e);
         }

--- a/framework/db/src/main/java/com/cloud/utils/db/EcInfo.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/EcInfo.java
@@ -57,10 +57,10 @@ public class EcInfo {
                     rawClass = HashSet.class;
                 } else if (List.class == rawClazz) {
                     rawClass = ArrayList.class;
-                } else if (Collection.class == Collection.class) {
+                } else if (Collection.class == rawClazz) {
                     rawClass = ArrayList.class;
                 } else {
-                    assert (false) : " We don't know how to create this calss " + rawType.toString() + " for " + attr.field.getName();
+                    assert (false) : " We don't know how to create this class " + rawType.toString() + " for " + attr.field.getName();
                 }
             } catch (NoSuchMethodException e) {
                 throw new CloudRuntimeException("Write your own support for " + rawClazz + " defined by " + attr.field.getName());

--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -874,7 +874,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         if (_idField.getAnnotation(EmbeddedId.class) == null) {
             sql.append(_table).append(".").append(DbUtil.getColumnName(_idField, null)).append(" = ? ");
         } else {
-            final Class<?> clazz = _idField.getClass();
+            s_logger.debug(String.format("field type vs declarator : %s vs %s", _idField.getType(), _idField.getDeclaringClass()));
+            final Class<?> clazz = _idField.getType();
             final AttributeOverride[] overrides = DbUtil.getAttributeOverrides(_idField);
             for (final Field field : clazz.getDeclaredFields()) {
                 sql.append(_table).append(".").append(DbUtil.getColumnName(field, overrides)).append(" = ? AND ");

--- a/pom.xml
+++ b/pom.xml
@@ -817,6 +817,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${cs.compiler-plugin.version}</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.18.0</version>
+                        </path>
+                        <!-- Other annotation processors go here.
+
+                        If 'annotationProcessorPaths' is set, processors will no longer be
+                        discovered on the regular -classpath; see also 'Using Error Prone
+                        together with other annotation processors' below. -->
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1074,15 +1100,26 @@
                     <configuration>
                         <source>${cs.jdk.version}</source>
                         <target>${cs.jdk.version}</target>
-                        <fork>true</fork>
-                        <meminitial>128m</meminitial>
-                        <maxmem>512m</maxmem>
+                        <encoding>UTF-8</encoding>
                         <compilerArgs>
                             <arg>-XDignore.symbol.file=true</arg>
                             <arg>--add-opens=java.base/java.lang=ALL-UNNAMED</arg>
                             <arg>--add-exports=java.base/sun.security.x509=ALL-UNNAMED</arg>
                             <arg>--add-exports=java.base/sun.security.provider=ALL-UNNAMED</arg>
+                            <arg>-XDcompilePolicy=simple</arg>
+                            <arg>-Xplugin:ErrorProne</arg>
+                            <arg>--illegal-access=warn</arg>
                         </compilerArgs>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>2.18.0</version>
+                            </path>
+                        </annotationProcessorPaths>
+                        <fork>true</fork>
+                        <meminitial>128m</meminitial>
+                        <maxmem>512m</maxmem>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -817,32 +817,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${cs.compiler-plugin.version}</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                    <encoding>UTF-8</encoding>
-                    <compilerArgs>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne</arg>
-                    </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.18.0</version>
-                        </path>
-                        <!-- Other annotation processors go here.
-
-                        If 'annotationProcessorPaths' is set, processors will no longer be
-                        discovered on the regular -classpath; see also 'Using Error Prone
-                        together with other annotation processors' below. -->
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1100,26 +1074,15 @@
                     <configuration>
                         <source>${cs.jdk.version}</source>
                         <target>${cs.jdk.version}</target>
-                        <encoding>UTF-8</encoding>
+                        <fork>true</fork>
+                        <meminitial>128m</meminitial>
+                        <maxmem>512m</maxmem>
                         <compilerArgs>
                             <arg>-XDignore.symbol.file=true</arg>
                             <arg>--add-opens=java.base/java.lang=ALL-UNNAMED</arg>
                             <arg>--add-exports=java.base/sun.security.x509=ALL-UNNAMED</arg>
                             <arg>--add-exports=java.base/sun.security.provider=ALL-UNNAMED</arg>
-                            <arg>-XDcompilePolicy=simple</arg>
-                            <arg>-Xplugin:ErrorProne</arg>
-                            <arg>--illegal-access=warn</arg>
                         </compilerArgs>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>com.google.errorprone</groupId>
-                                <artifactId>error_prone_core</artifactId>
-                                <version>2.18.0</version>
-                            </path>
-                        </annotationProcessorPaths>
-                        <fork>true</fork>
-                        <meminitial>128m</meminitial>
-                        <maxmem>512m</maxmem>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/utils/src/main/java/com/cloud/utils/SerialVersionUID.java
+++ b/utils/src/main/java/com/cloud/utils/SerialVersionUID.java
@@ -23,7 +23,7 @@ package com.cloud.utils;
  * purposes.  This is purely on an honor system though.  You should always
  **/
 public interface SerialVersionUID {
-    public static final long Base = 0x564D4F70 << 32;  // 100 brownie points if you guess what this is and tell me.
+    public static final long Base = 0x564D4F70L << 32;  // 100 brownie points if you guess what this is and tell me.
 
     public static final long UUID = Base | 0x1;
     public static final long CloudRuntimeException = Base | 0x2;

--- a/utils/src/main/java/com/cloud/utils/events/SubscriptionMgr.java
+++ b/utils/src/main/java/com/cloud/utils/events/SubscriptionMgr.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 
@@ -159,6 +160,11 @@ public class SubscriptionMgr {
                     this.methodName.equals(((SubscriberInfo)o).methodName);
             }
             return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.clazz, this.subscriber, this.methodName, this.method);
         }
     }
 }

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -716,6 +716,7 @@ public class NetUtilsTest {
         NetUtils.isIpv4("2001:db8:300::/64");
     }
 
+    @Test
     public void testAllIpsOfDefaultNic() {
         final String defaultHostIp = NetUtils.getDefaultHostIp();
         if (defaultHostIp != null) {

--- a/utils/src/test/java/org/apache/cloudstack/utils/redfish/RedfishClientTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/redfish/RedfishClientTest.java
@@ -87,7 +87,7 @@ public class RedfishClientTest {
     public void buildRequestUrlTestHttpsGetSystemId() {
         RedfishClient redfishclient = new RedfishClient(USERNAME, PASSWORD, true, false, REDFISHT_REQUEST_RETRIES);
         String result = redfishclient.buildRequestUrl(oobAddress, RedfishClient.RedfishCmdType.GetSystemId, systemId);
-        String expected = String.format("https://%s/redfish/v1/Systems/", oobAddress, systemId);
+        String expected = String.format("https://%s/redfish/v1/Systems/", oobAddress);
         Assert.assertEquals(expected, result);
     }
 
@@ -95,7 +95,7 @@ public class RedfishClientTest {
     public void buildRequestUrlTestGetSystemId() {
         RedfishClient redfishclient = new RedfishClient(USERNAME, PASSWORD, false, false, REDFISHT_REQUEST_RETRIES);
         String result = redfishclient.buildRequestUrl(oobAddress, RedfishClient.RedfishCmdType.GetSystemId, systemId);
-        String expected = String.format("http://%s/redfish/v1/Systems/", oobAddress, systemId);
+        String expected = String.format("http://%s/redfish/v1/Systems/", oobAddress);
         Assert.assertEquals(expected, result);
     }
 


### PR DESCRIPTION
### Description

This PR applies errorprone as in below diff and applies the suggested changes for the first few projects. The permanent application of errorProne is removed within the scope of this PR as most projects will give positives.

```
commit 9f9a2b6b7e094537fea75f633d355f983d4c15d7
Author: Daan Hoogland <daan@onecht.net>
Date:   Thu Jan 12 19:32:35 2023 +0100

    errorprone

diff --git a/pom.xml b/pom.xml
index 204c74cc76..13c46d7521 100644
--- a/pom.xml
+++ b/pom.xml
@@ -817,6 +817,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${cs.compiler-plugin.version}</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.18.0</version>
+                        </path>
+                        <!-- Other annotation processors go here.
+
+                        If 'annotationProcessorPaths' is set, processors will no longer be
+                        discovered on the regular -classpath; see also 'Using Error Prone
+                        together with other annotation processors' below. -->
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1074,15 +1100,26 @@
                     <configuration>
                         <source>${cs.jdk.version}</source>
                         <target>${cs.jdk.version}</target>
-                        <fork>true</fork>
-                        <meminitial>128m</meminitial>
-                        <maxmem>512m</maxmem>
+                        <encoding>UTF-8</encoding>
                         <compilerArgs>
                             <arg>-XDignore.symbol.file=true</arg>
                             <arg>--add-opens=java.base/java.lang=ALL-UNNAMED</arg>
                             <arg>--add-exports=java.base/sun.security.x509=ALL-UNNAMED</arg>
                             <arg>--add-exports=java.base/sun.security.provider=ALL-UNNAMED</arg>
+                            <arg>-XDcompilePolicy=simple</arg>
+                            <arg>-Xplugin:ErrorProne</arg>
+                            <arg>--illegal-access=warn</arg>
                         </compilerArgs>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>2.18.0</version>
+                            </path>
+                        </annotationProcessorPaths>
+                        <fork>true</fork>
+                        <meminitial>128m</meminitial>
+                        <maxmem>512m</maxmem>
                     </configuration>
                 </plugin>
                 <plugin>
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [x] CI/build
### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
Testing should be usual regression and monkey testing