### PR TITLE
[Veeam] Check for failures in the restore process

### DIFF
--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
@@ -345,7 +345,26 @@ public class VeeamClient {
                         String type = pair.second();
                         String path = url.replace(apiURI.toString(), "");
                         if (type.equals("RestoreSession")) {
-                            return checkIfRestoreSessionFinished(type, path);
+                            for (int j = 0; j < restoreTimeout; j++) {
+                                HttpResponse relatedResponse = get(path);
+                                RestoreSession session = parseRestoreSessionResponse(relatedResponse);
+                                if (session.getResult().equals("Success")) {
+                                    return true;
+                                }
+                                if (session.getResult().equalsIgnoreCase("Failed")) {
+                                    String sessionUid = session.getUid();
+                                    LOG.error(String.format("Failed to restore backup [%s] of VM [%s] due to [%s].",
+                                            sessionUid, session.getVmDisplayName(),
+                                            getRestoreVmErrorDescription(StringUtils.substringAfterLast(sessionUid, ":"))));
+                                    throw new CloudRuntimeException(String.format("Restore job [%s] failed.", sessionUid));
+                                }
+                                LOG.debug(String.format("Waiting %s seconds, out of a total of %s seconds, for the backup process to finish.", j, restoreTimeout));
+                                try {
+                                    Thread.sleep(1000);
+                                } catch (InterruptedException ignored) {
+                                }
+                            }
+                            throw new CloudRuntimeException("Related job type: " + type + " was not successful");
                         }
                     }
                     return true;
@@ -928,6 +947,29 @@ public class VeeamClient {
             throw new CloudRuntimeException("Failed to restore VM to location " + restoreLocation);
         }
         return new Pair<>(result.first(), restoreLocation);
