### PR TITLE
Fix UUID for child datastores in all cases

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5210,7 +5210,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                     String childPath = datacenterName + summary.getName();
                     poolInfo.setHostPath(childPath);
                     String uuid = childDsMo.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
-                    if (uuid == null) {
+                    if (uuid == null || !uuid.contains("-")) {
                         uuid = UUID.nameUUIDFromBytes(((pool.getHost() + childPath)).getBytes()).toString();
                     }
                     poolInfo.setUuid(uuid);


### PR DESCRIPTION
### Description

This PR fixes the issue #7999 

While putting the storage pool datastore cluster in maintenance mode, then there are chances that the cloud.uuid gets updated with UUID without hyphens ('-') which causes issue with sync storage pool.

In my case this is happening if there any hosts in the clusters which does not have access to the storage pool.

In this PR we are making sure that the UUID does not change to uuid without hyphens

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before and after putting the storage pool in maintenance mode, cloud.uuid has not changed
![image](https://github.com/apache/cloudstack/assets/3348673/a811e23a-6da2-4770-bc8c-c7d986990e99)

Before the fix, this UUID has changed to UUID without hyphens

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

1. Prepare a datastore cluster with 2 child datastores
2. Add datastore cluster as primary storage in CloudStack
3. Put the datastore cluster in maintenance mode or restart management server (as part of the fix, make sure the cloud.uuid in child storage pool does not. UUID has to be with hyphens)
4. Add or remove new child datastore in vCenter
5. Try sync storage pool operation on the datastore cluster => succeeded. 

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
