### PR TITLE
server,engine-schema: fix listing service offering for vm scale

### DIFF
--- a/engine/schema/src/main/java/com/cloud/service/ServiceOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/service/ServiceOfferingVO.java
@@ -22,20 +22,21 @@ import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-import javax.persistence.Id;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.persistence.Enumerated;
-import javax.persistence.EnumType;
+import javax.persistence.Transient;
+
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 import com.cloud.offering.ServiceOffering;
 import com.cloud.utils.db.GenericDao;
 import com.cloud.vm.VirtualMachine;
-import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 @Entity
 @Table(name = "service_offering")
@@ -196,6 +197,7 @@ public class ServiceOfferingVO implements ServiceOffering {
         vmType = offering.getSystemVmType();
         systemUse = offering.isSystemUse();
         dynamicScalingEnabled = offering.isDynamicScalingEnabled();
+        diskOfferingStrictness = offering.diskOfferingStrictness;
     }
 
     @Override

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/vo/ServiceOfferingVO.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/vo/ServiceOfferingVO.java
@@ -149,6 +149,7 @@ public class ServiceOfferingVO implements ServiceOffering {
         vmType = offering.getSystemVmType();
         systemUse = offering.isSystemUse();
         dynamicScalingEnabled = offering.isDynamicScalingEnabled();
+        diskOfferingStrictness = offering.diskOfferingStrictness;
     }
 
     @Override


### PR DESCRIPTION
### Description

Fixes #7389

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Steps
- Create a custom compute offering with `disk_offering_strictness=true`
- Deploy a VM using it
- Stop the VM
- Try to scale VM using UI

Without fix - all other supported offerings are listed UI
With fix - only those supported offerings are listed in UI which use the same disk offering as the current one


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
