### PR TITLE
Removed state for removed accounts

### DIFF
--- a/api/src/main/java/com/cloud/user/Account.java
+++ b/api/src/main/java/com/cloud/user/Account.java
@@ -30,7 +30,7 @@ public interface Account extends ControlledEntity, InternalIdentity, Identity {
      *  Account states.
      * */
     enum State {
-        DISABLED, ENABLED, LOCKED;
+        DISABLED, ENABLED, LOCKED, REMOVED;
 
         /**
          * The toString method was overridden to maintain consistency in the DB, as the GenericDaoBase uses toString in the enum value to make the sql statements

--- a/engine/schema/src/main/resources/META-INF/db/schema-41810to41900.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41810to41900.sql
@@ -180,3 +180,6 @@ CREATE TABLE `cloud`.`vm_scheduled_job` (
 -- Add support for different cluster types for kubernetes
 ALTER TABLE `cloud`.`kubernetes_cluster` ADD COLUMN `cluster_type` varchar(64) DEFAULT 'CloudManaged' COMMENT 'type of cluster';
 ALTER TABLE `cloud`.`kubernetes_cluster` MODIFY COLUMN `kubernetes_version_id` bigint unsigned NULL COMMENT 'the ID of the Kubernetes version of this Kubernetes cluster';
+
+-- Set removed state for all removed accounts
+UPDATE `cloud`.`account` SET state='removed' WHERE `removed` IS NOT NULL;

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -814,6 +814,9 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             return false;
         }
 
+        account.setState(State.REMOVED);
+        _accountDao.update(accountId, account);
+
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Removed account " + accountId);
         }


### PR DESCRIPTION
### Description

When deleting an account, its state is maintained as `Enabled` even if it is removed.

Accordingly the `Removed` state for accounts was created, which is always set when an account is deleted.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created and deleted an account. Then, I created a SELECT SQL query for the `account` table and the account state was `Removed`.