### PR TITLE
Allow altering only either CPU or memory during VM live scale

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1237,9 +1237,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     protected void updateInstanceDetails (Map<String, String> details, VirtualMachine vmInstance, Long newServiceOfferingId) {
         ServiceOfferingVO currentServiceOffering = serviceOfferingDao.findByIdIncludingRemoved(vmInstance.getId(), vmInstance.getServiceOfferingId());
         ServiceOfferingVO newServiceOffering = serviceOfferingDao.findById(newServiceOfferingId);
-        updateInstanceDetailsWithCurrentValue(newServiceOffering.getSpeed(), details, VmDetailConstants.CPU_SPEED, currentServiceOffering.getSpeed());
-        updateInstanceDetailsWithCurrentValue(newServiceOffering.getRamSize(), details, VmDetailConstants.MEMORY, currentServiceOffering.getRamSize());
-        updateInstanceDetailsWithCurrentValue(newServiceOffering.getCpu(), details, VmDetailConstants.CPU_NUMBER, currentServiceOffering.getCpu());
+        updateInstanceDetailsKeepCurrentValueIfNull(newServiceOffering.getSpeed(), details, VmDetailConstants.CPU_SPEED, currentServiceOffering.getSpeed());
+        updateInstanceDetailsKeepCurrentValueIfNull(newServiceOffering.getRamSize(), details, VmDetailConstants.MEMORY, currentServiceOffering.getRamSize());
+        updateInstanceDetailsKeepCurrentValueIfNull(newServiceOffering.getCpu(), details, VmDetailConstants.CPU_NUMBER, currentServiceOffering.getCpu());
     }
 
     /**
@@ -1251,7 +1251,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
      * @param currentValue     the current value of the detail constant
      */
 
