### PR TITLE
kvm: Add support for cgroupv2

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/MigrateCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/MigrateCommand.java
@@ -40,6 +40,9 @@ public class MigrateCommand extends Command {
     private boolean executeInSequence = false;
     private List<MigrateDiskInfo> migrateDiskInfoList = new ArrayList<>();
     private Map<String, DpdkTO> dpdkInterfaceMapping = new HashMap<>();
+
+    private int newVmCpuShares;
+
     Map<String, Boolean> vlanToPersistenceMap = new HashMap<>();
 
     public Map<String, DpdkTO> getDpdkInterfaceMapping() {
@@ -136,6 +139,14 @@ public class MigrateCommand extends Command {
 
     public void setMigrateDiskInfoList(List<MigrateDiskInfo> migrateDiskInfoList) {
         this.migrateDiskInfoList = migrateDiskInfoList;
+    }
+
+    public int getNewVmCpuShares() {
+        return newVmCpuShares;
+    }
+
+    public void setNewVmCpuShares(int newVmCpuShares) {
+        this.newVmCpuShares = newVmCpuShares;
     }
 
     public static class MigrateDiskInfo {

--- a/core/src/main/java/com/cloud/agent/api/PrepareForMigrationAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/PrepareForMigrationAnswer.java
@@ -28,6 +28,8 @@ public class PrepareForMigrationAnswer extends Answer {
 
     private Map<String, DpdkTO> dpdkInterfaceMapping = new HashMap<>();
 
+    private Integer newVmCpuShares = null;
+
     protected PrepareForMigrationAnswer() {
     }
 
@@ -49,5 +51,13 @@ public class PrepareForMigrationAnswer extends Answer {
 
     public Map<String, DpdkTO> getDpdkInterfaceMapping() {
         return this.dpdkInterfaceMapping;
+    }
+
+    public Integer getNewVmCpuShares() {
+        return newVmCpuShares;
+    }
+
+    public void setNewVmCpuShares(Integer newVmCpuShares) {
+        this.newVmCpuShares = newVmCpuShares;
     }
 }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -48,6 +48,7 @@ import javax.naming.ConfigurationException;
 import javax.persistence.EntityExistsException;
 
 import com.cloud.event.ActionEventUtils;
+import com.google.gson.Gson;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
 import org.apache.cloudstack.annotation.AnnotationService;
 import org.apache.cloudstack.annotation.dao.AnnotationDao;
@@ -2790,23 +2791,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         }
 
         boolean migrated = false;
-        Map<String, DpdkTO> dpdkInterfaceMapping = null;
+        Map<String, DpdkTO> dpdkInterfaceMapping = new HashMap<>();
         try {
-            final boolean isWindows = _guestOsCategoryDao.findById(_guestOsDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
-            Map<String, Boolean> vlanToPersistenceMap = getVlanToPersistenceMapForVM(vm.getId());
-            final MigrateCommand mc = new MigrateCommand(vm.getInstanceName(), dest.getHost().getPrivateIpAddress(), isWindows, to, getExecuteInSequence(vm.getHypervisorType()));
-            if (MapUtils.isNotEmpty(vlanToPersistenceMap)) {
-                mc.setVlanToPersistenceMap(vlanToPersistenceMap);
-            }
-
-            boolean kvmAutoConvergence = StorageManager.KvmAutoConvergence.value();
-            mc.setAutoConvergence(kvmAutoConvergence);
-            mc.setHostGuid(dest.getHost().getGuid());
-
-            dpdkInterfaceMapping = ((PrepareForMigrationAnswer) pfma).getDpdkInterfaceMapping();
-            if (MapUtils.isNotEmpty(dpdkInterfaceMapping)) {
-                mc.setDpdkInterfaceMapping(dpdkInterfaceMapping);
-            }
+            final MigrateCommand mc = buildMigrateCommand(vm, to, dest, pfma, dpdkInterfaceMapping);
 
             try {
                 final Answer ma = _agentMgr.send(vm.getLastHostId(), mc);
@@ -2876,6 +2863,43 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             work.setStep(Step.Done);
             _workDao.update(work.getId(), work);
         }
+    }
+
+    /**
+     * Create and set parameters for the {@link MigrateCommand} used in the migration and scaling of VMs.
+     */
+    protected MigrateCommand buildMigrateCommand(VMInstanceVO vmInstance, VirtualMachineTO virtualMachineTO, DeployDestination destination, Answer answer,
+                                                 Map<String, DpdkTO> dpdkInterfaceMapping) {
+        final boolean isWindows = _guestOsCategoryDao.findById(_guestOsDao.findById(vmInstance.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
+        final MigrateCommand migrateCommand = new MigrateCommand(vmInstance.getInstanceName(), destination.getHost().getPrivateIpAddress(), isWindows, virtualMachineTO,
+                getExecuteInSequence(vmInstance.getHypervisorType()));
+
+        Map<String, Boolean> vlanToPersistenceMap = getVlanToPersistenceMapForVM(vmInstance.getId());
+        if (MapUtils.isNotEmpty(vlanToPersistenceMap)) {
+            s_logger.debug(String.format("Setting VLAN persistence to [%s] as part of migrate command for VM [%s].", new Gson().toJson(vlanToPersistenceMap), virtualMachineTO));
+            migrateCommand.setVlanToPersistenceMap(vlanToPersistenceMap);
+        }
+
+        migrateCommand.setAutoConvergence(StorageManager.KvmAutoConvergence.value());
+        migrateCommand.setHostGuid(destination.getHost().getGuid());
+
+        PrepareForMigrationAnswer prepareForMigrationAnswer = (PrepareForMigrationAnswer) answer;
+
+        Map<String, DpdkTO> answerDpdkInterfaceMapping = prepareForMigrationAnswer.getDpdkInterfaceMapping();
+        if (MapUtils.isNotEmpty(answerDpdkInterfaceMapping) && dpdkInterfaceMapping != null) {
+            s_logger.debug(String.format("Setting DPDK interface mapping to [%s] as part of migrate command for VM [%s].", new Gson().toJson(vlanToPersistenceMap),
+                    virtualMachineTO));
+            dpdkInterfaceMapping.putAll(answerDpdkInterfaceMapping);
+            migrateCommand.setDpdkInterfaceMapping(dpdkInterfaceMapping);
+        }
+
+        Integer newVmCpuShares = prepareForMigrationAnswer.getNewVmCpuShares();
+        if (newVmCpuShares != null) {
+            s_logger.debug(String.format("Setting CPU shares to [%d] as part of migrate command for VM [%s].", newVmCpuShares, virtualMachineTO));
+            migrateCommand.setNewVmCpuShares(newVmCpuShares);
+        }
+
+        return migrateCommand;
     }
 
     private void updateVmPod(VMInstanceVO vm, long dstHostId) {
@@ -4395,16 +4419,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         boolean migrated = false;
         try {
-            Map<String, Boolean> vlanToPersistenceMap = getVlanToPersistenceMapForVM(vm.getId());
-            final boolean isWindows = _guestOsCategoryDao.findById(_guestOsDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
-            final MigrateCommand mc = new MigrateCommand(vm.getInstanceName(), dest.getHost().getPrivateIpAddress(), isWindows, to, getExecuteInSequence(vm.getHypervisorType()));
-            if (MapUtils.isNotEmpty(vlanToPersistenceMap)) {
-                mc.setVlanToPersistenceMap(vlanToPersistenceMap);
-            }
-
-            boolean kvmAutoConvergence = StorageManager.KvmAutoConvergence.value();
-            mc.setAutoConvergence(kvmAutoConvergence);
-            mc.setHostGuid(dest.getHost().getGuid());
+            final MigrateCommand mc = buildMigrateCommand(vm, to, dest, pfma, null);
 
             try {
                 final Answer ma = _agentMgr.send(vm.getLastHostId(), mc);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -72,6 +72,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.xerces.impl.xpath.regex.Match;
@@ -472,6 +473,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      */
     private static final String COMMAND_SET_MEM_BALLOON_STATS_PERIOD = "virsh dommemstat %s --period %s --live";
 
+    private static int hostCpuMaxCapacity = 0;
+
+    private static final int CGROUP_V2_UPPER_LIMIT = 10000;
+
+    private static final String COMMAND_GET_CGROUP_HOST_VERSION = "stat -fc %T /sys/fs/cgroup/";
+
+    public static final String CGROUP_V2 = "cgroup2fs";
+
     protected long getHypervisorLibvirtVersion() {
         return _hypervisorLibvirtVersion;
     }
@@ -545,6 +554,18 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             return cleanupNetworkElementCommand((IpAssocCommand)cmd);
         }
         return new ExecutionResult(true, null);
+    }
+
+    /**
+     * @return the host CPU max capacity according to the method {@link LibvirtComputingResource#calculateHostCpuMaxCapacity(int, Long)}; if the host utilizes cgroup v1, this
+     * value is 0.
+     */
+    public int getHostCpuMaxCapacity() {
+        return hostCpuMaxCapacity;
+    }
+
+    public void setHostCpuMaxCapacity(int hostCpuMaxCapacity) {
+        LibvirtComputingResource.hostCpuMaxCapacity = hostCpuMaxCapacity;
     }
 
     public LibvirtKvmAgentHook getTransformer() throws IOException {
@@ -2673,10 +2694,39 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      */
     protected CpuTuneDef createCpuTuneDef(VirtualMachineTO vmTO) {
         CpuTuneDef ctd = new CpuTuneDef();
-        int shares = vmTO.getCpus() * (vmTO.getMinSpeed() != null ? vmTO.getMinSpeed() : vmTO.getSpeed());
-        ctd.setShares(shares);
+        ctd.setShares(calculateCpuShares(vmTO));
         setQuotaAndPeriod(vmTO, ctd);
         return ctd;
+    }
+
+    /**
+     * Calculates the VM CPU shares considering the cgroup version of the host.
+     * <ul>
+     *     <li>
+     *         If the host utilize cgroup v1, then, the CPU shares is calculated as <b>VM CPU shares = CPU cores * CPU frequency</b>.
+     *     </li>
+     *     <li>
+     *         If the host utilize cgroup v2, the CPU shares calculation considers the cgroup v2 upper limit of <b>10,000</b>, and a linear scale conversion is applied
+     *         considering the maximum host CPU shares (i.e. using the number of CPU cores and CPU nominal frequency of the host). Therefore, the VM CPU shares is calculated as
+     *         <b>VM CPU shares = (VM requested shares * cgroup upper limit) / host max shares</b>.
+     *     </li>
+     * </ul>
+     */
+    public int calculateCpuShares(VirtualMachineTO vmTO) {
+        int vCpus = vmTO.getCpus();
+        int cpuSpeed = ObjectUtils.defaultIfNull(vmTO.getMinSpeed(), vmTO.getSpeed());
+        int requestedCpuShares = vCpus * cpuSpeed;
+        int hostCpuMaxCapacity = getHostCpuMaxCapacity();
+
+        if (hostCpuMaxCapacity > 0) {
+            int updatedCpuShares = (int) Math.ceil((requestedCpuShares * CGROUP_V2_UPPER_LIMIT) / (double) hostCpuMaxCapacity);
+            s_logger.debug(String.format("This host utilizes cgroupv2 (as the max shares value is [%s]), thus, the VM requested shares of [%s] will be converted to " +
+                    "consider the host limits; the new CPU shares value is [%s].", hostCpuMaxCapacity, requestedCpuShares, updatedCpuShares));
+            return updatedCpuShares;
+        }
+        s_logger.debug(String.format("This host does not have a maximum CPU shares set; therefore, this host utilizes cgroupv1 and the VM requested CPU shares [%s] will not be " +
+                "converted.", requestedCpuShares));
+        return requestedCpuShares;
     }
 
     private CpuModeDef createCpuModeDef(VirtualMachineTO vmTO, int vcpus) {
@@ -3469,8 +3519,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     @Override
     public StartupCommand[] initialize() {
-
         final KVMHostInfo info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem, _manualCpuSpeed);
+        calculateHostCpuMaxCapacity(info.getCpus(), info.getCpuSpeed());
 
         String capabilities = String.join(",", info.getCapabilities());
         if (dpdkSupport) {
@@ -3512,6 +3562,32 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             i++;
         }
         return startupCommandsArray;
+    }
+
+    /**
+     * Calculates and sets the host CPU max capacity according to the cgroup version of the host.
+     * <ul>
+     *     <li>
+     *         <b>cgroup v1</b>: the max CPU capacity for the host is set to <b>0</b>.
+     *     </li>
+     *     <li>
+     *         <b>cgroup v2</b>: the max CPU capacity for the host is the value of <b>cpuCores * cpuSpeed</b>.
+     *     </li>
+     * </ul>
+     */
+    protected void calculateHostCpuMaxCapacity(int cpuCores, Long cpuSpeed) {
+        String output = Script.runSimpleBashScript(COMMAND_GET_CGROUP_HOST_VERSION);
+        s_logger.info(String.format("Host uses control group [%s].", output));
+
+        if (!CGROUP_V2.equals(output)) {
+            s_logger.info(String.format("Setting host CPU max capacity to 0, as it uses cgroup v1.", getHostCpuMaxCapacity()));
+            setHostCpuMaxCapacity(0);
+            return;
+        }
+
+        s_logger.info(String.format("Calculating the max shares of the host."));
+        setHostCpuMaxCapacity(cpuCores * cpuSpeed.intValue());
+        s_logger.info(String.format("The max shares of the host is [%d].", getHostCpuMaxCapacity()));
     }
 
     private StartupStorageCommand createLocalStoragePool(String localStoragePath, String localStorageUUID, StartupRoutingCommand cmd) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPrepareForMigrationCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPrepareForMigrationCommandWrapper.java
@@ -122,11 +122,7 @@ public final class LibvirtPrepareForMigrationCommandWrapper extends CommandWrapp
                 return new PrepareForMigrationAnswer(command, "failed to connect physical disks to host");
             }
 
-            PrepareForMigrationAnswer answer = new PrepareForMigrationAnswer(command);
-            if (MapUtils.isNotEmpty(dpdkInterfaceMapping)) {
-                answer.setDpdkInterfaceMapping(dpdkInterfaceMapping);
-            }
-            return answer;
+            return createPrepareForMigrationAnswer(command, dpdkInterfaceMapping, libvirtComputingResource, vm);
         } catch (final LibvirtException | CloudRuntimeException | InternalErrorException | URISyntaxException e) {
             if (MapUtils.isNotEmpty(dpdkInterfaceMapping)) {
                 for (DpdkTO to : dpdkInterfaceMapping.values()) {
@@ -141,6 +137,22 @@ public final class LibvirtPrepareForMigrationCommandWrapper extends CommandWrapp
                 storagePoolMgr.disconnectPhysicalDisksViaVmSpec(vm);
             }
         }
+    }
+
+    protected PrepareForMigrationAnswer createPrepareForMigrationAnswer(PrepareForMigrationCommand command, Map<String, DpdkTO> dpdkInterfaceMapping,
+                                                                        LibvirtComputingResource libvirtComputingResource, VirtualMachineTO vm) {
+        PrepareForMigrationAnswer answer = new PrepareForMigrationAnswer(command);
+
+        if (MapUtils.isNotEmpty(dpdkInterfaceMapping)) {
+            s_logger.debug(String.format("Setting DPDK interface for the migration of VM [%s].", vm));
+            answer.setDpdkInterfaceMapping(dpdkInterfaceMapping);
+        }
+
+        int newCpuShares = libvirtComputingResource.calculateCpuShares(vm);
+        s_logger.debug(String.format("Setting CPU shares to [%s] for the migration of VM [%s].", newCpuShares, vm));
+        answer.setNewVmCpuShares(newCpuShares);
+
+        return answer;
     }
 
     private Answer handleRollback(PrepareForMigrationCommand command, LibvirtComputingResource libvirtComputingResource) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
@@ -39,8 +39,7 @@ public class LibvirtScaleVmCommandWrapper extends CommandWrapper<ScaleVmCommand,
 
         long newMemory = ByteScaleUtils.bytesToKibibytes(vmSpec.getMaxRam());
         int newVcpus = vmSpec.getCpus();
-        int newCpuSpeed = vmSpec.getMinSpeed() != null ? vmSpec.getMinSpeed() : vmSpec.getSpeed();
-        int newCpuShares = newVcpus * newCpuSpeed;
+        int newCpuShares = libvirtComputingResource.calculateCpuShares(vmSpec);
         String vmDefinition = vmSpec.toString();
         String scalingDetails = String.format("%s memory to [%s KiB], CPU cores to [%s] and cpu_shares to [%s]", vmDefinition, newMemory, newVcpus, newCpuShares);
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -6270,4 +6270,97 @@ public class LibvirtComputingResourceTest {
         Mockito.verify(loggerMock).debug("Skipping the memory balloon stats period setting for the VM (Libvirt Domain) with ID [1] and name [fake-VM-name] because this"
                 + " VM has no memory balloon.");
     }
+
+    @Test
+    public void calculateCpuSharesTestMinSpeedNullAndHostCgroupV1ShouldNotConsiderCgroupLimit() {
+        int cpuCores = 2;
+        int cpuSpeed = 2000;
+        int maxCpuShares = 0;
+        int expectedCpuShares = 4000;
+
+        Mockito.doReturn(cpuCores).when(vmTO).getCpus();
+        Mockito.doReturn(null).when(vmTO).getMinSpeed();
+        Mockito.doReturn(cpuSpeed).when(vmTO).getSpeed();
+        Mockito.doReturn(maxCpuShares).when(libvirtComputingResourceSpy).getHostCpuMaxCapacity();
+        int calculatedCpuShares = libvirtComputingResourceSpy.calculateCpuShares(vmTO);
+
+        Assert.assertEquals(expectedCpuShares, calculatedCpuShares);
+    }
+
+    @Test
+    public void calculateCpuSharesTestMinSpeedNotNullAndHostCgroupV1ShouldNotConsiderCgroupLimit() {
+        int cpuCores = 2;
+        int cpuSpeed = 2000;
+        int maxCpuShares = 0;
+        int expectedCpuShares = 4000;
+
+        Mockito.doReturn(cpuCores).when(vmTO).getCpus();
+        Mockito.doReturn(cpuSpeed).when(vmTO).getMinSpeed();
+        Mockito.doReturn(maxCpuShares).when(libvirtComputingResourceSpy).getHostCpuMaxCapacity();
+        int calculatedCpuShares = libvirtComputingResourceSpy.calculateCpuShares(vmTO);
+
+        Assert.assertEquals(expectedCpuShares, calculatedCpuShares);
+    }
+
+
+    @Test
+    public void calculateCpuSharesTestMinSpeedNullAndHostCgroupV2ShouldConsiderCgroupLimit() {
+        int cpuCores = 2;
+        int cpuSpeed = 2000;
+        int maxCpuShares = 5000;
+        int expectedCpuShares = 8000;
+
+        Mockito.doReturn(cpuCores).when(vmTO).getCpus();
+        Mockito.doReturn(null).when(vmTO).getMinSpeed();
+        Mockito.doReturn(cpuSpeed).when(vmTO).getSpeed();
+        Mockito.doReturn(maxCpuShares).when(libvirtComputingResourceSpy).getHostCpuMaxCapacity();
+        int calculatedCpuShares = libvirtComputingResourceSpy.calculateCpuShares(vmTO);
+
+        Assert.assertEquals(expectedCpuShares, calculatedCpuShares);
+    }
+
+    @Test
+    public void calculateCpuSharesTestMinSpeedNotNullAndHostCgroupV2ShouldConsiderCgroupLimit() {
+        int cpuCores = 2;
+        int cpuSpeed = 2000;
+        int maxCpuShares = 5000;
+        int expectedCpuShares = 8000;
+
+        Mockito.doReturn(cpuCores).when(vmTO).getCpus();
+        Mockito.doReturn(cpuSpeed).when(vmTO).getMinSpeed();
+        Mockito.doReturn(maxCpuShares).when(libvirtComputingResourceSpy).getHostCpuMaxCapacity();
+        int calculatedCpuShares = libvirtComputingResourceSpy.calculateCpuShares(vmTO);
+
+        Assert.assertEquals(expectedCpuShares, calculatedCpuShares);
+    }
+
+    @Test
+    public void setMaxHostCpuSharesIfCGroupV2TestShouldCalculateMaxCpuCapacityIfHostUtilizesCgroupV2() {
+        int cpuCores = 2;
+        long cpuSpeed = 2500L;
+        int expectedShares = 5000;
+
+        String hostCgroupVersion = LibvirtComputingResource.CGROUP_V2;
+        PowerMockito.mockStatic(Script.class);
+        Mockito.when(Script.runSimpleBashScript(Mockito.anyString())).thenReturn(hostCgroupVersion);
+
+        libvirtComputingResourceSpy.calculateHostCpuMaxCapacity(cpuCores, cpuSpeed);
+
+        Assert.assertEquals(expectedShares, libvirtComputingResourceSpy.getHostCpuMaxCapacity());
+    }
+
+    @Test
+    public void setMaxHostCpuSharesIfCGroupV2TestShouldNotCalculateMaxCpuCapacityIfHostDoesNotUtilizesCgroupV2() {
+        int cpuCores = 2;
+        long cpuSpeed = 2500L;
+        int expectedShares = 0;
+
+        String hostCgroupVersion = "tmpfs";
+        PowerMockito.mockStatic(Script.class);
+        Mockito.when(Script.runSimpleBashScript(Mockito.anyString())).thenReturn(hostCgroupVersion);
+
+        libvirtComputingResourceSpy.calculateHostCpuMaxCapacity(cpuCores, cpuSpeed);
+
+        Assert.assertEquals(expectedShares, libvirtComputingResourceSpy.getHostCpuMaxCapacity());
+    }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,8 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.cloudstack.utils.linux.MemStat;
+import com.cloud.agent.api.to.VirtualMachineTO;
+import org.apache.cloudstack.utils.security.ParserUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,7 +54,11 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 import com.cloud.agent.api.MigrateCommand;
@@ -444,6 +451,16 @@ public class LibvirtMigrateCommandWrapperTest {
         "  </seclabel>\n" +
         "</domain>";
 
+    @Mock
+    MigrateCommand migrateCommandMock;
+
+    @Mock
+    LibvirtComputingResource libvirtComputingResourceMock;
+
+    @Mock
+    VirtualMachineTO virtualMachineTOMock;
+
+    @Spy
     LibvirtMigrateCommandWrapper libvirtMigrateCmdWrapper = new LibvirtMigrateCommandWrapper();
 
     final String memInfo = "MemTotal:        5830236 kB\n" +
@@ -870,5 +887,68 @@ public class LibvirtMigrateCommandWrapperTest {
         String replaced = lw.replaceDpdkInterfaces(sourceDPDKVMToMigrate, dpdkPortMapping);
         Assert.assertTrue(replaced.contains("csdpdk-7"));
         Assert.assertFalse(replaced.contains("csdpdk-1"));
+    }
+
+    @Test
+    public void updateVmSharesIfNeededTestNewCpuSharesEqualCurrentSharesShouldNotUpdateVmShares() throws ParserConfigurationException, IOException, TransformerException,
+            SAXException {
+        int newVmCpuShares = 1000;
+        int currentVmCpuShares = 1000;
+
+        Mockito.doReturn(newVmCpuShares).when(migrateCommandMock).getNewVmCpuShares();
+        Mockito.doReturn(virtualMachineTOMock).when(migrateCommandMock).getVirtualMachine();
+        Mockito.doReturn(currentVmCpuShares).when(libvirtComputingResourceMock).calculateCpuShares(virtualMachineTOMock);
+
+        String finalXml = libvirtMigrateCmdWrapper.updateVmSharesIfNeeded(migrateCommandMock, fullfile, libvirtComputingResourceMock);
+
+        Assert.assertEquals(finalXml, fullfile);
+    }
+
+    @Test
+    public void updateVmSharesIfNeededTestNewCpuSharesHigherThanCurrentSharesShouldUpdateVmShares() throws ParserConfigurationException, IOException, TransformerException,
+            SAXException {
+        int newVmCpuShares = 2000;
+        int currentVmCpuShares = 1000;
+
+        Mockito.doReturn(newVmCpuShares).when(migrateCommandMock).getNewVmCpuShares();
+        Mockito.doReturn(virtualMachineTOMock).when(migrateCommandMock).getVirtualMachine();
+        Mockito.doReturn(currentVmCpuShares).when(libvirtComputingResourceMock).calculateCpuShares(virtualMachineTOMock);
+
+        String finalXml = libvirtMigrateCmdWrapper.updateVmSharesIfNeeded(migrateCommandMock, fullfile, libvirtComputingResourceMock);
+
+        InputStream inputStream = IOUtils.toInputStream(finalXml, StandardCharsets.UTF_8);
+        DocumentBuilderFactory docFactory = ParserUtils.getSaferDocumentBuilderFactory();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document document = docBuilder.parse(inputStream);
+
+        Element root = document.getDocumentElement();
+        Node sharesNode = root.getElementsByTagName("shares").item(0);
+        int updateShares = Integer.parseInt(sharesNode.getTextContent());
+
+        Assert.assertEquals(updateShares, newVmCpuShares);
+    }
+
+    @Test
+    public void updateVmSharesIfNeededTestNewCpuSharesLowerThanCurrentSharesShouldUpdateVmShares() throws ParserConfigurationException, IOException, TransformerException,
+            SAXException {
+        int newVmCpuShares = 500;
+        int currentVmCpuShares = 1000;
+
+        Mockito.doReturn(newVmCpuShares).when(migrateCommandMock).getNewVmCpuShares();
+        Mockito.doReturn(virtualMachineTOMock).when(migrateCommandMock).getVirtualMachine();
+        Mockito.doReturn(currentVmCpuShares).when(libvirtComputingResourceMock).calculateCpuShares(virtualMachineTOMock);
+
+        String finalXml = libvirtMigrateCmdWrapper.updateVmSharesIfNeeded(migrateCommandMock, fullfile, libvirtComputingResourceMock);
+
+        InputStream inputStream = IOUtils.toInputStream(finalXml, StandardCharsets.UTF_8);
+        DocumentBuilderFactory docFactory = ParserUtils.getSaferDocumentBuilderFactory();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document document = docBuilder.parse(inputStream);
+
+        Element root = document.getDocumentElement();
+        Node sharesNode = root.getElementsByTagName("shares").item(0);
+        int updateShares = Integer.parseInt(sharesNode.getTextContent());
+
+        Assert.assertEquals(updateShares, newVmCpuShares);
     }
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPrepareForMigrationCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPrepareForMigrationCommandWrapperTest.java
@@ -1,0 +1,73 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import com.cloud.agent.api.PrepareForMigrationAnswer;
+import com.cloud.agent.api.PrepareForMigrationCommand;
+import com.cloud.agent.api.to.DpdkTO;
+import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LibvirtPrepareForMigrationCommandWrapperTest {
+
+    @Mock
+    LibvirtComputingResource libvirtComputingResourceMock;
+
+    @Mock
+    PrepareForMigrationCommand prepareForMigrationCommandMock;
+
+    @Mock
+    VirtualMachineTO virtualMachineTOMock;
+
+    @Spy
+    LibvirtPrepareForMigrationCommandWrapper libvirtPrepareForMigrationCommandWrapperSpy = new LibvirtPrepareForMigrationCommandWrapper();
+
+    @Test
+    public void createPrepareForMigrationAnswerTestDpdkInterfaceNotEmptyShouldSetParamOnAnswer() {
+        Map<String, DpdkTO> dpdkInterfaceMapping = new HashMap<>();
+        dpdkInterfaceMapping.put("Interface", new DpdkTO());
+
+        PrepareForMigrationAnswer prepareForMigrationAnswer = libvirtPrepareForMigrationCommandWrapperSpy.createPrepareForMigrationAnswer(prepareForMigrationCommandMock, dpdkInterfaceMapping, libvirtComputingResourceMock,
+                virtualMachineTOMock);
+
+        Assert.assertEquals(prepareForMigrationAnswer.getDpdkInterfaceMapping(), dpdkInterfaceMapping);
+    }
+
+    @Test
+    public void createPrepareForMigrationAnswerTestVerifyThatCpuSharesIsSet() {
+        int cpuShares = 1000;
+        Mockito.doReturn(cpuShares).when(libvirtComputingResourceMock).calculateCpuShares(virtualMachineTOMock);
+        PrepareForMigrationAnswer prepareForMigrationAnswer = libvirtPrepareForMigrationCommandWrapperSpy.createPrepareForMigrationAnswer(prepareForMigrationCommandMock,null,
+                libvirtComputingResourceMock, virtualMachineTOMock);
+
+        Assert.assertEquals(cpuShares, prepareForMigrationAnswer.getNewVmCpuShares().intValue());
+    }
+}

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPrepareForMigrationCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPrepareForMigrationCommandWrapperTest.java
@@ -30,12 +30,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(value = {LibvirtPrepareForMigrationCommandWrapper.class})
 public class LibvirtPrepareForMigrationCommandWrapperTest {
 
     @Mock

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapperTest.java
@@ -207,9 +207,11 @@ public class LibvirtScaleVmCommandWrapperTest extends TestCase {
     @Test
     public void validateExecuteHandleLibvirtException() throws LibvirtException {
         String errorMessage = "";
+        int shares = vmTo.getCpus() * vmTo.getSpeed();
 
         Mockito.doReturn(vmTo).when(scaleVmCommandMock).getVirtualMachine();
         Mockito.doReturn(libvirtUtilitiesHelperMock).when(libvirtComputingResourceMock).getLibvirtUtilitiesHelper();
+        Mockito.doReturn(shares).when(libvirtComputingResourceMock).calculateCpuShares(vmTo);
         Mockito.doThrow(libvirtException).when(libvirtUtilitiesHelperMock).getConnectionByVmName(Mockito.anyString());
         Mockito.doReturn(errorMessage).when(libvirtException).getMessage();
 
@@ -222,9 +224,12 @@ public class LibvirtScaleVmCommandWrapperTest extends TestCase {
 
     @Test
     public void validateExecuteSuccessfully() throws LibvirtException {
+        int shares = vmTo.getCpus() * vmTo.getSpeed();
+
         Mockito.doReturn(vmTo).when(scaleVmCommandMock).getVirtualMachine();
         Mockito.doReturn(libvirtUtilitiesHelperMock).when(libvirtComputingResourceMock).getLibvirtUtilitiesHelper();
         Mockito.doReturn(connectMock).when(libvirtUtilitiesHelperMock).getConnectionByVmName(Mockito.anyString());
+        Mockito.doReturn(shares).when(libvirtComputingResourceMock).calculateCpuShares(vmTo);
         Mockito.doReturn(domainMock).when(connectMock).domainLookupByName(Mockito.anyString());
         Mockito.doNothing().when(libvirtScaleVmCommandWrapperSpy).scaleMemory(Mockito.any(), Mockito.anyLong(), Mockito.anyString());
         Mockito.doNothing().when(libvirtScaleVmCommandWrapperSpy).scaleVcpus(Mockito.any(), Mockito.anyInt(), Mockito.anyString());


### PR DESCRIPTION
### Description

## <section id="problem-description">1. Problem description</section>

In Apache CloudStack (ACS), when a VM is deployed in a host with the KVM hypervisor, an XML file is created in the assigned host, which has a property <code>shares</code> that defines the weight of the VM to access the host CPU. The value of this property has no unit, and it is a relative measure to calculate how much CPU a given VM will have in the host. However, this value has a limit, which depends on the version of cgroup utilized by the host's kernel. The problem lies at the range value of shares that varies between both versions: [2, 264144] for cgroups version 1; and [1, 10000] for cgroups version 2. Currently, ACS calculates the value of <code>shares</code> using Equation 1, presented below, where <code>CPU</code> is the number of cores and <code>speed</code> is the CPU frequency; both specified in the VM's compute offering. Therefore, if a compute offering has, for example, 6 cores at 2 GHz, the <code>shares</code> value will be 12000 and an exception will be thrown by libvirt if the host utilizes cgroup v2. The second version is becoming the default one in current Linux distributions; thus, it is necessary to address this limitation.

- **Equation 1**
  <code>shares = CPU * speed</code>

---
Fixes: #6744 

## <section id="proposed-changes">2. Proposed changes</section>

To address the problem described, we propose to apply a scale conversion considering the max <code>shares</code> of the host. Using the same formula currently utilized by ACS, it is possible to calculate the maximum <code>shares</code> of a VM for a given host. In other words, using the number of cores and the nominal speed of the host's CPU as the upper limit of <code>shares</code> allowed to a VM. Then, this value will be scaled to the allowed interval of [1, 10000] of cgroup v2 by using a linear scale conversion.

The VM <code>shares</code> would be calculated as Equation 2, presented below, where <code>VM requested shares</code> is the requested <code>shares</code> value calculated using Equation 1, <code>cgroup upper limit</code> is fixed with a value of 10000 (cgroups v2 upper limit), and <code>host max shares</code> is the maximum <code>shares</code> value of the host, calculated using Equation 1. Using Equation 2, the only case where a VM passes the cgroup v2 limit is when the user requests more resources than the host has, which is not possible with the current implementation of ACS.

- **Equation 2**
  <code>shares = (VM requested shares * cgroup upper limit)/host max shares</code>

To implement the proposal, the following APIs will be updated: <code>deployVirtualMachine</code>, <code>migrateVirtualMachine</code> and <code>scaleVirtualMachine</code>. When a VM is being deployed, a new verification will be added to find a suitable host. The max <code>shares</code> of each host will be calculated, and the VM calculated <code>shares</code> will be verified if it does not surpass the host's value. Likewise, the migration of VMs will have a similar new verification. Lastly, the scale of VMs will also have the same verification for the VM's host.

To determine the max <code>shares</code> of a given host, we will use the same equation currently used in ACS for calculating the <code>shares</code> of VMs, presented in <a href="#problem-description" class="internal-link">Section 1</a>. When Equation 1 is used to determine the maximum <code>shares</code> of a host, <code>CPU</code> is the number of cores of the host, and <code>speed</code> is the nominal CPU speed, i.e., considering the CPU's base frequency.

It is important to note that these changes are only for hosts with the KVM hypervisor using cgroup v2 for now.

## <section id="example">Example</section>

To exemplify the proposed changes, consider a host with the following specification: 32 CPU cores with nominal speed of 2 GHz; and a VM with a compute offering with 8 CPU cores and with speed of 2 GHz. With the current ACS implementation, the <code>shares</code> of the VM would be calculated as Equation 1. Thus, the VM <code>shares</code> would be 16000, over the cgroup v2 limit of 10000.

With the proposed changes, the VM <code>shares</code> would be calculated as Equation 2. In this example, <code>VM requested shares</code> is 16000, <code>cgroup upper limit</code> is fixed with a value of 10000, and <code>host max shares</code> is 64000. Therefore, the VM <code>shares</code> results in 2500, well below the cgroup v2 limit.

## <section id="real-case-scenarios">Real case scenarios</section>

To demonstrate real case scenarios, consider the following hosts:

- **Host A**
  - **\# of Cores:** 32
  - **CPU nominal frequency:** 2 GHz
  - **Max Shares:** 64000
- **Host B**
  - **\# of Cores:** 16
  - **CPU nominal frequency:** 2 GHz
  - **Max Shares:** 32000

Table 1 below presents a set of VMs with their requested resources, alongside the <code>shares</code> values considering the current implementation, and the new <code>shares</code> value, for each host, considering the proposed change using Equation 2.

- Table 1

<table>

<thead>

<tr>

<th rowspan="2">VM</th>

<th rowspan="2">CPU cores</th>

<th rowspan="2">CPU frequency (GHz)</th>

<th rowspan="2">Current shares</th>

<th colspan="2">New shares</th>

</tr>

<tr>

<th>For Host A</th>

<th>For Host B</th>

</tr>

</thead>

<tbody>

<tr>

<td>VM 1</td>

<td>2</td>

<td>2</td>

<td>4000</td>

<td>625</td>

<td>1250</td>

</tr>

<tr>

<td>VM 2</td>

<td>4</td>

<td>2</td>

<td>8000</td>

<td>1250</td>

<td>2500</td>

</tr>

<tr>

<td>VM 3</td>

<td>6</td>

<td>2</td>

<td>12000</td>

<td>1875</td>

<td>3750</td>

</tr>

<tr>

<td>VM 4</td>

<td>8</td>

<td>2</td>

<td>16000</td>

<td>2500</td>

<td>5000</td>

</tr>

<tr>

<td>VM 5</td>

<td>16</td>

<td>2</td>

<td>32000</td>

<td>5000</td>

<td>10000</td>

</tr>

<tr>

<td>VM 6</td>

<td>32</td>

<td>2</td>

<td>64000</td>

<td>10000</td>

<td>20000</td>

</tr>

</tbody>

</table>

Table 2 below presents if the same VMs in Table 1 would be allowed to be allocated to a given host, or if an exception would be thrown, considering current and proposed implementations. As we can see, with the current ACS implementation, VMs 3 through 6 would throw an exception when deploying in host A; even though the host has enough resources. VM 6 should throw an exception when trying to deploy it in host B in both implementations, as the host does not have enough resources to allocate it.

- Table 2

<table>

<thead>

<tr>

<th rowspan="2">VM</th>

<th colspan="2">Host A<br></th>

<th colspan="2">Host B</th>

</tr>

<tr>

<th>Current Implementation</th>

<th>Proposed Implementation</th>

<th>Current Implementation</th>

<th>Proposed Implementation</th>

</tr>

</thead>

<tbody>

<tr>

<td>VM 1</td>

<td>Allowed</td>

<td>Allowed</td>

<td>Allowed</td>

<td>Allowed</td>

</tr>

<tr>

<td>VM 2</td>

<td>Allowed</td>

<td>Allowed</td>

<td>Allowed</td>

<td>Allowed</td>

</tr>

<tr>

<td>VM 3</td>

<td>Exception</td>

<td>Allowed</td>

<td>Exception</td>

<td>Allowed</td>

</tr>

<tr>

<td>VM 4</td>

<td>Exception</td>

<td>Allowed</td>

<td>Exception</td>

<td>Allowed</td>

</tr>

<tr>

<td>VM 5</td>

<td>Exception</td>

<td>Allowed</td>

<td>Exception</td>

<td>Allowed</td>

</tr>

<tr>

<td>VM 6</td>

<td>Exception</td>

<td>Allowed</td>

<td>Exception</td>

<td>Exception</td>

</tr>

</tbody>

</table>

It is important to note that Equation 2 rounds up the <code>shares</code> value; thus, there is a precision loss with the conversion. Nevertheless, this precision loss should not be noticeable to the end user, as the <code>shares</code> value would need to be in a very close interval, e.g. <code>shares</code> values of <code>3997</code>, <code>3998</code> and <code>3999</code> would be considered as <code>1249</code> in host B with the new implementation. However, the precision loss is a small drawback for enabling support of cgroup v2 to ACS.

## <section id="future-works">3. Future works</section>

With the current proposal, only cgroups version 2 is addressed, as it has impactful limitations. Thus, as future work, cgroups version 1 will also be addressed using the same strategy of linear scale conversion.

### Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

Consider the host `host-1` with cgroup v2, `host-2` with cgroup v1 and the following custom constrained compute offering below:

- **Frequency:** 2 GHz
- **Cores:** 2 - 6
- **RAM**: 1 GB

## Deploy of VMs

I created the VM `vm-tmpfs` with 5 cores and allocated it to host `host-2`.
```bash
ubuntu@host-2:~$ virsh dumpxml --domain i-2-13-VM | grep shares
    <shares>10000</shares>
```

I created the VM `vm-cgroupv2` with 5 cores and allocated it to host `host-1`.
```bash
ubuntu@host-1:~$ virsh dumpxml --domain i-2-15-VM | grep shares
    <shares>6667</shares>
```

As expected, ACS considered the host resources to set the `shares` values. When the host utilizes the cgroup v1, the default behavior is not changed.

## VM live scale

I lived scale the VM `vm-tmpfs`, changing its number of cores from 5 to 6.

```bash
ubuntu@host-2:~$ virsh dumpxml --domain i-2-13-VM | grep shares
    <shares>10000</shares>
ubuntu@host-2:~$ virsh dumpxml --domain i-2-13-VM | grep shares
    <shares>12000</shares>
```

I lived scale the VM `vm-cgroupv2`, changing its number of cores from 5 to 6.
```bash
ubuntu@host-1:~$ virsh dumpxml --domain i-2-15-VM | grep shares
    <shares>6667</shares>
ubuntu@host-1:~$ virsh dumpxml --domain i-2-15-VM | grep shares
    <shares>8000</shares>
```

As expected, ACS considered the host resources to set the `shares` values. When the host utilizes the cgroup v1, the default behavior is not changed.

## VM migration

I migrated VM `vm-tmpfs` from host `host-2` to host `host-1` (from cgroupv1 to cgroupv2). After the migration, the `shares` values was changed to `8000`, as expected.
```bash
ubuntu@host-1:~$ virsh dumpxml --domain i-2-13-VM | grep shares
    <shares>8000</shares>
```

I migrated VM `vm-cgroupv2` from host `host-1` to host `host-2` (from cgroupv2 to cgroupv1). After the migration, the `shares` values was changed to `12000`, as expected.
```bash
ubuntu@host-2:~$ virsh dumpxml --domain i-2-15-VM | grep shares
    <shares>12000</shares>
```

#### How did you try to break this feature and the system with this change?

I migrated VMs between hosts with different cgroup versions, the VM migration section above describes this.
