### PR TITLE
Improve the description of config password.policy.minimum.digits

### DIFF
--- a/server/src/main/java/com/cloud/user/PasswordPolicy.java
+++ b/server/src/main/java/com/cloud/user/PasswordPolicy.java
@@ -43,7 +43,7 @@ public interface PasswordPolicy {
             Integer.class,
             "password.policy.minimum.uppercase.letters",
             "0",
-            "Minimum number of uppercase letters that the user's password must have. The value 0 means the user's password does not require any uppercase letters.",
+            "Minimum number of uppercase letters [A-Z] that the user's password must have. The value 0 means the user's password does not require any uppercase letters.",
             true,
             ConfigKey.Scope.Domain);
 
@@ -52,7 +52,7 @@ public interface PasswordPolicy {
             Integer.class,
             "password.policy.minimum.lowercase.letters",
             "0",
-            "Minimum number of lowercase letters that the user's password must have. The value 0 means the user's password does not require any lowercase letters.",
+            "Minimum number of lowercase letters [a-z] that the user's password must have. The value 0 means the user's password does not require any lowercase letters.",
             true,
             ConfigKey.Scope.Domain);
 
@@ -61,7 +61,7 @@ public interface PasswordPolicy {
             Integer.class,
             "password.policy.minimum.digits",
             "0",
-            "Minimum number of digits that the user's password must have. The value 0 means the user's password does not require any digits.",
+            "Minimum number of numeric characters [0-9] that the user's password must have. The value 0 means the user's password does not require any numeric characters.",
             true,
             ConfigKey.Scope.Domain);
 

--- a/server/src/main/java/com/cloud/user/PasswordPolicy.java
+++ b/server/src/main/java/com/cloud/user/PasswordPolicy.java
@@ -25,7 +25,8 @@ public interface PasswordPolicy {
             Integer.class,
             "password.policy.minimum.special.characters",
             "0",
-            "Minimum number of special characters that the user's password must have. The value 0 means the user's password does not require any special characters.",
+            "Minimum number of special characters that the user's password must have. Any character that is neither a letter nor numeric is considered special. " +
+                    "The value 0 means the user's password does not require any special characters.",
             true,
             ConfigKey.Scope.Domain);
 


### PR DESCRIPTION
### Description

Some operators interpret "minimum digits" as "minimum number of characters" and confuse the setting password.policy.minimum.digits with password.policy.minimum.length. This PR changes the description of password.policy.minimum.digits and three other related settings to make the distinction clearer.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?

I applied the changes in a local lab and verified the descriptions were updated through the UI.