### PR TITLE
cks,ui: allow changing stopped cluster offering, improvements

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -17,6 +17,29 @@
 
 package com.cloud.kubernetes.cluster.actionworkers;
 
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.command.user.firewall.CreateFirewallRuleCmd;
+import org.apache.cloudstack.api.command.user.vm.StartVMCmd;
+import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Level;
+
 import com.cloud.capacity.CapacityManager;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterDetailsVO;
@@ -76,28 +99,6 @@ import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.VMInstanceDao;
-
-import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseCmd;
-import org.apache.cloudstack.api.command.user.firewall.CreateFirewallRuleCmd;
-import org.apache.cloudstack.api.command.user.vm.StartVMCmd;
-import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-
-import javax.inject.Inject;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 public class KubernetesClusterResourceModifierActionWorker extends KubernetesClusterActionWorker {
 
@@ -669,7 +670,6 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
         } finally {
             // Deploying the autoscaler might fail but it can be deployed manually too, so no need to go to an alert state
             updateLoginUserDetails(null);
-            stateTransitTo(kubernetesCluster.getId(), KubernetesCluster.Event.OperationSucceeded);
         }
     }
 }

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
@@ -1,0 +1,115 @@
+package com.cloud.kubernetes.cluster;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.api.query.dao.TemplateJoinDao;
+import com.cloud.api.query.vo.TemplateJoinVO;
+import com.cloud.dc.DataCenter;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.storage.VMTemplateVO;
+import com.cloud.storage.dao.VMTemplateDao;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesClusterManagerImplTest {
+
+    @Mock
+    VMTemplateDao templateDao;
+
+    @Mock
+    TemplateJoinDao templateJoinDao;
+
+    @Spy
+    @InjectMocks
+    KubernetesClusterManagerImpl clusterManager;
+
+    @Test
+    public void testValidateKubernetesClusterScaleSizeNullNewSizeNoError() {
+        clusterManager.validateKubernetesClusterScaleSize(Mockito.mock(KubernetesClusterVO.class), null, 100, Mockito.mock(DataCenter.class));
+    }
+
+    @Test
+    public void testValidateKubernetesClusterScaleSizeSameNewSizeNoError() {
+        Long size = 2L;
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(size);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, size, 100, Mockito.mock(DataCenter.class));
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void testValidateKubernetesClusterScaleSizeStoppedCluster() {
+        Long size = 2L;
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(size);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Stopped);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 3L, 100, Mockito.mock(DataCenter.class));
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateKubernetesClusterScaleSizeZeroNewSize() {
+        Long size = 2L;
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Running);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(size);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 0L, 100, Mockito.mock(DataCenter.class));
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateKubernetesClusterScaleSizeOverMaxSize() {
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Running);
+        Mockito.when(clusterVO.getControlNodeCount()).thenReturn(1L);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 4L, 4, Mockito.mock(DataCenter.class));
+    }
+
+    @Test
+    public void testValidateKubernetesClusterScaleSizeDownsacaleNoError() {
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Running);
+        Mockito.when(clusterVO.getControlNodeCount()).thenReturn(1L);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(4L);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 2L, 10, Mockito.mock(DataCenter.class));
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateKubernetesClusterScaleSizeUpscaleDeletedTemplate() {
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Running);
+        Mockito.when(clusterVO.getControlNodeCount()).thenReturn(1L);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(2L);
+        Mockito.when(templateDao.findById(Mockito.anyLong())).thenReturn(null);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 4L, 10, Mockito.mock(DataCenter.class));
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testValidateKubernetesClusterScaleSizeUpscaleNotInZoneTemplate() {
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Running);
+        Mockito.when(clusterVO.getControlNodeCount()).thenReturn(1L);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(2L);
+        Mockito.when(templateDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(VMTemplateVO.class));
+        Mockito.when(templateJoinDao.newTemplateView(Mockito.any(VMTemplateVO.class), Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(null);
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 4L, 10, Mockito.mock(DataCenter.class));
+    }
+
+    @Test
+    public void testValidateKubernetesClusterScaleSizeUpscaleNoError() {
+        KubernetesClusterVO clusterVO = Mockito.mock(KubernetesClusterVO.class);
+        Mockito.when(clusterVO.getState()).thenReturn(KubernetesCluster.State.Running);
+        Mockito.when(clusterVO.getControlNodeCount()).thenReturn(1L);
+        Mockito.when(clusterVO.getNodeCount()).thenReturn(2L);
+        Mockito.when(templateDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(VMTemplateVO.class));
+        Mockito.when(templateJoinDao.newTemplateView(Mockito.any(VMTemplateVO.class), Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(TemplateJoinVO.class)));
+        clusterManager.validateKubernetesClusterScaleSize(clusterVO, 4L, 10, Mockito.mock(DataCenter.class));
+    }
+}

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
@@ -1,7 +1,5 @@
 package com.cloud.kubernetes.cluster;
 
