### PR TITLE
Enable defining a network as redundant during restart through the UI

### DIFF
--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -2992,7 +2992,6 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
         User callerUser = _accountMgr.getActiveUser(CallContext.current().getCallingUserId());
         if (makeRedundant && !_accountMgr.isRootAdmin(callerUser.getAccountId()) && !AllowUsersToMakeNetworksRedundant.value() ) {
             throw new InvalidParameterValueException("Could not make the network redundant. Please contact administrator.");
-                    AllowUsersToMakeNetworksRedundant.key()));
         }
 
         boolean livePatch = cmd.getLivePatch();

--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -2991,7 +2991,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
         boolean makeRedundant = cmd.getMakeRedundant();
         User callerUser = _accountMgr.getActiveUser(CallContext.current().getCallingUserId());
         if (makeRedundant && !_accountMgr.isRootAdmin(callerUser.getAccountId()) && !AllowUsersToMakeNetworksRedundant.value() ) {
-            throw new InvalidParameterValueException(String.format("Could not make network redundant as calling user is not Root Admin and [%s] is set to false.",
+            throw new InvalidParameterValueException("Could not make the network redundant. Please contact administrator.");
                     AllowUsersToMakeNetworksRedundant.key()));
         }
 

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -95,6 +95,7 @@
     ]
   },
   "plugins": [],
+  "allowMakingRouterRedundant": false,
   "apidocs": true,
   "basicZoneEnabled": true,
   "multipleServer": false,

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -171,13 +171,16 @@ export default {
             if (isGroupAction || record.vpcid == null) {
               fields.push('cleanup')
             }
+            if (!record.redundantrouter) {
+              fields.push('makeredundant')
+            }
             fields.push('livepatch')
             return fields
           },
           show: (record) => record.type !== 'L2',
           groupAction: true,
           popup: true,
-          groupMap: (selection, values) => { return selection.map(x => { return { id: x, cleanup: values.cleanup } }) }
+          groupMap: (selection, values) => { return selection.map(x => { return { id: x, cleanup: values.cleanup, makeredundant: values.makeredundant } }) }
         },
         {
           api: 'replaceNetworkACLList',

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -20,6 +20,7 @@ import store from '@/store'
 import tungsten from '@/assets/icons/tungsten.svg?inline'
 import { isAdmin } from '@/role'
 import { isZoneCreated } from '@/utils/zone'
+import { vueProps } from '@/vue-app'
 
 export default {
   name: 'network',
@@ -171,7 +172,7 @@ export default {
             if (isGroupAction || record.vpcid == null) {
               fields.push('cleanup')
             }
-            if (!record.redundantrouter) {
+            if (!record.redundantrouter && vueProps.$config.allowMakingRouterRedundant) {
               fields.push('makeredundant')
             }
             fields.push('livepatch')


### PR DESCRIPTION
### Description

By utilizing the `restartNetwork` API and setting the `makeredundant` parameter to true, ACS allows the user to make a guest network redundant during its restart process; however, this feature was only available through the API.
An adjustment was made to add this functionality to the UI.
### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/49285692/230111548-58fb8645-e893-4e9f-adce-0bb26a279456.png)
