### PR TITLE
Update XenServer610WrapperTest.java

### DIFF
--- a/plugins/hypervisors/xenserver/src/test/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/XenServer610WrapperTest.java
+++ b/plugins/hypervisors/xenserver/src/test/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/XenServer610WrapperTest.java
@@ -259,7 +259,7 @@ public class XenServer610WrapperTest {
         final Connection conn = Mockito.mock(Connection.class);
         final VirtualMachineTO vmSpec = Mockito.mock(VirtualMachineTO.class);
 
-        final VolumeTO volume1 =MockVolumeTO(path);
+        final VolumeTO volume1 = MockVolumeTO(path);
         final VolumeTO volume2 = MockVolumeTO(path);
 
         final SR sr1 = Mockito.mock(SR.class);
@@ -475,6 +475,7 @@ public class XenServer610WrapperTest {
 
         assertFalse(answer.getResult());
     }
+
     VolumeTO MockVolumeTO(String path){
         VolumeTO vol = Mockito.mock(VolumeTO.class);
         when(vol.getPath()).thenReturn(path);

--- a/plugins/hypervisors/xenserver/src/test/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/XenServer610WrapperTest.java
+++ b/plugins/hypervisors/xenserver/src/test/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/XenServer610WrapperTest.java
@@ -259,8 +259,8 @@ public class XenServer610WrapperTest {
         final Connection conn = Mockito.mock(Connection.class);
         final VirtualMachineTO vmSpec = Mockito.mock(VirtualMachineTO.class);
 
-        final VolumeTO volume1 = Mockito.mock(VolumeTO.class);
-        final VolumeTO volume2 = Mockito.mock(VolumeTO.class);
+        final VolumeTO volume1 =MockVolumeTO(path);
+        final VolumeTO volume2 = MockVolumeTO(path);
 
         final SR sr1 = Mockito.mock(SR.class);
         final SR sr2 = Mockito.mock(SR.class);
@@ -294,9 +294,6 @@ public class XenServer610WrapperTest {
 
         when(xenServer610Resource.getConnection()).thenReturn(conn);
         when(vmSpec.getName()).thenReturn(vmName);
-
-        when(volume1.getPath()).thenReturn(path);
-        when(volume2.getPath()).thenReturn(path);
 
         when(nic1.getMac()).thenReturn(mac);
         when(nic2.getMac()).thenReturn(mac);
@@ -369,8 +366,8 @@ public class XenServer610WrapperTest {
         final Connection conn = Mockito.mock(Connection.class);
         final VirtualMachineTO vmSpec = Mockito.mock(VirtualMachineTO.class);
 
-        final VolumeTO volume1 = Mockito.mock(VolumeTO.class);
-        final VolumeTO volume2 = Mockito.mock(VolumeTO.class);
+        final VolumeTO volume1 = MockVolumeTO(path);
+        final VolumeTO volume2 = MockVolumeTO(path);
 
         final SR sr1 = Mockito.mock(SR.class);
         final SR sr2 = Mockito.mock(SR.class);
@@ -398,9 +395,6 @@ public class XenServer610WrapperTest {
 
         when(xenServer610Resource.getConnection()).thenReturn(conn);
         when(vmSpec.getName()).thenReturn(vmName);
-
-        when(volume1.getPath()).thenReturn(path);
-        when(volume2.getPath()).thenReturn(path);
 
         when(xenServer610Resource.getVDIbyUuid(conn, volume1.getPath())).thenReturn(vdi1);
         when(xenServer610Resource.getVDIbyUuid(conn, volume2.getPath())).thenReturn(vdi2);
@@ -480,5 +474,10 @@ public class XenServer610WrapperTest {
         //        }
 
         assertFalse(answer.getResult());
+    }
+    VolumeTO MockVolumeTO(String path){
+        VolumeTO vol = Mockito.mock(VolumeTO.class);
+        when(vol.getPath()).thenReturn(path);
+        return vol;
     }
 }


### PR DESCRIPTION
### Description
This PR addresses a problem analogous to the one presented in Issue #8088. The core of the issue is repetitive mock object creation for `VolumeTO` within the test suite of `XenServer610WrapperTest.java`. In this refactoring process, I have streamlined the mock creation process for `VolumeTO` to enhance code maintainability and reduce redundancy.

#### Proposed Changes
Aiming to provide a solution similar to what has been described for Issue #8088, I've introduced a method named `MockVolumeTO(String path)`. This method is specifically crafted to create consistent mock objects for `VolumeTO` based on the supplied path.

#### Benefits of the Proposed Refactoring:

- **The utilization of the `MockVolumeTO(String path)` method greatly simplifies the test cases within `XenServer610WrapperTest.java`, ensuring they are more comprehensible and easier to manage.**
- **Should there be a necessity in the future to modify the `VolumeTO` mock creation process, developers can easily implement these changes within the `MockVolumeTO` method, preventing the need for dispersed modifications across the test class.**

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
**Fixes: Issue similar to #8088**
