### PR TITLE
Fix typo in ssvm check script

### DIFF
--- a/systemvm/agent/scripts/ssvm-check.sh
+++ b/systemvm/agent/scripts/ssvm-check.sh
@@ -103,10 +103,10 @@ else
     echo "Verifying if we can at least ping the storage"
     STORAGE_ADDRESSES=`grep "secondaryStorageServerAddress" $CMDLINE | sed -E 's/.*secondaryStorageServerAddress=([^ ]*).*/\1/g'`
 
-    if [[ -z "$STORAGE_ADDRESS" ]]
+    if [[ -z "$STORAGE_ADDRESSES" ]]
     then
       STORAGE_NETWORK_GATEWAY=`grep "storagegateway" $CMDLINE | sed -E 's/.*storagegateway=([^ ]*).*/\1/g'`
-      echo "Storage address is empty, trying to ping storage network gateway instead ($STORAGE_NETWORK_GATEWAY)"
+      echo "Storage addresses list is empty, trying to ping storage network gateway instead ($STORAGE_NETWORK_GATEWAY)"
       ping -c 2  $STORAGE_NETWORK_GATEWAY
       if [ $? -eq 0 ]
       then
@@ -118,7 +118,7 @@ else
       fi
     else
       echo "Storage address(s): $STORAGE_ADDRESSES, trying to ping"
-      STORAGE_ADDRESS_LIST=$(echo $STORAGE_ADDRESSES | tr ",")
+      STORAGE_ADDRESS_LIST=$(echo $STORAGE_ADDRESSES | tr "," "\n")
       for STORAGE_ADDRESS in $STORAGE_ADDRESS_LIST
       do
         echo "Pinging storage address: $STORAGE_ADDRESS"

--- a/systemvm/agent/scripts/ssvm-check.sh
+++ b/systemvm/agent/scripts/ssvm-check.sh
@@ -106,7 +106,7 @@ else
     if [[ -z "$STORAGE_ADDRESSES" ]]
     then
       STORAGE_NETWORK_GATEWAY=`grep "storagegateway" $CMDLINE | sed -E 's/.*storagegateway=([^ ]*).*/\1/g'`
-      echo "Storage addresses list is empty, trying to ping storage network gateway instead ($STORAGE_NETWORK_GATEWAY)"
+      echo "Storage address list is empty, trying to ping storage network gateway instead ($STORAGE_NETWORK_GATEWAY)"
       ping -c 2  $STORAGE_NETWORK_GATEWAY
       if [ $? -eq 0 ]
       then


### PR DESCRIPTION
### Description

This PR fixes a typo, which causes an incorrect check for the NFS connection.

```
ERROR: Storage nfs is not currently mounted
Verifying if we can at least ping the storage
Storage address is empty, trying to ping storage network gateway instead ()
ping: missing host operand
Try 'ping --help' or 'ping --usage' for more information.
WARNING: Cannot ping nfs storage network gateway
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

