### PR TITLE
server: fix resource count updated unmanage vm

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -8494,9 +8494,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VM_STOP, vm.getAccountId(), vm.getDataCenterId(),
                     vm.getId(), vm.getHostName(), vm.getServiceOfferingId(), vm.getTemplateId(),
                     vm.getHypervisorType().toString(), VirtualMachine.class.getName(), vm.getUuid(), vm.isDisplayVm());
-            resourceCountDecrement(vm.getAccountId(), vm.isDisplayVm(), cpu, ram);
         }
-
         // VM destroy usage event
         UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VM_DESTROY, vm.getAccountId(), vm.getDataCenterId(),
                 vm.getId(), vm.getHostName(), vm.getServiceOfferingId(), vm.getTemplateId(),


### PR DESCRIPTION
### Description

This PR ensures that the resource counts are not decremented twice for a running VM while unmanaging.
Currently, the code does the same operation for a non-stopped VM twice. This could lead to resource count discrepancy for an account or domain.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Before fix:
- Create an account
- Deploy a VM for that account
- Observe the account limits and count
- Unmanage the VM
- Again observe the account limits and count. There will be some negative values for VM, CPU and memory as the resource counts have been decremented twice

```
(localcloud) 🐱 > list virtualmachines account=ACSuser
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "ACSUser",
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 500,
      "created": "2024-06-12T12:48:59+0000",
      "details": {
        "cpuOvercommitRatio": "2.0",
        "dataDiskController": "osdefault",
        "memoryOvercommitRatio": "1.0",
        "rootDiskController": "ide"
      },
      "displayname": "uservm",
      "displayvm": true,
      "domain": "ROOT",
      "domainid": "8ce79cd7-1d86-11ef-a886-1e0095000407",
      "guestosid": "8cf5785f-1d86-11ef-a886-1e0095000407",
      "haenable": false,
      "hasannotations": false,
      "hostcontrolstate": "Enabled",
      "hostid": "13b19f23-b01f-49b3-98bb-f708cc668b47",
      "hostname": "10.0.35.149",
      "hypervisor": "VMware",
      "id": "bab406c5-f235-4cd2-b365-10338d613f7a",
      "instancename": "i-4-10-VM",
      "isdynamicallyscalable": false,
      "lastupdated": "2024-06-12T12:49:18+0000",
      "memory": 512,
      "name": "uservm",
      "nic": [
        {
          "broadcasturi": "vlan://2047",
          "deviceid": "0",
          "extradhcpoption": [],
          "id": "30a97242-158e-41ae-ac4b-eefbc73d09a8",
          "isdefault": true,
          "isolationuri": "vlan://2047",
          "macaddress": "02:01:00:ce:00:01",
          "networkid": "fb6d8567-74d6-43cc-a4bb-539c165c5a63",
          "networkname": "usernet",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "L2"
        }
      ],
      "osdisplayname": "CentOS 5.3 (64-bit)",
      "ostypeid": "8cf5785f-1d86-11ef-a886-1e0095000407",
      "passwordenabled": false,
      "pooltype": "NetworkFilesystem",
      "receivedbytes": 0,
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "sentbytes": 0,
      "serviceofferingid": "7d856b41-9a5e-40c4-b96d-72217a82fa5f",
      "serviceofferingname": "Small Instance",
      "state": "Running",
      "tags": [],
      "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
      "templateformat": "OVA",
      "templateid": "8cf00de6-1d86-11ef-a886-1e0095000407",
      "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
      "templatetype": "BUILTIN",
      "userid": "cd6f78c9-ed6f-44ae-8733-570148c28540",
      "username": "user",
      "zoneid": "40e1cd6a-9353-4325-bd43-d0ffa691f10e",
      "zonename": "pr8601-t10311-vmware-67u3"
    }
  ]
}
(localcloud) 🐱 > list accounts id=39223f34-f465-438f-8d43-04ff0670514d 
{
  "account": [
    {
      "accounttype": 0,
      "cpuavailable": "39",
      "cpulimit": "40",
      "cputotal": 1,
      "created": "2024-05-29T06:48:57+0000",
      "domain": "ROOT",
      "domainid": "8ce79cd7-1d86-11ef-a886-1e0095000407",
      "domainpath": "ROOT",
      "groups": [],
      "id": "39223f34-f465-438f-8d43-04ff0670514d",
      "ipavailable": "16",
      "iplimit": "20",
      "iptotal": 0,
      "isdefault": false,
      "memoryavailable": "40448",
      "memorylimit": "40960",
      "memorytotal": 512,
      "name": "ACSUser",
      "networkavailable": "19",
      "networklimit": "20",
      "networktotal": 1,
      "primarystorageavailable": "198",
      "primarystoragelimit": "200",
      "primarystoragetotal": 2,
      "projectavailable": "Unlimited",
      "projectlimit": "Unlimited",
      "projecttotal": 0,
      "roleid": "a51b7f95-1d86-11ef-a886-1e0095000407",
      "rolename": "User",
      "roletype": "User",
      "secondarystorageavailable": "400.0",
      "secondarystoragelimit": "400",
      "secondarystoragetotal": 0,
      "snapshotavailable": "20",
      "snapshotlimit": "20",
      "snapshottotal": 0,
      "state": "enabled",
      "templateavailable": "20",
      "templatelimit": "20",
      "templatetotal": 0,
      "user": [
        {
          "account": "ACSUser",
          "accountid": "39223f34-f465-438f-8d43-04ff0670514d",
          "accounttype": 0,
          "created": "2024-05-29T06:49:01+0000",
          "domain": "ROOT",
          "domainid": "8ce79cd7-1d86-11ef-a886-1e0095000407",
          "email": "sblab@shapeblue.com",
          "firstname": "ACloudStack",
          "id": "cd6f78c9-ed6f-44ae-8733-570148c28540",
          "is2faenabled": false,
          "is2famandated": false,
          "iscallerchilddomain": false,
          "isdefault": false,
          "lastname": "User",
          "roleid": "a51b7f95-1d86-11ef-a886-1e0095000407",
          "rolename": "User",
          "roletype": "User",
          "state": "enabled",
          "timezone": "Etc/UTC",
          "username": "user",
          "usersource": "native"
        }
      ],
      "vmavailable": "19",
      "vmlimit": "20",
      "vmrunning": 1,
      "vmstopped": 0,
      "vmtotal": 1,
      "volumeavailable": "19",
      "volumelimit": "20",
      "volumetotal": 1,
      "vpcavailable": "20",
      "vpclimit": "20",
      "vpctotal": 0
    }
  ],
  "count": 1
}
(localcloud) 🐱 > unmanage virtualmachine id=bab406c5-f235-4cd2-b365-10338d613f7a 
{
  "unmanagevirtualmachineresponse": {
    "details": "VM unmanaged successfully",
    "success": true
  }
}
(localcloud) 🐱 > list accounts id=39223f34-f465-438f-8d43-04ff0670514d 
{
  "account": [
    {
      "accounttype": 0,
      "cpuavailable": "41",
      "cpulimit": "40",
      "cputotal": -1,
      "created": "2024-05-29T06:48:57+0000",
      "domain": "ROOT",
      "domainid": "8ce79cd7-1d86-11ef-a886-1e0095000407",
      "domainpath": "ROOT",
      "groups": [],
      "id": "39223f34-f465-438f-8d43-04ff0670514d",
      "ipavailable": "16",
      "iplimit": "20",
      "iptotal": 0,
      "isdefault": false,
      "memoryavailable": "41472",
      "memorylimit": "40960",
      "memorytotal": -512,
      "name": "ACSUser",
      "networkavailable": "19",
      "networklimit": "20",
      "networktotal": 1,
      "primarystorageavailable": "200",
      "primarystoragelimit": "200",
      "primarystoragetotal": 0,
      "projectavailable": "Unlimited",
      "projectlimit": "Unlimited",
      "projecttotal": 0,
      "roleid": "a51b7f95-1d86-11ef-a886-1e0095000407",
      "rolename": "User",
      "roletype": "User",
      "secondarystorageavailable": "400.0",
      "secondarystoragelimit": "400",
      "secondarystoragetotal": 0,
      "snapshotavailable": "20",
      "snapshotlimit": "20",
      "snapshottotal": 0,
      "state": "enabled",
      "templateavailable": "20",
      "templatelimit": "20",
      "templatetotal": 0,
      "user": [
        {
          "account": "ACSUser",
          "accountid": "39223f34-f465-438f-8d43-04ff0670514d",
          "accounttype": 0,
          "created": "2024-05-29T06:49:01+0000",
          "domain": "ROOT",
          "domainid": "8ce79cd7-1d86-11ef-a886-1e0095000407",
          "email": "sblab@shapeblue.com",
          "firstname": "ACloudStack",
          "id": "cd6f78c9-ed6f-44ae-8733-570148c28540",
          "is2faenabled": false,
          "is2famandated": false,
          "iscallerchilddomain": false,
          "isdefault": false,
          "lastname": "User",
          "roleid": "a51b7f95-1d86-11ef-a886-1e0095000407",
          "rolename": "User",
          "roletype": "User",
          "state": "enabled",
          "timezone": "Etc/UTC",
          "username": "user",
          "usersource": "native"
        }
      ],
      "vmavailable": "21",
      "vmlimit": "20",
      "vmrunning": 0,
      "vmstopped": 0,
      "vmtotal": -1,
      "volumeavailable": "20",
      "volumelimit": "20",
      "volumetotal": 0,
      "vpcavailable": "20",
      "vpclimit": "20",
      "vpctotal": 0
    }
  ],
  "count": 1
}
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
