### PR TITLE
marvin: newer python setuptools doesn't like -SNAPSHOT in marvin version

### DIFF
--- a/tools/marvin/mvn-setup.py
+++ b/tools/marvin/mvn-setup.py
@@ -48,7 +48,7 @@ def runSetupScript(args):
 
 
 if __name__ == "__main__":
-    version = sys.argv[1]
+    version = sys.argv[1].replace("-SNAPSHOT", "")
     remainingArgs = sys.argv[2:]
     replaceVersion(setupScript, version)
     runSetupScript(remainingArgs)


### PR DESCRIPTION
### Description

Newer python setuptools doesn't like -SNAPSHOT in marvin version. This has been reported such as https://github.com/pypa/setuptools/issues/3772

The fix is to either downgrade or fix the version string to use something that setuptools likes.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested on mbx. Found that when setuptools is upgraded to v66+, this breaks Marvin installation. Refer: https://github.com/pypa/setuptools/issues/3772