### PR TITLE
Fix NPE in management server logs due to /proc/cpuinfo output

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -974,8 +974,16 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         private double getSystemCpuCyclesTotal() {
             String cpucaps = Script.runSimpleBashScript("cat /proc/cpuinfo | grep \"cpu MHz\" | grep \"cpu MHz\" | cut -f 2 -d : | tr -d ' '| tr '\\n' \" \"");
             double totalcpucap = 0;
-            for (String cpucap : cpucaps.split(" ")) {
-                totalcpucap += Double.parseDouble(cpucap);
+            if (StringUtils.isEmpty(cpucaps)) {
+                String totalCpus = Script.runSimpleBashScript("nproc --all| tr '\\n' \" \"");
+                String maxCpuSpeed = Script.runSimpleBashScript("lscpu | egrep 'CPU max MHz' | head -1 | cut -f 2 -d : | tr -d ' '| tr '\\n' \" \"");
+                if (StringUtils.isNotEmpty(totalCpus) && StringUtils.isNotEmpty(maxCpuSpeed)) {
+                    totalcpucap = Double.parseDouble(totalCpus) * Double.parseDouble(maxCpuSpeed);
+                }
+            } else {
+                for (String cpucap : cpucaps.split(" ")) {
+                    totalcpucap += Double.parseDouble(cpucap);
+                }
             }
             return totalcpucap;
         }


### PR DESCRIPTION
This fixes a case wherein for some reason the /proc/cpuinfo isn't returning expected output, such as in case of experimental ARM64 M1 Mac Mini host. Found this over the weekend, tested the fix.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)