### PR TITLE
Fix: memory leak on volume allocation

### DIFF
--- a/api/src/main/java/com/cloud/deploy/DeployDestination.java
+++ b/api/src/main/java/com/cloud/deploy/DeployDestination.java
@@ -147,13 +147,7 @@ public class DeployDestination implements Serializable {
         destination.append("Storage(");
         if (displayStorage && _storage != null) {
             StringBuffer storageBuf = new StringBuffer();
-            //String storageStr = "";
             for (Volume vol : _storage.keySet()) {
-                if (!storageBuf.toString().equals("")) {
-                    storageBuf.append(storageBuf.toString());
-                    storageBuf.append(", ");
-                }
-                storageBuf.append(storageBuf);
                 storageBuf.append("Volume(");
                 storageBuf.append(vol.getId());
                 storageBuf.append("|");
@@ -162,7 +156,7 @@ public class DeployDestination implements Serializable {
                 storageBuf.append(_storage.get(vol).getId());
                 storageBuf.append(")");
             }
-            destination.append(storageBuf.toString());
+            destination.append(storageBuf);
         }
         return destination.append(")]").toString();
     }

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
@@ -149,4 +149,12 @@ public interface HostDao extends GenericDao<HostVO, Long>, StateDao<Status, Stat
      * @return the number of hosts/agents this {@see ManagementServer} has responsibility over
      */
     int countByMs(long msid);
+
+    /**
+     * Retrieves the hypervisor versions of the hosts in the datacenter which are in Up state in ascending order
+     * @param datacenterId data center id
+     * @param hypervisorType hypervisor type of the hosts
+     * @return ordered list of hypervisor versions
+     */
+    List<String> listOrderedHostsHypervisorVersionsInDatacenter(long datacenterId, HypervisorType hypervisorType);
 }

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
@@ -90,7 +90,10 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             "from vm_instance vm " +
             "join host h on (vm.host_id=h.id) " +
             "where vm.service_offering_id= ? and vm.state not in (\"Destroyed\", \"Expunging\", \"Error\") group by h.id";
-
+    private static final String GET_ORDERED_HW_VERSIONS_IN_DC = "select hypervisor_version from host " +
+            "where type = 'Routing' and status = 'Up' and hypervisor_type = '?' " +
+            "group by hypervisor_version " +
+            "order by hypervisor_version asc";
 
     protected SearchBuilder<HostVO> TypePodDcStatusSearch;
 
@@ -1297,6 +1300,24 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         SearchCriteria<HostVO> sc = ResponsibleMsCountSearch.create();
         sc.setParameters("managementServerId", msid);
         return getCount(sc);
