### PR TITLE
smoke test: fixes test_vm_deployment_planner

### DIFF
--- a/test/integration/smoke/test_vm_deployment_planner.py
+++ b/test/integration/smoke/test_vm_deployment_planner.py
@@ -69,8 +69,7 @@ class TestVMDeploymentPlanner(cloudstackTestCase):
         cmd = deployVirtualMachine.deployVirtualMachineCmd()
         template = get_template(
             self.apiclient,
-            self.zone.id,
-            hypervisor=self.hypervisor
+            self.zone.id
         )
         cmd.zoneid = self.zone.id
         cmd.templateid = template.id


### PR DESCRIPTION
### Description

This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
This doesn't fix #7717 , but removes the abundant requirement from test_vm_deployment_planner, which looks for a specific template using the wrong hypervisor. The described issue in #7717 remains that the testclient doesn't have the right type of hypervisor configured.

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
