### PR TITLE
server: set Default NIC when VM has no default NIC

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -4329,7 +4329,9 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         if (nic == null || vmProfile.getType() == VirtualMachine.Type.User) {
             final int deviceId = _nicDao.getFreeDeviceId(vm.getId());
 
-            nic = allocateNic(requested, network, false, deviceId, vmProfile).first();
+            boolean isDefaultNic = getNicProfileDefaultNic(requested);
+
+            nic = allocateNic(requested, network, isDefaultNic, deviceId, vmProfile).first();
 
             if (nic == null) {
                 throw new CloudRuntimeException("Failed to allocate nic for vm " + vm + " in network " + network);
@@ -4355,6 +4357,16 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         }
 
         return nic;
+    }
+
+    private boolean getNicProfileDefaultNic(NicProfile nicProfile) {
+        if (nicProfile != null) {
+            s_logger.debug(String.format("Using requested nic profile isDefaultNic value [%s].", nicProfile.isDefaultNic()));
+            return nicProfile.isDefaultNic();
+        }
+
+        s_logger.debug("Using isDefaultNic default value [false] as requested nic profile is null.");
+        return false;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1425,6 +1425,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             }
         }
 
+        setNicAsDefaultIfNeeded(vmInstance, profile);
+
         NicProfile guestNic = null;
         boolean cleanUp = true;
 
@@ -1451,6 +1453,18 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         CallContext.current().putContextParameter(Nic.class, guestNic.getUuid());
         s_logger.debug(String.format("Successful addition of %s from %s through %s", network, vmInstance, guestNic));
         return _vmDao.findById(vmInstance.getId());
+    }
+
+    /**
+     * Set NIC as default if VM has no default NIC
+     * @param vmInstance VM instance to be checked
+     * @param nicProfile NIC profile to be updated
+     */
+    public void setNicAsDefaultIfNeeded(UserVmVO vmInstance, NicProfile nicProfile) {
+        if (_networkModel.getDefaultNic(vmInstance.getId()) == null) {
+            s_logger.debug(String.format("Setting NIC %s as default as VM %s has no default NIC.", nicProfile.getName(), vmInstance.getName()));
+            nicProfile.setDefaultNic(true);
+        }
     }
 
     /**

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -3071,6 +3071,7 @@
 "message.vr.alert.upon.network.offering.creation.l2": "As virtual routers are not created for L2 networks, the compute offering will not be used.",
 "message.vr.alert.upon.network.offering.creation.others": "As none of the obligatory services for creating a virtual router (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) are enabled, the virtual router will not be created and the compute offering will not be used.",
 "message.warn.filetype": "jpg, jpeg, png, bmp and svg are the only supported image formats.",
+"message.warn.importing.instance.without.nic": "WARNING: this instance is being imported without NICs and many network resources will not be available. Consider creating a NIC via VCenter before importing or as soon as the instance is imported.",
 "message.warn.zone.mtu.update": "Please note that this limit won't affect pre-existing network’s MTU settings",
 "message.zone.creation.complete": "Zone creation complete.",
 "message.zone.detail.description": "Populate zone details.",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -2475,6 +2475,7 @@
 "message.vr.alert.upon.network.offering.creation.l2": "Como VRs não são criados para redes do tipo L2, a oferta de computação não será utilizada.",
 "message.vr.alert.upon.network.offering.creation.others": "Como nenhum dos serviços obrigatórios para criação do VR (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) foram habilitados, o VR não será criado e a oferta de computação não será usada.",
 "message.warn.filetype": "jpg, jpeg, png, bmp e svg s\u00e3o os \u00fanicos formatos de imagem suportados",
+"message.warn.importing.instance.without.nic": "AVISO: essa instância está sendo importada sem NICs e muitos recursos de rede não estarão disponíveis. Considere criar uma NIC antes de importar via VCenter ou assim que a instância for importada.",
 "message.zone.creation.complete": "Cria\u00e7\u00e3o de zona completa",
 "message.zone.detail.description": "Preencha os detalhes da zona",
 "message.zone.detail.hint": "Uma zona \u00e9 a maior unidade organizacional no CloudStack, e normalmente corresponde a um \u00fanico datacenter. As zonas proporcionam isolamento f\u00edsico e redund\u00e2ncia. Uma zona consiste em um ou mais pods (cada um contendo hosts e servidores de armazenamento prim\u00e1rio) e um servidor de armazenamento secund\u00e1rio que \u00e9 compartilhado por todos os pods da zona.",

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -227,6 +227,13 @@
                   filterMatchKey="broadcasturi"
                   @select-multi-network="updateMultiNetworkOffering" />
               </div>
+              <a-row v-else style="margin: 12px 0">
+                <a-alert type="warning">
+                  <template #message>
+                    <div v-html="$t('message.warn.importing.instance.without.nic')"></div>
+                  </template>
+                </a-alert>
+              </a-row>
               <a-row :gutter="12">
                 <a-col :md="24" :lg="12">
                   <a-form-item name="migrateallowed" ref="migrateallowed">


### PR DESCRIPTION
### Description

ACS allows you to add NICs to a VM without them, although it is not possible to set them as default since the `updateDefaultNicForVirtualMachine` API only updates the default NIC if a default NIC already exists, otherwise an exception is thrown.

For this reason, when a NIC is added and the VM that the NIC is being created for has no default NIC, the NIC will be marked as default.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Imported a VM without NICs, added some NICs and the first one was set as default.