### PR TITLE
Support Jetty's live cert reload on HTTPS frontend

### DIFF
--- a/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.server.handler.MovedContextHandler;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.ssl.KeyStoreScanner;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -241,6 +242,14 @@ public class ServerDaemon implements Daemon {
             sslConnector.setPort(httpsPort);
             sslConnector.setHost(bindInterface);
             server.addConnector(sslConnector);
+
+            // add scanner to auto-reload certs
+            try {
+                KeyStoreScanner scanner = new KeyStoreScanner(sslContextFactory);
+                server.addBean(scanner);
+            } catch (Throwable ex) {
+                LOG.error("failed to set up keystore scanner, manual refresh of certificates will be required", ex);
+            }
         }
     }
 

--- a/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/main/java/org/apache/cloudstack/ServerDaemon.java
@@ -247,7 +247,7 @@ public class ServerDaemon implements Daemon {
             try {
                 KeyStoreScanner scanner = new KeyStoreScanner(sslContextFactory);
                 server.addBean(scanner);
-            } catch (Throwable ex) {
+            } catch (Exception ex) {
                 LOG.error("failed to set up keystore scanner, manual refresh of certificates will be required", ex);
             }
         }


### PR DESCRIPTION
### Description

This PR implements Jetty's hot certificate reload per https://github.com/eclipse/jetty.project/pull/5042

When the keystore changes, the API server begins using the new certificate. Note that this functionality doesn't support live change of keystore password, only certificate.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally with self-signed certs.  Changed the cert in the keystore while management server was running, reloaded the website, and inspected the https certificate.

Tested against `cmk`, which continued to function after the cert change.  Also tested against UI - website needed to be refreshed due to browser security. Perhaps a future enhancement would catch these errors and auto-refresh?

Here you can see the local cloudstack management server using a new cert after it is loaded into a keystore:
```
[root@kvmlab1 management]# echo | openssl s_client -showcerts -connect localhost:8443 2>/dev/null | openssl x509 -inform pem -noout -text | grep "Not Before"
            Not Before: Mar 21 21:09:50 2023 GMT
```
change cert
```
[root@kvmlab1 management]# openssl x509 -req -in cloud.csr -signkey cloud.key > cloud.crt
Signature ok
subject=C = US, ST = UT, L = Alpine, O = Marcus, OU = Marcus, CN = kvmlab1, emailAddress = example@example.com
Getting Private key

[root@kvmlab1 management]# openssl pkcs12 -export -in cloud.crt -inkey cloud.key -name cloud -passout pass:****** > cloud-localhost.pk12

[root@kvmlab1 management]# keytool -importkeystore -srckeystore cloud-localhost.pk12 -srcstoretype PKCS12 -destkeystore cloud.jks  -deststoretype JKS -srcstorepass ****** -deststorepass ******  -destkeypass ****** -noprompt
Importing keystore cloud-localhost.pk12 to cloud.jks...
Warning: Overwriting existing alias cloud in destination keystore
Entry for alias cloud successfully imported.
Import command completed:  1 entries successfully imported, 0 entries failed or cancelled
```
check cert
```
[root@kvmlab1 management]# echo | openssl s_client -showcerts -connect localhost:8443 2>/dev/null | openssl x509 -inform pem -noout -text | grep "Not Before"
            Not Before: Mar 21 21:24:47 2023 GMT
```