### PR TITLE
server: validate ip address value on update config

### DIFF
--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
@@ -16,22 +16,37 @@
 // under the License.
 package com.cloud.configuration;
 
-import com.cloud.utils.net.NetUtils;
+import java.util.List;
+
+import org.apache.cloudstack.framework.config.ConfigDepot;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.List;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.storage.StorageManager;
+import com.cloud.utils.net.NetUtils;
 
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(NetUtils.class)
 public class ConfigurationManagerImplTest {
+    @Mock
+    ConfigDepot configDepot;
     ConfigurationManagerImpl configurationManagerImplSpy = Mockito.spy(new ConfigurationManagerImpl());
+
+    @Before
+    public void setUp() throws Exception {
+        configurationManagerImplSpy._configDepot = configDepot;
+    }
+
     @Test
     public void validateIfIntValueIsInRangeTestValidValueReturnNull() {
         String testVariable = configurationManagerImplSpy.validateIfIntValueIsInRange("String name", "3", "1-5");
@@ -190,5 +205,51 @@ public class ConfigurationManagerImplTest {
     public void validateRangeOtherTestInvalidValueReturnString() {
         String testVariable = configurationManagerImplSpy.validateRangeOther("NameTest1", "ThisShouldNotWork", "ThisShouldWork,ThisShouldAlsoWork,SoShouldThis");
         Assert.assertNotNull(testVariable);
+    }
+
+    @Test
+    public void testValidateIpAddressRelatedConfigValuesUnrelated() {
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues(StorageManager.PreferredStoragePool.key(), "something");
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.ip", "");
+        Mockito.when(configurationManagerImplSpy._configDepot.get("config.ip")).thenReturn(null);
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.ip", "something");
+        ConfigKey<?> key = StorageManager.MountDisabledStoragePool;
+        Mockito.doReturn(key).when(configurationManagerImplSpy._configDepot).get(StorageManager.MountDisabledStoragePool.key());
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues(StorageManager.MountDisabledStoragePool.key(), "false");
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateIpAddressRelatedConfigValuesInvalidIp() {
+        ConfigKey<String> key = StorageManager.PreferredStoragePool; // Any ConfigKey of String type
+        Mockito.doReturn(key).when(configurationManagerImplSpy._configDepot).get("config.ip");
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.ip", "abcdefg");
+    }
+
+    @Test
+    public void testValidateIpAddressRelatedConfigValuesValidIp() {
+        ConfigKey<String> key = StorageManager.PreferredStoragePool; // Any ConfigKey of String type
+        Mockito.doReturn(key).when(configurationManagerImplSpy._configDepot).get("config.ip");
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.ip", "192.168.1.1");
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateIpAddressRelatedConfigValuesInvalidIpRange() {
+        ConfigKey<String> key = StorageManager.PreferredStoragePool; // Any ConfigKey of String type. RemoteAccessVpnManagerImpl.RemoteAccessVpnClientIpRange not accessible here
+        Mockito.doReturn(key).when(configurationManagerImplSpy._configDepot).get("config.iprange");
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.iprange", "xyz-192.168.1.20");
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateIpAddressRelatedConfigValuesInvalidIpRange1() {
+        ConfigKey<String> key = StorageManager.PreferredStoragePool; // Any ConfigKey of String type. RemoteAccessVpnManagerImpl.RemoteAccessVpnClientIpRange not accessible here
+        Mockito.doReturn(key).when(configurationManagerImplSpy._configDepot).get("config.iprange");
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.iprange", "192.168.1.20");
+    }
+
+    @Test
+    public void testValidateIpAddressRelatedConfigValuesValidIpRange() {
+        ConfigKey<String> key = StorageManager.PreferredStoragePool; // Any ConfigKey of String type. RemoteAccessVpnManagerImpl.RemoteAccessVpnClientIpRange not accessible here
+        Mockito.doReturn(key).when(configurationManagerImplSpy._configDepot).get("config.iprange");
+        configurationManagerImplSpy.validateIpAddressRelatedConfigValues("config.iprange", "192.168.1.1-192.168.1.100");
     }
 }


### PR DESCRIPTION
### Description

Fixes #6958

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
Using cmk passing valid and invalid IP range,

```
(local) 🍀 > list configurations name="remote.access.vpn.client.iprange"
{
  "configuration": [
    {
      "category": "Network",
      "component": "RemoteAccessVpnService",
      "defaultvalue": "10.1.2.1-10.1.2.8",
      "description": "The range of ips to be allocated to remote access vpn clients. The first ip in the range is used by the VPN server",
      "displaytext": "Remote access vpn client iprange",
      "group": "Miscellaneous",
      "isdynamic": false,
      "name": "remote.access.vpn.client.iprange",
      "subgroup": "Others",
      "type": "String",
      "value": "10.1.2.1-10.1.2.8"
    }
  ],
  "count": 1
}
(local) 🐃 > update configuration name="remote.access.vpn.client.iprange" value="10.1.2.1-10.1.2"
🙈 Error: (HTTP 431, error code 4350) Invalid IP address value(s) specified for the config value
(local) 🐘 > update configuration name="remote.access.vpn.client.iprange" value="10.1.2.1-10.1.2.10"
{
  "configuration": {
    "category": "Network",
    "component": "RemoteAccessVpnService",
    "defaultvalue": "10.1.2.1-10.1.2.8",
    "description": "The range of ips to be allocated to remote access vpn clients. The first ip in the range is used by the VPN server",
    "displaytext": "Remote access vpn client iprange",
    "group": "Miscellaneous",
    "isdynamic": false,
    "name": "remote.access.vpn.client.iprange",
    "subgroup": "Others",
    "type": "String",
    "value": "10.1.2.1-10.1.2.10"
  }
}
```