### PR TITLE
Allow editing of host and storage tags of system offerings in the UI

### DIFF
--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -126,7 +126,7 @@ export default {
         dataView: true,
         params: { issystem: 'true' },
         docHelp: 'adminguide/service_offerings.html#modifying-or-deleting-a-service-offering',
-        args: ['name', 'displaytext']
+        args: ['name', 'displaytext', 'storagetags', 'hosttags']
       }, {
         api: 'deleteServiceOffering',
         icon: 'delete-outlined',

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -109,7 +109,7 @@ export default {
       permission: ['listServiceOfferings', 'listInfrastructure'],
       params: { issystem: 'true', isrecursive: 'true' },
       columns: ['name', 'systemvmtype', 'cpunumber', 'cpuspeed', 'memory', 'storagetype', 'order'],
-      details: ['name', 'id', 'displaytext', 'systemvmtype', 'provisioningtype', 'storagetype', 'iscustomized', 'limitcpuuse', 'cpunumber', 'cpuspeed', 'memory', 'hosttags', 'tags', 'domain', 'zone', 'created', 'dynamicscalingenabled', 'diskofferingstrictness'],
+      details: ['name', 'id', 'displaytext', 'systemvmtype', 'provisioningtype', 'storagetype', 'iscustomized', 'limitcpuuse', 'cpunumber', 'cpuspeed', 'memory', 'storagetags', 'hosttags', 'tags', 'domain', 'zone', 'created', 'dynamicscalingenabled', 'diskofferingstrictness'],
       actions: [{
         api: 'createServiceOffering',
         icon: 'plus-outlined',


### PR DESCRIPTION
### Description
CloudStack allows you to change host tags and storage tags of system offerings through the API, but it was missing from the UI. This just added the fields so the UI window is the same as the compute offering's window.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):
![image](https://github.com/apache/cloudstack/assets/22242548/219ad68e-353b-4b81-91da-58793d48974c)



### How Has This Been Tested?
I created a system offering without host or storage tags, added them through the edit window and verified they were added. I then created another offering with tags, deleted one of them and changed the other to a different one.