### PR TITLE
Fix casting exception during backup NIC synchronization

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -148,7 +148,7 @@ import com.vmware.vim25.VirtualDeviceBackingInfo;
 import com.vmware.vim25.VirtualDeviceConnectInfo;
 import com.vmware.vim25.VirtualDisk;
 import com.vmware.vim25.VirtualDiskFlatVer2BackingInfo;
-import com.vmware.vim25.VirtualE1000;
+import com.vmware.vim25.VirtualEthernetCard;
 import com.vmware.vim25.VirtualEthernetCardNetworkBackingInfo;
 import com.vmware.vim25.VirtualMachineConfigSummary;
 import com.vmware.vim25.VirtualMachineRuntimeInfo;
@@ -901,7 +901,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
     /**
      * Get network MO from VM NIC
      */
-    private NetworkMO getNetworkMO(VirtualE1000 nic, VmwareContext context) {
+    private NetworkMO getNetworkMO(VirtualEthernetCard nic, VmwareContext context) {
         VirtualDeviceConnectInfo connectable = nic.getConnectable();
         VirtualEthernetCardNetworkBackingInfo info = (VirtualEthernetCardNetworkBackingInfo)nic.getBacking();
         ManagedObjectReference networkMor = info.getNetwork();
@@ -912,7 +912,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
     }
 
     private Pair<String, String> getNicMacAddressAndNetworkName(VirtualDevice nicDevice, VmwareContext context) throws Exception {
-        VirtualE1000 nic = (VirtualE1000)nicDevice;
+        VirtualEthernetCard nic = (VirtualEthernetCard)nicDevice;
         String macAddress = nic.getMacAddress();
         NetworkMO networkMO = getNetworkMO(nic, context);
         String networkName = networkMO.getName();


### PR DESCRIPTION
### Description

After a backup is successfully restored in Veeam, CloudStack tries to synchronize the restored VM; however, during the NIC synchronization process, all NIC devices are cast to `VirtualE1000`, whether they are an `E1000` or not, resulting in a casting exception being thrown and the process failing when they are not.

This PR addresses the fix for this issue.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

This was tested in a local lab. 

Before the changes, whenever I tried to restore a backup of a VM that had a network adapter of types `PCNet32`, `Vmxnet2` or `Vmxnet3`, I would receive the following error message:
```
(<vm_name>) Error during vm backup restoration and import: class com.vmware.vim25.VirtualPCNet32 cannot be cast to class com.vmware.vim25.VirtualE1000 (com.vmware.vim25.VirtualPCNet32 and com.vmware.vim25.VirtualE1000 are in unnamed module of loader 'app')
```

With these changes, I was able to successfully restore the backups.
