### PR TITLE
Fix role escalation prevention

### DIFF
--- a/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -107,6 +107,10 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
 
     @Override
     public boolean checkAccess(Account account, String commandName) {
+        if (isEnabled()) {
+            return true;
+        }
+
         RoleType roleType = accountService.getRoleType(account);
         if (isApiAllowed(commandName, roleType)) {
             return true;

--- a/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/main/java/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -76,12 +76,12 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
         if (roleService.isEnabled()) {
             LOGGER.debug("RoleService is enabled. We will use it instead of StaticRoleBasedAPIAccessChecker.");
         }
-        return roleService.isEnabled();
+        return !roleService.isEnabled();
     }
 
     @Override
     public List<String> getApisAllowedToUser(Role role, User user, List<String> apiNames) throws PermissionDeniedException {
-        if (isEnabled()) {
+        if (!isEnabled()) {
             return apiNames;
         }
 
@@ -93,7 +93,7 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
 
     @Override
     public boolean checkAccess(User user, String commandName) throws PermissionDeniedException {
-        if (isEnabled()) {
+        if (!isEnabled()) {
             return true;
         }
 
@@ -107,7 +107,7 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIA
 
     @Override
     public boolean checkAccess(Account account, String commandName) {
-        if (isEnabled()) {
+        if (!isEnabled()) {
             return true;
         }
 


### PR DESCRIPTION
### Description

While checking an account access to prevent the role escalation, the `checkAccess` method is using both `DynamicRoleBasedAPIAccessChecker` and `StaticRoleBasedAPIAccessChecker` (legacy) classes and that is causing some inconsistences in the validations, consequently allowing the role escalation.

For this reason, the `StaticRoleBasedAPIAccessChecker` was disabled if `DynamicRoleBasedAPIAccessChecker` is enabled.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

- I have created a domain admin custom role (DA2) and allowed all API's to it using the `*` regex;
- Removed an API that it had in common with default domain admin role;
- Tried to create a default domain admin account using a DA2 account;
- Received an exception from the role eslacation prevention.