### PR TITLE
Fix for direct download templates with multiple bypassed references

### DIFF
--- a/engine/storage/src/test/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImplTest.java
+++ b/engine/storage/src/test/java/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImplTest.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.storage.image.db;
+
+import com.cloud.storage.VMTemplateStorageResourceAssoc;
+import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
+import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TemplateDataStoreDaoImplTest {
+
+    private final TemplateDataStoreDaoImpl dao = new TemplateDataStoreDaoImpl();
+
+    private static final long templateId = 1;
+    private static final long templateSize = 9999;
+
+    @Test
+    public void testGetValidGreaterSizeBypassedTemplateEmptyList() {
+        TemplateDataStoreVO ref = dao.getValidGreaterSizeBypassedTemplate(null, templateId);
+        Assert.assertNull(ref);
+    }
+
+    private TemplateDataStoreVO createNewTestReferenceRecord() {
+        TemplateDataStoreVO ref = new TemplateDataStoreVO();
+        ref.setTemplateId(templateId);
+        ref.setState(ObjectInDataStoreStateMachine.State.Ready);
+        ref.setDownloadState(VMTemplateStorageResourceAssoc.Status.BYPASSED);
+        ref.setSize(templateSize);
+        return ref;
+    }
+
+    @Test
+    public void testGetValidGreaterSizeBypassedTemplateMultipleRecords() {
+        TemplateDataStoreVO ref1 = createNewTestReferenceRecord();
+        TemplateDataStoreVO ref2 = createNewTestReferenceRecord();
+        TemplateDataStoreVO ref3 = createNewTestReferenceRecord();
+        ref1.setSize(1111L);
+        ref3.setSize(2L);
+        TemplateDataStoreVO ref = dao.getValidGreaterSizeBypassedTemplate(Arrays.asList(ref1, ref2, ref3), templateId);
+        Assert.assertNotNull(ref);
+        Assert.assertEquals(templateSize, ref.getSize());
+    }
+
+    @Test
+    public void testGetValidGreaterSizeBypassedTemplateOneRecord() {
+        TemplateDataStoreVO ref1 = createNewTestReferenceRecord();
+        TemplateDataStoreVO ref = dao.getValidGreaterSizeBypassedTemplate(List.of(ref1), templateId);
+        Assert.assertNotNull(ref);
+        Assert.assertEquals(templateSize, ref.getSize());
+    }
+
+    @Test
+    public void testGetValidGreaterSizeBypassedTemplateOneRecordInvalidState() {
+        TemplateDataStoreVO ref1 = createNewTestReferenceRecord();
+        ref1.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOADED);
+        TemplateDataStoreVO ref = dao.getValidGreaterSizeBypassedTemplate(List.of(ref1), templateId);
+        Assert.assertNull(ref);
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes an issue observed on multiple zones and direct download templates on KVM, in which a template gets multiple records on the `template_store_ref` table. When this happens, the template cannot be used as direct download. In case of a system VM template using direct download, system VM deployments fail

````
mysql> select id,store_id,template_id,created,download_state,state from template_store_ref where template_id=233 and state="Ready" and download_state="BYPASSED" and store_id is null;
+----+----------+-------------+---------------------+----------------+-------+
| id | store_id | template_id | created             | download_state | state |
+----+----------+-------------+---------------------+----------------+-------+
| 37 |     NULL |         233 | 2022-10-25 14:08:04 | BYPASSED       | Ready |
| 55 |     NULL |         233 | 2022-12-19 19:39:55 | BYPASSED       | Ready |
+----+----------+-------------+---------------------+----------------+-------+
````

````
2023-03-10 16:33:49,090 INFO  [o.a.c.e.o.VolumeOrchestrator] (consoleproxy-1:ctx-4dfae95a ctx-6bc31aad) (logid:fbb8b2fb) adding disk object ROOT-15571 to v-15571-VM
2023-03-10 16:33:49,097 DEBUG [c.c.u.d.T.Transaction] (consoleproxy-1:ctx-4dfae95a) (logid:fbb8b2fb) Rolling back the transaction: Time = 132 Name =  consoleproxy-1; called by -TransactionLegacy.rollback:888-TransactionLegacy.removeUpTo:831-TransactionLegacy.close:655-Transaction.execute:38-VirtualMachineManagerImpl.allocate:470-VirtualMachineManagerImpl.allocate:535-ConsoleProxyManagerImpl.createProxyInstance:699-ConsoleProxyManagerImpl.startNew:571-ConsoleProxyManagerImpl.allocCapacity:808-ConsoleProxyManagerImpl.expandPool:1538-ConsoleProxyManagerImpl.expandPool:165-SystemVmLoadScanner.loadScan:121
2023-03-10 16:33:49,103 WARN  [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:ctx-4dfae95a) (logid:fbb8b2fb) Unable to allocate console proxy standby capacity for zone [1] due to [Template 233 has not been completely downloaded to zone 1].
com.cloud.utils.exception.CloudRuntimeException: Template 233 has not been completely downloaded to zone 1
    at com.cloud.template.TemplateManagerImpl.getTemplateSize(TemplateManagerImpl.java:2021)
    at jdk.internal.reflect.GeneratedMethodAccessor940.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
    at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
    at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
    at com.sun.proxy.$Proxy215.getTemplateSize(Unknown Source)
    at org.apache.cloudstack.engine.orchestration.VolumeOrchestrator.allocateTemplatedVolume(VolumeOrchestrator.java:874)
    at org.apache.cloudstack.engine.orchestration.VolumeOrchestrator.allocateTemplatedVolumes(VolumeOrchestrator.java:995)
````

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Register a direct download template for all zones
- Add a new zone
- Observe multiple BYPASSED records on the template_store_ref table
