### PR TITLE
dashboard: on admin dashboard use red-dot icon when hosts are in alert

### DIFF
--- a/ui/src/views/dashboard/CapacityDashboard.vue
+++ b/ui/src/views/dashboard/CapacityDashboard.vue
@@ -112,8 +112,8 @@
                 :value-style="{ color: $config.theme['@primary-color'] }">
                 <template #prefix>
                   <database-outlined/>
-                  <status class="status" text="Alert" style="margin-left: -10px" v-if="data.alertHosts > 0"/>
-                  <span v-else>!</span>
+                  <a-badge v-if="data.alertHosts > 0" count="!" style="margin-left: -5px" />
+                  <a-badge v-else count="✓" style="margin-left: -5px" :number-style="{ backgroundColor: '#52c41a' }" />
                 </template>
               </a-statistic>
             </router-link>

--- a/ui/src/views/dashboard/CapacityDashboard.vue
+++ b/ui/src/views/dashboard/CapacityDashboard.vue
@@ -112,7 +112,8 @@
                 :value-style="{ color: $config.theme['@primary-color'] }">
                 <template #prefix>
                   <database-outlined/>
-                  <status class="status" text="Alert" style="margin-left: -10px"/>
+                  <status class="status" text="Alert" style="margin-left: -10px" v-if="data.alertHosts > 0"/>
+                  <span v-else>!</span>
                 </template>
               </a-statistic>
             </router-link>


### PR DESCRIPTION
This improves the function to not show the red-dot status on host icon when there are no hosts in alert state. Instead a colour/theme matching exclaimation is show next to the host icon.

Minor polish issue, show host icon with red-dot when there are hosts in alert state:
 
<img width="380" alt="Screenshot 2023-10-25 at 4 16 40 PM" src="https://github.com/apache/cloudstack/assets/95203/4c3d0327-c62b-4a1d-86c0-5ae9db029ef7">

Or, just the colour-icon matching exclaimation when no hosts are in alert state:

<img width="358" alt="Screenshot 2023-10-25 at 4 17 30 PM" src="https://github.com/apache/cloudstack/assets/95203/dd4c462d-463c-4352-99fb-f410e228b060">

