### PR TITLE
Adding a default setter for domainPath in ControlledEntityResponse and populated the same in createNetworkResponse method of ApiResponseHelper  #8086

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/ControlledEntityResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ControlledEntityResponse.java
@@ -27,4 +27,6 @@ public interface ControlledEntityResponse {
     public void setDomainId(String domainId);
 
     public void setDomainName(String domainName);
+
+    public default void setDomainPath(String domainPath){}
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2583,9 +2583,10 @@ public class ApiResponseHelper implements ResponseGenerator {
                 Domain domain = ApiDBUtils.findDomainById(domainNetworkDetails.first());
                 if (domain != null) {
                     response.setDomainId(domain.getUuid());
-
-                    StringBuilder domainPath = new StringBuilder("ROOT");
-                    (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+                    StringBuilder domainPath = new StringBuilder();
+                    if(!ObjectUtils.isEmpty(domain.getPath())){
+                        (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+                    }
                     response.setDomainPath(domainPath.toString());
                 }
             }
@@ -2598,8 +2599,10 @@ public class ApiResponseHelper implements ResponseGenerator {
             if (domain != null) {
                 response.setDomainId(domain.getUuid());
                 response.setDomainName(domain.getName());
-                StringBuilder domainPath = new StringBuilder("ROOT");
-                (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+                StringBuilder domainPath = new StringBuilder();
+                if(!ObjectUtils.isEmpty(domain.getPath())){
+                    (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+                }
                 response.setDomainPath(domainPath.toString());
             }
 
@@ -2849,8 +2852,10 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(object.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
-        StringBuilder domainPath = new StringBuilder("ROOT");
-        (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+        StringBuilder domainPath = new StringBuilder();
+        if(!ObjectUtils.isEmpty(domain.getPath())){
+            (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+        }
         response.setDomainPath(domainPath.toString());
     }
 

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2583,14 +2583,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 Domain domain = ApiDBUtils.findDomainById(domainNetworkDetails.first());
                 if (domain != null) {
                     response.setDomainId(domain.getUuid());
-                    StringBuilder domainPath = new StringBuilder();
-                    if(ObjectUtils.isEmpty(domain.getPath()) || domain.getPath().equals("/")){
-                        domainPath.append("/");
-                    }
-                    else{
-                        (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
-                    }
-                    response.setDomainPath(domainPath.toString());
+                    response.setDomainPath(getDomainPath(domain.getPath()));
                 }
             }
             response.setSubdomainAccess(domainNetworkDetails.second());
@@ -2602,14 +2595,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             if (domain != null) {
                 response.setDomainId(domain.getUuid());
                 response.setDomainName(domain.getName());
-                StringBuilder domainPath = new StringBuilder();
-                if(ObjectUtils.isEmpty(domain.getPath()) || domain.getPath().equals("/")){
-                    domainPath.append("/");
-                }
-                else{
-                    (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
-                }
-                response.setDomainPath(domainPath.toString());
+                response.setDomainPath(getDomainPath(domain.getPath()));
             }
 
         }
@@ -2858,14 +2844,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(object.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
-        StringBuilder domainPath = new StringBuilder();
-        if(ObjectUtils.isEmpty(domain.getPath()) || domain.getPath().equals("/")){
-            domainPath.append("/");
-        }
-        else{
-            (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
-        }
-        response.setDomainPath(domainPath.toString());
+        response.setDomainPath(getDomainPath(domain.getPath()));
     }
 
     private void populateOwner(ControlledViewEntityResponse response, ControlledEntity object) {
@@ -5107,5 +5086,16 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setState(stateToSet);
         response.setObjectName("firewallrule");
         return response;
+    }
+
+    private String getDomainPath(String path){
+        StringBuilder domainPath = new StringBuilder();
+        if(ObjectUtils.isEmpty(path) || path.equals("/")){
+            domainPath.append("/");
+        }
+        else{
+            (domainPath.append(path)).deleteCharAt(domainPath.length() - 1);
+        }
+        return domainPath.toString();
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2584,7 +2584,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 if (domain != null) {
                     response.setDomainId(domain.getUuid());
                     StringBuilder domainPath = new StringBuilder();
-                    if(ObjectUtils.isEmpty(domain.getPath())){
+                    if(ObjectUtils.isEmpty(domain.getPath()) || domain.getPath().equals("/")){
                         domainPath.append("/");
                     }
                     else{
@@ -2603,7 +2603,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 response.setDomainId(domain.getUuid());
                 response.setDomainName(domain.getName());
                 StringBuilder domainPath = new StringBuilder();
-                if(ObjectUtils.isEmpty(domain.getPath())){
+                if(ObjectUtils.isEmpty(domain.getPath()) || domain.getPath().equals("/")){
                     domainPath.append("/");
                 }
                 else{
@@ -2859,7 +2859,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
         StringBuilder domainPath = new StringBuilder();
-        if(ObjectUtils.isEmpty(domain.getPath())){
+        if(ObjectUtils.isEmpty(domain.getPath()) || domain.getPath().equals("/")){
             domainPath.append("/");
         }
         else{

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2584,7 +2584,10 @@ public class ApiResponseHelper implements ResponseGenerator {
                 if (domain != null) {
                     response.setDomainId(domain.getUuid());
                     StringBuilder domainPath = new StringBuilder();
-                    if(!ObjectUtils.isEmpty(domain.getPath())){
+                    if(ObjectUtils.isEmpty(domain.getPath())){
+                        domainPath.append("/");
+                    }
+                    else{
                         (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
                     }
                     response.setDomainPath(domainPath.toString());
@@ -2600,7 +2603,10 @@ public class ApiResponseHelper implements ResponseGenerator {
                 response.setDomainId(domain.getUuid());
                 response.setDomainName(domain.getName());
                 StringBuilder domainPath = new StringBuilder();
-                if(!ObjectUtils.isEmpty(domain.getPath())){
+                if(ObjectUtils.isEmpty(domain.getPath())){
+                    domainPath.append("/");
+                }
+                else{
                     (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
                 }
                 response.setDomainPath(domainPath.toString());
@@ -2853,7 +2859,10 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
         StringBuilder domainPath = new StringBuilder();
-        if(!ObjectUtils.isEmpty(domain.getPath())){
+        if(ObjectUtils.isEmpty(domain.getPath())){
+            domainPath.append("/");
+        }
+        else{
             (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
         }
         response.setDomainPath(domainPath.toString());

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2598,6 +2598,9 @@ public class ApiResponseHelper implements ResponseGenerator {
             if (domain != null) {
                 response.setDomainId(domain.getUuid());
                 response.setDomainName(domain.getName());
+                StringBuilder domainPath = new StringBuilder("ROOT");
+                (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+                response.setDomainPath(domainPath.toString());
             }
 
         }
@@ -2846,6 +2849,9 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(object.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
+        StringBuilder domainPath = new StringBuilder("ROOT");
+        (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
+        response.setDomainPath(domainPath.toString());
     }
 
     private void populateOwner(ControlledViewEntityResponse response, ControlledEntity object) {


### PR DESCRIPTION

### Description

- Adding a default method setDomainPath in ControlledEntityResponse to avoid creating a variable and setter definitions in all implementations of ControlledEntityResponse  class. 
- and populated the same in createNetworkResponse method of ApiResponseHelper

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
**Before-**
![Screenshot from 2023-11-09 16-14-55](https://github.com/apache/cloudstack/assets/12611123/45a80502-f30d-4654-a326-56f80daa8dd0)

**After-**
![Screenshot from 2023-11-09 16-15-17](https://github.com/apache/cloudstack/assets/12611123/2603c223-677f-4dce-b435-0b3d9a99fe54)





### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
Created a guest network and called the `list networks filter=name,type,domainpath`  before and after the code change

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
