### PR TITLE
System VMs in listHostsMetrics API

### DIFF
--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -682,8 +682,10 @@ public class MetricsServiceImpl extends MutualExclusiveIdsManagerBase implements
             final Float cpuDisableThreshold = DeploymentClusterPlanner.ClusterCPUCapacityDisableThreshold.valueIn(clusterId);
             final Float memoryDisableThreshold = DeploymentClusterPlanner.ClusterMemoryCapacityDisableThreshold.valueIn(clusterId);
 
-            Long upInstances = 0L;
-            Long totalInstances = 0L;
+            long upInstances = 0L;
+            long totalInstances = 0L;
+            long upSystemInstances = 0L;
+            long totalSystemInstances = 0L;
             for (final VMInstanceVO instance: vmInstanceDao.listByHostId(hostId)) {
                 if (instance == null) {
                     continue;
@@ -693,10 +695,16 @@ public class MetricsServiceImpl extends MutualExclusiveIdsManagerBase implements
                     if (instance.getState() == VirtualMachine.State.Running) {
                         upInstances++;
                     }
+                } else if (instance.getType().isUsedBySystem()) {
+                    totalSystemInstances++;
+                    if (instance.getState() == VirtualMachine.State.Running) {
+                        upSystemInstances++;
+                    }
                 }
             }
             metricsResponse.setPowerState(hostResponse.getOutOfBandManagementResponse().getPowerState());
             metricsResponse.setInstances(upInstances, totalInstances);
+            metricsResponse.setSystemInstances(upSystemInstances, totalSystemInstances);
             metricsResponse.setCpuTotal(hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
             metricsResponse.setCpuUsed(hostResponse.getCpuUsed(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
             metricsResponse.setCpuAllocated(hostResponse.getCpuAllocated(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
@@ -36,6 +36,10 @@ public class HostMetricsResponse extends HostResponse {
     @Param(description = "instances on the host")
     private String instances;
 
+    @SerializedName("systeminstances")
+    @Param(description = "system vm instances on the host")
+    private String systemInstances;
+
     @SerializedName("cputotalghz")
     @Param(description = "the total cpu capacity in Ghz")
     private String cpuTotal;
@@ -108,10 +112,12 @@ public class HostMetricsResponse extends HostResponse {
         this.powerState = powerState;
     }
 
-    public void setInstances(final Long running, final Long total) {
-        if (running != null && total != null) {
-            this.instances = String.format("%d / %d", running, total);
-        }
+    public void setSystemInstances(final long running, final long total) {
+        this.systemInstances = String.format("%d / %d", running, total);
+    }
+
+    public void setInstances(final long running, final long total) {
+        this.instances = String.format("%d / %d", running, total);
     }
 
     public void setCpuTotal(final Integer cpuNumber, final Long cpuSpeed) {


### PR DESCRIPTION
### Description

The `listHostsMetrics` API returns the number of user VMs on the host. Although it doesn't return any data from the system VM instances on it.

Due to this, the `systeminstances` field was created in the `listHostsMetrics` API, which returns how many system VMs are running on the host and how many system VMs the host has in total.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I called the `listHostsMetrics` API via CloudMonkey and the `systeminstances` field was filled with the number of system VMs running on the host and the total of system VMs on the host.