### PR TITLE
Fix direct download https compressed qcow2 template checker

### DIFF
--- a/core/src/main/java/org/apache/cloudstack/direct/download/HttpsDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/HttpsDirectTemplateDownloader.java
@@ -176,15 +176,15 @@ public class HttpsDirectTemplateDownloader extends DirectTemplateDownloaderImpl 
 
     @Override
     public Long getRemoteFileSize(String url, String format) {
-        if ("qcow2".equalsIgnoreCase(format) && url.endsWith(".qcow2")) {
-            //Avoid compressed qcow2 files
+        if ("qcow2".equalsIgnoreCase(format)) {
             try {
                 URL urlObj = new URL(url);
                 HttpsURLConnection urlConnection = (HttpsURLConnection)urlObj.openConnection();
                 SSLContext context = getSSLContext();
                 urlConnection.setSSLSocketFactory(context.getSocketFactory());
                 urlConnection.connect();
-                return QCOW2Utils.getVirtualSize(urlConnection.getInputStream());
+                boolean isCompressed = !url.endsWith("qcow2");
+                return QCOW2Utils.getVirtualSize(urlObj.openStream(), isCompressed);
             } catch (IOException e) {
                 throw new CloudRuntimeException(String.format("Cannot obtain qcow2 virtual size due to: %s", e.getMessage()), e);
             }

--- a/core/src/main/java/org/apache/cloudstack/direct/download/HttpsDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/HttpsDirectTemplateDownloader.java
@@ -176,7 +176,8 @@ public class HttpsDirectTemplateDownloader extends DirectTemplateDownloaderImpl 
 
     @Override
     public Long getRemoteFileSize(String url, String format) {
-        if ("qcow2".equalsIgnoreCase(format)) {
+        if ("qcow2".equalsIgnoreCase(format) && url.endsWith(".qcow2")) {
+            //Avoid compressed qcow2 files
             try {
                 URL urlObj = new URL(url);
                 HttpsURLConnection urlConnection = (HttpsURLConnection)urlObj.openConnection();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckUrlCommand.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckUrlCommand.java
@@ -40,6 +40,11 @@ public class LibvirtCheckUrlCommand extends CommandWrapper<CheckUrlCommand, Chec
         boolean checkResult = DirectDownloadHelper.checkUrlExistence(url);
         if (checkResult) {
             remoteSize = DirectDownloadHelper.getFileSize(url, cmd.getFormat());
+            if (remoteSize == null || remoteSize < 0) {
+                s_logger.error(String.format("Couldn't properly retrieve the remote size of the template on " +
+                        "url %s, obtained size = %s", url, remoteSize));
+                return new CheckUrlAnswer(false, remoteSize);
+            }
         }
         return new CheckUrlAnswer(checkResult, remoteSize);
     }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -347,7 +347,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             // and as such can be easily read.
 
             try (InputStream inputStream = td.getS3ObjectInputStream();) {
-                dnld.setTemplatesize(QCOW2Utils.getVirtualSize(inputStream));
+                dnld.setTemplatesize(QCOW2Utils.getVirtualSize(inputStream, false));
             }
             catch (IOException e) {
                 result = "Couldn't read QCOW2 virtual size. Error: " + e.getMessage();

--- a/utils/src/test/java/com/cloud/utils/storage/QCOW2UtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/storage/QCOW2UtilsTest.java
@@ -24,7 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class QCOW2UtilsTest {
         ByteBuffer byteBuffer = ByteBuffer.allocate(72);
 
         // Magic
-        byteBuffer.put("QFI".getBytes(Charset.forName("UTF-8")));
+        byteBuffer.put("QFI".getBytes(StandardCharsets.UTF_8));
         byteBuffer.put((byte)0xfb);
 
         // Version
@@ -116,6 +116,6 @@ public class QCOW2UtilsTest {
 
     @Test
     public void getVirtualSizeTest() throws IOException {
-        assertEquals(virtualSize.longValue(), QCOW2Utils.getVirtualSize(inputStream));
+        assertEquals(virtualSize.longValue(), QCOW2Utils.getVirtualSize(inputStream, false));
     }
 }


### PR DESCRIPTION
### Description

This PR fixes an issue on direct download while registering HTTPS compressed files
Fixes: #7929 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
