### PR TITLE
Prometheus exporter fix cpu/memory usage labels

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -158,20 +158,20 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             final String cpuFactor = String.valueOf(CapacityManager.CpuOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO cpuCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU);
             if (cpuCapacity != null && cpuCapacity.getCapacityState() == CapacityState.Enabled) {
-                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, cpuCapacity.getUsedCapacity(), isDedicated, hostTags));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, ALLOCATED, cpuCapacity.getUsedCapacity(), isDedicated, hostTags));
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, cpuCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {
-                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, 0L, isDedicated, hostTags));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, ALLOCATED, 0L, isDedicated, hostTags));
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, 0L, isDedicated, hostTags));
             }
 
             final String memoryFactor = String.valueOf(CapacityManager.MemOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO memCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_MEMORY);
             if (memCapacity != null && memCapacity.getCapacityState() == CapacityState.Enabled) {
-                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, memCapacity.getUsedCapacity(), isDedicated, hostTags));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, ALLOCATED, memCapacity.getUsedCapacity(), isDedicated, hostTags));
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, memCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {
-                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, 0L, isDedicated, hostTags));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, ALLOCATED, 0L, isDedicated, hostTags));
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, 0L, isDedicated, hostTags));
             }
 

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import com.cloud.configuration.dao.ResourceCountDao;
 import com.cloud.dc.DedicatedResourceVO;
 import com.cloud.dc.dao.DedicatedResourceDao;
+import com.cloud.host.HostStats;
 import com.cloud.user.Account;
 import com.cloud.user.dao.AccountDao;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
@@ -127,6 +128,8 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         Map<String, Integer> upHosts = new HashMap<>();
         Map<String, Integer> downHosts = new HashMap<>();
 
+        HostStats hostStats;
+
         for (final HostVO host : hostDao.listAll()) {
             if (host == null || host.getType() != Host.Type.Routing || host.getDataCenterId() != dcId) {
                 continue;
@@ -144,6 +147,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             metricsList.add(new ItemHostIsDedicated(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), isDedicated));
 
             String hostTags = markTagMaps(host, totalHosts, upHosts,  downHosts);
+            hostStats = ApiDBUtils.getHostStatistics(host.getId());
 
             // Get account, domain details for dedicated hosts
             if (isDedicated == 1) {
@@ -157,11 +161,15 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
 
             final String cpuFactor = String.valueOf(CapacityManager.CpuOverprovisioningFactor.valueIn(host.getClusterId()));
             final CapacityVO cpuCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU);
+            final double cpuUsedMhz = hostStats.getCpuUtilization() * host.getCpus() * host.getSpeed() / 100.0 ;
+
             if (cpuCapacity != null && cpuCapacity.getCapacityState() == CapacityState.Enabled) {
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, ALLOCATED, cpuCapacity.getUsedCapacity(), isDedicated, hostTags));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, cpuUsedMhz, isDedicated, hostTags));
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, cpuCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, ALLOCATED, 0L, isDedicated, hostTags));
+                metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, USED, 0L, isDedicated, hostTags));
                 metricsList.add(new ItemHostCpu(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), cpuFactor, TOTAL, 0L, isDedicated, hostTags));
             }
 
@@ -169,9 +177,11 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             final CapacityVO memCapacity = capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_MEMORY);
             if (memCapacity != null && memCapacity.getCapacityState() == CapacityState.Enabled) {
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, ALLOCATED, memCapacity.getUsedCapacity(), isDedicated, hostTags));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, hostStats.getUsedMemory(), isDedicated, hostTags));
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, memCapacity.getTotalCapacity(), isDedicated, hostTags));
             } else {
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, ALLOCATED, 0L, isDedicated, hostTags));
+                metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, USED, 0, isDedicated, hostTags));
                 metricsList.add(new ItemHostMemory(zoneName, zoneUuid, host.getName(), host.getUuid(), host.getPrivateIpAddress(), memoryFactor, TOTAL, 0L, isDedicated, hostTags));
             }
 


### PR DESCRIPTION
### Description

This PR fixes the prometheus exporter issue that reports used memory instead of allocated memory.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

Closes [#7625  ](https://github.com/apache/cloudstack/issues/7625)

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

The prometheus exporter output now matches the `cmk` output. Check out the #7625 for more details:


##### Memory

```
root@mgt01:~# curl http://127.0.0.1:9595/metrics | grep cloudstack_host_memory_usage_mibs_total
cloudstack_host_memory_usage_mibs_total{zone="Zone1",hostname="node01",ip="10.1.2.5",overprovisioningfactor="1.0",filter="allocated",dedicated="0",tags=""} 512.00
cloudstack_host_memory_usage_mibs_total{zone="Zone1",hostname="node01",ip="10.1.2.5",overprovisioningfactor="1.0",filter="total",dedicated="0",tags=""} 2907.71
cloudstack_host_memory_usage_mibs_total{zone="Zone1",hostname="node02",ip="10.1.2.6",overprovisioningfactor="1.0",filter="allocated",dedicated="0",tags=""} 1024.00
cloudstack_host_memory_usage_mibs_total{zone="Zone1",hostname="node02",ip="10.1.2.6",overprovisioningfactor="1.0",filter="total",dedicated="0",tags=""} 2907.70
cloudstack_host_memory_usage_mibs_total{zone="Zone1",filter="allocated"} 1536.00
root@mgt01:~# cmk list hostsmetrics filter=memoryallocated,memoryused,memorytotal,name
{
  "count": 2,
  "host": [
    {
      "memoryallocated": 1073741824,
      "memorytotal": 3048947712,
      "memoryused": 1249058816,
      "name": "node02"
    },
    {
      "memoryallocated": 536870912,
      "memorytotal": 3048960000,
      "memoryused": 1262129152,
      "name": "node01"
    }
  ]
}
```

##### CPU

```
root@mgt01:~# curl http://127.0.0.1:9595/metrics | grep cloudstack_host_cpu_usage_mhz_total
cloudstack_host_cpu_usage_mhz_total{zone="Zone1",hostname="node01",ip="10.1.2.5",overprovisioningfactor="1.0",filter="allocated",tags=""} 500.00
cloudstack_host_cpu_usage_mhz_total{zone="Zone1",hostname="node01",ip="10.1.2.5",overprovisioningfactor="1.0",filter="total",tags=""} 4398.00
cloudstack_host_cpu_usage_mhz_total{zone="Zone1",hostname="node02",ip="10.1.2.6",overprovisioningfactor="1.0",filter="allocated",tags=""} 500.00
cloudstack_host_cpu_usage_mhz_total{zone="Zone1",hostname="node02",ip="10.1.2.6",overprovisioningfactor="1.0",filter="total",tags=""} 4400.00
cloudstack_host_cpu_usage_mhz_total{zone="Zone1",filter="allocated"} 1000.00
root@mgt01:~# cmk list hostsmetrics filter=cpuallocatedghz,cpuusedghz,cputotalghz,name
{
  "count": 2,
  "host": [
    {
      "cpuallocatedghz": "0.50 Ghz",
      "cputotalghz": "4.40 Ghz",
      "cpuusedghz": "0.06 Ghz",
      "name": "node02"
    },
    {
      "cpuallocatedghz": "0.50 Ghz",
      "cputotalghz": "4.40 Ghz",
      "cpuusedghz": "0.05 Ghz",
      "name": "node01"
    }
  ]
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
