### PR TITLE
Fix disk offering override in VM deployment wizard

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1339,14 +1339,10 @@ export default {
           this.overrideDiskOffering = null
         }
 
-        if (iso) {
-          if (this.serviceOffering?.diskofferingid) {
-            this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === this.serviceOffering.diskofferingid)
-          }
-        } else {
-          if (this.diskSelected) {
-            this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.diskofferingid)
-          }
+        if (iso && this.serviceOffering?.diskofferingid) {
+          this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === this.serviceOffering.diskofferingid)
+        } else if (!iso && this.diskSelected) {
+          this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.diskofferingid)
         }
 
         this.zone = _.find(this.options.zones, (option) => option.id === instanceConfig.zoneid)

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1331,36 +1331,24 @@ export default {
         }
 
         this.serviceOffering = _.find(this.options.serviceOfferings, (option) => option.id === instanceConfig.computeofferingid)
-        if (this.serviceOffering?.diskofferingid) {
-          if (iso) {
-            this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === this.serviceOffering.diskofferingid)
-          } else {
-            instanceConfig.overridediskofferingid = this.serviceOffering.diskofferingid
-          }
-        }
-        if (!iso && this.diskSelected) {
-          this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.diskofferingid)
-        }
-        if (this.rootDiskSelected?.id) {
-          instanceConfig.overridediskofferingid = this.rootDiskSelected.id
-        }
+
+        instanceConfig.overridediskofferingid = this.rootDiskSelected?.id || this.serviceOffering?.diskofferingid
         if (instanceConfig.overridediskofferingid) {
           this.overrideDiskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.overridediskofferingid)
         } else {
           this.overrideDiskOffering = null
         }
 
-        if (!iso && this.diskSelected) {
-          this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.diskofferingid)
-        }
-        if (this.rootDiskSelected?.id) {
-          instanceConfig.overridediskofferingid = this.rootDiskSelected.id
-        }
-        if (instanceConfig.overridediskofferingid) {
-          this.overrideDiskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.overridediskofferingid)
+        if (iso) {
+          if (this.serviceOffering?.diskofferingid) {
+            this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === this.serviceOffering.diskofferingid)
+          }
         } else {
-          this.overrideDiskOffering = null
+          if (this.diskSelected) {
+            this.diskOffering = _.find(this.options.diskOfferings, (option) => option.id === instanceConfig.diskofferingid)
+          }
         }
+
         this.zone = _.find(this.options.zones, (option) => option.id === instanceConfig.zoneid)
         this.affinityGroups = _.filter(this.options.affinityGroups, (option) => _.includes(instanceConfig.affinitygroupids, option.id))
         this.networks = this.getSelectedNetworksWithExistingConfig(_.filter(this.options.networks, (option) => _.includes(instanceConfig.networkids, option.id)))
@@ -1637,6 +1625,7 @@ export default {
         this.showRootDiskSizeChanger = false
       } else {
         this.rootDiskSelected = null
+        this.form.overridediskofferingid = undefined
       }
       this.showOverrideDiskOfferingOption = val
     },
