### PR TITLE
Make displayText in createNetwork optional

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
@@ -46,7 +46,7 @@ import com.cloud.network.Network;
 import com.cloud.network.Network.GuestType;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.utils.net.NetUtils;
-import org.apache.commons.lang3.StringUtils;
+
 
 @APICommand(name = "createNetwork", description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
@@ -219,7 +219,10 @@ public class CreateNetworkCmd extends BaseCmd implements UserCmd {
     }
 
     public String getDisplayText() {
-        return StringUtils.isEmpty(displayText) ? name : displayText;
+        if(displayText == null)
+            return name;
+        else
+            return displayText;
     }
 
     public String getNetworkDomain() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
@@ -61,7 +61,7 @@ public class CreateNetworkCmd extends BaseCmd implements UserCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "the name of the network")
     private String name;
 
-    @Parameter(name = ApiConstants.DISPLAY_TEXT, type = CommandType.STRING, required = true, description = "the display text of the network")
+    @Parameter(name = ApiConstants.DISPLAY_TEXT, type = CommandType.STRING, required = false, description = "the display text of the network")
     private String displayText;
 
     @Parameter(name = ApiConstants.NETWORK_OFFERING_ID,
@@ -218,7 +218,10 @@ public class CreateNetworkCmd extends BaseCmd implements UserCmd {
     }
 
     public String getDisplayText() {
-        return displayText;
+        if(displayText == null)
+            return name;
+        else
+            return displayText;
     }
 
     public String getNetworkDomain() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
@@ -46,6 +46,7 @@ import com.cloud.network.Network;
 import com.cloud.network.Network.GuestType;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.utils.net.NetUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @APICommand(name = "createNetwork", description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
@@ -218,10 +219,7 @@ public class CreateNetworkCmd extends BaseCmd implements UserCmd {
     }
 
     public String getDisplayText() {
-        if(displayText == null)
-            return name;
-        else
-            return displayText;
+        return StringUtils.isEmpty(displayText) ? name : displayText;
     }
 
     public String getNetworkDomain() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmd.java
@@ -46,7 +46,7 @@ import com.cloud.network.Network;
 import com.cloud.network.Network.GuestType;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.utils.net.NetUtils;
-
+import org.apache.commons.lang3.StringUtils;
 
 @APICommand(name = "createNetwork", description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
@@ -219,10 +219,7 @@ public class CreateNetworkCmd extends BaseCmd implements UserCmd {
     }
 
     public String getDisplayText() {
-        if(displayText == null)
-            return name;
-        else
-            return displayText;
+        return StringUtils.isEmpty(displayText) ? name : displayText;
     }
 
     public String getNetworkDomain() {

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
@@ -110,6 +110,7 @@ public class CreateNetworkCmdTest extends TestCase {
         String description = null;
         String netName = "net-isolated";
         ReflectionTestUtils.setField(cmd, "displayText", description);
+        ReflectionTestUtils.setField(cmd, "name", netName);
         Assert.assertEquals(cmd.getDisplayText(), netName);
     }
 

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
@@ -109,7 +109,6 @@ public class CreateNetworkCmdTest extends TestCase {
     public void testGetDisplayTextWhenEmpty() {
         String description = null;
         String netName = "net-isolated";
-        ReflectionTestUtils.setField(cmd, "displayText", description);
         ReflectionTestUtils.setField(cmd, "name", netName);
         Assert.assertEquals(cmd.getDisplayText(), netName);
     }

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
@@ -100,10 +100,17 @@ public class CreateNetworkCmdTest extends TestCase {
         Assert.assertEquals(cmd.getNetworkName(), netName);
     }
 
-    public void testGetDisplayText() {
+    public void testGetDisplayTextWhenNotEmpty() {
         String description = "Isolated Network";
         ReflectionTestUtils.setField(cmd, "displayText", description);
         Assert.assertEquals(cmd.getDisplayText(), description);
+    }
+
+    public void testGetDisplayTextWhenEmpty() {
+        String description = null;
+        String netName = "net-isolated";
+        ReflectionTestUtils.setField(cmd, "displayText", description);
+        Assert.assertEquals(cmd.getDisplayText(), netName);
     }
 
     public void testGetNetworkDomain() {

--- a/test/integration/smoke/test_create_network.py
+++ b/test/integration/smoke/test_create_network.py
@@ -289,3 +289,86 @@ class TestNetworkManagement(cloudstackTestCase):
         )
 
         self.cleanup.append(self.network_offering)
+
+    @attr(tags=["adeancedsg"], required_hardware="false")
+    def test_03_create_network_with_empty_displayText(self):
+        """Create Shared network with empty displayText
+           and verify value of displayText after network
+           is being created.
+        """
+        # Update the global setting to true
+        Configurations.update(self.apiclient,
+                              name="allow.duplicate.networkname",
+                              value="true"
+                              )
+
+        # Create network offering
+        self.network_offering = NetworkOffering.create(
+            self.apiclient,
+            self.testdata["network_offering_shared"]
+        )
+
+        NetworkOffering.update(
+            self.network_offering,
+            self.apiclient,
+            id=self.network_offering.id,
+            state="enabled"
+        )
+
+        physical_network, vlan = get_free_vlan(self.apiclient, self.zone.id)
+        self.testdata["shared_network_sg"]["physicalnetworkid"] = physical_network.id
+
+        random_subnet_number = random.randrange(100, 199)
+        self.testdata["shared_network_sg"]["specifyVlan"] = 'True'
+        self.testdata["shared_network_sg"]["specifyIpRanges"] = 'True'
+        self.testdata["shared_network_sg"]["name"] = "Shared-Network-SG-Test-vlan-1"
+        self.testdata["shared_network_sg"]["displayText"] = ''
+        self.testdata["shared_network_sg"]["vlan"] = "vlan://" + str(random_subnet_number)
+        self.testdata["shared_network_sg"]["startip"] = "192.168." + str(random_subnet_number) + ".1"
+        self.testdata["shared_network_sg"]["endip"] = "192.168." + str(random_subnet_number) + ".10"
+        self.testdata["shared_network_sg"]["gateway"] = "192.168." + str(random_subnet_number) + ".254"
+        self.testdata["shared_network_sg"]["netmask"] = "255.255.255.0"
+        self.testdata["shared_network_sg"]["acltype"] = "account"
+
+        # Create the first network with empty displayText
+        network1 = Network.create(
+            self.apiclient,
+            self.testdata["shared_network_sg"],
+            networkofferingid=self.network_offering.id,
+            zoneid=self.zone.id,
+            accountid=self.account.name,
+            domainid=self.account.domainid
+        )
+
+        self.cleanup.append(network1)
+
+        self.assertEqual(
+            network.displayText,
+            self.testdata["shared_network_sg"]["name"],
+            msg="displayText does not match name"
+        )
+
+        self.testdata["shared_network_sg"]["displayText"] = 'test'
+
+        #Create the second network with non-empty displayText
+        network2 = Network.create(
+            self.apiclient,
+            self.testdata["shared_network_sg"],
+            networkofferingid=self.network_offering.id,
+            zoneid=self.zone.id,
+            accountid=self.account.name,
+            domainid=self.account.domainid
+        )
+
+        self.assertNotEqual(
+            network.displayText,
+            self.testdata["shared_network_sg"]["name"],
+            msg="displayText does not match name"
+        )
+
+        self.cleanup.append(network2)
+
+        return
+
+
+

--- a/test/integration/smoke/test_create_network.py
+++ b/test/integration/smoke/test_create_network.py
@@ -365,10 +365,7 @@ class TestNetworkManagement(cloudstackTestCase):
         self.assertNotEqual(
             network2.displayText,
             self.testdata["shared_network_sg"]["name"],
-            msg="displayText does not match name"
+            msg="displayText and name are equal"
         )
 
         return
-
-
-

--- a/test/integration/smoke/test_create_network.py
+++ b/test/integration/smoke/test_create_network.py
@@ -290,7 +290,7 @@ class TestNetworkManagement(cloudstackTestCase):
 
         self.cleanup.append(self.network_offering)
 
-    @attr(tags=["adeancedsg"], required_hardware="false")
+    @attr(tags=["adeancedsg", "simulator"], required_hardware="false")
     def test_03_create_network_with_empty_displayText(self):
         """Create Shared network with empty displayText
            and verify value of displayText after network

--- a/test/integration/smoke/test_create_network.py
+++ b/test/integration/smoke/test_create_network.py
@@ -307,6 +307,7 @@ class TestNetworkManagement(cloudstackTestCase):
             self.apiclient,
             self.testdata["network_offering_shared"]
         )
+        self.cleanup.append( self.network_offering)
 
         NetworkOffering.update(
             self.network_offering,

--- a/test/integration/smoke/test_create_network.py
+++ b/test/integration/smoke/test_create_network.py
@@ -290,7 +290,7 @@ class TestNetworkManagement(cloudstackTestCase):
 
         self.cleanup.append(self.network_offering)
 
-    @attr(tags=["adeancedsg", "simulator"], required_hardware="false")
+    @attr(tags=["adeancedsg", "Simulator"], required_hardware="false")
     def test_03_create_network_with_empty_displayText(self):
         """Create Shared network with empty displayText
            and verify value of displayText after network
@@ -343,7 +343,7 @@ class TestNetworkManagement(cloudstackTestCase):
         self.cleanup.append(network1)
 
         self.assertEqual(
-            network.displayText,
+            network1.displayText,
             self.testdata["shared_network_sg"]["name"],
             msg="displayText does not match name"
         )
@@ -360,13 +360,13 @@ class TestNetworkManagement(cloudstackTestCase):
             domainid=self.account.domainid
         )
 
+        self.cleanup.append(network2)
+
         self.assertNotEqual(
-            network.displayText,
+            network2.displayText,
             self.testdata["shared_network_sg"]["name"],
             msg="displayText does not match name"
         )
-
-        self.cleanup.append(network2)
 
         return
 

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -40,7 +40,7 @@
               <tooltip-label :title="$t('label.displaytext')" :tooltip="apiParams.displaytext.description"/>
             </template>
             <a-input
-             v-model:value="form.name"
+             v-model:value="form.displaytext"
               :placeholder="apiParams.displaytext.description"/>
           </a-form-item>
           <a-form-item ref="zoneid" name="zoneid">

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -40,7 +40,7 @@
               <tooltip-label :title="$t('label.displaytext')" :tooltip="apiParams.displaytext.description"/>
             </template>
             <a-input
-             v-model:value="form.displaytext"
+             v-model:value="form.name"
               :placeholder="apiParams.displaytext.description"/>
           </a-form-item>
           <a-form-item ref="zoneid" name="zoneid">
@@ -394,7 +394,6 @@ export default {
       this.form = reactive({})
       this.rules = reactive({
         name: [{ required: true, message: this.$t('message.error.name') }],
-        displaytext: [{ required: true, message: this.$t('message.error.display.text') }],
         zoneid: [{ type: 'number', required: true, message: this.$t('message.error.select') }],
         networkofferingid: [{ type: 'number', required: true, message: this.$t('message.error.select') }],
         vpcid: [{ required: true, message: this.$t('message.error.select') }]

--- a/ui/src/views/network/CreateL2NetworkForm.vue
+++ b/ui/src/views/network/CreateL2NetworkForm.vue
@@ -40,7 +40,7 @@
               <tooltip-label :title="$t('label.displaytext')" :tooltip="apiParams.displaytext.description"/>
             </template>
             <a-input
-              v-model:value="form.name"
+              v-model:value="form.displaytext"
               :placeholder="apiParams.displaytext.description"/>
           </a-form-item>
           <a-form-item name="zoneid" ref="zoneid">

--- a/ui/src/views/network/CreateL2NetworkForm.vue
+++ b/ui/src/views/network/CreateL2NetworkForm.vue
@@ -40,7 +40,7 @@
               <tooltip-label :title="$t('label.displaytext')" :tooltip="apiParams.displaytext.description"/>
             </template>
             <a-input
-              v-model:value="form.displaytext"
+              v-model:value="form.name"
               :placeholder="apiParams.displaytext.description"/>
           </a-form-item>
           <a-form-item name="zoneid" ref="zoneid">
@@ -266,7 +266,6 @@ export default {
       })
       this.rules = reactive({
         name: [{ required: true, message: this.$t('message.error.name') }],
-        displaytext: [{ required: true, message: this.$t('message.error.display.text') }],
         zoneid: [{ required: true, message: this.$t('message.error.select') }],
         networkofferingid: [{ required: true, message: this.$t('message.error.select') }],
         vlanid: [{ required: true, message: this.$t('message.please.enter.value') }]

--- a/ui/src/views/network/CreateSharedNetworkForm.vue
+++ b/ui/src/views/network/CreateSharedNetworkForm.vue
@@ -40,7 +40,7 @@
               <tooltip-label :title="$t('label.displaytext')" :tooltip="apiParams.displaytext.description"/>
             </template>
             <a-input
-              v-model:value="form.displaytext"
+              v-model:value="form.name"
               :placeholder="apiParams.displaytext.description"/>
           </a-form-item>
           <a-form-item v-if="isObjectEmpty(zone)" name="zoneid" ref="zoneid">
@@ -590,7 +590,6 @@ export default {
       })
       this.rules = reactive({
         name: [{ required: true, message: this.$t('message.error.name') }],
-        displaytext: [{ required: true, message: this.$t('message.error.display.text') }],
         zoneid: [{ type: 'number', required: true, message: this.$t('message.error.select') }],
         vlan: [{ required: true, message: this.$t('message.please.enter.value') }],
         networkofferingid: [{ type: 'number', required: true, message: this.$t('message.error.select') }],

--- a/ui/src/views/network/CreateSharedNetworkForm.vue
+++ b/ui/src/views/network/CreateSharedNetworkForm.vue
@@ -40,7 +40,7 @@
               <tooltip-label :title="$t('label.displaytext')" :tooltip="apiParams.displaytext.description"/>
             </template>
             <a-input
-              v-model:value="form.name"
+              v-model:value="form.displaytext"
               :placeholder="apiParams.displaytext.description"/>
           </a-form-item>
           <a-form-item v-if="isObjectEmpty(zone)" name="zoneid" ref="zoneid">


### PR DESCRIPTION
### Description
This is a improvement change to make displayText field optional for createNetwork as mentioned in issue #6855. 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
