### PR TITLE
load (domains) continuously in dropdown boxes

### DIFF
--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -459,15 +459,26 @@ export default {
       this.updateVPCCheckAndFetchNetworkOfferingData()
     },
     fetchDomainData () {
+      this.domainLoading = true
+      this.loadMoreDomains(1)
+    },
+    loadMoreDomains (page) {
       const params = {}
       params.listAll = true
       params.details = 'min'
-      this.domainLoading = true
+      params.pagesize = 100
+      params.page = page
+      var domainCount
       api('listDomains', params).then(json => {
         const listDomains = json.listdomainsresponse.domain
+        domainCount = json.listdomainsresponse.count
         this.domains = this.domains.concat(listDomains)
       }).finally(() => {
-        this.domainLoading = false
+        if (domainCount <= this.domains.length) {
+          this.domainLoading = false
+        } else {
+          this.loadMoreDomains(page + 1)
+        }
         this.form.domainid = 0
         this.handleDomainChange(this.domains[0])
       })

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -77,7 +77,7 @@
               :filterOption="(input, option) => {
                 return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
               }"
-              :loading="domainLoading"
+              :loading="domain.loading"
               :placeholder="apiParams.domainid.description"
               @change="val => { handleDomainChange(domains[val]) }">
               <a-select-option v-for="(opt, optIndex) in domains" :key="optIndex">
@@ -345,7 +345,7 @@ export default {
     return {
       actionLoading: false,
       domains: [],
-      domainLoading: false,
+      domain: { loading: false },
       selectedDomain: {},
       accountVisible: isAdminOrDomainAdmin(),
       accounts: [],
@@ -459,25 +459,25 @@ export default {
       this.updateVPCCheckAndFetchNetworkOfferingData()
     },
     fetchDomainData () {
-      this.domainLoading = true
-      this.loadMoreDomains(1)
+      this.domain.loading = true
+      this.loadMore('listDomains', 1, this.domain)
     },
-    loadMoreDomains (page) {
+    loadMore (apiToCall, page, sema) {
       const params = {}
       params.listAll = true
       params.details = 'min'
       params.pagesize = 100
       params.page = page
-      var domainCount
-      api('listDomains', params).then(json => {
+      var count
+      api(apiToCall, params).then(json => {
         const listDomains = json.listdomainsresponse.domain
-        domainCount = json.listdomainsresponse.count
+        count = json.listdomainsresponse.count
         this.domains = this.domains.concat(listDomains)
       }).finally(() => {
-        if (domainCount <= this.domains.length) {
-          this.domainLoading = false
+        if (count <= this.domains.length) {
+          sema.loading = false
         } else {
-          this.loadMoreDomains(page + 1)
+          this.loadMore(apiToCall, page + 1, sema)
         }
         this.form.domainid = 0
         this.handleDomainChange(this.domains[0])


### PR DESCRIPTION
### Description

This PR attempts to load items (PoC for domains on the network creation tab) in case there is more to load than the default 500 maximum.

This should be generalised to a mechanism that applies to any dropdown UI item, but is now only for a particular instance.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #7780

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
create loads of domains 26*((26*3)+26)+1 and in the network create dialog add one by typing a partial name that is beyond the 500 mark. I create domains a-z with subdomain <x>a through <x>z  and sub-sub-domain 1st, 2nd and 3rd

What is still missing is searching for the last 3rd for instance. There are 26*26 (676) domains named 3rd, and if I want to select the last one. A thing that may also be missing in the domain overview search and in the results of #7766 , this does address the comment in https://github.com/apache/cloudstack/pull/7766#pullrequestreview-1549019223 but as said, not in a generic way (yet)