### PR TITLE
Add index on cluster_details.name for FirstFitPlanner speedup

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class DbUpgradeUtils {
 
-    private static final DatabaseAccessObject dao = new DatabaseAccessObject();
+    private static DatabaseAccessObject dao = new DatabaseAccessObject();
 
     public static void addIndexIfNeeded(Connection conn, String tableName, String columnName) {
         String indexName = dao.generateIndexName(tableName, columnName);

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
@@ -21,10 +21,14 @@ import java.util.List;
 
 public class DbUpgradeUtils {
 
-    private static DatabaseAccessObject dao = new DatabaseAccessObject();
+    private static final DatabaseAccessObject dao = new DatabaseAccessObject();
 
-    public static void addIndex(Connection conn, String tableName, String columnName) {
-        dao.addIndexIfNeeded(conn, tableName, columnName);
+    public static void addIndexIfNeeded(Connection conn, String tableName, String columnName) {
+        String indexName = dao.generateIndexName(tableName, columnName);
+
+        if (!dao.indexExists(conn, tableName, indexName)) {
+            dao.createIndex(conn, tableName, columnName, indexName);
+        }
     }
 
     public static void addForeignKey(Connection conn, String tableName, String tableColumn, String foreignTableName, String foreignColumnName) {

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
@@ -23,6 +23,10 @@ public class DbUpgradeUtils {
 
     private static DatabaseAccessObject dao = new DatabaseAccessObject();
 
+    public static void addIndex(Connection conn, String tableName, String columnName) {
+        dao.addIndexIfNeeded(conn, tableName, columnName);
+    }
+
     public static void addForeignKey(Connection conn, String tableName, String tableColumn, String foreignTableName, String foreignColumnName) {
         dao.addForeignKey(conn, tableName, tableColumn, foreignTableName, foreignColumnName);
     }

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41800to41810.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41800to41810.java
@@ -69,6 +69,7 @@ public class Upgrade41800to41810 implements DbUpgrade, DbUpgradeSystemVmTemplate
         copyGuestOsMappingsToVMware80u1();
         addForeignKeyToAutoscaleVmprofiles(conn);
         mergeDuplicateGuestOSes();
+        addIndexes(conn);
     }
 
     private void mergeDuplicateGuestOSes() {
@@ -241,5 +242,9 @@ public class Upgrade41800to41810 implements DbUpgrade, DbUpgradeSystemVmTemplate
 
     private void addForeignKeyToAutoscaleVmprofiles(Connection conn) {
         DbUpgradeUtils.addForeignKey(conn, "autoscale_vmprofiles", "user_data_id", "user_data", "id");
+    }
+
+    private void addIndexes(Connection conn) {
+        DbUpgradeUtils.addIndex(conn, "cluster_details", "name");
     }
 }

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41800to41810.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41800to41810.java
@@ -245,6 +245,6 @@ public class Upgrade41800to41810 implements DbUpgrade, DbUpgradeSystemVmTemplate
     }
 
     private void addIndexes(Connection conn) {
-        DbUpgradeUtils.addIndex(conn, "cluster_details", "name");
+        DbUpgradeUtils.addIndexIfNeeded(conn, "cluster_details", "name");
     }
 }


### PR DESCRIPTION
### Description

This PR addresses slowness in FirstFitPlanner, looking for a cluster with capacity for new VM.

Adding an index to `cluster_details.name` yields a ~10x speed improvement in this query, and 2-3x improvement in overall time to create 1000 VMs in parallel during scale testing.  The performance of this query is dependent on number of clusters, so one environment is not directly comparable to another.

Using slow query logging, creating 1000 VMs with 100 parallel workers on a 100 cluster zone:

```
# Query_time: 19.002664  
SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 1 AND cluster_details.name= 'cpuOvercommitRatio' AND ((total_capacity * cluster_details.value ) - used_capacity + reserved_capacity) >= 100 AND capacity.cluster_id IN (SELECT distinct capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN  `cloud`.`cluster_details` cluster_details ON (capacity.cluster_id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 0 AND cluster_details.name= 'memoryOvercommitRatio' AND ((total_capacity * cluster_details.value) - used_capacity + reserved_capacity) >= 1073741824);  

# Query_time: 20.131617
SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 1 AND cluster_details.name= 'cpuOvercommitRatio' AND ((total_capacity * cluster_details.value ) - used_capacity + reserved_capacity) >= 100 AND capacity.cluster_id IN (SELECT distinct capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN  `cloud`.`cluster_details` cluster_details ON (capacity.cluster_id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 0 AND cluster_details.name= 'memoryOvercommitRatio' AND ((total_capacity * cluster_details.value) - used_capacity + reserved_capacity) >= 1073741824);

# Query_time: 12.710961
SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 1 AND cluster_details.name= 'cpuOvercommitRatio' AND ((total_capacity * cluster_details.value ) - used_capacity + reserved_capacity) >= 100 AND capacity.cluster_id IN (SELECT distinct capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN  `cloud`.`cluster_details` cluster_details ON (capacity.cluster_id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 0 AND cluster_details.name= 'memoryOvercommitRatio' AND ((total_capacity * cluster_details.value) - used_capacity + reserved_capacity) >= 1073741824); 
```

Same test after index:

```
# Query_time: 1.139716 
SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 1 AND cluster_details.name= 'cpuOvercommitRatio' AND ((total_capacity * cluster_details.value ) - used_capacity + reserved_capacity) >= 100 AND capacity.cluster_id IN (SELECT distinct capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN  `cloud`.`cluster_details` cluster_details ON (capacity.cluster_id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 0 AND cluster_details.name= 'memoryOvercommitRatio' AND ((total_capacity * cluster_details.value) - used_capacity + reserved_capacity) >= 1073741824);  

# Query_time: 1.025688  
SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 1 AND cluster_details.name= 'cpuOvercommitRatio' AND ((total_capacity * cluster_details.value ) - used_capacity + reserved_capacity) >= 100 AND capacity.cluster_id IN (SELECT distinct capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN  `cloud`.`cluster_details` cluster_details ON (capacity.cluster_id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 0 AND cluster_details.name= 'memoryOvercommitRatio' AND ((total_capacity * cluster_details.value) - used_capacity + reserved_capacity) >= 1073741824);

# Query_time: 2.250430
SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 1 AND cluster_details.name= 'cpuOvercommitRatio' AND ((total_capacity * cluster_details.value ) - used_capacity + reserved_capacity) >= 100 AND capacity.cluster_id IN (SELECT distinct capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN  `cloud`.`cluster_details` cluster_details ON (capacity.cluster_id = cluster_details.cluster_id ) WHERE capacity.data_center_id = 1 AND capacity_type = 0 AND cluster_details.name= 'memoryOvercommitRatio' AND ((total_capacity * cluster_details.value) - used_capacity + reserved_capacity) >= 1073741824);
```

Running the query directly with no load, this query goes from 0.85s to 0.12s when an index is added.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested upgrade path locally:

```
4.18.0.0 to 4.18.1.0:

DEBUG [c.c.u.d.DatabaseAccessObject] (main:null) (logid:) Created index i_cluster_details__name
...
DEBUG [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Upgrade completed for version 4.18.1.0

mysql> show indexes from cluster_details where Key_name="i_cluster_details__name";
+-----------------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
| Table           | Non_unique | Key_name                | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Visible | Expression |
+-----------------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
| cluster_details |          1 | i_cluster_details__name |            1 | name        | A         |           2 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
+-----------------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
```

In case index already exists:
```
4.18.0.0 to 4.18.1.0 where index already exists:

DEBUG [c.c.u.d.DatabaseAccessObject] (main:null) (logid:) Index i_cluster_details__name already exists
...
DEBUG [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Upgrade completed for version 4.18.1.0
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
