### PR TITLE
Fix: Convert volume to another directory instead of copying it while taking volume snapshots on KVM

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1715,11 +1715,11 @@ public class KVMStorageProcessor implements StorageProcessor {
                     snapshotPath = getSnapshotPathInPrimaryStorage(primaryPool.getLocalPath(), snapshotName);
 
                     String diskLabel = takeVolumeSnapshot(resource.getDisks(conn, vmName), snapshotName, diskPath, vm);
-                    String copyResult = copySnapshotToPrimaryStorageDir(primaryPool, diskPath, snapshotPath, volume);
+                    String convertResult = convertBaseFileToSnapshotFileInPrimaryStorageDir(primaryPool, diskPath, snapshotPath, volume, cmd.getWait());
 
                     mergeSnapshotIntoBaseFile(vm, diskLabel, diskPath, snapshotName, volume, conn);
 
-                    validateCopyResult(copyResult, snapshotPath);
+                    validateConvertResult(convertResult, snapshotPath);
                 } catch (LibvirtException e) {
                     if (!e.getMessage().contains(LIBVIRT_OPERATION_NOT_SUPPORTED_MESSAGE)) {
                         throw e;
@@ -1784,8 +1784,8 @@ public class KVMStorageProcessor implements StorageProcessor {
                     }
                 } else {
                     snapshotPath = getSnapshotPathInPrimaryStorage(primaryPool.getLocalPath(), snapshotName);
-                    String copyResult = copySnapshotToPrimaryStorageDir(primaryPool, diskPath, snapshotPath, volume);
-                    validateCopyResult(copyResult, snapshotPath);
+                    String copyResult = convertBaseFileToSnapshotFileInPrimaryStorageDir(primaryPool, diskPath, snapshotPath, volume, cmd.getWait());
+                    validateConvertResult(copyResult, snapshotPath);
                 }
             }
 
@@ -1838,13 +1838,13 @@ public class KVMStorageProcessor implements StorageProcessor {
         s_logger.debug(String.format("Full VM Snapshot [%s] of VM [%s] took [%s] seconds to finish.", snapshotName, vmName, (System.currentTimeMillis() - start)/1000));
     }
 
