### PR TITLE
Enable CPU cap in VRs if the offering has a CPU cap limitation

### DIFF
--- a/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -542,6 +542,7 @@ public class NetworkHelperImpl implements NetworkHelper {
 
                 router.setDynamicallyScalable(template.isDynamicallyScalable());
                 router.setRole(Role.VIRTUAL_ROUTER);
+                router.setLimitCpuUse(routerOffering.getLimitCpuUse());
                 router = _routerDao.persist(router);
 
                 reallocateRouterNetworks(routerDeploymentDefinition, router, template, null);


### PR DESCRIPTION
### Description

When deploying a new VR, using a network offering with CPU cap, this limitation is not respected in the VR, because in the definition and persistence of VR in database, the configuration of CPU cap of the network offering is not considered, and always uses the value `false`. This PR aims to fix this behavior, to respect the CPU cap of the network offering.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
It was tested in a local lab:

1. I created new isolated networks, and also created new VMs that use they;
2. I executed an `dumpxml` in the VR definition;
3. Before, the XML of the VR does not have the cpushared tag;
4. Now, the definition of the VR have the cpushares tag, when using a network offering with CPU cap.