### PR TITLE
Adjusts/fixes in quota tariff APIs

### DIFF
--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
@@ -35,7 +35,7 @@ import javax.inject.Inject;
 import java.util.Date;
 
 @APICommand(name = "quotaTariffCreate", responseObject = QuotaTariffResponse.class, description = "Creates a quota tariff for a resource.", since = "4.18.0.0",
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {RoleType.Admin})
+requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {RoleType.Admin})
 public class QuotaTariffCreateCmd extends BaseCmd {
     protected Logger logger = Logger.getLogger(getClass());
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
@@ -42,10 +42,10 @@ public class QuotaTariffCreateCmd extends BaseCmd {
     @Inject
     QuotaResponseBuilder responseBuilder;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Quota tariff's name", length = 32)
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Quota tariff's name", length = 65535)
     private String name;
 
-    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "Quota tariff's description.", length = 256)
+    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "Quota tariff's description.", length = 65535)
     private String description;
 
     @Parameter(name = ApiConstants.USAGE_TYPE, type = CommandType.INTEGER, required = true, description = "Integer value for the usage type of the resource.")
@@ -54,7 +54,9 @@ public class QuotaTariffCreateCmd extends BaseCmd {
     @Parameter(name = "value", type = CommandType.DOUBLE, required = true, description = "The quota tariff value of the resource as per the default unit.")
     private Double value;
 
-    @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule.",
+    @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule. It can receive a JS script that results in either " +
+            "a boolean or a numeric value: if it results in a boolean value, the tariff value will be applied according to the result; if it results in a numeric value, the numeric " +
+            "value will be applied; if the result is neither a boolean nor a value, the tariff will not be applied. If the rule is not informed, the tariff value will be applied.",
             length = 65535)
     private String activationRule;
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
@@ -55,9 +55,9 @@ public class QuotaTariffCreateCmd extends BaseCmd {
     private Double value;
 
     @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule. It can receive a JS script that results in either " +
-            "a boolean or a numeric value: if it results in a boolean value, the tariff value will be applied according to the result; if it results in a numeric value, the numeric " +
-            "value will be applied; if the result is neither a boolean nor a value, the tariff will not be applied. If the rule is not informed, the tariff value will be applied.",
-            length = 65535)
+            "a boolean or a numeric value: if it results in a boolean value, the tariff value will be applied according to the result; if it results in a numeric value, the " +
+            "numeric value will be applied; if the result is neither a boolean nor a numeric value, the tariff will not be applied. If the rule is not informed, the tariff " +
+            "value will be applied.", length = 65535)
     private String activationRule;
 
     @Parameter(name = ApiConstants.START_DATE, type = CommandType.DATE, description = "The effective start date on/after which the quota tariff is effective. Use yyyy-MM-dd as"
@@ -67,10 +67,6 @@ public class QuotaTariffCreateCmd extends BaseCmd {
     @Parameter(name = ApiConstants.END_DATE, type = CommandType.DATE, description = "The end date of the quota tariff. Use yyyy-MM-dd as the date format, e.g."
             + " endDate=2009-06-03.")
     private Date endDate;
-
-    public QuotaTariffCreateCmd() {
-        super();
-    }
 
     @Override
     public void execute() {
@@ -110,10 +106,6 @@ public class QuotaTariffCreateCmd extends BaseCmd {
         return usageType;
     }
 
-    public void setUsageType(Integer usageType) {
-        this.usageType = usageType;
-    }
-
     public Double getValue() {
         return value;
     }
@@ -124,10 +116,6 @@ public class QuotaTariffCreateCmd extends BaseCmd {
 
     public String getActivationRule() {
         return activationRule;
-    }
-
-    public void setActivationRule(String activationRule) {
-        this.activationRule = activationRule;
     }
 
     public Date getStartDate() {

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
@@ -34,8 +34,8 @@ import javax.inject.Inject;
 
 import java.util.Date;
 
-@APICommand(name = "quotaTariffCreate", responseObject = QuotaTariffResponse.class, description = "Creates a quota tariff for a resource.", since = "4.17.0.0",
-requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {RoleType.Admin})
+@APICommand(name = "quotaTariffCreate", responseObject = QuotaTariffResponse.class, description = "Creates a quota tariff for a resource.", since = "4.18.0.0",
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {RoleType.Admin})
 public class QuotaTariffCreateCmd extends BaseCmd {
     protected Logger logger = Logger.getLogger(getClass());
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
@@ -39,16 +39,16 @@ public class QuotaTariffDeleteCmd extends BaseCmd {
     @Inject
     QuotaResponseBuilder responseBuilder;
 
-    @Parameter(name = ApiConstants.UUID, type = BaseCmd.CommandType.STRING, required = true, entityType = QuotaTariffResponse.class,
-            description = "UUID of the quota tariff", validations = {ApiArgValidator.UuidString})
-    private String quotaTariffUuid;
+    @Parameter(name = ApiConstants.ID, type = BaseCmd.CommandType.STRING, required = true, entityType = QuotaTariffResponse.class,
+            description = "ID of the quota tariff", validations = {ApiArgValidator.UuidString})
+    private String id;
 
-    public String getQuotaTariffUuid() {
-        return quotaTariffUuid;
+    public String getId() {
+        return id;
     }
 
-    public void setQuotaTariffId(String quotaTariffUuid) {
-        this.quotaTariffUuid = quotaTariffUuid;
+    public void setId(String id) {
+        this.id = id;
     }
 
     public QuotaTariffDeleteCmd() {
@@ -57,7 +57,7 @@ public class QuotaTariffDeleteCmd extends BaseCmd {
 
     @Override
     public void execute() {
-        boolean result = responseBuilder.deleteQuotaTariff(getQuotaTariffUuid());
+        boolean result = responseBuilder.deleteQuotaTariff(getId());
         SuccessResponse response = new SuccessResponse(getCommandName());
         response.setSuccess(result);
         setResponseObject(response);

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
@@ -32,7 +32,7 @@ import org.apache.log4j.Logger;
 import javax.inject.Inject;
 
 @APICommand(name = "quotaTariffDelete", description = "Marks a quota tariff as removed.", responseObject = SuccessResponse.class, requestHasSensitiveInfo = false,
-responseHasSensitiveInfo = false, since = "4.17.0.0", authorized = {RoleType.Admin})
+responseHasSensitiveInfo = false, since = "4.18.0.0", authorized = {RoleType.Admin})
 public class QuotaTariffDeleteCmd extends BaseCmd {
     protected Logger logger = Logger.getLogger(getClass());
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
@@ -47,14 +47,6 @@ public class QuotaTariffDeleteCmd extends BaseCmd {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public QuotaTariffDeleteCmd() {
-        super();
-    }
-
     @Override
     public void execute() {
         boolean result = responseBuilder.deleteQuotaTariff(getId());

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffListCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffListCmd.java
@@ -43,21 +43,21 @@ public class QuotaTariffListCmd extends BaseListCmd {
     @Inject
     QuotaResponseBuilder _responseBuilder;
 
-    @Parameter(name = ApiConstants.USAGE_TYPE, type = CommandType.INTEGER, required = false, description = "Usage type of the resource")
+    @Parameter(name = ApiConstants.USAGE_TYPE, type = CommandType.INTEGER, description = "Usage type of the resource")
     private Integer usageType;
 
-    @Parameter(name = ApiConstants.START_DATE, type = CommandType.DATE, required = false, description = "The start date of the quota tariff. Use yyyy-MM-dd as the date format, "
+    @Parameter(name = ApiConstants.START_DATE, type = CommandType.DATE, description = "The start date of the quota tariff. Use yyyy-MM-dd as the date format, "
             + "e.g. startDate=2009-06-03.")
     private Date effectiveDate;
 
-    @Parameter(name = ApiConstants.END_DATE, type = CommandType.DATE, required = false, description = "The end date of the quota tariff. Use yyyy-MM-dd as the date format, e.g. "
+    @Parameter(name = ApiConstants.END_DATE, type = CommandType.DATE, description = "The end date of the quota tariff. Use yyyy-MM-dd as the date format, e.g. "
             + "endDate=2021-11-03.", since = "4.18.0.0")
     private Date endDate;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = false, description = "The name of the quota tariff.", since = "4.18.0.0")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "The name of the quota tariff.", since = "4.18.0.0")
     private String name;
 
-    @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, required = false, description = "False will list only not removed quota tariffs. If set to True, we will "
+    @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, description = "False will list only not removed quota tariffs. If set to True, we will "
             + "list all, including the removed ones. The default is false.", since = "4.18.0.0")
     private boolean listAll = false;
 
@@ -69,7 +69,7 @@ public class QuotaTariffListCmd extends BaseListCmd {
     public void execute() {
         final Pair<List<QuotaTariffVO>, Integer> result = _responseBuilder.listQuotaTariffPlans(this);
 
-        final List<QuotaTariffResponse> responses = new ArrayList<QuotaTariffResponse>();
+        final List<QuotaTariffResponse> responses = new ArrayList<>();
 
         s_logger.trace(String.format("Adding quota tariffs [%s] to response of API quotaTariffList.", ReflectionToStringBuilderUtils.reflectCollection(responses)));
 
@@ -77,7 +77,7 @@ public class QuotaTariffListCmd extends BaseListCmd {
             responses.add(_responseBuilder.createQuotaTariffResponse(resource));
         }
 
-        final ListResponse<QuotaTariffResponse> response = new ListResponse<QuotaTariffResponse>();
+        final ListResponse<QuotaTariffResponse> response = new ListResponse<>();
         response.setResponses(responses, result.second());
         response.setResponseName(getCommandName());
         setResponseObject(response);
@@ -89,15 +89,11 @@ public class QuotaTariffListCmd extends BaseListCmd {
     }
 
     public Date getEffectiveDate() {
-        return effectiveDate ==null ? null : new Date(effectiveDate.getTime());
+        return effectiveDate;
     }
 
     public Integer getUsageType() {
         return usageType;
-    }
-
-    public void setUsageType(Integer usageType) {
-        this.usageType = usageType;
     }
 
     public Date getEndDate() {

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffListCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffListCmd.java
@@ -51,14 +51,14 @@ public class QuotaTariffListCmd extends BaseListCmd {
     private Date effectiveDate;
 
     @Parameter(name = ApiConstants.END_DATE, type = CommandType.DATE, required = false, description = "The end date of the quota tariff. Use yyyy-MM-dd as the date format, e.g. "
-            + "endDate=2021-11-03.")
+            + "endDate=2021-11-03.", since = "4.18.0.0")
     private Date endDate;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = false, description = "The name of the quota tariff.")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = false, description = "The name of the quota tariff.", since = "4.18.0.0")
     private String name;
 
     @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, required = false, description = "False will list only not removed quota tariffs. If set to True, we will "
-            + "list all, including the removed ones. The default is false.")
+            + "list all, including the removed ones. The default is false.", since = "4.18.0.0")
     private boolean listAll = false;
 
     public QuotaTariffListCmd() {

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
@@ -42,27 +42,31 @@ public class QuotaTariffUpdateCmd extends BaseCmd {
     @Inject
     QuotaResponseBuilder _responseBuilder;
 
-    @Parameter(name = ApiConstants.USAGE_TYPE, type = CommandType.INTEGER, description = "Integer value for the usage type of the resource")
+    @Parameter(name = ApiConstants.USAGE_TYPE, type = CommandType.INTEGER, description = "DEPRECATED. Integer value for the usage type of the resource")
     private Integer usageType;
 
     @Parameter(name = ApiConstants.VALUE, type = CommandType.DOUBLE, description = "The quota tariff value of the resource as per the default unit.")
     private Double value;
 
-    @Parameter(name = ApiConstants.START_DATE, type = CommandType.DATE, description = "The effective start date on/after which the quota tariff is effective. Use yyyy-MM-dd as"
-            + " the date format, e.g. startDate=2009-06-03.")
+    @Parameter(name = ApiConstants.START_DATE, type = CommandType.DATE, description = "DEPRECATED. The effective start date on/after which the quota tariff is effective. " +
+            "Use yyyy-MM-dd as the date format, e.g. startDate=2009-06-03.")
     private Date startDate;
 
     @Parameter(name = ApiConstants.END_DATE, type = CommandType.DATE, description = "The end date of the quota tariff. Use yyyy-MM-dd as the date format, e.g."
             + " endDate=2009-06-03.", since = "4.18.0.0")
     private Date endDate;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Quota tariff's name", since = "4.18.0.0")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Quota tariff's name", length = 65535, since = "4.18.0.0")
     private String name;
 
-    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "Quota tariff's description. Inform empty to remove the description.", since = "4.18.0.0")
+    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "Quota tariff's description. Inform empty to remove the description.", length = 65535,
+            since = "4.18.0.0")
     private String description;
 
-    @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule. Inform empty to remove the activation rule.")
+    @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule. It can receive a JS script that results in either " +
+            "a boolean or a numeric value: if it results in a boolean value, the tariff value will be applied according to the result; if it results in a numeric value, the " +
+            "numeric value will be applied; if the result is neither a boolean nor a value, the tariff will not be applied. If the rule is not informed, the tariff value will be " +
+            "applied. Inform empty to remove the activation rule.", length = 65535, since = "4.18.0.0")
     private String activationRule;
 
     public Integer getUsageType() {

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
@@ -65,16 +65,12 @@ public class QuotaTariffUpdateCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule. It can receive a JS script that results in either " +
             "a boolean or a numeric value: if it results in a boolean value, the tariff value will be applied according to the result; if it results in a numeric value, the " +
-            "numeric value will be applied; if the result is neither a boolean nor a value, the tariff will not be applied. If the rule is not informed, the tariff value will be " +
-            "applied. Inform empty to remove the activation rule.", length = 65535, since = "4.18.0.0")
+            "numeric value will be applied; if the result is neither a boolean nor a numeric value, the tariff will not be applied. If the rule is not informed, the tariff " +
+            "value will be applied. Inform empty to remove the activation rule.", length = 65535, since = "4.18.0.0")
     private String activationRule;
 
     public Integer getUsageType() {
         return usageType;
-    }
-
-    public void setUsageType(Integer usageType) {
-        this.usageType = usageType;
     }
 
     public Double getValue() {

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
@@ -53,13 +53,13 @@ public class QuotaTariffUpdateCmd extends BaseCmd {
     private Date startDate;
 
     @Parameter(name = ApiConstants.END_DATE, type = CommandType.DATE, description = "The end date of the quota tariff. Use yyyy-MM-dd as the date format, e.g."
-            + " endDate=2009-06-03.")
+            + " endDate=2009-06-03.", since = "4.18.0.0")
     private Date endDate;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Quota tariff's name")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Quota tariff's name", since = "4.18.0.0")
     private String name;
 
-    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "Quota tariff's description. Inform empty to remove the description.")
+    @Parameter(name = ApiConstants.DESCRIPTION, type = CommandType.STRING, description = "Quota tariff's description. Inform empty to remove the description.", since = "4.18.0.0")
     private String description;
 
     @Parameter(name = ApiConstants.ACTIVATION_RULE, type = CommandType.STRING, description = "Quota tariff's activation rule. Inform empty to remove the activation rule.")
@@ -82,11 +82,11 @@ public class QuotaTariffUpdateCmd extends BaseCmd {
     }
 
     public Date getStartDate() {
-        return startDate == null ? null : new Date(startDate.getTime());
+        return startDate;
     }
 
     public void setStartDate(Date startDate) {
-        this.startDate = startDate == null ? null : new Date(startDate.getTime());
+        this.startDate = startDate;
     }
 
     public Date getEndDate() {


### PR DESCRIPTION
### Description

PR #5909 was created during the release 4.17.0.0 and the parameter `since` in APIs was written as `4.17.0.0`; however, #5909 was really introduced only in 4.18.0.0.

This PR intends to adjust the `since` in the introduced APIs and parameters and also:
- improve the parameters documentation;
- adjust parameters length, according to the field in the database;
- rename parameter `UUID` of `quotaTariffDelete` to `ID`, to follow the pattern we use along other APIs;
- cleanup some unused/unnecessary code in the Cmd classes;


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?

I retested the whole tariff CRUD, as follows:
<details><summary>Creating a tariff</summary>

  ```
  (lab)  > quota tariffcreate name='test-aadjusts' usagetype=12 value=0 description="a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose"
  {
    "quotatariff": {
      "currency": "$",
      "description": "a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose",
      "effectiveDate": "2023-01-31T01:50:38+0000",
      "name": "test-adjusts",
      "tariffValue": 0,
      "usageDiscriminator": "None",
      "usageName": "PORT_FORWARDING_RULE",
      "usageType": 12,
      "usageTypeDescription": "Port Forwarding Usage",
      "usageUnit": "Policy*Month",
      "uuid": "c30cacf7-a378-4e43-8ec0-6c5ad2d0d9e9"
    }
  }
  ```
</details>



<details><summary>Listing the tariffs after creating</summary>

  ```
  (lab)  > quota tarifflist name=test-adjusts listall=true
  {
    "count": 1,
    "quotatariff": [
      {
        "currency": "$",
        "description": "a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose",
        "effectiveDate": "2023-01-31T01:50:38+0000",
        "name": "test-adjusts",
        "tariffValue": 0,
        "usageDiscriminator": "None",
        "usageName": "PORT_FORWARDING_RULE",
        "usageType": 12,
        "usageTypeDescription": "Port Forwarding Usage",
        "usageUnit": "Policy*Month",
        "uuid": "c30cacf7-a378-4e43-8ec0-6c5ad2d0d9e9"
      }
    ]
  }
  ```
</details>

<details><summary>Updating the tariff</summary>

  ```
  (lab)  > quota tariffupdate name=test-adjusts activationrule="a rule" description="a simple description"
  {
    "quotatariff": {
      "activationRule": "a rule",
      "currency": "$",
      "description": "a simple description",
      "effectiveDate": "2023-01-31T01:50:38+0000",
      "name": "test-adjusts",
      "tariffValue": 0,
      "usageDiscriminator": "None",
      "usageName": "PORT_FORWARDING_RULE",
      "usageType": 12,
      "usageTypeDescription": "Port Forwarding Usage",
      "usageUnit": "Policy*Month",
      "uuid": "2d9afee9-960d-4b32-9a68-6a4939e59b6b"
    }
  }
  ``` 
</details>


<details><summary>Listing the tariffs after updating</summary>

  ```
  (lab)  > quota tarifflist name=test-adjusts listall=true
  {
    "count": 2,
    "quotatariff": [
      {
        "currency": "$",
        "description": "a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose",
        "effectiveDate": "2023-01-31T01:50:38+0000",
        "name": "test-adjusts",
        "removed": "2023-01-31T01:51:58+0000",
        "tariffValue": 0,
        "usageDiscriminator": "None",
        "usageName": "PORT_FORWARDING_RULE",
        "usageType": 12,
        "usageTypeDescription": "Port Forwarding Usage",
        "usageUnit": "Policy*Month",
        "uuid": "c30cacf7-a378-4e43-8ec0-6c5ad2d0d9e9"
      },
      {
        "activationRule": "a rule",
        "currency": "$",
        "description": "a simple description",
        "effectiveDate": "2023-01-31T01:50:38+0000",
        "name": "test-adjusts",
        "tariffValue": 0,
        "usageDiscriminator": "None",
        "usageName": "PORT_FORWARDING_RULE",
        "usageType": 12,
        "usageTypeDescription": "Port Forwarding Usage",
        "usageUnit": "Policy*Month",
        "uuid": "2d9afee9-960d-4b32-9a68-6a4939e59b6b"
      }
    ]
  }
  ```
</details>


<details><summary>Removing the tariff</summary>

  ```
  (lab)  > quota tariffdelete id=2d9afee9-960d-4b32-9a68-6a4939e59b6b
  {
    "success": true
  }
  ```
</details>


<details><summary>Listing the tariffs after removing</summary>

  ```
  (lab)  > quota tarifflist name=test-adjusts listall=true
  {
    "count": 2,
    "quotatariff": [
      {
        "currency": "$",
        "description": "a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose | a long description that will describe the tariff's purpose",
        "effectiveDate": "2023-01-31T01:50:38+0000",
        "name": "test-adjusts",
        "removed": "2023-01-31T01:51:58+0000",
        "tariffValue": 0,
        "usageDiscriminator": "None",
        "usageName": "PORT_FORWARDING_RULE",
        "usageType": 12,
        "usageTypeDescription": "Port Forwarding Usage",
        "usageUnit": "Policy*Month",
        "uuid": "c30cacf7-a378-4e43-8ec0-6c5ad2d0d9e9"
      },
      {
        "activationRule": "a rule",
        "currency": "$",
        "description": "a simple description",
        "effectiveDate": "2023-01-31T01:50:38+0000",
        "name": "test-adjusts",
        "removed": "2023-01-31T01:52:34+0000",
        "tariffValue": 0,
        "usageDiscriminator": "None",
        "usageName": "PORT_FORWARDING_RULE",
        "usageType": 12,
        "usageTypeDescription": "Port Forwarding Usage",
        "usageUnit": "Policy*Month",
        "uuid": "2d9afee9-960d-4b32-9a68-6a4939e59b6b"
      }
    ]
  }
```