### PR TITLE
api,server: fix VM.CREATE events on vm deploy without start

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -54,6 +54,8 @@ import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.LogLevel;
@@ -74,9 +76,6 @@ import com.cloud.utils.net.Dhcp;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VmDetailConstants;
-
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 
 @APICommand(name = "deployVirtualMachine", description = "Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
@@ -766,32 +765,28 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     public void execute() {
         UserVm result;
 
-        if (getStartVm()) {
-            try {
-                CallContext.current().setEventDetails("Vm Id: " + getEntityUuid());
-                result = _userVmService.startVirtualMachine(this);
-            } catch (ResourceUnavailableException ex) {
-                s_logger.warn("Exception: ", ex);
-                throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, ex.getMessage());
-            } catch (ResourceAllocationException ex) {
-                s_logger.warn("Exception: ", ex);
-                throw new ServerApiException(ApiErrorCode.RESOURCE_ALLOCATION_ERROR, ex.getMessage());
-            } catch (ConcurrentOperationException ex) {
-                s_logger.warn("Exception: ", ex);
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
-            } catch (InsufficientCapacityException ex) {
-                StringBuilder message = new StringBuilder(ex.getMessage());
-                if (ex instanceof InsufficientServerCapacityException) {
-                    if (((InsufficientServerCapacityException)ex).isAffinityApplied()) {
-                        message.append(", Please check the affinity groups provided, there may not be sufficient capacity to follow them");
-                    }
+        try {
+            CallContext.current().setEventDetails("Vm Id: " + getEntityUuid());
+            result = _userVmService.startVirtualMachine(this);
+        } catch (ResourceUnavailableException ex) {
+            s_logger.warn("Exception: ", ex);
+            throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, ex.getMessage());
+        } catch (ResourceAllocationException ex) {
+            s_logger.warn("Exception: ", ex);
+            throw new ServerApiException(ApiErrorCode.RESOURCE_ALLOCATION_ERROR, ex.getMessage());
+        } catch (ConcurrentOperationException ex) {
+            s_logger.warn("Exception: ", ex);
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
+        } catch (InsufficientCapacityException ex) {
+            StringBuilder message = new StringBuilder(ex.getMessage());
+            if (ex instanceof InsufficientServerCapacityException) {
+                if (((InsufficientServerCapacityException)ex).isAffinityApplied()) {
+                    message.append(", Please check the affinity groups provided, there may not be sufficient capacity to follow them");
                 }
-                s_logger.info(ex);
-                s_logger.info(message.toString(), ex);
-                throw new ServerApiException(ApiErrorCode.INSUFFICIENT_CAPACITY_ERROR, message.toString());
             }
-        } else {
-            result = _userVmService.getUserVm(getEntityId());
+            s_logger.info(ex);
+            s_logger.info(message.toString(), ex);
+            throw new ServerApiException(ApiErrorCode.INSUFFICIENT_CAPACITY_ERROR, message.toString());
         }
 
         if (result != null) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4810,7 +4810,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     }
 
     @Override
-    @ActionEvent(eventType = EventTypes.EVENT_VM_CREATE, eventDescription = "starting Vm", async = true)
+    @ActionEvent(eventType = EventTypes.EVENT_VM_CREATE, eventDescription = "deploying Vm", async = true)
     public UserVm startVirtualMachine(DeployVMCmd cmd) throws ResourceUnavailableException, InsufficientCapacityException, ConcurrentOperationException, ResourceAllocationException {
         long vmId = cmd.getEntityId();
         if (!cmd.getStartVm()) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -51,7 +51,6 @@ import javax.naming.ConfigurationException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
-import com.cloud.resourcelimit.CheckedReservation;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -279,6 +278,7 @@ import com.cloud.org.Cluster;
 import com.cloud.org.Grouping;
 import com.cloud.resource.ResourceManager;
 import com.cloud.resource.ResourceState;
+import com.cloud.resourcelimit.CheckedReservation;
 import com.cloud.server.ManagementService;
 import com.cloud.server.ResourceTag;
 import com.cloud.server.StatsCollector;
@@ -323,6 +323,7 @@ import com.cloud.user.AccountService;
 import com.cloud.user.ResourceLimitService;
 import com.cloud.user.SSHKeyPairVO;
 import com.cloud.user.User;
+import com.cloud.user.UserData;
 import com.cloud.user.UserStatisticsVO;
 import com.cloud.user.UserVO;
 import com.cloud.user.VmDiskStatisticsVO;
@@ -332,7 +333,6 @@ import com.cloud.user.dao.UserDao;
 import com.cloud.user.dao.UserDataDao;
 import com.cloud.user.dao.UserStatisticsDao;
 import com.cloud.user.dao.VmDiskStatisticsDao;
-import com.cloud.user.UserData;
 import com.cloud.uservm.UserVm;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.Journal;
@@ -4813,6 +4813,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     @ActionEvent(eventType = EventTypes.EVENT_VM_CREATE, eventDescription = "starting Vm", async = true)
     public UserVm startVirtualMachine(DeployVMCmd cmd) throws ResourceUnavailableException, InsufficientCapacityException, ConcurrentOperationException, ResourceAllocationException {
         long vmId = cmd.getEntityId();
+        if (!cmd.getStartVm()) {
+            return getUserVm(vmId);
+        }
         Long podId = null;
         Long clusterId = null;
         Long hostId = cmd.getHostId();


### PR DESCRIPTION
### Description

Fixes #6697

Allows the server to generate started and completed events for VM.CREATE event type when VM is deployed with startvm=false.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

https://user-images.githubusercontent.com/153340/231080758-4de924a6-f7c1-4eb3-bbcb-db9030b3fa58.mp4

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Without fix (tested deplovm with and without start. VM.CREATE is not published as completed when startvm=false):
```
(local) 🦇 > deploy virtualmachine zoneid=104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54 templateid=9f4b9f63-ed72-11ed-a4b9-645d8651f45a serviceofferingid=fca539e1-5b51-4b2f-a162-19a0594ca1fc name=no-fix-start
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2023-05-08T13:26:12+0530",
    "details": {},
    "displayname": "no-fix-start",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2b10df2a-ed72-11ed-a4b9-645d8651f45a",
    "guestosid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "haenable": false,
    "hasannotations": false,
    "hostcontrolstate": "Enabled",
    "hostid": "39d90d82-d64c-4691-bb11-8974475fedeb",
    "hostname": "SimulatedAgent.6642a6a9-2fb8-4d12-92cf-0237c21089aa",
    "hypervisor": "Simulator",
    "id": "915064ca-d5a6-493f-a4c8-f06ab0c606d8",
    "instancename": "i-2-3-VM",
    "isdynamicallyscalable": false,
    "jobid": "4c234e63-d735-41ad-aeda-ce5f5300d8f2",
    "jobstatus": 0,
    "lastupdated": "2023-05-08T13:26:15+0530",
    "memory": 512,
    "name": "no-fix-start",
    "nic": [
      {
        "broadcasturi": "vlan://123",
        "deviceid": "0",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "3fcf85d8-78a9-47ab-90d3-147b5a8f84a8",
        "ipaddress": "10.1.1.128",
        "isdefault": true,
        "isolationuri": "vlan://123",
        "macaddress": "02:00:2e:35:00:01",
        "netmask": "255.255.255.0",
        "networkid": "0515986f-28cd-4a31-9eec-63535f7166d7",
        "networkname": "admin-network",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "fca539e1-5b51-4b2f-a162-19a0594ca1fc",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "templateid": "9f4b9f63-ed72-11ed-a4b9-645d8651f45a",
    "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "userid": "2b11cbb8-ed72-11ed-a4b9-645d8651f45a",
    "username": "admin",
    "zoneid": "104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🐣 > list events filter=id,type,description,state pagesize=10 page=1
{
  "count": 8,
  "event": [
    {
      "description": "Successfully completed starting Vm. Vm Id: 915064ca-d5a6-493f-a4c8-f06ab0c606d8",
      "id": "cd9c2bc8-cc28-417f-8dea-7e3ee6e46914",
      "state": "Completed",
      "type": "VM.CREATE"
    },
    {
      "description": "Assigned Zone Vlan: 123 Network Id: 204",
      "id": "384bbe1d-4c80-4516-b1c7-7e15abf6bfae",
      "state": "Completed",
      "type": "ZONE.VLAN.ASSIGN"
    },
    {
      "description": "Successfully created entity for creating firewall rule",
      "id": "081c70cb-50fb-4a98-978a-efbc0414293e",
      "state": "Created",
      "type": "FIREWALL.OPEN"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: 275df8d6-ddbe-4baa-868a-a659a58c3714 Vm Id: 84322306-0090-4267-9067-7f5636d01cd0",
      "id": "91fcad75-f3b6-434a-85e1-5515ed6a0e67",
      "state": "Created",
      "type": "VOLUME.CREATE"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: 1d30c846-54f5-4ed9-a920-9693c79e8565 Vm Id: 915064ca-d5a6-493f-a4c8-f06ab0c606d8",
      "id": "a2c86302-8036-479c-998b-5282e806c709",
      "state": "Created",
      "type": "VOLUME.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: 915064ca-d5a6-493f-a4c8-f06ab0c606d8",
      "id": "8c5de74b-58ae-473c-9ce3-0231b5a5964c",
      "state": "Scheduled",
      "type": "VM.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: 915064ca-d5a6-493f-a4c8-f06ab0c606d8",
      "id": "a1675755-dc7c-4791-9454-2d257af3749f",
      "state": "Started",
      "type": "VM.CREATE"
    },
    {
      "description": "user has logged in from IP Address /127.0.0.1",
      "id": "83278bb1-7f7d-4543-a035-baebc997fe7a",
      "state": "Completed",
      "type": "USER.LOGIN"
    }
  ]
}
(local) 🕷 > deploy virtualmachine zoneid=104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54 templateid=9f4b9f63-ed72-11ed-a4b9-645d8651f45a serviceofferingid=fca539e1-5b51-4b2f-a162-19a0594ca1fc startvm=false name=no-fix-no-start
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2023-05-08T13:27:48+0530",
    "details": {
      "deployvm": "true"
    },
    "displayname": "no-fix-no-start",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2b10df2a-ed72-11ed-a4b9-645d8651f45a",
    "guestosid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "haenable": false,
    "hasannotations": false,
    "hypervisor": "Simulator",
    "id": "e4f30c4a-d9cd-4f46-a86e-eb702533c662",
    "instancename": "i-2-5-VM",
    "isdynamicallyscalable": false,
    "jobid": "f0492d42-20de-4ba3-9289-c374c574c1e7",
    "jobstatus": 0,
    "memory": 512,
    "name": "no-fix-no-start",
    "nic": [
      {
        "broadcasturi": "vlan://123",
        "deviceid": "0",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "37783efa-8acf-453f-bc97-ba50714907b7",
        "ipaddress": "10.1.1.113",
        "isdefault": true,
        "isolationuri": "vlan://123",
        "macaddress": "02:00:31:5b:00:03",
        "netmask": "255.255.255.0",
        "networkid": "0515986f-28cd-4a31-9eec-63535f7166d7",
        "networkname": "admin-network",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "passwordenabled": false,
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "fca539e1-5b51-4b2f-a162-19a0594ca1fc",
    "serviceofferingname": "Small Instance",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "templateid": "9f4b9f63-ed72-11ed-a4b9-645d8651f45a",
    "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "userid": "2b11cbb8-ed72-11ed-a4b9-645d8651f45a",
    "username": "admin",
    "zoneid": "104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🦍 > list events filter=id,type,description,state pagesize=6 page=1
{
  "count": 10,
  "event": [
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: 71bd070e-b2e3-4543-b23a-6052efc64dd2 Vm Id: e4f30c4a-d9cd-4f46-a86e-eb702533c662",
      "id": "f472d5ed-3a6f-4ebf-9123-f303b2fc216b",
      "state": "Created",
      "type": "VOLUME.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: e4f30c4a-d9cd-4f46-a86e-eb702533c662",
      "id": "c509137b-f3c9-4629-bea9-abca852a50e8",
      "state": "Scheduled",
      "type": "VM.CREATE"
    },
    {
      "description": "Successfully completed starting Vm. Vm Id: 915064ca-d5a6-493f-a4c8-f06ab0c606d8",
      "id": "cd9c2bc8-cc28-417f-8dea-7e3ee6e46914",
      "state": "Completed",
      "type": "VM.CREATE"
    },
    {
      "description": "Assigned Zone Vlan: 123 Network Id: 204",
      "id": "384bbe1d-4c80-4516-b1c7-7e15abf6bfae",
      "state": "Completed",
      "type": "ZONE.VLAN.ASSIGN"
    },
    {
      "description": "Successfully created entity for creating firewall rule",
      "id": "081c70cb-50fb-4a98-978a-efbc0414293e",
      "state": "Created",
      "type": "FIREWALL.OPEN"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: 275df8d6-ddbe-4baa-868a-a659a58c3714 Vm Id: 84322306-0090-4267-9067-7f5636d01cd0",
      "id": "91fcad75-f3b6-434a-85e1-5515ed6a0e67",
      "state": "Created",
      "type": "VOLUME.CREATE"
    }
  ]
}

```

**With fix (VM.CREATE as completed is published even with startvm=false)**
```
(local) 🐣 > deploy virtualmachine zoneid=104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54 templateid=9f4b9f63-ed72-11ed-a4b9-645d8651f45a serviceofferingid=fca539e1-5b51-4b2f-a162-19a0594ca1fc name=fix-start
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "bootmode": "legacy",
    "boottype": "Bios",
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2023-05-08T13:47:49+0530",
    "details": {},
    "displayname": "fix-start",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2b10df2a-ed72-11ed-a4b9-645d8651f45a",
    "guestosid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "haenable": false,
    "hasannotations": false,
    "hostcontrolstate": "Enabled",
    "hostid": "ae82f829-5fba-49b5-8c77-645f48c64918",
    "hostname": "SimulatedAgent.2bc85dd9-7015-485a-8225-569c4058ac6d",
    "hypervisor": "Simulator",
    "id": "5d8dd74a-efc3-414b-9966-61553223a73a",
    "instancename": "i-2-6-QA",
    "isdynamicallyscalable": false,
    "jobid": "388f779f-9cdf-448c-b98e-b87c41f56566",
    "jobstatus": 0,
    "lastupdated": "2023-05-08T13:47:51+0530",
    "memory": 512,
    "name": "fix-start",
    "nic": [
      {
        "broadcasturi": "vlan://123",
        "deviceid": "0",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "3a4c5f63-2d6d-4d35-b183-1416deb26f42",
        "ipaddress": "10.1.1.170",
        "isdefault": true,
        "isolationuri": "vlan://123",
        "macaddress": "02:00:59:1e:00:04",
        "netmask": "255.255.255.0",
        "networkid": "0515986f-28cd-4a31-9eec-63535f7166d7",
        "networkname": "admin-network",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "fca539e1-5b51-4b2f-a162-19a0594ca1fc",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "templateid": "9f4b9f63-ed72-11ed-a4b9-645d8651f45a",
    "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "userid": "2b11cbb8-ed72-11ed-a4b9-645d8651f45a",
    "username": "admin",
    "zoneid": "104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🐓 > list events filter=id,type,description,state pagesize=8 page=1
{
  "count": 15,
  "event": [
    {
      "description": "Successfully completed deploying Vm. Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "e55c9bf2-ad3d-49b7-9acc-1eecb25e370a",
      "state": "Completed",
      "type": "VM.CREATE"
    },
    {
      "description": "user has logged in from IP Address /127.0.0.1",
      "id": "2e1dfa11-3780-47b9-b86b-21f1b3d471b0",
      "state": "Completed",
      "type": "USER.LOGIN"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: e4dd0164-de81-41e7-b64e-5d84d46614b7 Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "02df99c3-e7f3-402d-8d2d-56d1f117ecc5",
      "state": "Created",
      "type": "VOLUME.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "bb09ddf4-e266-437a-8bc1-61cbde7094d2",
      "state": "Scheduled",
      "type": "VM.CREATE"
    },
    {
      "description": "deploying Vm. Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "9ae51b12-22cc-4dd9-8b40-0b499a7df897",
      "state": "Started",
      "type": "VM.CREATE"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: 71bd070e-b2e3-4543-b23a-6052efc64dd2 Vm Id: e4f30c4a-d9cd-4f46-a86e-eb702533c662",
      "id": "f472d5ed-3a6f-4ebf-9123-f303b2fc216b",
      "state": "Created",
      "type": "VOLUME.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: e4f30c4a-d9cd-4f46-a86e-eb702533c662",
      "id": "c509137b-f3c9-4629-bea9-abca852a50e8",
      "state": "Scheduled",
      "type": "VM.CREATE"
    },
    {
      "description": "Successfully completed starting Vm. Vm Id: 915064ca-d5a6-493f-a4c8-f06ab0c606d8",
      "id": "cd9c2bc8-cc28-417f-8dea-7e3ee6e46914",
      "state": "Completed",
      "type": "VM.CREATE"
    }
  ]
}
(local) 🐓 > deploy virtualmachine zoneid=104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54 templateid=9f4b9f63-ed72-11ed-a4b9-645d8651f45a serviceofferingid=fca539e1-5b51-4b2f-a162-19a0594ca1fc startvm=false name=fix-no-start
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2023-05-08T13:48:34+0530",
    "details": {
      "deployvm": "true"
    },
    "displayname": "fix-no-start",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "2b10df2a-ed72-11ed-a4b9-645d8651f45a",
    "guestosid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "haenable": false,
    "hasannotations": false,
    "hypervisor": "Simulator",
    "id": "0434ffb3-2006-4e93-8c25-089803851377",
    "instancename": "i-2-7-QA",
    "isdynamicallyscalable": false,
    "jobid": "2b0c517a-f60f-4051-a0fa-7e27378ae804",
    "jobstatus": 0,
    "memory": 512,
    "name": "fix-no-start",
    "nic": [
      {
        "broadcasturi": "vlan://123",
        "deviceid": "0",
        "extradhcpoption": [],
        "gateway": "10.1.1.1",
        "id": "30541ce3-4559-4975-b17c-a998a3aba88a",
        "ipaddress": "10.1.1.250",
        "isdefault": true,
        "isolationuri": "vlan://123",
        "macaddress": "02:00:05:dd:00:05",
        "netmask": "255.255.255.0",
        "networkid": "0515986f-28cd-4a31-9eec-63535f7166d7",
        "networkname": "admin-network",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "Isolated"
      }
    ],
    "osdisplayname": "CentOS 5.6 (64-bit)",
    "ostypeid": "2aff87a2-ed72-11ed-a4b9-645d8651f45a",
    "passwordenabled": false,
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "fca539e1-5b51-4b2f-a162-19a0594ca1fc",
    "serviceofferingname": "Small Instance",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "templateid": "9f4b9f63-ed72-11ed-a4b9-645d8651f45a",
    "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
    "userid": "2b11cbb8-ed72-11ed-a4b9-645d8651f45a",
    "username": "admin",
    "zoneid": "104ca6f0-0a0f-4be7-ab4d-2ce1e091bb54",
    "zonename": "Sandbox-simulator"
  }
}
(local) 🐛 > list events filter=id,type,description,state pagesize=8 page=1
{
  "count": 19,
  "event": [
    {
      "description": "Successfully completed deploying Vm. Vm Id: 0434ffb3-2006-4e93-8c25-089803851377",
      "id": "e5d8cb91-2f11-47d0-9fb2-4786a6d5a4db",
      "state": "Completed",
      "type": "VM.CREATE"
    },
    {
      "description": "deploying Vm. Vm Id: 0434ffb3-2006-4e93-8c25-089803851377",
      "id": "bfd1709e-da75-498f-9ada-657df6fb5859",
      "state": "Started",
      "type": "VM.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: 0434ffb3-2006-4e93-8c25-089803851377",
      "id": "da819f7d-b69a-4666-a772-a2115a4c0440",
      "state": "Scheduled",
      "type": "VM.CREATE"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: 9bdfa54b-bd51-4c43-b0d2-612be1af9bc6 Vm Id: 0434ffb3-2006-4e93-8c25-089803851377",
      "id": "0967ccd2-2571-4ce2-89ab-a8f2caf4ce1c",
      "state": "Created",
      "type": "VOLUME.CREATE"
    },
    {
      "description": "Successfully completed deploying Vm. Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "e55c9bf2-ad3d-49b7-9acc-1eecb25e370a",
      "state": "Completed",
      "type": "VM.CREATE"
    },
    {
      "description": "starting Vm. Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "bb09ddf4-e266-437a-8bc1-61cbde7094d2",
      "state": "Scheduled",
      "type": "VM.CREATE"
    },
    {
      "description": "user has logged in from IP Address /127.0.0.1",
      "id": "2e1dfa11-3780-47b9-b86b-21f1b3d471b0",
      "state": "Completed",
      "type": "USER.LOGIN"
    },
    {
      "description": "Successfully created entity for creating ROOT volume. Volume Id: e4dd0164-de81-41e7-b64e-5d84d46614b7 Vm Id: 5d8dd74a-efc3-414b-9966-61553223a73a",
      "id": "02df99c3-e7f3-402d-8d2d-56d1f117ecc5",
      "state": "Created",
      "type": "VOLUME.CREATE"
    }
  ]
}

```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
