### PR TITLE
Fix Quota plugin state on QuotaSummaryResponse

### DIFF
--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
@@ -173,7 +173,7 @@ public class QuotaResponseBuilderImpl implements QuotaResponseBuilder {
         return new Pair<>(result, count);
     }
 
-    private QuotaSummaryResponse getQuotaSummaryResponse(final Account account) {
+    protected QuotaSummaryResponse getQuotaSummaryResponse(final Account account) {
         Calendar[] period = _statement.getCurrentStatementTime();
 
         if (account != null) {

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
@@ -192,6 +192,7 @@ public class QuotaResponseBuilderImpl implements QuotaResponseBuilder {
             qr.setStartDate(period[0].getTime());
             qr.setEndDate(period[1].getTime());
             qr.setCurrency(QuotaConfig.QuotaCurrencySymbol.value());
+            qr.setQuotaEnabled(QuotaConfig.QuotaAccountEnabled.valueIn(account.getId()));
             qr.setObjectName("summary");
             return qr;
         } else {

--- a/plugins/database/quota/src/test/java/org/apache/cloudstack/api/response/QuotaResponseBuilderImplTest.java
+++ b/plugins/database/quota/src/test/java/org/apache/cloudstack/api/response/QuotaResponseBuilderImplTest.java
@@ -16,24 +16,32 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.cloud.domain.DomainVO;
+import com.cloud.domain.dao.DomainDao;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.command.QuotaEmailTemplateListCmd;
 import org.apache.cloudstack.api.command.QuotaEmailTemplateUpdateCmd;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.quota.QuotaService;
+import org.apache.cloudstack.quota.QuotaStatement;
+import org.apache.cloudstack.quota.constant.QuotaConfig;
 import org.apache.cloudstack.quota.constant.QuotaTypes;
 import org.apache.cloudstack.quota.dao.QuotaBalanceDao;
 import org.apache.cloudstack.quota.dao.QuotaCreditsDao;
 import org.apache.cloudstack.quota.dao.QuotaEmailTemplatesDao;
 import org.apache.cloudstack.quota.dao.QuotaTariffDao;
+import org.apache.cloudstack.quota.dao.QuotaUsageDao;
 import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
 import org.apache.cloudstack.quota.vo.QuotaCreditsVO;
 import org.apache.cloudstack.quota.vo.QuotaEmailTemplatesVO;
@@ -87,10 +95,37 @@ public class QuotaResponseBuilderImplTest extends TestCase {
     @Mock
     QuotaTariffVO quotaTariffVoMock;
 
+    @Mock
+    QuotaStatement quotaStatementMock;
+
+    @Mock
+    DomainDao domainDaoMock;
+
+    @Mock
+    QuotaUsageDao quotaUsageDaoMock;
+
     @InjectMocks
     QuotaResponseBuilderImpl quotaResponseBuilderSpy = Mockito.spy(QuotaResponseBuilderImpl.class);
 
     Date date = new Date();
+
+    @Mock
+    Account accountMock;
+
+    @Mock
+    DomainVO domainVOMock;
+
+    private void overrideDefaultQuotaEnabledConfigValue(final Object value) throws IllegalAccessException, NoSuchFieldException {
+        Field f = ConfigKey.class.getDeclaredField("_defaultValue");
+        f.setAccessible(true);
+        f.set(QuotaConfig.QuotaAccountEnabled, value);
+    }
+
+    private Calendar[] createPeriodForQuotaSummary() {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR, 0);
+        return new Calendar[] {calendar, calendar};
+    }
 
     private QuotaTariffVO makeTariffTestData() {
         QuotaTariffVO tariffVO = new QuotaTariffVO();
@@ -338,5 +373,37 @@ public class QuotaResponseBuilderImplTest extends TestCase {
         Assert.assertTrue(quotaResponseBuilderSpy.deleteQuotaTariff(""));
 
         Mockito.verify(quotaTariffVoMock).setRemoved(Mockito.any(Date.class));
+    }
+
+    @Test
+    public void getQuotaSummaryResponseTestAccountIsNotNullQuotaIsDisabledShouldReturnFalse() throws NoSuchFieldException, IllegalAccessException {
+        Calendar[] period = createPeriodForQuotaSummary();
+        overrideDefaultQuotaEnabledConfigValue("false");
+
+        Mockito.doReturn(accountMock).when(accountDaoMock).findActiveAccount(Mockito.anyString(), Mockito.anyLong());
+        Mockito.doReturn(period).when(quotaStatementMock).getCurrentStatementTime();
+        Mockito.doReturn(domainVOMock).when(domainDaoMock).findById(Mockito.anyLong());
+        Mockito.doReturn(BigDecimal.ZERO).when(quotaBalanceDaoMock).lastQuotaBalance(Mockito.anyLong(), Mockito.anyLong(), Mockito.any(Date.class));
+        Mockito.doReturn(BigDecimal.ZERO).when(quotaUsageDaoMock).findTotalQuotaUsage(Mockito.anyLong(), Mockito.anyLong(), Mockito.isNull(), Mockito.any(Date.class), Mockito.any(Date.class));
+
+        QuotaSummaryResponse quotaSummaryResponse = quotaResponseBuilderSpy.getQuotaSummaryResponse(accountMock);
+
+        assertFalse(quotaSummaryResponse.getQuotaEnabled());
+    }
+
+    @Test
+    public void getQuotaSummaryResponseTestAccountIsNotNullQuotaIsEnabledShouldReturnTrue() throws NoSuchFieldException, IllegalAccessException {
+        Calendar[] period = createPeriodForQuotaSummary();
+        overrideDefaultQuotaEnabledConfigValue("true");
+
+        Mockito.doReturn(accountMock).when(accountDaoMock).findActiveAccount(Mockito.anyString(), Mockito.anyLong());
+        Mockito.doReturn(period).when(quotaStatementMock).getCurrentStatementTime();
+        Mockito.doReturn(domainVOMock).when(domainDaoMock).findById(Mockito.anyLong());
+        Mockito.doReturn(BigDecimal.ZERO).when(quotaBalanceDaoMock).lastQuotaBalance(Mockito.anyLong(), Mockito.anyLong(), Mockito.any(Date.class));
+        Mockito.doReturn(BigDecimal.ZERO).when(quotaUsageDaoMock).findTotalQuotaUsage(Mockito.anyLong(), Mockito.anyLong(), Mockito.isNull(), Mockito.any(Date.class), Mockito.any(Date.class));
+
+        QuotaSummaryResponse quotaSummaryResponse = quotaResponseBuilderSpy.getQuotaSummaryResponse(accountMock);
+
+        assertTrue(quotaSummaryResponse.getQuotaEnabled());
     }
 }


### PR DESCRIPTION
### Description

This PR aims to fix a feature introduced in PR[#6690](https://github.com/apache/cloudstack/pull/6690). It was added the parameter `quotaenabled` to the response of the Quota Summary  API. However, this parameter was not set, and thus, always returned false. This PR fix this behavior, returning the correct value according to the configuration value.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
This was tested in a local lab with user `dom01`  with the Quota plugin enabled and with user `dom02` with the plugin disabled. The image below presents the correct behavior for Quota summary response.

![image](https://user-images.githubusercontent.com/42067040/219699538-840f8b3d-3256-4a53-a964-ad03b26d52b4.png)

