### PR TITLE
ui: bump UI pkg version to match CloudStacks

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudstack-ui",
-  "version": "1.0.0",
+  "version": "4.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstack-ui",
   "description": "Modern role-based Apache CloudStack UI",
-  "version": "1.0.0",
+  "version": "4.18.1",
   "homepage": "https://cloudstack.apache.org/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This uses the version in UI's package.json same as CloudStack's. The idea is that static assets aren't cached per discussion on https://github.com/apache/cloudstack/issues/7546

Fixes #7546

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