-import static org.junit.Assert.*;
-
 import java.util.List;
 
 import org.junit.Test;

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.kubernetes.cluster;
 
 import java.util.List;

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -504,7 +504,7 @@ export default {
           message: 'message.kubernetes.cluster.scale',
           docHelp: 'plugins/cloudstack-kubernetes-service.html#scaling-kubernetes-cluster',
           dataView: true,
-          show: (record) => { return ['Created', 'Running'].includes(record.state) },
+          show: (record) => { return ['Created', 'Running', 'Stopped'].includes(record.state) },
           popup: true,
           component: shallowRef(defineAsyncComponent(() => import('@/views/compute/ScaleKubernetesCluster.vue')))
         },


### PR DESCRIPTION
### Description

Fixes #7454

- Allows changing compute offering for a stopped cluster
- Allows compute offering change when the cluster has autoscaling enabled
 
### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
Using cmk:

Service offerings:
```
(localcloud) 🐱 > list serviceofferings id=5b9471db-0f98-4ad4-8e27-d31935c1d5fe 
{
  "count": 1,
  "serviceoffering": [
    {
      "cacheMode": "none",
      "cpunumber": 2,
      "cpuspeed": 1000,
      "created": "2023-05-22T08:22:32+0000",
      "defaultuse": false,
      "diskofferingstrictness": false,
      "displaytext": "CKS Instance",
      "dynamicscalingenabled": true,
      "encryptroot": false,
      "hasannotations": false,
      "id": "5b9471db-0f98-4ad4-8e27-d31935c1d5fe",
      "iscustomized": false,
      "issystem": false,
      "isvolatile": false,
      "limitcpuuse": false,
      "memory": 2048,
      "name": "CKS Instance",
      "offerha": false,
      "provisioningtype": "thin",
      "rootdisksize": 0,
      "storagetype": "shared"
    }
  ]
}
(localcloud) 🐱 > list serviceofferings id=54a44f69-2803-4a84-aeca-df7f81aa9c1b 
{
  "count": 1,
  "serviceoffering": [
    {
      "cacheMode": "none",
      "cpunumber": 2,
      "cpuspeed": 1000,
      "created": "2023-05-23T11:58:51+0000",
      "defaultuse": false,
      "diskofferingstrictness": false,
      "displaytext": "Upgrade CKS Instance",
      "dynamicscalingenabled": true,
      "encryptroot": false,
      "hasannotations": false,
      "id": "54a44f69-2803-4a84-aeca-df7f81aa9c1b",
      "iscustomized": false,
      "issystem": false,
      "isvolatile": false,
      "limitcpuuse": false,
      "memory": 2560,
      "name": "Upgrade CKS Instance",
      "offerha": false,
      "provisioningtype": "thin",
      "rootdisksize": 0,
      "storagetype": "shared"
    }
  ]
}
```

