### PR TITLE
Allow admin/users to add comments to Management Servers

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/annotation/AnnotationService.java
+++ b/api/src/main/java/org/apache/cloudstack/annotation/AnnotationService.java
@@ -45,7 +45,7 @@ public interface AnnotationService {
         SERVICE_OFFERING(false), DISK_OFFERING(false), NETWORK_OFFERING(false),
         ZONE(false), POD(false), CLUSTER(false), HOST(false), DOMAIN(false),
         PRIMARY_STORAGE(false), SECONDARY_STORAGE(false), VR(false), SYSTEM_VM(false),
-        AUTOSCALE_VM_GROUP(true);
+        AUTOSCALE_VM_GROUP(true), MANAGEMENT_SERVER(false),;
 
         private final boolean usersAllowed;
 

--- a/api/src/main/java/org/apache/cloudstack/api/ApiCommandResourceType.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiCommandResourceType.java
@@ -77,7 +77,8 @@ public enum ApiCommandResourceType {
     Pod(com.cloud.dc.Pod.class),
     VmSnapshot(com.cloud.vm.snapshot.VMSnapshot.class),
     Role(org.apache.cloudstack.acl.Role.class),
-    VpnCustomerGateway(com.cloud.network.Site2SiteCustomerGateway.class);
+    VpnCustomerGateway(com.cloud.network.Site2SiteCustomerGateway.class),
+    ManagementServer(org.apache.cloudstack.management.ManagementServerHost.class);
 
     private final Class<?> clazz;
 

--- a/api/src/main/java/org/apache/cloudstack/management/ManagementServerHost.java
+++ b/api/src/main/java/org/apache/cloudstack/management/ManagementServerHost.java
@@ -16,10 +16,11 @@
 // under the License.
 package org.apache.cloudstack.management;
 
+import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
 
-public interface ManagementServerHost extends InternalIdentity, Identity {
+public interface ManagementServerHost extends InternalIdentity, Identity, ControlledEntity {
     enum State {
         Up, Down, PreparingToShutDown, ReadyToShutDown, ShuttingDown
     }

--- a/framework/cluster/src/main/java/com/cloud/cluster/ManagementServerHostVO.java
+++ b/framework/cluster/src/main/java/com/cloud/cluster/ManagementServerHostVO.java
@@ -125,6 +125,11 @@ public class ManagementServerHostVO implements ManagementServerHost {
     }
 
     @Override
+    public Class<?> getEntityType() {
+        return ManagementServerHost.class;
+    }
+
+    @Override
     public String getName() {
         return name;
     }
@@ -195,5 +200,15 @@ public class ManagementServerHostVO implements ManagementServerHost {
     @Override
     public String toString() {
         return new StringBuilder("ManagementServer[").append("-").append(id).append("-").append(msid).append("-").append(state).append("]").toString();
+    }
+
+    @Override
+    public long getDomainId() {
+        return 1L;
+    }
+
+    @Override
+    public long getAccountId() {
+        return 1L;
     }
 }

--- a/server/src/main/java/org/apache/cloudstack/annotation/AnnotationManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/annotation/AnnotationManagerImpl.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.cluster.ManagementServerHostVO;
 import com.cloud.user.dao.UserDataDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.Role;
@@ -50,6 +51,7 @@ import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
+import com.cloud.cluster.dao.ManagementServerHostDao;
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.HostPodVO;
@@ -158,6 +160,8 @@ public final class AnnotationManagerImpl extends ManagerBase implements Annotati
     @Inject
     private UserDataDao userDataDao;
     @Inject
+    private ManagementServerHostDao managementServerHostDao;
+    @Inject
     EntityManager entityManager;
 
     private static final List<RoleType> adminRoles = Collections.singletonList(RoleType.Admin);
@@ -192,6 +196,7 @@ public final class AnnotationManagerImpl extends ManagerBase implements Annotati
         s_typeMap.put(EntityType.VR, ApiCommandResourceType.DomainRouter);
         s_typeMap.put(EntityType.SYSTEM_VM, ApiCommandResourceType.SystemVm);
         s_typeMap.put(EntityType.AUTOSCALE_VM_GROUP, ApiCommandResourceType.AutoScaleVmGroup);
+        s_typeMap.put(EntityType.MANAGEMENT_SERVER, ApiCommandResourceType.Host);
     }
 
     public List<KubernetesClusterHelper> getKubernetesClusterHelpers() {
@@ -532,6 +537,8 @@ public final class AnnotationManagerImpl extends ManagerBase implements Annotati
                 return kubernetesClusterHelpers.get(0).findByUuid(entityUuid);
             case AUTOSCALE_VM_GROUP:
                 return autoScaleVmGroupDao.findByUuid(entityUuid);
+            case MANAGEMENT_SERVER:
+                return managementServerHostDao.findByUuid(entityUuid);
             default:
                 throw new CloudRuntimeException("Invalid entity type " + type);
         }
@@ -607,6 +614,9 @@ public final class AnnotationManagerImpl extends ManagerBase implements Annotati
             case SYSTEM_VM:
                 VMInstanceVO instance = vmInstanceDao.findByUuid(entityUuid);
                 return instance != null ? instance.getInstanceName() : null;
+            case MANAGEMENT_SERVER:
+                ManagementServerHostVO mgmtServer = managementServerHostDao.findByUuid(entityUuid);
+                return mgmtServer != null ? mgmtServer.getName() : null;
             default:
                 return null;
         }

--- a/test/integration/smoke/test_annotations.py
+++ b/test/integration/smoke/test_annotations.py
@@ -83,6 +83,7 @@ class TestAnnotations(cloudstackTestCase):
         cls.host = list_hosts(cls.apiclient,
                                zoneid=cls.zone.id,
                                type='Routing')[0]
+        cls.mgmt_server = list_mgmt_servers(cls.apiclient)[0]
 
     @classmethod
     def tearDownClass(cls):
@@ -133,6 +134,12 @@ class TestAnnotations(cloudstackTestCase):
     def test_01_add_annotation(self):
         """Testing the addAnnotations API ability to add an annoatation per host"""
         self.addAnnotation("annotation1", self.host.id, "HOST")
+        self.assertEqual(self.added_annotations[-1].annotation.annotation, "annotation1")
+
+    @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
+    def test_01_add_ms_annotation(self):
+        """Testing the addAnnotations API ability to add an annoatation per management server"""
+        self.addAnnotation("annotation1", self.mgmt_server.id, "MANAGEMENT_SERVER")
         self.assertEqual(self.added_annotations[-1].annotation.annotation, "annotation1")
 
     @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")

--- a/test/integration/smoke/test_annotations.py
+++ b/test/integration/smoke/test_annotations.py
@@ -139,8 +139,8 @@ class TestAnnotations(cloudstackTestCase):
     @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
     def test_01_add_ms_annotation(self):
         """Testing the addAnnotations API ability to add an annoatation per management server"""
-        self.addAnnotation("annotation1", self.mgmt_server.id, "MANAGEMENT_SERVER")
-        self.assertEqual(self.added_annotations[-1].annotation.annotation, "annotation1")
+        self.addAnnotation("mgmt-server-annotation1", self.mgmt_server.id, "MANAGEMENT_SERVER")
+        self.assertEqual(self.added_annotations[-1].annotation.annotation, "mgmt-server-annotation1")
 
     @attr(tags=["devcloud", "advanced", "advancedns", "smoke", "basic", "sg"], required_hardware="false")
     def test_02_add_multiple_annotations(self):

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -58,6 +58,7 @@ from marvin.cloudstackAPI import (listConfigurations,
                                   listNetworkOfferings,
                                   listResourceLimits,
                                   listVPCOfferings,
+                                  listManagementServers,
                                   migrateSystemVm)
 from marvin.sshClient import SshClient
 from marvin.codes import (PASS, FAILED, ISOLATED_NETWORK, VPC_NETWORK,
@@ -1056,6 +1057,14 @@ def list_vpc_offerings(apiclient, **kwargs):
         cmd.listall=True
     return(apiclient.listVPCOfferings(cmd))
 
+def list_mgmt_servers(apiclient, **kwargs):
+    """ Lists Management Servers """
+
+    cmd = listManagementServers.listManagementServersCmd()
+    [setattr(cmd, k, v) for k, v in list(kwargs.items())]
+    if 'account' in list(kwargs.keys()) and 'domainid' in list(kwargs.keys()):
+        cmd.listall=True
+    return(apiclient.listManagementServers(cmd))
 
 def update_resource_count(apiclient, domainid, accountid=None,
                           projectid=None, rtype=None):

--- a/ui/src/components/view/AnnotationsTab.vue
+++ b/ui/src/components/view/AnnotationsTab.vue
@@ -192,6 +192,7 @@ export default {
         case 'SystemVm': return 'SYSTEM_VM'
         case 'VirtualRouter': return 'VR'
         case 'AutoScaleVmGroup': return 'AUTOSCALE_VM_GROUP'
+        case 'ManagementServer': return 'MANAGEMENT_SERVER'
         default: return ''
       }
     },

--- a/ui/src/config/section/infra/managementServers.js
+++ b/ui/src/config/section/infra/managementServers.js
@@ -24,6 +24,7 @@ export default {
   icon: 'CloudServerOutlined',
   docHelp: 'conceptsandterminology/concepts.html#management-server-overview',
   permission: ['listManagementServersMetrics'],
+  resourceType: 'ManagementServer',
   columns: () => {
     const fields = ['name', 'state', 'version']
     const metricsFields = ['collectiontime', 'availableprocessors', 'cpuload', 'heapmemoryused', 'agentcount']
@@ -80,6 +81,9 @@ export default {
           value: (record, params) => { return record.id }
         }
       }
+    }, {
+      name: 'comments',
+      component: shallowRef(defineAsyncComponent(() => import('@/components/view/AnnotationsTab.vue')))
     }
   ]
 }


### PR DESCRIPTION
### Description

This PR adds support for annotations to be added for the management server as a resource/type.

As an operator I want to be able to leave a comment for my colleagues concerning one of the management servers in our system. (i.E. an annotation needs to be enabled for mshosts)

Added support in UI/API to facilitate this.



### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
