### PR TITLE
Make `addGuestOs` `details` parameter optional

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/guest/AddGuestOsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/guest/AddGuestOsCmd.java
@@ -28,6 +28,7 @@ import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.GuestOSCategoryResponse;
 import org.apache.cloudstack.api.response.GuestOSResponse;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.commons.collections.MapUtils;
 
 import com.cloud.event.EventTypes;
 import com.cloud.storage.GuestOS;
@@ -57,7 +58,7 @@ public class AddGuestOsCmd extends BaseAsyncCreateCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = false, description = "Optional name for Guest OS")
     private String osName;
 
-    @Parameter(name = ApiConstants.DETAILS, type = CommandType.MAP, required = true, description = "Map of (key/value pairs)")
+    @Parameter(name = ApiConstants.DETAILS, type = CommandType.MAP, required = false, description = "Optional map of (key/value pairs)")
     private Map details;
 
 
@@ -79,7 +80,7 @@ public class AddGuestOsCmd extends BaseAsyncCreateCmd {
 
     public Map getDetails() {
         Map<String, String> detailsMap = new HashMap<String, String>();
-        if (!details.isEmpty()) {
+        if (MapUtils.isNotEmpty(details)) {
             Collection<?> servicesCollection = details.values();
             Iterator<?> iter = servicesCollection.iterator();
             while (iter.hasNext()) {


### PR DESCRIPTION
### Description
The `details` parameter in the `addGuestOs` API is currently mandatory, even though it is only used for XenServer configurations, thus, for other hypervisors it is not needed. This PR makes the parameter optional. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/48719461/231778917-e882cd1c-e5da-469f-87e1-ecfe086c07ac.png)
After:
![image](https://user-images.githubusercontent.com/48719461/231778974-d11e5877-6cf9-4654-8234-07de8daaa336.png)

### How Has This Been Tested?
A guest OS was created without informing the `details` and everything went smoothly. 