### PR TITLE
Introduce domainid and account parameter in createTemplate API

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java
@@ -252,9 +252,7 @@ public class CreateTemplateCmd extends BaseAsyncCreateCmd implements UserCmd {
     @Override
     public long getEntityOwnerId() {
         Account callingAccount = CallContext.current().getCallingAccount();
-        // Perform access check on volume/snapshot for callingAccount
         ensureAccessCheck(callingAccount);
-        // Obtain accountIdToUse using (account and domainId) | projectId
         return findAccountIdToUse(callingAccount);
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java
@@ -46,7 +46,6 @@ import com.cloud.event.EventTypes;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.PermissionDeniedException;
 import com.cloud.exception.ResourceAllocationException;
-import com.cloud.projects.Project;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.Volume;
 import com.cloud.template.VirtualMachineTemplate;
@@ -141,10 +140,14 @@ public class CreateTemplateCmd extends BaseAsyncCreateCmd implements UserCmd {
     @Parameter(name = ApiConstants.DOMAIN_ID,
           type = CommandType.UUID,
           entityType = DomainResponse.class,
-          description = "an optional domainId. If the account parameter is used, domainId must also be used.")
+          description = "an optional domainId. If the account parameter is used, domainId must also be used.",
+          since = "4.19.0")
     private Long domainId;
 
-    @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "an optional accountName. Must be used with domainId.")
+    @Parameter(name = ApiConstants.ACCOUNT,
+          type = CommandType.STRING,
+          description = "an optional accountName. Must be used with domainId.",
+          since = "4.19.0")
     private String accountName;
 
     // ///////////////////////////////////////////////////
@@ -248,53 +251,13 @@ public class CreateTemplateCmd extends BaseAsyncCreateCmd implements UserCmd {
 
     @Override
     public long getEntityOwnerId() {
-        Long volumeId = getVolumeId();
-        Long snapshotId = getSnapshotId();
         Account callingAccount = CallContext.current().getCallingAccount();
-        if (volumeId != null) {
-            Volume volume = _entityMgr.findById(Volume.class, volumeId);
-            if (volume != null) {
-                _accountService.checkAccess(callingAccount, SecurityChecker.AccessType.UseEntry, false, volume);
-            } else {
-                throw new InvalidParameterValueException("Unable to find volume by id=" + volumeId);
-            }
-        } else {
-            Snapshot snapshot = _entityMgr.findById(Snapshot.class, snapshotId);
-            if (snapshot != null) {
-                _accountService.checkAccess(callingAccount, SecurityChecker.AccessType.UseEntry, false, snapshot);
-            } else {
-                throw new InvalidParameterValueException("Unable to find snapshot by id=" + snapshotId);
-            }
-        }
-
-        Account accountToUse = callingAccount;
-        if (accountName != null && domainId != null) {
-            try {
-                accountToUse = _accountService.getAccount(_accountService.finalyzeAccountId(accountName, domainId, projectId, true));
-
-            } catch (Exception exception) {
-                s_logger.info("Unable to find accountId associated with accountName=" + accountName + " and domainId="
-                      + domainId + " using account=" + accountToUse);
-            }
-        } else if (projectId != null) {
-            final Project project = _projectService.getProject(projectId);
-            if (project != null) {
-                if (project.getState() == Project.State.Active) {
-                    accountToUse = _accountService.getAccount(project.getProjectAccountId());
-                    _accountService.checkAccess(callingAccount, SecurityChecker.AccessType.UseEntry, false, accountToUse);
-                } else {
-                    final PermissionDeniedException ex =
-                          new PermissionDeniedException("Can't add resources to the project with specified projectId in state=" + project.getState() +
-                                " as it's no longer active");
-                    ex.addProxyObject(project.getUuid(), "projectId");
-                    throw ex;
-                }
-            } else {
-                throw new InvalidParameterValueException("Unable to find project by id");
-            }
-        }
-        return accountToUse.getId();
+        // Perform access check on volume/snapshot for callingAccount
+        ensureAccessCheck(callingAccount);
+        // Obtain accountIdToUse using (account and domainId) | projectId
+        return findAccountIdToUse(callingAccount);
     }
+
 
     @Override
     public String getEventType() {
@@ -352,5 +315,48 @@ public class CreateTemplateCmd extends BaseAsyncCreateCmd implements UserCmd {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to create private template");
         }
 
+    }
+
+    /***
+     * Performs access check on volume and snapshot for given account
+     * @param account
+     */
+    private void ensureAccessCheck(Account account) {
+        if (volumeId != null) {
+            Volume volume = _entityMgr.findById(Volume.class, volumeId);
+            if (volume != null) {
+                _accountService.checkAccess(account, SecurityChecker.AccessType.UseEntry, false, volume);
+            } else {
+                throw new InvalidParameterValueException("Unable to find volume by id=" + volumeId);
+            }
+        } else {
+            Snapshot snapshot = _entityMgr.findById(Snapshot.class, snapshotId);
+            if (snapshot != null) {
+                _accountService.checkAccess(account, SecurityChecker.AccessType.UseEntry, false, snapshot);
+            } else {
+                throw new InvalidParameterValueException("Unable to find snapshot by id=" + snapshotId);
+            }
+        }
+    }
+
+    /***
+     * Find accountId based on accountName and domainId or projectId
+     * if not found, return callingAccountId for further use
+     * @param callingAccount
+     * @return accountId
+     */
+    private Long findAccountIdToUse(Account callingAccount) {
+        Long accountIdToUse = null;
+        try {
+            accountIdToUse = _accountService.finalyzeAccountId(accountName, domainId, projectId, true);
+        } catch (InvalidParameterValueException | PermissionDeniedException ex) {
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("An exception occurred while finalizing account id with accountName, domainId and projectId" +
+                      "using callingAccountId=%s", callingAccount.getUuid()), ex);
+            }
+            s_logger.warn("Unable to find accountId associated with accountName=" + accountName + " and domainId="
+                  + domainId + " or projectId=" + projectId + ", using callingAccountId=" + callingAccount.getUuid());
+        }
+        return accountIdToUse != null ? accountIdToUse : callingAccount.getAccountId();
     }
 }

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmdTest.java
@@ -29,4 +29,12 @@ public class CreateTemplateCmdTest {
         ReflectionTestUtils.setField(cmd, "zoneId", id);
         Assert.assertEquals(id, cmd.getZoneId());
     }
