### PR TITLE
Allow admins to disable the 2FA of users in subdomains

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -3327,7 +3327,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     protected UserTwoFactorAuthenticationSetupResponse disableTwoFactorAuthentication(Long userId, Account caller, Account owner) {
         UserVO userVO = null;
         if (userId != null) {
-            userVO = validateUser(userId, caller.getDomainId());
+            userVO = validateUser(userId);
             owner = _accountService.getActiveAccountById(userVO.getAccountId());
         } else {
             userId = CallContext.current().getCallingUserId();
@@ -3349,15 +3349,12 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return response;
     }
 
-    private UserVO validateUser(Long userId, Long domainId) {
+    private UserVO validateUser(Long userId) {
         UserVO user = null;
         if (userId != null) {
             user = _userDao.findById(userId);
             if (user == null) {
                 throw new InvalidParameterValueException("Invalid user ID provided");
-            }
-            if (_accountDao.findById(user.getAccountId()).getDomainId() != domainId) {
-                throw new InvalidParameterValueException("User doesn't belong to the specified account or domain");
             }
         }
         return user;

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -875,19 +875,17 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
     @Test
     public void testDisableUserTwoFactorAuthentication() {
         Long userId = 1L;
+        Long accountId = 2L;
 
         UserVO userVO = Mockito.mock(UserVO.class);
         Account caller = Mockito.mock(Account.class);
+        Account owner = Mockito.mock(Account.class);
 
-        AccountVO accountMock = Mockito.mock(AccountVO.class);
         Mockito.doNothing().when(accountManagerImpl).checkAccess(nullable(Account.class), Mockito.isNull(), nullable(Boolean.class), nullable(Account.class));
 
-        Mockito.when(caller.getDomainId()).thenReturn(1L);
         Mockito.when(userDaoMock.findById(userId)).thenReturn(userVO);
-        Mockito.when(userVO.getAccountId()).thenReturn(1L);
-        Mockito.when(_accountDao.findById(1L)).thenReturn(accountMock);
-        Mockito.when(accountMock.getDomainId()).thenReturn(1L);
-        Mockito.when(_accountService.getActiveAccountById(1L)).thenReturn(caller);
+        Mockito.when(userVO.getAccountId()).thenReturn(accountId);
+        Mockito.when(_accountService.getActiveAccountById(accountId)).thenReturn(owner);
 
         userVoMock.setKeyFor2fa("EUJEAEDVOURFZTE6OGWVTJZMI54QGMIL");
         userVoMock.setUser2faProvider("totp");
@@ -895,8 +893,9 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
 
         Mockito.when(userDaoMock.createForUpdate()).thenReturn(userVoMock);
 
-        UserTwoFactorAuthenticationSetupResponse response = accountManagerImpl.disableTwoFactorAuthentication(userId, caller, caller);
+        UserTwoFactorAuthenticationSetupResponse response = accountManagerImpl.disableTwoFactorAuthentication(userId, caller, owner);
 
+        Mockito.verify(accountManagerImpl).checkAccess(caller, null, true, owner);
         Assert.assertNull(response.getSecretCode());
         Assert.assertNull(userVoMock.getKeyFor2fa());
         Assert.assertNull(userVoMock.getUser2faProvider());


### PR DESCRIPTION
### Description

Admins should be able to disable the 2FA of users that lost their second factor; however, the `setupUserTwoFactorAuthentication` API only allows them to disable the 2FA of users in the same domain. This means that, if the root admin wants to disable the 2FA of a user in ROOT/test, he must create a domain admin account in ROOT/test and log into that account to do this.

This PR addresses this issue by allowing admins to disable the 2FA of users in their subdomains.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I did the following tests in a local lab:

| Number | Test | Previous result | New result | New result was expected (Y/N)? |
| - | - | - | - | - |
| 1 | Disable your own 2FA as the root admin | Success | Success | Y |
| 2 | Disable the 2FA of a user in ROOT as the root admin | Success | Success | Y |
| 3 | Disable the 2FA of a user in ROOT/test as the root admin | Exception | Success | Y |
| 4 | Disable your own 2FA as the domain admin of ROOT/test | Success | Success | Y |
| 5 | Disable the 2FA of a user in ROOT/test as the domain admin of ROOT/test | Success | Success | Y |
| 6 | Disable the 2FA of a user in ROOT/test/test2 as the domain admin of ROOT/test | Exception | Success | Y |
| 7 | Disable the 2FA of a domain admin of ROOT/test as another domain admin of ROOT/test | Success | Success | Y |
| 8 | Disable the 2FA of a domain admin of ROOT/test/test2 as the domain admin of ROOT/test | Exception | Success | Y |
| 9 | Disable the 2FA of a domain admin of ROOT as the domain admin of ROOT/test | Exception | Exception | Y |
| 10 | Disable the 2FA of a domain admin of ROOT/test3 as the domain admin of ROOT/test | Exception | Exception | Y |
| 11 | Disable your own 2FA as a non-administrator user | Success | Success | Y |