### PR TITLE
marvin: install mysql-connector-python version 8.0.31

### DIFF
--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -46,7 +46,7 @@ setup(name="Marvin",
                 "marvin.sandbox.basic"],
       license="LICENSE.txt",
       install_requires=[
-          "mysql-connector-python >= 1.1.6",
+          "mysql-connector-python == 8.0.20",
           "requests >= 2.2.1",
           "paramiko >= 1.13.0",
           "nose >= 1.3.3",

--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -46,7 +46,7 @@ setup(name="Marvin",
                 "marvin.sandbox.basic"],
       license="LICENSE.txt",
       install_requires=[
-          "mysql-connector-python == 8.0.20",
+          "mysql-connector-python == 8.0.31",
           "requests >= 2.2.1",
           "paramiko >= 1.13.0",
           "nose >= 1.3.3",

--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -46,7 +46,7 @@ setup(name="Marvin",
                 "marvin.sandbox.basic"],
       license="LICENSE.txt",
       install_requires=[
-          "mysql-connector-python == 8.0.30",
+          "mysql-connector-python <= 8.0.30",
           "requests >= 2.2.1",
           "paramiko >= 1.13.0",
           "nose >= 1.3.3",

--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -46,7 +46,7 @@ setup(name="Marvin",
                 "marvin.sandbox.basic"],
       license="LICENSE.txt",
       install_requires=[
-          "mysql-connector-python == 8.0.31",
+          "mysql-connector-python == 8.0.30",
           "requests >= 2.2.1",
           "paramiko >= 1.13.0",
           "nose >= 1.3.3",


### PR DESCRIPTION
On EL7 and EL8, when Marvin is installed and if newer mysql-connector-python is installed leads to errors which aren't compatible with python 2.7 and 3.6.