### PR TITLE
Use direct download timeout configs for URL check during registerTemplate

### DIFF
--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/CheckUrlCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/CheckUrlCommand.java
@@ -25,6 +25,9 @@ public class CheckUrlCommand extends Command {
 
     private String format;
     private String url;
+    private Integer connectTimeout;
+    private Integer connectionRequestTimeout;
+    private Integer socketTimeout;
 
     public String getFormat() {
         return format;
@@ -34,10 +37,25 @@ public class CheckUrlCommand extends Command {
         return url;
     }
 
+    public Integer getConnectTimeout() { return connectTimeout; }
+
+    public Integer getConnectionRequestTimeout() { return connectionRequestTimeout; }
+
+    public Integer getSocketTimeout() { return socketTimeout; }
+
     public CheckUrlCommand(final String format,final String url) {
         super();
         this.format = format;
         this.url = url;
+    }
+
+    public CheckUrlCommand(final String format,final String url, Integer connectTimeout, Integer connectionRequestTimeout, Integer socketTimeout) {
+        super();
+        this.format = format;
+        this.url = url;
+        this.connectTimeout = connectTimeout;
+        this.socketTimeout = socketTimeout;
+        this.connectionRequestTimeout = connectionRequestTimeout;
     }
 
     @Override

--- a/core/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadHelper.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadHelper.java
@@ -54,7 +54,7 @@ public class DirectDownloadHelper {
 
     public static boolean checkUrlExistence(String url) {
         try {
-            DirectTemplateDownloader checker = getCheckerDownloader(url);
+            DirectTemplateDownloader checker = getCheckerDownloader(url, null, null, null);
             return checker.checkUrl(url);
         } catch (CloudRuntimeException e) {
             LOGGER.error(String.format("Cannot check URL %s is reachable due to: %s", url, e.getMessage()), e);
@@ -62,22 +62,37 @@ public class DirectDownloadHelper {
         }
     }
 
-    private static DirectTemplateDownloader getCheckerDownloader(String url) {
+    public static boolean checkUrlExistence(String url, Integer connectTimeout, Integer connectionRequestTimeout, Integer socketTimeout) {
+        try {
+            DirectTemplateDownloader checker = getCheckerDownloader(url, connectTimeout, connectionRequestTimeout, socketTimeout);
+            return checker.checkUrl(url);
+        } catch (CloudRuntimeException e) {
+            LOGGER.error(String.format("Cannot check URL %s is reachable due to: %s", url, e.getMessage()), e);
+            return false;
+        }
+    }
+
+    private static DirectTemplateDownloader getCheckerDownloader(String url, Integer connectTimeout, Integer connectionRequestTimeout, Integer socketTimeout) {
         if (url.toLowerCase().startsWith("https:")) {
-            return new HttpsDirectTemplateDownloader(url);
+            return new HttpsDirectTemplateDownloader(url, connectTimeout, connectionRequestTimeout, socketTimeout);
         } else if (url.toLowerCase().startsWith("http:")) {
-            return new HttpDirectTemplateDownloader(url);
+            return new HttpDirectTemplateDownloader(url, connectTimeout, socketTimeout);
         } else if (url.toLowerCase().startsWith("nfs:")) {
             return new NfsDirectTemplateDownloader(url);
         } else if (url.toLowerCase().endsWith(".metalink")) {
-            return new MetalinkDirectTemplateDownloader(url);
+            return new MetalinkDirectTemplateDownloader(url, connectTimeout, socketTimeout);
         } else {
             throw new CloudRuntimeException(String.format("Cannot find a download checker for url: %s", url));
         }
     }
 
     public static Long getFileSize(String url, String format) {
-        DirectTemplateDownloader checker = getCheckerDownloader(url);
+        DirectTemplateDownloader checker = getCheckerDownloader(url, null, null, null);
+        return checker.getRemoteFileSize(url, format);
+    }
+
+    public static Long getFileSize(String url, String format, Integer connectTimeout, Integer connectionRequestTimeout, Integer socketTimeout) {
+        DirectTemplateDownloader checker = getCheckerDownloader(url, connectTimeout, connectionRequestTimeout, socketTimeout);
         return checker.getRemoteFileSize(url, format);
     }
 }

--- a/core/src/main/java/org/apache/cloudstack/direct/download/HttpDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/HttpDirectTemplateDownloader.java
@@ -50,8 +50,8 @@ public class HttpDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
     protected GetMethod request;
     protected Map<String, String> reqHeaders = new HashMap<>();
 
-    protected HttpDirectTemplateDownloader(String url) {
-        this(url, null, null, null, null, null, null, null);
+    protected HttpDirectTemplateDownloader(String url, Integer connectTimeout, Integer socketTimeout) {
+        this(url, null, null, null, null, connectTimeout, socketTimeout, null);
     }
 
     public HttpDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum,

--- a/core/src/main/java/org/apache/cloudstack/direct/download/HttpsDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/HttpsDirectTemplateDownloader.java
@@ -65,8 +65,8 @@ public class HttpsDirectTemplateDownloader extends DirectTemplateDownloaderImpl 
     protected CloseableHttpClient httpsClient;
     private HttpUriRequest req;
 
-    protected HttpsDirectTemplateDownloader(String url) {
-        this(url, null, null, null, null, null, null, null, null);
+    protected HttpsDirectTemplateDownloader(String url, Integer connectTimeout, Integer connectionRequestTimeout, Integer socketTimeout) {
+        this(url, null, null, null, null, connectTimeout, socketTimeout, connectionRequestTimeout, null);
     }
 
     public HttpsDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers,

--- a/core/src/main/java/org/apache/cloudstack/direct/download/MetalinkDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/MetalinkDirectTemplateDownloader.java
@@ -60,8 +60,8 @@ public class MetalinkDirectTemplateDownloader extends DirectTemplateDownloaderIm
         }
     }
 
-    protected MetalinkDirectTemplateDownloader(String url) {
-        this(url, null, null, null, null, null, null, null);
+    protected MetalinkDirectTemplateDownloader(String url, Integer connectTimeout, Integer socketTimeout) {
+        this(url, null, null, null, null, connectTimeout, socketTimeout, null);
     }
 
     public MetalinkDirectTemplateDownloader(String url, String destPoolPath, Long templateId, String checksum,

--- a/core/src/test/java/org/apache/cloudstack/direct/download/BaseDirectTemplateDownloaderTest.java
+++ b/core/src/test/java/org/apache/cloudstack/direct/download/BaseDirectTemplateDownloaderTest.java
@@ -56,7 +56,7 @@ public class BaseDirectTemplateDownloaderTest {
     private HttpEntity httpEntity;
 
     @InjectMocks
-    protected HttpsDirectTemplateDownloader httpsDownloader = new HttpsDirectTemplateDownloader(httpUrl);
+    protected HttpsDirectTemplateDownloader httpsDownloader = new HttpsDirectTemplateDownloader(httpUrl, 1000, 1000, 1000);
 
     @Before
     public void init() throws IOException {

--- a/core/src/test/java/org/apache/cloudstack/direct/download/MetalinkDirectTemplateDownloaderTest.java
+++ b/core/src/test/java/org/apache/cloudstack/direct/download/MetalinkDirectTemplateDownloaderTest.java
@@ -25,7 +25,8 @@ import org.mockito.InjectMocks;
 public class MetalinkDirectTemplateDownloaderTest extends BaseDirectTemplateDownloaderTest {
 
     @InjectMocks
-    protected MetalinkDirectTemplateDownloader metalinkDownloader = new MetalinkDirectTemplateDownloader(httpsUrl);
+    protected MetalinkDirectTemplateDownloader metalinkDownloader = new MetalinkDirectTemplateDownloader(httpsUrl, 1000, 1000);
+
     @Test
     public void testCheckUrlMetalink() {
         metalinkDownloader.downloader = httpsDownloader;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckUrlCommand.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckUrlCommand.java
@@ -35,11 +35,16 @@ public class LibvirtCheckUrlCommand extends CommandWrapper<CheckUrlCommand, Chec
     @Override
     public CheckUrlAnswer execute(CheckUrlCommand cmd, LibvirtComputingResource serverResource) {
         final String url = cmd.getUrl();
-        s_logger.info("Checking URL: " + url);
+        final Integer connectTimeout = cmd.getConnectTimeout();
+        final Integer connectionRequestTimeout = cmd.getConnectionRequestTimeout();
+        final Integer socketTimeout = cmd.getSocketTimeout();
+
+        s_logger.info(String.format("Checking URL: %s, with connect timeout: %d, connect request timeout: %d, socket timeout: %d", url, connectTimeout, connectionRequestTimeout, socketTimeout));
         Long remoteSize = null;
-        boolean checkResult = DirectDownloadHelper.checkUrlExistence(url);
+
+        boolean checkResult = DirectDownloadHelper.checkUrlExistence(url, connectTimeout, connectionRequestTimeout, socketTimeout);
         if (checkResult) {
-            remoteSize = DirectDownloadHelper.getFileSize(url, cmd.getFormat());
+            remoteSize = DirectDownloadHelper.getFileSize(url, cmd.getFormat(), connectTimeout, connectionRequestTimeout, socketTimeout);
             if (remoteSize == null || remoteSize < 0) {
                 s_logger.error(String.format("Couldn't properly retrieve the remote size of the template on " +
                         "url %s, obtained size = %s", url, remoteSize));

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -39,6 +39,7 @@ import org.apache.cloudstack.api.command.user.iso.RegisterIsoCmd;
 import org.apache.cloudstack.api.command.user.template.DeleteTemplateCmd;
 import org.apache.cloudstack.api.command.user.template.GetUploadParamsForTemplateCmd;
 import org.apache.cloudstack.api.command.user.template.RegisterTemplateCmd;
+import org.apache.cloudstack.direct.download.DirectDownloadManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -167,7 +168,10 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
         if (host == null) {
             throw new CloudRuntimeException("Couldn't find a host to validate URL " + url);
         }
-        CheckUrlCommand cmd = new CheckUrlCommand(format, url);
+        Integer socketTimeout = DirectDownloadManager.DirectDownloadSocketTimeout.value();
+        Integer connectRequestTimeout = DirectDownloadManager.DirectDownloadConnectionRequestTimeout.value();
+        Integer connectTimeout = DirectDownloadManager.DirectDownloadConnectTimeout.value();
+        CheckUrlCommand cmd = new CheckUrlCommand(format, url, connectTimeout, connectRequestTimeout, socketTimeout);
         s_logger.debug("Performing URL " + url + " validation on host " + host.getId());
         Answer answer = _agentMgr.easySend(host.getId(), cmd);
         if (answer == null || !answer.getResult()) {


### PR DESCRIPTION
### Description

This PR allows the direct download timeout configurations to apply to the URL check during registerTemplate. 

There is already support in the Downloader classes for these configurations for the actual download of templates, and the ConfigKeys already exist, so just needed to pass these in the CheckUrlCommand

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally, confirmed config items are passed along.

mgmt server:
```
2023-09-06 14:41:09,340 DEBUG [c.c.a.m.ClusteredAgentAttache] (qtp1911152052-21:ctx-09dfd07c ctx-600dfd34) (logid:1083f2be) (extid:) Seq 43-7668222790528401454: Forwarding Seq 43-7668222790528401454:  { Cmd , MgmtId: 31239355356821, via: 43(kvmlab2), Ver: v1, Flags: 100011, [{"org.apache.cloudstack.agent.directdownload.CheckUrlCommand":{"format":"QCOW2","url":"https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2","connectTimeout":"7000","connectionRequestTimeout":"5000","socketTimeout":"8000","wait":"0","bypassHostMaintenance":"false"}}] } to 5074163034
2023-09-06 14:41:11,405 DEBUG [c.c.a.t.Request] (AgentManager-Handler-8:null) (logid:) (extid:) Seq 43-7668222790528401454: Processing:  { Ans: , MgmtId: 31239355356821, via: 43, Ver: v1, Flags: 10, [{"org.apache.cloudstack.agent.directdownload.CheckUrlAnswer":{"templateSize":"(5.00 GB) 5368709120","result":"true","wait":"0","bypassHostMaintenance":"false"}}] }
```

hypervisor:
```
2023-09-06 14:41:09,385 DEBUG [cloud.agent.Agent] (agentRequest-Handler-4:null) (logid:1083f2be) Request:Seq 43-7668222790528401454:  { Cmd , MgmtId: 31239355356821, via: 43, Ver: v1, Flags: 100011, [{"org.apache.cloudstack.agent.directdownload.CheckUrlCommand":{"format":"QCOW2","url":"https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2","connectTimeout":"7000","connectionRequestTimeout":"5000","socketTimeout":"8000","wait":"0","bypassHostMaintenance":"false"}}] }
2023-09-06 14:41:09,386 DEBUG [cloud.agent.Agent] (agentRequest-Handler-4:null) (logid:1083f2be) Processing command: org.apache.cloudstack.agent.directdownload.CheckUrlCommand
2023-09-06 14:41:09,386 INFO  [resource.wrapper.LibvirtCheckUrlCommand] (agentRequest-Handler-4:null) (logid:1083f2be) Checking URL: https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2, with connect timeout: 7000, connect request timeout: 5000, socket timeout: 8000
2023-09-06 14:41:11,404 DEBUG [cloud.agent.Agent] (agentRequest-Handler-4:null) (logid:1083f2be) Seq 43-7668222790528401454:  { Ans: , MgmtId: 31239355356821, via: 43, Ver: v1, Flags: 10, [{"org.apache.cloudstack.agent.directdownload.CheckUrlAnswer":{"templateSize":"(5.00 GB) 5368709120","result":"true","wait":"0","bypassHostMaintenance":"false"}}] }
```
Updated unit tests to use the new constructor.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
