### PR TITLE
guestos: prevent upgrade failures on existing mappings

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/GuestOsMapper.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/GuestOsMapper.java
@@ -16,15 +16,15 @@
 // under the License.
 package com.cloud.upgrade;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.log4j.Logger;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
 import javax.inject.Inject;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.log4j.Logger;
 
 import com.cloud.storage.GuestOSHypervisorMapping;
 import com.cloud.storage.GuestOSHypervisorVO;
@@ -104,7 +104,16 @@ public class GuestOsMapper {
     }
 
     public void addGuestOsHypervisorMapping(GuestOSHypervisorMapping mapping, long guestOsId) {
-        if(!isValidGuestOSHypervisorMapping(mapping)) {
+        if (!isValidGuestOSHypervisorMapping(mapping)) {
+            return;
+        }
+        if (guestOSDao.findById(guestOsId) == null) {
+            LOG.debug(String.format("Skipping adding guest OS hypervisor mapping - %s as guest OS ID: %d not preset", mapping, guestOsId));
+            return;
+        }
+        GuestOSHypervisorVO existingMapping = guestOSHypervisorDao.findByOsIdAndHypervisor(guestOsId, mapping.getHypervisorType(), mapping.getHypervisorVersion());
+        if (existingMapping != null) {
+            LOG.debug(String.format("Skipping adding guest OS hypervisor mapping - %s for guest OS ID: %d as a mapping already exist", mapping, guestOsId));
             return;
         }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/GuestOsMapper.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/GuestOsMapper.java
@@ -123,15 +123,6 @@ public class GuestOsMapper {
         if (shouldAddingGuestOsHypervisorMappingBeSkipped(mapping, guestOsId)) {
             return;
         }
-        if (guestOSDao.findById(guestOsId) == null) {
-            LOG.debug(String.format("Skipping adding guest OS hypervisor mapping - %s as guest OS ID: %d not preset", mapping, guestOsId));
-            return;
-        }
-        GuestOSHypervisorVO existingMapping = guestOSHypervisorDao.findByOsIdAndHypervisor(guestOsId, mapping.getHypervisorType(), mapping.getHypervisorVersion());
-        if (existingMapping != null) {
-            LOG.debug(String.format("Skipping adding guest OS hypervisor mapping - %s for guest OS ID: %d as a mapping already exist", mapping, guestOsId));
-            return;
-        }
 
         LOG.debug("Adding guest OS hypervisor mapping - " + mapping.toString());
         GuestOSHypervisorVO guestOsMapping = new GuestOSHypervisorVO();


### PR DESCRIPTION
### Description
4.18 upgrades may fail when a certain guest OS is not present in the DB or if the guest OS hypervisor mapping is already present.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
