### PR TITLE
engine-storage: fix errored template becomes active

### DIFF
--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -286,6 +286,23 @@ public class TemplateServiceImpl implements TemplateService {
         }
     }
 
+    protected boolean isSkipTemplateStoreDownload(VMTemplateVO template, Long zoneId) {
+        if (template.isPublicTemplate()) {
+            return false;
+        }
+        if (template.isFeatured()) {
+            return false;
+        }
+        if (TemplateType.SYSTEM.equals(template.getTemplateType())) {
+            return false;
+        }
+        if (zoneId != null &&  _vmTemplateStoreDao.findByTemplateZone(template.getId(), zoneId, DataStoreRole.Image) == null) {
+            s_logger.debug(String.format("Template %s is not present on any image store for the zone ID: %d, its download cannot be skipped", template.getUniqueName(), zoneId));
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public void handleTemplateSync(DataStore store) {
         if (store == null) {
@@ -513,7 +530,7 @@ public class TemplateServiceImpl implements TemplateService {
                                 continue;
                             }
                             // if this is private template, skip sync to a new image store
-                            if (!tmplt.isPublicTemplate() && !tmplt.isFeatured() && tmplt.getTemplateType() != TemplateType.SYSTEM) {
+                            if (isSkipTemplateStoreDownload(tmplt, zoneId)) {
                                 s_logger.info("Skip sync downloading private template " + tmplt.getUniqueName() + " to a new image store");
                                 continue;
                             }

--- a/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
+++ b/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.storage.image;
+
+import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.Storage;
+import com.cloud.storage.VMTemplateVO;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TemplateServiceImplTest {
+
+    @InjectMocks
+    @Spy
+    TemplateServiceImpl templateService;
+
+    @Mock
+    TemplateDataStoreDao templateDataStoreDao;
+
+    @Test
+    public void testIsSkipTemplateStoreDownloadPublicTemplate() {
+        VMTemplateVO templateVO = Mockito.mock(VMTemplateVO.class);
+        Mockito.when(templateVO.isPublicTemplate()).thenReturn(true);
+        Assert.assertFalse(templateService.isSkipTemplateStoreDownload(templateVO, 1L));
+    }
+
+    @Test
+    public void testIsSkipTemplateStoreDownloadFeaturedTemplate() {
+        VMTemplateVO templateVO = Mockito.mock(VMTemplateVO.class);
+        Mockito.when(templateVO.isFeatured()).thenReturn(true);
+        Assert.assertFalse(templateService.isSkipTemplateStoreDownload(templateVO, 1L));
+    }
+
+    @Test
+    public void testIsSkipTemplateStoreDownloadSystemTemplate() {
+        VMTemplateVO templateVO = Mockito.mock(VMTemplateVO.class);
+        Mockito.when(templateVO.getTemplateType()).thenReturn(Storage.TemplateType.SYSTEM);
+        Assert.assertFalse(templateService.isSkipTemplateStoreDownload(templateVO, 1L));
+    }
+
+    @Test
+    public void testIsSkipTemplateStoreDownloadPrivateNoRefTemplate() {
+        VMTemplateVO templateVO = Mockito.mock(VMTemplateVO.class);
+        long id = 1L;
+        Mockito.when(templateVO.getId()).thenReturn(id);
+        Mockito.when(templateDataStoreDao.findByTemplateZone(id, id, DataStoreRole.Image)).thenReturn(null);
+        Assert.assertFalse(templateService.isSkipTemplateStoreDownload(templateVO, id));
+    }
+
+    @Test
+    public void testIsSkipTemplateStoreDownloadPrivateExistingTemplate() {
+        VMTemplateVO templateVO = Mockito.mock(VMTemplateVO.class);
+        long id = 1L;
+        Mockito.when(templateVO.getId()).thenReturn(id);
+        Mockito.when(templateDataStoreDao.findByTemplateZone(id, id, DataStoreRole.Image)).thenReturn(Mockito.mock(TemplateDataStoreVO.class));
+        Assert.assertTrue(templateService.isSkipTemplateStoreDownload(templateVO, id));
+    }
+}


### PR DESCRIPTION
### Description

Fixes #7342

When MS is restarted, failed non-public, non-featured, user templates are set to Active as their redownload is not attempted. This PR fixes the case.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
