### PR TITLE
KVM: revert libvirtd config and retry if fail to add a host

### DIFF
--- a/scripts/util/keystore-setup
+++ b/scripts/util/keystore-setup
@@ -23,6 +23,7 @@ KS_VALIDITY="$4"
 CSR_FILE="$5"
 
 ALIAS="cloud"
+LIBVIRTD_FILE="/etc/libvirt/libvirtd.conf"
 
 # Re-use existing password or use the one provided
 if [ -f "$PROPS_FILE" ]; then
@@ -46,6 +47,27 @@ keytool -genkey -storepass "$KS_PASS" -keypass "$KS_PASS" -alias "$ALIAS" -keyal
 rm -f "$CSR_FILE"
 addresses=$(ip address | grep inet | awk '{print $2}' | sed 's/\/.*//g' | grep -v '^169.254.' | grep -v '^127.0.0.1' | egrep -v '^::1|^fe80' | grep -v '^::1' | sed 's/^/ip:/g' | tr '\r\n' ',')
 keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" > /dev/null 2>&1
+
+if [ $? -ne 0 ];then
+    echo "Failed to generate CSR file, retrying after removing existing settings"
+
+    if [ -f "$LIBVIRTD_FILE" ]; then
+        echo "Reverting libvirtd to not listen on TLS"
+        sed -i "s,^listen_tls=1,listen_tls=0,g" $LIBVIRTD_FILE
+        systemctl restart libvirtd
+    fi
+
+    echo "Removing cloud.* files in /etc/cloudstack/agent"
+    rm -f /etc/cloudstack/agent/cloud.*
+
+    echo "Retrying to generate CSR file"
+    keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" >/dev/null 2>&1
+    if [ $? -ne 0 ];then
+        echo "Failed to generate CSR file while retrying"
+        exit 1
+    fi
+fi
+
 cat "$CSR_FILE"
 
 # Fix file permissions

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -260,10 +260,11 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
 
             final String privateKey = _configDao.getValue("ssh.privatekey");
             if (!SSHCmdHelper.acquireAuthorizedConnectionWithPublicKey(sshConnection, username, privateKey)) {
-                s_logger.error("Failed to authenticate with ssh key");
                 if (org.apache.commons.lang3.StringUtils.isEmpty(password)) {
+                    s_logger.error("Failed to authenticate with ssh key");
                     throw new DiscoveredWithErrorException("Authentication error with ssh private key");
                 }
+                s_logger.info("Failed to authenticate with ssh key, retrying with password");
                 if (!sshConnection.authenticateWithPassword(username, password)) {
                     s_logger.error("Failed to authenticate with password");
                     throw new DiscoveredWithErrorException("Authentication error with host password");


### PR DESCRIPTION

### Description

This PR fixes #6716

If a KVM host has been added to cloudstack environment before, then we reset agent.properties to original file (./agent/conf/agent.properties), and add the host to cloudstack again, we will face the following error:

2023-01-11 20:54:03,734 DEBUG [c.c.h.k.d.LibvirtServerDiscoverer] (qtp1647766367-13:ctx-17f9aff7 ctx-47c881cb) (logid:49819f17)  can't setup agent, due to com.cloud.utils.exception.CloudRuntimeException: Failed to setup keystore on the KVM host: 10.0.32.229 - Failed to setup keystore on the KVM host: 10.0.32.229 com.cloud.utils.exception.CloudRuntimeException: Failed to setup keystore on the KVM host: 10.0.32.229
        at com.cloud.hypervisor.kvm.discoverer.LibvirtServerDiscoverer.setupAgentSecurity(LibvirtServerDiscoverer.java:178)
        at com.cloud.hypervisor.kvm.discoverer.LibvirtServerDiscoverer.find(LibvirtServerDiscoverer.java:320)

This is because the libvirtd has been configured to listen on LTS port when the host was added to cloudstack before. When try to add host again, cloudstack will generate a new keystore passphrase which is not same as before, and wrong password for existing keystore.

The issue can be fixed by
(1) revert libvirtd config to not use TLS
(2) remove all existing keystore/certificate
(3) generate new keystore/certificate
(4) setup agent, etc

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

- add a host to cloudstack
- remove it (after put into maintenance, or force remove it)
- download https://github.com/apache/cloudstack/blob/main/agent/conf/agent.properties and copy to /etc/cloudstack/agent/agent.properties
- add host again

prior to this change, it fails with `Failed to setup keystore on the KVM host`
with this change, it succeeds
