### PR TITLE
PowerFlex: Handle missing volumes gracefully during delete volume

### DIFF
--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/client/ScaleIOGatewayClientImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/client/ScaleIOGatewayClientImpl.java
@@ -738,11 +738,20 @@ public class ScaleIOGatewayClientImpl implements ScaleIOGatewayClient {
         try {
             unmapVolumeFromAllSdcs(volumeId);
         } catch (Exception ignored) {}
-        Boolean removeVolumeStatus = post(
-                "/instances/Volume::" + volumeId + "/action/removeVolume",
-                "{\"removeMode\":\"ONLY_ME\"}", Boolean.class);
-        if (removeVolumeStatus != null) {
-            return removeVolumeStatus;
+
+        try {
+            Boolean removeVolumeStatus = post(
+                    "/instances/Volume::" + volumeId + "/action/removeVolume",
+                    "{\"removeMode\":\"ONLY_ME\"}", Boolean.class);
+            if (removeVolumeStatus != null) {
+                return removeVolumeStatus;
+            }
+        } catch (Exception ex) {
+            if (ex instanceof ServerApiException && ex.getMessage().contains("Could not find the volume")) {
+                LOG.warn(String.format("API says deleting volume %s does not exist, handling gracefully", volumeId));
+                return true;
+            }
+            throw ex;
         }
         return false;
     }


### PR DESCRIPTION
### Description

This PR allows the PowerFlex plugin to gracefully handle the case where volume has already been removed from the backend PowerFlex storage and a user attempts to expunge volume.  

Without this, attempting to also clean up in cloudstack results in volumes that are stuck in `Destroy` state, unless an admin manually edits the database.  If the volume is missing on the back end and admins want to recover, they can still attempt to fix this in some way and the record would be preserved in CloudStack as long as a volume expunge is not attempted.

```
Failed to expunge the volume Vol[37950|name=testvol|vm=null|DATADISK] in Primary data store : Unable to delete PowerFlex volume: xxxxx:xxxxx due to API failed due to: {"message":"Could not find the volume","httpStatusCode":500,"errorCode":79}
```

We catch this error case and match the error message to determine if the volume is already gone. There may be some document for handling the error codes more directly, but currently the PowerFlex client doesn't handle errors in this way.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
