### PR TITLE
Prioritize hypervisor.uri configuration

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1004,10 +1004,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         rollingMaintenanceExecutor = BooleanUtils.isTrue(AgentPropertiesFileHandler.getPropertyValue(AgentProperties.ROLLING_MAINTENANCE_SERVICE_EXECUTOR_DISABLED)) ? new RollingMaintenanceAgentExecutor(hooksDir) :
                 new RollingMaintenanceServiceExecutor(hooksDir);
 
-        hypervisorURI = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.HYPERVISOR_URI);
-        if (hypervisorURI == null) {
-            hypervisorURI = LibvirtConnection.getHypervisorURI(hypervisorType.toString());
-        }
+        hypervisorURI = LibvirtConnection.getHypervisorURI(hypervisorType.toString());
 
         networkDirectSourceMode = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.NETWORK_DIRECT_SOURCE_MODE);
         networkDirectDevice = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.NETWORK_DIRECT_DEVICE);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtConnection.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtConnection.java
@@ -19,6 +19,8 @@ package com.cloud.hypervisor.kvm.resource;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.cloud.agent.properties.AgentProperties;
+import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import org.apache.log4j.Logger;
 import org.libvirt.Connect;
 import org.libvirt.LibvirtException;
@@ -88,10 +90,15 @@ public class LibvirtConnection {
     }
 
     static String getHypervisorURI(String hypervisorType) {
+        String uri = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.HYPERVISOR_URI);
+        if (uri != null) {
+            return uri;
+        }
+
         if ("LXC".equalsIgnoreCase(hypervisorType)) {
             return "lxc:///";
-        } else {
-            return "qemu:///system";
         }
+
+        return "qemu:///system";
     }
 }


### PR DESCRIPTION
### Description

The KVM Agent has the `hypervisor.uri` configuration to define the connection with Libvirt; however, this property is ignored and a hardcoded value is used in many parts of the code.

This PR intends to prioritize the `hypervisor.uri` property in Libvirt connections and use the hypervisor default URI only when this configuration is not defined.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I followed the same steps from `How did you try to break this feature...` and verified that the host was only using the URI defined in the `hypervisor.uri` property.


#### How did you try to break this feature and the system with this change?

1. Add the `hypervisor.uri` property to a host's agent.properties, `hypervisor.uri=qemu:///session` for example;
2. Check the agent logs;
3. Although the `hypervisor.uri` property is defined, the agent is still using the hypervisor default URI in many connections;