### PR TITLE
ui: fix custom offering cpuspeed during vm import

### DIFF
--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -177,6 +177,7 @@
                 :maxCpu="getMaxCpu()"
                 :minMemory="getMinMemory()"
                 :maxMemory="getMaxMemory()"
+                :cpuSpeed="getCPUSpeed()"
                 @update-iops-value="updateFieldValue"
                 @update-compute-cpunumber="updateFieldValue"
                 @update-compute-cpuspeed="updateFieldValue"
@@ -521,6 +522,9 @@ export default {
         return this.resource.memory
       }
       return 'serviceofferingdetails' in this.computeOffering ? this.computeOffering.serviceofferingdetails.maxmemory * 1 : Number.MAX_SAFE_INTEGER
+    },
+    getCPUSpeed () {
+      return (this.computeOffering.iscustomized ? this.resource.cpuspeed : 0) || this.computeOffering?.cpuspeed * 1 || 0
     },
     fetchOptions (param, name, exclude) {
       if (exclude && exclude.length > 0) {

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -524,7 +524,13 @@ export default {
       return 'serviceofferingdetails' in this.computeOffering ? this.computeOffering.serviceofferingdetails.maxmemory * 1 : Number.MAX_SAFE_INTEGER
     },
     getCPUSpeed () {
-      return (this.computeOffering.iscustomized ? this.resource.cpuspeed : 0) || this.computeOffering?.cpuspeed * 1 || 0
+      if (!this.computeOffering) {
+        return 0
+      }
+      if (this.computeOffering.cpuspeed) {
+        return this.computeOffering.cpuspeed * 1
+      }
+      return this.resource.cpuspeed * 1 || 0
     },
     fetchOptions (param, name, exclude) {
       if (exclude && exclude.length > 0) {


### PR DESCRIPTION
### Description

Fixes #7420

Fixes CPU speed param value when using custom compute offering during VM import

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

https://user-images.githubusercontent.com/153340/231072144-f360de75-951d-4617-a3b6-a91b348cb0a2.mp4



### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
