### PR TITLE
Added steps to get the offical docker image for cloudstack simulator

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -11,8 +11,18 @@ Dockerfiles used to build CloudStack images are available on Docker hub.
 CloudStack Simulator is an all in one CloudStack Build including the simulator that mimic Hypervisor. This is useful to test CloudStack API behavior without having to deploy real hypervisor nodes. CloudStack Simulator is used for tests and CI.
 
 ```
-docker pull cloudstack/simulator
-docker run --name simulator -p 8080:5050 -d cloudstack/simulator
+docker pull apache/cloudstack-simulator
+
+or pull it with a particular build tag
+
+docker pull apache/cloudstack-simulator:4.17.2.0
+
+docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator
+
+or 
+
+docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.17.2.0
+
 ```
 
 Access CloudStack UI


### PR DESCRIPTION
### Description



This PR updates the README.md file in directory tools/docker/


We should use the offical docker image for Apache Cloudstack simulator https://hub.docker.com/r/apache/cloudstack-simulator

The community build of the simulator https://registry.hub.docker.com/r/cloudstack/simulator/tags  is showing as 4 years old.

The offical docker image from Apache contains the latest build and is having the tags as well for a particular builds



❯ docker search --format "{{.Name}}: {{.StarCount}}" apache/cloudstack
apache/cloudstack-cloudmonkey: 0
apache/cloudstack-kubernetes-autoscaler: 0
apache/cloudstack-kubernetes-provider: 0
apache/cloudstack-primate: 0
apache/cloudstack-ec2stack: 0
apache/cloudstack-simulator: 0



❯ docker search --format "{{.Name}}: {{.StarCount}}" cloudstack/
cloudstack/simulator: 14
cloudstack/management_centos6: 6
cloudstack/cloudstack-ec2stack: 1
cloudstack/marvin: 0
cloudstack/package-docker-deb: 0
cloudstack/marvin2: 0



### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested locally with the apache/cloudstack-simulator and it works fine

docker pull apache/cloudstack-simulator:4.17.2.0
docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.17.2.0
