### PR TITLE
UI: Infer template settings in the deploy VM wizard

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1797,7 +1797,7 @@ export default {
           this.fetchBootModes(this.form.boottype)
           this.defaultBootMode = template.details?.UEFI || this.options.bootModes?.[0]?.id || undefined
           this.form.bootmode = this.defaultBootMode
-          this.form.iothreadsenabled = template.details?.iothreads ? template.details.iothreads === 'enabled' : null
+          this.form.iothreadsenabled = template.details && Object.prototype.hasOwnProperty.call(template.details, 'iothreads')
           this.form.iodriverpolicy = template.details?.['io.policy']
           this.form.keyboard = template.details?.keyboard
         }

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1789,11 +1789,17 @@ export default {
         if (template) {
           var size = template.size / (1024 * 1024 * 1024) || 0 // bytes to GB
           this.dataPreFill.minrootdisksize = Math.ceil(size)
-          this.defaultBootType = this.template?.details?.UEFI ? 'UEFI' : ''
-          this.fetchBootModes(this.defaultBootType)
-          this.defaultBootMode = this.template?.details?.UEFI
-          this.updateTemplateLinkedUserData(this.template.userdataid)
-          this.userdataDefaultOverridePolicy = this.template.userdatapolicy
+          this.updateTemplateLinkedUserData(template.userdataid)
+          this.userdataDefaultOverridePolicy = template.userdatapolicy
+          this.form.dynamicscalingenabled = template.isdynamicallyscalable
+          this.defaultBootType = template.details?.UEFI ? 'UEFI' : 'BIOS'
+          this.form.boottype = this.defaultBootType
+          this.fetchBootModes(this.form.boottype)
+          this.defaultBootMode = template.details?.UEFI || this.options.bootModes?.[0]?.id || undefined
+          this.form.bootmode = this.defaultBootMode
+          this.form.iothreadsenabled = template.details?.iothreads ? template.details.iothreads === 'enabled' : null
+          this.form.iodriverpolicy = template.details?.['io.policy']
+          this.form.keyboard = template.details?.keyboard
         }
       } else if (name === 'isoid') {
         this.templateConfigurations = []


### PR DESCRIPTION
### Description

In the deploy VM wizard, the settings inherited from a template (`iothreads`, `iothreads`, `io.policy`, `keyboard`, `UEFI` and dynamically scalable) are not automatically inferred after selecting the template. This would not matter for most of these settings if the user did not change the fields, since they would still be inherited when the parameters were null; however, the boot type and mode would always default to BIOS and LEGACY, even when set to something else in the template.

This PR aims to address this issue by making the deploy VM wizard automatically infer the settings inherited from a template.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

In the deploy VM wizard:
1. I selected a template with dynamic scaling enabled and the settings `keyboard=jp`, `io.policy=io_uring`, `UEFI=LEGACY` and `iothreads=enabled`. Then, I verified that the fields were automatically inferred and, after deploying, that the expected parameters were present in the API call.
2. I selected the same template as in item 1, changed the value in the fields and verified that the parameters also changed in the API call.
3. I selected a template that had dynamic scaling disabled and no settings. Then, I verified that the fields were not automatically inferred (except dynamic scaling) and, after deploying, that the corresponding parameters were not in the API call (with the exception of `dynamicscalingenabled=false`).
4. I selected the template from item 1 and then selected the template from item 3. Finally, I verified that the fields in the UI and the parameters in the API call had the same values as in item 3.