+
+    @Test
+    public void testDomainId() {
+        final CreateTemplateCmd cmd = new CreateTemplateCmd();
+        Long id = 2L;
+        ReflectionTestUtils.setField(cmd, "domainId", id);
+        Assert.assertEquals(id, cmd.getDomainId());
+    }
 }

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmdTest.java
@@ -37,4 +37,12 @@ public class CreateTemplateCmdTest {
         ReflectionTestUtils.setField(cmd, "domainId", id);
         Assert.assertEquals(id, cmd.getDomainId());
     }
+
+    @Test
+    public void testGetAccountName() {
+        final CreateTemplateCmd cmd = new CreateTemplateCmd();
+        String accountName = "user1";
+        ReflectionTestUtils.setField(cmd, "accountName", accountName);
+        Assert.assertEquals(accountName, cmd.getAccountName());
+    }
 }


### PR DESCRIPTION
### Description
This PR introduces domainid and account as optional parameter for createTemplate API. It will allow admin to create templates for specified domain belonging to specific account.

Fixes: https://github.com/apache/cloudstack/issues/5793#issuecomment-1792003872

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
<img width="1431" alt="Screenshot 2023-11-09 at 6 57 07 PM" src="https://github.com/apache/cloudstack/assets/2009663/caf6db14-8edf-4b4f-a2d6-7643b56f35d2">
<img width="1431" alt="Screenshot 2023-11-09 at 6 57 39 PM" src="https://github.com/apache/cloudstack/assets/2009663/657c433d-0205-45f4-9830-98e4c1e41444">
<img width="1156" alt="Screenshot 2023-11-09 at 7 02 32 PM" src="https://github.com/apache/cloudstack/assets/2009663/e7973215-cfd3-4176-8470-654e3f6ee8c7">
<img width="1156" alt="Screenshot 2023-11-09 at 8 10 44 PM" src="https://github.com/apache/cloudstack/assets/2009663/b7aea8be-a483-43f2-a8fe-1392383a0c88">




### How Has This Been Tested?
It's tested using 2 different users belonging to separate domains, 
- Create two domains - d1 and d2
- Create normal user accounts in both domains - u1 and u2, associated them to d1 and d2 respectively
- Deploy a VM, vm1, with u1,  stop it; repeat steps with u2 account
- Using ROOT admin try creating template using vol_u1, passing account u1 and domain d1
- Using ROOT admin try creating template using vol_u1, passing account u2 and domain d2
- Using ROOT admin try creating template using vol_u2, passing account u2 and domain d2
- Using ROOT admin try creating template using vol_u2, passing account u1 and domain d1 
- Using ROOT admin try creating a template using vm1's volume and vm2's volume without passing domain and account

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
