### PR TITLE
ui: extend role isPublic parameter

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/CreateRoleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/CreateRoleCmd.java
@@ -48,8 +48,7 @@ public class CreateRoleCmd extends RoleCmd {
             description = "ID of the role to be cloned from. Either roleid or type must be passed in")
     private Long roleId;
 
-    @Parameter(name = ApiConstants.IS_PUBLIC, type = CommandType.BOOLEAN, description = "Indicates whether the role will be visible to all users (public) or only to root admins (private)." +
-            " If this parameter is not specified during the creation of the role its value will be defaulted to true (public).")
+    @Parameter(name = ApiConstants.IS_PUBLIC, type = CommandType.BOOLEAN, description = "Indicates whether the role will be visible to all users (public) or only to root admins (private). Default is true.")
     private boolean publicRole = true;
 
     /////////////////////////////////////////////////////

--- a/ui/src/config/section/role.js
+++ b/ui/src/config/section/role.js
@@ -23,7 +23,7 @@ export default {
   docHelp: 'adminguide/accounts.html#roles',
   permission: ['listRoles', 'listRolePermissions'],
   columns: ['name', 'type', 'description'],
-  details: ['name', 'id', 'type', 'description'],
+  details: ['name', 'id', 'type', 'description', 'ispublic'],
   tabs: [{
     name: 'details',
     component: shallowRef(defineAsyncComponent(() => import('@/components/view/DetailsTab.vue')))
@@ -53,7 +53,7 @@ export default {
       icon: 'edit-outlined',
       label: 'label.edit.role',
       dataView: true,
-      args: ['name', 'description', 'type'],
+      args: ['name', 'description', 'type', 'ispublic'],
       mapping: {
         type: {
           options: ['Admin', 'DomainAdmin', 'User']

--- a/ui/src/views/iam/CreateRole.vue
+++ b/ui/src/views/iam/CreateRole.vue
@@ -99,6 +99,13 @@
           </a-select>
         </a-form-item>
 
+        <a-form-item name="ispublic" ref="ispublic">
+          <template #label>
+            <tooltip-label :title="$t('label.ispublic')" :tooltip="apiParams.ispublic.description"/>
+          </template>
+          <a-switch v-model:checked="form.ispublic"/>
+        </a-form-item>
+
         <div :span="24" class="action-button">
           <a-button @click="closeAction">{{ $t('label.cancel') }}</a-button>
           <a-button :loading="loading" ref="submit" type="primary" @click="handleSubmit">{{ $t('label.ok') }}</a-button>
@@ -150,7 +157,8 @@ export default {
     initForm () {
       this.formRef = ref()
       this.form = reactive({
-        using: 'type'
+        using: 'type',
+        ispublic: true
       })
       this.rules = reactive({
         name: [{ required: true, message: this.$t('message.error.required.input') }],

--- a/ui/src/views/iam/ImportRole.vue
+++ b/ui/src/views/iam/ImportRole.vue
@@ -80,6 +80,13 @@
           </a-select>
         </a-form-item>
 
+        <a-form-item name="ispublic" ref="ispublic">
+          <template #label>
+            <tooltip-label :title="$t('label.ispublic')" :tooltip="apiParams.ispublic.description"/>
+          </template>
+          <a-switch v-model:checked="form.ispublic"/>
+        </a-form-item>
+
         <a-form-item name="forced" ref="forced">
           <template #label>
             <tooltip-label :title="$t('label.forced')" :tooltip="apiParams.forced.description"/>
@@ -124,7 +131,7 @@ export default {
   methods: {
     initForm () {
       this.formRef = ref()
-      this.form = reactive({})
+      this.form = reactive({ ispublic: true })
       this.rules = reactive({
         file: [
           { required: true, message: this.$t('message.error.required.input') },


### PR DESCRIPTION
### Description

The concept of public roles was introduced in the PR [#6960](https://github.com/apache/cloudstack/pull/6960), however this resource was not extended to the UI. Thus, a field was added in the role creation, update and import form that allows you to choose whether the role is public or not.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created, imported and updated some roles, then I checked the result of these operations in the database.

| N° | Test | isPublic | Expected result |
| ------ | ------ | ------ | ------ |
| 1 | Create a role with `isPublic` field checked | True | Y |
| 2 | Create a role with `isPublic` field unchecked | False | Y |
| 3 | Update a role with `isPublic` field checked | True | Y |
| 4 | Update a role with `isPublic` field unchecked | False | Y |
| 5 | Import a role with `isPublic` field checked | True | Y |
| 6 | Import a role with `isPublic` field unchecked | False | Y |