### PR TITLE
vmware: support vsphere 8 specific version

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
@@ -19,9 +19,11 @@
 -- Schema upgrade from 4.17.2.0 to 4.18.0.0
 --;
 
--- Add support for VMware 8.0
+-- Add support for VMware 8.0 and 8.0a (8.0.0.1)
 INSERT IGNORE INTO `cloud`.`hypervisor_capabilities` (uuid, hypervisor_type, hypervisor_version, max_guests_limit, security_group_enabled, max_data_volumes_limit, max_hosts_per_cluster, storage_motion_supported, vm_snapshot_enabled) values (UUID(), 'VMware', '8.0', 1024, 0, 59, 64, 1, 1);
+INSERT IGNORE INTO `cloud`.`hypervisor_capabilities` (uuid, hypervisor_type, hypervisor_version, max_guests_limit, security_group_enabled, max_data_volumes_limit, max_hosts_per_cluster, storage_motion_supported, vm_snapshot_enabled) values (UUID(), 'VMware', '8.0.0.1', 1024, 0, 59, 64, 1, 1);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'VMware', '8.0', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='VMware' AND hypervisor_version='7.0.3.0';
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'VMware', '8.0.0.1', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='VMware' AND hypervisor_version='7.0.3.0';
 
 -- Enable CPU cap for default system offerings;
 UPDATE `cloud`.`service_offering` so


### PR DESCRIPTION
### Description

Add support for specific/available version 8.0.0.1 (8.0a). Without this, most of the lifecycle works except for vMotion (VM migration) which complains about missing VMware version hypervisor capabilities.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<img width="726" alt="Screenshot 2023-01-23 at 3 04 38 AM" src="https://user-images.githubusercontent.com/95203/213957917-8a2adaa0-a189-4510-be1e-18c79a775c12.png">
<img width="803" alt="Screenshot 2023-01-23 at 3 05 06 AM" src="https://user-images.githubusercontent.com/95203/213957924-814ee68c-41c8-4e3e-befd-ddb52e54a344.png">


### How Has This Been Tested?

Tested with https://github.com/shapeblue/mbx on Ubuntu 22.04 host using vmware 8.0.0.1 template.