### PR TITLE
Fix deploy as is VM start after template deletion

### DIFF
--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -666,16 +666,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
             Pair<Class<?>, Long> tmplt = new Pair<Class<?>, Long>(VirtualMachineTemplate.class, template.getId());
             _messageBus.publish(_name, EntityManager.MESSAGE_REMOVE_ENTITY_EVENT, PublishScope.LOCAL, tmplt);
 
-            // Remove template details
-            templateDetailsDao.removeDetails(template.getId());
-
-            // Remove deploy-as-is details (if any and if there are no VMs using it)
-            if (template.isDeployAsIs()) {
-                List<VMInstanceVO> vmInstanceVOList = _vmInstanceDao.listNonExpungedByTemplate(template.getId());
-                if (CollectionUtils.isEmpty(vmInstanceVOList)) {
-                    templateDeployAsIsDetailsDao.removeDetails(template.getId());
-                }
-            }
+            checkAndRemoveTemplateDetails(template);
 
             // Remove comments (if any)
             AnnotationService.EntityType entityType = template.getFormat().equals(ImageFormat.ISO) ?
@@ -684,6 +675,23 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
 
         }
         return success;
+    }
+
+    /**
+     * removes details of the template and
+     * if the template is registered as deploy as is,
+     * then it also deletes the details related to deploy as is only if there are no VMs using the template
+     * @param template
+     */
+    void checkAndRemoveTemplateDetails(VMTemplateVO template) {
+        templateDetailsDao.removeDetails(template.getId());
+
+        if (template.isDeployAsIs()) {
+            List<VMInstanceVO> vmInstanceVOList = _vmInstanceDao.listNonExpungedByTemplate(template.getId());
+            if (CollectionUtils.isEmpty(vmInstanceVOList)) {
+                templateDeployAsIsDetailsDao.removeDetails(template.getId());
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -665,9 +665,6 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
             // Remove template details
             templateDetailsDao.removeDetails(template.getId());
 
-            // Remove deploy-as-is details (if any)
-            templateDeployAsIsDetailsDao.removeDetails(template.getId());
-
             // Remove comments (if any)
             AnnotationService.EntityType entityType = template.getFormat().equals(ImageFormat.ISO) ?
                     AnnotationService.EntityType.ISO : AnnotationService.EntityType.TEMPLATE;


### PR DESCRIPTION
### Description

This PR fixes the issue #7970 

Fix is to keep the template deploy as is details even after the template is deleted. VM start need to know whether the vapp property is password or not which are saved in template_deploy_as_is_details table.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI


#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

1. Registered a VMware template with "Read VM settings from OVA" enabled
2. Created a VM with it
3. Force delete the template
4. Stop and start the VM => succeeded 

