### PR TITLE
LibvirtServerDiscoverer should only process added hosts relevant to hypervisor type

### DIFF
--- a/server/src/main/java/com/cloud/hypervisor/discoverer/CustomServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/discoverer/CustomServerDiscoverer.java
@@ -29,4 +29,9 @@ public class CustomServerDiscoverer extends LibvirtServerDiscoverer {
     protected String getPatchPath() {
         return "scripts/vm/hypervisor/kvm/";
     }
+
+    @Override
+    public void processHostAdded(long hostId) {
+        // Not using super class implementation here.
+    }
 }

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -110,7 +110,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
     @Override
     public void processHostAdded(long hostId) {
         HostVO host = hostDao.findById(hostId);
-        if (host != null) {
+        if (host != null && getHypervisorType().equals(host.getHypervisorType())) {
             directDownloadManager.syncCertificatesToHost(hostId, host.getDataCenterId());
         }
     }


### PR DESCRIPTION
### Description

This PR keeps `LibvirtServerDiscoverer` from attempting to push direct download certs to other hosts when `addHost` API is used to add direct agent hosts and direct download certs are installed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested locally by adding simulator hosts via API after adding direct download certs to zone.