### PR TITLE
Add plugin dir to developer jetty:run classpath for plugin dev

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -642,7 +642,7 @@
                     <webAppSourceDirectory>${project.build.directory}/classes/META-INF/webapp/</webAppSourceDirectory>
                     <webApp>
                         <contextPath>/client</contextPath>
-                        <extraClasspath>${project.build.directory}/conf/;${project.build.directory}/common;${project.build.directory}/utilities/scripts/db/;${project.build.directory}/utilities/scripts/db/db/;${project.build.directory}/plugins/*;${project.build.directory}/cloud-client-ui-${project.version}.jar</extraClasspath>
+                        <extraClasspath>${project.build.directory}/conf/;${project.build.directory}/common;${project.build.directory}/utilities/scripts/db/;${project.build.directory}/utilities/scripts/db/db/;${project.build.directory}/plugins/*</extraClasspath>
                         <webInfIncludeJarPattern>.*/cloud.*jar$|.*/classes/.*</webInfIncludeJarPattern>
                     </webApp>
                     <systemProperties>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -642,7 +642,7 @@
                     <webAppSourceDirectory>${project.build.directory}/classes/META-INF/webapp/</webAppSourceDirectory>
                     <webApp>
                         <contextPath>/client</contextPath>
-                        <extraClasspath>${project.build.directory}/conf/;${project.build.directory}/common;${project.build.directory}/utilities/scripts/db/;${project.build.directory}/utilities/scripts/db/db/;${project.build.directory}/cloud-client-ui-${project.version}.jar</extraClasspath>
+                        <extraClasspath>${project.build.directory}/conf/;${project.build.directory}/common;${project.build.directory}/utilities/scripts/db/;${project.build.directory}/utilities/scripts/db/db/;${project.build.directory}/plugins/*;${project.build.directory}/cloud-client-ui-${project.version}.jar</extraClasspath>
                         <webInfIncludeJarPattern>.*/cloud.*jar$|.*/classes/.*</webInfIncludeJarPattern>
                     </webApp>
                     <systemProperties>
@@ -729,6 +729,7 @@
                                         <exclude name="*.in" />
                                     </fileset>
                                 </copy>
+                                <mkdir dir="${project.build.directory}/plugins" />
                             </target>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <cs.jaxws.version>2.3.2-1</cs.jaxws.version>
         <cs.jersey-client.version>2.26</cs.jersey-client.version>
         <cs.jetty.version>9.4.51.v20230217</cs.jetty.version>
-        <cs.jetty-maven-plugin.version>9.4.27.v20200227</cs.jetty-maven-plugin.version>
+        <cs.jetty-maven-plugin.version>9.4.51.v20230217</cs.jetty-maven-plugin.version>
         <cs.jna.version>5.5.0</cs.jna.version>
         <cs.joda-time.version>2.12.5</cs.joda-time.version>
         <cs.jpa.version>2.2.1</cs.jpa.version>


### PR DESCRIPTION
### Description

This PR is a simple change to allow adding plugins to CloudStack when running in developer mode.  Simply drop plugin jar into `client/target/plugins` before launching `mvn -pl :cloud-client-ui jetty:run`.

Also bumping the version of jetty-maven-plugin to the same as main jetty server.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial
