### PR TITLE
New configs for quota email's headers and footers

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/constant/QuotaConfig.java
@@ -63,6 +63,12 @@ public interface QuotaConfig {
     ConfigKey<Boolean> QuotaAccountEnabled = new ConfigKey<>("Advanced", Boolean.class, "quota.account.enabled", "true", "Indicates whether Quota plugin is enabled or not for " +
             "the account.", true, ConfigKey.Scope.Account);
 
+    ConfigKey<String> QuotaEmailHeader = new ConfigKey<>("Advanced", String.class, "quota.email.header", "",
+            "Text to be added as a header for quota emails. Line breaks are not automatically inserted between this section and the body.", true, ConfigKey.Scope.Domain);
+
+    ConfigKey<String> QuotaEmailFooter = new ConfigKey<>("Advanced", String.class, "quota.email.footer", "",
+            "Text to be added as a footer for quota emails. Line breaks are not automatically inserted between this section and the body.", true, ConfigKey.Scope.Domain);
+
     enum QuotaEmailTemplateTypes {
         QUOTA_LOW, QUOTA_EMPTY, QUOTA_UNLOCK_ACCOUNT, QUOTA_STATEMENT
     }

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaAlertManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaAlertManagerImplTest.java
@@ -71,6 +71,21 @@ public class QuotaAlertManagerImplTest extends TestCase {
     @Mock
     private ConfigurationDao configDao;
 
+    @Mock
+    private QuotaAccountVO quotaAccountVOMock;
+
+    @Mock
+    private List<QuotaAlertManagerImpl.DeferredQuotaEmail> deferredQuotaEmailListMock;
+
+    @Mock
+    private QuotaManagerImpl quotaManagerMock;
+
+    @Mock
+    private Date balanceDateMock;
+
+    @Mock
+    private AccountVO accountMock;
+
     @Spy
     @InjectMocks
     private QuotaAlertManagerImpl quotaAlertManager = new QuotaAlertManagerImpl();
@@ -162,8 +177,20 @@ public class QuotaAlertManagerImplTest extends TestCase {
         quotaAlertManager.sendQuotaAlert(email);
         assertTrue(email.getSendDate() != null);
 
-        Mockito.verify(quotaAlertManager, Mockito.times(1)).sendQuotaAlert(Mockito.anyString(), Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(quotaAlertManager, Mockito.times(1)).sendQuotaAlert(Mockito.any(), Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(quotaAlertManager.mailSender, Mockito.times(1)).sendMail(Mockito.any(SMTPMailProperties.class));
+    }
+
+    @Test
+    public void addHeaderAndFooterTestIfHeaderAndFootersAreAdded() {
+        String body = quotaAlertManager.addHeaderAndFooter("body", "Header", "Footer");
+        assertEquals("HeaderbodyFooter", body);
+    }
+
+    @Test
+    public void addHeaderAndFooterTestIfHeaderAndFootersAreNotAddedIfEmpty() {
+        String body = quotaAlertManager.addHeaderAndFooter("body", "", "");
+        assertEquals("body", body);
     }
 
     @Test

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/quota/QuotaServiceImpl.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/quota/QuotaServiceImpl.java
@@ -141,7 +141,8 @@ public class QuotaServiceImpl extends ManagerBase implements QuotaService, Confi
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {QuotaPluginEnabled, QuotaEnableEnforcement, QuotaCurrencySymbol, QuotaStatementPeriod, QuotaSmtpHost, QuotaSmtpPort, QuotaSmtpTimeout,
-                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender, QuotaSmtpEnabledSecurityProtocols, QuotaSmtpUseStartTLS, QuotaActivationRuleTimeout, QuotaAccountEnabled};
+                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender, QuotaSmtpEnabledSecurityProtocols, QuotaSmtpUseStartTLS, QuotaActivationRuleTimeout, QuotaAccountEnabled,
+                QuotaEmailHeader, QuotaEmailFooter};
     }
 
     @Override


### PR DESCRIPTION
### Description

Two new settings at domain level were added to allow definition of header and footer of Quota emails:
- `quota.email.header`: defines the header of all Quota emails.
- `quota.email.footer`: defines the footer of all Quota emails.

The settings are added directly to the body of the text, so if you want a line break between the header/footer and the body of the text, you need to make it explicit (e.g. `<br/>`). By default the header/footer are not defined.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Defined the header and footer as `<h1>header</h1>` and `f<b>oot</b><u>er</u><script>alert(1)</script>`.   
Result:
![image](https://github.com/apache/cloudstack/assets/48719461/6b867b28-4d41-4796-8206-80707b027ba5)