### PR TITLE
Quota VM_DISK tariff calculation

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/usage/UsageUnitTypes.java
+++ b/api/src/main/java/org/apache/cloudstack/usage/UsageUnitTypes.java
@@ -22,7 +22,9 @@ public enum UsageUnitTypes {
     IP_MONTH ("IP*Month"),
     GB ("GB"),
     GB_MONTH ("GB*Month"),
-    POLICY_MONTH ("Policy*Month");
+    POLICY_MONTH ("Policy*Month"),
+    IOPS ("IOPS"),
+    BYTES ("Bytes");
 
     private final String description;
 

--- a/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
@@ -1080,6 +1080,6 @@ INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`)
 INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`) VALUES (UUID(), 3, 'assignVolume', 'ALLOW');
 
 
--- Increases the overall size of the decimal places of the column `quota_used` from 15 to 20.
+-- Increases the precision of the column `quota_used` from 15 to 20, keeping the scale of 8.
 
 ALTER TABLE `cloud_usage`.`quota_usage` MODIFY COLUMN quota_used decimal(20,8) unsigned NOT NULL;

--- a/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41720to41800.sql
@@ -1079,3 +1079,7 @@ CREATE TABLE IF NOT EXISTS `cloud`.`console_session` (
 INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`) VALUES (UUID(), 2, 'assignVolume', 'ALLOW');
 INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`) VALUES (UUID(), 3, 'assignVolume', 'ALLOW');
 
+
+-- Increases the overall size of the decimal places of the column `quota_used` from 15 to 20.
+
+ALTER TABLE `cloud_usage`.`quota_usage` MODIFY COLUMN quota_used decimal(20,8) unsigned NOT NULL;

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -45,7 +45,6 @@ import org.apache.cloudstack.quota.vo.QuotaAccountVO;
 import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
 import org.apache.cloudstack.quota.vo.QuotaTariffVO;
 import org.apache.cloudstack.quota.vo.QuotaUsageVO;
-import org.apache.cloudstack.usage.UsageTypes;
 import org.apache.cloudstack.usage.UsageUnitTypes;
 import org.apache.cloudstack.utils.bytescale.ByteScaleUtils;
 import org.apache.cloudstack.utils.jsinterpreter.JsInterpreter;

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -95,9 +95,6 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
     static final BigDecimal GiB_DECIMAL = BigDecimal.valueOf(ByteScaleUtils.GiB);
     List<Account.Type> lockablesAccountTypes = Arrays.asList(Account.Type.NORMAL, Account.Type.DOMAIN_ADMIN);
 
-    List<Integer> usageTypesToAvoidCalculation = Arrays.asList(UsageTypes.VM_DISK_IO_READ, UsageTypes.VM_DISK_IO_WRITE, UsageTypes.VM_DISK_BYTES_READ,
-            UsageTypes.VM_DISK_BYTES_WRITE);
-
     public QuotaManagerImpl() {
         super();
     }
