### PR TITLE
cloudstack-setup-agent: mask libvirt non-monolithic services

### DIFF
--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -618,17 +618,19 @@ class libvirtConfigRedhat(serviceCfgBase):
             cfo.save()
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
                 bash("/bin/systemctl mask \
-                libvirtd.socket \
-                libvirtd-ro.socket \
-                libvirtd-admin.socket \
-                libvirtd-tls.socket \
-                libvirtd-tcp.socket \
-                virtqemud.socket \
-                virtqemud-ro.socket \
-                virtqemud-admin.socket \
-                virtqemud \
-                virtnetworkd \
-                virtstoraged");
+                    libvirtd.socket \
+                    libvirtd-ro.socket \
+                    libvirtd-admin.socket \
+                    libvirtd-tls.socket \
+                    libvirtd-tcp.socket");
+            if os.path.exists("/lib/systemd/system/virtqemud.socket"):
+                bash("/bin/systemctl mask \
+                    virtqemud.socket \
+                    virtqemud-ro.socket \
+                    virtqemud-admin.socket \
+                    virtqemud \
+                    virtnetworkd \
+                    virtstoraged");
 
             filename = "/etc/libvirt/qemu.conf"
 
@@ -658,17 +660,19 @@ class libvirtConfigSUSE(serviceCfgBase):
 
             if os.path.exists("/usr/lib/systemd/system/libvirtd.socket"):
                 bash("/bin/systemctl mask \
-                libvirtd.socket \
-                libvirtd-ro.socket \
-                libvirtd-admin.socket \
-                libvirtd-tls.socket \
-                libvirtd-tcp.socket \
-                virtqemud.socket \
-                virtqemud-ro.socket \
-                virtqemud-admin.socket \
-                virtqemud \
-                virtnetworkd \
-                virtstoraged");
+                    libvirtd.socket \
+                    libvirtd-ro.socket \
+                    libvirtd-admin.socket \
+                    libvirtd-tls.socket \
+                    libvirtd-tcp.socket");
+            if os.path.exists("/usr/lib/systemd/system/virtqemud.socket"):
+                bash("/bin/systemctl mask \
+                    virtqemud.socket \
+                    virtqemud-ro.socket \
+                    virtqemud-admin.socket \
+                    virtqemud \
+                    virtnetworkd \
+                    virtstoraged");
 
             cfo = configFileOps("/etc/sysconfig/libvirtd", self)
             cfo.addEntry("LIBVIRTD_ARGS", "-l")
@@ -709,17 +713,19 @@ class libvirtConfigUbuntu(serviceCfgBase):
             cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l'")
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
                 bash("/bin/systemctl mask \
-                libvirtd.socket \
-                libvirtd-ro.socket \
-                libvirtd-admin.socket \
-                libvirtd-tls.socket \
-                libvirtd-tcp.socket \
-                virtqemud.socket \
-                virtqemud-ro.socket \
-                virtqemud-admin.socket \
-                virtqemud \
-                virtnetworkd \
-                virtstoraged");
+                    libvirtd.socket \
+                    libvirtd-ro.socket \
+                    libvirtd-admin.socket \
+                    libvirtd-tls.socket \
+                    libvirtd-tcp.socket");
+            if os.path.exists("/lib/systemd/system/virtqemud.socket"):
+                bash("/bin/systemctl mask \
+                    virtqemud.socket \
+                    virtqemud-ro.socket \
+                    virtqemud-admin.socket \
+                    virtqemud \
+                    virtnetworkd \
+                    virtstoraged");
 
     def config(self):
         try:

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -665,14 +665,6 @@ class libvirtConfigSUSE(serviceCfgBase):
                     libvirtd-admin.socket \
                     libvirtd-tls.socket \
                     libvirtd-tcp.socket");
