### PR TITLE
Send console text slower to avoid overloading remote keyboard buffer

### DIFF
--- a/systemvm/agent/noVNC/core/rfb.js
+++ b/systemvm/agent/noVNC/core/rfb.js
@@ -433,21 +433,30 @@ export default class RFB extends EventTargetMixin {
         this._resumeAuthentication();
     }
 
-    sendText(text) {
-        for (var i = 0; i < text.length; i++) {
-            const character = text.charAt(i);
-            var charCode = USKeyTable[character] || false;
-            if (charCode) {
-                this.sendKey(charCode, character, true);
-                this.sendKey(charCode, character, false);
-            } else {
-                charCode = text.charCodeAt(i)
-                this.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", true);
-                this.sendKey(charCode, character, true);
-                this.sendKey(charCode, character, false);
-                this.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", false);
+     sendText(text) {
+        const sleep = (time) => {
+            return new Promise(resolve => setTimeout(resolve, time))
+        }
+
+        const keyboardTypeText = async () => {
+            for (var i = 0; i < text.length; i++) {
+                const character = text.charAt(i);
+                var charCode = USKeyTable[character] || false;
+                if (charCode) {
+                    this.sendKey(charCode, character, true);
+                    this.sendKey(charCode, character, false);
+                } else {
+                    charCode = text.charCodeAt(i)
+                    this.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", true);
+                    this.sendKey(charCode, character, true);
+                    this.sendKey(charCode, character, false);
+                    this.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", false);
+                }
+                await sleep(25)
             }
         }
+
+        keyboardTypeText()
     }
 
     sendCtrlAltDel() {


### PR DESCRIPTION
### Description

This PR slows down the console paste text function in the console ever so slightly, adding 25ms between each character. It was found that when large text is pasted, say an SSH key or something over 100 characters, it would stop somewhere in the 100-200 character range, and if the last character was capitalized it would be stuck with left shift held down. 

In debugging, I ran noVNC locally with websockify against a Qemu VNC and took the whole console proxy out of the equation and was still able to reproduce it. I traced the websocket packets and we were clearly firing off all of the keypresses just fine, but the ones on the end were getting dropped VNC server side. It seems we are overloading a keyboard buffer, or something along those lines when we send all of the keypress messages at once. It was also observed that we were able to send off all of the messages via websocket in just a few ms but the typing on the guest side took a few seconds, so there is some buffering and processing going on and I think we are just hitting some limit in this.

This `sendText` function doesn't seem to exist in upstream noVNC, so just patching it here seems reasonable. I suspect we added this for feature parity with whatever noVNC replaced.

In testing it is now much more reliable in sending a few paragraphs of text, and not visibly slower than before, but obviously still too slow to do anything really big with it. It isn't really the goal to be able to paste full documents.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots

Before fix, paste is cut off:

<img width="1149" alt="Screenshot 2023-04-26 at 10 56 11 AM" src="https://user-images.githubusercontent.com/1047709/234648337-025c49fb-91d6-42ae-ac5f-38b32b2516ec.png">


After fix:

<img width="1131" alt="Screenshot 2023-04-26 at 10 51 44 AM" src="https://user-images.githubusercontent.com/1047709/234648409-0332fd85-6324-4f98-b38a-6ff9f2ef4ad4.png">


### How Has This Been Tested?
Hot patched several console proxies in testing environments, and their handling of large pastes improved.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
