### PR TITLE
[NSX] Fix delete DHCP relay on segment deletion was missing zone name

### DIFF
--- a/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/agent/api/DeleteNsxSegmentCommand.java
+++ b/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/agent/api/DeleteNsxSegmentCommand.java
@@ -19,7 +19,7 @@ package org.apache.cloudstack.agent.api;
 import com.cloud.network.dao.NetworkVO;
 
 public class DeleteNsxSegmentCommand extends CreateNsxSegmentCommand {
-    public DeleteNsxSegmentCommand(String accountName, String vpcName, NetworkVO network) {
-        super(null, network.getDataCenterId(), accountName, network.getAccountId(), vpcName, network);
+    public DeleteNsxSegmentCommand(String zoneName, String accountName, String vpcName, NetworkVO network) {
+        super(zoneName, network.getDataCenterId(), accountName, network.getAccountId(), vpcName, network);
     }
 }

--- a/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/resource/NsxResource.java
+++ b/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/resource/NsxResource.java
@@ -417,9 +417,12 @@ public class NsxResource implements ServerResource {
             Thread.sleep(30*1000);
             String segmentName = getSegmentName(cmd.getAccountName(), cmd.getTierNetwork().getName(), cmd.getVpcName());
             Segments segmentService = (Segments) nsxService.apply(Segments.class);
+            LOGGER.debug(String.format("Removing the segment with ID %s", segmentName));
             segmentService.delete(segmentName);
             DhcpRelayConfigs dhcpRelayConfig = (DhcpRelayConfigs) nsxService.apply(DhcpRelayConfigs.class);
-            dhcpRelayConfig.delete(getDhcpRelayId(cmd.getZoneName(), cmd.getAccountName(), cmd.getVpcName(), cmd.getTierNetwork().getName()));
+            String dhcpRelayId = getDhcpRelayId(cmd.getZoneName(), cmd.getAccountName(), cmd.getVpcName(), cmd.getTierNetwork().getName());
+            LOGGER.debug(String.format("Removing the DHCP relay config with ID %s", dhcpRelayId));
+            dhcpRelayConfig.delete(dhcpRelayId);
         } catch (Exception e) {
             LOGGER.error(String.format("Failed to delete NSX segment: %s", getSegmentName(cmd.getAccountName(), cmd.getTierNetwork().getName(), cmd.getVpcName())));
             return new NsxAnswer(cmd, new CloudRuntimeException(e.getMessage()));

--- a/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/service/NsxElement.java
+++ b/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/service/NsxElement.java
@@ -59,6 +59,7 @@ import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.utils.Pair;
 import com.cloud.utils.component.AdapterBase;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachineProfile;
@@ -195,7 +196,13 @@ public class NsxElement extends AdapterBase implements DhcpServiceProvider, DnsS
     public boolean destroy(Network network, ReservationContext context) throws ConcurrentOperationException, ResourceUnavailableException {
         Account account = accountMgr.getAccount(network.getAccountId());
         NetworkVO networkVO = networkDao.findById(network.getId());
-        return nsxService.deleteNetwork(account.getAccountName(), networkVO);
+        DataCenterVO zone = dataCenterDao.findById(network.getDataCenterId());
+        if (Objects.isNull(zone)) {
+            String msg = String.format("Cannot fing zone with ID %s", network.getDataCenterId());
+            LOGGER.error(msg);
+            throw new CloudRuntimeException(msg);
+        }
+        return nsxService.deleteNetwork(zone.getName(), account.getAccountName(), networkVO);
     }
 
     @Override

--- a/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/service/NsxServiceImpl.java
+++ b/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/service/NsxServiceImpl.java
@@ -47,13 +47,13 @@ public class NsxServiceImpl implements NsxService {
         return result.getResult();
     }
 
-    public boolean deleteNetwork(String accountName, NetworkVO network) {
+    public boolean deleteNetwork(String zoneName, String accountName, NetworkVO network) {
         String vpcName = null;
         if (Objects.nonNull(network.getVpcId())) {
             VpcVO vpc = vpcDao.findById(network.getVpcId());
             vpcName = Objects.nonNull(vpc) ? vpc.getName() : null;
         }
-        DeleteNsxSegmentCommand deleteNsxSegmentCommand = new DeleteNsxSegmentCommand(accountName, vpcName, network);
+        DeleteNsxSegmentCommand deleteNsxSegmentCommand = new DeleteNsxSegmentCommand(zoneName, accountName, vpcName, network);
         NsxAnswer result = nsxControllerUtils.sendNsxCommand(deleteNsxSegmentCommand, network.getDataCenterId());
         return result.getResult();
     }


### PR DESCRIPTION
### Description

This PR fixes the DHCP relay config deletion

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
