### PR TITLE
events,alerts: Add missing indexes

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/DatabaseAccessObject.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/DatabaseAccessObject.java
@@ -21,6 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 public class DatabaseAccessObject {
@@ -85,8 +86,8 @@ public class DatabaseAccessObject {
         return columnExists;
     }
 
-    public String generateIndexName(String tableName, String columnName) {
-        return String.format("i_%s__%s", tableName, columnName);
+    public String generateIndexName(String tableName, String... columnName) {
+        return String.format("i_%s__%s", tableName, StringUtils.join(columnName, "__"));
     }
 
     public boolean indexExists(Connection conn, String tableName, String indexName) {
@@ -101,8 +102,8 @@ public class DatabaseAccessObject {
         return false;
     }
 
-    public void createIndex(Connection conn, String tableName, String columnName, String indexName) {
-        String stmt = String.format("CREATE INDEX %s on %s (%s)", indexName, tableName, columnName);
+    public void createIndex(Connection conn, String tableName, String indexName, String... columnNames) {
+        String stmt = String.format("CREATE INDEX %s ON %s (%s)", indexName, tableName, StringUtils.join(columnNames, ", "));
         s_logger.debug("Statement: " + stmt);
         try (PreparedStatement pstmt = conn.prepareStatement(stmt)) {
             pstmt.execute();

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/DbUpgradeUtils.java
@@ -23,11 +23,11 @@ public class DbUpgradeUtils {
 
     private static DatabaseAccessObject dao = new DatabaseAccessObject();
 
-    public static void addIndexIfNeeded(Connection conn, String tableName, String columnName) {
-        String indexName = dao.generateIndexName(tableName, columnName);
+    public static void addIndexIfNeeded(Connection conn, String tableName, String... columnNames) {
+        String indexName = dao.generateIndexName(tableName, columnNames);
 
         if (!dao.indexExists(conn, tableName, indexName)) {
-            dao.createIndex(conn, tableName, columnName, indexName);
+            dao.createIndex(conn, tableName, indexName, columnNames);
         }
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41810to41900.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41810to41900.java
@@ -76,6 +76,7 @@ public class Upgrade41810to41900 implements DbUpgrade, DbUpgradeSystemVmTemplate
     public void performDataMigration(Connection conn) {
         decryptConfigurationValuesFromAccountAndDomainScopesNotInSecureHiddenCategories(conn);
         migrateBackupDates(conn);
+        addIndexes(conn);
     }
 
     @Override
@@ -252,6 +253,13 @@ public class Upgrade41810to41900 implements DbUpgrade, DbUpgradeSystemVmTemplate
             LOG.error(message, e);
             throw new CloudRuntimeException(message, e);
         }
+    }
+
+    private void addIndexes(Connection conn) {
+        DbUpgradeUtils.addIndexIfNeeded(conn, "alert", "archived", "created");
+        DbUpgradeUtils.addIndexIfNeeded(conn, "alert", "type", "data_center_id", "pod_id");
+
+        DbUpgradeUtils.addIndexIfNeeded(conn, "event", "resource_type", "resource_id");
     }
 
 }

--- a/engine/schema/src/test/java/com/cloud/upgrade/dao/DatabaseAccessObjectTest.java
+++ b/engine/schema/src/test/java/com/cloud/upgrade/dao/DatabaseAccessObjectTest.java
@@ -93,8 +93,8 @@ public class DatabaseAccessObjectTest {
 
     @Test
     public void generateIndexNameTest() {
-        String indexName = dao.generateIndexName("mytable","mycolumn");
-        Assert.assertEquals( "i_mytable__mycolumn", indexName);
+        String indexName = dao.generateIndexName("mytable","mycolumn1", "mycolumn2");
+        Assert.assertEquals( "i_mytable__mycolumn1__mycolumn2", indexName);
     }
 
     @Test
@@ -136,10 +136,11 @@ public class DatabaseAccessObjectTest {
 
         Connection conn = connectionMock;
         String tableName = "mytable";
-        String columnName = "mycolumn";
+        String columnName1 = "mycolumn1";
+        String columnName2 = "mycolumn2";
         String indexName = "myindex";
 
-        dao.createIndex(conn, tableName, columnName, indexName);
+        dao.createIndex(conn, tableName, indexName, columnName1, columnName2);
         verify(connectionMock, times(1)).prepareStatement(anyString());
         verify(preparedStatementMock, times(1)).execute();
         verify(preparedStatementMock, times(1)).close();


### PR DESCRIPTION
### Description

This PR adds missing indexes on `alerts` & `events` tables.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

For alerts table, some of the queries are part of a couple of APIs and some operations. I have added the index for the same. Ref: 
https://github.com/apache/cloudstack/blob/8f390873772ef59c3ba81c837fffe707ebd80e72/engine/schema/src/main/java/com/cloud/alert/dao/AlertDaoImpl.java#L40-L45

For Events table, we query for `resource_id` & `resource_type` in the UI for a resource's events. Indexes were missing, so I have added those.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?


**Events** 
  `24309` rows
    Query:
```sql
SELECT * FROM event_view WHERE event_view.account_type != 5 AND event_view.archived = FALSE AND event_view.resource_id = 3686 AND event_view.resource_type = 'VirtualMachine' ORDER BY event_view.created DESC , event_view.id  LIMIT 0 , 10
```
    Before 0.04ms
    After 0.004ms


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
