### PR TITLE
Let Prometheus exporter plugin support utf8 characters

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
@@ -59,7 +59,7 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
                 responseCode = 200;
             }
             byte[] bytesToOutput = response.getBytes(StandardCharsets.UTF_8);
-            httpExchange.getResponseHeaders().set("content-type", "text/plain");
+            httpExchange.getResponseHeaders().set("content-type", "text/plain; charset=UTF-8");
             httpExchange.sendResponseHeaders(responseCode, bytesToOutput.length);
             final OutputStream os = httpExchange.getResponseBody();
             try {

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class PrometheusExporterServerImpl extends ManagerBase implements PrometheusExporterServer, Configurable {
@@ -57,11 +58,21 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
                 response = prometheusExporter.getMetrics();
                 responseCode = 200;
             }
+            byte[] bytesToOutput = response.getBytes(StandardCharsets.UTF_8);
             httpExchange.getResponseHeaders().set("content-type", "text/plain");
-            httpExchange.sendResponseHeaders(responseCode, response.length());
+            httpExchange.sendResponseHeaders(responseCode, bytesToOutput.length);
             final OutputStream os = httpExchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
+            try {
+                os.write(bytesToOutput);
+            } catch (IOException e) {
+                LOG.error(String.format("could not export Prometheus data due to %s", e.getLocalizedMessage()));
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Error during Prometheus export: ", e);
+                }
+                os.write("The system could not export Prometheus due to an internal error. Contact your operator to learn about the reason.".getBytes());
+            } finally {
+                os.close();
+            }
         }
     }
 


### PR DESCRIPTION
### Description

This PR fixes a bug where the length of the httpresponse was set to the length of the contents before unicode conversion. Any non english  character would break this.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #8203

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
in simulator,
- the prometheus exporter was enabled
- domains with names ééñ and 中文 were created
- a curl done

```
cloudstack_domain_resource_count{domain="/", type="memory"} 0
cloudstack_domain_resource_count{domain="/", type="cpu"} 0
cloudstack_domain_resource_count{domain="/", type="primary_storage"} 0
cloudstack_domain_resource_count{domain="/", type="secondary_storage"} 4294967296
cloudstack_domain_resource_count{domain="/ééñ/", type="memory"} 0
cloudstack_domain_resource_count{domain="/ééñ/", type="cpu"} 0
cloudstack_domain_resource_count{domain="/ééñ/", type="primary_storage"} 0
cloudstack_domain_resource_count{domain="/ééñ/", type="secondary_storage"} 0
cloudstack_domain_resource_count{domain="/中文/", type="memory"} 0
cloudstack_domain_resource_count{domain="/中文/", type="cpu"} 0
cloudstack_domain_resource_count{domain="/中文/", type="primary_storage"} 0
cloudstack_domain_resource_count{domain="/中文/", type="secondary_storage"} 0
```