### PR TITLE
Fix tests on CS build when cloudstack-management service is running

### DIFF
--- a/plugins/storage/volume/scaleio/src/test/java/org/apache/cloudstack/storage/datastore/client/ScaleIOGatewayClientImplTest.java
+++ b/plugins/storage/volume/scaleio/src/test/java/org/apache/cloudstack/storage/datastore/client/ScaleIOGatewayClientImplTest.java
@@ -58,7 +58,8 @@ public class ScaleIOGatewayClientImplTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
-            .httpsPort(port)
+            .dynamicHttpsPort()
+            .dynamicPort()
             .needClientAuth(false)
             .basicAdminAuthenticator(username, password)
             .bindAddress("localhost"));
@@ -70,7 +71,7 @@ public class ScaleIOGatewayClientImplTest {
                         .withHeader("content-type", "application/json;charset=UTF-8")
                         .withBody(sessionKey)));
 
-        client = new ScaleIOGatewayClientImpl(String.format("https://localhost:%d/api", port), username, password, false, timeout, maxConnections);
+        client = new ScaleIOGatewayClientImpl(String.format("https://localhost:%d/api", wireMockRule.httpsPort()), username, password, false, timeout, maxConnections);
 
         wireMockRule.stubFor(post("/api/types/Volume/instances")
                 .willReturn(aResponse()


### PR DESCRIPTION
I didn't have time to investigate the change in Mockito rules,  but after the upgrade of Mockito the maven build without skipping the tests is failing (if there is a running CS mgmt) with:

> [ERROR] Tests run: 5, Failures: 0, Errors: 5, Skipped: 0, Time elapsed: 0.329 s <<< FAILURE! - in org.apache.cloudstack.storage.datastore.client.ScaleIOGatewayClientImplTest
> [ERROR] testCreateSingleVolume(org.apache.cloudstack.storage.datastore.client.ScaleIOGatewayClientImplTest)  Time elapsed: 0.257 s  <<< ERROR!
> com.github.tomakehurst.wiremock.common.FatalStartupException: java.lang.RuntimeException: java.net.BindException: Address already in use
> Caused by: java.lang.RuntimeException: java.net.BindException: Address already in use
> Caused by: java.net.BindException: Address already in use

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