+    }
+
+    @Override
+    public List<String> listOrderedHostsHypervisorVersionsInDatacenter(long datacenterId, HypervisorType hypervisorType) {
+        PreparedStatement pstmt = null;
+        List<String> result = new ArrayList<>();
+        try {
+            TransactionLegacy txn = TransactionLegacy.currentTxn();
+            pstmt = txn.prepareAutoCloseStatement(GET_ORDERED_HW_VERSIONS_IN_DC);
+            pstmt.setString(1, Objects.toString(hypervisorType));
+            ResultSet resultSet = pstmt.executeQuery();
+            while (resultSet.next()) {
+                result.add(resultSet.getString(1));
+            }
+        } catch (SQLException e) {
+            s_logger.error("Error trying to obtain hypervisor version on datacenter", e);
+        }
+        return result;
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
@@ -91,7 +91,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             "join host h on (vm.host_id=h.id) " +
             "where vm.service_offering_id= ? and vm.state not in (\"Destroyed\", \"Expunging\", \"Error\") group by h.id";
     private static final String GET_ORDERED_HW_VERSIONS_IN_DC = "select hypervisor_version from host " +
-            "where type = 'Routing' and status = 'Up' and hypervisor_type = '?' " +
+            "where type = 'Routing' and status = 'Up' and hypervisor_type = ? and data_center_id = ? " +
             "group by hypervisor_version " +
             "order by hypervisor_version asc";
 
@@ -1310,6 +1310,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             TransactionLegacy txn = TransactionLegacy.currentTxn();
             pstmt = txn.prepareAutoCloseStatement(GET_ORDERED_HW_VERSIONS_IN_DC);
             pstmt.setString(1, Objects.toString(hypervisorType));
+            pstmt.setLong(2, datacenterId);
             ResultSet resultSet = pstmt.executeQuery();
             while (resultSet.next()) {
                 result.add(resultSet.getString(1));

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -4092,12 +4092,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     }
 
     protected String getMinimumHypervisorVersionInDatacenter(long datacenterId, HypervisorType hypervisorType) {
+        String defaultHypervisorVersion = "default";
         if (hypervisorType == HypervisorType.Simulator) {
-            return "default";
+            return defaultHypervisorVersion;
         }
         List<String> hwVersions = _hostDao.listOrderedHostsHypervisorVersionsInDatacenter(datacenterId, hypervisorType);
-        String minHwVersion = CollectionUtils.isNotEmpty(hwVersions) ? hwVersions.get(0) : "default";
-        return StringUtils.isBlank(minHwVersion) ? "default" : minHwVersion;
+        String minHwVersion = CollectionUtils.isNotEmpty(hwVersions) ? hwVersions.get(0) : defaultHypervisorVersion;
+        return StringUtils.isBlank(minHwVersion) ? defaultHypervisorVersion : minHwVersion;
     }
 
     private Long getDeviceId(UserVmVO vm, Long deviceId) {

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -1197,4 +1197,36 @@ public class VolumeApiServiceImplTest {
         boolean result = volumeApiServiceImpl.isNewDiskOfferingTheSameAndCustomServiceOffering(existingDiskOffering, newDiskOffering);
         Assert.assertEquals(expectedResult, result);
     }
+
+    private void testBaseListOrderedHostsHypervisorVersionInDc(List<String> hwVersions, HypervisorType hypervisorType,
+                                                               String expected) {
+        when(_hostDao.listOrderedHostsHypervisorVersionsInDatacenter(anyLong(), any(HypervisorType.class)))
+                .thenReturn(hwVersions);
+        String min = volumeApiServiceImpl.getMinimumHypervisorVersionInDatacenter(1L, hypervisorType);
+        Assert.assertEquals(expected, min);
+    }
+
+    @Test
+    public void testGetMinimumHypervisorVersionInDatacenterSimulator() {
+        List<String> hwVersions = List.of("4.17.3.0-SNAPSHOT");
+        HypervisorType hypervisorType = HypervisorType.Simulator;
+        String expected = "default";
+        testBaseListOrderedHostsHypervisorVersionInDc(hwVersions, hypervisorType, expected);
+    }
+
+    @Test
+    public void testGetMinimumHypervisorVersionInDatacenterEmptyVersion() {
+        List<String> hwVersions = List.of("", "xxxx", "yyyy");
+        HypervisorType hypervisorType = HypervisorType.KVM;
+        String expected = "default";
+        testBaseListOrderedHostsHypervisorVersionInDc(hwVersions, hypervisorType, expected);
+    }
+
+    @Test
+    public void testGetMinimumHypervisorVersionInDatacenterVersions() {
+        List<String> hwVersions = List.of("6.7", "6.7.1", "6.7.2");
+        HypervisorType hypervisorType = HypervisorType.VMware;
+        String expected = "6.7";
+        testBaseListOrderedHostsHypervisorVersionInDc(hwVersions, hypervisorType, expected);
+    }
 }

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -919,7 +919,6 @@ class TestVMLifeCycle(cloudstackTestCase):
             max_volumes = 6
 
         # Create and attach volumes
-        volume_ids = []
         self.services["custom_volume"]["customdisksize"] = 1
         self.services["custom_volume"]["zoneid"] = self.zone.id
         for i in range(max_volumes):
@@ -930,7 +929,6 @@ class TestVMLifeCycle(cloudstackTestCase):
                 domainid=self.account.domainid,
                 diskofferingid=custom_disk_offering.id
             )
-            volume_ids.append(volume.id)
             self.cleanup.append(volume)
             VirtualMachine.attach_volume(vm, self.apiclient, volume)
 

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -873,6 +873,68 @@ class TestVMLifeCycle(cloudstackTestCase):
 
         self.assertEqual(Volume.list(self.apiclient, id=vol1.id), None, "List response contains records when it should not")
 
