### PR TITLE
Add unit test cases using a secret with slashes to UriUtils

### DIFF
--- a/utils/src/test/java/com/cloud/utils/UriUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/UriUtilsTest.java
@@ -122,6 +122,8 @@ public class UriUtilsTest {
         String url6 = String.format("rbd://%s:3300", host);
         String url7 = String.format("rbd://%s", host);
         String url8 = String.format("rbd://user@%s", host);
+        String url9 = String.format("rbd://user:AQC18pNko3r2GRAAh/3PxIr0lTKMzLL1CAaDww==@%s:3300/pool", host);
+        String url10 = String.format("rbd://user:AQC18pNko3r2GRAAh/3PxIr0lTKMzLL1CAaDww==@%s:3300/pool/volume2", host);
 
         testGetUriInfoInternal(url0, host);
         testGetUriInfoInternal(url1, host);
@@ -132,6 +134,8 @@ public class UriUtilsTest {
         testGetUriInfoInternal(url6, host);
         testGetUriInfoInternal(url7, host);
         testGetUriInfoInternal(url8, host);
+        testGetUriInfoInternal(url9, host);
+        testGetUriInfoInternal(url10, host);
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR adds URL parsing test cases against real credentials produced by Ceph. One specific target is the infamous slash character should break the existing parser.

I am expecting this PR to fail unit tests, as it is meant to engage a discussion about cleaning up the URI parser.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

N/A


### Screenshots (if appropriate):


### How Has This Been Tested?

N/A
