### PR TITLE
test: reduce PowerMock usage for code coverage

### DIFF
--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/CreateNetworkCmdTest.java
@@ -17,26 +17,27 @@
 
 package org.apache.cloudstack.api.command.user.network;
 
+import org.apache.cloudstack.api.ResponseGenerator;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.response.NetworkResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.network.Network;
 import com.cloud.network.NetworkService;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.utils.db.EntityManager;
-import junit.framework.TestCase;
-import org.apache.cloudstack.api.ResponseGenerator;
-import org.apache.cloudstack.api.ResponseObject;
-import org.apache.cloudstack.api.response.NetworkResponse;
-import org.junit.Assert;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
-@RunWith(PowerMockRunner.class)
-public class CreateNetworkCmdTest extends TestCase {
+@RunWith(MockitoJUnitRunner.class)
+public class CreateNetworkCmdTest {
 
     @Mock
     public EntityManager _entityMgr;
@@ -46,66 +47,78 @@ public class CreateNetworkCmdTest extends TestCase {
 
     @InjectMocks
     CreateNetworkCmd cmd = new CreateNetworkCmd();
+
+    @Test
     public void testGetNetworkOfferingId() {
         Long networkOfferingId = 1L;
         ReflectionTestUtils.setField(cmd, "networkOfferingId", networkOfferingId);
         Assert.assertEquals(cmd.getNetworkOfferingId(), networkOfferingId);
     }
 
+    @Test
     public void testGetGateway() {
         String gateway = "10.10.10.1";
         ReflectionTestUtils.setField(cmd, "gateway", gateway);
         Assert.assertEquals(cmd.getGateway(), gateway);
     }
 
+    @Test
     public void testGetIsolatedPvlan() {
         String isolatedPvlan = "1234";
         ReflectionTestUtils.setField(cmd, "isolatedPvlan", isolatedPvlan);
         Assert.assertEquals(cmd.getIsolatedPvlan(), isolatedPvlan);
     }
 
+    @Test
     public void testGetAccountName() {
         String accountName = "admin";
         ReflectionTestUtils.setField(cmd, "accountName", accountName);
         Assert.assertEquals(cmd.getAccountName(), accountName);
     }
 
+    @Test
     public void testGetDomainId() {
         Long domainId = 1L;
         ReflectionTestUtils.setField(cmd, "domainId", domainId);
         Assert.assertEquals(cmd.getDomainId(), domainId);
     }
 
+    @Test
     public void testGetNetmask() {
         String netmask = "255.255.255.0";
         ReflectionTestUtils.setField(cmd, "netmask", netmask);
         Assert.assertEquals(cmd.getNetmask(), netmask);
     }
 
+    @Test
     public void testGetStartIp() {
         String startIp = "10.10.10.2";
         ReflectionTestUtils.setField(cmd, "startIp", startIp);
         Assert.assertEquals(cmd.getStartIp(), startIp);
     }
 
+    @Test
     public void testGetEndIp() {
         String endIp = "10.10.10.10";
         ReflectionTestUtils.setField(cmd, "endIp", endIp);
         Assert.assertEquals(cmd.getEndIp(), endIp);
     }
 
+    @Test
     public void testGetNetworkName() {
         String netName = "net-isolated";
         ReflectionTestUtils.setField(cmd, "name", netName);
         Assert.assertEquals(cmd.getNetworkName(), netName);
     }
 
+    @Test
     public void testGetDisplayTextWhenNotEmpty() {
         String description = "Isolated Network";
         ReflectionTestUtils.setField(cmd, "displayText", description);
         Assert.assertEquals(cmd.getDisplayText(), description);
     }
 
+    @Test
     public void testGetDisplayTextWhenEmpty() {
         String description = null;
         String netName = "net-isolated";
@@ -113,65 +126,74 @@ public class CreateNetworkCmdTest extends TestCase {
         Assert.assertEquals(cmd.getDisplayText(), netName);
     }
 
+    @Test
     public void testGetNetworkDomain() {
         String netDomain = "cs1cloud.internal";
         ReflectionTestUtils.setField(cmd, "networkDomain", netDomain);
         Assert.assertEquals(cmd.getNetworkDomain(), netDomain);
     }
 
+    @Test
     public void testGetProjectId() {
         Long projectId = 1L;
         ReflectionTestUtils.setField(cmd, "projectId", projectId);
         Assert.assertEquals(cmd.getProjectId(), projectId);
     }
 
+    @Test
     public void testGetAclType() {
         String aclType = "account";
         ReflectionTestUtils.setField(cmd, "aclType", aclType);
         Assert.assertEquals(cmd.getAclType(), aclType);
     }
 
+    @Test
     public void testGetSubdomainAccess() {
         Boolean subDomAccess = false;
         ReflectionTestUtils.setField(cmd, "subdomainAccess", subDomAccess);
         Assert.assertEquals(cmd.getSubdomainAccess(), subDomAccess);
     }
 
+    @Test
     public void testGetVpcId() {
         Long vpcId = 1L;
         ReflectionTestUtils.setField(cmd, "vpcId", vpcId);
         Assert.assertEquals(cmd.getVpcId(), vpcId);
     }
 
+    @Test
     public void testGetDisplayNetwork() {
         Boolean displayNet = true;
         ReflectionTestUtils.setField(cmd, "displayNetwork", displayNet);
         Assert.assertEquals(cmd.getDisplayNetwork(), displayNet);
     }
 
+    @Test
     public void testGetExternalId() {
         String externalId = "1";
         ReflectionTestUtils.setField(cmd, "externalId", externalId);
         Assert.assertEquals(cmd.getExternalId(), externalId);
     }
 
+    @Test
     public void testGetAssociatedNetworkId() {
         Long associatedNetId = 1L;
         ReflectionTestUtils.setField(cmd, "associatedNetworkId", associatedNetId);
         Assert.assertEquals(cmd.getAssociatedNetworkId(), associatedNetId);
     }
 
+    @Test
     public void testIsDisplayNullDefaultsToTrue() {
         Boolean displayNetwork = null;
         ReflectionTestUtils.setField(cmd, "displayNetwork", displayNetwork);
         Assert.assertTrue(cmd.isDisplay());
     }
 
+    @Test
     public void testGetPhysicalNetworkIdForInvalidNetOfferingId() {
         Long physicalNetworkId = 1L;
 
         ReflectionTestUtils.setField(cmd, "physicalNetworkId", physicalNetworkId);
-        Mockito.when(_entityMgr.findById(NetworkOffering.class, 1L)).thenReturn(null);
         try {
             cmd.getPhysicalNetworkId();
         } catch (Exception e) {
@@ -179,6 +201,7 @@ public class CreateNetworkCmdTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetPhysicalNetworkIdForInvalidAssociatedNetId() {
         Long physicalNetworkId = 1L;
         Long networkOfferingId = 1L;
@@ -196,6 +219,7 @@ public class CreateNetworkCmdTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetPhysicalNetworkIdForAssociatedNetIdForNonSharedNet() {
         Long physicalNetworkId = 1L;
         Long networkOfferingId = 1L;
@@ -215,6 +239,7 @@ public class CreateNetworkCmdTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetPhysicalNetworkIdForNonSharedNet() {
         Long physicalNetworkId = 1L;
         Long networkOfferingId = 1L;
@@ -230,6 +255,7 @@ public class CreateNetworkCmdTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetPhysicalNetworkIdForSharedNet() {
         Long physicalNetworkId = 1L;
         Long networkOfferingId = 1L;
@@ -245,6 +271,7 @@ public class CreateNetworkCmdTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetZoneId() {
         Long physicalNetworkId = 1L;
         Long networkOfferingId = 1L;
@@ -258,30 +285,35 @@ public class CreateNetworkCmdTest extends TestCase {
         Assert.assertEquals(cmd.getZoneId(), zoneId);
     }
 
+    @Test
     public void testGetPublicMtuWhenNotSet() {
         Integer publicMtu = null;
         ReflectionTestUtils.setField(cmd, "publicMtu", publicMtu);
         Assert.assertEquals(NetworkService.DEFAULT_MTU, cmd.getPublicMtu());
     }
 
+    @Test
     public void testGetPublicMtuWhenSet() {
         Integer publicMtu = 1450;
         ReflectionTestUtils.setField(cmd, "publicMtu", publicMtu);
         Assert.assertEquals(cmd.getPublicMtu(), publicMtu);
     }
 
+    @Test
     public void testGetPrivateMtuWhenNotSet() {
         Integer privateMtu = null;
         ReflectionTestUtils.setField(cmd, "privateMtu", privateMtu);
         Assert.assertEquals(NetworkService.DEFAULT_MTU, cmd.getPrivateMtu());
     }
 
+    @Test
     public void testGetPrivateMtuWhenSet() {
         Integer privateMtu = 1250;
         ReflectionTestUtils.setField(cmd, "privateMtu", privateMtu);
         Assert.assertEquals(cmd.getPrivateMtu(), privateMtu);
     }
 
+    @Test
     public void testExecute() throws InsufficientCapacityException, ResourceAllocationException {
         ReflectionTestUtils.setField(cmd, "displayText", "testNetwork");
         ReflectionTestUtils.setField(cmd, "name", "testNetwork");

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/UpdateNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/UpdateNetworkCmdTest.java
@@ -17,25 +17,25 @@
 
 package org.apache.cloudstack.api.command.user.network;
 
-import com.cloud.exception.InsufficientCapacityException;
-import com.cloud.network.Network;
-import com.cloud.network.NetworkService;
-import com.cloud.offering.NetworkOffering;
-import com.cloud.utils.db.EntityManager;
-import junit.framework.TestCase;
 import org.apache.cloudstack.api.ResponseGenerator;
 import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.response.NetworkResponse;
 import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@RunWith(PowerMockRunner.class)
-public class UpdateNetworkCmdTest extends TestCase {
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.network.Network;
+import com.cloud.network.NetworkService;
+import com.cloud.utils.db.EntityManager;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateNetworkCmdTest {
 
     @Mock
     NetworkService networkService;
@@ -45,115 +45,131 @@ public class UpdateNetworkCmdTest extends TestCase {
     @InjectMocks
     UpdateNetworkCmd cmd = new UpdateNetworkCmd();
 
+    @Test
     public void testGetId() {
         Long id = 1L;
         ReflectionTestUtils.setField(cmd, "id", id);
         Assert.assertEquals(cmd.getId(), id);
     }
 
+    @Test
     public void testGetNetworkName() {
         String name = "testNetwork";
         ReflectionTestUtils.setField(cmd, "name", name);
         Assert.assertEquals(cmd.getNetworkName(), name);
     }
 
+    @Test
     public void testGetDisplayText() {
         String displayText = "test network";
         ReflectionTestUtils.setField(cmd, "displayText", displayText);
         Assert.assertEquals(cmd.getDisplayText(), displayText);
     }
 
+    @Test
     public void testGetNetworkDomain() {
         String netDomain = "cs1cloud.internal";
         ReflectionTestUtils.setField(cmd, "networkDomain", netDomain);
         Assert.assertEquals(cmd.getNetworkDomain(), netDomain);
     }
 
+    @Test
     public void testGetNetworkOfferingId() {
         Long networkOfferingId = 1L;
         ReflectionTestUtils.setField(cmd, "networkOfferingId", networkOfferingId);
         Assert.assertEquals(cmd.getNetworkOfferingId(), networkOfferingId);
     }
 
+    @Test
     public void testGetChangeCidr() {
         Boolean changeCidr = true;
         ReflectionTestUtils.setField(cmd, "changeCidr", changeCidr);
         Assert.assertTrue(cmd.getChangeCidr());
     }
 
+    @Test
     public void testGetGuestVmCidr() {
         String guestVmCidr = "10.10.0.0/24";
         ReflectionTestUtils.setField(cmd, "guestVmCidr", guestVmCidr);
         Assert.assertEquals(cmd.getGuestVmCidr(), guestVmCidr);
     }
 
+    @Test
     public void testGetDisplayNetwork() {
         Boolean displayNetwork = true;
         ReflectionTestUtils.setField(cmd, "displayNetwork", displayNetwork);
         Assert.assertTrue(cmd.getDisplayNetwork());
     }
 
+    @Test
     public void testGetUpdateInSequenceIfNull() {
         Boolean updateInSequence = null;
         ReflectionTestUtils.setField(cmd, "updateInSequence", updateInSequence);
         Assert.assertFalse(cmd.getUpdateInSequence());
     }
 
+    @Test
     public void testGetUpdateInSequenceIfValidValuePassed() {
         Boolean updateInSequence = true;
         ReflectionTestUtils.setField(cmd, "updateInSequence", updateInSequence);
         Assert.assertTrue(cmd.getUpdateInSequence());
     }
 
+    @Test
     public void testGetForcedIfNull() {
         Boolean forced = null;
         ReflectionTestUtils.setField(cmd, "forced", forced);
         Assert.assertFalse(cmd.getUpdateInSequence());
     }
 
+    @Test
     public void testGetForcedIfValidValuePassed() {
         Boolean forced = true;
         ReflectionTestUtils.setField(cmd, "forced", forced);
         Assert.assertTrue(cmd.getForced());
     }
 
+    @Test
     public void testGetPublicMtu() {
         Integer publicMtu = 1450;
         ReflectionTestUtils.setField(cmd, "publicMtu", publicMtu);
         Assert.assertEquals(cmd.getPublicMtu(), publicMtu);
     }
 
+    @Test
     public void testGetPublicMtuIfNull() {
         Integer publicMtu = null;
         ReflectionTestUtils.setField(cmd, "publicMtu", publicMtu);
         Assert.assertNull(cmd.getPublicMtu());
     }
 
+    @Test
     public void testGetPrivateMtu() {
         Integer privateMtu = 1450;
         ReflectionTestUtils.setField(cmd, "privateMtu", privateMtu);
         Assert.assertEquals(cmd.getPrivateMtu(), privateMtu);
     }
 
+    @Test
     public void testGetPrivateMtuIfNull() {
         Integer privateMtu = null;
         ReflectionTestUtils.setField(cmd, "privateMtu", privateMtu);
         Assert.assertNull(cmd.getPrivateMtu());
     }
 
+    @Test
     public void testEventDescription() {
         long networkOfferingId = 1L;
         Network network = Mockito.mock(Network.class);
-        NetworkOffering offering = Mockito.mock(NetworkOffering.class);
         ReflectionTestUtils.setField(cmd, "networkOfferingId", networkOfferingId);
         ReflectionTestUtils.setField(cmd, "id", 1L);
         Mockito.when(networkService.getNetwork(Mockito.any(Long.class))).thenReturn(network);
         Mockito.when(network.getNetworkOfferingId()).thenReturn(networkOfferingId);
-        Mockito.when(_entityMgr.findById(NetworkOffering.class, networkOfferingId)).thenReturn(offering);
         String msg = cmd.getEventDescription();
         Assert.assertTrue(msg.contains("Updating network"));
     }
 
+    @Test
     public void testExecute() throws InsufficientCapacityException {
         long networkId = 1L;
         Integer publicmtu = 1200;

--- a/plugins/affinity-group-processors/non-strict-host-affinity/src/test/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/non-strict-host-affinity/src/test/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessorTest.java
@@ -19,13 +19,15 @@
 
 package org.apache.cloudstack.affinity;
 
-import com.cloud.deploy.DataCenterDeployment;
-import com.cloud.deploy.DeploymentPlan;
-import com.cloud.deploy.DeploymentPlanner.ExcludeList;
-import com.cloud.vm.VMInstanceVO;
-import com.cloud.vm.VirtualMachine;
-import com.cloud.vm.VirtualMachineProfile;
-import com.cloud.vm.dao.VMInstanceDao;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
 import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
 import org.junit.Assert;
@@ -35,19 +37,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import com.cloud.deploy.DataCenterDeployment;
+import com.cloud.deploy.DeploymentPlan;
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.VMInstanceDao;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.when;
-
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class NonStrictHostAffinityProcessorTest {
 
     @Spy


### PR DESCRIPTION
### Description

JaCoCo used for code coverage calculation in the project doesn't support PowerMockito classes. This PR attemps to reduce usage of PowerMockito.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
