### PR TITLE
Qemu migration hook: check for source length before using element 0

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -61,21 +61,23 @@ def handleMigrateBegin():
     try:
         domain = parse(sys.stdin)
         for interface in domain.getElementsByTagName("interface"):
-            source = interface.getElementsByTagName("source")[0]
-            bridge = source.getAttribute("bridge")
-            if isOldStyleBridge(bridge):
-                vlanId = bridge.replace("cloudVirBr", "")
-                phyDev = getGuestNetworkDevice()
-            elif isNewStyleBridge(bridge):
-                vlanId = re.sub(r"br(\w+)-", "", bridge)
-                phyDev = re.sub(r"-(\d+)$", "" , re.sub(r"^br", "" ,bridge))
-                netlib = networkConfig()
-                if not netlib.isNetworkDev(phyDev):
+            sources = interface.getElementsByTagName("source")
+            if sources.length > 0:
+                source = interface.getElementsByTagName("source")[0]
+                bridge = source.getAttribute("bridge")
+                if isOldStyleBridge(bridge):
+                    vlanId = bridge.replace("cloudVirBr", "")
                     phyDev = getGuestNetworkDevice()
-            else:
-                continue
-            newBrName = "br" + phyDev + "-" + vlanId
-            source.setAttribute("bridge", newBrName)
+                elif isNewStyleBridge(bridge):
+                    vlanId = re.sub(r"br(\w+)-", "", bridge)
+                    phyDev = re.sub(r"-(\d+)$", "" , re.sub(r"^br", "" ,bridge))
+                    netlib = networkConfig()
+                    if not netlib.isNetworkDev(phyDev):
+                        phyDev = getGuestNetworkDevice()
+                else:
+                    continue
+                newBrName = "br" + phyDev + "-" + vlanId
+                source.setAttribute("bridge", newBrName)
         print(domain.toxml())
     except:
         pass


### PR DESCRIPTION
### Description

This PR checks that the NodeList returned from grabbing "source" element on a network interface actually returns items before trying to use the first element.

Not all network interface XML has a "source" field, so this would break qemu hooks from processing in some cases. The index out of bounds exception is silently swallowed, because I guess we don't want this to be fatal.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Ran a few different types of VM XML through the script via:

```
cat vm.xml | /etc/libvirt/hooks/qemu vm-name migrate begin -
```

Previously no output would be returned, with patch we get VM XML. Not sure if there is an existing test framework for these scripts to add some example XML to run through it at packaging/build time.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
