### PR TITLE
Do not list Quota API's to accounts with Quota disabled

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/BaseCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/BaseCmd.java
@@ -380,10 +380,9 @@ public abstract class BaseCmd {
     }
 
     /**
-     * To be overwritten by any class who needs specific validation
+     * Method intended to execute command's specific permissions and parameters. Should be overwritten by any class who needs specific validation.
      */
-    public void validateSpecificParameters(final Map<String, String> params){
-        // To be overwritten by any class who needs specific validation
+    public void validateCommandSpecificPermissionsAndParameters(final Map<String, String> params){
     }
 
     /**

--- a/api/src/main/java/org/apache/cloudstack/api/BaseListCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/BaseListCmd.java
@@ -118,8 +118,8 @@ public abstract class BaseListCmd extends BaseCmd implements IBaseListCmd {
     }
 
     @Override
-    public void validateSpecificParameters(final Map<String, String> params){
-        super.validateSpecificParameters(params);
+    public void validateCommandSpecificPermissionsAndParameters(final Map<String, String> params){
+        super.validateCommandSpecificPermissionsAndParameters(params);
 
         final Object pageSizeObj = params.get(ApiConstants.PAGE_SIZE);
         Long pageSize = null;

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/PluginAccessConfigs.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/PluginAccessConfigs.java
@@ -1,0 +1,10 @@
+package org.apache.cloudstack.framework.config;
+
+public interface PluginAccessConfigs {
+
+    public static final ConfigKey<Boolean> QuotaPluginEnabled = new ConfigKey<Boolean>("Advanced", Boolean.class, "quota.enable.service", "false",
+            "Indicates whether Quota plugin is enabled or not.", true);
+
+    ConfigKey<Boolean> QuotaAccountEnabled = new ConfigKey<>("Advanced", Boolean.class, "quota.account.enabled", "true", "Indicates whether Quota plugin is enabled or not for " +
+            "the account.", true, ConfigKey.Scope.Account);
+}

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/PluginAccessConfigs.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/PluginAccessConfigs.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.framework.config;
 
 public interface PluginAccessConfigs {

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
@@ -18,11 +18,9 @@
 package org.apache.cloudstack.quota.constant;
 
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.PluginAccessConfigs;
 
-public interface QuotaConfig {
-
-    public static final ConfigKey<Boolean> QuotaPluginEnabled = new ConfigKey<Boolean>("Advanced", Boolean.class, "quota.enable.service", "false",
-            "Indicates whether Quota plugin is enabled or not.", true);
+public interface QuotaConfig extends PluginAccessConfigs {
 
     public static final ConfigKey<String> QuotaEnableEnforcement = new ConfigKey<String>("Advanced", String.class, "quota.enable.enforcement", "false",
             "Enable the usage quota enforcement, i.e. on true when exceeding quota the respective account will be locked.", true);

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -68,7 +68,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
     List<PluggableService> _services = null;
     protected static Map<String, ApiDiscoveryResponse> s_apiNameDiscoveryResponseMap = null;
 
-    List<String> quotaCmdList;
+    private List<String> quotaCmdList;
 
     @Inject
     AccountService accountService;
@@ -271,7 +271,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
             if (!s_apiNameDiscoveryResponseMap.containsKey(name))
                 return null;
 
-            if (accountNotAdminAndQuotaEnabledAndQuotaAccountNotEnabledAndApiNameInQuotaCmdList(user, name, account))
+            if (isAccountNotAdminAndQuotaEnabledAndQuotaAccountNotEnabledAndApiNameInQuotaCmdList(user, name, account))
                 return null;
 
             for (APIChecker apiChecker : _apiAccessCheckers) {
@@ -317,13 +317,9 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         }
     }
 
-    private boolean accountNotAdminAndQuotaEnabledAndQuotaAccountNotEnabledAndApiNameInQuotaCmdList(User user, String name, Account account) {
-        if (account.getType() != Account.Type.ADMIN && PluginAccessConfigs.QuotaPluginEnabled.value() &&
-            !PluginAccessConfigs.QuotaAccountEnabled.valueIn(user.getAccountId()) && quotaCmdList.parallelStream().anyMatch(name::equalsIgnoreCase)) {
-
-            return true;
-        }
-        return false;
+    private boolean isAccountNotAdminAndQuotaEnabledAndQuotaAccountNotEnabledAndApiNameInQuotaCmdList(User user, String name, Account account) {
+        return account.getType() != Account.Type.ADMIN && PluginAccessConfigs.QuotaPluginEnabled.value() &&
+                !PluginAccessConfigs.QuotaAccountEnabled.valueIn(user.getAccountId()) && quotaCmdList.parallelStream().anyMatch(name::equalsIgnoreCase);
     }
 
     @Override

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBalanceCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBalanceCmd.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
@@ -34,7 +33,7 @@ import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
 import org.apache.cloudstack.api.response.QuotaStatementItemResponse;
 
 @APICommand(name = "quotaBalance", responseObject = QuotaStatementItemResponse.class, description = "Create a quota balance statement", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaBalanceCmd extends BaseCmd {
+public class QuotaBalanceCmd extends QuotaBaseCmd {
 
     public static final Logger s_logger = Logger.getLogger(QuotaBalanceCmd.class);
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBaseCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBaseCmd.java
@@ -35,6 +35,11 @@ public abstract class QuotaBaseCmd extends BaseCmd {
 
     public static void validateQuotaAccountEnabled(BaseCmd cmd) {
         Account caller = CallContext.current().getCallingAccount();
+
+        if (caller.getType().equals(Account.Type.ADMIN)) {
+            return;
+        }
+
         if (!QuotaConfig.QuotaPluginEnabled.value() || !QuotaConfig.QuotaAccountEnabled.valueIn(caller.getAccountId())){
             throw new UnavailableCommandException(String.format("The API [%s] is not available for account %s.", cmd.getActualCommandName(),
                     ReflectionToStringBuilderUtils.reflectOnlySelectedFields(caller, "accountName", "uuid")));

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBaseCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBaseCmd.java
@@ -1,0 +1,44 @@
+//Licensed to the Apache Software Foundation (ASF) under one
+//or more contributor license agreements.  See the NOTICE file
+//distributed with this work for additional information
+//regarding copyright ownership.  The ASF licenses this file
+//to you under the Apache License, Version 2.0 (the
+//"License"); you may not use this file except in compliance
+//with the License.  You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing,
+//software distributed under the License is distributed on an
+//"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//KIND, either express or implied.  See the License for the
+//specific language governing permissions and limitations
+//under the License.
+package org.apache.cloudstack.api.command;
+
+import com.cloud.exception.UnavailableCommandException;
+import com.cloud.user.Account;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.quota.constant.QuotaConfig;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+
+import java.util.Map;
+
+public abstract class QuotaBaseCmd extends BaseCmd {
+
+    @Override
+    public void validateCommandSpecificPermissionsAndParameters(final Map<String, String> params) {
+        validateQuotaAccountEnabled(this);
+        super.validateCommandSpecificPermissionsAndParameters(params);
+    }
+
+    public static void validateQuotaAccountEnabled(BaseCmd cmd) {
+        Account caller = CallContext.current().getCallingAccount();
+        if (!QuotaConfig.QuotaPluginEnabled.value() || !QuotaConfig.QuotaAccountEnabled.valueIn(caller.getAccountId())){
+            throw new UnavailableCommandException(String.format("The API [%s] is not available for account %s.", cmd.getActualCommandName(),
+                    ReflectionToStringBuilderUtils.reflectOnlySelectedFields(caller, "accountName", "uuid")));
+        }
+    }
+
+}

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBaseListCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaBaseListCmd.java
@@ -1,0 +1,31 @@
+//Licensed to the Apache Software Foundation (ASF) under one
+//or more contributor license agreements.  See the NOTICE file
+//distributed with this work for additional information
+//regarding copyright ownership.  The ASF licenses this file
+//to you under the Apache License, Version 2.0 (the
+//"License"); you may not use this file except in compliance
+//with the License.  You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing,
+//software distributed under the License is distributed on an
+//"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//KIND, either express or implied.  See the License for the
+//specific language governing permissions and limitations
+//under the License.
+package org.apache.cloudstack.api.command;
+
+import org.apache.cloudstack.api.BaseListCmd;
+
+
+import java.util.Map;
+
+public abstract class QuotaBaseListCmd extends BaseListCmd {
+
+    @Override
+    public void validateCommandSpecificPermissionsAndParameters(final Map<String, String> params) {
+        QuotaBaseCmd.validateQuotaAccountEnabled(this);
+        super.validateCommandSpecificPermissionsAndParameters(params);
+    }
+}

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaCreditsCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaCreditsCmd.java
@@ -21,7 +21,6 @@ import com.cloud.user.Account;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.DomainResponse;
@@ -34,7 +33,7 @@ import org.apache.log4j.Logger;
 import javax.inject.Inject;
 
 @APICommand(name = "quotaCredits", responseObject = QuotaCreditsResponse.class, description = "Add +-credits to an account", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaCreditsCmd extends BaseCmd {
+public class QuotaCreditsCmd extends QuotaBaseCmd {
 
     @Inject
     QuotaResponseBuilder _responseBuilder;

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaEmailTemplateListCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaEmailTemplateListCmd.java
@@ -17,7 +17,6 @@
 package org.apache.cloudstack.api.command;
 
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.BaseListCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.QuotaEmailTemplateResponse;
@@ -27,7 +26,7 @@ import org.apache.log4j.Logger;
 import javax.inject.Inject;
 
 @APICommand(name = "quotaEmailTemplateList", responseObject = QuotaEmailTemplateResponse.class, description = "Lists all quota email templates", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaEmailTemplateListCmd extends BaseListCmd {
+public class QuotaEmailTemplateListCmd extends QuotaBaseListCmd {
     public static final Logger s_logger = Logger.getLogger(QuotaEmailTemplateListCmd.class);
 
     @Inject

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaEmailTemplateUpdateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaEmailTemplateUpdateCmd.java
@@ -19,7 +19,6 @@ package org.apache.cloudstack.api.command;
 import com.cloud.user.Account;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiErrorCode;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.QuotaResponseBuilder;
@@ -31,7 +30,7 @@ import javax.inject.Inject;
 import java.util.Arrays;
 
 @APICommand(name = "quotaEmailTemplateUpdate", responseObject = SuccessResponse.class, description = "Updates existing email templates for quota alerts", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaEmailTemplateUpdateCmd extends BaseCmd {
+public class QuotaEmailTemplateUpdateCmd extends QuotaBaseCmd {
     public static final Logger s_logger = Logger.getLogger(QuotaEmailTemplateUpdateCmd.class);
 
     @Inject

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaStatementCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaStatementCmd.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
@@ -36,7 +35,7 @@ import org.apache.log4j.Logger;
 import com.cloud.user.Account;
 
 @APICommand(name = "quotaStatement", responseObject = QuotaStatementItemResponse.class, description = "Create a quota statement", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaStatementCmd extends BaseCmd {
+public class QuotaStatementCmd extends QuotaBaseCmd {
 
     public static final Logger s_logger = Logger.getLogger(QuotaStatementCmd.class);
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
@@ -21,7 +21,6 @@ import com.cloud.utils.Pair;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseListCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.ListResponse;
@@ -35,7 +34,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 @APICommand(name = "quotaSummary", responseObject = QuotaSummaryResponse.class, description = "Lists balance and quota usage for all accounts", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaSummaryCmd extends BaseListCmd {
+public class QuotaSummaryCmd extends QuotaBaseListCmd {
     public static final Logger s_logger = Logger.getLogger(QuotaSummaryCmd.class);
 
     @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, required = false, description = "Optional, Account Id for which statement needs to be generated")

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffCreateCmd.java
@@ -22,7 +22,6 @@ import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.QuotaResponseBuilder;
@@ -36,7 +35,7 @@ import java.util.Date;
 
 @APICommand(name = "quotaTariffCreate", responseObject = QuotaTariffResponse.class, description = "Creates a quota tariff for a resource.", since = "4.18.0.0",
 requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {RoleType.Admin})
-public class QuotaTariffCreateCmd extends BaseCmd {
+public class QuotaTariffCreateCmd extends QuotaBaseCmd {
     protected Logger logger = Logger.getLogger(getClass());
 
     @Inject

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffDeleteCmd.java
@@ -33,7 +33,7 @@ import javax.inject.Inject;
 
 @APICommand(name = "quotaTariffDelete", description = "Marks a quota tariff as removed.", responseObject = SuccessResponse.class, requestHasSensitiveInfo = false,
 responseHasSensitiveInfo = false, since = "4.18.0.0", authorized = {RoleType.Admin})
-public class QuotaTariffDeleteCmd extends BaseCmd {
+public class QuotaTariffDeleteCmd extends QuotaBaseCmd {
     protected Logger logger = Logger.getLogger(getClass());
 
     @Inject

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffListCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffListCmd.java
@@ -21,7 +21,6 @@ import com.cloud.utils.Pair;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseListCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.QuotaResponseBuilder;
@@ -37,7 +36,7 @@ import java.util.Date;
 import java.util.List;
 
 @APICommand(name = "quotaTariffList", responseObject = QuotaTariffResponse.class, description = "Lists all quota tariff plans", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaTariffListCmd extends BaseListCmd {
+public class QuotaTariffListCmd extends QuotaBaseListCmd {
     public static final Logger s_logger = Logger.getLogger(QuotaTariffListCmd.class);
 
     @Inject

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaTariffUpdateCmd.java
@@ -22,7 +22,6 @@ import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.QuotaResponseBuilder;
@@ -36,7 +35,7 @@ import java.util.Date;
 
 @APICommand(name = "quotaTariffUpdate", responseObject = QuotaTariffResponse.class, description = "Update the tariff plan for a resource", since = "4.7.0",
 requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {RoleType.Admin})
-public class QuotaTariffUpdateCmd extends BaseCmd {
+public class QuotaTariffUpdateCmd extends QuotaBaseCmd {
     public static final Logger s_logger = Logger.getLogger(QuotaTariffUpdateCmd.class);
 
     @Inject

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaUpdateCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaUpdateCmd.java
@@ -19,7 +19,6 @@ package org.apache.cloudstack.api.command;
 import com.cloud.user.Account;
 
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.response.QuotaUpdateResponse;
 import org.apache.cloudstack.quota.QuotaAlertManager;
 import org.apache.cloudstack.quota.QuotaManager;
@@ -31,7 +30,7 @@ import java.util.Calendar;
 import javax.inject.Inject;
 
 @APICommand(name = "quotaUpdate", responseObject = QuotaUpdateResponse.class, description = "Update quota calculations, alerts and statements", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class QuotaUpdateCmd extends BaseCmd {
+public class QuotaUpdateCmd extends QuotaBaseCmd {
 
     public static final Logger s_logger = Logger.getLogger(QuotaUpdateCmd.class);
 

--- a/server/src/main/java/com/cloud/api/dispatch/SpecificCmdValidationWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/SpecificCmdValidationWorker.java
@@ -28,7 +28,7 @@ public class SpecificCmdValidationWorker implements DispatchWorker {
     @SuppressWarnings("unchecked")
     @Override
     public void handle(final DispatchTask task) {
-        task.getCmd().validateSpecificParameters(task.getParams());
+        task.getCmd().validateCommandSpecificPermissionsAndParameters(task.getParams());
     }
 
 }

--- a/server/src/test/java/com/cloud/api/dispatch/SpecificCmdValidationWorkerTest.java
+++ b/server/src/test/java/com/cloud/api/dispatch/SpecificCmdValidationWorkerTest.java
@@ -43,6 +43,6 @@ public class SpecificCmdValidationWorkerTest {
         worker.handle(new DispatchTask(cmd, params));
 
         // Assert
-        verify(cmd, times(1)).validateSpecificParameters(params);
+        verify(cmd, times(1)).validateCommandSpecificPermissionsAndParameters(params);
     }
 }


### PR DESCRIPTION
### Description

Currently, even if an account has the Quota plugin disabled, they may still list and use the Quota APIs. This PR fixes this behavior, making the `quota.account.enabled` be respected when listing APIs and calling APIs. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
A new role was created and granted permission to call all Quota APIs, then a new account was created from that role.
With the plugin enabled for this account, all Quota APIs were called and worked as expected. Then the plugin was disabled for the account and all the APIs were called again, all the calls got a permission denied error, except the `quotaIsEnable` API, which continued to work (as expected).
Finally, still with quota disabled for the account, a sync was done using CloudMonkey to verify that the quota APIs would not be discovered, and only `quotaIsEnable` was discovered for that account (as expected).
