### PR TITLE
ui: speed up compute instance listing

### DIFF
--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -32,9 +32,9 @@ export default {
       permission: ['listVirtualMachinesMetrics'],
       resourceType: 'UserVm',
       params: () => {
-        var params = {}
+        var params = { details: 'servoff,tmpl,nics' }
         if (store.getters.metrics) {
-          params = { state: 'running' }
+          params = { details: 'servoff,tmpl,nics,stats' }
         }
         return params
       },

--- a/ui/src/store/mutation-types.js
+++ b/ui/src/store/mutation-types.js
@@ -37,6 +37,7 @@ export const DOMAIN_STORE = 'DOMAIN_STORE'
 export const DARK_MODE = 'DARK_MODE'
 export const VUE_VERSION = 'VUE_VERSION'
 export const CUSTOM_COLUMNS = 'CUSTOM_COLUMNS'
+export const RELOAD_ALL_PROJECTS = 'RELOAD_ALL_PROJECTS'
 
 export const CONTENT_WIDTH_TYPE = {
   Fluid: 'Fluid',

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -858,6 +858,11 @@ export default {
         delete params.showunique
       }
 
+      if (['listVirtualMachinesMetrics'].includes(this.apiName) && this.dataView) {
+        delete params.state
+        delete params.details
+      }
+
       this.loading = true
       if (this.$route.params && this.$route.params.id) {
         params.id = this.$route.params.id

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -859,7 +859,6 @@ export default {
       }
 
       if (['listVirtualMachinesMetrics'].includes(this.apiName) && this.dataView) {
-        delete params.state
         delete params.details
       }
 


### PR DESCRIPTION
The default listVirtualMachinesMetrics APIs assumings details=all which isn't really used in the list view. By changing this to a subset of details, we can see gains upto 10x in listing speed in the UI. When moving to the resource/detail view of the UI, don't pass state or details so `all` the details of the instance are returned.

Possibly fixes #7910

In the screenshot below, we can see passing details=min, and other combinations show significant reduction in network time (from 300-400ms to 20-40ms)

<img width="1408" alt="Screenshot 2023-08-25 at 12 25 22 PM" src="https://github.com/apache/cloudstack/assets/95203/1102cd95-688f-44ee-8955-aa5caceae53d">
<img width="1408" alt="Screenshot 2023-08-25 at 12 28 25 PM" src="https://github.com/apache/cloudstack/assets/95203/4552e96f-f971-46f8-9261-9abe69918169">


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)