### PR TITLE
smoke test: fix test_deploy_vm_extra_config_data.py on kvm

### DIFF
--- a/test/integration/smoke/test_deploy_vm_extra_config_data.py
+++ b/test/integration/smoke/test_deploy_vm_extra_config_data.py
@@ -74,7 +74,7 @@ class TestAddConfigtoDeployVM(cloudstackTestCase):
             cls.services["service_offerings"]["small"]
         )
 
-        cls.cleanup = [
+        cls._cleanup = [
             cls.account,
             cls.service_offering
         ]
@@ -83,14 +83,9 @@ class TestAddConfigtoDeployVM(cloudstackTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            cls.apiclient = super(TestAddConfigtoDeployVM, cls).getClsTestClient().getApiClient()
-            cls.reset_hosts_hugepages()
-            # Clean up, terminate the created templates
-            cleanup_resources(cls.apiclient, cls.cleanup)
+        super(TestAddConfigtoDeployVM, cls).tearDownClass()
 
-        except Exception as e:
-            raise Exception("Warning: Exception during cleanup : %s" % e)
+        cls.reset_hosts_hugepages()
 
     @classmethod
     def set_hosts_hugepages(cls):


### PR DESCRIPTION
### Description

This PR fixes the smoke test failures in trillian test

```
test_02_deploy_vm_with_extraconfig_kvm | Error | 0.14 | test_deploy_vm_extra_config_data.py
test_03_update_vm_with_extraconfig_kvm | Error | 1.13 | test_deploy_vm_extra_config_data.py

```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
