### PR TITLE
VR: do not restart conntrackd if no guest networks 

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
@@ -86,7 +86,7 @@ def mkdir(name, mode, fatal):
         os.makedirs(name, mode)
     except OSError as e:
         if e.errno != 17:
-            print "failed to make directories " + name + " due to :" + e.strerror
+            print("failed to make directories " + name + " due to :" + e.strerror)
             if(fatal):
                 sys.exit(1)
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
@@ -85,7 +85,7 @@ class CsRedundant(object):
 
         # No redundancy if there is no guest network
         if guest is None:
-            self.set_backup()
+            self.set_backup(restart_conntrackd=False)
             self._redundant_off()
             return
 
@@ -111,9 +111,9 @@ class CsRedundant(object):
             CsHelper.service("keepalived", "stop")
             return
 
-        CsHelper.mkdir(self.CS_RAMDISK_DIR, 0755, False)
+        CsHelper.mkdir(self.CS_RAMDISK_DIR, 0o755, False)
         CsHelper.mount_tmpfs(self.CS_RAMDISK_DIR)
-        CsHelper.mkdir(self.CS_ROUTER_DIR, 0755, False)
+        CsHelper.mkdir(self.CS_ROUTER_DIR, 0o755, False)
         for s in self.CS_TEMPLATES:
             d = s
             if s.endswith(".templ"):
@@ -222,10 +222,9 @@ class CsRedundant(object):
                 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 s.bind('/tmp/primary_lock')
                 return s
-            except socket.error, e:
+            except socket.error as e:
                 error_code = e.args[0]
                 error_string = e.args[1]
-                print "Process already running (%d:%s). Exiting" % (error_code, error_string)
                 logging.info("Primary is already running, waiting")
                 sleep(time_between)
 
@@ -261,7 +260,7 @@ class CsRedundant(object):
         interfaces = [interface for interface in self.address.get_interfaces() if interface.is_public()]
         CsHelper.reconfigure_interfaces(self.cl, interfaces)
 
-    def set_backup(self):
+    def set_backup(self, restart_conntrackd=True):
         """ Set the current router to backup """
         if not self.cl.is_redundant():
             logging.error("Set backup called on non-redundant router")
@@ -282,7 +281,10 @@ class CsRedundant(object):
 
         self._remove_ipv6_guest_gateway()
 
-        CsHelper.service("conntrackd", "restart")
+        if restart_conntrackd:
+            CsHelper.service("conntrackd", "restart")
+        else:
+            CsHelper.service("conntrackd", "stop")
         CsHelper.service("ipsec", "stop")
         CsHelper.service("xl2tpd", "stop")
 

--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -702,11 +702,11 @@ routing_svcs() {
    echo "cloud nfs-common portmap" > /var/cache/cloud/disabled_svcs
    if [ "$RROUTER" -eq "1" ]
    then
-       echo "keepalived conntrackd" >> /var/cache/cloud/enabled_svcs
-       echo "dnsmasq" >> /var/cache/cloud/disabled_svcs
+       echo "keepalived" >> /var/cache/cloud/enabled_svcs
+       echo "dnsmasq conntrackd" >> /var/cache/cloud/disabled_svcs
    else
        echo "dnsmasq" >> /var/cache/cloud/enabled_svcs
-       echo "keepalived conntrackd " >> /var/cache/cloud/disabled_svcs
+       echo "keepalived conntrackd" >> /var/cache/cloud/disabled_svcs
    fi
 }
 


### PR DESCRIPTION
### Description

This PR fixes #6702 

The service `conntrackd` will be started by the script `/opt/cloud/bin/cs/CsRedundant.py`, therefore add it to disabled_svcs so it is not started automatically when VR is started.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