+    @attr(tags = ["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    def test_12_start_vm_multiple_volumes_allocated(self):
+        """Test attaching 14 datadisks and start VM
+        """
+
+        # Validate the following
+        # 1. Deploys a VM without starting it and attaches 14 datadisks to it
+        # 2. Start VM successfully
+        # 3. Destroys the VM with DataDisks option
+
+        custom_disk_offering = DiskOffering.list(self.apiclient, name='Custom')[0]
+
+        # Create VM without starting it
+        vm = VirtualMachine.create(
+            self.apiclient,
+            self.services["small"],
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            serviceofferingid=self.small_offering.id,
+            startvm=False
+        )
+
+        # Create and attach volumes
+        volume_ids = []
+        for i in range(14):
+            volume = Volume.create_custom_disk(
+                self.apiclient,
+                self.services["custom_volume"],
+                account=self.account.name,
+                domainid=self.account.domainid,
+                diskofferingid=custom_disk_offering.id
+            )
+            volume_ids.append(volume.id)
+            VirtualMachine.attach_volume(vm, self.apiclient, volume)
+
+        # Start the VM
+        self.debug("Starting VM - ID: %s" % vm.id)
+        vm.start(self.apiclient)
+        list_vm_response = VirtualMachine.list(
+            self.apiclient,
+            id=vm.id
+        )
+        self.assertEqual(
+            isinstance(list_vm_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        self.assertNotEqual(
+            len(list_vm_response),
+            0,
+            "Check VM available in List Virtual Machines"
+        )
+        self.assertEqual(
+            list_vm_response[0].state,
+            "Running",
+            "Check virtual machine is in running state"
+        )
+
+        # Destroy VM and volumes
+        self.debug("Destroy VM - ID: %s" % vm.id)
+        vm.delete(self.apiclient, volumeIds=volume_ids)
+
 
 class TestSecuredVmMigration(cloudstackTestCase):
 

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -897,6 +897,8 @@ class TestVMLifeCycle(cloudstackTestCase):
 
         # Create and attach volumes
         volume_ids = []
+        self.services["custom_volume"]["customdisksize"] = 1
+        self.services["custom_volume"]["zoneid"] = self.zone.id
         for i in range(14):
             volume = Volume.create_custom_disk(
                 self.apiclient,


### PR DESCRIPTION
### Description

This PR fixes a memory leak issue observed when attaching more than 10 volumes on a stopped VM and try to start it.

Could be reproduced by:
- Create a VM without starting it
- Create 14 data disks and attach them to the VM
- Start VM

<img width="776" alt="Screenshot 2023-01-24 at 11 18 44" src="https://user-images.githubusercontent.com/5295080/214828525-f4f74da9-e412-4b7f-9598-a1132acf82c1.png">

````
{
  "accountid": "cdd3f51c-9862-11ed-8965-1e00dc0000f6",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.StartVMCmdByAdmin",
  "completed": "2023-01-24T15:19:50+0000",
  "created": "2023-01-24T15:19:47+0000",
  "jobid": "da7e88d1-a8c4-4d44-91b3-21cef885769f",
  "jobinstanceid": "d4fed850-c112-489a-84dd-8bb875ba0e10",
  "jobinstancetype": "VirtualMachine",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "Java heap space"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "cdd4db33-9862-11ed-8965-1e00dc0000f6"
}
🙈 Error: async API failed for job da7e88d1-a8c4-4d44-91b3-21cef885769f
````

This was caused by extra logging on the deployment planner. An example on a VM deployment with 1 datadisk:

Before the fix:
````
2023-01-25 10:24:30,203 DEBUG [c.c.d.DeploymentPlanningManagerImpl] (API-Job-Executor-31:ctx-7c14f8a1 job-228 ctx-bd96ad97) (logid:b91e0e7d) Returning Deployment Destination: Dest[Zone(Id)-Pod(Id)-Cluster(Id)-Host(Id)-Storage(Volume(Id|Type-->Pool(Id))] : Dest[Zone(1)-Pod(1)-Cluster(1)-Host(2)-Storage(Volume(82|ROOT-->Pool(2)Volume(82|ROOT-->Pool(2), Volume(82|ROOT-->Pool(2)Volume(82|ROOT-->Pool(2), Volume(83|DATADISK-->Pool(1))]
````

After the fix:
````
2023-01-25 11:18:09,612 DEBUG [c.c.d.DeploymentPlanningManagerImpl] (API-Job-Executor-1:ctx-9f7540cf job-234 ctx-9db31cfd) (logid:50df4eb2) Returning Deployment Destination: Dest[Zone(Id)-Pod(Id)-Cluster(Id)-Host(Id)-Storage(Volume(Id|Type-->Pool(Id))] : Dest[Zone(1)-Pod(1)-Cluster(1)-Host(2)-Storage(Volume(84|ROOT-->Pool(2)Volume(85|DATADISK-->Pool(1))]
````

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