@@ -344,12 +341,6 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
     }
 
     protected boolean shouldCalculateUsageRecord(AccountVO accountVO, UsageVO usageRecord) {
-        if (usageTypesToAvoidCalculation.contains(usageRecord.getUsageType())) {
-            s_logger.debug(String.format("Considering usage record [%s] as calculated and skipping it because the calculation of the types [%s] has not been implemented yet.",
-                    usageRecord, usageTypesToAvoidCalculation));
-            return false;
-        }
-
         if (Boolean.FALSE.equals(QuotaConfig.QuotaAccountEnabled.valueIn(accountVO.getAccountId()))) {
             s_logger.debug(String.format("Considering usage record [%s] as calculated and skipping it because account [%s] has the quota plugin disabled.",
                     usageRecord, accountVO.reflectionToString()));
@@ -558,6 +549,10 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             case GB_MONTH:
                 BigDecimal gbInUse = BigDecimal.valueOf(usageRecord.getSize()).divide(GiB_DECIMAL, 8, RoundingMode.HALF_EVEN);
                 return rawUsage.multiply(costPerHour).multiply(gbInUse);
+
+            case BYTES:
+            case IOPS:
+                return rawUsage.multiply(aggregatedQuotaTariffsValue);
 
             default:
                 return BigDecimal.ZERO;

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaTypes.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaTypes.java
@@ -47,10 +47,10 @@ public class QuotaTypes extends UsageTypes {
         quotaTypeList.put(PORT_FORWARDING_RULE, new QuotaTypes(PORT_FORWARDING_RULE, "PORT_FORWARDING_RULE", UsageUnitTypes.POLICY_MONTH.toString(), "Port Forwarding Usage"));
         quotaTypeList.put(NETWORK_OFFERING, new QuotaTypes(NETWORK_OFFERING, "NETWORK_OFFERING", UsageUnitTypes.POLICY_MONTH.toString(), "Network Offering Usage"));
         quotaTypeList.put(VPN_USERS, new QuotaTypes(VPN_USERS, "VPN_USERS", UsageUnitTypes.POLICY_MONTH.toString(), "VPN users usage"));
-        quotaTypeList.put(VM_DISK_IO_READ, new QuotaTypes(VM_DISK_IO_READ, "VM_DISK_IO_READ", UsageUnitTypes.GB.toString(), "VM Disk usage(I/O Read)"));
-        quotaTypeList.put(VM_DISK_IO_WRITE, new QuotaTypes(VM_DISK_IO_WRITE, "VM_DISK_IO_WRITE", UsageUnitTypes.GB.toString(), "VM Disk usage(I/O Write)"));
-        quotaTypeList.put(VM_DISK_BYTES_READ, new QuotaTypes(VM_DISK_BYTES_READ, "VM_DISK_BYTES_READ", UsageUnitTypes.GB.toString(), "VM Disk usage(Bytes Read)"));
-        quotaTypeList.put(VM_DISK_BYTES_WRITE, new QuotaTypes(VM_DISK_BYTES_WRITE, "VM_DISK_BYTES_WRITE", UsageUnitTypes.GB.toString(), "VM Disk usage(Bytes Write)"));
+        quotaTypeList.put(VM_DISK_IO_READ, new QuotaTypes(VM_DISK_IO_READ, "VM_DISK_IO_READ", UsageUnitTypes.IOPS.toString(), "VM Disk usage(I/O Read)"));
+        quotaTypeList.put(VM_DISK_IO_WRITE, new QuotaTypes(VM_DISK_IO_WRITE, "VM_DISK_IO_WRITE", UsageUnitTypes.IOPS.toString(), "VM Disk usage(I/O Write)"));
+        quotaTypeList.put(VM_DISK_BYTES_READ, new QuotaTypes(VM_DISK_BYTES_READ, "VM_DISK_BYTES_READ", UsageUnitTypes.BYTES.toString(), "VM Disk usage(Bytes Read)"));
+        quotaTypeList.put(VM_DISK_BYTES_WRITE, new QuotaTypes(VM_DISK_BYTES_WRITE, "VM_DISK_BYTES_WRITE", UsageUnitTypes.BYTES.toString(), "VM Disk usage(Bytes Write)"));
         quotaTypeList.put(VM_SNAPSHOT, new QuotaTypes(VM_SNAPSHOT, "VM_SNAPSHOT", UsageUnitTypes.GB_MONTH.toString(), "VM Snapshot storage usage"));
         quotaTypeList.put(VOLUME_SECONDARY, new QuotaTypes(VOLUME_SECONDARY, "VOLUME_SECONDARY", UsageUnitTypes.GB_MONTH.toString(), "Volume secondary storage usage"));
         quotaTypeList.put(VM_SNAPSHOT_ON_PRIMARY, new QuotaTypes(VM_SNAPSHOT_ON_PRIMARY, "VM_SNAPSHOT_ON_PRIMARY", UsageUnitTypes.GB_MONTH.toString(), "VM Snapshot primary storage usage"));

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
@@ -166,6 +166,12 @@ public class QuotaManagerImplTest {
                    expected = 5.5555556;
                    break;
 
+               case BYTES:
+               case IOPS:
+                   //The value 4000.0 is referent to the calculation ( raw usage * tariffs values ).
+                   expected = 4000.0;
+                   break;
+
                default:
                    break;
            }


### PR DESCRIPTION
### Description

Currently, the quota plugin ignores the tariff calculation for the types below:

* VM_DISK_IO_READ
* VM_DISK_IO_WRITE
* VM_DISK_BYTES_READ
* VM_DISK_BYTES_WRITE

The code was changed as to now calculate the quota tariff for these types. Moreover, the unit types were changed as well, as shown in the table below. It is noteworthy that the raw values for these types are not modified; therefore, the calculation of the tariff for them are: `TARIFF * CONSUMPTION`.

| Type | Unit |
| ------ | ------ |
| VM_DISK_IO_READ | IOPS |
| VM_DISK_IO_WRITE | IOPS |
| VM_DISK_BYTES_READ | Bytes |
| VM_DISK_BYTES_WRITE | Bytes |

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

This was tested in a local lab creating a quota tariff for each type. Then, I reinstalled a previously created VM and generated a quota statement.

Creating a quota tariff with type `VM_DISK_IO_READ`:
~~~
(lab-bryan) 🐱 > quota tariffcreate name=mr-443-21 usagetype=21 value=30
{
  "quotatariff": {
    "currency": "$",
    "effectiveDate": "2023-01-24T15:39:39+0000",
    "name": "mr-443-21",
    "tariffValue": 30,
    "usageDiscriminator": "None",
    "usageName": "VM_DISK_IO_READ",
    "usageType": 21,
    "usageTypeDescription": "VM Disk usage(I/O Read)",
    "usageUnit": "IOPS",
    "uuid": "e580d696-5e5e-4423-87e5-130298a2cb0f"
  }
}
~~~

~~~
(lab) 🐱 > quota statement accountid=af16aaed-26de-11ec-8dcf-5254005dcdac account=admin domainid=52d83793-26de-11ec-8dcf-5254005dcdac startdate=2023-01-23 enddate=2023-01-25
{
  "statement": {
    "currency": "$",
    "enddate": "2023-01-25T23:59:59+0000",
    "quotausage": [
      (...)
      {
        "accountid": "af16aaed-26de-11ec-8dcf-5254005dcdac",
        "domain": "52d83793-26de-11ec-8dcf-5254005dcdac",
        "name": "VM_DISK_IO_READ",
        "quota": 771439.82,
        "type": 21,
        "unit": "IOPS"
      },
      {
        "accountid": "af16aaed-26de-11ec-8dcf-5254005dcdac",
        "domain": "52d83793-26de-11ec-8dcf-5254005dcdac",
        "name": "VM_DISK_IO_WRITE",
        "quota": 0.44,
        "type": 22,
        "unit": "IOPS"
      },
      {
        "accountid": "af16aaed-26de-11ec-8dcf-5254005dcdac",
        "domain": "52d83793-26de-11ec-8dcf-5254005dcdac",
        "name": "VM_DISK_BYTES_READ",
        "quota": 12667348.48,
        "type": 23,
        "unit": "Bytes"
      },
      {
        "accountid": "af16aaed-26de-11ec-8dcf-5254005dcdac",
        "domain": "52d83793-26de-11ec-8dcf-5254005dcdac",
        "name": "VM_DISK_BYTES_WRITE",
        "quota": 2929711.64,
        "type": 24,
        "unit": "Bytes"
      }
      (...)
    ],
    "startdate": "2023-01-23T00:00:00+0000",
    "totalquota": 16368503.29
  }
}
~~~
