### PR TITLE
server: KVM guru should pass max memory as per VM transfer object

### DIFF
--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -213,7 +213,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
         Integer maxHostCpuCore = max.second();
 
         long minMemory = virtualMachineTo.getMinRam();
-        Long maxMemory = minMemory;
+        Long maxMemory = virtualMachineTo.getMaxRam();
         int minCpuCores = virtualMachineTo.getCpus();
         Integer maxCpuCores = minCpuCores;
 


### PR DESCRIPTION
This makes the KVM guru pass the max memory to KVM agent by picking the max. memory from the VM transfer object. This lets the cluster/agent decide if VM should start with the min or max memory depending on whether vm.memballoon.disable is false (default) or true.

When `vm.memballoon.disable` is true, VMs start with max. memory. Right now the max memory isn't sent to the KVM agent causing the regression. This feature is defined at https://github.com/apache/cloudstack/blob/main/agent/conf/agent.properties#L220

Also fixes #7430

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->