@@ -1875,7 +1864,6 @@ export default {
       if (this.loading.deploy) return
       this.formRef.value.validate().then(async () => {
         const values = toRaw(this.form)
-
         if (!values.templateid && !values.isoid) {
           this.$notification.error({
             message: this.$t('message.request.failed'),
@@ -1962,7 +1950,7 @@ export default {
         if (this.selectedTemplateConfiguration) {
           deployVmData['details[0].configurationId'] = this.selectedTemplateConfiguration.id
         }
-        if (!this.serviceOffering.diskofferingstrictness && values.overridediskofferingid) {
+        if (!this.serviceOffering.diskofferingstrictness && values.overridediskofferingid && !values.isoid) {
           deployVmData.overridediskofferingid = values.overridediskofferingid
           if (values.rootdisksize && values.rootdisksize > 0) {
             deployVmData.rootdisksize = values.rootdisksize

--- a/ui/src/views/compute/wizard/DiskOfferingSelection.vue
+++ b/ui/src/views/compute/wizard/DiskOfferingSelection.vue
@@ -227,6 +227,7 @@ export default {
       this.selectedRowKeys = value
       this.$emit('select-disk-offering-item', value[0])
       this.$emit('on-selected-disk-size', this.diskSelected)
+      this.$emit('on-selected-root-disk-size', this.diskSelected)
     },
     handleSearch (value) {
       this.filter = value


### PR DESCRIPTION
### Description

This PR fixes four issues related to the disk offering override in the VM deployment wizard:

1. When a user selects a compute offering associated to a disk offering, enables root disk offering override and selects an offer other than the default one, the UI freezes. This only happens when the UI is not running locally;
2. When a user enables root disk offering override and selects an offer by clicking inside its radio button, the radio button becomes checked, but the selected root disk offering is not updated and the VM gets deployed with the default offering;
3. When a user enables root disk offering override, selects an offer, disables the override and deploys a VM, the root disk offering still gets overridden and the VM is deployed with the selected offer;
4. When a user deploys a VM using an ISO, if the compute offering has been selected before the ISO, and it does not have a compute only disk offering, the selected disk offering always gets overridden by the disk offering associated to the compute offering.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

First, I created two disk offerings:
1. Name and description: D1. QoS type: Hypervisor. Disk read rate (IOPS) and disk write rate (IOPS): 500;
2. Name and description: D2. QoS type: Hypervisor. Disk read rate (IOPS) and disk write rate (IOPS): 1000.

And one compute offering:
- Name and description: C1. CPU cores: 1. CPU (in MHz): 2000. Memory (in MB): 1024. Compute only disk offering disabled. Disk offerings: D1.

Tests related to the UI freezing when selecting a root disk offering:
- I selected the compute offering Small Instance and deployed a VM. I verified that the root disk did not use any disk offering and had the default size;
- I selected the compute offering Small Instance, enabled the override, disabled the override and deployed a VM. I verified that the root disk did not use any disk offering and had the default size;
- I selected the compute offering Small Instance, enabled the override, selected the disk offering D2, changed the disk size to 9 GB and deployed a VM. I verified that the root disk was using D2 and had 9 GB;
- I selected the compute offering C1 and deployed a VM. I verified that the root disk was using D1 and had the default size;
- I selected the compute offering C1, enabled the override, disabled the override and deployed a VM. I verified that the root disk was using D1 and had the default size;
- I selected the compute offering C1, enabled the override, selected the disk offering D2, changed the disk size to 9 GB and deployed a VM. I verified that the root disk was using D2 and had 9 GB;
- I selected the compute offering C1, enabled the override, selected the disk offering Medium and deployed a VM. I verified that the root disk was using Medium and had 20 GB;

Tests related to the selected root disk offering not updating when clicking inside a radio button:
- I selected the compute offering C1, enabled the override, selected the disk offering D2 by clicking inside its radio button, changed the disk size to 9 GB and deployed a VM. I verified that the root disk was using D2 and had 9 GB.

Tests related to the root disk offering being overridden even though the override was disabled:
- I selected the compute offering Small Instance, enabled the override, selected the disk offering D2, changed the disk size to 12 GB, disabled the override and deployed a VM. I verified that the root disk was not using any disk offering and had the default size.
- I selected the compute offering C1, enabled the override, selected the disk offering D2, disabled the override and deployed a VM. I verified that the root disk was using D1 and had the default size;
- I selected the compute offering C1, enabled the override, selected the disk offering Medium, disabled the override and deployed a VM. I verified that the root disk was using D1 and had the default size.

Tests related to the disk offering always being overridden when deploying using an ISO:
- I selected the compute offering C1, an ISO and the disk size D1, changed the disk size to 12 GB and deployed a VM. I verified that the volume was using D1 and had 12 GB;
- I selected the compute offering C1, an ISO, the disk size Medium and deployed a VM. I verified that the volume was using Medium and had 20 GB.