### PR TITLE
Fix console access on XCPng/Xen

### DIFF
--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/NoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/NoVncClient.java
@@ -155,7 +155,8 @@ public class NoVncClient {
         }
 
         // Proxy that we support RFB 3.3 only
-        return RfbConstants.RFB_PROTOCOL_VERSION + "\n";
+        return String.format("%s%s\n", RfbConstants.RFB_PROTOCOL_VERSION_MAJOR,
+                RfbConstants.VNC_PROTOCOL_VERSION_MINOR_TUNNEL);
     }
 
     /**

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/RfbConstants.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/RfbConstants.java
@@ -21,8 +21,8 @@ import java.nio.charset.Charset;
 public interface RfbConstants {
 
     public static final String RFB_PROTOCOL_VERSION_MAJOR = "RFB 003.";
-    // public static final String VNC_PROTOCOL_VERSION_MINOR = "003";
     public static final String VNC_PROTOCOL_VERSION_MINOR = "008";
+    public static final String VNC_PROTOCOL_VERSION_MINOR_TUNNEL = "003";
     public static final String RFB_PROTOCOL_VERSION = RFB_PROTOCOL_VERSION_MAJOR + VNC_PROTOCOL_VERSION_MINOR;
 
     /**


### PR DESCRIPTION
### Description

This PR fixes the console access on XCPng/XenServer observed on the 4.18 RC1 (fixing the RFB protocol version for tunnel connection after PR #7015 was merged) 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
View any VM console