k8s cluster deployment and stopping:
```
(localcloud) 🐱 > create kubernetescluster zoneid=28693109-f77c-42ad-a3d7-e04c40800e1f name=t1 description=t1 kubernetesversionid=53bf05e1-1b7b-49f3-976b-7127a62ab8a0 serviceofferingid=5b9471db-0f98-4ad4-8e27-d31935c1d5fe size=1
{
  "kubernetescluster": {
    "account": "admin",
    "associatednetworkname": "t1-network",
    "autoscalingenabled": false,
    "controlnodes": 1,
    "cpunumber": "4",
    "created": "2023-05-23T11:57:56+0000",
    "description": "t1",
    "domain": "ROOT",
    "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
    "endpoint": "https://10.0.54.163:6443/",
    "hasannotations": false,
    "id": "99c71dba-285c-48a7-942a-8e712e32e99d",
    "ipaddress": "10.0.54.163",
    "ipaddressid": "d973691c-4d20-4a29-871e-dbee002f8ba4",
    "kubernetesversionid": "53bf05e1-1b7b-49f3-976b-7127a62ab8a0",
    "kubernetesversionname": "v1.26.0",
    "masternodes": 1,
    "memory": "4096",
    "name": "t1",
    "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
    "serviceofferingid": "5b9471db-0f98-4ad4-8e27-d31935c1d5fe",
    "serviceofferingname": "CKS Instance",
    "size": 1,
    "state": "Running",
    "templateid": "11db18e7-43b7-4e3c-991c-a3b5c2f61968",
    "virtualmachines": [
      {
        "account": "admin",
        "affinitygroup": [],
        "created": "2023-05-23T11:58:31+0000",
        "details": {
          "controlNodeLoginUser": "cloud",
          "cpuOvercommitRatio": "2.0",
          "memoryOvercommitRatio": "1.0",
          "rootdisksize": "8"
        },
        "displayname": "t1-control-1884879a45c",
        "displayvm": true,
        "domain": "ROOT",
        "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
        "guestosid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "haenable": false,
        "hasannotations": false,
        "hostcontrolstate": "Enabled",
        "hostid": "cb8a8132-ef62-46df-b5b0-8a4cbeb41ca9",
        "hostname": "pr7479-t6536-kvm-centos7-kvm2",
        "hypervisor": "KVM",
        "id": "5f3da9b7-a7d7-4d2c-946c-719923506a39",
        "instancename": "i-2-65-VM",
        "isdynamicallyscalable": false,
        "lastupdated": "2023-05-23T11:58:43+0000",
        "name": "t1-control-1884879a45c",
        "nic": [
          {
            "broadcasturi": "vlan://1629",
            "deviceid": "0",
            "extradhcpoption": [],
            "gateway": "10.1.1.1",
            "id": "27252d7f-773a-4a67-97d3-81487ab41c0b",
            "ipaddress": "10.1.1.177",
            "isdefault": true,
            "isolationuri": "vlan://1629",
            "macaddress": "02:00:4a:bc:00:02",
            "netmask": "255.255.255.0",
            "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
            "networkname": "t1-network",
            "secondaryip": [],
            "traffictype": "Guest",
            "type": "Isolated"
          }
        ],
        "osdisplayname": "Debian GNU/Linux 5.0 (64-bit)",
        "ostypeid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "pooltype": "NetworkFilesystem",
        "receivedbytes": 0,
        "securitygroup": [],
        "sentbytes": 0,
        "state": "Running",
        "tags": [],
        "userid": "21d66d69-f85b-11ed-9f8f-1e009f00014a",
        "username": "admin",
        "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
        "zonename": "pr7479-t6536-kvm-centos7"
      },
      {
        "account": "admin",
        "affinitygroup": [],
        "created": "2023-05-23T11:58:44+0000",
        "details": {
          "controlNodeLoginUser": "cloud",
          "cpuOvercommitRatio": "2.0",
          "memoryOvercommitRatio": "1.0",
          "rootdisksize": "8"
        },
        "displayname": "t1-node-1884879d541",
        "displayvm": true,
        "domain": "ROOT",
        "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
        "guestosid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "haenable": false,
        "hasannotations": false,
        "hostcontrolstate": "Enabled",
        "hostid": "cb8a8132-ef62-46df-b5b0-8a4cbeb41ca9",
        "hostname": "pr7479-t6536-kvm-centos7-kvm2",
        "hypervisor": "KVM",
        "id": "c267ae48-b24b-45e4-a03c-d4a8d010e214",
        "instancename": "i-2-66-VM",
        "isdynamicallyscalable": false,
        "lastupdated": "2023-05-23T11:58:58+0000",
        "name": "t1-node-1884879d541",
        "nic": [
          {
            "broadcasturi": "vlan://1629",
            "deviceid": "0",
            "extradhcpoption": [],
            "gateway": "10.1.1.1",
            "id": "c8c43943-fb83-45ce-bdca-1cee12187296",
            "ipaddress": "10.1.1.2",
            "isdefault": true,
            "isolationuri": "vlan://1629",
            "macaddress": "02:00:30:c7:00:03",
            "netmask": "255.255.255.0",
            "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
            "networkname": "t1-network",
            "secondaryip": [],
            "traffictype": "Guest",
            "type": "Isolated"
          }
        ],
        "osdisplayname": "Debian GNU/Linux 5.0 (64-bit)",
        "ostypeid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "pooltype": "NetworkFilesystem",
        "receivedbytes": 0,
        "securitygroup": [],
        "sentbytes": 0,
        "state": "Running",
        "tags": [],
        "userid": "21d66d69-f85b-11ed-9f8f-1e009f00014a",
        "username": "admin",
        "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
        "zonename": "pr7479-t6536-kvm-centos7"
      }
    ],
    "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
    "zonename": "pr7479-t6536-kvm-centos7"
  }
}
(localcloud) 🐱 > stop kubernetescluster id=99c71dba-285c-48a7-942a-8e712e32e99d
{
  "success": true
}
```

