### PR TITLE
Trigger out of band VM state update via libvirt event when VM stops

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/PingCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/PingCommand.java
@@ -24,6 +24,7 @@ import com.cloud.host.Host;
 public class PingCommand extends Command {
     Host.Type hostType;
     long hostId;
+    boolean outOfBand;
 
     protected PingCommand() {
     }
@@ -33,6 +34,12 @@ public class PingCommand extends Command {
         hostId = id;
     }
 
+    public PingCommand(Host.Type type, long id, boolean oob) {
+        hostType = type;
+        hostId = id;
+        outOfBand = oob;
+    }
+
     public Host.Type getHostType() {
         return hostType;
     }
@@ -40,6 +47,10 @@ public class PingCommand extends Command {
     public long getHostId() {
         return hostId;
     }
+
+    public boolean getOutOfBand() { return outOfBand; }
+
+    public void setOutOfBand(boolean oob) { this.outOfBand = oob; }
 
     @Override
     public boolean executeInSequence() {

--- a/core/src/main/java/com/cloud/resource/AgentStatusUpdater.java
+++ b/core/src/main/java/com/cloud/resource/AgentStatusUpdater.java
@@ -1,0 +1,5 @@
+package com.cloud.resource;
+
+public interface AgentStatusUpdater {
+    void triggerUpdate();
+}

--- a/core/src/main/java/com/cloud/resource/AgentStatusUpdater.java
+++ b/core/src/main/java/com/cloud/resource/AgentStatusUpdater.java
@@ -1,5 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.resource;
 
+/**
+ * AgentStatusUpdater is an agent with triggerable update functionality
+ */
 public interface AgentStatusUpdater {
+    /**
+     * Trigger the sending of an update (Ping).
+     */
     void triggerUpdate();
 }

--- a/core/src/main/java/com/cloud/resource/ResourceStatusUpdater.java
+++ b/core/src/main/java/com/cloud/resource/ResourceStatusUpdater.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.resource;
 
 /**
@@ -5,6 +21,8 @@ package com.cloud.resource;
  */
 public interface ResourceStatusUpdater {
     /**
+     * Register an AgentStatusUpdater to use for triggering out of band updates.
+     *
      * @param updater The object to call triggerUpdate() on
      */
     void registerStatusUpdater(AgentStatusUpdater updater);

--- a/core/src/main/java/com/cloud/resource/ResourceStatusUpdater.java
+++ b/core/src/main/java/com/cloud/resource/ResourceStatusUpdater.java
@@ -1,0 +1,11 @@
+package com.cloud.resource;
+
+/**
+ * ResourceStatusUpdater is a resource that can trigger out of band status updates
+ */
+public interface ResourceStatusUpdater {
+    /**
+     * @param updater The object to call triggerUpdate() on
+     */
+    void registerStatusUpdater(AgentStatusUpdater updater);
+}

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3726,7 +3726,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             if (cmd instanceof PingRoutingCommand) {
                 final PingRoutingCommand ping = (PingRoutingCommand)cmd;
                 if (ping.getHostVmStateReport() != null) {
-                    _syncMgr.processHostVmStatePingReport(agentId, ping.getHostVmStateReport());
+                    _syncMgr.processHostVmStatePingReport(agentId, ping.getHostVmStateReport(), ping.getOutOfBand());
                 }
 
                 scanStalledVMInTransitionStateOnUpHost(agentId);

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachinePowerStateSync.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachinePowerStateSync.java
@@ -27,7 +27,7 @@ public interface VirtualMachinePowerStateSync {
     void processHostVmStateReport(long hostId, Map<String, HostVmStateReportEntry> report);
 
     // to adapt legacy ping report
-    void processHostVmStatePingReport(long hostId, Map<String, HostVmStateReportEntry> report);
+    void processHostVmStatePingReport(long hostId, Map<String, HostVmStateReportEntry> report, boolean force);
 
     Map<Long, VirtualMachine.PowerState> convertVmStateReport(Map<String, HostVmStateReportEntry> states);
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -83,6 +83,7 @@ import org.libvirt.DomainInfo;
 import org.libvirt.DomainInfo.DomainState;
 import org.libvirt.DomainInterfaceStats;
 import org.libvirt.DomainSnapshot;
+import org.libvirt.Library;
 import org.libvirt.LibvirtException;
 import org.libvirt.MemoryStatistic;
 import org.libvirt.Network;
@@ -90,12 +91,15 @@ import org.libvirt.SchedParameter;
 import org.libvirt.SchedUlongParameter;
 import org.libvirt.Secret;
 import org.libvirt.VcpuInfo;
+import org.libvirt.event.DomainEventDetail;
+import org.libvirt.event.StoppedDetail;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
@@ -175,6 +179,8 @@ import com.cloud.network.Networks.BroadcastDomainType;
 import com.cloud.network.Networks.IsolationType;
 import com.cloud.network.Networks.RouterPrivateIpStrategy;
 import com.cloud.network.Networks.TrafficType;
+import com.cloud.resource.AgentStatusUpdater;
+import com.cloud.resource.ResourceStatusUpdater;
 import com.cloud.resource.RequestWrapper;
 import com.cloud.resource.ServerResource;
 import com.cloud.resource.ServerResourceBase;
@@ -224,10 +230,11 @@ import com.google.gson.Gson;
  *         private mac addresses for domrs | mac address | start + 126 || ||
  *         pool | the parent of the storage pool hierarchy * }
  **/
-public class LibvirtComputingResource extends ServerResourceBase implements ServerResource, VirtualRouterDeployer {
+public class LibvirtComputingResource extends ServerResourceBase implements ServerResource, VirtualRouterDeployer, ResourceStatusUpdater {
     protected static Logger s_logger = Logger.getLogger(LibvirtComputingResource.class);
 
     private static final String CONFIG_VALUES_SEPARATOR = ",";
+
 
     private static final String LEGACY = "legacy";
     private static final String SECURE = "secure";
@@ -457,6 +464,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected CPUStat _cpuStat = new CPUStat();
     protected MemStat _memStat = new MemStat(_dom0MinMem, _dom0OvercommitMem);
     private final LibvirtUtilitiesHelper libvirtUtilitiesHelper = new LibvirtUtilitiesHelper();
+    private AgentStatusUpdater _agentStatusUpdater;
 
     protected Boolean enableManuallySettingCpuTopologyOnKvmVm = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ENABLE_MANUALLY_SETTING_CPU_TOPOLOGY_ON_KVM_VM);
 
@@ -479,6 +487,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     protected long getHypervisorQemuVersion() {
         return _hypervisorQemuVersion;
+    }
+
+    @Override
+    public void registerStatusUpdater(AgentStatusUpdater updater) {
+        _agentStatusUpdater = updater;
     }
 
     @Override
@@ -3590,7 +3603,58 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } catch (final CloudRuntimeException e) {
             s_logger.debug("Unable to initialize local storage pool: " + e);
         }
+        setupLibvirtEventListener();
         return sscmd;
+    }
+
+    private void setupLibvirtEventListener() {
+        try {
+            final Thread t = new Thread(() -> {
+                try {
+                    Library.runEventLoop();
+                } catch (LibvirtException e) {
+                    s_logger.error("LibvirtException was thrown in event loop: ", e);
+                } catch (InterruptedException e) {
+                    s_logger.error("Libvirt event loop was interrupted: ", e);
+                }
+            });
+            t.setDaemon(true);
+            t.start();
+
+            Connect conn = LibvirtConnection.getConnection();
+            conn.addLifecycleListener((domain, domainEvent) -> {
+                try {
+                    s_logger.debug(String.format("Got event lifecycle change on Domain %s, event %s", domain.getName(), domainEvent));
+                    if (domainEvent != null) {
+                        switch (domainEvent.getType()) {
+                            case STOPPED:
+                                /* libvirt-destroyed VMs have detail StoppedDetail.DESTROYED, self shutdown guests are StoppedDetail.SHUTDOWN
+                                * Checking for this helps us differentiate between events where cloudstack or admin stopped the VM vs guest
+                                * initiated, and avoid pushing extra updates for actions we are initiating without a need for extra tracking */
+                                DomainEventDetail detail = domainEvent.getDetail();
+                                if (StoppedDetail.SHUTDOWN.equals(detail) || StoppedDetail.CRASHED.equals(detail)) {
+                                    s_logger.info("Triggering out of band status update due to completed self-shutdown or crash of VM");
+                                    _agentStatusUpdater.triggerUpdate();
+                                } else {
+                                    s_logger.debug("Event detail: " + detail);
+                                }
+                                break;
+                            default:
+                                s_logger.debug(String.format("No handling for event %s", domainEvent));
+                        }
+                    }
+                } catch (LibvirtException e) {
+                    s_logger.error("Libvirt exception while processing lifecycle event", e);
+                } catch (Throwable e) {
+                    s_logger.error("Error during lifecycle", e);
+                }
+                return 0;
+            });
+
+            s_logger.debug("Set up the libvirt domain event lifecycle listener");
+        } catch (LibvirtException e) {
+            s_logger.error("Failed to get libvirt connection for domain event lifecycle", e);
+        }
     }
 
     public String diskUuidToSerial(String uuid) {


### PR DESCRIPTION
### Description
Pushing this to get some feedback, trying to provide a feature and reusing some functionality like the existing VM power state reporting, rather than inventing whole new messaging.

This PR allows KVM to detect guests that stop or crash, and immediately trigger a power state report to update the VM state in CloudStack.

In current design, Agent is responsible for sending pings on interval. These pings contain a state report for each VM. If something changes in between these pings, it can potentially take a long time for discovery of VM state change.

When Agent first starts, it loads the `ServerResource` (implementation is `LibvirtComputingResource` in the shipping agent) and initializes it. Then later it calls the ServerResource `getCurrentStatus()` to collect the host and VM status to send `PingCommand` on intervals. This change adds two interfaces - if the `ServerResource` implements `ResourceStatusUpdater`, then the agent registers itself as an `AgentStatusUpdater`, which gives the `ServerResource` a way to trigger an update, by calling `AgentStatusUpdater.triggerUpdate()`. This keeps the implementation of monitoring and collecting the VM status in the ServerResource, while allowing the `Agent` to still handle sending the update, and not requiring all existing implementations of `ServerResource` and `IAgentControl` to implement these by changing the existing interfaces. There may be a cleaner way to do this.

In LibvirtComputingResource, we register an event listener, and process domain lifecycle events, looking only for `STOPPED` events that are due to a crash or a shutdown. Domain stop due to things like `virsh destroy`" or cloudstack issuing a stop will have a detail of `DESTROYED` or `MIGRATED` in the case of migration, rather than `CRASHED` or `SHUTDOWN`. I considered briefly adding some code to track if we were in the middle of a StopCommand or similar to filter out superfluous events, this seems simpler, at the expense of not being able to update on admin `virsh destroy`.

The PingCommand has been given a boolean to indicate if the Ping is out of band. This is important, because the code that processes pings on the management server will ignore pings that come more often than the expected interval (presumably to avoid state thrashing?). This boolean gives us the ability to force processing of pings if they are out of band. Therefore it's also important that we are only triggering these on valid state change events, and not issuing superfluous updates any time a VM stops due to cloudstack issuing stop, etc.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested locally by shutting down VM within guest, vs `virsh destroy` or stopping via CloudStack API. Tested to ensure listener still works after libvirt restart.

There are no existing tests for VirtualMachienPowerStateSyncImpl, and the change here is very minor (reacting to the boolean).

It seems tricky to build a unit test for the Libvirt event listener.

Could possibly write a smoke test to ssh into a vm, shut it down, and check the state of the VM via API?

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
