### PR TITLE
secondary-storage: delete backedup snapshot dir on delete

### DIFF
--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -2034,6 +2034,10 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             }
             // delete snapshot in the directory if exists
             String lPath = absoluteSnapshotPath + "/*" + snapshotName + "*";
+            if (absoluteSnapshotPath.endsWith(snapshotName)) {
+                s_logger.debug(String.format("Snapshot file %s is present in the same name directory %s. Deleting the directory", snapshotName, absoluteSnapshotPath));
+                lPath = absoluteSnapshotPath;
+            }
             String result = deleteLocalFile(lPath);
             if (result != null) {
                 details = "failed to delete snapshot " + lPath + " , err=" + result;

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -1997,6 +1997,17 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         }
     }
 
+    protected String getSnapshotFilepathForDelete(String path, String snapshotName) {
+        String finalPath = path + "/*" + snapshotName + "*";
+        if (!path.endsWith(snapshotName)) {
+            return finalPath;
+        }
+        if (s_logger.isDebugEnabled()) {
+            s_logger.debug(String.format("Snapshot file %s is present in the same name directory %s. Deleting the directory", snapshotName, path));
+        }
+        return path;
+    }
+
     protected Answer deleteSnapshot(final DeleteCommand cmd) {
         DataTO obj = cmd.getData();
         DataStoreTO dstore = obj.getDataStore();
@@ -2033,11 +2044,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 return new Answer(cmd, true, details);
             }
             // delete snapshot in the directory if exists
