### PR TITLE
ui: fix snapshot copy actions for non-rootadmins

### DIFF
--- a/ui/src/views/storage/SnapshotZones.vue
+++ b/ui/src/views/storage/SnapshotZones.vue
@@ -49,7 +49,7 @@
         </template>
         <template v-if="column.key === 'actions'">
           <tooltip-button
-            v-if="record.datastoretype==='Image' && record.state==='BackedUp'"
+            v-if="record.state==='BackedUp'"
             style="margin-right: 5px"
             :disabled="!(copyApi in $store.getters.apis)"
             :title="$t('label.action.copy.snapshot')"
@@ -57,7 +57,7 @@
             :loading="copyLoading"
             @onClick="showCopySnapshot(record)" />
           <tooltip-button
-            v-if="record.datastoretype==='Image' && record.state==='BackedUp'"
+            v-if="record.state==='BackedUp'"
             style="margin-right: 5px"
             :disabled="!(deleteApi in $store.getters.apis)"
             :title="$t('label.action.delete.snapshot')"


### PR DESCRIPTION
### Description

Fixes Snapshot copy, zone delete option not showing in UI for non-rootadmin roles.
We already use param in API call to filter backed up snapshot copies.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![Screenshot from 2023-10-31 18-17-27](https://github.com/apache/cloudstack/assets/153340/de6fe89a-fe5b-49a1-a0c9-716e86187f00)

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
