### PR TITLE
refactor MockNetworkVO

### DIFF
--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/InstanceIpModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/InstanceIpModelTest.java
@@ -16,6 +16,7 @@
 // under the License.
 
 package org.apache.cloudstack.network.contrail.model;
+
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -44,19 +45,19 @@ import net.juniper.contrail.api.ApiConnectorMock;
 
 public class InstanceIpModelTest extends TestCase {
     private static final Logger s_logger =
-        Logger.getLogger(InstanceIpModelTest.class);
+            Logger.getLogger(InstanceIpModelTest.class);
 
     @Test
     public void testCreateInstanceIp() throws IOException {
 
         ContrailManagerImpl contrailMgr = mock(ContrailManagerImpl.class);
-        ModelController controller      = mock(ModelController.class);
+        ModelController controller = mock(ModelController.class);
         ApiConnector api = new ApiConnectorMock(null, 0);
         when(controller.getApiAccessor()).thenReturn(api);
         when(controller.getManager()).thenReturn(contrailMgr);
 
         // Create Virtual-Network (VN)
-        NetworkVO network =  new MockNetworkVO(Network.State.Implemented).getNetwork();
+        NetworkVO network = MockNetworkVO.getNetwork(Network.State.Implemented);
         NetworkDao networkDao = mock(NetworkDao.class);
         when(networkDao.findById(anyLong())).thenReturn(network);
         when(controller.getNetworkDao()).thenReturn(networkDao);
@@ -79,7 +80,7 @@ public class InstanceIpModelTest extends TestCase {
         when(vm.getState()).thenReturn(VirtualMachine.State.Running);
         when(vm.getDomainId()).thenReturn(10L);
         when(vm.getAccountId()).thenReturn(42L);
-        UserVmDao VmDao      = mock(UserVmDao.class);
+        UserVmDao VmDao = mock(UserVmDao.class);
         when(VmDao.findById(anyLong())).thenReturn(null);
         when(controller.getVmDao()).thenReturn(VmDao);
 

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/InstanceIpModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/InstanceIpModelTest.java
@@ -56,14 +56,7 @@ public class InstanceIpModelTest extends TestCase {
         when(controller.getManager()).thenReturn(contrailMgr);
 
         // Create Virtual-Network (VN)
-        NetworkVO network = mock(NetworkVO.class);
-        when(network.getName()).thenReturn("testnetwork");
-        when(network.getState()).thenReturn(Network.State.Implemented);
-        when(network.getGateway()).thenReturn("10.1.1.1");
-        when(network.getCidr()).thenReturn("10.1.1.0/24");
-        when(network.getPhysicalNetworkId()).thenReturn(42L);
-        when(network.getDomainId()).thenReturn(10L);
-        when(network.getAccountId()).thenReturn(42L);
+        NetworkVO network =  new MockNetworkVO(Network.State.Implemented).getNetwork();
         NetworkDao networkDao = mock(NetworkDao.class);
         when(networkDao.findById(anyLong())).thenReturn(network);
         when(controller.getNetworkDao()).thenReturn(networkDao);

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/MockNetworkVO.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/MockNetworkVO.java
@@ -26,7 +26,8 @@ import static org.mockito.Mockito.when;
 public class MockNetworkVO {
 
     private NetworkVO network;
-    MockNetworkVO(Network.State state){
+
+    MockNetworkVO(Network.State state) {
         network = mock(NetworkVO.class);
         when(network.getName()).thenReturn("testnetwork");
         when(network.getState()).thenReturn(state);
@@ -39,6 +40,11 @@ public class MockNetworkVO {
 
     public NetworkVO getNetwork() {
         return network;
+    }
+
+    public static NetworkVO getNetwork(Network.State state) {
+        MockNetworkVO mockNetwork = new MockNetworkVO(state);
+        return mockNetwork.getNetwork();
     }
 
 }

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/MockNetworkVO.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/MockNetworkVO.java
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.network.contrail.model;
+
+import com.cloud.network.Network;
+import com.cloud.network.dao.NetworkVO;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockNetworkVO {
+
+    private NetworkVO network;
+    MockNetworkVO(Network.State state){
+        network = mock(NetworkVO.class);
+        when(network.getName()).thenReturn("testnetwork");
+        when(network.getState()).thenReturn(state);
+        when(network.getGateway()).thenReturn("10.1.1.1");
+        when(network.getCidr()).thenReturn("10.1.1.0/24");
+        when(network.getPhysicalNetworkId()).thenReturn(42L);
+        when(network.getDomainId()).thenReturn(10L);
+        when(network.getAccountId()).thenReturn(42L);
+    }
+
+    public NetworkVO getNetwork() {
+        return network;
+    }
+
+}

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VMInterfaceModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VMInterfaceModelTest.java
@@ -58,14 +58,7 @@ public class VMInterfaceModelTest extends TestCase {
         when(controller.getApiAccessor()).thenReturn(api);
 
         // Create Virtual-Network (VN)
-        NetworkVO network = mock(NetworkVO.class);
-        when(network.getName()).thenReturn("testnetwork");
-        when(network.getState()).thenReturn(Network.State.Implemented);
-        when(network.getGateway()).thenReturn("10.1.1.1");
-        when(network.getCidr()).thenReturn("10.1.1.0/24");
-        when(network.getPhysicalNetworkId()).thenReturn(42L);
-        when(network.getDomainId()).thenReturn(10L);
-        when(network.getAccountId()).thenReturn(42L);
+        NetworkVO network =  new MockNetworkVO(Network.State.Implemented).getNetwork();
         NetworkDao networkDao = mock(NetworkDao.class);
         when(networkDao.findById(anyLong())).thenReturn(network);
         when(controller.getNetworkDao()).thenReturn(networkDao);

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VMInterfaceModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VMInterfaceModelTest.java
@@ -16,6 +16,7 @@
 // under the License.
 
 package org.apache.cloudstack.network.contrail.model;
+
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -45,20 +46,20 @@ import net.juniper.contrail.api.types.VirtualMachineInterface;
 
 public class VMInterfaceModelTest extends TestCase {
     private static final Logger s_logger =
-        Logger.getLogger(VMInterfaceModelTest.class);
+            Logger.getLogger(VMInterfaceModelTest.class);
 
     @Test
     public void testCreateVMInterface() throws IOException {
 
         String uuid;
         ContrailManagerImpl contrailMgr = mock(ContrailManagerImpl.class);
-        ModelController controller      = mock(ModelController.class);
+        ModelController controller = mock(ModelController.class);
         ApiConnector api = new ApiConnectorMock(null, 0);
         when(controller.getManager()).thenReturn(contrailMgr);
         when(controller.getApiAccessor()).thenReturn(api);
 
         // Create Virtual-Network (VN)
-        NetworkVO network =  new MockNetworkVO(Network.State.Implemented).getNetwork();
+        NetworkVO network = MockNetworkVO.getNetwork(Network.State.Implemented);
         NetworkDao networkDao = mock(NetworkDao.class);
         when(networkDao.findById(anyLong())).thenReturn(network);
         when(controller.getNetworkDao()).thenReturn(networkDao);
@@ -81,7 +82,7 @@ public class VMInterfaceModelTest extends TestCase {
         when(vm.getState()).thenReturn(VirtualMachine.State.Running);
         when(vm.getDomainId()).thenReturn(10L);
         when(vm.getAccountId()).thenReturn(42L);
-        UserVmDao VmDao      = mock(UserVmDao.class);
+        UserVmDao VmDao = mock(UserVmDao.class);
         when(VmDao.findById(anyLong())).thenReturn(null);
         when(controller.getVmDao()).thenReturn(VmDao);
 

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualMachineModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualMachineModelTest.java
@@ -80,14 +80,7 @@ public class VirtualMachineModelTest extends TestCase {
         when(controller.getApiAccessor()).thenReturn(api);
 
         // Create Virtual-Network (VN)
-        NetworkVO network = mock(NetworkVO.class);
-        when(network.getName()).thenReturn("testnetwork");
-        when(network.getState()).thenReturn(Network.State.Allocated);
-        when(network.getGateway()).thenReturn("10.1.1.1");
-        when(network.getCidr()).thenReturn("10.1.1.0/24");
-        when(network.getPhysicalNetworkId()).thenReturn(42L);
-        when(network.getDomainId()).thenReturn(10L);
-        when(network.getAccountId()).thenReturn(42L);
+        NetworkVO network =  new MockNetworkVO(Network.State.Allocated).getNetwork();
 
         when(contrailMgr.getCanonicalName(network)).thenReturn("testnetwork");
         when(contrailMgr.getProjectId(network.getDomainId(), network.getAccountId())).thenReturn("testProjectId");

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualMachineModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualMachineModelTest.java
@@ -46,18 +46,18 @@ public class VirtualMachineModelTest extends TestCase {
     @Test
     public void testVirtualMachineDBLookup() {
         ModelDatabase db = new ModelDatabase();
-        VMInstanceVO vm  = mock(VMInstanceVO.class);
+        VMInstanceVO vm = mock(VMInstanceVO.class);
 
         // Create 3 dummy Virtual Machine model objects
         // Add these models to database.
         // Each VM is identified by unique UUId.
-        VirtualMachineModel  vm0 = new VirtualMachineModel(vm, "fbc1f8fa-4b78-45ee-bba0-b551dbf72353");
+        VirtualMachineModel vm0 = new VirtualMachineModel(vm, "fbc1f8fa-4b78-45ee-bba0-b551dbf72353");
         db.getVirtualMachines().add(vm0);
 
-        VirtualMachineModel  vm1 = new VirtualMachineModel(vm, "fbc1f8fa-4b78-45ee-bba0-b551dbf83464");
+        VirtualMachineModel vm1 = new VirtualMachineModel(vm, "fbc1f8fa-4b78-45ee-bba0-b551dbf83464");
         db.getVirtualMachines().add(vm1);
 
-        VirtualMachineModel  vm2 = new VirtualMachineModel(vm, "fbc1f8fa-4b78-45ee-bba0-b551dbf94575");
+        VirtualMachineModel vm2 = new VirtualMachineModel(vm, "fbc1f8fa-4b78-45ee-bba0-b551dbf94575");
         db.getVirtualMachines().add(vm2);
 
         s_logger.debug("No of Vitual Machines added to database : " + db.getVirtualMachines().size());
@@ -74,13 +74,13 @@ public class VirtualMachineModelTest extends TestCase {
 
         String uuid = UUID.randomUUID().toString();
         ContrailManagerImpl contrailMgr = mock(ContrailManagerImpl.class);
-        ModelController controller      = mock(ModelController.class);
+        ModelController controller = mock(ModelController.class);
         ApiConnector api = new ApiConnectorMock(null, 0);
         when(controller.getManager()).thenReturn(contrailMgr);
         when(controller.getApiAccessor()).thenReturn(api);
 
         // Create Virtual-Network (VN)
-        NetworkVO network =  new MockNetworkVO(Network.State.Allocated).getNetwork();
+        NetworkVO network = MockNetworkVO.getNetwork(Network.State.Allocated);
 
         when(contrailMgr.getCanonicalName(network)).thenReturn("testnetwork");
         when(contrailMgr.getProjectId(network.getDomainId(), network.getAccountId())).thenReturn("testProjectId");
@@ -92,7 +92,7 @@ public class VirtualMachineModelTest extends TestCase {
         when(vm.getDomainId()).thenReturn(10L);
         when(vm.getAccountId()).thenReturn(42L);
 
-        UserVmDao VmDao      = mock(UserVmDao.class);
+        UserVmDao VmDao = mock(UserVmDao.class);
         when(VmDao.findById(anyLong())).thenReturn(null);
         when(controller.getVmDao()).thenReturn(VmDao);
 

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualNetworkModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualNetworkModelTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import com.cloud.network.Network;
 import junit.framework.TestCase;
 import net.juniper.contrail.api.ApiConnector;
 import net.juniper.contrail.api.ApiConnectorMock;
@@ -115,34 +116,13 @@ public class VirtualNetworkModelTest extends TestCase {
         when(vn3.getNetworkPolicy()).thenReturn(policyRefs3);
 
         //Virtual-Network 1
-        NetworkVO network1 = mock(NetworkVO.class);
-        when(network1.getName()).thenReturn("testnetwork");
-        when(network1.getState()).thenReturn(State.Allocated);
-        when(network1.getGateway()).thenReturn("10.1.1.1");
-        when(network1.getCidr()).thenReturn("10.1.1.0/24");
-        when(network1.getPhysicalNetworkId()).thenReturn(42L);
-        when(network1.getDomainId()).thenReturn(10L);
-        when(network1.getAccountId()).thenReturn(42L);
+        NetworkVO network1 =  new MockNetworkVO(State.Allocated).getNetwork();
 
         //Virtual-Network 2
-        NetworkVO network2 = mock(NetworkVO.class);
-        when(network2.getName()).thenReturn("Testnetwork");
-        when(network2.getState()).thenReturn(State.Allocated);
-        when(network2.getGateway()).thenReturn("10.1.1.1");
-        when(network2.getCidr()).thenReturn("10.1.1.0/24");
-        when(network2.getPhysicalNetworkId()).thenReturn(42L);
-        when(network2.getDomainId()).thenReturn(10L);
-        when(network2.getAccountId()).thenReturn(42L);
+        NetworkVO network2 = new MockNetworkVO(State.Allocated).getNetwork();
 
         //Virtual-Network 3
-        NetworkVO network3 = mock(NetworkVO.class);
-        when(network3.getName()).thenReturn("Testnetwork");
-        when(network3.getState()).thenReturn(State.Allocated);
-        when(network3.getGateway()).thenReturn("10.1.1.1");
-        when(network3.getCidr()).thenReturn("10.1.1.0/24");
-        when(network3.getPhysicalNetworkId()).thenReturn(42L);
-        when(network3.getDomainId()).thenReturn(10L);
-        when(network3.getAccountId()).thenReturn(42L);
+        NetworkVO network3 = new MockNetworkVO(State.Allocated).getNetwork();
 
         when(contrailMgr.getCanonicalName(network1)).thenReturn("testnetwork");
         when(contrailMgr.getProjectId(network1.getDomainId(), network1.getAccountId())).thenReturn("testProjectId");
@@ -185,14 +165,7 @@ public class VirtualNetworkModelTest extends TestCase {
         when(controller.getApiAccessor()).thenReturn(api);
 
         // Create Virtual-Network (VN)
-        NetworkVO network = mock(NetworkVO.class);
-        when(network.getName()).thenReturn("testnetwork");
-        when(network.getState()).thenReturn(State.Allocated);
-        when(network.getGateway()).thenReturn("10.1.1.1");
-        when(network.getCidr()).thenReturn("10.1.1.0/24");
-        when(network.getPhysicalNetworkId()).thenReturn(42L);
-        when(network.getDomainId()).thenReturn(10L);
-        when(network.getAccountId()).thenReturn(42L);
+        NetworkVO network = new MockNetworkVO(State.Allocated).getNetwork();
 
         when(contrailMgr.getCanonicalName(network)).thenReturn("testnetwork");
         when(contrailMgr.getProjectId(network.getDomainId(), network.getAccountId())).thenReturn("testProjectId");

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualNetworkModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualNetworkModelTest.java
@@ -115,13 +115,13 @@ public class VirtualNetworkModelTest extends TestCase {
         when(vn3.getNetworkPolicy()).thenReturn(policyRefs3);
 
         //Virtual-Network 1
-        NetworkVO network1 =  new MockNetworkVO(State.Allocated).getNetwork();
+        NetworkVO network1 = MockNetworkVO.getNetwork(State.Allocated);
 
         //Virtual-Network 2
-        NetworkVO network2 = new MockNetworkVO(State.Allocated).getNetwork();
+        NetworkVO network2 = MockNetworkVO.getNetwork(State.Allocated);
 
         //Virtual-Network 3
-        NetworkVO network3 = new MockNetworkVO(State.Allocated).getNetwork();
+        NetworkVO network3 = MockNetworkVO.getNetwork(State.Allocated);
 
         when(contrailMgr.getCanonicalName(network1)).thenReturn("testnetwork");
         when(contrailMgr.getProjectId(network1.getDomainId(), network1.getAccountId())).thenReturn("testProjectId");
@@ -158,13 +158,13 @@ public class VirtualNetworkModelTest extends TestCase {
 
         String uuid = UUID.randomUUID().toString();
         ContrailManagerImpl contrailMgr = mock(ContrailManagerImpl.class);
-        ModelController controller      = mock(ModelController.class);
+        ModelController controller = mock(ModelController.class);
         ApiConnector api = new ApiConnectorMock(null, 0);
         when(controller.getManager()).thenReturn(contrailMgr);
         when(controller.getApiAccessor()).thenReturn(api);
 
         // Create Virtual-Network (VN)
-        NetworkVO network = new MockNetworkVO(State.Allocated).getNetwork();
+        NetworkVO network = MockNetworkVO.getNetwork(State.Allocated);
 
         when(contrailMgr.getCanonicalName(network)).thenReturn("testnetwork");
         when(contrailMgr.getProjectId(network.getDomainId(), network.getAccountId())).thenReturn("testProjectId");

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualNetworkModelTest.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/model/VirtualNetworkModelTest.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import com.cloud.network.Network;
 import junit.framework.TestCase;
 import net.juniper.contrail.api.ApiConnector;
 import net.juniper.contrail.api.ApiConnectorMock;


### PR DESCRIPTION
### Description
This PR addresses a problem similar to the one mentioned in Issue #8087 by adopting the same solution approach used in PR #8098. Specifically, it refactors the mock object creation for `NetworkVO` across test suites of four classes: `InstanceIpModelTest.java`, `VirtualMachineModelTest.java`, `VirtualNetworkModelTest.java`, and the `testCreateVMInterface` method in another class. The central concern is the repetitive mock object creations for `NetworkVO`.

#### Proposed Changes
Following the methodology from PR #8098, I've introduced a new and reusable `MockNetworkVO` class. This class is designated for creating `NetworkVO` mock objects with consistent behavior, aiming to eliminate redundancy.

#### Benefits of the Proposed Refactoring:

- **This refactoring leads to a cleaner codebase, streamlining the test cases and enhancing maintainability.**
- **Should there arise a need to modify the `NetworkVO` mock creation process in the future, adjustments will only be necessary within the `MockNetworkVO` class. This centralizes modifications instead of scattering them across multiple test classes.**

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
**Fixes: Similar Issue to #8087**