-            if os.path.exists("/usr/lib/systemd/system/virtqemud.socket"):
-                bash("/bin/systemctl mask \
-                    virtqemud.socket \
-                    virtqemud-ro.socket \
-                    virtqemud-admin.socket \
-                    virtqemud \
-                    virtnetworkd \
-                    virtstoraged");
 
             cfo = configFileOps("/etc/sysconfig/libvirtd", self)
             cfo.addEntry("LIBVIRTD_ARGS", "-l")

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -617,8 +617,18 @@ class libvirtConfigRedhat(serviceCfgBase):
             cfo.addEntry("LIBVIRTD_ARGS", "-l")
             cfo.save()
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
-                bash("/bin/systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket");
-                bash("/bin/systemctl mask virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket virtqemud virtnetworkd virtstoraged");
+                bash("/bin/systemctl mask \
+                libvirtd.socket \
+                libvirtd-ro.socket \
+                libvirtd-admin.socket \
+                libvirtd-tls.socket \
+                libvirtd-tcp.socket \
+                virtqemud.socket \
+                virtqemud-ro.socket \
+                virtqemud-admin.socket \
+                virtqemud \
+                virtnetworkd \
+                virtstoraged");
 
             filename = "/etc/libvirt/qemu.conf"
 

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -708,8 +708,18 @@ class libvirtConfigUbuntu(serviceCfgBase):
             cfo = configFileOps("/etc/default/libvirtd", self)
             cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l'")
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
-                bash("/bin/systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket");
-                bash("/bin/systemctl mask virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket virtqemud virtnetworkd virtstoraged");
+                bash("/bin/systemctl mask \
+                libvirtd.socket \
+                libvirtd-ro.socket \
+                libvirtd-admin.socket \
+                libvirtd-tls.socket \
+                libvirtd-tcp.socket \
+                virtqemud.socket \
+                virtqemud-ro.socket \
+                virtqemud-admin.socket \
+                virtqemud \
+                virtnetworkd \
+                virtstoraged");
 
     def config(self):
         try:

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -657,8 +657,18 @@ class libvirtConfigSUSE(serviceCfgBase):
             configureLibvirtConfig(self.syscfg.env.secure, self)
 
             if os.path.exists("/usr/lib/systemd/system/libvirtd.socket"):
-                bash("/bin/systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket");
-                bash("/bin/systemctl mask virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket virtqemud virtnetworkd virtstoraged");
+                bash("/bin/systemctl mask \
+                libvirtd.socket \
+                libvirtd-ro.socket \
+                libvirtd-admin.socket \
+                libvirtd-tls.socket \
+                libvirtd-tcp.socket \
+                virtqemud.socket \
+                virtqemud-ro.socket \
+                virtqemud-admin.socket \
+                virtqemud \
+                virtnetworkd \
+                virtstoraged");
 
             cfo = configFileOps("/etc/sysconfig/libvirtd", self)
             cfo.addEntry("LIBVIRTD_ARGS", "-l")

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -617,11 +617,8 @@ class libvirtConfigRedhat(serviceCfgBase):
             cfo.addEntry("LIBVIRTD_ARGS", "-l")
             cfo.save()
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
-                bash("/bin/systemctl mask libvirtd.socket");
-                bash("/bin/systemctl mask libvirtd-ro.socket");
-                bash("/bin/systemctl mask libvirtd-admin.socket");
-                bash("/bin/systemctl mask libvirtd-tls.socket");
-                bash("/bin/systemctl mask libvirtd-tcp.socket");
+                bash("/bin/systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket");
+                bash("/bin/systemctl mask virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket virtqemud virtnetworkd virtstoraged");
 
             filename = "/etc/libvirt/qemu.conf"
 
@@ -650,11 +647,8 @@ class libvirtConfigSUSE(serviceCfgBase):
             configureLibvirtConfig(self.syscfg.env.secure, self)
 
             if os.path.exists("/usr/lib/systemd/system/libvirtd.socket"):
-                bash("/bin/systemctl mask libvirtd.socket");
-                bash("/bin/systemctl mask libvirtd-ro.socket");
-                bash("/bin/systemctl mask libvirtd-admin.socket");
-                bash("/bin/systemctl mask libvirtd-tls.socket");
-                bash("/bin/systemctl mask libvirtd-tcp.socket");
+                bash("/bin/systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket");
+                bash("/bin/systemctl mask virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket virtqemud virtnetworkd virtstoraged");
 
             cfo = configFileOps("/etc/sysconfig/libvirtd", self)
             cfo.addEntry("LIBVIRTD_ARGS", "-l")
