### PR TITLE
Improve template download error message

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -329,6 +329,7 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
         Long[] hostsToRetry = getHostsToRetryOn(host, storagePoolVO);
         int hostIndex = 0;
         Answer answer = null;
+        String answerDetails = "";
         Long hostToSendDownloadCmd = hostsToRetry[hostIndex];
         boolean continueRetrying = true;
         while (!downloaded && retry > 0 && continueRetrying) {
@@ -349,6 +350,7 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
                 if (answer != null) {
                     DirectDownloadAnswer ans = (DirectDownloadAnswer)answer;
                     downloaded = answer.getResult();
+                    answerDetails = answer.getDetails();
                     continueRetrying = ans.isRetryOnOtherHosts();
                 }
                 hostToSendDownloadCmd = hostsToRetry[(hostIndex + 1) % hostsToRetry.length];
@@ -362,7 +364,10 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
         }
         if (!downloaded) {
             logUsageEvent(template, poolId);
-            throw new CloudRuntimeException("Template " + template.getId() + " could not be downloaded on pool " + poolId + ", failing after trying on several hosts");
+            if (!answerDetails.isEmpty()){
+                answerDetails = String.format(" Details: %s", answerDetails);
+            }
+            throw new CloudRuntimeException(String.format("Template %d could not be downloaded on pool %d, failing after trying on several hosts%s", template.getId(), poolId, answerDetails));
         }
         return answer;
     }

--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -368,7 +368,7 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
             logUsageEvent(template, poolId);
             if (!answerDetails.isEmpty()){
                 Account caller = CallContext.current().getCallingAccount();
-                if (caller != null && caller.getType() == Account.ACCOUNT_TYPE_ADMIN){
+                if (caller != null && caller.getType() == Account.Type.ADMIN){
                     errorDetails = String.format(" Details: %s", answerDetails);
                 }
             }


### PR DESCRIPTION
### Description

This PR...
Improves the error messages to more accurately describe the reasons for failure to download a template. This is done via surfacing the underlying reason for the failure in the error message. This will facilitate troubleshooting.

This improved error messages are only shown to the admin role, for the rest of the users there is no change in error message details (tested with non-admin account).

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Manual testing via setting up a development environment and triggering failures. Two scenarios were tested with below resulting error messages. Several other failure reasons will be surfaced as well.

-Example: Template checksum mismatch
Before:
Unable to orchestrate start VM instance {id: "3112", name: "i-2-3112-VM", uuid: "db19b8af-00e0-4f7a-803b-a6c3b022ba5d", type="User"} due to [Template 203 could not be downloaded on pool 1, failing after trying on several hosts].

Now:
Unable to orchestrate start VM instance {id: "3112", name: "i-2-3112-VM", uuid: "db19b8af-00e0-4f7a-803b-a6c3b022ba5d", type="User"} due to [Template 203 could not be downloaded on pool 1, failing after trying on several hosts Details: Checksum validation failed].

UI:

![Screenshot 2023-09-28 at 5 20 39 PM](https://github.com/apache/cloudstack/assets/2266908/8fd39970-c8db-4cfb-b8ec-b59ba413f5c7)



-Example: Wrong template url

Before:
Unable to orchestrate start VM instance {id:
"3110", name: "¡-2-3110-VM", uuid:
"40478bcf-5ffa-4a18-9d22-
739d149df76", type="User") due to [Template 203 could not be downloaded on pool 1, failing after trying on several hosts].

Now:
Unable to orchestrate start VM instance {id:
"3110", name: "¡-2-3110-VM", uuid:
"40478bcf-5ffa-4a18-9d22-
739d149df76", type="User") due to [Template 203 could not be downloaded on pool 1, failing after trying on several hosts Details: Unable to download template: Error on HTTPS response].

UI:

![Screenshot 2023-09-28 at 5 19 26 PM](https://github.com/apache/cloudstack/assets/2266908/b7b776f0-bb5d-47e5-886a-6ca14fec4106)
