### PR TITLE
Fix templates and ISOs listing pagination

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -29,7 +29,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -3813,9 +3812,60 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             }
         }
 
+        applyPublicTemplateSharingRestrictions(sc, caller);
+
         return templateChecks(isIso, hypers, tags, name, keyword, hyperType, onlyReady, bootable, zoneId, showDomr, caller,
                 showRemovedTmpl, parentTemplateId, showUnique, searchFilter, sc);
 
+    }
+
+    /**
+     * If the caller is not a root admin, restricts the search to return only public templates from the domain which
+     * the caller belongs to and domains with the setting 'share.public.templates.with.other.domains' enabled.
+     */
+    protected void applyPublicTemplateSharingRestrictions(SearchCriteria<TemplateJoinVO> sc, Account caller) {
+        if (caller.getType() == Account.Type.ADMIN) {
+            s_logger.debug(String.format("Account [%s] is a root admin. Therefore, it has access to all public templates.", caller));
+            return;
+        }
+
+        List<TemplateJoinVO> publicTemplates = _templateJoinDao.listPublicTemplates();
+
+        Set<Long> unsharableDomainIds = new HashSet<>();
+        for (TemplateJoinVO template : publicTemplates) {
+            addDomainIdToSetIfDomainDoesNotShareTemplates(template.getDomainId(), caller, unsharableDomainIds);
+        }
+
+        if (!unsharableDomainIds.isEmpty()) {
+            s_logger.info(String.format("The public templates belonging to the domains [%s] will not be listed to account [%s] as they have the configuration [%s] marked as 'false'.", unsharableDomainIds, caller, QueryService.SharePublicTemplatesWithOtherDomains.key()));
+            sc.addAnd("domainId", SearchCriteria.Op.NOTIN, unsharableDomainIds.toArray());
+        }
+    }
+
+    /**
+     * Adds the provided domain ID to the set if the domain does not share templates with the account. That is, if:
+     * (1) the template does not belong to the domain of the account AND
+     * (2) the domain of the template has the setting 'share.public.templates.with.other.domains' disabled.
+     */
+    protected void addDomainIdToSetIfDomainDoesNotShareTemplates(long domainId, Account account, Set<Long> unsharableDomainIds) {
+        if (domainId == account.getDomainId()) {
+            s_logger.trace(String.format("Domain [%s] will not be added to the set of domains with unshared templates since the account [%s] belongs to it.", domainId, account));
+            return;
+        }
+
+        if (unsharableDomainIds.contains(domainId)) {
+            s_logger.trace(String.format("Domain [%s] is already on the set of domains with unshared templates.", domainId));
+            return;
+        }
+
+        if (!checkIfDomainSharesTemplates(domainId)) {
+            s_logger.debug(String.format("Domain [%s] will be added to the set of domains with unshared templates as configuration [%s] is false.", domainId, QueryService.SharePublicTemplatesWithOtherDomains.key()));
+            unsharableDomainIds.add(domainId);
+        }
+    }
+
+    protected boolean checkIfDomainSharesTemplates(Long domainId) {
+        return QueryService.SharePublicTemplatesWithOtherDomains.valueIn(domainId);
     }
 
     private Pair<List<TemplateJoinVO>, Integer> templateChecks(boolean isIso, List<HypervisorType> hypers, Map<String, String> tags, String name, String keyword,
@@ -3947,25 +3997,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             templates = _templateJoinDao.searchByTemplateZonePair(showRemoved, templateZonePairs);
         }
 
-        if(caller.getType() != Account.Type.ADMIN) {
-            templates = applyPublicTemplateRestriction(templates, caller);
-            count = templates.size();
-        }
-
         return new Pair<List<TemplateJoinVO>, Integer>(templates, count);
