### PR TITLE
Don't allow users to remove their account or user.

### DIFF
--- a/ui/src/config/section/account.js
+++ b/ui/src/config/section/account.js
@@ -196,6 +196,11 @@ export default {
       message: 'message.delete.account',
       dataView: true,
       show: (record, store) => {
+        // Don't allow users to delete their account
+        if (record.id !== 'undefined' && store.userInfo.accountid === record.id) {
+          return false
+        }
+
         return ['Admin', 'DomainAdmin'].includes(store.userInfo.roletype) && !record.isdefault &&
           !(record.domain === 'ROOT' && record.name === 'admin' && record.accounttype === 1)
       },

--- a/ui/src/config/section/user.js
+++ b/ui/src/config/section/user.js
@@ -145,6 +145,11 @@ export default {
       message: 'message.delete.user',
       dataView: true,
       show: (record, store) => {
+        // Don't allow users to delete their account
+        if (record.id !== 'undefined' && store.userInfo.id === record.id) {
+          return false
+        }
+
         return ['Admin', 'DomainAdmin'].includes(store.userInfo.roletype) && !record.isdefault &&
           !(record.domain === 'ROOT' && record.account === 'admin' && record.accounttype === 1)
       }


### PR DESCRIPTION
### Description

Cloudstack users can delete their account accidentally and lock themselves from accessing the CloudStack panel. A link to an account placed next to ISO, template, VM and other entities in CloudStack's UI. If customers doesn't paying attention, they would click on the account link instead of the link to the entity they want (vm, template, ISO etc.) Then, if they had wanted to delete that entity, they would press delete button without realising they were on the account page, and press Confirm.

Mailing list [[link]](https://lists.apache.org/thread/0787mmvfo32tqgx63jqc58ko1zfzbs90)

This PR don't allow users to remove their account or their user.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### Screenshots (if appropriate):

https://user-images.githubusercontent.com/9499410/219402523-e878deb1-23f9-400b-98ef-113c447dec88.mp4



### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Create two account, `Acc1` and `Acc2`.
2. Login as the `Acc1`
3. Go to the `Acc1` page, delete button is `not` there.
4. Go to the `Acc2` page, delete button is there.
5. Logout and login as the `Acc2`
6. Again, you can see the delete button for the `Acc1` but not for yourself.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
