### PR TITLE
Fix acquire console session issue

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/ConsoleSessionVO.java
+++ b/engine/schema/src/main/java/com/cloud/vm/ConsoleSessionVO.java
@@ -27,6 +27,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 @Entity
 @Table(name = "console_session")
@@ -56,6 +58,7 @@ public class ConsoleSessionVO {
     private long hostId;
 
     @Column(name = "acquired")
+    @Temporal(value = TemporalType.TIMESTAMP)
     private Date acquired;
 
     @Column(name = "removed")

--- a/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDaoImpl.java
@@ -19,21 +19,16 @@
 
 package com.cloud.vm.dao;
 
-import java.sql.PreparedStatement;
 import java.util.Date;
 
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
-import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.vm.ConsoleSessionVO;
-import org.apache.log4j.Logger;
 
 public class ConsoleSessionDaoImpl extends GenericDaoBase<ConsoleSessionVO, Long> implements ConsoleSessionDao {
 
     private final SearchBuilder<ConsoleSessionVO> searchByRemovedDate;
-    private static final String ACQUIRE_CONSOLE_SESSION = "UPDATE console_session SET acquired = ? WHERE id = ?";
-    private static final Logger LOGGER = Logger.getLogger(ConsoleSessionDaoImpl.class);
 
     public ConsoleSessionDaoImpl() {
         searchByRemovedDate = createSearchBuilder();
@@ -65,20 +60,9 @@ public class ConsoleSessionDaoImpl extends GenericDaoBase<ConsoleSessionVO, Long
 
     @Override
     public void acquireSession(String sessionUuid) {
-        TransactionLegacy txn = TransactionLegacy.currentTxn();
         ConsoleSessionVO consoleSessionVO = findByUuid(sessionUuid);
-        long consoleSessionId = consoleSessionVO.getId();
-        try {
-            txn.start();
-            PreparedStatement preparedStatement = txn.prepareAutoCloseStatement(ACQUIRE_CONSOLE_SESSION);
-            preparedStatement.setDate(1, new java.sql.Date(-1L));
-            preparedStatement.setLong(2, consoleSessionId);
-            preparedStatement.executeUpdate();
-            txn.commit();
-        } catch (Exception e) {
-            txn.rollback();
-            LOGGER.warn(String.format("Failed acquiring console session id = %s: %s", consoleSessionId, e.getMessage()), e);
-        }
+        consoleSessionVO.setAcquired(new Date());
+        update(consoleSessionVO.getId(), consoleSessionVO);
     }
 
 

--- a/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDaoImpl.java
@@ -19,16 +19,21 @@
 
 package com.cloud.vm.dao;
 
+import java.sql.PreparedStatement;
 import java.util.Date;
 
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.vm.ConsoleSessionVO;
+import org.apache.log4j.Logger;
 
 public class ConsoleSessionDaoImpl extends GenericDaoBase<ConsoleSessionVO, Long> implements ConsoleSessionDao {
 
     private final SearchBuilder<ConsoleSessionVO> searchByRemovedDate;
+    private static final String ACQUIRE_CONSOLE_SESSION = "UPDATE console_session SET acquired = ? WHERE id = ?";
+    private static final Logger LOGGER = Logger.getLogger(ConsoleSessionDaoImpl.class);
 
     public ConsoleSessionDaoImpl() {
         searchByRemovedDate = createSearchBuilder();
@@ -60,9 +65,20 @@ public class ConsoleSessionDaoImpl extends GenericDaoBase<ConsoleSessionVO, Long
 
     @Override
     public void acquireSession(String sessionUuid) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
         ConsoleSessionVO consoleSessionVO = findByUuid(sessionUuid);
-        consoleSessionVO.setAcquired(new Date());
-        update(consoleSessionVO.getId(), consoleSessionVO);
+        long consoleSessionId = consoleSessionVO.getId();
+        try {
+            txn.start();
+            PreparedStatement preparedStatement = txn.prepareAutoCloseStatement(ACQUIRE_CONSOLE_SESSION);
+            preparedStatement.setDate(1, new java.sql.Date(-1L));
+            preparedStatement.setLong(2, consoleSessionId);
+            preparedStatement.executeUpdate();
+            txn.commit();
+        } catch (Exception e) {
+            txn.rollback();
+            LOGGER.warn(String.format("Failed acquiring console session id = %s: %s", consoleSessionId, e.getMessage()), e);
+        }
     }
 
 


### PR DESCRIPTION
### Description

This PR fixes the VM console display on the main branch

Fixes: #7550 

Before the fix:
````
2023-05-24 19:03:06,005 DEBUG [c.c.c.AgentHookBase] (AgentManager-Handler-8:null) (logid:) Acquiring session [cbc024b7-209a-4518-b582-7cc45272a29b] as it was just used.
2023-05-24 19:03:06,007 DEBUG [c.c.u.d.T.Transaction] (AgentManager-Handler-8:null) (logid:) Rolling back the transaction: Time = 1 Name =  -ClusteredAgentManagerImpl$ClusteredAgentHandler.doTask:624-Task.call:83-Task.call:29-FutureTask.run:264-ThreadPoolExecutor.runWorker:1128-ThreadPoolExecutor$Worker.run:628-Thread.run:829; called by -TransactionLegacy.rollback:888-TransactionLegacy.removeUpTo:831-TransactionLegacy.close:655-TransactionContextInterceptor.invoke:36-ReflectiveMethodInvocation.proceed:175-ExposeInvocationInterceptor.invoke:97-ReflectiveMethodInvocation.proceed:186-JdkDynamicAopProxy.invoke:215-$Proxy251.acquireSession:-1-ConsoleAccessManagerImpl.acquireSession:251-AgentHookBase.onConsoleAccessAuthentication:114-ConsoleProxyListener.processControlCommand:61
2023-05-24 19:03:06,009 WARN  [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-8:null) (logid:) Caught: 
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: com.mysql.cj.jdbc.ClientPreparedStatement: UPDATE console_session SET console_session.acquired=** NOT SPECIFIED ** WHERE console_session.id = 13 
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:847)
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:802)
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:1399)
	at com.cloud.vm.dao.ConsoleSessionDaoImpl.acquireSession(ConsoleSessionDaoImpl.java:65)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at com.cloud.utils.db.TransactionContextInterceptor.invoke(TransactionContextInterceptor.java:34)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy251.acquireSession(Unknown Source)
	at org.apache.cloudstack.consoleproxy.ConsoleAccessManagerImpl.acquireSession(ConsoleAccessManagerImpl.java:251)
	at com.cloud.consoleproxy.AgentHookBase.onConsoleAccessAuthentication(AgentHookBase.java:114)
	at com.cloud.consoleproxy.ConsoleProxyListener.processControlCommand(ConsoleProxyListener.java:61)
	at com.cloud.agent.manager.AgentManagerImpl.handleControlCommand(AgentManagerImpl.java:300)
	at com.cloud.agent.manager.AgentManagerImpl$AgentHandler.processRequest(AgentManagerImpl.java:1364)
	at com.cloud.agent.manager.AgentManagerImpl$AgentHandler.doTask(AgentManagerImpl.java:1450)
	at com.cloud.agent.manager.ClusteredAgentManagerImpl$ClusteredAgentHandler.doTask(ClusteredAgentManagerImpl.java:709)
	at com.cloud.utils.nio.Task.call(Task.java:83)
	at com.cloud.utils.nio.Task.call(Task.java:29)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.sql.SQLException: No value specified for parameter 1
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	... 36 more
2023-05-24 19:03:06,011 DEBUG [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-8:null) (logid:) SeqA 3-126: Sending Seq 3-126:  { Ans: , MgmtId: 167781138, via: 3, Ver: v1, Flags: 100010, [{"com.cloud.agent.api.Answer":{"result":"false","details":"DB Exception on: com.mysql.cj.jdbc.ClientPreparedStatement: UPDATE console_session SET console_session.acquired=** NOT SPECIFIED ** WHERE console_session.id = 13 ","wait":"0","bypassHostMaintenance":"false"}}] }
````

After the fix: VM console displayed correctly

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
View VM console