-    protected void validateCopyResult(String copyResult, String snapshotPath) throws CloudRuntimeException, IOException {
-        if (copyResult == null) {
+    protected void validateConvertResult(String convertResult, String snapshotPath) throws CloudRuntimeException, IOException {
+        if (convertResult == null) {
             return;
         }
 
         Files.deleteIfExists(Paths.get(snapshotPath));
-        throw new CloudRuntimeException(copyResult);
+        throw new CloudRuntimeException(convertResult);
     }
 
     /**
@@ -1901,20 +1901,31 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     /**
-     * Creates the snapshot directory in the primary storage, if it does not exist; then copies the base file (VM's old writing file) to the snapshot dir..
+     * Creates the snapshot directory in the primary storage, if it does not exist; then, converts the base file (VM's old writing file) to the snapshot directory.
      * @param primaryPool Storage to create folder, if not exists;
-     * @param baseFile Base file of VM, which will be copied;
-     * @param snapshotPath Path to copy the base file;
-     * @return null if copies successfully or a error message.
+     * @param baseFile Base file of VM, which will be converted;
+     * @param snapshotPath Path to convert the base file;
+     * @return null if the conversion occurs successfully or an error message that must be handled.
      */
-    protected String copySnapshotToPrimaryStorageDir(KVMStoragePool primaryPool, String baseFile, String snapshotPath, VolumeObjectTO volume) {
+    protected String convertBaseFileToSnapshotFileInPrimaryStorageDir(KVMStoragePool primaryPool, String baseFile, String snapshotPath, VolumeObjectTO volume, int wait) {
         try {
+            s_logger.debug(String.format("Trying to convert volume [%s] (%s) to snapshot [%s].", volume, baseFile, snapshotPath));
+
             primaryPool.createFolder(TemplateConstants.DEFAULT_SNAPSHOT_ROOT_DIR);
-            Files.copy(Paths.get(baseFile), Paths.get(snapshotPath));
-            s_logger.debug(String.format("Copied %s snapshot from [%s] to [%s].", volume, baseFile, snapshotPath));
+
+            QemuImgFile srcFile = new QemuImgFile(baseFile);
+            srcFile.setFormat(PhysicalDiskFormat.QCOW2);
+
+            QemuImgFile destFile = new QemuImgFile(snapshotPath);
+            destFile.setFormat(PhysicalDiskFormat.QCOW2);
+
+            QemuImg q = new QemuImg(wait);
+            q.convert(srcFile, destFile);
+
+            s_logger.debug(String.format("Converted volume [%s] (from path \"%s\") to snapshot [%s].", volume, baseFile, snapshotPath));
             return null;
-        } catch (IOException ex) {
-            return String.format("Unable to copy %s snapshot [%s] to [%s] due to [%s].", volume, baseFile, snapshotPath, ex.getMessage());
+        } catch (QemuImgException | LibvirtException ex) {
+            return String.format("Failed to convert %s snapshot of volume [%s] to [%s] due to [%s].", volume, baseFile, snapshotPath, ex.getMessage());
         }
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1784,8 +1784,8 @@ public class KVMStorageProcessor implements StorageProcessor {
                     }
                 } else {
                     snapshotPath = getSnapshotPathInPrimaryStorage(primaryPool.getLocalPath(), snapshotName);
-                    String copyResult = convertBaseFileToSnapshotFileInPrimaryStorageDir(primaryPool, diskPath, snapshotPath, volume, cmd.getWait());
-                    validateConvertResult(copyResult, snapshotPath);
+                    String convertResult = convertBaseFileToSnapshotFileInPrimaryStorageDir(primaryPool, diskPath, snapshotPath, volume, cmd.getWait());
+                    validateConvertResult(convertResult, snapshotPath);
                 }
             }
 


### PR DESCRIPTION
### Description

This PR address issue #8034.

While taking the volume snapshot on KVM, we call the method `copySnapshotToPrimaryStorageDir`. This method copies the base snapshot file to another directory, to enable the block commit for the delta of the disk right after taking the snapshot and avoid creating chains in the primary storage. However, copying a file (via the operating system) with a backing store will also copy the reference; therefore, it causes problems when the volume is not consolidated yet (which is always executed in KVM in volume migration process). If we create a template from the snapshot, and the deployment destination does not have access to the backing store file, the template will not be usable, as it would have a backing store pointing to the template that generated the volume.

This PR intends to solve this situation by converting the base volume to the snapshot file instead of just copying it.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

### How Has This Been Tested?

I created a VM from a template and checked the volume's chain:

- VM's XML:
```xml
      <source file='/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b' index='2'/>
      <backingStore type='file' index='3'>
        <format type='qcow2'/>
        <source file='/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/bb4b7b6f-5249-4c18-a5f6-dd886683b702'/>
        <backingStore/>
      </backingStore>
``` 

- Template file info:
```
qemu-img info -U /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/bb4b7b6f-5249-4c18-a5f6-dd886683b702
image: /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/bb4b7b6f-5249-4c18-a5f6-dd886683b702
file format: qcow2
virtual size: 8 GiB (8589934592 bytes)
disk size: 2.6 GiB
cluster_size: 65536
Format specific information:
    compat: 0.10
    refcount bits: 16
```

- Volume file info:
```
qemu-img info -U /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b
image: /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b
file format: qcow2
virtual size: 8 GiB (8589934592 bytes)
disk size: 1.66 GiB
cluster_size: 65536
backing file: /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/bb4b7b6f-5249-4c18-a5f6-dd886683b702
backing file format: qcow2
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
``` 

Then, I triggered a manual volume snapshot with the VM still running:


<details><summary>logs</summary>

``` 
2023-10-04 12:42:57,212 DEBUG [storage.resource.StorageSubsystemCommandHandlerBase] (agentRequest-Handler-5:null) (logid:ae8045e2) Executing command CreateObjectCommand: [{"data":{"org.apache.cloudstack.storage.to.SnapshotObjectTO":{"volume":{"uuid":"72a45236-0fc8-48ec-9fff-b6894c48273b","volumeType":"ROOT","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"dc916dc7-cc1c-3f3d-905b-b198daf15a79","name":"storage-1-nfs","id":1,"poolType":"NetworkFilesystem","host":"192.168.31.140","path":"/mnt/primary-storage","port":2049,"url":"NetworkFilesystem://192.168.31.140/mnt/primary-storage/?ROLE=Primary&STOREUUID=dc916dc7-cc1c-3f3d-905b-b198daf15a79","isManaged":false}},"name":"ROOT-190","size":8589934592,"path":"72a45236-0fc8-48ec-9fff-b6894c48273b","volumeId":187,"vmName":"i-2-190-VM","accountId":2,"format":"QCOW2","provisioningType":"THIN","poolId":1,"id":187,"deviceId":0,"bytesReadRate":104857600,"bytesWriteRate":104857600,"iopsReadRate":1000,"iopsWriteRate":1000,"cacheMode":"NONE","hypervisorType":"KVM","directDownload":false,"deployAsIs":false},"dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"dc916dc7-cc1c-3f3d-905b-b198daf15a79","name":"storage-1-nfs","id":1,"poolType":"NetworkFilesystem","host":"192.168.31.140","path":"/mnt/primary-storage","port":2049,"url":"NetworkFilesystem://192.168.31.140/mnt/primary-storage/?ROLE=Primary&STOREUUID=dc916dc7-cc1c-3f3d-905b-b198daf15a79","isManaged":false}},"vmName":"i-2-190-VM","name":"test1","hypervisorType":"KVM","id":13,"quiescevm":false,"physicalSize":0}},"wait":0,"bypassHostMaintenance":false}].
2023-10-04 12:42:57,212 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:42:57,224 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:ae8045e2) Trying to fetch storage pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 from libvirt
2023-10-04 12:42:57,224 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:42:57,294 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:ae8045e2) Successfully refreshed pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 Capacity: (72.83 GB) 78201749504 Used: (46.07 GB) 49466834944 Available: (26.76 GB) 28734914560
2023-10-04 12:42:57,294 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:ae8045e2) Trying to fetch storage pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 from libvirt
2023-10-04 12:42:57,295 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:42:57,307 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-5:null) (logid:ae8045e2) Successfully refreshed pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 Capacity: (72.83 GB) 78201749504 Used: (46.07 GB) 49466834944 Available: (26.76 GB) 28734914560
2023-10-04 12:42:57,362 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ae8045e2) Pool [{"uuid":"dc916dc7-cc1c-3f3d-905b-b198daf15a79","localPath":"\/mnt\/dc916dc7-cc1c-3f3d-905b-b198daf15a79"}] has enough available size [28734914560] to take volume [{"name":"72a45236-0fc8-48ec-9fff-b6894c48273b","path":"\/mnt\/dc916dc7-cc1c-3f3d-905b-b198daf15a79\/72a45236-0fc8-48ec-9fff-b6894c48273b","size":1777606656}] snapshot.
2023-10-04 12:42:57,369 DEBUG [kvm.resource.LibvirtVMDef] (agentRequest-Handler-5:null) (logid:ae8045e2) Using informed label [hdc] for volume [null].
2023-10-04 12:42:57,729 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ae8045e2) Snapshot [41db256b-d8fa-4350-bc9e-0d62e4e9b176] took [0] seconds to finish.
2023-10-04 12:42:57,731 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ae8045e2) Trying to convert volume [volumeTO[uuid=72a45236-0fc8-48ec-9fff-b6894c48273b|path=72a45236-0fc8-48ec-9fff-b6894c48273b|datastore=PrimaryDataStoreTO[uuid=dc916dc7-cc1c-3f3d-905b-b198daf15a79|name=storage-1-nfs|id=1|pooltype=NetworkFilesystem]]] (/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b) to snapshot [/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/snapshots/41db256b-d8fa-4350-bc9e-0d62e4e9b176].
2023-10-04 12:42:57,741 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-5:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:42:57,750 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:ae8045e2) Executing: qemu-img convert -O qcow2 -U --image-opts driver=qcow2,file.filename=/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/snapshots/41db256b-d8fa-4350-bc9e-0d62e4e9b176 
2023-10-04 12:42:57,753 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:ae8045e2) Executing while with timeout : 3600000
2023-10-04 12:47:55,770 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:ae8045e2) Execution is successful.
2023-10-04 12:47:55,773 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ae8045e2) Converted volume [volumeTO[uuid=72a45236-0fc8-48ec-9fff-b6894c48273b|path=72a45236-0fc8-48ec-9fff-b6894c48273b|datastore=PrimaryDataStoreTO[uuid=dc916dc7-cc1c-3f3d-905b-b198daf15a79|name=storage-1-nfs|id=1|pooltype=NetworkFilesystem]]] (from path "/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b") to snapshot [/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/snapshots/41db256b-d8fa-4350-bc9e-0d62e4e9b176].
2023-10-04 12:47:55,774 DEBUG [resource.wrapper.LibvirtUtilitiesHelper] (agentRequest-Handler-5:null) (logid:ae8045e2) The current Libvirt's version [6000000] supports the flag '--delete' on command 'virsh blockcommit'.
2023-10-04 12:47:55,775 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:ae8045e2) Executing: /bin/bash -c virsh blockcommit i-2-190-VM vda --base /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/72a45236-0fc8-48ec-9fff-b6894c48273b --active --wait --delete --pivot 
2023-10-04 12:47:55,777 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:ae8045e2) Executing while with timeout : 3600000
2023-10-04 12:47:56,551 DEBUG [utils.script.Script] (agentRequest-Handler-5:null) (logid:ae8045e2) Execution is successful.
2023-10-04 12:47:56,556 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ae8045e2) Successfully merged snapshot [41db256b-d8fa-4350-bc9e-0d62e4e9b176] into VM [i-2-190-VM] volumeTO[uuid=72a45236-0fc8-48ec-9fff-b6894c48273b|path=72a45236-0fc8-48ec-9fff-b6894c48273b|datastore=PrimaryDataStoreTO[uuid=dc916dc7-cc1c-3f3d-905b-b198daf15a79|name=storage-1-nfs|id=1|pooltype=NetworkFilesystem]] base file.
2023-10-04 12:47:56,557 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-5:null) (logid:ae8045e2) The current Libvirt's version supports the flag '--delete' on command 'virsh blockcommit', we will skip the manually deletion of the unused snapshot file [/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/41db256b-d8fa-4350-bc9e-0d62e4e9b176] as it already was automatically deleted.

...


2023-10-04 12:47:57,968 DEBUG [storage.resource.StorageSubsystemCommandHandlerBase] (agentRequest-Handler-1:null) (logid:ae8045e2) Executing command CopyCommand: [{"srcTO":{"org.apache.cloudstack.storage.to.SnapshotObjectTO":{"path":"/mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/snapshots/41db256b-d8fa-4350-bc9e-0d62e4e9b176","volume":{"uuid":"72a45236-0fc8-48ec-9fff-b6894c48273b","volumeType":"ROOT","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"dc916dc7-cc1c-3f3d-905b-b198daf15a79","name":"storage-1-nfs","id":1,"poolType":"NetworkFilesystem","host":"192.168.31.140","path":"/mnt/primary-storage","port":2049,"url":"NetworkFilesystem://192.168.31.140/mnt/primary-storage/?ROLE=Primary&STOREUUID=dc916dc7-cc1c-3f3d-905b-b198daf15a79","isManaged":false}},"name":"ROOT-190","size":8589934592,"path":"72a45236-0fc8-48ec-9fff-b6894c48273b","volumeId":187,"vmName":"i-2-190-VM","accountId":2,"format":"QCOW2","provisioningType":"THIN","poolId":1,"id":187,"deviceId":0,"bytesReadRate":104857600,"bytesWriteRate":104857600,"iopsReadRate":1000,"iopsWriteRate":1000,"cacheMode":"NONE","hypervisorType":"KVM","directDownload":false,"deployAsIs":false},"dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"dc916dc7-cc1c-3f3d-905b-b198daf15a79","name":"storage-1-nfs","id":1,"poolType":"NetworkFilesystem","host":"192.168.31.140","path":"/mnt/primary-storage","port":2049,"url":"NetworkFilesystem://192.168.31.140/mnt/primary-storage/?ROLE=Primary&STOREUUID=dc916dc7-cc1c-3f3d-905b-b198daf15a79","isManaged":false}},"vmName":"i-2-190-VM","name":"test1","hypervisorType":"KVM","id":13,"quiescevm":false,"physicalSize":0}},"destTO":{"org.apache.cloudstack.storage.to.SnapshotObjectTO":{"path":"snapshots/2/187","volume":{"uuid":"72a45236-0fc8-48ec-9fff-b6894c48273b","volumeType":"ROOT","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"dc916dc7-cc1c-3f3d-905b-b198daf15a79","name":"storage-1-nfs","id":1,"poolType":"NetworkFilesystem","host":"192.168.31.140","path":"/mnt/primary-storage","port":2049,"url":"NetworkFilesystem://192.168.31.140/mnt/primary-storage/?ROLE=Primary&STOREUUID=dc916dc7-cc1c-3f3d-905b-b198daf15a79","isManaged":false}},"name":"ROOT-190","size":8589934592,"path":"72a45236-0fc8-48ec-9fff-b6894c48273b","volumeId":187,"vmName":"i-2-190-VM","accountId":2,"format":"QCOW2","provisioningType":"THIN","poolId":1,"id":187,"deviceId":0,"bytesReadRate":104857600,"bytesWriteRate":104857600,"iopsReadRate":1000,"iopsWriteRate":1000,"cacheMode":"NONE","hypervisorType":"KVM","directDownload":false,"deployAsIs":false},"dataStore":{"com.cloud.agent.api.to.NfsTO":{"_url":"nfs://192.168.30.140/mnt/secondary-storage","_role":"Image"}},"vmName":"i-2-190-VM","name":"test1","hypervisorType":"KVM","id":13,"quiescevm":false,"physicalSize":0}},"executeInSequence":false,"options":{"snapshot.backup.to.secondary":"true","fullSnapshot":"true"},"options2":{},"wait":21600,"bypassHostMaintenance":false}].
2023-10-04 12:47:57,968 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-1:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:47:57,970 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Attempting to create storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a (NetworkFilesystem) in libvirt
2023-10-04 12:47:57,970 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-1:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:47:57,974 WARN  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a was not found running in libvirt. Need to create it.
2023-10-04 12:47:57,974 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Didn't find an existing storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a by UUID, checking for pools with duplicate paths
2023-10-04 12:47:57,977 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Checking path of existing pool f838fe2f-44a9-455f-8f3e-5fe9589f45b0 against pool we want to create
2023-10-04 12:47:57,981 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Checking path of existing pool df4a775d-eb19-495b-a73b-002077b254c1 against pool we want to create
2023-10-04 12:47:57,986 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Checking path of existing pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 against pool we want to create
2023-10-04 12:47:57,990 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Attempting to create storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a
2023-10-04 12:47:57,991 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) <pool type='netfs'>
2023-10-04 12:47:57,991 DEBUG [utils.script.Script] (agentRequest-Handler-1:null) (logid:ae8045e2) Executing: /bin/bash -c mountpoint -q /mnt/ad0eb7cd-40b5-3d48-b83c-604e20b7744a 
2023-10-04 12:47:57,993 DEBUG [utils.script.Script] (agentRequest-Handler-1:null) (logid:ae8045e2) Executing while with timeout : 3600000
2023-10-04 12:47:57,997 DEBUG [utils.script.Script] (agentRequest-Handler-1:null) (logid:ae8045e2) Exit value is 1
2023-10-04 12:47:57,997 DEBUG [utils.script.Script] (agentRequest-Handler-1:null) (logid:ae8045e2) 1
2023-10-04 12:47:58,118 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Trying to fetch storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a from libvirt
2023-10-04 12:47:58,119 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-1:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:47:58,128 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Successfully refreshed pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a Capacity: (72.83 GB) 78201749504 Used: (50.15 GB) 53843329024 Available: (22.69 GB) 24358420480
2023-10-04 12:47:58,129 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Trying to fetch storage pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 from libvirt
2023-10-04 12:47:58,129 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-1:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:47:58,137 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Successfully refreshed pool dc916dc7-cc1c-3f3d-905b-b198daf15a79 Capacity: (72.83 GB) 78201749504 Used: (48.08 GB) 51625066496 Available: (24.75 GB) 26576683008
2023-10-04 12:47:58,338 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-1:null) (logid:ae8045e2) Executing: /usr/share/cloudstack-common/scripts/storage/qcow2/managesnapshot.sh -b /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/snapshots/41db256b-d8fa-4350-bc9e-0d62e4e9b176 -n 41db256b-d8fa-4350-bc9e-0d62e4e9b176 -p /mnt/ad0eb7cd-40b5-3d48-b83c-604e20b7744a/snapshots/2/187 -t 41db256b-d8fa-4350-bc9e-0d62e4e9b176 
2023-10-04 12:47:58,342 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-1:null) (logid:ae8045e2) Executing while with timeout : 21600000
2023-10-04 12:50:53,604 DEBUG [kvm.storage.KVMStorageProcessor] (agentRequest-Handler-1:null) (logid:ae8045e2) Execution is successful.
2023-10-04 12:50:54,000 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Attempting to remove storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a from libvirt
2023-10-04 12:50:54,001 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-1:null) (logid:ae8045e2) Looking for libvirtd connection at: qemu:///system
2023-10-04 12:50:54,008 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a has no corresponding secret. Not removing any secret.
2023-10-04 12:50:54,329 INFO  [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:ae8045e2) Storage pool ad0eb7cd-40b5-3d48-b83c-604e20b7744a was successfully removed from libvirt.
2023-10-04 12:50:54,332 DEBUG [cloud.agent.Agent] (agentRequest-Handler-1:null) (logid:ae8045e2) Seq 30-2203667592667725915:  { Ans: , MgmtId: 90520745551922, via: 30, Ver: v1, Flags: 10, [{"org.apache.cloudstack.storage.command.CopyCmdAnswer":{"newData":{"org.apache.cloudstack.storage.to.SnapshotObjectTO":{"path":"snapshots/2/187/41db256b-d8fa-4350-bc9e-0d62e4e9b176","id":"0","quiescevm":"false","physicalSize":"3857645568"}},"result":"true","wait":"0","bypassHostMaintenance":"false"}}] }
```

</details>

After that, I checked the snapshot's file on the secondary storage and identified that it did not have a chain (i.e.: it was consolidated):
```
qemu-img info -U snapshots/2/187/41db256b-d8fa-4350-bc9e-0d62e4e9b176 
image: snapshots/2/187/41db256b-d8fa-4350-bc9e-0d62e4e9b176
file format: qcow2
virtual size: 8 GiB (8589934592 bytes)
disk size: 3.59 GiB
cluster_size: 65536
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
```

Then, I created a template from the snapshot and a VM with the template:

- VM's root volume info:

``` 
qemu-img info -U /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/26bc588d-f1e7-42db-95cd-82bf32597fe6
image: /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/26bc588d-f1e7-42db-95cd-82bf32597fe6
file format: qcow2
virtual size: 8 GiB (8589934592 bytes)
disk size: 324 KiB
cluster_size: 65536
backing file: /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/f234d832-11d3-4e9a-860a-09e1d6ebeae1
backing file format: qcow2
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
``` 

- Template info:
``` 
qemu-img info -U /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/f234d832-11d3-4e9a-860a-09e1d6ebeae1
image: /mnt/dc916dc7-cc1c-3f3d-905b-b198daf15a79/f234d832-11d3-4e9a-860a-09e1d6ebeae1
file format: qcow2
virtual size: 8 GiB (8589934592 bytes)
disk size: 3.59 GiB
cluster_size: 65536
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
``` 

With that, it was concluded that the template was a single file, without references to the template of the volume that generated the snapshot.