-            String lPath = absoluteSnapshotPath + "/*" + snapshotName + "*";
-            if (absoluteSnapshotPath.endsWith(snapshotName)) {
-                s_logger.debug(String.format("Snapshot file %s is present in the same name directory %s. Deleting the directory", snapshotName, absoluteSnapshotPath));
-                lPath = absoluteSnapshotPath;
-            }
+            String lPath = getSnapshotFilepathForDelete(absoluteSnapshotPath, snapshotName);
             String result = deleteLocalFile(lPath);
             if (result != null) {
                 details = "failed to delete snapshot " + lPath + " , err=" + result;

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -1998,9 +1998,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     }
 
     protected String getSnapshotFilepathForDelete(String path, String snapshotName) {
-        String finalPath = path + "/*" + snapshotName + "*";
         if (!path.endsWith(snapshotName)) {
-            return finalPath;
+            return path + "/*" + snapshotName + "*";
         }
         if (s_logger.isDebugEnabled()) {
             s_logger.debug(String.format("Snapshot file %s is present in the same name directory %s. Deleting the directory", snapshotName, path));

--- a/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResourceTest.java
+++ b/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResourceTest.java
@@ -91,4 +91,21 @@ public class NfsSecondaryStorageResourceTest {
         testLogAppender.assertMessagesLogged();
 
     }
+
+    private void performGetSnapshotFilepathForDeleteTest(String expected, String path, String name) {
+        Assert.assertEquals("Incorrect resultant snapshot delete path", expected, resource.getSnapshotFilepathForDelete(path, name));
+    }
+
+    @Test
+    public void testGetSnapshotFilepathForDelete() {
+        performGetSnapshotFilepathForDeleteTest("/snapshots/2/10/somename",
+                "/snapshots/2/10/somename",
+                "somename");
+        performGetSnapshotFilepathForDeleteTest("/snapshots/2/10/diffName/*diffname*",
+                "/snapshots/2/10/diffName",
+                "diffname");
+        performGetSnapshotFilepathForDeleteTest("/snapshots/2/10/*somename*",
+                "/snapshots/2/10",
+                "somename");
+    }
 }


### PR DESCRIPTION
### Description

Fixes #7516

When a backed-up snapshot is deleted and the snapshot file is present in the same name directory (probably only for VMware), the whole directory can be deleted.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

**Tested deleting a backedup volume snapshot on VMware**
Logs:
```
2023-05-12 09:45:49,879 DEBUG [cloud.agent.Agent] (agentRequest-Handler-4:null) Request:Seq 5-731553464470994956:  { Cmd , MgmtId: 32988117074588, via: 5, Ver: v1, Flags: 100011, [{"org.apache.cloudstack.storage.command.DeleteCommand":{"data":{"org.apache.cloudstack.storage.to.SnapshotObjectTO":{"path":"snapshots/2/10/900f3dd1-5be2-4036-ae08-b93548d9e5c8/900f3dd1-5be2-4036-ae08-b93548d9e5c8","volume":{"uuid":"56730834-50ec-45be-b1e0-2040a271a1c3","volumeType":"ROOT","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"e13a6bdb-50ff-30d9-b446-653989234532","name":"ref-trl-4867-v-M7-abhishek-kumar-esxi-pri2","id":"2","poolType":"NetworkFilesystem","host":"10.0.32.4","path":"/acs/primary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-esxi-pri2","port":"2049","url":"NetworkFilesystem://10.0.32.4/acs/primary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-esxi-pri2/?ROLE=Primary&STOREUUID=e13a6bdb-50ff-30d9-b446-653989234532","isManaged":"false"}},"name":"ROOT-10","size":"(2.00 GB) 2147483648","path":"ROOT-10","volumeId":"10","vmName":"i-2-10-VM","accountId":"2","chainInfo":"{"diskDeviceBusName":"ide0:1","diskChain":["[e13a6bdb50ff30d9b446653989234532] i-2-10-VM/ROOT-10.vmdk","[e13a6bdb50ff30d9b446653989234532] 85ae42cf969a3bd99d767590746a5209/85ae42cf969a3bd99d767590746a5209.vmdk"]}","format":"OVA","provisioningType":"THIN","poolId":"2","id":"10","deviceId":"0","hypervisorType":"VMware","directDownload":"false","deployAsIs":"false"},"dataStore":{"com.cloud.agent.api.to.NfsTO":{"_url":"NFS://10.0.32.4/acs/secondary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-sec1","_role":"Image"}},"vmName":"i-2-10-VM","name":"VM-5128d690-2204-415a-85e8-fb6516d1974f_ROOT-10_20230512094317","hypervisorType":"VMware","id":"6","quiescevm":"false","physicalSize":"0"}},"wait":"0","bypassHostMaintenance":"false"}}] }
2023-05-12 09:45:49,883 DEBUG [cloud.agent.Agent] (agentRequest-Handler-4:null) Processing command: org.apache.cloudstack.storage.command.DeleteCommand
2023-05-12 09:45:49,886 INFO  [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Determined host 10.0.32.4 corresponds to IP 10.0.32.4
2023-05-12 09:45:49,886 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Mounting device with nfs-style path of 10.0.32.4:/acs/secondary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-sec1
2023-05-12 09:45:49,887 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) mount NFS://10.0.32.4/acs/secondary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-sec1 on /mnt/SecStorage/18061267-f04b-31f5-9b46-f508765a8cef nfsVersion=null
2023-05-12 09:45:49,887 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) making available /mnt/SecStorage/18061267-f04b-31f5-9b46-f508765a8cef on NFS://10.0.32.4/acs/secondary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-sec1
2023-05-12 09:45:49,887 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) local folder for mount will be /mnt/SecStorage/18061267-f04b-31f5-9b46-f508765a8cef
2023-05-12 09:45:49,888 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Executing: mount 
2023-05-12 09:45:49,893 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Executing while with timeout : 1440000
2023-05-12 09:45:49,894 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Execution is successful.
2023-05-12 09:45:49,894 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Some device already mounted at /mnt/SecStorage/18061267-f04b-31f5-9b46-f508765a8cef, no need to mount NFS://10.0.32.4/acs/secondary/ref-trl-4867-v-M7-abhishek-kumar/ref-trl-4867-v-M7-abhishek-kumar-sec1
2023-05-12 09:45:49,909 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Snapshot file 900f3dd1-5be2-4036-ae08-b93548d9e5c8 is present in the same name directory /mnt/SecStorage/18061267-f04b-31f5-9b46-f508765a8cef/snapshots/2/10/900f3dd1-5be2-4036-ae08-b93548d9e5c8. Deleting the directory
2023-05-12 09:45:49,909 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Executing: /bin/bash -c rm -rf /mnt/SecStorage/18061267-f04b-31f5-9b46-f508765a8cef/snapshots/2/10/900f3dd1-5be2-4036-ae08-b93548d9e5c8 
2023-05-12 09:45:49,911 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Executing while with timeout : 3600000
2023-05-12 09:45:50,014 DEBUG [storage.resource.NfsSecondaryStorageResource] (agentRequest-Handler-4:null) Execution is successful.
```

Storage
before deletion:
```
[root@nfs snapshots]# tree
.
└── 2
    ├── 10
    │   ├── 1039daff-ef99-41df-bffd-ee345490d42b
    │   ├── 52794c72-b196-4de2-aaa8-3a0132806a15
    │   ├── 900f3dd1-5be2-4036-ae08-b93548d9e5c8
    │   │   ├── 900f3dd1-5be2-4036-ae08-b93548d9e5c8-disk0.vmdk
    │   │   ├── 900f3dd1-5be2-4036-ae08-b93548d9e5c8-disk1.nvram
    │   │   └── 900f3dd1-5be2-4036-ae08-b93548d9e5c8.ovf
    │   ├── bd232cab-baa1-4ac5-9b10-bbc48c2bc312
    │   └── fd57cb44-0559-490c-998d-5313eec52cef
    │       ├── fd57cb44-0559-490c-998d-5313eec52cef-disk0.vmdk
    │       ├── fd57cb44-0559-490c-998d-5313eec52cef-disk1.nvram
    │       └── fd57cb44-0559-490c-998d-5313eec52cef.ovf
    └── 9
        └── 91fa77c2-15cc-412d-9358-b1178730ce43

9 directories, 6 files
```

after deletion:
```
[root@sl-nestednfs snapshots]# tree
.
└── 2
    ├── 10
    │   ├── 1039daff-ef99-41df-bffd-ee345490d42b
    │   ├── 52794c72-b196-4de2-aaa8-3a0132806a15
    │   ├── bd232cab-baa1-4ac5-9b10-bbc48c2bc312
    │   └── fd57cb44-0559-490c-998d-5313eec52cef
    │       ├── fd57cb44-0559-490c-998d-5313eec52cef-disk0.vmdk
    │       ├── fd57cb44-0559-490c-998d-5313eec52cef-disk1.nvram
    │       └── fd57cb44-0559-490c-998d-5313eec52cef.ovf
    └── 9
        └── 91fa77c2-15cc-412d-9358-b1178730ce43

8 directories, 3 files
```
