### PR TITLE
Fix VNC SecurityType None on RFB v3.8

### DIFF
--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
@@ -200,7 +200,7 @@ public class ConsoleProxyNoVncClient implements ConsoleProxyClient {
         client.processHandshakeSecurityType(secType, getClientHostPassword(),
                 getClientHostAddress(), getClientHostPort());
 
-        client.processSecurityResultMsg(secType);
+        client.processSecurityResultMsg();
         byte[] securityResultToClient = new byte[] { 0, 0, 0, 0 };
         sendMessageToVNCClient(securityResultToClient, 4);
         client.setWaitForNoVnc(true);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/NoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/NoVncClient.java
@@ -472,18 +472,13 @@ public class NoVncClient {
         return new Pair<>(result, message);
     }
 
-    public void processSecurityResultMsg(int securityType) {
+    public void processSecurityResultMsg() {
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Processing security result message");
         }
 
-        int result;
-        if (securityType == RfbConstants.NO_AUTH) {
-            result = RfbConstants.VNC_AUTH_OK;
-        } else {
-            nioSocketConnection.waitForBytesAvailableForReading(1);
-            result = nioSocketConnection.readUnsignedInteger(32);
-        }
+        nioSocketConnection.waitForBytesAvailableForReading(1);
+        int result = nioSocketConnection.readUnsignedInteger(32);
 
         Pair<Boolean, String> securityResultType = processSecurityResultType(result);
         boolean success = BooleanUtils.toBoolean(securityResultType.first());


### PR DESCRIPTION
### Description

This PR fixes the console access for Vmware 6.7 which offers SecurityType = 1 (None) - Reference: https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#721none

The CPVM access uses the RFB protocol 3.8 since #7015 (previously it used version 3.3). From the link above:
````
Version 3.8 onwards
The protocol continues with the SecurityResult message.
Version 3.3 and 3.7
The protocol passes to the initialisation phase ([Initialisation Messages](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#initialisation-messages)).
````

This PR fixes the behavior of the security type None, continuing with the SecurityResult message instead of the Initialisation Phase as it was on version 3.3

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Vmware 6.7 environment
Access any VM console before the fix -> Observe that the console is visible for less than a second, then an error is thrown
After the fix -> Console access works fine