@@ -694,11 +688,8 @@ class libvirtConfigUbuntu(serviceCfgBase):
             cfo = configFileOps("/etc/default/libvirtd", self)
             cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l'")
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
-                bash("/bin/systemctl mask libvirtd.socket");
-                bash("/bin/systemctl mask libvirtd-ro.socket");
-                bash("/bin/systemctl mask libvirtd-admin.socket");
-                bash("/bin/systemctl mask libvirtd-tls.socket");
-                bash("/bin/systemctl mask libvirtd-tcp.socket");
+                bash("/bin/systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket");
+                bash("/bin/systemctl mask virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket virtqemud virtnetworkd virtstoraged");
 
     def config(self):
         try:

--- a/python/lib/cloudutils/syscfg.py
+++ b/python/lib/cloudutils/syscfg.py
@@ -45,6 +45,8 @@ class sysConfigAgentFactory:
             return sysConfigRedhat7(glbEnv)
         elif distribution == "RHEL8":
             return sysConfigRedhat8(glbEnv)
+        elif distribution == "RHEL9":
+            return sysConfigRedhat9(glbEnv)
         elif distribution == "SUSE":
             return sysConfigSUSE(glbEnv)
         else:
@@ -214,6 +216,18 @@ class sysConfigRedhat7(sysConfigAgentRedhat7Base):
 class sysConfigRedhat8(sysConfigAgentRedhat8Base):
     def __init__(self, glbEnv):
         super(sysConfigRedhat8, self).__init__(glbEnv)
+        self.services = [hostConfig(self),
+                         securityPolicyConfigRedhat(self),
+                         networkConfigRedhat(self),
+                         libvirtConfigRedhat(self),
+                         firewallConfigAgent(self),
+                         nfsConfig(self),
+                         cloudAgentConfig(self)]
+
+#it covers RHEL9
+class sysConfigRedhat9(sysConfigAgentRedhat8Base):
+    def __init__(self, glbEnv):
+        super(sysConfigRedhat9, self).__init__(glbEnv)
         self.services = [hostConfig(self),
                          securityPolicyConfigRedhat(self),
                          networkConfigRedhat(self),

--- a/python/lib/cloudutils/syscfg.py
+++ b/python/lib/cloudutils/syscfg.py
@@ -37,16 +37,14 @@ class sysConfigAgentFactory:
         distribution = glbEnv.distribution.getVersion()
         if distribution == "Ubuntu":
             return sysConfigAgentUbuntu(glbEnv)
-        elif distribution == "Fedora" or distribution == "RHEL6":
-            return sysConfigRedhat6(glbEnv)
         elif distribution == "CentOS" or distribution == "RHEL5":
-            return sysConfigRedhat5(glbEnv)
+            return sysConfigEL5(glbEnv)
+        elif distribution == "Fedora" or distribution == "RHEL6":
+            return sysConfigEL6(glbEnv)
         elif distribution == "RHEL7":
-            return sysConfigRedhat7(glbEnv)
-        elif distribution == "RHEL8":
-            return sysConfigRedhat8(glbEnv)
-        elif distribution == "RHEL9":
-            return sysConfigRedhat9(glbEnv)
+            return sysConfigEL7(glbEnv)
+        elif distribution in ["RHEL8", "RHEL9"]:
+            return sysConfigEL(glbEnv)
         elif distribution == "SUSE":
             return sysConfigSUSE(glbEnv)
         else:
@@ -153,10 +151,10 @@ class sysConfigAgentRedhat7Base(sysConfigAgent):
         self.svo = serviceOpsRedhat7Later()
         super(sysConfigAgentRedhat7Base, self).__init__(env)
 
-class sysConfigAgentRedhat8Base(sysConfigAgent):
+class sysConfigAgentELBase(sysConfigAgent):
     def __init__(self, env):
         self.svo = serviceOpsRedhat7Later()
-        super(sysConfigAgentRedhat8Base, self).__init__(env)
+        super(sysConfigAgentELBase, self).__init__(env)
 
 class sysConfigAgentSUSE(sysConfigAgent):
     def __init__(self, env):
@@ -176,10 +174,21 @@ class sysConfigAgentUbuntu(sysConfigAgent):
                          nfsConfig(self),
                          cloudAgentConfig(self)]
 
-#it covers RHEL6/Fedora13/Fedora14
-class sysConfigRedhat6(sysConfigAgentRedhatBase):
+#It covers RHEL5/CentOS5, the mainly difference is that there is no cgroup
+class sysConfigEL5(sysConfigAgentRedhatBase):
     def __init__(self, glbEnv):
