### PR TITLE
Inject hypervisor type and volume format on Quota tariffs

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -455,7 +455,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
 
         }
 
-        jsInterpreter.injectVariable("resourceType", presetVariables.getResourceType());
+        jsInterpreter.injectStringVariable("resourceType", presetVariables.getResourceType());
         jsInterpreter.injectVariable("value", presetVariables.getValue().toString());
         jsInterpreter.injectVariable("zone", presetVariables.getZone().toString());
     }

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import com.cloud.hypervisor.Hypervisor;
 import org.apache.cloudstack.acl.RoleVO;
 import org.apache.cloudstack.acl.dao.RoleDao;
 import org.apache.cloudstack.backup.BackupOfferingVO;
@@ -65,6 +66,7 @@ import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.GuestOSVO;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
+import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.DiskOfferingDao;
@@ -318,6 +320,10 @@ public class PresetVariableHelper {
 
         value.setTags(getPresetVariableValueResourceTags(vmId, ResourceObjectType.UserVm));
         value.setTemplate(getPresetVariableValueTemplate(vmVo.getTemplateId()));
+        Hypervisor.HypervisorType hypervisorType = vmVo.getHypervisorType();
+        if (hypervisorType != null) {
+            value.setHypervisorType(hypervisorType.name());
+        }
     }
 
     protected void logNotLoadingMessageInTrace(String resource, int usageType) {
@@ -470,6 +476,11 @@ public class PresetVariableHelper {
 
         value.setTags(getPresetVariableValueResourceTags(volumeId, ResourceObjectType.Volume));
         value.setSize(ByteScaleUtils.bytesToMebibytes(volumeVo.getSize()));
+
+        ImageFormat format = volumeVo.getFormat();
+        if (format != null) {
+            value.setVolumeFormat(format.name());
+        }
     }
 
     protected GenericPresetVariable getPresetVariableValueDiskOffering(Long diskOfferingId) {
@@ -558,6 +569,10 @@ public class PresetVariableHelper {
         value.setSnapshotType(Snapshot.Type.values()[snapshotVo.getSnapshotType()]);
         value.setStorage(getPresetVariableValueStorage(getSnapshotDataStoreId(snapshotId, usageRecord.getZoneId()), usageType));
         value.setTags(getPresetVariableValueResourceTags(snapshotId, ResourceObjectType.Snapshot));
+        Hypervisor.HypervisorType hypervisorType = snapshotVo.getHypervisorType();
+        if (hypervisorType != null) {
+            value.setHypervisorType(hypervisorType.name());
+        }
     }
 
     protected SnapshotDataStoreVO getSnapshotImageStoreRef(long snapshotId, long zoneId) {
@@ -621,6 +636,11 @@ public class PresetVariableHelper {
         value.setName(vmSnapshotVo.getName());
         value.setTags(getPresetVariableValueResourceTags(vmSnapshotId, ResourceObjectType.VMSnapshot));
         value.setVmSnapshotType(vmSnapshotVo.getType());
+
+        VMInstanceVO vmVo = vmInstanceDao.findByIdIncludingRemoved(vmSnapshotVo.getVmId());
+        if (vmVo != null && vmVo.getHypervisorType() != null) {
+            value.setHypervisorType(vmVo.getHypervisorType().name());
+        }
     }
 
     protected void loadPresetVariableValueForBackup(UsageVO usageRecord, Value value) {

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/Value.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/Value.java
@@ -41,6 +41,8 @@ public class Value extends GenericPresetVariable {
     private Storage storage;
     private ComputingResources computingResources;
     private BackupOffering backupOffering;
+    private String hypervisorType;
+    private String volumeFormat;
 
     public Host getHost() {
         return host;
@@ -184,5 +186,23 @@ public class Value extends GenericPresetVariable {
     public void setBackupOffering(BackupOffering backupOffering) {
         this.backupOffering = backupOffering;
         fieldNamesToIncludeInToString.add("backupOffering");
+    }
+
+    public void setHypervisorType(String hypervisorType) {
+        this.hypervisorType = hypervisorType;
+        fieldNamesToIncludeInToString.add("hypervisorType");
+    }
+
+    public String getHypervisorType() {
+        return hypervisorType;
+    }
+
+    public void setVolumeFormat(String volumeFormat) {
+        this.volumeFormat = volumeFormat;
+        fieldNamesToIncludeInToString.add("volumeFormat");
+    }
+
+    public String getVolumeFormat() {
+        return volumeFormat;
     }
 }

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
@@ -267,7 +267,7 @@ public class QuotaManagerImplTest {
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("account"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("domain"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock, Mockito.never()).injectVariable(Mockito.eq("project"), Mockito.anyString());
-        Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("resourceType"), Mockito.anyString());
+        Mockito.verify(jsInterpreterMock).injectStringVariable(Mockito.eq("resourceType"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("value"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("zone"), Mockito.anyString());
     }
@@ -288,7 +288,7 @@ public class QuotaManagerImplTest {
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("account"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("domain"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("project"), Mockito.anyString());
-        Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("resourceType"), Mockito.anyString());
+        Mockito.verify(jsInterpreterMock).injectStringVariable(Mockito.eq("resourceType"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("value"), Mockito.anyString());
         Mockito.verify(jsInterpreterMock).injectVariable(Mockito.eq("zone"), Mockito.anyString());
     }

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/ValueTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/ValueTest.java
@@ -136,4 +136,18 @@ public class ValueTest {
         variable.setBackupOffering(null);
         Assert.assertTrue(variable.fieldNamesToIncludeInToString.contains("backupOffering"));
     }
+
+    @Test
+    public void setHypervisorTypeTestAddFieldHypervisorTypeToCollection() {
+        Value variable = new Value();
+        variable.setHypervisorType(null);
+        Assert.assertTrue(variable.fieldNamesToIncludeInToString.contains("hypervisorType"));
+    }
+
+    @Test
+    public void setVolumeFormatTestAddFieldVolumeFormatToCollection() {
+        Value variable = new Value();
+        variable.setVolumeFormat(null);
+        Assert.assertTrue(variable.fieldNamesToIncludeInToString.contains("volumeFormat"));
+    }
 }

--- a/utils/src/main/java/org/apache/cloudstack/utils/jsinterpreter/JsInterpreter.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/jsinterpreter/JsInterpreter.java
@@ -78,11 +78,26 @@ public class JsInterpreter implements Closeable {
     }
 
     /**
-     * Adds the parameters to a Map that will be converted to JS variables right before executing the scripts..
+     * Adds the parameters to a Map that will be converted to JS variables right before executing the script.
      * @param key The name of the variable.
      * @param value The value of the variable.
      */
     public void injectVariable(String key, String value) {
+        logger.trace(String.format(injectingLogMessage, key, value));
+        variables.put(key, value);
+    }
+
+    /**
+     * Adds the parameter, surrounded by double quotes, to a Map that will be converted to a JS variable right before executing the script.
+     * @param key The name of the variable.
+     * @param value The value of the variable.
+     */
+    public void injectStringVariable(String key, String value) {
+        if (value == null) {
+            logger.trace(String.format("Not injecting [%s] because its value is null.", key));
+            return;
+        }
+        value = String.format("\"%s\"", value);
         logger.trace(String.format(injectingLogMessage, key, value));
         variables.put(key, value);
     }

--- a/utils/src/test/java/org/apache/cloudstack/utils/jsinterpreter/JsInterpreterTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/jsinterpreter/JsInterpreterTest.java
@@ -179,4 +179,22 @@ public class JsInterpreterTest {
         Assert.assertEquals(scriptEngineMock, jsInterpreterSpy.interpreter);
         Mockito.verify(nashornScriptEngineFactoryMock).getScriptEngine("--no-java");
     }
+
+    @Test
+    public void injectStringVariableTestNullValueDoNothing() {
+        jsInterpreterSpy.variables = new LinkedHashMap<>();
+
+        jsInterpreterSpy.injectStringVariable("a", null);
+
+        Assert.assertTrue(jsInterpreterSpy.variables.isEmpty());
+    }
+
+    @Test
+    public void injectStringVariableTestNotNullValueSurroundWithDoubleQuotes() {
+        jsInterpreterSpy.variables = new LinkedHashMap<>();
+
+        jsInterpreterSpy.injectStringVariable("a", "b");
+
+        Assert.assertEquals(jsInterpreterSpy.variables.get("a"), "\"b\"");
+    }
 }


### PR DESCRIPTION
### Description

This PR adds two new preset variables into the Quota activation rules: hypervisor type and volume format. This allows operators to customize tariffs based on these two properties.

The respective preset variable will be injected into tariffs with the following usage types:
- RUNNING_VM: `value.hypervisorType`;
- ALLOCATED_VM: `value.hypervisorType`;
- VM_SNAPSHOT: `value.hypervisorType`;
- SNAPSHOT: `value.hypervisorType`;
- VOLUME: `value.volumeFormat`;
- VOLUME_SECONDARY: `value.volumeFormat`.

Example of an activation rule using `value.hypervisorType`:
```js
if (value.hypervisorType=='KVM') {
  1
} else {
  2
}
```

Example of an activation rule using `value.volumeFormat`:
```js
if (value.volumeFormat=='QCOW2') {
  3
} else {
  4
}
```

Furthermore, this PR also fixes the preset variable `resourceType` being injected into the JavaScript interpreter without quotes, which prevented the activation rules from executing.

```
2023-10-05 16:43:08,886 ERROR [o.a.c.q.QuotaManagerImpl] (qtp1955920234-22:ctx-d90594cb ctx-6d904941) (logid:5f086162) Failed to calculate the quota usage for account [{"accountName":"fabricio","domainId":1,"id":21,"uuid":"ae254524-854a-4049-9d1b-721cfaffdd71"}] due to [Unable to execute script [ account = {"role":{"type":"User","id":"64b4ca77-26de-11ec-8dcf-5254005dcdac","name":"User"},"id":"ae254524-854a-4049-9d1b-721cfaffdd71","name":"fabricio"}; domain = {"path":"\/","id":"52d83793-26de-11ec-8dcf-5254005dcdac","name":"ROOT"}; resourceType = KVM; value = {"accountResources":[{"domainId":"52d83793-26de-11ec-8dcf-5254005dcdac","zoneId":"8b2ceb16-a2f2-40ea-8968-9e08984bdb17"},{"domainId":"52d83793-26de-11ec-8dcf-5254005dcdac","zoneId":"8b2ceb16-a2f2-40ea-8968-9e08984bdb17"},{"domainId":"52d83793-26de-11ec-8dcf-5254005dcdac","zoneId":"8b2ceb16-a2f2-40ea-8968-9e08984bdb17"}],"computeOffering":{"customized":false,"id":"ab647165-7a0a-4984-8452-7bfceb036528","name":"Small Instance"},"computingResources":{"cpuNumber":1,"cpuSpeed":500,"memory":512},"host":{"tags":[],"id":"3d7d8532-d0cf-476c-a36e-1b936d780abb","name":"cloudstack-lab-host-2"},"hypervisorType":"KVM","osName":"Ubuntu 18.04 LTS","tags":{},"template":{"id":"bb4b7b6f-5249-4c18-a5f6-dd886683b702","name":"Ubuntu Bionic"},"id":"a83ece0c-58e7-4bc5-8564-f70fe8e34fc0","name":"t2"}; zone = {"id":"8b2ceb16-a2f2-40ea-8968-9e08984bdb17","name":"sc-floripa-01"}; if (value.hypervisorType=='KVM') { 1 } else { 2 }] due to [javax.script.ScriptException: ReferenceError: "KVM" is not defined in <eval> at line number 1]].
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created two tariffs through CloudMonkey:

```
(admin) 🐱 > quota tariffcreate activationrule="if (value.hypervisorType=='KVM') { 1 } else { 2 }" usagetype=1 value=0 name="hypervisor" description="hypervisor"
{
  "quotatariff": {
    "activationRule": "if (value.hypervisorType=='KVM') { 1 } else { 2 }",
    "currency": "$",
    "description": "hypervisor",
    "effectiveDate": "2023-10-04T21:46:19+0000",
    "name": "hypervisor",
    "tariffValue": 0,
    "usageDiscriminator": "None",
    "usageName": "RUNNING_VM",
    "usageType": 1,
    "usageTypeDescription": "Running Vm Usage",
    "usageUnit": "Compute*Month",
    "uuid": "85941d4b-cc6e-4e18-ba85-7708ea3a41eb"
  }
}


(admin) 🐱 > quota tariffcreate activationrule="if (value.volumeFormat=='QCOW2') { 3 } else { 4 }" usagetype=6 value=0 name="volume format" description="volume format"
{
  "quotatariff": {
    "activationRule": "if (value.volumeFormat=='QCOW2') { 3 } else { 4 }",
    "currency": "$",
    "description": "volume format",
    "effectiveDate": "2023-10-04T21:48:42+0000",
    "name": "volume format",
    "tariffValue": 0,
    "usageDiscriminator": "None",
    "usageName": "VOLUME",
    "usageType": 6,
    "usageTypeDescription": "Volume Usage",
    "usageUnit": "GB*Month",
    "uuid": "7b6c9eae-b369-40b7-adc3-0add4abf27bd"
  }
}
```

Then, I deployed a virtual machine using KVM, called `quotaUpdate` and verified through the logs that that the calculated value was 1 for the first tariff and 3 for the second.