-    }
-
-    private List<TemplateJoinVO> applyPublicTemplateRestriction(List<TemplateJoinVO> templates, Account caller){
-        List<Long> unsharableDomainIds = templates.stream()
-                .map(TemplateJoinVO::getDomainId)
-                .distinct()
-                .filter(domainId -> domainId != caller.getDomainId())
-                .filter(Predicate.not(QueryService.SharePublicTemplatesWithOtherDomains::valueIn))
-                .collect(Collectors.toList());
-
-        return templates.stream()
-                .filter(Predicate.not(t -> unsharableDomainIds.contains(t.getDomainId())))
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDao.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDao.java
@@ -48,6 +48,8 @@ public interface TemplateJoinDao extends GenericDao<TemplateJoinVO, Long> {
 
     List<TemplateJoinVO> listActiveTemplates(long storeId);
 
+    List<TemplateJoinVO> listPublicTemplates();
+
     Pair<List<TemplateJoinVO>, Integer> searchIncludingRemovedAndCount(final SearchCriteria<TemplateJoinVO> sc, final Filter filter);
 
     List<TemplateJoinVO> findByDistinctIds(Long... ids);

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -104,6 +104,8 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
 
     private final SearchBuilder<TemplateJoinVO> activeTmpltSearch;
 
+    private final SearchBuilder<TemplateJoinVO> publicTmpltSearch;
+
     protected TemplateJoinDaoImpl() {
 
         tmpltIdPairSearch = createSearchBuilder();
@@ -136,6 +138,10 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         activeTmpltSearch.cp();
         activeTmpltSearch.cp();
         activeTmpltSearch.done();
+
+        publicTmpltSearch = createSearchBuilder();
+        publicTmpltSearch.and("public", publicTmpltSearch.entity().isPublicTemplate(), SearchCriteria.Op.EQ);
+        publicTmpltSearch.done();
 
         // select distinct pair (template_id, zone_id)
         _count = "select count(distinct temp_zone_pair) from template_view WHERE ";
@@ -570,6 +576,13 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         sc.setParameters("public", Boolean.FALSE);
         sc.setParameters("publicNoUrl",Boolean.TRUE);
         return searchIncludingRemoved(sc, null, null, false);
+    }
+
+    @Override
+    public List<TemplateJoinVO> listPublicTemplates() {
+        SearchCriteria<TemplateJoinVO> sc = publicTmpltSearch.create();
+        sc.setParameters("public", Boolean.TRUE);
+        return listBy(sc);
     }
 
     @Override

--- a/server/src/test/java/com/cloud/api/query/QueryManagerImplTest.java
+++ b/server/src/test/java/com/cloud/api/query/QueryManagerImplTest.java
@@ -17,7 +17,9 @@
 
 package com.cloud.api.query;
 
+import com.cloud.api.query.dao.TemplateJoinDao;
 import com.cloud.api.query.vo.EventJoinVO;
+import com.cloud.api.query.vo.TemplateJoinVO;
 import com.cloud.event.dao.EventJoinDao;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.PermissionDeniedException;
@@ -48,10 +50,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.mockito.Mockito.when;
@@ -61,12 +66,27 @@ public class QueryManagerImplTest {
     public static final long USER_ID = 1;
     public static final long ACCOUNT_ID = 1;
 
+    @Spy
+    @InjectMocks
+    private QueryManagerImpl queryManagerImplSpy = new QueryManagerImpl();
+
     @Mock
     EntityManager entityManager;
+
     @Mock
     AccountManager accountManager;
+
     @Mock
     EventJoinDao eventJoinDao;
+
+    @Mock
+    Account accountMock;
+
+    @Mock
+    TemplateJoinDao templateJoinDaoMock;
+
+    @Mock
+    SearchCriteria searchCriteriaMock;
 
     private AccountVO account;
     private UserVO user;
@@ -175,5 +195,68 @@ public class QueryManagerImplTest {
         Mockito.when(entityManager.findByUuidIncludingRemoved(Network.class, uuid)).thenReturn(network);
         Mockito.doThrow(new PermissionDeniedException("Denied")).when(accountManager).checkAccess(account, SecurityChecker.AccessType.ListEntry, false, network);
         queryManager.searchForEvents(cmd);
+    }
+
+    @Test
+    public void applyPublicTemplateRestrictionsTestDoesNotApplyRestrictionsWhenCallerIsRootAdmin() {
+        Mockito.when(accountMock.getType()).thenReturn(Account.Type.ADMIN);
+
+        queryManagerImplSpy.applyPublicTemplateSharingRestrictions(searchCriteriaMock, accountMock);
+
+        Mockito.verify(searchCriteriaMock, Mockito.never()).addAnd(Mockito.anyString(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void applyPublicTemplateRestrictionsTestAppliesRestrictionsWhenCallerIsNotRootAdmin() {
+        long callerDomainId = 1L;
+        long sharableDomainId = 2L;
+        long unsharableDomainId = 3L;
+
+        Mockito.when(accountMock.getType()).thenReturn(Account.Type.NORMAL);
+
+        Mockito.when(accountMock.getDomainId()).thenReturn(callerDomainId);
+        TemplateJoinVO templateMock1 = Mockito.mock(TemplateJoinVO.class);
+        Mockito.when(templateMock1.getDomainId()).thenReturn(callerDomainId);
+        Mockito.lenient().doReturn(false).when(queryManagerImplSpy).checkIfDomainSharesTemplates(callerDomainId);
+
+        TemplateJoinVO templateMock2 = Mockito.mock(TemplateJoinVO.class);
+        Mockito.when(templateMock2.getDomainId()).thenReturn(sharableDomainId);
+        Mockito.doReturn(true).when(queryManagerImplSpy).checkIfDomainSharesTemplates(sharableDomainId);
+
+        TemplateJoinVO templateMock3 = Mockito.mock(TemplateJoinVO.class);
+        Mockito.when(templateMock3.getDomainId()).thenReturn(unsharableDomainId);
+        Mockito.doReturn(false).when(queryManagerImplSpy).checkIfDomainSharesTemplates(unsharableDomainId);
+
+        List<TemplateJoinVO> publicTemplates = List.of(templateMock1, templateMock2, templateMock3);
+        Mockito.when(templateJoinDaoMock.listPublicTemplates()).thenReturn(publicTemplates);
+
+        queryManagerImplSpy.applyPublicTemplateSharingRestrictions(searchCriteriaMock, accountMock);
+
+        Mockito.verify(searchCriteriaMock).addAnd("domainId", SearchCriteria.Op.NOTIN, unsharableDomainId);
+    }
+
+    @Test
+    public void addDomainIdToSetIfDomainDoesNotShareTemplatesTestDoesNotAddWhenCallerBelongsToDomain() {
+        long domainId = 1L;
+        Set<Long> set = new HashSet<>();
+
+        Mockito.when(accountMock.getDomainId()).thenReturn(domainId);
+
+        queryManagerImplSpy.addDomainIdToSetIfDomainDoesNotShareTemplates(domainId, accountMock, set);
+
+        Assert.assertEquals(0, set.size());
+    }
+
+    @Test
+    public void addDomainIdToSetIfDomainDoesNotShareTemplatesTestAddsWhenDomainDoesNotShareTemplates() {
+        long domainId = 1L;
+        Set<Long> set = new HashSet<>();
+
+        Mockito.when(accountMock.getDomainId()).thenReturn(2L);
+        Mockito.doReturn(false).when(queryManagerImplSpy).checkIfDomainSharesTemplates(domainId);
+
+        queryManagerImplSpy.addDomainIdToSetIfDomainDoesNotShareTemplates(domainId, accountMock, set);
+
+        Assert.assertTrue(set.contains(domainId));
     }
 }


### PR DESCRIPTION
### Description

After the changes in #4774, when an account other than the root admin lists templates/ISOs with pagination, count gets set to the number of items returned in that page. For example, when the user lists 10 templates/ISOs and 15 entries are found, in the first page, count is set to 10 (the number of items being returned), as opposed to 15 (the total number of items). As a result, the deploy VM wizard only shows the first page of templates/ISOs.

This PR fixes this behavior and makes count return the correct number of found entries.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Everything has been tested in a local lab.

In the tested scenario, the following domains have templates:
- `ROOT`: 13 public and featured templates;
- `ROOT/test`: 4 public and featured templates.

<details>

<summary>
CloudMonkey command used to list templates.
</summary>

```
list templates templatefilter=featured page=1 pageSize=5
```

</details>

In every test, the expected number of templates/ISOs was returned.

With `share.public.templates.with.other.domains` set to `true` in both domains:
- In the root admin account, I listed the templates. I verified that the expected value of 17 was returned;
- In a user account belonging to `ROOT`, I listed the templates. I verified that the expected value of 17 was returned;
- In a user account belonging to `ROOT/test`, I listed the templates. I verified that the expected value of 17 was returned;
- I marked a template belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT`, I listed the templates. I verified that the expected value of 16 was returned;
- I marked a template belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT/test`, I listed the templates. I verified that the expected value of 16 was returned;
- I marked a template belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT`, I listed the templates. I verified that the expected value of 16 was returned;
- I marked a template belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT/test`, I listed the template. I verified that the expected value of 16 was returned.

With `share.public.templates.with.other.domains` set to `false` in both domains:
- In the root admin account, I listed the templates. I verified that the expected value of 17 was returned;
- In a user account belonging to `ROOT`, I listed the templates. I verified that the expected value of 13 was returned;
- In a user account belonging to `ROOT/test`, I listed the templates. I verified that the expected value of 4 was returned;
- I marked a template belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT`, I listed the templates. I verified that the expected value of 12 was returned;
- I marked a template belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT/test`, I listed the templates. I verified that the expected value of 4 was returned;
- I marked a template belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT`, I listed the templates. I verified that the expected value of 13 was returned;
- I marked a template belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT/test`, I listed the template. I verified that the expected value of 3 was returned.

I also verified the behavior of the listIsos API. In the tested scenario, the following domains have ISOs:
- `ROOT`: 11 public and featured ISOs;
- `ROOT/test`: 2 public and featured ISOs.

<details>

<summary>
CloudMonkey command used to list ISOs.
</summary>

```
list isos page=1 pageSize=5 isoFilter=featured bootable=true
```

</details>

With `share.public.templates.with.other.domains` set to `true` in both domains:
- In the root admin account, I listed the ISOs. I verified that the expected value of 13 was returned;
- In a user account belonging to `ROOT`, I listed the ISOs. I verified that the expected value of 13 was returned;
- In a user account belonging to `ROOT/test`, I listed the ISOs. I verified that the expected value of 13 was returned;
- I marked an ISO belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT`, I listed the ISOs. I verified that the expected value of 12 was returned;
- I marked an ISO belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT/test`, I listed the ISOs. I verified that the expected value of 12 was returned;
- I marked an ISO belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT`, I listed the ISOs. I verified that the expected value of 12 was returned;
- I marked an ISO belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT/test`, I listed the ISOs. I verified that the expected value of 12 was returned.

With `share.public.templates.with.other.domains` set to `false` in both domains:
- In the root admin account, I listed the ISOs. I verified that the expected value of 13 was returned;
- In a user account belonging to `ROOT`, I listed the ISOs. I verified that the expected value of 11 was returned;
- In a user account belonging to `ROOT/test`, I listed the ISOs. I verified that the expected value of 2 was returned;
- I marked an ISO belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT`, I listed the ISOs. I verified that the expected value of 10 was returned;
- I marked an ISO belonging to `ROOT` as not public. Then, in a user account belonging to `ROOT/test`, I listed the ISOs. I verified that the expected value of 2 was returned;
- I marked an ISO belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT`, I listed the ISOs. I verified that the expected value of 11 was returned;
- I marked an ISO belonging to `ROOT/test` as not public. Then, in a user account belonging to `ROOT/test`, I listed the ISOs. I verified that the expected value of 1 was returned.

I also verified the changes in the UI. Before, the deploy VM wizard showed only one page of templates/ISOs. After the changes, all pages are shown as expected.