-        super(sysConfigRedhat6, self).__init__(glbEnv)
+        super(sysConfigEL5, self).__init__(glbEnv)
+        self.services = [hostConfig(self),
+                         securityPolicyConfigRedhat(self),
+                         networkConfigRedhat(self),
+                         libvirtConfigRedhat(self),
+                         firewallConfigAgent(self),
+                         cloudAgentConfig(self)]
+
+#it covers RHEL6/Fedora13/Fedora14
+class sysConfigEL6(sysConfigAgentRedhatBase):
+    def __init__(self, glbEnv):
+        super(sysConfigEL6, self).__init__(glbEnv)
         self.services = [hostConfig(self),
                          cgroupConfig(self),
                          securityPolicyConfigRedhat(self),
@@ -189,21 +198,10 @@ class sysConfigRedhat6(sysConfigAgentRedhatBase):
                          nfsConfig(self),
                          cloudAgentConfig(self)]
 
-#It covers RHEL5/CentOS5, the mainly difference is that there is no cgroup
-class sysConfigRedhat5(sysConfigAgentRedhatBase):
-    def __init__(self, glbEnv):
-        super(sysConfigRedhat5, self).__init__(glbEnv)
-        self.services = [hostConfig(self),
-                         securityPolicyConfigRedhat(self),
-                         networkConfigRedhat(self),
-                         libvirtConfigRedhat(self),
-                         firewallConfigAgent(self),
-                         cloudAgentConfig(self)]
-
 #it covers RHEL7
-class sysConfigRedhat7(sysConfigAgentRedhat7Base):
+class sysConfigEL7(sysConfigAgentRedhat7Base):
     def __init__(self, glbEnv):
-        super(sysConfigRedhat7, self).__init__(glbEnv)
+        super(sysConfigEL7, self).__init__(glbEnv)
         self.services = [hostConfig(self),
                          securityPolicyConfigRedhat(self),
                          networkConfigRedhat(self),
@@ -212,22 +210,10 @@ class sysConfigRedhat7(sysConfigAgentRedhat7Base):
                          nfsConfig(self),
                          cloudAgentConfig(self)]
 
-#it covers RHEL8
-class sysConfigRedhat8(sysConfigAgentRedhat8Base):
+#it covers RHEL8 and later
+class sysConfigEL(sysConfigAgentELBase):
     def __init__(self, glbEnv):
-        super(sysConfigRedhat8, self).__init__(glbEnv)
-        self.services = [hostConfig(self),
-                         securityPolicyConfigRedhat(self),
-                         networkConfigRedhat(self),
-                         libvirtConfigRedhat(self),
-                         firewallConfigAgent(self),
-                         nfsConfig(self),
-                         cloudAgentConfig(self)]
-
-#it covers RHEL9
-class sysConfigRedhat9(sysConfigAgentRedhat8Base):
-    def __init__(self, glbEnv):
-        super(sysConfigRedhat9, self).__init__(glbEnv)
+        super(sysConfigEL, self).__init__(glbEnv)
         self.services = [hostConfig(self),
                          securityPolicyConfigRedhat(self),
                          networkConfigRedhat(self),

--- a/python/lib/cloudutils/utilities.py
+++ b/python/lib/cloudutils/utilities.py
@@ -120,6 +120,10 @@ class Distribution:
                 version.find("CentOS Linux release 8") != -1 or version.find("CentOS release 8.") != -1 or
                 version.find("Linux release 8") != -1):
                 self.distro = "RHEL8"
+            elif (version.find("Red Hat Enterprise Linux Server release 9") != -1 or version.find("Scientific Linux release 9") != -1 or
+                version.find("Red Hat Enterprise Linux release 9") != -1 or version.find("Linux release 9.") != -1 or
+                version.find("Linux release 9") != -1):
+                self.distro = "RHEL9"
             elif version.find("CentOS") != -1:
                 self.distro = "CentOS"
             else:


### PR DESCRIPTION
This masks sockets such as virtqemud.socket virtqemud-ro.socket virtqemud-admin.socket, and services virtqemud virtnetworkd virtstoraged that block libvirtd to be used a monolithic service. Useful for both EL9 and existing Ubuntu 22.04, and newer distros.

Didn't test with these changes, but after setting up a local RHEL9+KVM env I had to run these to block them from interfering with the libvirtd process.