-    protected void updateInstanceDetailsWithCurrentValue(Integer newValue, Map<String, String> details, String detailsConstant, Integer currentValue) {
+    protected void updateInstanceDetailsKeepCurrentValueIfNull(Integer newValue, Map<String, String> details, String detailsConstant, Integer currentValue) {
         if (newValue == null && details.get(detailsConstant) == null) {
             String currentValueString = String.valueOf(currentValue);
             s_logger.debug(String.format("[%s] was not specified, keeping the current value: [%s].", detailsConstant, currentValueString));

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1925,7 +1925,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
         CallContext.current().setEventDetails("Vm Id: " + vm.getUuid());
 
-//        boolean result = upgradeVirtualMachine(vmId, newServiceOfferingId, cmd.getDetails());
         Map<String, String> cmdDetails = cmd.getDetails();
 
         updateInstanceDetails(cmdDetails, vm, newServiceOfferingId);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1254,7 +1254,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     protected void updateInstanceDetailsKeepCurrentValueIfNull(Integer newValue, Map<String, String> details, String detailsConstant, Integer currentValue) {
         if (newValue == null && details.get(detailsConstant) == null) {
             String currentValueString = String.valueOf(currentValue);
-            s_logger.debug(String.format("[%s] was not specified, keeping the current value: [%s].", detailsConstant, currentValueString));
+            logger.debug("{} was not specified, keeping the current value: {}.", detailsConstant, currentValueString);
             details.put(detailsConstant, currentValueString);
         }
     }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -400,7 +400,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     @Inject
     private VMTemplateZoneDao _templateZoneDao;
     @Inject
-    private TemplateDataStoreDao _templateStoreDao;
+    protected TemplateDataStoreDao _templateStoreDao;
     @Inject
     private DomainDao _domainDao;
     @Inject
@@ -1227,6 +1227,39 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         return userVm;
     }
 
+    /**
+     Updates the instance details map with the current values of the instance for the CPU speed, memory, and CPU number if they have not been specified.
+     @param details Map containing the instance details.
+     @param vmInstance The virtual machine instance.
+     @param newServiceOfferingId The ID of the new service offering.
+     */
+
+    protected void updateInstanceDetails (Map<String, String> details, VirtualMachine vmInstance, Long newServiceOfferingId) {
+        ServiceOfferingVO currentServiceOffering = serviceOfferingDao.findByIdIncludingRemoved(vmInstance.getId(), vmInstance.getServiceOfferingId());
+        ServiceOfferingVO newServiceOffering = serviceOfferingDao.findById(newServiceOfferingId);
+        updateInstanceDetailsWithCurrentValue(newServiceOffering.getSpeed(), details, VmDetailConstants.CPU_SPEED, currentServiceOffering.getSpeed());
+        updateInstanceDetailsWithCurrentValue(newServiceOffering.getRamSize(), details, VmDetailConstants.MEMORY, currentServiceOffering.getRamSize());
+        updateInstanceDetailsWithCurrentValue(newServiceOffering.getCpu(), details, VmDetailConstants.CPU_NUMBER, currentServiceOffering.getCpu());
+    }
+
+    /**
+     * Updates a specific instance detail with the current instance value if the new value is null.
+     *
+     * @param newValue         the new value to be set
+     * @param details          a map of instance details
+     * @param detailsConstant  the name of the detail constant to be updated
+     * @param currentValue     the current value of the detail constant
+     */
+
+    protected void updateInstanceDetailsWithCurrentValue(Integer newValue, Map<String, String> details, String detailsConstant, Integer currentValue) {
+        if (newValue == null && details.get(detailsConstant) == null) {
+            String currentValueString = String.valueOf(currentValue);
+            s_logger.debug(String.format("[%s] was not specified, keeping the current value: [%s].", detailsConstant, currentValueString));
+            details.put(detailsConstant, currentValueString);
+        }
+    }
+
+
     private void validateOfferingMaxResource(ServiceOfferingVO offering) {
         Integer maxCPUCores = ConfigurationManagerImpl.VM_SERVICE_OFFERING_MAX_CPU_CORES.value() == 0 ? Integer.MAX_VALUE: ConfigurationManagerImpl.VM_SERVICE_OFFERING_MAX_CPU_CORES.value();
         if (offering.getCpu() > maxCPUCores) {
@@ -1892,7 +1925,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
         CallContext.current().setEventDetails("Vm Id: " + vm.getUuid());
 
-        boolean result = upgradeVirtualMachine(vmId, newServiceOfferingId, cmd.getDetails());
+//        boolean result = upgradeVirtualMachine(vmId, newServiceOfferingId, cmd.getDetails());
+        Map<String, String> cmdDetails = cmd.getDetails();
+
+        updateInstanceDetails(cmdDetails, vm, newServiceOfferingId);
+
+        boolean result = upgradeVirtualMachine(vmId, newServiceOfferingId, cmdDetails);
         if (result) {
             UserVmVO vmInstance = _vmDao.findById(vmId);
             if (vmInstance.getState().equals(State.Stopped)) {

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -1406,11 +1406,11 @@ public class UserVmManagerImplTest {
     }
 
     @Test
-    public void updateInstanceDetailsWithCurrentValueTestDetailsConstantIsNotNullDoNothing() {
+    public void updateInstanceDetailsKeepCurrentValueIfNullTestDetailsConstantIsNotNullDoNothing() {
         int currentValue = 123;
 
         for (String detailsConstant : detailsConstants) {
-            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(null, customParameters, detailsConstant, currentValue);
+            userVmManagerImpl.updateInstanceDetailsKeepCurrentValueIfNull(null, customParameters, detailsConstant, currentValue);
         }
 
         Assert.assertEquals(customParameters.get(VmDetailConstants.MEMORY), "2048");
@@ -1419,12 +1419,12 @@ public class UserVmManagerImplTest {
     }
 
     @Test
-    public void updateInstanceDetailsWithCurrentValueTestNewValueIsNotNullDoNothing() {
+    public void updateInstanceDetailsKeepCurrentValueIfNullTestNewValueIsNotNullDoNothing() {
         Map<String, String> details = new HashMap<>();
         int currentValue = 123;
 
         for (String detailsConstant : detailsConstants) {
-            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(321, details, detailsConstant, currentValue);
+            userVmManagerImpl.updateInstanceDetailsKeepCurrentValueIfNull(321, details, detailsConstant, currentValue);
         }
 
         Assert.assertNull(details.get(VmDetailConstants.MEMORY));
@@ -1433,12 +1433,12 @@ public class UserVmManagerImplTest {
     }
 
     @Test
-    public void updateInstanceDetailsWithCurrentValueTestBothValuesAreNullKeepCurrentValue() {
+    public void updateInstanceDetailsKeepCurrentValueIfNullTestBothValuesAreNullKeepCurrentValue() {
         Map<String, String> details = new HashMap<>();
         int currentValue = 123;
 
         for (String detailsConstant : detailsConstants) {
-            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(null, details, detailsConstant, currentValue);
+            userVmManagerImpl.updateInstanceDetailsKeepCurrentValueIfNull(null, details, detailsConstant, currentValue);
         }
 
         Assert.assertEquals(details.get(VmDetailConstants.MEMORY), String.valueOf(currentValue));
@@ -1447,11 +1447,11 @@ public class UserVmManagerImplTest {
     }
 
     @Test
-    public void updateInstanceDetailsWithCurrentValueTestNeitherValueIsNullDoNothing() {
+    public void updateInstanceDetailsKeepCurrentValueIfNullTestNeitherValueIsNullDoNothing() {
         int currentValue = 123;
 
         for (String detailsConstant : detailsConstants) {
-            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(321, customParameters, detailsConstant, currentValue);
+            userVmManagerImpl.updateInstanceDetailsKeepCurrentValueIfNull(321, customParameters, detailsConstant, currentValue);
         }
 
         Assert.assertEquals(customParameters.get(VmDetailConstants.MEMORY), "2048");
@@ -1467,8 +1467,8 @@ public class UserVmManagerImplTest {
         Mockito.doReturn(serviceOffering).when(_serviceOfferingDao).findByIdIncludingRemoved(Mockito.anyLong(), Mockito.anyLong());
         userVmManagerImpl.updateInstanceDetails(null, vmInstanceMock, 0l);
 
-        Mockito.verify(userVmManagerImpl).updateInstanceDetailsWithCurrentValue(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.CPU_SPEED), Mockito.any());
-        Mockito.verify(userVmManagerImpl).updateInstanceDetailsWithCurrentValue(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.MEMORY), Mockito.any());
-        Mockito.verify(userVmManagerImpl).updateInstanceDetailsWithCurrentValue(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.CPU_NUMBER), Mockito.any());
+        Mockito.verify(userVmManagerImpl).updateInstanceDetailsKeepCurrentValueIfNull(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.CPU_SPEED), Mockito.any());
+        Mockito.verify(userVmManagerImpl).updateInstanceDetailsKeepCurrentValueIfNull(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.MEMORY), Mockito.any());
+        Mockito.verify(userVmManagerImpl).updateInstanceDetailsKeepCurrentValueIfNull(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.CPU_NUMBER), Mockito.any());
     }
 }

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -263,6 +263,9 @@ public class UserVmManagerImplTest {
     @Mock
     ServiceOfferingJoinDao serviceOfferingJoinDao;
 
+    @Mock
+    private VMInstanceVO vmInstanceMock;
+
     private static final long vmId = 1l;
     private static final long zoneId = 2L;
     private static final long accountId = 3L;
@@ -272,6 +275,8 @@ public class UserVmManagerImplTest {
     private static final long GiB_TO_BYTES = 1024 * 1024 * 1024;
 
     private Map<String, String> customParameters = new HashMap<>();
+
+    String[] detailsConstants = {VmDetailConstants.MEMORY, VmDetailConstants.CPU_NUMBER, VmDetailConstants.CPU_SPEED};
 
     private DiskOfferingVO smallerDisdkOffering = prepareDiskOffering(5l * GiB_TO_BYTES, 1l, 1L, 2L);
     private DiskOfferingVO largerDisdkOffering = prepareDiskOffering(10l * GiB_TO_BYTES, 2l, 10L, 20L);
@@ -289,6 +294,10 @@ public class UserVmManagerImplTest {
         CallContext.register(callerUser, callerAccount);
 
         customParameters.put(VmDetailConstants.ROOT_DISK_SIZE, "123");
+        customParameters.put(VmDetailConstants.MEMORY, "2048");
+        customParameters.put(VmDetailConstants.CPU_NUMBER, "4");
+        customParameters.put(VmDetailConstants.CPU_SPEED, "1000");
+
         lenient().doNothing().when(resourceLimitMgr).incrementResourceCount(anyLong(), any(Resource.ResourceType.class));
         lenient().doNothing().when(resourceLimitMgr).decrementResourceCount(anyLong(), any(Resource.ResourceType.class), anyLong());
 
@@ -1394,5 +1403,72 @@ public class UserVmManagerImplTest {
         when(vmSnapshotDaoMock.findByVm(vmId)).thenReturn(vmSnapshots);
 
         userVmManagerImpl.restoreVirtualMachine(accountMock, vmId, newTemplateId);
+    }
+
+    @Test
+    public void updateInstanceDetailsWithCurrentValueTestDetailsConstantIsNotNullDoNothing() {
+        int currentValue = 123;
+
+        for (String detailsConstant : detailsConstants) {
+            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(null, customParameters, detailsConstant, currentValue);
+        }
+
+        Assert.assertEquals(customParameters.get(VmDetailConstants.MEMORY), "2048");
+        Assert.assertEquals(customParameters.get(VmDetailConstants.CPU_NUMBER), "4");
+        Assert.assertEquals(customParameters.get(VmDetailConstants.CPU_SPEED), "1000");
+    }
+
+    @Test
+    public void updateInstanceDetailsWithCurrentValueTestNewValueIsNotNullDoNothing() {
+        Map<String, String> details = new HashMap<>();
+        int currentValue = 123;
+
+        for (String detailsConstant : detailsConstants) {
+            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(321, details, detailsConstant, currentValue);
+        }
+
+        Assert.assertNull(details.get(VmDetailConstants.MEMORY));
+        Assert.assertNull(details.get(VmDetailConstants.CPU_NUMBER));
+        Assert.assertNull(details.get(VmDetailConstants.CPU_SPEED));
+    }
+
+    @Test
+    public void updateInstanceDetailsWithCurrentValueTestBothValuesAreNullKeepCurrentValue() {
+        Map<String, String> details = new HashMap<>();
+        int currentValue = 123;
+
+        for (String detailsConstant : detailsConstants) {
+            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(null, details, detailsConstant, currentValue);
+        }
+
+        Assert.assertEquals(details.get(VmDetailConstants.MEMORY), String.valueOf(currentValue));
+        Assert.assertEquals(details.get(VmDetailConstants.CPU_NUMBER), String.valueOf(currentValue));
+        Assert.assertEquals(details.get(VmDetailConstants.CPU_SPEED),String.valueOf(currentValue));
+    }
+
+    @Test
+    public void updateInstanceDetailsWithCurrentValueTestNeitherValueIsNullDoNothing() {
+        int currentValue = 123;
+
+        for (String detailsConstant : detailsConstants) {
+            userVmManagerImpl.updateInstanceDetailsWithCurrentValue(321, customParameters, detailsConstant, currentValue);
+        }
+
+        Assert.assertEquals(customParameters.get(VmDetailConstants.MEMORY), "2048");
+        Assert.assertEquals(customParameters.get(VmDetailConstants.CPU_NUMBER), "4");
+        Assert.assertEquals(customParameters.get(VmDetailConstants.CPU_SPEED),"1000");
+    }
+
+    @Test
+    public void updateInstanceDetailsTestAllConstantsAreUpdated() {
+        Mockito.doReturn(serviceOffering).when(_serviceOfferingDao).findById(Mockito.anyLong());
+        Mockito.doReturn(1L).when(vmInstanceMock).getId();
+        Mockito.doReturn(1L).when(vmInstanceMock).getServiceOfferingId();
+        Mockito.doReturn(serviceOffering).when(_serviceOfferingDao).findByIdIncludingRemoved(Mockito.anyLong(), Mockito.anyLong());
+        userVmManagerImpl.updateInstanceDetails(null, vmInstanceMock, 0l);
+
+        Mockito.verify(userVmManagerImpl).updateInstanceDetailsWithCurrentValue(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.CPU_SPEED), Mockito.any());
+        Mockito.verify(userVmManagerImpl).updateInstanceDetailsWithCurrentValue(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.MEMORY), Mockito.any());
+        Mockito.verify(userVmManagerImpl).updateInstanceDetailsWithCurrentValue(Mockito.any(), Mockito.any(), Mockito.eq(VmDetailConstants.CPU_NUMBER), Mockito.any());
     }
 }


### PR DESCRIPTION
### Description

The API  `scaleVirtualMachine`  requires the specification of both vCPU quantity and memory amount, resulting in an error if either was omitted. This means that if an operator wants to increase the quantity of vCPUs while maintaining the existing memory, they were obligate to provide the current memory value as well.

An alteration has been introduced to the API to allow operators to input only the parameters they intend to modify while retaining the current values for the rest.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

I applied the changes in a local lab and verified that if I used the API while inputting only one of the parameters, the scale was successful, and the  others kept the current value.