### PR TITLE
UI: Add button to copy VM console URL to clipboard

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -502,6 +502,7 @@
 "label.copied.clipboard": "Copied to clipboard",
 "label.copy": "Copy",
 "label.copy.clipboard": "Copy to clipboard",
+"label.copy.consoleurl": "Copy console URL to clipboard",
 "label.copyid": "Copy ID",
 "label.core": "Core",
 "label.core.zone.type": "Core zone type",

--- a/ui/src/components/view/ActionButton.vue
+++ b/ui/src/components/view/ActionButton.vue
@@ -21,7 +21,26 @@
       <template #title>
         {{ $t('label.view.console') }}
       </template>
-      <console :resource="resource" :size="size" />
+      <console
+        style="margin-top: -5px;"
+        :resource="resource"
+        size="default"
+        v-if="resource.id"
+        icon="code"
+      />
+    </a-tooltip>
+    <a-tooltip arrowPointAtCenter placement="bottomRight" v-if="resource && resource.id && dataView">
+      <template #title>
+        {{ $t('label.copy.consoleurl') }}
+      </template>
+      <console
+        copyUrlToClipboard
+        style="margin-top: -5px;"
+        :resource="resource"
+        size="default"
+        v-if="resource.id"
+        icon="copy"
+      />
     </a-tooltip>
     <a-tooltip
       v-for="(action, actionIndex) in actions"

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -88,7 +88,24 @@
                 <template #title>
                   <span>{{ $t('label.view.console') }}</span>
                 </template>
-                <console style="margin-top: -5px;" :resource="resource" size="default" v-if="resource.id" />
+                <console
+                  style="margin-top: -5px;"
+                  :resource="resource"
+                  size="default"
+                  v-if="resource.id"
+                />
+              </a-tooltip>
+              <a-tooltip placement="right" >
+                <template #title>
+                  <span>{{ $t('label.copy.consoleurl') }}</span>
+                </template>
+                <console
+                  copyUrlToClipboard
+                  style="margin-top: -5px;"
+                  :resource="resource"
+                  size="default"
+                  v-if="resource.id"
+                />
               </a-tooltip>
             </div>
           </slot>

--- a/ui/src/components/widgets/Console.vue
+++ b/ui/src/components/widgets/Console.vue
@@ -20,7 +20,8 @@
     v-if="['vm', 'systemvm', 'router', 'ilbvm'].includes($route.meta.name) && 'listVirtualMachines' in $store.getters.apis && 'createConsoleEndpoint' in $store.getters.apis"
     @click="consoleUrl">
     <a-button style="margin-left: 5px" shape="circle" type="dashed" :size="size" :disabled="['Stopped', 'Error', 'Destroyed'].includes(resource.state) || resource.hostcontrolstate === 'Offline'" >
-      <code-outlined />
+      <code-outlined v-if="!copyUrlToClipboard"/>
+      <copy-outlined v-else />
     </a-button>
   </a>
 </template>
@@ -39,7 +40,8 @@ export default {
     size: {
       type: String,
       default: 'small'
-    }
+    },
+    copyUrlToClipboard: Boolean
   },
   data () {
     return {
@@ -53,7 +55,21 @@ export default {
       api('createConsoleEndpoint', params).then(json => {
         this.url = (json && json.createconsoleendpointresponse) ? json.createconsoleendpointresponse.consoleendpoint.url : '#/exception/404'
         if (json.createconsoleendpointresponse.consoleendpoint.success) {
-          window.open(this.url, '_blank')
+          if (this.copyUrlToClipboard) {
+            this.$message.success({
+              content: this.$t('label.copied.clipboard')
+            })
+            const hiddenElement = document.createElement('textarea')
+            hiddenElement.value = this.url
+            document.body.appendChild(hiddenElement)
+            hiddenElement.focus()
+            hiddenElement.select()
+
+            document.execCommand('copy')
+            document.body.removeChild(hiddenElement)
+          } else {
+            window.open(this.url, '_blank')
+          }
         } else {
           this.$notification.error({
             message: this.$t('error.execute.api.failed') + ' ' + 'createConsoleEndpoint',


### PR DESCRIPTION
### Description

This PR adds a new button that allows the user to copy the VM console URL to the clipboard. VM consoles have a security mechanism that allows for a one-time use per URL (see #6577). Therefore, if the same URL is accessed again, an error message is displayed. When access to the console is requested via the UI button, a new tab is opened which automatically connects to the VM console.  However, for the purpose of obtaining only the URL for later use or sharing, it is more convenient to copy the URL rather than opening it directly in a new tab. The new button appears alongside the existing button that opens the console in a new tab

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/48932878/226007219-38238f7f-68bf-43fc-a633-8e3432e26217.png)

### How Has This Been Tested?
I conducted manual testing in a local lab environment. During the testing process, I clicked the new added button and then accessed the copied URL. This allowed me to access the console in the same way as the existing "View Console" button.