### PR TITLE
ui: don't skip if dataview has multiple items in response

### DIFF
--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -942,10 +942,6 @@ export default {
           console.log('DEBUG - Discarding API response as its `id` does not match the uuid on the browser path')
           return
         }
-        if (this.dataView && apiItemCount > 1) {
-          console.log('DEBUG - Discarding API response as got more than one item in data view', this.$route.params, this.items)
-          return
-        }
 
         this.items = json[responseName][objectName]
         if (!this.items || this.items.length === 0) {


### PR DESCRIPTION
This would fix the case of multiple items return in API response for a resource such as a template or ISO in case of multi-zone env.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
