### PR TITLE
Set number of hours per month with actual number in Quota

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -18,6 +18,9 @@ package org.apache.cloudstack.quota;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -89,10 +92,10 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
 
     private TimeZone _usageTimezone;
     private int _aggregationDuration = 0;
-
-    static final BigDecimal s_hoursInMonth = BigDecimal.valueOf(DateUtil.HOURS_IN_A_MONTH);
     static final BigDecimal GiB_DECIMAL = BigDecimal.valueOf(ByteScaleUtils.GiB);
     List<Account.Type> lockablesAccountTypes = Arrays.asList(Account.Type.NORMAL, Account.Type.DOMAIN_ADMIN);
+
+    static BigDecimal hoursInCurrentMonth;
 
     public QuotaManagerImpl() {
         super();
@@ -269,6 +272,8 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         String accountsToString = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(accounts, "id", "uuid", "accountName", "domainId");
 
         s_logger.info(String.format("Starting quota usage calculation for accounts [%s].", accountsToString));
+
+        setHoursInCurrentMonth();
 
         Map<Integer, Pair<List<QuotaTariffVO>, Boolean>> mapQuotaTariffsPerUsageType = createMapQuotaTariffsPerUsageType();
 
@@ -533,7 +538,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
 
     protected BigDecimal getUsageValueAccordingToUsageUnitType(UsageVO usageRecord, BigDecimal aggregatedQuotaTariffsValue, String quotaUnit) {
         BigDecimal rawUsage = BigDecimal.valueOf(usageRecord.getRawUsage());
-        BigDecimal costPerHour = aggregatedQuotaTariffsValue.divide(s_hoursInMonth, 8, RoundingMode.HALF_EVEN);
+        BigDecimal costPerHour = aggregatedQuotaTariffsValue.divide(hoursInCurrentMonth, 8, RoundingMode.HALF_EVEN);
 
         switch (UsageUnitTypes.getByDescription(quotaUnit)) {
             case COMPUTE_MONTH:
@@ -556,6 +561,14 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             default:
                 return BigDecimal.ZERO;
         }
+    }
+
+    protected void setHoursInCurrentMonth() {
+        LocalDate currentDate = LocalDate.now();
+        Month currentMonth = currentDate.getMonth();
+        int hoursInMonth = YearMonth.of(currentDate.getYear(), currentMonth).lengthOfMonth() * 24;
+        hoursInCurrentMonth = new BigDecimal(hoursInMonth);
+        s_logger.debug(String.format("Considering [%s] as the total hours in the current month [%s] for the Quota calculation.", hoursInCurrentMonth, currentMonth));
     }
 
     @Override

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
@@ -143,6 +143,7 @@ public class QuotaManagerImplTest {
         Mockito.doReturn(10.0).when(usageVoMock).getRawUsage();
         Mockito.doReturn(ByteScaleUtils.GiB).when(usageVoMock).getSize();
         BigDecimal aggregatedQuotaTariffsValue = new BigDecimal(400);
+        quotaManagerImplSpy.hoursInCurrentMonth = new BigDecimal(720);
 
         Arrays.asList(UsageUnitTypes.values()).forEach(type -> {
            BigDecimal result = quotaManagerImplSpy.getUsageValueAccordingToUsageUnitType(usageVoMock, aggregatedQuotaTariffsValue, type.toString());

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
@@ -142,8 +142,9 @@ public class QuotaManagerImplTest {
     public void getUsageValueAccordingToUsageUnitTypeTestAllTypes() {
         Mockito.doReturn(10.0).when(usageVoMock).getRawUsage();
         Mockito.doReturn(ByteScaleUtils.GiB).when(usageVoMock).getSize();
+        Mockito.doReturn(new Date(0, 8, 10)).when(usageVoMock).getStartDate();
         BigDecimal aggregatedQuotaTariffsValue = new BigDecimal(400);
-        quotaManagerImplSpy.hoursInCurrentMonth = new BigDecimal(720);
+
 
         Arrays.asList(UsageUnitTypes.values()).forEach(type -> {
            BigDecimal result = quotaManagerImplSpy.getUsageValueAccordingToUsageUnitType(usageVoMock, aggregatedQuotaTariffsValue, type.toString());

--- a/utils/src/main/java/com/cloud/utils/DateUtil.java
+++ b/utils/src/main/java/com/cloud/utils/DateUtil.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.YearMonth;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -335,5 +336,9 @@ public class DateUtil {
                 .withMinute(localDateTime.getMinute())
                 .withSecond(localDateTime.getSecond());
         return zonedDate;
+    }
+
+    public static int getHoursInCurrentMonth(Date date) {
+        return YearMonth.of(date.getYear(), date.getMonth() + 1).lengthOfMonth() * 24;
     }
 }


### PR DESCRIPTION
### Description

The Quota usage value for monthly usage types uses the cost per hour to calculate the total tariff value in a particular period. In order to define the cost per hour, it takes into account the total number of hours in each month. However, this value is currently fixed at 720 hours for every month. 

This causes incorrect values when calculating the cost per hour, resulting in costs being higher than expected. Therefore, this PR aims to calculate the number of hours in each month based on the actual number of days of each month.

For example, if the tariff value is 100 per month, the current cost per hour is 0.138888889 for every month. For 1 hour per month the total cost in a year would be 1.666666668.
With the adjustments to the cost per hour of this PR, the costs per hour would be: 0.134408602 (January, March, May, July, August, October, December), 0.148809524 (February of a non-leap year), 0.143678161 (February of a leap year), and 0.138888889 (April, June, September, November). This results in 1.645225294 for a non-leap year and 1.640093931 for a leap year at 1 hour per month, which is a difference of about 1.3% in costs to the current method.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### How Has This Been Tested?

In a local lab I applied the changes, and manually changed the current month of the MS to every month in a year (including February of a leap year) and verified if the cost per hour was calculated correctly using the number of hours of each month when the `quotaUpdate` API was called. 
