### PR TITLE
[Veeam] Restore only a specified volume

### DIFF
--- a/api/src/main/java/com/cloud/hypervisor/HypervisorGuru.java
+++ b/api/src/main/java/com/cloud/hypervisor/HypervisorGuru.java
@@ -89,7 +89,7 @@ public interface HypervisorGuru extends Adapter {
     VirtualMachine importVirtualMachineFromBackup(long zoneId, long domainId, long accountId, long userId,
                                                   String vmInternalName, Backup backup) throws Exception;
 
-    boolean attachRestoredVolumeToVirtualMachine(long zoneId, String location, Backup.VolumeInfo volumeInfo,
+    boolean attachRestoredVolumeToVirtualMachine(long zoneId, String restoredVolumeLocation, Backup.VolumeInfo volumeInfo,
                                                  VirtualMachine vm, long poolId, Backup backup) throws Exception;
     /**
      * Will generate commands to migrate a vm to a pool. For now this will only work for stopped VMs on Vmware.

--- a/api/src/main/java/org/apache/cloudstack/backup/BackupProvider.java
+++ b/api/src/main/java/org/apache/cloudstack/backup/BackupProvider.java
@@ -93,7 +93,7 @@ public interface BackupProvider {
     /**
      * Restore a volume from a backup
      */
-    Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String hostIp, String dataStoreUuid);
+    Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String host, String dataStore, VirtualMachine vm);
 
     /**
      * Returns backup metrics for a list of VMs in a zone

--- a/plugins/backup/dummy/src/main/java/org/apache/cloudstack/backup/DummyBackupProvider.java
+++ b/plugins/backup/dummy/src/main/java/org/apache/cloudstack/backup/DummyBackupProvider.java
@@ -78,7 +78,7 @@ public class DummyBackupProvider extends AdapterBase implements BackupProvider {
     }
 
     @Override
-    public Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String hostIp, String dataStoreUuid) {
+    public Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String host, String dataStore, VirtualMachine vm) {
         s_logger.debug("Restoring volume " + volumeUuid + "from backup " + backup.getUuid() + " on the Dummy Backup Provider");
         throw new CloudRuntimeException("Dummy plugin does not support this feature");
     }

--- a/plugins/backup/networker/src/main/java/org/apache/cloudstack/backup/NetworkerBackupProvider.java
+++ b/plugins/backup/networker/src/main/java/org/apache/cloudstack/backup/NetworkerBackupProvider.java
@@ -369,12 +369,12 @@ public class NetworkerBackupProvider extends AdapterBase implements BackupProvid
     }
 
     @Override
-    public Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String hostIp, String dataStoreUuid) {
+    public Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String host, String dataStore, VirtualMachine vm) {
         String networkerServer;
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
         VMInstanceVO backupSourceVm = vmInstanceDao.findById(backup.getVmId());
-        StoragePoolHostVO dataStore = storagePoolHostDao.findByUuid(dataStoreUuid);
-        HostVO hostVO = hostDao.findByIp(hostIp);
+        StoragePoolHostVO datastore = storagePoolHostDao.findByUuid(dataStore);
+        HostVO hostVO = hostDao.findByIp(host);
 
         final Long zoneId = backup.getZoneId();
         final String externalBackupId = backup.getExternalId();
@@ -437,7 +437,7 @@ public class NetworkerBackupProvider extends AdapterBase implements BackupProvid
         script.add("-n");
         script.add(restoredVolume.getUuid());
         script.add("-p");
-        script.add(dataStore.getLocalPath());
+        script.add(datastore.getLocalPath());
         script.add("-a");
         script.add(volume.getUuid());
 

--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/VeeamBackupProvider.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/VeeamBackupProvider.java
@@ -36,7 +36,9 @@ import org.apache.cloudstack.backup.veeam.VeeamClient;
 import org.apache.cloudstack.backup.veeam.api.Job;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
+import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.log4j.Logger;
 
@@ -45,6 +47,9 @@ import com.cloud.hypervisor.vmware.VmwareDatacenter;
 import com.cloud.hypervisor.vmware.VmwareDatacenterZoneMap;
 import com.cloud.hypervisor.vmware.dao.VmwareDatacenterDao;
 import com.cloud.hypervisor.vmware.dao.VmwareDatacenterZoneMapDao;
+import com.cloud.serializer.GsonHelper;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
 import com.cloud.utils.Pair;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.db.Transaction;
@@ -58,6 +63,7 @@ import com.cloud.vm.dao.VMInstanceDao;
 public class VeeamBackupProvider extends AdapterBase implements BackupProvider, Configurable {
 
     private static final Logger LOG = Logger.getLogger(VeeamBackupProvider.class);
+    private static final Gson GSON = GsonHelper.getGson();
     public static final String BACKUP_IDENTIFIER = "-CSBKP-";
 
     public ConfigKey<String> VeeamUrl = new ConfigKey<>("Advanced", String.class,
@@ -238,10 +244,31 @@ public class VeeamBackupProvider extends AdapterBase implements BackupProvider, 
     }
 
     @Override
-    public Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String hostIp, String dataStoreUuid) {
+    public Pair<Boolean, String> restoreBackedUpVolume(Backup backup, String volumeUuid, String host, String dataStore, VirtualMachine vm) {
+        Pair<Boolean, String> result = new Pair<>(false, "");
         final Long zoneId = backup.getZoneId();
         final String restorePointId = backup.getExternalId();
-        return getClient(zoneId).restoreVMToDifferentLocation(restorePointId, hostIp, dataStoreUuid);
+
+        VMInstanceVO vmVO = vmInstanceDao.findById(backup.getVmId());
+        VolumeVO volumeVO = volumeDao.findByUuid(volumeUuid);
+        long totalDeviceIds = volumeDao.findByInstance(vm.getId()).stream().mapToLong(VolumeVO::getDeviceId).max().orElse(0L);
+        long newDeviceId = totalDeviceIds + 1;
+        LOG.debug(String.format("VM [%s] has [%s] deviceIds. Trying to restore volume [%s] using restorePoint [%s] and with [%s] as the new deviceId.", vm.getUuid(),
+                totalDeviceIds, volumeUuid, restorePointId, newDeviceId));
+
+        VirtualMachineDiskInfo fromJson = GSON.fromJson(volumeVO.getChainInfo(), VirtualMachineDiskInfo.class);
+        String type = fromJson.getControllerFromDeviceBusName().toUpperCase();
+        String virtualDeviceNode = StringUtils.substringAfter(fromJson.getDiskDeviceBusName(), ":");
+        for (String name : fromJson.getDiskChain()) {
+            String diskName = StringUtils.substringAfter(name, "/");
+            try {
+                result = getClient(zoneId).restoreVolume(volumeUuid, vmVO.getUuid(), restorePointId, host, dataStore, type, virtualDeviceNode, diskName, newDeviceId, vm);
+            } catch (Exception e) {
+                LOG.error(String.format("Failed to restore volume [%s] in VM [%s], with type [%s], node [%s] and disk name [%s], using target host [%s] and datastore [%s] due to [%s].",
+                        volumeUuid, vmVO.getUuid(), type, virtualDeviceNode, diskName, host, dataStore, e.getMessage()), e);
+            }
+        }
+        return result;
     }
 
     @Override
@@ -338,6 +365,31 @@ public class VeeamBackupProvider extends AdapterBase implements BackupProvider, 
                 }
             }
         });
+    }
+
+    protected String createVolumeInfoFromVolumes(List<String> paths) {
+        List<VolumeVO> vmVolumes = new ArrayList<>();
+        try {
+            for (String diskName : paths) {
+                VolumeVO volumeVO = volumeDao.findByPath(diskName);
+                if (volumeVO != null) {
+                    vmVolumes.add(volumeVO);
+                }
+            }
+
+            List<Backup.VolumeInfo> list = new ArrayList<>();
+            for (VolumeVO vol : vmVolumes) {
+                list.add(new Backup.VolumeInfo(vol.getUuid(), vol.getPath(), vol.getVolumeType(), vol.getSize(), vol.getDeviceId()));
+            }
+            return GSON.toJson(list.toArray(), Backup.VolumeInfo[].class);
+        } catch (Exception e) {
+            if (CollectionUtils.isEmpty(vmVolumes) || vmVolumes.get(0).getInstanceId() == null) {
+                LOG.error(String.format("Failed to create VolumeInfo of VM [id: null] volumes due to: [%s].", e.getMessage()), e);
+            } else {
+                LOG.error(String.format("Failed to create VolumeInfo of VM [id: %s] volumes due to: [%s].", vmVolumes.get(0).getInstanceId(), e.getMessage()), e);
+            }
+            throw e;
+        }
     }
 
     @Override

--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.UUID;
 
+import com.cloud.utils.UuidUtils;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -702,7 +703,7 @@ public class VeeamClient {
     }
 
     protected String removeDashesIfDatastoreNameIsUuid(String datastore) {
-        if (!UuidUtils.validateUUID(datastore)) {
+        if (!UuidUtils.isUuid(datastore)) {
             return datastore;
         }
         LOG.trace(String.format("Removing the dash symbol of datastore name [%s] because this name is a valid UUID used by ACS. This happens because when a new NFS storage is created via ACS, "
@@ -718,8 +719,8 @@ public class VeeamClient {
         final List<String> cmds = Arrays.asList(
                 "$points = Get-VBRRestorePoint",
                 String.format("foreach($point in $points) { if ($point.Id -eq '%s') { break; } }", restorePointId),
-                String.format("$server = Get-VBRServer -Name \"%s\"", hostIp),
-                String.format("$ds = Find-VBRViDatastore -Server:$server -Name \"%s\"", datastoreId),
+                String.format("$server = Get-VBRServer -Name \"%s\"", host),
+                String.format("$ds = Find-VBRViDatastore -Server:$server -Name \"%s\"", datastore),
                 String.format("$job = Start-VBRRestoreVM -RestorePoint:$point -Server:$server -Datastore:$ds -VMName \"%s\" -RunAsync", restoreLocation),
                 "while (-not (Get-VBRRestoreSession -Id $job.Id).IsCompleted) { Start-Sleep -Seconds 10 }"
         );

--- a/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
+++ b/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
@@ -24,25 +24,17 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.times;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
 import org.apache.cloudstack.backup.BackupOffering;
-import org.apache.cloudstack.backup.veeam.api.RestoreSession;
-import org.apache.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.test.util.ReflectionTestUtils;
 
-import com.cloud.utils.Pair;
-import com.cloud.utils.exception.CloudRuntimeException;
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.cloud.utils.LogUtils;
 import javax.inject.Inject;
 
 import com.cloud.storage.StorageManager;

--- a/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/guru/VMwareGuruTest.java
+++ b/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/guru/VMwareGuruTest.java
@@ -20,12 +20,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
-import java.util.Date;
 
+import com.cloud.agent.api.Command;
+import com.cloud.agent.api.MigrateVmToPoolCommand;
+import com.cloud.dc.ClusterDetailsDao;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.storage.Storage;
+import com.cloud.storage.StoragePool;
+import com.cloud.storage.StoragePoolHostVO;
+import com.cloud.storage.Volume;
+import com.cloud.storage.dao.StoragePoolHostDao;
+import com.cloud.utils.Pair;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineManager;
 import org.apache.cloudstack.backup.Backup;
 import org.apache.cloudstack.backup.Backup.VolumeInfo;
-import org.apache.cloudstack.backup.BackupVO;
-import org.apache.log4j.Logger;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,14 +53,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import com.cloud.hypervisor.vmware.mo.VirtualMachineMO;
-import com.cloud.storage.VolumeApiService;
 import com.cloud.storage.VolumeVO;
-import com.cloud.storage.dao.VolumeDao;
-import com.cloud.vm.VMInstanceVO;
 import com.vmware.vim25.VirtualDisk;
 import com.vmware.vim25.VirtualDiskFlatVer2BackingInfo;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,10 +143,10 @@ public class VMwareGuruTest {
     public void createVolumeInfoFromVolumesTestCorrectlyConvertOfVolumes() {
         List<VolumeVO> volumesToTest = new ArrayList<>();
 
-        VolumeVO root = new VolumeVO("test", 1l, 1l, 1l, 1l, 1l, "test", "/root/dir", ProvisioningType.THIN, 555l, Volume.Type.ROOT);
+        VolumeVO root = new VolumeVO("test", 1l, 1l, 1l, 1l, 1l, "test", "/root/dir", Storage.ProvisioningType.THIN, 555l, Volume.Type.ROOT);
         String rootUuid = root.getUuid();
 
-        VolumeVO data = new VolumeVO("test", 1l, 1l, 1l, 1l, 1l, "test", "/root/dir/data", ProvisioningType.THIN, 1111000l, Volume.Type.DATADISK);
+        VolumeVO data = new VolumeVO("test", 1l, 1l, 1l, 1l, 1l, "test", "/root/dir/data", Storage.ProvisioningType.THIN, 1111000l, Volume.Type.DATADISK);
         String dataUuid = data.getUuid();
 
         volumesToTest.add(root);
@@ -157,7 +165,7 @@ public class VMwareGuruTest {
         Mockito.when(volumeInfo.getSize()).thenReturn(52l);
         Mockito.when(vmInstanceVO.getVirtualDisks()).thenReturn(new ArrayList<>());
         try {
-            guru.findRestoredVolume(volumeInfo, vmInstanceVO, null, 0);
+            vMwareGuru.findRestoredVolume(volumeInfo, vmInstanceVO, null, 0);
         } catch (Exception e) {
             assertEquals("Volume to restore could not be found", e.getMessage());
         }
@@ -177,7 +185,7 @@ public class VMwareGuruTest {
         Mockito.when(virtualDisk.getBacking()).thenReturn(info);
         Mockito.when(virtualDisk.getUnitNumber()).thenReturn(1);
         Mockito.when(vmInstanceVO.getVirtualDisks()).thenReturn(disks);
-        VirtualDisk findRestoredVolume = guru.findRestoredVolume(volumeInfo, vmInstanceVO, "test", 1);
+        VirtualDisk findRestoredVolume = vMwareGuru.findRestoredVolume(volumeInfo, vmInstanceVO, "test", 1);
         assertNotNull(findRestoredVolume);
     }
 }

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -344,7 +344,7 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
     }
 
     @Override
-    public boolean attachRestoredVolumeToVirtualMachine(long zoneId, String location, Backup.VolumeInfo volumeInfo,
+    public boolean attachRestoredVolumeToVirtualMachine(long zoneId, String restoredVolumeLocation, Backup.VolumeInfo volumeInfo,
                                                         VirtualMachine vm, long poolId, Backup backup) throws Exception {
         return false;
     }

--- a/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
@@ -132,14 +132,14 @@ public class BackupManagerTest {
         String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
 
         Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
-                Mockito.eq("127.0.0.1"), Mockito.eq("e9804933-8609-4de3-bccc-6278072a496c"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success"));
-        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+                Mockito.eq("127.0.0.1"), Mockito.eq("e9804933-8609-4de3-bccc-6278072a496c"), Mockito.any())).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues, null);
 
         assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
         assertEquals("Success", restoreBackedUpVolume.second());
 
         Mockito.verify(backupProvider, times(1)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyString());
+                Mockito.anyString(), Mockito.anyString(), Mockito.any());
     }
 
     @Test
@@ -148,14 +148,14 @@ public class BackupManagerTest {
         String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
 
         Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
-                Mockito.eq("127.0.0.1"), Mockito.eq("datastore-name"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success2"));
-        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+                Mockito.eq("127.0.0.1"), Mockito.eq("datastore-name"), Mockito.any())).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success2"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues, null);
 
         assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
         assertEquals("Success2", restoreBackedUpVolume.second());
 
         Mockito.verify(backupProvider, times(2)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyString());
+                Mockito.anyString(), Mockito.anyString(), Mockito.any());
     }
 
     @Test
@@ -164,14 +164,14 @@ public class BackupManagerTest {
         String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
 
         Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
-                Mockito.eq("hostname"), Mockito.eq("e9804933-8609-4de3-bccc-6278072a496c"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success3"));
-        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+                Mockito.eq("hostname"), Mockito.eq("e9804933-8609-4de3-bccc-6278072a496c"), Mockito.any())).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success3"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues, null);
 
         assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
         assertEquals("Success3", restoreBackedUpVolume.second());
 
         Mockito.verify(backupProvider, times(3)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyString());
+                Mockito.anyString(), Mockito.anyString(), Mockito.any());
     }
 
     @Test
@@ -180,13 +180,13 @@ public class BackupManagerTest {
         String volumeUuid = "5f4ed903-ac23-4f8a-b595-69c73c40593f";
 
         Mockito.when(backupProvider.restoreBackedUpVolume(Mockito.any(), Mockito.eq(volumeUuid),
-                Mockito.eq("hostname"), Mockito.eq("datastore-name"))).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success4"));
-        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues);
+                Mockito.eq("hostname"), Mockito.eq("datastore-name"), Mockito.any())).thenReturn(new Pair<Boolean, String>(Boolean.TRUE, "Success4"));
+        Pair<Boolean,String> restoreBackedUpVolume = backupManager.restoreBackedUpVolume(volumeUuid, backupVO, backupProvider, hostPossibleValues, datastoresPossibleValues, null);
 
         assertEquals(Boolean.TRUE, restoreBackedUpVolume.first());
         assertEquals("Success4", restoreBackedUpVolume.second());
 
         Mockito.verify(backupProvider, times(4)).restoreBackedUpVolume(Mockito.any(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyString());
+                Mockito.anyString(), Mockito.anyString(), Mockito.any());
     }
 }

--- a/utils/src/main/java/com/cloud/utils/UuidUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UuidUtils.java
@@ -24,7 +24,7 @@ import org.apache.xerces.impl.xpath.regex.RegularExpression;
 
 public class UuidUtils {
 
-    private static final RegularExpression uuidRegex = new RegularExpression("[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}");
+    private static final RegularExpression uuidRegex = new RegularExpression("[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$");
 
     public static String first(String uuid) {
         return uuid.substring(0, uuid.indexOf('-'));

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineDiskInfoBuilder.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineDiskInfoBuilder.java
@@ -76,6 +76,19 @@ public class VirtualMachineDiskInfoBuilder {
         return null;
     }
 
+    public VirtualMachineDiskInfo getDiskInfoByBackingFileBaseName(String diskBackingFileBaseName, String dataStoreName, String busName) {
+        for (Map.Entry<String, List<String>> entry : disks.entrySet()) {
+            if (chainContains(entry.getValue(), diskBackingFileBaseName, dataStoreName) && entry.getKey().equals(busName)) {
+                VirtualMachineDiskInfo diskInfo = new VirtualMachineDiskInfo();
+                diskInfo.setDiskDeviceBusName(entry.getKey());
+                diskInfo.setDiskChain(entry.getValue().toArray(new String[1]));
+                return diskInfo;
+            }
+        }
+
+        return null;
+    }
+
     private List<String> getDiskChainContainer(String diskDeviceBusName) {
         assert (diskDeviceBusName != null);
         List<String> chain = disks.get(diskDeviceBusName);

--- a/vmware-base/src/test/java/com/cloud/hypervisor/vmware/mo/VirtualMachineDiskInfoBuilderTest.java
+++ b/vmware-base/src/test/java/com/cloud/hypervisor/vmware/mo/VirtualMachineDiskInfoBuilderTest.java
@@ -1,0 +1,39 @@
+package com.cloud.hypervisor.vmware.mo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VirtualMachineDiskInfoBuilderTest {
+
+    @Test
+    public void getDiskInfoByBackingFileBaseNameTestFindDisk() {
+        VirtualMachineDiskInfoBuilder virtualMachineDiskInfoBuilder = new VirtualMachineDiskInfoBuilder();
+        Map<String, List<String>> disks = new HashMap<String, List<String>>();
+        String[] diskChain = new String[]{"[somedatastorename] i-3-VM-somePath/ROOT-1.vmdk"};
+        disks.put("scsi0:0", Arrays.asList(diskChain));
+        virtualMachineDiskInfoBuilder.disks = disks;
+        VirtualMachineDiskInfo findedDisk = virtualMachineDiskInfoBuilder.getDiskInfoByBackingFileBaseName("ROOT-1", "somedatastorename", "scsi0:0");
+        assertEquals("scsi", findedDisk.getControllerFromDeviceBusName());
+        assertArrayEquals(findedDisk.getDiskChain(), diskChain);
+    }
+
+    @Test
+    public void getDiskInfoByBackingFileBaseNameTestNotFindDisk() {
+        VirtualMachineDiskInfoBuilder virtualMachineDiskInfoBuilder = new VirtualMachineDiskInfoBuilder();
+        Map<String, List<String>> disks = new HashMap<String, List<String>>();
+        disks.put("scsi0:0", Arrays.asList(new String[]{"[somedatastorename] i-3-VM-somePath/ROOT-1.vmdk"}));
+        virtualMachineDiskInfoBuilder.disks = disks;
+        VirtualMachineDiskInfo findedDisk = virtualMachineDiskInfoBuilder.getDiskInfoByBackingFileBaseName("ROOT-1", "somedatastorename", "ide0:0");
+        assertEquals(null, findedDisk);
+    }
+}


### PR DESCRIPTION
### Description

Using VMWare with Veeam on ACS, when restoring a volume from a backup, ACS creates a new VM from the backup, detaches all volumes, and attaches the selected volume to the original VM. 

Veeam allows restoring only the selected volume, which is faster and more performant than the current approach. This PR aims to improve the volume restore process using this native option of Veeam.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
It was tested in a local lab:

1. I created a new VM and attached this VM to a Backup Offering;
2. I made some manual backups;
3. I restore some volume of this backups, and check if, in Veeam and vCenter, only the selected volume are restored.