### PR TITLE
Add EncryptedElementType key resolver to SAML plugin

### DIFF
--- a/plugins/user-authenticators/saml2/src/main/java/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmd.java
+++ b/plugins/user-authenticators/saml2/src/main/java/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmd.java
@@ -55,9 +55,10 @@ import org.opensaml.saml2.core.Issuer;
 import org.opensaml.saml2.core.Response;
 import org.opensaml.saml2.core.StatusCode;
 import org.opensaml.saml2.encryption.Decrypter;
+import org.opensaml.saml2.encryption.EncryptedElementTypeEncryptedKeyResolver;
 import org.opensaml.xml.ConfigurationException;
+import org.opensaml.xml.encryption.ChainingEncryptedKeyResolver;
 import org.opensaml.xml.encryption.DecryptionException;
-import org.opensaml.xml.encryption.EncryptedKeyResolver;
 import org.opensaml.xml.encryption.InlineEncryptedKeyResolver;
 import org.opensaml.xml.io.UnmarshallingException;
 import org.opensaml.xml.security.SecurityHelper;
@@ -253,7 +254,9 @@ public class SAML2LoginAPIAuthenticatorCmd extends BaseCmd implements APIAuthent
                     Credential credential = SecurityHelper.getSimpleCredential(idpMetadata.getEncryptionCertificate().getPublicKey(),
                             spMetadata.getKeyPair().getPrivate());
                     StaticKeyInfoCredentialResolver keyInfoResolver = new StaticKeyInfoCredentialResolver(credential);
-                    EncryptedKeyResolver keyResolver = new InlineEncryptedKeyResolver();
+                    ChainingEncryptedKeyResolver keyResolver = new ChainingEncryptedKeyResolver();
+                    keyResolver.getResolverChain().add(new InlineEncryptedKeyResolver());
+                    keyResolver.getResolverChain().add(new EncryptedElementTypeEncryptedKeyResolver());
                     Decrypter decrypter = new Decrypter(null, keyInfoResolver, keyResolver);
                     decrypter.setRootInNewDocument(true);
                     List<EncryptedAssertion> encryptedAssertions = processedSAMLResponse.getEncryptedAssertions();


### PR DESCRIPTION
### Description

There are multiple ways in which a SAML response can be formatted, especially when encryption is enabled.  This PR removes the hardcoding of `EncryptedKeyResolver`= `InlineEncryptedKeyResolver` in favor of using a `ChainingEncryptedKeyResolver` which will try multiple resolvers. It preserves the `InlineEncryptedKeyResolver` as the first option but adds `EncryptedElementTypeEncryptedKeyResolver` to the chain of resolvers to try.

`ChainingEncryptedKeyResolver` is a bit finicky in that you can't provide it a list of resolvers, you can only fetch its internal list and add to it.

Theoretically we could add all of the resolver types to the chain, but for now just preserving the ones known to be in use.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
Tested locally against an installed IDP that provides the `EncryptedElementType` of XML response.