### PR TITLE
Add check on host's status while deleting config drive on host cache

### DIFF
--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.network.element;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.UnsupportedServiceException;
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
+import com.cloud.host.Status;
 import com.cloud.hypervisor.HypervisorGuruManager;
 import com.cloud.network.Network;
 import com.cloud.network.Network.Capability;
@@ -571,6 +573,10 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         HostVO hostVO = _hostDao.findById(hostId);
         if (hostVO == null) {
             LOG.warn(String.format("Host %s appears to be unavailable, skipping deletion of config-drive ISO on host cache", hostId));
+            return false;
+        }
+        if (!Arrays.asList(Status.Up, Status.Connecting).contains(hostVO.getStatus())) {
+            LOG.warn(String.format("Host status %s is not Up or Connecting, skipping deletion of config-drive ISO on host cache", hostId));
             return false;
         }
 


### PR DESCRIPTION
### Description
This PR adds a check on host's status. Without this if the agent is not in Up or Connecting state, expunging of a VM fails.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Steps to reproduce:
1. Enable `vm.configdrive.force.host.cache.use` in `Global Configuration`.
2. Create a L2 network with config drive
3. Deploy  a vm with the L2 network created in previous step
4. Stop the vm and destroy vm (not expunge it)
5. Stop the cloudstack-agent on the VM's host
6. Expunge the vm


<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #7428 

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
Setup an environment using mbx and following the steps above to reproduce it.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
