### PR TITLE
marvin,test: fix directdownload template checksum test

### DIFF
--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -1316,7 +1316,6 @@ class TestCreateTemplateWithDirectDownload(cloudstackTestCase):
         Deploy a VM from a Direct Download registered template with wrong checksum
         """
         self.template["checksum"]="{MD5}" + ("X" * 32)
-        print(self.template)
         tmpl = Template.register(self.apiclient, self.template, zoneid=self.zone.id, hypervisor=self.hypervisor, randomize_name=False)
         self.cleanup.append(tmpl)
 
@@ -1341,7 +1340,6 @@ class TestCreateTemplateWithDirectDownload(cloudstackTestCase):
             )
             if type(list_virtual_machine_response) == list and len(list_virtual_machine_response) > 0:
                 for virtual_machine_response in list_virtual_machine_response:
-                    print(virtual_machine_response)
                     VirtualMachine.delete(virtual_machine_response, self.apiclient, expunge=True)
 
         if failed == True:

--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -989,6 +989,8 @@ class TestTemplates(cloudstackTestCase):
                         )
 
         for template in list_template_response:
+            if template.directdownload == True:
+                continue
             self.assertNotEqual(
                         len(template.downloaddetails),
                         0,
@@ -1248,11 +1250,7 @@ class TestCreateTemplateWithDirectDownload(cloudstackTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            cleanup_resources(cls.apiclient, cls._cleanup)
-        except Exception as e:
-            raise Exception("Warning: Exception during cleanup : %s" % e)
-        return
+        super(TestCreateTemplateWithDirectDownload, cls).tearDownClass()
 
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()
@@ -1264,13 +1262,7 @@ class TestCreateTemplateWithDirectDownload(cloudstackTestCase):
         return
 
     def tearDown(self):
-        try:
-            #Clean up, terminate the created templates
-            cleanup_resources(self.apiclient, self.cleanup)
-
-        except Exception as e:
-            raise Exception("Warning: Exception during cleanup : %s" % e)
-        return
+        super(TestCreateTemplateWithDirectDownload, self).tearDown()
 
     @attr(tags=["advanced", "smoke"], required_hardware="true")
     def test_01_register_template_direct_download_flag(self):
@@ -1323,10 +1315,12 @@ class TestCreateTemplateWithDirectDownload(cloudstackTestCase):
         """
         Deploy a VM from a Direct Download registered template with wrong checksum
         """
-        self.template["checksum"]="{MD5}XXXXXXX"
+        self.template["checksum"]="{MD5}" + ("X" * 32)
+        print(self.template)
         tmpl = Template.register(self.apiclient, self.template, zoneid=self.zone.id, hypervisor=self.hypervisor, randomize_name=False)
         self.cleanup.append(tmpl)
 
+        failed = False
         try:
             virtual_machine = VirtualMachine.create(
                 self.apiclient,
@@ -1337,8 +1331,20 @@ class TestCreateTemplateWithDirectDownload(cloudstackTestCase):
                 serviceofferingid=self.service_offering.id
             )
             self.cleanup.append(virtual_machine)
-            self.fail("Expected to fail deployment")
+            failed = True
         except Exception as e:
             self.debug("Expected exception")
+            list_virtual_machine_response = VirtualMachine.list(
+                self.apiclient,
+                templateid=tmpl.id,
+                listall=True
+            )
+            if type(list_virtual_machine_response) == list and len(list_virtual_machine_response) > 0:
+                for virtual_machine_response in list_virtual_machine_response:
+                    print(virtual_machine_response)
+                    VirtualMachine.delete(virtual_machine_response, self.apiclient, expunge=True)
+
+        if failed == True:
+            self.fail("Expected to fail VM deployment with wrong checksum template")
 
         return

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1518,6 +1518,8 @@ class Template:
 
         if "directdownload" in services:
             cmd.directdownload = services["directdownload"]
+        if "checksum" in services:
+            cmd.checksum = services["checksum"]
 
         # Register Template
         template = apiclient.registerTemplate(cmd)


### PR DESCRIPTION
### Description

During failure while deploying a VM with the wrong checksum template, VM may be left in Error state. This PR adds code to delete such VM. Before wrong checksum test was not running correctly as the checksum parameter was not even passed while registering the template.

Fixes failures reported in https://github.com/apache/cloudstack/pull/7345#issuecomment-1760648666

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
