### PR TITLE
.asf.yaml: Enable Github Discussions for CloudStack

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,7 @@ github:
   features:
     wiki: true
     issues: true
+    discussions: true
     projects: true
 
   enabled_merge_buttons:
@@ -61,3 +62,9 @@ github:
     - winterhazel
 
   protected_branches: ~
+
+notifications:
+  commits:      commits@cloudstack.apache.org
+  issues:       commits@cloudstack.apache.org
+  pullrequests: commits@cloudstack.apache.org
+  discussions:  users@cloudstack.apache.org


### PR DESCRIPTION
This enables Github Discussions feature for Apache CloudStack repository. Several tech-savvy users are already using CloudStack issues to report bugs, improvements and ideas, and finding using mailing list old-school. The discussions feature presents a forum and can help community have both users (including non-technical users) and developers on the same platform. Further, the discussions feature is proposed to be connected to the users@ mailing list so traditional users can benefit from discussions happening on Github Discusssions forum.

This PR MUST NOT be merged without consensus, for which please chime in at: https://lists.apache.org/thread/hs0295hw9rnmhoh9l2qo5hc4b62hhvk8

Other Apache TLPs are using this feature already, that you can check here for example:
https://github.com/apache/apisix/discussions
https://github.com/apache/pulsar/discussions
https://github.com/apache/airflow/discussions
https://github.com/apache/streampipes/discussions