+    }
+
+    /**
+     * Tries to retrieve the error's descripton of the Veeam restore task that errored.
+     * @param uid Session uid in Veeam of restore process;
+     * @return the description found in Veeam about the cause of error in restore process.
+     */
+    protected String getRestoreVmErrorDescription(String uid) {
+        LOG.debug(String.format("Trying to find cause of error in restore process [%s].", uid));
+        List<String> cmds = Arrays.asList(
+                String.format("$restoreUid = '%s'", uid),
+                "$restore = Get-VBRRestoreSession -Id $restoreUid",
+                "if ($restore) {",
+                    "Write-Output $restore.Description",
+                "} else {",
+                    "Write-Output 'Cannot find restore session with provided uid $restoreUid'",
+                "}"
+        );
+        Pair<Boolean, String> result = executePowerShellCommands(cmds);
+        if (result != null && result.first()) {
+            return result.second();
+        }
+        return String.format("Failed to get description of failed restore session [%s]. Please contact an administrator.", uid);
     }
 
     private boolean isLegacyServer() {

--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
@@ -367,12 +367,12 @@ public class VeeamClient {
      * There is also a timeout defined in the global configuration, backup.plugin.veeam.restore.timeout,<br/>
      * that is used to wait for the restore to complete before throwing a {@link CloudRuntimeException}.
      */
-    protected boolean checkIfRestoreSessionFinished(String type, String path) throws IOException {
+    protected void checkIfRestoreSessionFinished(String type, String path) throws IOException {
         for (int j = 0; j < restoreTimeout; j++) {
             HttpResponse relatedResponse = get(path);
             RestoreSession session = parseRestoreSessionResponse(relatedResponse);
             if (session.getResult().equals("Success")) {
-                return true;
+                return;
             }
 
             if (session.getResult().equalsIgnoreCase("Failed")) {

--- a/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
+++ b/plugins/backup/veeam/src/main/java/org/apache/cloudstack/backup/veeam/VeeamClient.java
@@ -382,7 +382,7 @@ public class VeeamClient {
                         getRestoreVmErrorDescription(StringUtils.substringAfterLast(sessionUid, ":"))));
                 throw new CloudRuntimeException(String.format("Restore job [%s] failed.", sessionUid));
             }
-            LOG.debug(String.format("Waiting %s seconds, out of a total of %s seconds, for the backup process to finish.", j, restoreTimeout));
+            LOG.debug(String.format("Waiting %s seconds, out of a total of %s seconds, for the restore backup process to finish.", j, restoreTimeout));
 
             try {
                 Thread.sleep(1000);
@@ -943,12 +943,12 @@ public class VeeamClient {
     }
 
     /**
-     * Tries to retrieve the error's descripton of the Veeam restore task that errored.
-     * @param uid Session uid in Veeam of restore process;
-     * @return the description found in Veeam about the cause of error in restore process.
+     * Tries to retrieve the error's description of the Veeam restore task that resulted in an error.
+     * @param uid Session uid in Veeam of the restore process;
+     * @return the description found in Veeam about the cause of error in the restore process.
      */
     protected String getRestoreVmErrorDescription(String uid) {
-        LOG.debug(String.format("Trying to find cause of error in restore process [%s].", uid));
+        LOG.debug(String.format("Trying to find the cause of error in the restore process [%s].", uid));
         List<String> cmds = Arrays.asList(
                 String.format("$restoreUid = '%s'", uid),
                 "$restore = Get-VBRRestoreSession -Id $restoreUid",
@@ -962,7 +962,7 @@ public class VeeamClient {
         if (result != null && result.first()) {
             return result.second();
         }
-        return String.format("Failed to get description of failed restore session [%s]. Please contact an administrator.", uid);
+        return String.format("Failed to get the description of the failed restore session [%s]. Please contact an administrator.", uid);
     }
 
     private boolean isLegacyServer() {

--- a/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
+++ b/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
@@ -58,6 +58,8 @@ public class VeeamClientTest {
     private VeeamClient mockClient;
     private static final SimpleDateFormat newDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
+    private VeeamClient mock = Mockito.mock(VeeamClient.class);
+
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(9399);
 
@@ -169,6 +171,42 @@ public class VeeamClientTest {
         }
         Mockito.verify(mockClient, times(10)).get(Mockito.anyString());
     }
+
+    @Test
+    public void getRestoreVmErrorDescriptionTestFindErrorDescription() {
+        Pair<Boolean, String> response = new Pair<>(true, "Example of error description found in Veeam.");
+        Mockito.when(mock.getRestoreVmErrorDescription("uuid")).thenCallRealMethod();
+        Mockito.when(mock.executePowerShellCommands(Mockito.any())).thenReturn(response);
+        String result = mock.getRestoreVmErrorDescription("uuid");
+        Assert.assertEquals("Example of error description found in Veeam.", result);
+    }
+
+    @Test
+    public void getRestoreVmErrorDescriptionTestNotFindErrorDescription() {
+        Pair<Boolean, String> response = new Pair<>(true, "Cannot find restore session with provided uid uuid");
+        Mockito.when(mock.getRestoreVmErrorDescription("uuid")).thenCallRealMethod();
+        Mockito.when(mock.executePowerShellCommands(Mockito.any())).thenReturn(response);
+        String result = mock.getRestoreVmErrorDescription("uuid");
+        Assert.assertEquals("Cannot find restore session with provided uid uuid", result);
+    }
+
+    @Test
+    public void getRestoreVmErrorDescriptionTestWhenPowerShellOutputIsNull() {
+        Mockito.when(mock.getRestoreVmErrorDescription("uuid")).thenCallRealMethod();
+        Mockito.when(mock.executePowerShellCommands(Mockito.any())).thenReturn(null);
+        String result = mock.getRestoreVmErrorDescription("uuid");
+        Assert.assertEquals("Failed to get description of failed restore session [uuid]. Please contact an administrator.", result);
+    }
+
+    @Test
+    public void getRestoreVmErrorDescriptionTestWhenPowerShellOutputIsFalse() {
+        Pair<Boolean, String> response = new Pair<>(false, null);
+        Mockito.when(mock.getRestoreVmErrorDescription("uuid")).thenCallRealMethod();
+        Mockito.when(mock.executePowerShellCommands(Mockito.any())).thenReturn(response);
+        String result = mock.getRestoreVmErrorDescription("uuid");
+        Assert.assertEquals("Failed to get description of failed restore session [uuid]. Please contact an administrator.", result);
+    }
+
 
     private void verifyBackupMetrics(Map<String, Backup.Metric> metrics) {
         Assert.assertEquals(2, metrics.size());

--- a/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
+++ b/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
@@ -195,7 +195,7 @@ public class VeeamClientTest {
         Mockito.when(mock.getRestoreVmErrorDescription("uuid")).thenCallRealMethod();
         Mockito.when(mock.executePowerShellCommands(Mockito.any())).thenReturn(null);
         String result = mock.getRestoreVmErrorDescription("uuid");
-        Assert.assertEquals("Failed to get description of failed restore session [uuid]. Please contact an administrator.", result);
+        Assert.assertEquals("Failed to get the description of the failed restore session [uuid]. Please contact an administrator.", result);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class VeeamClientTest {
         Mockito.when(mock.getRestoreVmErrorDescription("uuid")).thenCallRealMethod();
         Mockito.when(mock.executePowerShellCommands(Mockito.any())).thenReturn(response);
         String result = mock.getRestoreVmErrorDescription("uuid");
-        Assert.assertEquals("Failed to get description of failed restore session [uuid]. Please contact an administrator.", result);
+        Assert.assertEquals("Failed to get the description of the failed restore session [uuid]. Please contact an administrator.", result);
     }
 
 

--- a/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
+++ b/plugins/backup/veeam/src/test/java/org/apache/cloudstack/backup/veeam/VeeamClientTest.java
@@ -163,7 +163,7 @@ public class VeeamClientTest {
             Mockito.when(mockClient.get(Mockito.anyString())).thenReturn(httpResponse);
             Mockito.when(mockClient.parseRestoreSessionResponse(httpResponse)).thenReturn(restoreSession);
             Mockito.when(restoreSession.getResult()).thenReturn("No Success");
-            Mockito.when(mockClient.checkIfRestoreSessionFinished(Mockito.eq("RestoreTest"), Mockito.eq("any"))).thenCallRealMethod();
+            Mockito.doCallRealMethod().when(mockClient).checkIfRestoreSessionFinished(Mockito.eq("RestoreTest"), Mockito.eq("any"));
             mockClient.checkIfRestoreSessionFinished("RestoreTest", "any");
             fail();
         } catch (Exception e) {


### PR DESCRIPTION
### Description

Using the VMware hypervisor with the Veeam plugin active, when restoring a backup, ACS only verifies if the restore has finished successfully, ignoring any failure and making the user wait the timeout defined in `backup.plugin.veeam.restore.timeout`. This behavior has been fixed by this PR.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
It was tested in a local lab:

1. I created one VM, added this VM to one backup offering, and made one manual backup;
2. I tested restoring this backup, and canceled the restore in Veeam server;
3. Before, I needed to wait for the timeout of the restore process to be reached before I was notified that the restore failed;
4. Now, the ACS notifies me when it receives the failure message from Veeam.