### PR TITLE
scripts: fix kvm host undefined version

### DIFF
--- a/scripts/vm/hypervisor/versions.sh
+++ b/scripts/vm/hypervisor/versions.sh
@@ -29,18 +29,33 @@ DIST="Unknown Linux"
 REV="X.Y"
 CODENAME=""
 
-if [ -f /etc/redhat-release ] ; then
+function get_from_redhat_release {
 	DIST=`cat /etc/redhat-release | awk '{print $1}'`
 	CODENAME=`cat /etc/redhat-release | sed s/.*\(// | sed s/\)//`
 	REV=`cat /etc/redhat-release | awk '{print $3,$4}' | grep -o "[0-9.]*"`
-elif [ -f /etc/lsb-release ] ; then
+}
+
+function get_from_lsb_release {
 	DIST=`cat /etc/lsb-release | grep DISTRIB_ID | tr "\n" ' '| sed s/.*=//`
 	REV=`cat /etc/lsb-release | grep DISTRIB_RELEASE | tr "\n" ' '| sed s/.*=//`
 	CODENAME=`cat /etc/lsb-release | grep DISTRIB_CODENAME | tr "\n" ' '| sed s/.*=//`
-elif [ -f /etc/os-release ] ; then
+}
+
+function get_from_os_release {
 	DIST=`grep -e "^NAME=" /etc/os-release | awk -F\" '{print $2}'`
 	REV=`grep -e "^VERSION_ID=" /etc/os-release | awk -F\" '{print $2}'`
 	CODENAME=`grep -e "^PRETTY_NAME=" /etc/os-release | awk -F\" '{print $2}'`
+}
+
+if [ -f /etc/redhat-release ] ; then
+	get_from_redhat_release
+	if [ -z "$REV" ] && [ -f /etc/os-release ]; then
+	    get_from_os_release
+    fi
+elif [ -f /etc/lsb-release ] ; then
+	get_from_lsb_release
+elif [ -f /etc/os-release ] ; then
+	get_from_os_release
 fi
 
 echo Host.OS=${DIST}


### PR DESCRIPTION
### Description
On Oracle Linux 9.0, version shows as undefined and even Host.OS shows as "Red". This change fixes the script to use `/etc/os-release` ins such cases.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before change
![image](https://user-images.githubusercontent.com/153340/217517887-6c6fd844-3033-49f9-bb86-2ec8f4e97ddf.png)

After changer, after re-adding the host
![Screenshot from 2023-02-08 17-01-21](https://user-images.githubusercontent.com/153340/217518032-78875145-899d-4557-b010-dafd2d168cd5.png)

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Before changes,
```
[root@ref-trl-4390-k-Mol9-abhishek-kumar-kvm1 ~]# /usr/share/cloudstack-common/scripts/vm/hypervisor/versions.sh
Host.OS=Red
Host.OS.Version=
Host.OS.Kernel.Version=5.15.0-1.43.4.1.el9uek.x86_64
```

After change,
```
[root@ref-trl-4390-k-Mol9-abhishek-kumar-kvm1 ~]# /usr/share/cloudstack-common/scripts/vm/hypervisor/versions.sh
Host.OS=Oracle Linux Server
Host.OS.Version=9.0
Host.OS.Kernel.Version=5.15.0-1.43.4.1.el9uek.x86_64
```
