### PR TITLE
SSVM: 'allow from' private IP in other SSVMs if the public IP is in allowed internal sites cidrs

### DIFF
--- a/core/src/main/java/com/cloud/storage/template/TemplateConstants.java
+++ b/core/src/main/java/com/cloud/storage/template/TemplateConstants.java
@@ -27,12 +27,10 @@ public final class TemplateConstants {
 
     public static final String DEFAULT_SYSTEM_VM_TEMPLATE_PATH = "template/tmpl/1/";
 
-    public static final String DEFAULT_SYSTEM_VM_TMPLT_NAME = "routing";
-
     public static final int DEFAULT_TMPLT_COPY_PORT = 80;
     public static final String DEFAULT_TMPLT_COPY_INTF = "eth2";
+    public static final String TMPLT_COPY_INTF_PRIVATE = "eth1";
 
-    public static final String DEFAULT_SSL_CERT_DOMAIN = "realhostip.com";
     public static final String DEFAULT_HTTP_AUTH_USER = "cloud";
 
 }

--- a/systemvm/agent/scripts/ipfirewall.sh
+++ b/systemvm/agent/scripts/ipfirewall.sh
@@ -32,7 +32,7 @@ config_htaccess() {
 }
 
 ips(){
-  grep "^allow from $1$" $HTACCESS || echo "allow from $1" >> $HTACCESS
+  grep -e "^allow from $1$" $HTACCESS || echo "allow from $1" >> $HTACCESS
   result=$?
   return $result
 }

--- a/systemvm/agent/scripts/ipfirewall.sh
+++ b/systemvm/agent/scripts/ipfirewall.sh
@@ -32,7 +32,7 @@ config_htaccess() {
 }
 
 ips(){
-  echo "allow from $1" >> $HTACCESS
+  grep "^allow from $1$" $HTACCESS || echo "allow from $1" >> $HTACCESS
   result=$?
   return $result
 }


### PR DESCRIPTION

### Description

This PR fixes #5678 

Normally SSVMs in multiple zones communicate via the public IPs.
In some cases, the public IPs are in the internal allowed sites. There are some routes in SSVMs which causes the communication to use the private IPs. We need to add the private IP of other SSVM to /var/www/html/copy/.htaccess if the public IP is in secstorage.allowed.internal.sites


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Without this PR, SSVM contains only public IP of another SSVM
```
root@s-8-VM:~# cat /var/www/html/copy/.htaccess
Options -Indexes
order deny,allow
deny from all
allow from 10.0.17.55
```
With this PR, it has both private and public IP of another SSVM
```
root@s-8-VM:~# cat /var/www/html/copy/.htaccess
Options -Indexes
order deny,allow
deny from all
allow from 10.0.17.55
allow from 10.0.40.129
```

The SSVM has route to all internal allowed sites via private nic, for example (secstorage.allowed.internal.sites=10.0.0.0/16)
```
root@s-8-VM:~# ip route
default via 10.0.96.1 dev eth2 
8.8.4.4 via 10.0.32.1 dev eth1 
10.0.0.0/16 via 10.0.32.1 dev eth1 
10.0.32.0/20 dev eth1 proto kernel scope link src 10.0.36.127 
10.0.96.0/20 dev eth2 proto kernel scope link src 10.0.99.22 
169.254.0.0/16 dev eth0 proto kernel scope link src 169.254.148.119 
```

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