Scale cluster for offering and start:
```
(localcloud) 🐱 > scale kubernetescluster id=99c71dba-285c-48a7-942a-8e712e32e99d serviceofferingid=54a44f69-2803-4a84-aeca-df7f81aa9c1b 
{
  "kubernetescluster": {
    "account": "admin",
    "associatednetworkname": "t1-network",
    "autoscalingenabled": false,
    "controlnodes": 1,
    "cpunumber": "4",
    "created": "2023-05-23T11:57:56+0000",
    "description": "t1",
    "domain": "ROOT",
    "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
    "endpoint": "https://10.0.54.163:6443/",
    "hasannotations": false,
    "id": "99c71dba-285c-48a7-942a-8e712e32e99d",
    "ipaddress": "10.0.54.163",
    "ipaddressid": "d973691c-4d20-4a29-871e-dbee002f8ba4",
    "kubernetesversionid": "53bf05e1-1b7b-49f3-976b-7127a62ab8a0",
    "kubernetesversionname": "v1.26.0",
    "masternodes": 1,
    "memory": "5120",
    "name": "t1",
    "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
    "serviceofferingid": "54a44f69-2803-4a84-aeca-df7f81aa9c1b",
    "serviceofferingname": "Upgrade CKS Instance",
    "size": 1,
    "state": "Stopped",
    "templateid": "11db18e7-43b7-4e3c-991c-a3b5c2f61968",
    "virtualmachines": [
      {
        "account": "admin",
        "affinitygroup": [],
        "created": "2023-05-23T11:58:31+0000",
        "details": {
          "Message.ReservedCapacityFreed.Flag": "false",
          "controlNodeLoginUser": "cloud",
          "cpuOvercommitRatio": "2.0",
          "memoryOvercommitRatio": "1.0",
          "rootdisksize": "8"
        },
        "displayname": "t1-control-1884879a45c",
        "displayvm": true,
        "domain": "ROOT",
        "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
        "guestosid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "haenable": false,
        "hasannotations": false,
        "hypervisor": "KVM",
        "id": "5f3da9b7-a7d7-4d2c-946c-719923506a39",
        "instancename": "i-2-65-VM",
        "isdynamicallyscalable": false,
        "lastupdated": "2023-05-23T12:21:50+0000",
        "name": "t1-control-1884879a45c",
        "nic": [
          {
            "deviceid": "0",
            "extradhcpoption": [],
            "gateway": "10.1.1.1",
            "id": "27252d7f-773a-4a67-97d3-81487ab41c0b",
            "ipaddress": "10.1.1.177",
            "isdefault": true,
            "macaddress": "02:00:4a:bc:00:02",
            "netmask": "255.255.255.0",
            "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
            "networkname": "t1-network",
            "secondaryip": [],
            "traffictype": "Guest",
            "type": "Isolated"
          }
        ],
        "osdisplayname": "Debian GNU/Linux 5.0 (64-bit)",
        "ostypeid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "pooltype": "NetworkFilesystem",
        "receivedbytes": 0,
        "securitygroup": [],
        "sentbytes": 0,
        "state": "Stopped",
        "tags": [],
        "userid": "21d66d69-f85b-11ed-9f8f-1e009f00014a",
        "username": "admin",
        "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
        "zonename": "pr7479-t6536-kvm-centos7"
      },
      {
        "account": "admin",
        "affinitygroup": [],
        "created": "2023-05-23T11:58:44+0000",
        "details": {
          "Message.ReservedCapacityFreed.Flag": "false",
          "controlNodeLoginUser": "cloud",
          "cpuOvercommitRatio": "2.0",
          "memoryOvercommitRatio": "1.0",
          "rootdisksize": "8"
        },
        "displayname": "t1-node-1884879d541",
        "displayvm": true,
        "domain": "ROOT",
        "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
        "guestosid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "haenable": false,
        "hasannotations": false,
        "hypervisor": "KVM",
        "id": "c267ae48-b24b-45e4-a03c-d4a8d010e214",
        "instancename": "i-2-66-VM",
        "isdynamicallyscalable": false,
        "lastupdated": "2023-05-23T12:21:54+0000",
        "name": "t1-node-1884879d541",
        "nic": [
          {
            "deviceid": "0",
            "extradhcpoption": [],
            "gateway": "10.1.1.1",
            "id": "c8c43943-fb83-45ce-bdca-1cee12187296",
            "ipaddress": "10.1.1.2",
            "isdefault": true,
            "macaddress": "02:00:30:c7:00:03",
            "netmask": "255.255.255.0",
            "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
            "networkname": "t1-network",
            "secondaryip": [],
            "traffictype": "Guest",
            "type": "Isolated"
          }
        ],
        "osdisplayname": "Debian GNU/Linux 5.0 (64-bit)",
        "ostypeid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "pooltype": "NetworkFilesystem",
        "receivedbytes": 0,
        "securitygroup": [],
        "sentbytes": 0,
        "state": "Stopped",
        "tags": [],
        "userid": "21d66d69-f85b-11ed-9f8f-1e009f00014a",
        "username": "admin",
        "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
        "zonename": "pr7479-t6536-kvm-centos7"
      }
    ],
    "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
    "zonename": "pr7479-t6536-kvm-centos7"
  }
}
(localcloud) 🐱 > list virtualmachines id=5f3da9b7-a7d7-4d2c-946c-719923506a39 filter=id,name,serviceofferingid,serviceofferingname
{
  "count": 1,
  "virtualmachine": [
    {
      "id": "5f3da9b7-a7d7-4d2c-946c-719923506a39",
      "name": "t1-control-1884879a45c",
      "serviceofferingid": "54a44f69-2803-4a84-aeca-df7f81aa9c1b",
      "serviceofferingname": "Upgrade CKS Instance"
    }
  ]
}
(localcloud) 🐱 > start kubernetescluster id=99c71dba-285c-48a7-942a-8e712e32e99d 
{
  "kubernetescluster": {
    "account": "admin",
    "associatednetworkname": "t1-network",
    "autoscalingenabled": false,
    "controlnodes": 1,
    "cpunumber": "4",
    "created": "2023-05-23T11:57:56+0000",
    "description": "t1",
    "domain": "ROOT",
    "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
    "endpoint": "https://10.0.54.163:6443/",
    "hasannotations": false,
    "id": "99c71dba-285c-48a7-942a-8e712e32e99d",
    "ipaddress": "10.0.54.163",
    "ipaddressid": "d973691c-4d20-4a29-871e-dbee002f8ba4",
    "kubernetesversionid": "53bf05e1-1b7b-49f3-976b-7127a62ab8a0",
    "kubernetesversionname": "v1.26.0",
    "masternodes": 1,
    "memory": "5120",
    "name": "t1",
    "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
    "serviceofferingid": "54a44f69-2803-4a84-aeca-df7f81aa9c1b",
    "serviceofferingname": "Upgrade CKS Instance",
    "size": 1,
    "state": "Running",
    "templateid": "11db18e7-43b7-4e3c-991c-a3b5c2f61968",
    "virtualmachines": [
      {
        "account": "admin",
        "affinitygroup": [],
        "created": "2023-05-23T11:58:31+0000",
        "details": {
          "Message.ReservedCapacityFreed.Flag": "false",
          "controlNodeLoginUser": "cloud",
          "cpuOvercommitRatio": "2.0",
          "memoryOvercommitRatio": "1.0",
          "rootdisksize": "8"
        },
        "displayname": "t1-control-1884879a45c",
        "displayvm": true,
        "domain": "ROOT",
        "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
        "guestosid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "haenable": false,
        "hasannotations": false,
        "hostcontrolstate": "Enabled",
        "hostid": "cb8a8132-ef62-46df-b5b0-8a4cbeb41ca9",
        "hostname": "pr7479-t6536-kvm-centos7-kvm2",
        "hypervisor": "KVM",
        "id": "5f3da9b7-a7d7-4d2c-946c-719923506a39",
        "instancename": "i-2-65-VM",
        "isdynamicallyscalable": false,
        "lastupdated": "2023-05-23T12:23:36+0000",
        "name": "t1-control-1884879a45c",
        "nic": [
          {
            "broadcasturi": "vlan://1629",
            "deviceid": "0",
            "extradhcpoption": [],
            "gateway": "10.1.1.1",
            "id": "27252d7f-773a-4a67-97d3-81487ab41c0b",
            "ipaddress": "10.1.1.177",
            "isdefault": true,
            "isolationuri": "vlan://1629",
            "macaddress": "02:00:4a:bc:00:02",
            "netmask": "255.255.255.0",
            "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
            "networkname": "t1-network",
            "secondaryip": [],
            "traffictype": "Guest",
            "type": "Isolated"
          }
        ],
        "osdisplayname": "Debian GNU/Linux 5.0 (64-bit)",
        "ostypeid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "pooltype": "NetworkFilesystem",
        "receivedbytes": 0,
        "securitygroup": [],
        "sentbytes": 0,
        "state": "Running",
        "tags": [],
        "userid": "21d66d69-f85b-11ed-9f8f-1e009f00014a",
        "username": "admin",
        "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
        "zonename": "pr7479-t6536-kvm-centos7"
      },
      {
        "account": "admin",
        "affinitygroup": [],
        "created": "2023-05-23T11:58:44+0000",
        "details": {
          "Message.ReservedCapacityFreed.Flag": "false",
          "controlNodeLoginUser": "cloud",
          "cpuOvercommitRatio": "2.0",
          "memoryOvercommitRatio": "1.0",
          "rootdisksize": "8"
        },
        "displayname": "t1-node-1884879d541",
        "displayvm": true,
        "domain": "ROOT",
        "domainid": "06f469cb-f85b-11ed-9f8f-1e009f00014a",
        "guestosid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "haenable": false,
        "hasannotations": false,
        "hostcontrolstate": "Enabled",
        "hostid": "a7f5d4cc-f9fa-4177-b0a4-d1ac44a2ec95",
        "hostname": "pr7479-t6536-kvm-centos7-kvm1",
        "hypervisor": "KVM",
        "id": "c267ae48-b24b-45e4-a03c-d4a8d010e214",
        "instancename": "i-2-66-VM",
        "isdynamicallyscalable": false,
        "lastupdated": "2023-05-23T12:23:48+0000",
        "name": "t1-node-1884879d541",
        "nic": [
          {
            "broadcasturi": "vlan://1629",
            "deviceid": "0",
            "extradhcpoption": [],
            "gateway": "10.1.1.1",
            "id": "c8c43943-fb83-45ce-bdca-1cee12187296",
            "ipaddress": "10.1.1.2",
            "isdefault": true,
            "isolationuri": "vlan://1629",
            "macaddress": "02:00:30:c7:00:03",
            "netmask": "255.255.255.0",
            "networkid": "fa5c4f55-1897-4418-9f5b-3f654e86cf7e",
            "networkname": "t1-network",
            "secondaryip": [],
            "traffictype": "Guest",
            "type": "Isolated"
          }
        ],
        "osdisplayname": "Debian GNU/Linux 5.0 (64-bit)",
        "ostypeid": "06fce009-f85b-11ed-9f8f-1e009f00014a",
        "pooltype": "NetworkFilesystem",
        "receivedbytes": 0,
        "securitygroup": [],
        "sentbytes": 0,
        "state": "Running",
        "tags": [],
        "userid": "21d66d69-f85b-11ed-9f8f-1e009f00014a",
        "username": "admin",
        "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
        "zonename": "pr7479-t6536-kvm-centos7"
      }
    ],
    "zoneid": "28693109-f77c-42ad-a3d7-e04c40800e1f",
    "zonename": "pr7479-t6536-kvm-centos7"
  }
}
```

Verify cluster VMs are having new offering:
```
(localcloud) 🐱 > list virtualmachines ids=5f3da9b7-a7d7-4d2c-946c-719923506a39,c267ae48-b24b-45e4-a03c-d4a8d010e214 filter=id,name,serviceofferingid,serviceofferingname,state
{
  "count": 2,
  "virtualmachine": [
    {
      "id": "5f3da9b7-a7d7-4d2c-946c-719923506a39",
      "name": "t1-control-1884879a45c",
      "serviceofferingid": "54a44f69-2803-4a84-aeca-df7f81aa9c1b",
      "serviceofferingname": "Upgrade CKS Instance",
      "state": "Running"
    },
    {
      "id": "c267ae48-b24b-45e4-a03c-d4a8d010e214",
      "name": "t1-node-1884879d541",
      "serviceofferingid": "54a44f69-2803-4a84-aeca-df7f81aa9c1b",
      "serviceofferingname": "Upgrade CKS Instance",
      "state": "Running"
    }
  ]
}
```