### PR TITLE
Tungsten: change conserve_mode of default network offering to 0

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41800to41810.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41800to41810.sql
@@ -19,3 +19,5 @@
 -- Schema upgrade from 4.18.0.0 to 4.18.1.0
 --;
 
+-- Update conserve_mode of the default network offering for Tungsten Fabric (this fixes issue #7241)
+UPDATE `cloud`.`network_offerings` SET conserve_mode = 0 WHERE unique_name ='DefaultTungstenFarbicNetworkOffering';

--- a/plugins/network-elements/tungsten/src/main/java/org/apache/cloudstack/network/tungsten/api/command/ConfigTungstenFabricServiceCmd.java
+++ b/plugins/network-elements/tungsten/src/main/java/org/apache/cloudstack/network/tungsten/api/command/ConfigTungstenFabricServiceCmd.java
@@ -139,7 +139,7 @@ public class ConfigTungstenFabricServiceCmd extends BaseCmd {
                     networkOfferingVO = new NetworkOfferingVO(NETWORKOFFERING,
                             "Default offering for Tungsten-Fabric Network", Networks.TrafficType.Guest, false, false,
                             null, null, true, NetworkOffering.Availability.Optional, null, Network.GuestType.Isolated,
-                            true, false, false, false, true, false);
+                            false, false, false, false, true, false);
                     networkOfferingVO.setForTungsten(true);
                     networkOfferingVO.setState(NetworkOffering.State.Enabled);
                     networkOfferingDao.persist(networkOfferingVO);


### PR DESCRIPTION
### Description

This PR fixes #7241 


<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
