### PR TITLE
Increase reserve on ScaleIO disk formatting for fragmentation

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
@@ -552,12 +552,12 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
 
     /**
      * Calculates usable size from raw size, assuming qcow2 requires 192k/1GB for metadata
-     * We also remove 32MiB for potential encryption/safety factor.
+     * We also remove 128MiB for encryption/fragmentation/safety factor.
      * @param raw size in bytes
      * @return usable size in bytesbytes
      */
     public static long getUsableBytesFromRawBytes(Long raw) {
-        long usable = raw - (32 << 20) - ((raw >> 30) * 200704);
+        long usable = raw - (128 << 20) - ((raw >> 30) * 200704);
         if (usable < 0) {
             usable = 0L;
         }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
@@ -23,9 +23,9 @@ import org.junit.Test;
 public class ScaleIOStorageAdaptorTest {
     @Test
     public void getUsableBytesFromRawBytesTest() {
-        Assert.assertEquals("Overhead calculated for 8Gi size", 8554774528L, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(8L << 30));
-        Assert.assertEquals("Overhead calculated for 4Ti size", 4294130925568L, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(4000L << 30));
-        Assert.assertEquals("Overhead calculated for 500Gi size", 536737005568L, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(500L << 30));
+        Assert.assertEquals("Overhead calculated for 8Gi size", 8454111232L, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(8L << 30));
+        Assert.assertEquals("Overhead calculated for 4Ti size", 4294030262272L, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(4000L << 30));
+        Assert.assertEquals("Overhead calculated for 500Gi size", 536636342272L, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(500L << 30));
         Assert.assertEquals("Unsupported small size", 0, ScaleIOStorageAdaptor.getUsableBytesFromRawBytes(1L));
     }
 }


### PR DESCRIPTION
### Description

This PR increases the overhead calculated for ScaleIO encrypted volumes slightly from 32MB to 128MB, due to edge cases found with lots of small writes over many weeks causing excessive fragmentation.  Ideally discard/fstrim is being issued in the guest to free some meaningful amount of space occasionally, but this should help for situations where that isn't guaranteed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally, and updated the unit tests to verify the return value is as expected.