### PR TITLE
API doc build fix

### DIFF
--- a/tools/apidoc/build-apidoc.sh
+++ b/tools/apidoc/build-apidoc.sh
@@ -59,8 +59,12 @@ fi
 # Default case for Linux sed, just use "-i"
 sedi='-i'
 case "$(uname)" in
-  # For macOS, use two parameters
-  Darwin*) sedi='-i ""'
+  # For macOS, use two parameters, if gnu sed is not set up
+  Darwin*)
+    if ! $(which sed | grep -q gnu); then
+      sedi='-i ""'
+    fi
+  ;;
 esac
 
 set -e


### PR DESCRIPTION
### Description

This PR keeps the same `sed` flags as Linux build hosts, if the end user has installed GNU sed rather than the one shipping with MacOS.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
