### PR TITLE
UI: Fix hide delete button for templates that are in Installing template state

### DIFF
--- a/ui/src/views/image/TemplateZones.vue
+++ b/ui/src/views/image/TemplateZones.vue
@@ -66,7 +66,7 @@
           @onClick="showCopyTemplate(record)" />
         <tooltip-button
           style="margin-right: 5px"
-          :disabled="!('deleteTemplate' in $store.getters.apis)"
+          :disabled="!('deleteTemplate' in $store.getters.apis && !record.status.startsWith('Installing'))"
           :title="$t('label.action.delete.template')"
           type="primary"
           :danger="true"

--- a/ui/src/views/image/TemplateZones.vue
+++ b/ui/src/views/image/TemplateZones.vue
@@ -66,7 +66,7 @@
           @onClick="showCopyTemplate(record)" />
         <tooltip-button
           style="margin-right: 5px"
-          :disabled="!('deleteTemplate' in $store.getters.apis && !record.status.startsWith('Installing'))"
+          :disabled="!('deleteTemplate' in $store.getters.apis) || record.status.startsWith('Installing')"
           :title="$t('label.action.delete.template')"
           type="primary"
           :danger="true"


### PR DESCRIPTION
### Description

This PR hides the Delete Template button when a template is installing

Fixes: #7865 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?