### PR TITLE
Set encrypted PowerFlex datadisk format correctly

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1609,6 +1609,9 @@ public class KVMStorageProcessor implements StorageProcessor {
                 if (vol.getQemuEncryptFormat() != null) {
                     newVol.setEncryptFormat(vol.getQemuEncryptFormat().toString());
                 }
+                if (vol.getFormat() != null) {
+                    format = vol.getFormat();
+                }
             }
             newVol.setSize(volume.getSize());
             newVol.setFormat(ImageFormat.valueOf(format.toString().toUpperCase()));

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/driver/ScaleIOPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/driver/ScaleIOPrimaryDataStoreDriver.java
@@ -504,11 +504,7 @@ public class ScaleIOPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
             volume.setFolder(scaleIOVolume.getVtreeId());
             volume.setSize(scaleIOVolume.getSizeInKb() * 1024);
             volume.setPoolType(Storage.StoragePoolType.PowerFlex);
-            if (volumeInfo.getVolumeType().equals(Volume.Type.ROOT)) {
-                volume.setFormat(volumeInfo.getFormat());
-            } else {
-                volume.setFormat(Storage.ImageFormat.RAW);
-            }
+            volume.setFormat(volumeInfo.getFormat());
             volume.setPoolId(storagePoolId);
             VolumeObject createdObject = VolumeObject.getVolumeObject(volumeInfo.getDataStore(), volume);
             createdObject.update();
@@ -1202,7 +1198,7 @@ public class ScaleIOPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
             if (payload.instanceName != null) {
                 VMInstanceVO instance = vmInstanceDao.findVMByInstanceName(payload.instanceName);
-                if (instance.getState().equals(VirtualMachine.State.Running)) {
+                if (instance != null && instance.getState().equals(VirtualMachine.State.Running)) {
                     hostId = instance.getHostId();
                     attachedRunning = true;
                 }


### PR DESCRIPTION
### Description

This PR:

1) Sets disk format correctly according to thin/thick provisioned PowerFlex volumes when encryption is in play. It delegates the volume format to the implementation (ScaleIOStorageAdaptor) and ensures it is passed back so it is stored properly in the VolumeVO. 

This allows us to trigger the code that resizes the qcow2 container if we are thin provisioned - this wasn't working for data volumes when VM was stopped because they were hard coded to RAW format.

2) Defensive coding in case volume has no VM instance name (detached)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally against powerflex, both detached and attached volume.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
