### PR TITLE
storage: allow VM snapshots without memory for KVM when global setting allows

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/StorageVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/StorageVMSnapshotStrategy.java
@@ -59,7 +59,6 @@ import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.GuestOSVO;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
-import com.cloud.storage.Storage;
 import com.cloud.storage.VolumeApiService;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.SnapshotDao;

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/StorageVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/StorageVMSnapshotStrategy.java
@@ -360,10 +360,6 @@ public class StorageVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
 
     @Override
     public StrategyPriority canHandle(Long vmId, Long rootPoolId, boolean snapshotMemory) {
-        //This check could be removed when PR #5297 is merged
-        if (vmHasNFSOrLocalVolumes(vmId)) {
-            return StrategyPriority.CANT_HANDLE;
-        }
         if (SnapshotManager.VmStorageSnapshotKvm.value() && !snapshotMemory) {
             UserVmVO vm = userVmDao.findById(vmId);
             if (vm.getState() == VirtualMachine.State.Running) {
@@ -464,18 +460,5 @@ public class StorageVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
         payload.setAsyncBackup(false);
         payload.setQuiescevm(false);
         return payload;
-    }
-
-    private boolean vmHasNFSOrLocalVolumes(long vmId) {
-        List<VolumeObjectTO> volumeTOs = vmSnapshotHelper.getVolumeTOList(vmId);
-
-        for (VolumeObjectTO volumeTO : volumeTOs) {
-            Long poolId = volumeTO.getPoolId();
-            Storage.StoragePoolType poolType = vmSnapshotHelper.getStoragePoolType(poolId);
-            if (poolType == Storage.StoragePoolType.NetworkFilesystem || poolType == Storage.StoragePoolType.Filesystem) {
-                return true;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
This removes the conditional logic which is recommended in comments to remove it after PR #5297 is merged, and that is certainly applicable for ACS 4.18+. Only when the global setting is enabled and memory isn't selected, VM snapshot could be allowed for VMs on KVM that have qemu-guest-agent running.

Refer:
https://github.com/apache/cloudstack/pull/3724
https://github.com/apache/cloudstack/pull/5297

Doc improvement PR - https://github.com/apache/cloudstack-documentation/pull/353

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
 
### Testing

1. After applying this fix on a 4.18.1 env, I could take a disk-only snapshots on VM with root/data disks and having qemu-guest-agent installed (and the global setting enabled):

<img width="1108" alt="Screenshot 2023-10-10 at 2 13 07 PM" src="https://github.com/apache/cloudstack/assets/95203/62c429a1-e291-49a2-8147-2399816a39d1">

2. On taking a disk-only snapshot of a running VM, I see snapshot (external) files created on the storage directory on the primary storage (tested local storage, but behaviour would be same on nfs as well). In my case there was a root disk and data disk, and therefore two files seen. This is also in the snapshot_store_ref table:

```
*************************** 36. row ***************************
                id: 352
          store_id: 17
       snapshot_id: 185
           created: 2023-10-10 08:51:09
      last_updated: NULL
            job_id: NULL
        store_role: Primary
              size: 26843545600
     physical_size: 26843545600
parent_snapshot_id: 0
      install_path: /var/lib/libvirt/images/snapshots/2013cd98-17c8-4bd0-aeec-a6f97ebacb0b
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2023-10-10 08:51:10
         volume_id: 758
*************************** 37. row ***************************
                id: 353
          store_id: 17
       snapshot_id: 186
           created: 2023-10-10 08:51:10
      last_updated: NULL
            job_id: NULL
        store_role: Primary
              size: 53687091200
     physical_size: 53687091200
parent_snapshot_id: 0
      install_path: /var/lib/libvirt/images/snapshots/8d287129-658f-4f90-82b5-4478b8bc7c65
             state: Ready
      update_count: 2
           ref_cnt: 0
           updated: 2023-10-10 08:51:10
         volume_id: 759
```

3. However, creating (volume) snapshot from VM snapshot somehow failed for me.

4. Reverting the snapshot also failed as this was a disk-only snapshot and VM was running. After stopping the VM, reverting the disk-only VM snapshot worked for me.