### PR TITLE
Keep deleted projects name

### DIFF
--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectDaoImpl.java
@@ -33,7 +33,6 @@ import com.cloud.utils.db.GenericSearchBuilder;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.SearchCriteria.Func;
-import com.cloud.utils.db.TransactionLegacy;
 
 @Component
 public class ProjectDaoImpl extends GenericDaoBase<ProjectVO, Long> implements ProjectDao {
@@ -71,22 +70,8 @@ public class ProjectDaoImpl extends GenericDaoBase<ProjectVO, Long> implements P
     @Override
     @DB
     public boolean remove(Long projectId) {
-        boolean result = false;
-        TransactionLegacy txn = TransactionLegacy.currentTxn();
-        txn.start();
-        ProjectVO projectToRemove = findById(projectId);
-        projectToRemove.setName(null);
-        if (!update(projectId, projectToRemove)) {
-            s_logger.warn("Failed to reset name for the project id=" + projectId + " as a part of project remove");
-            return false;
-        }
-
         _tagsDao.removeByIdAndType(projectId, ResourceObjectType.Project);
-        result = super.remove(projectId);
-        txn.commit();
-
-        return result;
-
+        return super.remove(projectId);
     }
 
     @Override


### PR DESCRIPTION
### Description

When deleting a project, its name is always set to `null`. To maintain the integrity of the project's database history, this behavior was removed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created and deleted a project. Then, I created a SELECT SQL query for the `projects` table and the deleted project's name was there.