### PR TITLE
Fixed Hashmap Key value comparision

### DIFF
--- a/engine/schema/src/test/java/com/cloud/network/as/AutoScaleVmProfileVOTest.java
+++ b/engine/schema/src/test/java/com/cloud/network/as/AutoScaleVmProfileVOTest.java
@@ -17,6 +17,7 @@
 package com.cloud.network.as;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,14 +43,14 @@ public class AutoScaleVmProfileVOTest {
     public void testCounterParamsForUpdate() {
         AutoScaleVmProfileVO profile = new AutoScaleVmProfileVO();
 
-        Map<String, HashMap<String, String>> counterParamList = new HashMap<>();
-        counterParamList.put("0", new HashMap<>() {{ put("name", "snmpcommunity"); put("value", "public"); }});
-        counterParamList.put("1", new HashMap<>() {{ put("name", "snmpport"); put("value", "161"); }});
+        Map<String, LinkedHashMap<String, String>> counterParamList = new LinkedHashMap<>();
+        counterParamList.put("0", new LinkedHashMap<>() {{ put("name", "snmpcommunity"); put("value", "public"); }});
+        counterParamList.put("1", new LinkedHashMap<>() {{ put("name", "snmpport"); put("value", "161"); }});
 
         profile.setCounterParamsForUpdate(counterParamList);
         Assert.assertEquals("snmpcommunity=public&snmpport=161", profile.getCounterParamsString());
+        List<Pair<String, String>> counterParams = profile.getCounterParams();
 
-        List<Pair<String, String>>  counterParams = profile.getCounterParams();
         Assert.assertEquals(2, counterParams.size());
         Assert.assertEquals("snmpcommunity", counterParams.get(0).first());
         Assert.assertEquals("public", counterParams.get(0).second());
@@ -69,10 +70,17 @@ public class AutoScaleVmProfileVOTest {
 
         List<Pair<String, String>> otherDeployParamsList = profile.getOtherDeployParamsList();
         Assert.assertEquals(2, otherDeployParamsList.size());
-        Assert.assertEquals("serviceofferingid", otherDeployParamsList.get(0).first());
-        Assert.assertEquals("a7fb50f6-01d9-11ed-8bc1-77f8f0228926", otherDeployParamsList.get(0).second());
-        Assert.assertEquals("rootdisksize", otherDeployParamsList.get(1).first());
-        Assert.assertEquals("10", otherDeployParamsList.get(1).second());
+        Assert.assertTrue(containsPair(otherDeployParamsList, "serviceofferingid", "a7fb50f6-01d9-11ed-8bc1-77f8f0228926"));
+        Assert.assertTrue(containsPair(otherDeployParamsList, "rootdisksize", "10"));
+    }
+
+    private boolean containsPair(List<Pair<String, String>> list, String key, String value) {
+        for (Pair<String, String> pair : list) {
+            if (key.equals(pair.first()) && value.equals(pair.second())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Test


### PR DESCRIPTION
### Description
The PR fixes the following tests which could produce non-deterministic/flaky pass/fail result
`com.cloud.network.as.AutoScaleVmProfileVOTest#tstSetOtherDeployParamsForUpdate`
`com.cloud.network.as.AutoScaleVmProfileVOTest#testCounterParamsForUpdate`

### Setup:
Java version: 11.0.20.1
Maven version: 3.8.8

### Test failure reproduction:
The tests compares the keys and values of hashmap (based on index) with hardcoded string and asserts if they are equal. However, the order of key value pairs within hashmap is not gauranteed. Hence the test can fail. This issue was verified using the [NonDex plugin](https://github.com/TestingResearchIllinois/NonDex).

### Steps
```
git clone https://github.com/apache/cloudstack.git
cd cloudstack
mvn install -pl engine/schema -am -DskipTests
mvn -pl engine/schema edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloud.network.as.AutoScaleVmProfileVOTest#tstSetOtherDeployParamsForUpdate
```

### Root cause and fix

Test Failue in Nondex Mode
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.068 s <<< FAILURE! - in com.cloud.network.as.AutoScaleVmProfileVOTest
[ERROR] tstSetOtherDeployParamsForUpdate(com.cloud.network.as.AutoScaleVmProfileVOTest)  Time elapsed: 0.061 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[serviceofferingid]> but was:<[rootdisksize]>
	at com.cloud.network.as.AutoScaleVmProfileVOTest.tstSetOtherDeployParamsForUpdate(AutoScaleVmProfileVOTest.java:72)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   AutoScaleVmProfileVOTest.tstSetOtherDeployParamsForUpdate:72 expected:<[serviceofferingid]> but was:<[rootdisksize]>
[INFO]
```
The above error occurs when comparing the keys and values of a [Hashmap](https://github.com/kavvya97/cloudstack/blob/main/engine/schema/src/test/java/com/cloud/network/as/AutoScaleVmProfileVOTest.java#L64). The expected string is a hardcoded key/value pair. The actual string is derived by parsing the hashmap and get the key by index. The comparision fails in some cases because the hashmap does not maintain order of contents.

### Fix
The Fix implements a custom method 'Contains pair' to check if `otherDeployParamsList` contains the specific key and value pairs. If the List contains the specific key value pairs, It return true. This ensures that assertion does not consider the order of contents in Hashmap.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity
This code modifies only test files and should not affect anything in production

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?
The test passes when run with the NonDex tool after the implementation of the fix. (`mvn -pl engine/schema edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloud.network.as.AutoScaleVmProfileVOTest#tstSetOtherDeployParamsForUpdate`)

#### How did you try to break this feature and the system with this change?
The change only creates a new test utility and calls it within a single test. Hence it should not affect any other code
