### PR TITLE
increase log detail for limit checking, fix getDomainReservation()

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDaoImpl.java
@@ -63,7 +63,7 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
     @Override
     public long getDomainReservation(Long domainId, Resource.ResourceType resourceType) {
         long total = 0;
-        SearchCriteria<ReservationVO> sc = listAccountAndTypeSearch.create();
+        SearchCriteria<ReservationVO> sc = listDomainAndTypeSearch.create();
         sc.setParameters(DOMAIN_ID, domainId);
         sc.setParameters(RESOURCE_TYPE, resourceType);
         List<ReservationVO> reservations = listBy(sc);

--- a/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -433,8 +433,25 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
                 long currentDomainResourceCount = _resourceCountDao.getResourceCount(domainId, ResourceOwnerType.Domain, type);
                 long currentResourceReservation = reservationDao.getDomainReservation(domainId, type);
                 long requestedDomainResourceCount = currentDomainResourceCount + currentResourceReservation + numResources;
-                String messageSuffix = " domain resource limits of Type '" + type + "'" + " for Domain Id = " + domainId + " is exceeded: Domain Resource Limit = " + toHumanReadableSize(domainResourceLimit)
-                        + ", Current Domain Resource Amount = " + toHumanReadableSize(currentDomainResourceCount) + ", Requested Resource Amount = " + toHumanReadableSize(numResources) + ".";
+
+                String convDomainResourceLimit = String.valueOf(domainResourceLimit);
+                String convCurrentDomainResourceCount = String.valueOf(currentDomainResourceCount);
+                String convCurrentResourceReservation = String.valueOf(currentResourceReservation);
+                String convNumResources = String.valueOf(numResources);
+
+                if (type == ResourceType.secondary_storage || type == ResourceType.primary_storage){
+                    convDomainResourceLimit = toHumanReadableSize(domainResourceLimit);
+                    convCurrentDomainResourceCount = toHumanReadableSize(currentDomainResourceCount);
+                    convCurrentResourceReservation = toHumanReadableSize(currentResourceReservation);
+                    convNumResources = toHumanReadableSize(numResources);
+                }
+
+                String messageSuffix = String.format(
+                        " domain resource limits of Type '%s' for Domain Id = %s is exceeded: Domain Resource Limit = %s, " +
+                        "Current Domain Resource Amount = %s, Current Resource Reservation = %s, Requested Resource Amount = %s.",
+                        type, domainId, convDomainResourceLimit,
+                        convCurrentDomainResourceCount, convCurrentResourceReservation, convNumResources
+                );
 
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Checking if" + messageSuffix);
@@ -460,17 +477,22 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
         String convertedAccountResourceLimit = String.valueOf(accountResourceLimit);
         String convertedCurrentResourceCount = String.valueOf(currentResourceCount);
+        String convertedCurrentResourceReservation = String.valueOf(currentResourceReservation);
         String convertedNumResources = String.valueOf(numResources);
 
         if (type == ResourceType.secondary_storage || type == ResourceType.primary_storage){
             convertedAccountResourceLimit = toHumanReadableSize(accountResourceLimit);
             convertedCurrentResourceCount = toHumanReadableSize(currentResourceCount);
+            convertedCurrentResourceReservation = toHumanReadableSize(currentResourceReservation);
             convertedNumResources = toHumanReadableSize(numResources);
         }
 
-        String messageSuffix = " amount of resources of Type = '" + type + "' for " + (project == null ? "Account Name = " + account.getAccountName() : "Project Name = " + project.getName())
-                + " in Domain Id = " + account.getDomainId() + " is exceeded: Account Resource Limit = " + convertedAccountResourceLimit + ", Current Account Resource Amount = " + convertedCurrentResourceCount
-                + ", Requested Resource Amount = " + convertedNumResources + ".";
+        String messageSuffix = String.format(
+                " amount of resources of Type = '%s' for %s in Domain Id = %s is exceeded: " +
+                "Account Resource Limit = %s, Current Account Resource Amount = %s, Current Account Resource Reservation = %s, Requested Resource Amount = %s.",
+                type, (project == null ? "Account Name = " + account.getAccountName() : "Project Name = " + project.getName()), account.getDomainId(),
+                convertedAccountResourceLimit, convertedCurrentResourceCount, convertedCurrentResourceReservation, convertedNumResources
+        );
 
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Checking if" + messageSuffix);


### PR DESCRIPTION
### Description

In troubleshooting ops issues we see logs like:

Maximum domain resource limits of Type 'user_vm' for Domain Id = 763 is exceeded: Domain Resource Limit = (1 bytes) 1, Current Domain Resource Amount = (0 bytes) 0, Requested Resource Amount = (1 bytes) 1."

However there is one missing value (currentResourceReservation) that is used in the calculation of limit check but it is not logged, which leads to confusion. Above we see we are using “0” and requested 1, with our limit being 1, but was rejected. Without logging all the values used in the calculation we don’t understand why it failed.

Additionally, if we had this log above it would be clearer that a second bug is occurring. When we query for domain level resource reservations in “getDomainReservation” the actual SearchBuilder is the listAccountAndTypeSearch, not the listDomainAndTypeSearch. As a result, when we call getDomainReservation the query returns any outstanding domain reservation for any account, as domain ID is not a valid filter for the account search.

This PR:

- Increases detailed information in log for checking resource limit to include reservations information for functions: checkDomainResourceLimit() and checkAccountResourceLimit

- Fixes getDomainReservation() to use listDomainAndTypeSearch instead of listAccountAndTypeSearch

#### Testing
Log generation manually tested

#### Log samples

Before the change

(logprefix) ... Checking if amount of resources of Type = 'user_vm' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 20, Current Account Resource Amount = 0, Requested Resource Amount = 1.
(logprefix) ... Checking if amount of resources of Type = 'cpu' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 40, Current Account Resource Amount = 0, Requested Resource Amount = 1.
(logprefix) ... Checking if amount of resources of Type = 'memory' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 40960, Current Account Resource Amount = 0, Requested Resource Amount = 512.
(logprefix) ... Checking if amount of resources of Type = 'volume' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 20, Current Account Resource Amount = 0, Requested Resource Amount = 1.
(logprefix) ... Checking if amount of resources of Type = 'primary_storage' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = (200.00 GB) 214748364800, Current Account Resource Amount = (0 bytes) 0, Requested Resource Amount = (5.00 GB) 5368709120.


After the change

(logprefix) ... Checking if amount of resources of Type = 'user_vm' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 20, Current Account Resource Amount = 1, Current Account Resource Reservation = 0, Requested Resource Amount = 1.
(logprefix) ... Checking if amount of resources of Type = 'cpu' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 40, Current Account Resource Amount = 1, Current Account Resource Reservation = 0, Requested Resource Amount = 1.
(logprefix) ... Checking if amount of resources of Type = 'memory' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 40960, Current Account Resource Amount = 512, Current Account Resource Reservation = 0, Requested Resource Amount = 512.
(logprefix) ... Checking if amount of resources of Type = 'volume' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = 20, Current Account Resource Amount = 1, Current Account Resource Reservation = 0, Requested Resource Amount = 1.
(logprefix) ... Checking if amount of resources of Type = 'primary_storage' for Account Name = domainadmin_user in Domain Id = 1 is exceeded: Account Resource Limit = (200.00 GB) 214748364800, Current Account Resource Amount = (5.00 GB) 5368709120, Current Account Resource Reservation = (0 bytes) 0, Requested Resource Amount = (5.00 GB) 5368709120.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial
