### PR TITLE
ui: Fix refresh and re-route behaviour

### DIFF
--- a/ui/src/utils/request.js
+++ b/ui/src/utils/request.js
@@ -194,7 +194,11 @@ const sourceToken = {
   },
   cancel: () => {
     if (!source) sourceToken.init()
-    source.cancel()
+    if (source) {
+      source.cancel()
+    } else {
+      console.log('Source token failed to be cancelled')
+    }
   }
 }
 

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -622,7 +622,7 @@ export default {
     next()
   },
   beforeRouteLeave (to, from, next) {
-    console.log('DEBUG - Due to route change, cancelling any on-going API request', this.apiName)
+    console.log('DEBUG - Due to route change, ignoring results for any on-going API request', this.apiName)
     sourceToken.cancel()
     sourceToken.init()
     this.currentPath = this.$route.fullPath

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -933,8 +933,7 @@ export default {
         }
 
         if ((this.apiName.toLowerCase() + 'response') !== responseName.toLowerCase()) {
-          console.log('DEBUG - Discarding API response as expected API response key does not match response name:', responseName)
-          return
+          console.log('DEBUG - Found that API', this.apiName, ' does not match its expected response key name (apiname+response): ', responseName)
         }
         if ('id' in this.$route.params && this.$route.params.id !== params.id) {
           console.log('DEBUG - Discarding API response as its `id` does not match $route.param.id')

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -932,11 +932,8 @@ export default {
           break
         }
 
-        if ((this.apiName.toLowerCase() + 'response') !== responseName.toLowerCase()) {
-          console.log('DEBUG - Found that API', this.apiName, ' does not match its expected response key name (apiname+response): ', responseName)
-        }
         if ('id' in this.$route.params && this.$route.params.id !== params.id) {
-          console.log('DEBUG - Discarding API response as its `id` does not match $route.param.id')
+          console.log('DEBUG - Discarding API response as its `id` does not match the uuid on the browser path')
           return
         }
         if (this.dataView && apiItemCount > 1) {
@@ -949,9 +946,6 @@ export default {
           this.items = []
         }
         this.itemCount = apiItemCount
-        if (this.itemCount !== this.items.length) {
-          console.log('WARN: API items length does not match the API return count, something is wrong')
-        }
 
         if (['listTemplates', 'listIsos'].includes(this.apiName) && this.items.length > 1) {
           this.items = [...new Map(this.items.map(x => [x.id, x])).values()]


### PR DESCRIPTION
This introduces change in AutogenView to do the following:

- Cancel old list API requests when the route is changed (between different list view or list and resource views)
- In the handler of an API call made in the fetchData(), to check if the json received is for the current route/id (API)
- Add console log for debugging which may be removed if this passes code review and testing

Fixes #7840

How was this tested?
- In my env the listVirtualMachines API takes time to complete, so I go to the instances page and go quick back/forth other views; for example, go to instances page that doesn't load and click on 2nd VM (or go to instance page and search something that returns faster than the whole list API and go the VM). When the original list API call completes, the current VM is replaced by the first VM in the list.
- Check console log with the fix and network to see that old API (xhr) requests that haven't completed are cancelled when the route/view is changed between list and resource views of different resources

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
