### PR TITLE
Added upper case JPEG extension for icon upload

### DIFF
--- a/ui/src/components/view/UploadResourceIcon.vue
+++ b/ui/src/components/view/UploadResourceIcon.vue
@@ -195,7 +195,7 @@ export default {
       this.options.img = ''
     },
     beforeUpload (file) {
-      if (!/\.(svg|jpg|jpeg|png|bmp|SVG|JPG|PNG)$/.test(file.name)) {
+      if (!/\.(svg|jpg|jpeg|png|bmp|SVG|JPG|JPEG|PNG)$/.test(file.name)) {
         this.showAlert = true
       }
       const reader = new FileReader()


### PR DESCRIPTION
### Description

This PR updates the  file UploadResourceIcon.vue in directory ui/src/components/view

Currently if a file contains Captial JPEG extension, the icon fails to upload 


Changed line number 198 to include capital JPEG extension 


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):
![UI](https://user-images.githubusercontent.com/1401014/218423824-6f3a007e-6f9b-4eb3-9d9b-904b3fba64ac.png)


### How Has This Been Tested?