### PR TITLE
cks: Fix provider deployment when cluster is in a project

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/resources/script/deploy-cloudstack-secret
+++ b/plugins/integrations/kubernetes-service/src/main/resources/script/deploy-cloudstack-secret
@@ -24,6 +24,7 @@ Arguments:
   -u, --url string         ID of the cluster
   -k, --key string         API Key
   -s, --secret string      Secret Key
+  -p, --project string     Project ID
 Other arguments:
   -h, --help              Display this help message and exit
 Examples:
@@ -34,6 +35,8 @@ USAGE
 API_URL=""
 API_KEY=""
 SECRET_KEY=""
+PROJECT_ID=""
+PROJECT=""
 while [ -n "$1" ]; do
     case "$1" in
         -h | --help)
@@ -51,6 +54,11 @@ while [ -n "$1" ]; do
             SECRET_KEY=$2
             shift 2
             ;;
+        -p | --project)
+            PROJECT_ID=$2
+            shift 2
+            PROJECT="project-id = $PROJECT_ID"
+            ;;
         -*|*)
             echo "ERROR: no such option $1. -h or --help for help"
             exit 1
@@ -62,7 +70,9 @@ cat > /tmp/cloud-config <<EOF
 api-url = $API_URL
 api-key = $API_KEY
 secret-key = $SECRET_KEY
+$PROJECT
 EOF
+
 # Create secret if not exists
 /opt/bin/kubectl -n kube-system get secret cloudstack-secret || /opt/bin/kubectl -n kube-system create secret generic cloudstack-secret --from-file=/tmp/cloud-config
 rm /tmp/cloud-config


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/6987
When a CKS cluster is created in a project, the project-id is now passed as part of the cloud-config used in the cloud provider

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

When a cluster is created in a project

```
kubectl --kubeconfig kube.conf get secrets -n kube-system cloudstack-secret -o json | jq '.data."cloud-config"' | tr -d '"' | base64 -d
[Global]
api-url = http://xxxxxxxxx:8080/client/api
api-key = xxxxxxxxxxxxxxx
secret-key = xxxxxxxxxxxxxxxxxxxxx
project-id = xxxxxxxxxxxxxxxxx


kubectl --kubeconfig kube.conf -n ingress-nginx get services -o wide -w ingress-nginx-controller
NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE     SELECTOR
ingress-nginx-controller   LoadBalancer   10.99.51.184   xxxxxxxxxx   80:31379/TCP,443:31074/TCP   6m20s   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/name=ingress-nginx
```


