### PR TITLE
UI: Fix domain admins cannot create service offerings

### DIFF
--- a/ui/src/views/offering/AddComputeOffering.vue
+++ b/ui/src/views/offering/AddComputeOffering.vue
@@ -683,6 +683,7 @@ export default {
     this.initForm()
     this.fetchData()
     this.isPublic = isAdmin()
+    this.form.ispublic = this.isPublic
   },
   methods: {
     initForm () {
@@ -764,7 +765,6 @@ export default {
         this.fetchStorageTagData()
         this.fetchDeploymentPlannerData()
       } else if (this.isDomainAdmin()) {
-        this.form.ispublic = false
         this.checkIfDomainAdminIsAllowedToInformTag()
         if (this.isDomainAdminAllowedToInformTags) {
           this.fetchStorageTagData()

--- a/ui/src/views/offering/AddComputeOffering.vue
+++ b/ui/src/views/offering/AddComputeOffering.vue
@@ -764,6 +764,7 @@ export default {
         this.fetchStorageTagData()
         this.fetchDeploymentPlannerData()
       } else if (this.isDomainAdmin()) {
+        this.form.ispublic = false
         this.checkIfDomainAdminIsAllowedToInformTag()
         if (this.isDomainAdminAllowedToInformTags) {
           this.fetchStorageTagData()


### PR DESCRIPTION
### Description

This PR allows domain admins to create service offerings, allowing them to select the domain when creating the service offering
Fixes: #7259 


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
The domain admins have the option to select the domain on the service offering creation
<img width="741" alt="Screenshot 2023-02-17 at 21 10 42" src="https://user-images.githubusercontent.com/5295080/219819534-d5363107-866f-4752-b6b3-ea4d038ee5ae.png">


### How Has This Been Tested?
Login as domain admin, create service offering