### PR TITLE
remove supportedOwner from Resource.ResourceType

### DIFF
--- a/api/src/main/java/com/cloud/configuration/Resource.java
+++ b/api/src/main/java/com/cloud/configuration/Resource.java
@@ -22,53 +22,32 @@ public interface Resource {
     String UNLIMITED = "Unlimited";
 
     enum ResourceType { // Primary and Secondary storage are allocated_storage and not the physical storage.
-        user_vm("user_vm", 0, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        public_ip("public_ip", 1, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        volume("volume", 2, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        snapshot("snapshot", 3, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        template("template", 4, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        project("project", 5, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        network("network", 6, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        vpc("vpc", 7, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        cpu("cpu", 8, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        memory("memory", 9, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        primary_storage("primary_storage", 10, ResourceOwnerType.Account, ResourceOwnerType.Domain),
-        secondary_storage("secondary_storage", 11, ResourceOwnerType.Account, ResourceOwnerType.Domain);
+        user_vm("user_vm", 0),
+        public_ip("public_ip", 1),
+        volume("volume", 2),
+        snapshot("snapshot", 3),
+        template("template", 4),
+        project("project", 5),
+        network("network", 6),
+        vpc("vpc", 7),
+        cpu("cpu", 8),
+        memory("memory", 9),
+        primary_storage("primary_storage", 10),
+        secondary_storage("secondary_storage", 11);
 
         private String name;
-        private ResourceOwnerType[] supportedOwners;
         private int ordinal;
         public static final long bytesToKiB = 1024;
         public static final long bytesToMiB = bytesToKiB * 1024;
         public static final long bytesToGiB = bytesToMiB * 1024;
 
-        ResourceType(String name, int ordinal, ResourceOwnerType... supportedOwners) {
+        ResourceType(String name, int ordinal) {
             this.name = name;
-            this.supportedOwners = supportedOwners;
             this.ordinal = ordinal;
         }
 
         public String getName() {
             return name;
-        }
-
-        public ResourceOwnerType[] getSupportedOwners() {
-            return supportedOwners;
-        }
-
-        public boolean supportsOwner(ResourceOwnerType ownerType) {
-            boolean success = false;
-            if (supportedOwners != null) {
-                int length = supportedOwners.length;
-                for (int i = 0; i < length; i++) {
-                    if (supportedOwners[i].getName().equalsIgnoreCase(ownerType.getName())) {
-                        success = true;
-                        break;
-                    }
-                }
-            }
-
-            return success;
         }
 
         public int getOrdinal() {

--- a/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDaoImpl.java
@@ -36,7 +36,6 @@ import com.cloud.configuration.ResourceCountVO;
 import com.cloud.configuration.ResourceLimit;
 import com.cloud.domain.DomainVO;
 import com.cloud.domain.dao.DomainDao;
-import com.cloud.exception.UnsupportedServiceException;
 import com.cloud.user.AccountVO;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.db.DB;
@@ -171,9 +170,6 @@ public class ResourceCountDaoImpl extends GenericDaoBase<ResourceCountVO, Long> 
 
         ResourceType[] resourceTypes = Resource.ResourceType.values();
         for (ResourceType resourceType : resourceTypes) {
-            if (!resourceType.supportsOwner(ownerType)) {
-                continue;
-            }
             ResourceCountVO resourceCountVO = new ResourceCountVO(resourceType, 0, ownerId, ownerType);
             persist(resourceCountVO);
         }
@@ -215,17 +211,6 @@ public class ResourceCountDaoImpl extends GenericDaoBase<ResourceCountVO, Long> 
         } else {
             return new ArrayList<ResourceCountVO>();
         }
-    }
-
-    @Override
-    public ResourceCountVO persist(ResourceCountVO resourceCountVO) {
-        ResourceOwnerType ownerType = resourceCountVO.getResourceOwnerType();
-        ResourceType resourceType = resourceCountVO.getType();
-        if (!resourceType.supportsOwner(ownerType)) {
-            throw new UnsupportedServiceException("Resource type " + resourceType + " is not supported for owner of type " + ownerType.getName());
-        }
-
-        return super.persist(resourceCountVO);
     }
 
     @Override

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -1315,22 +1315,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         List<ResourceCountVO> domainResourceCount = _resourceCountDao.listResourceCountByOwnerType(ResourceOwnerType.Domain);
         List<ResourceCountVO> accountResourceCount = _resourceCountDao.listResourceCountByOwnerType(ResourceOwnerType.Account);
 
-        final List<ResourceType> accountSupportedResourceTypes = new ArrayList<ResourceType>();
-        final List<ResourceType> domainSupportedResourceTypes = new ArrayList<ResourceType>();
+        final int expectedCount = resourceTypes.length;
 
-        for (ResourceType resourceType : resourceTypes) {
-            if (resourceType.supportsOwner(ResourceOwnerType.Account)) {
-                accountSupportedResourceTypes.add(resourceType);
-            }
-            if (resourceType.supportsOwner(ResourceOwnerType.Domain)) {
-                domainSupportedResourceTypes.add(resourceType);
-            }
-        }
-
-        final int accountExpectedCount = accountSupportedResourceTypes.size();
-        final int domainExpectedCount = domainSupportedResourceTypes.size();
-
-        if ((domainResourceCount.size() < domainExpectedCount * domains.size())) {
+        if ((domainResourceCount.size() < expectedCount * domains.size())) {
             s_logger.debug("resource_count table has records missing for some domains...going to insert them");
             for (final DomainVO domain : domains) {
                 // Lock domain
@@ -1344,8 +1331,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                             domainCountStr.add(domainCount.getType().toString());
                         }
 
-                        if (domainCountStr.size() < domainExpectedCount) {
-                            for (ResourceType resourceType : domainSupportedResourceTypes) {
+                        if (domainCountStr.size() < expectedCount) {
+                            for (ResourceType resourceType : resourceTypes) {
                                 if (!domainCountStr.contains(resourceType.toString())) {
                                     ResourceCountVO resourceCountVO = new ResourceCountVO(resourceType, 0, domain.getId(), ResourceOwnerType.Domain);
                                     s_logger.debug("Inserting resource count of type " + resourceType + " for domain id=" + domain.getId());
@@ -1359,7 +1346,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             }
         }
 
-        if ((accountResourceCount.size() < accountExpectedCount * accounts.size())) {
+        if ((accountResourceCount.size() < expectedCount * accounts.size())) {
             s_logger.debug("resource_count table has records missing for some accounts...going to insert them");
             for (final AccountVO account : accounts) {
                 // lock account
@@ -1373,8 +1360,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                             accountCountStr.add(accountCount.getType().toString());
                         }
 
-                        if (accountCountStr.size() < accountExpectedCount) {
-                            for (ResourceType resourceType : accountSupportedResourceTypes) {
+                        if (accountCountStr.size() < expectedCount) {
+                            for (ResourceType resourceType : resourceTypes) {
                                 if (!accountCountStr.contains(resourceType.toString())) {
                                     ResourceCountVO resourceCountVO = new ResourceCountVO(resourceType, 0, account.getId(), ResourceOwnerType.Account);
                                     s_logger.debug("Inserting resource count of type " + resourceType + " for account id=" + account.getId());


### PR DESCRIPTION
### Description

The `ResourceType` enum, which is part of the `Resource` interface, includes an argument called `supportedOwners` that is used to indicate which types of owners are supported - either Domain, Account or both. However, every type of owner enumerated is supported by both options, making this validation unnecessary.

This argument has been removed, along with its getter method.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor
