### PR TITLE
UI: Project column in Default View

### DIFF
--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -327,6 +327,10 @@
         <router-link v-if="record.roleid && $router.resolve('/role/' + record.roleid).matched[0].redirect !== '/exception/404'" :to="{ path: '/role/' + record.roleid }">{{ text }}</router-link>
         <span v-else>{{ text }}</span>
       </template>
+      <template v-if="column.key === 'project'">
+        <router-link v-if="$router.resolve('/project/' + record.projectid).matched[0].redirect !== '/exception/404'" :to="{ path: '/project/' + record.projectid }">{{ text }}</router-link>
+        <span v-else>{{ text }}</span>
+      </template>
       <template v-if="column.key === 'templateversion'">
         <span>  {{ record.version }} </span>
       </template>

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -61,17 +61,17 @@ export default {
         if (store.getters.metrics) {
           fields.push(...metricsFields)
         }
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(2, 0, 'instancename')
-          fields.push('account')
           fields.push('hostname')
+          fields.push('account')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
         } else {
           fields.push('serviceofferingname')
+        }
+        if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         fields.push('zonename')
         return fields
@@ -465,12 +465,14 @@ export default {
       resourceType: 'VMSnapshot',
       columns: () => {
         const fields = ['displayname', 'state', 'name', 'type', 'current', 'parentName', 'created']
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
+        } else if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         return fields
       },
@@ -538,11 +540,11 @@ export default {
       permission: ['listKubernetesClusters'],
       columns: (store) => {
         var fields = ['name', 'state', 'clustertype', 'size', 'cpunumber', 'memory', 'kubernetesversionname']
-        if (store.listAllProjects) {
-          fields.push('project')
-        }
         if (['Admin', 'DomainAdmin'].includes(store.userInfo.roletype)) {
           fields.push('account')
+        }
+        if (store.listAllProjects) {
+          fields.push('project')
         }
         if (store.apis.scaleKubernetesCluster.params.filter(x => x.name === 'autoscalingenabled').length > 0) {
           fields.splice(2, 0, 'autoscalingenabled')
@@ -811,12 +813,14 @@ export default {
       permission: ['listSSHKeyPairs'],
       columns: () => {
         var fields = ['name', 'fingerprint']
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
+        } else if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         return fields
       },
@@ -964,12 +968,14 @@ export default {
       permission: ['listAffinityGroups'],
       columns: () => {
         var fields = ['name', 'type', 'description']
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
+        } else if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         return fields
       },

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -964,7 +964,6 @@ export default {
       permission: ['listAffinityGroups'],
       columns: () => {
         var fields = ['name', 'type', 'description']
-        console.log(store.getters)
         if (store.getters.listAllProjects) {
           fields.push('project')
         }

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -65,9 +65,15 @@ export default {
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(2, 0, 'instancename')
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('hostname')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
         } else {
           fields.push('serviceofferingname')
         }
@@ -535,6 +541,9 @@ export default {
         var fields = ['name', 'state', 'clustertype', 'size', 'cpunumber', 'memory', 'kubernetesversionname']
         if (['Admin', 'DomainAdmin'].includes(store.userInfo.roletype)) {
           fields.push('account')
+          if (store.listAllProjects) {
+            fields.push('project')
+          }
         }
         if (store.apis.scaleKubernetesCluster.params.filter(x => x.name === 'autoscalingenabled').length > 0) {
           fields.splice(2, 0, 'autoscalingenabled')
@@ -633,7 +642,13 @@ export default {
       docHelp: 'adminguide/autoscale_without_netscaler.html',
       resourceType: 'AutoScaleVmGroup',
       permission: ['listAutoScaleVmGroups'],
-      columns: ['name', 'state', 'associatednetworkname', 'publicip', 'publicport', 'privateport', 'minmembers', 'maxmembers', 'availablevirtualmachinecount', 'account'],
+      columns: (store) => {
+        var fields = ['name', 'state', 'associatednetworkname', 'publicip', 'publicport', 'privateport', 'minmembers', 'maxmembers', 'availablevirtualmachinecount', 'account']
+        if (store.listAllProjects) {
+          fields.push('project')
+        }
+        return fields
+      },
       details: ['name', 'id', 'account', 'domain', 'associatednetworkname', 'associatednetworkid', 'lbruleid', 'lbprovider', 'publicip', 'publicipid', 'publicport', 'privateport', 'minmembers', 'maxmembers', 'availablevirtualmachinecount', 'interval', 'state', 'created'],
       related: [{
         name: 'vm',
@@ -737,7 +752,15 @@ export default {
       docHelp: 'adminguide/virtual_machines.html#changing-the-vm-name-os-or-group',
       resourceType: 'VMInstanceGroup',
       permission: ['listInstanceGroups'],
-      columns: ['name', 'account', 'domain'],
+
+      columns: (store) => {
+        var fields = ['name', 'account']
+        if (store.listAllProjects) {
+          fields.push('project')
+        }
+        fields.push('domain')
+        return fields
+      },
       details: ['name', 'id', 'account', 'domain', 'created'],
       related: [{
         name: 'vm',
@@ -791,6 +814,9 @@ export default {
         var fields = ['name', 'fingerprint']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
         }
         return fields
@@ -941,6 +967,9 @@ export default {
         var fields = ['name', 'type', 'description']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
         }
         return fields

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -61,19 +61,15 @@ export default {
         if (store.getters.metrics) {
           fields.push(...metricsFields)
         }
-
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(2, 0, 'instancename')
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
           fields.push('hostname')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
         } else {
           fields.push('serviceofferingname')
         }
@@ -469,9 +465,12 @@ export default {
       resourceType: 'VMSnapshot',
       columns: () => {
         const fields = ['displayname', 'state', 'name', 'type', 'current', 'parentName', 'created']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
-          fields.push('domain')
           fields.push('account')
+          fields.push('domain')
         }
         return fields
       },
@@ -539,11 +538,11 @@ export default {
       permission: ['listKubernetesClusters'],
       columns: (store) => {
         var fields = ['name', 'state', 'clustertype', 'size', 'cpunumber', 'memory', 'kubernetesversionname']
+        if (store.listAllProjects) {
+          fields.push('project')
+        }
         if (['Admin', 'DomainAdmin'].includes(store.userInfo.roletype)) {
           fields.push('account')
-          if (store.listAllProjects) {
-            fields.push('project')
-          }
         }
         if (store.apis.scaleKubernetesCluster.params.filter(x => x.name === 'autoscalingenabled').length > 0) {
           fields.splice(2, 0, 'autoscalingenabled')
@@ -812,11 +811,11 @@ export default {
       permission: ['listSSHKeyPairs'],
       columns: () => {
         var fields = ['name', 'fingerprint']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
           fields.push('domain')
         }
         return fields
@@ -892,7 +891,7 @@ export default {
       docHelp: 'adminguide/virtual_machines.html#user-data-and-meta-data',
       permission: ['listUserData'],
       columns: () => {
-        var fields = ['name', 'id']
+        var fields = ['name', 'id', 'project']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
           fields.push('domain')
@@ -965,11 +964,12 @@ export default {
       permission: ['listAffinityGroups'],
       columns: () => {
         var fields = ['name', 'type', 'description']
+        console.log(store.getters)
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
           fields.push('domain')
         }
         return fields

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -891,7 +891,7 @@ export default {
       docHelp: 'adminguide/virtual_machines.html#user-data-and-meta-data',
       permission: ['listUserData'],
       columns: () => {
-        var fields = ['name', 'id', 'project']
+        var fields = ['name', 'id']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
           fields.push('domain')

--- a/ui/src/config/section/event.js
+++ b/ui/src/config/section/event.js
@@ -15,13 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import store from '@/store'
+
 export default {
   name: 'event',
   title: 'label.events',
   icon: 'ScheduleOutlined',
   docHelp: 'adminguide/events.html',
   permission: ['listEvents'],
-  columns: ['level', 'type', 'state', 'description', 'resource', 'username', 'account', 'domain', 'created'],
+  columns: () => {
+    var fields = ['level', 'type', 'state', 'description', 'resource', 'username', 'account']
+    if (store.getters.listAllProjects) {
+      fields.push('project')
+    }
+    fields.push(...['domain', 'created'])
+    return fields
+  },
   details: ['username', 'id', 'description', 'resourcetype', 'resourceid', 'state', 'level', 'type', 'account', 'domain', 'created'],
   searchFilters: ['level', 'domainid', 'account', 'keyword', 'resourcetype'],
   related: [{

--- a/ui/src/config/section/image.js
+++ b/ui/src/config/section/image.js
@@ -46,6 +46,9 @@ export default {
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('size')
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
         }
         if (['Admin'].includes(store.getters.userInfo.roletype)) {
           fields.push('templatetype')
@@ -219,6 +222,9 @@ export default {
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('size')
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
         }
         if (['Admin'].includes(store.getters.userInfo.roletype)) {
           fields.push('order')

--- a/ui/src/config/section/image.js
+++ b/ui/src/config/section/image.js
@@ -46,9 +46,9 @@ export default {
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('size')
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
+        }
+        if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         if (['Admin'].includes(store.getters.userInfo.roletype)) {
           fields.push('templatetype')
@@ -222,9 +222,9 @@ export default {
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('size')
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
+        }
+        if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         if (['Admin'].includes(store.getters.userInfo.roletype)) {
           fields.push('order')

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -343,16 +343,19 @@ export default {
       },
       columns: () => {
         const fields = ['name', 'state', 'ipaddress']
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(2, 0, 'instancename')
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
           fields.push('hostname')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
         } else {
           fields.push('serviceofferingname')
         }

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -343,6 +343,9 @@ export default {
       },
       columns: () => {
         const fields = ['name', 'state', 'ipaddress']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(2, 0, 'instancename')
           fields.push('account')

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -34,10 +34,16 @@ export default {
       permission: ['listNetworks'],
       resourceType: 'Network',
       columns: () => {
-        var fields = ['name', 'state', 'type', 'vpcname', 'cidr', 'ip6cidr', 'broadcasturi', 'domainpath', 'account', 'zonename']
+        var fields = ['name', 'state', 'type', 'vpcname', 'cidr', 'ip6cidr', 'broadcasturi', 'domainpath']
         if (!isAdmin()) {
           fields = fields.filter(function (e) { return e !== 'broadcasturi' })
         }
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        } else {
+          fields.push('account')
+        }
+        fields.push('zonename')
         return fields
       },
       details: () => {
@@ -197,7 +203,14 @@ export default {
       docHelp: 'adminguide/networking_and_traffic.html#configuring-a-virtual-private-cloud',
       permission: ['listVPCs'],
       resourceType: 'Vpc',
-      columns: ['name', 'state', 'displaytext', 'cidr', 'account', 'domain', 'zonename'],
+      columns: () => {
+        var fields = ['name', 'state', 'displaytext', 'cidr', 'account']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
+        fields.push(...['domain', 'zonename'])
+        return fields
+      },
       details: ['name', 'id', 'displaytext', 'cidr', 'networkdomain', 'ip6routes', 'ispersistent', 'redundantvpcrouter', 'restartrequired', 'zonename', 'account', 'domain', 'dns1', 'dns2', 'ip6dns1', 'ip6dns2', 'publicmtu'],
       searchFilters: ['name', 'zoneid', 'domainid', 'account', 'tags'],
       related: [{
@@ -729,7 +742,14 @@ export default {
       docHelp: 'adminguide/networking_and_traffic.html#reserving-public-ip-addresses-and-vlans-for-accounts',
       permission: ['listPublicIpAddresses'],
       resourceType: 'PublicIpAddress',
-      columns: ['ipaddress', 'state', 'associatednetworkname', 'vpcname', 'virtualmachinename', 'allocated', 'account', 'domain', 'zonename'],
+      columns: () => {
+        var fields = ['ipaddress', 'state', 'associatednetworkname', 'vpcname', 'virtualmachinename', 'allocated', 'account']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
+        fields.push(...['domain', 'zonename'])
+        return fields
+      },
       details: ['ipaddress', 'id', 'associatednetworkname', 'virtualmachinename', 'networkid', 'issourcenat', 'isstaticnat', 'virtualmachinename', 'vmipaddress', 'vlan', 'allocated', 'account', 'domain', 'zonename'],
       filters: ['allocated', 'reserved', 'free'],
       component: shallowRef(() => import('@/views/network/PublicIpResource.vue')),
@@ -1119,7 +1139,14 @@ export default {
       title: 'label.vpncustomergatewayid',
       icon: 'lock-outlined',
       permission: ['listVpnCustomerGateways'],
-      columns: ['name', 'gateway', 'cidrlist', 'ipsecpsk', 'account', 'domain'],
+      columns: () => {
+        var fields = ['name', 'gateway', 'cidrlist', 'ipsecpsk', 'account']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
+        fields.push('domain')
+        return fields
+      },
       details: ['name', 'id', 'gateway', 'cidrlist', 'ipsecpsk', 'ikepolicy', 'ikelifetime', 'ikeversion', 'esppolicy', 'esplifetime', 'dpd', 'splitconnections', 'forceencap', 'account', 'domain'],
       searchFilters: ['keyword', 'domainid', 'account'],
       resourceType: 'VPNCustomerGateway',

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -49,14 +49,14 @@ export default {
         if (store.getters.metrics) {
           fields.push(...metricsFields)
         }
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (store.getters.userInfo.roletype === 'Admin') {
-          fields.push('account')
           fields.push('storage')
+          fields.push('account')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
+        }
+        if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         fields.push('zonename')
 
@@ -313,12 +313,14 @@ export default {
       resourceType: 'Snapshot',
       columns: () => {
         var fields = ['name', 'state', 'volumename', 'intervaltype', 'physicalsize', 'created']
-        if (store.getters.listAllProjects) {
-          fields.push('project')
-        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
+        } else if (store.getters.listAllProjects) {
+          fields.push('project')
         }
         fields.push('zonename')
         return fields

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -49,18 +49,14 @@ export default {
         if (store.getters.metrics) {
           fields.push(...metricsFields)
         }
-
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
           fields.push('storage')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
         }
         fields.push('zonename')
 
@@ -317,11 +313,11 @@ export default {
       resourceType: 'Snapshot',
       columns: () => {
         var fields = ['name', 'state', 'volumename', 'intervaltype', 'physicalsize', 'created']
+        if (store.getters.listAllProjects) {
+          fields.push('project')
+        }
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
-          if (store.getters.listAllProjects) {
-            fields.push('project')
-          }
           fields.push('domain')
         }
         fields.push('zonename')

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -52,9 +52,15 @@ export default {
 
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('storage')
         } else if (store.getters.userInfo.roletype === 'DomainAdmin') {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
         }
         fields.push('zonename')
 
@@ -313,6 +319,9 @@ export default {
         var fields = ['name', 'state', 'volumename', 'intervaltype', 'physicalsize', 'created']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('account')
+          if (store.getters.listAllProjects) {
+            fields.push('project')
+          }
           fields.push('domain')
         }
         fields.push('zonename')

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -879,6 +879,9 @@ export default {
           this.$store.getters.customColumns[this.$store.getters.userInfo.id][this.$route.path] = this.selectedColumns
         } else {
           this.selectedColumns = this.$store.getters.customColumns[this.$store.getters.userInfo.id][this.$route.path] || this.selectedColumns
+          if (this.$store.getters.listAllProjects && !this.projectView) {
+            this.selectedColumns.push('project')
+          }
           this.updateSelectedColumns()
         }
       }


### PR DESCRIPTION
### Description

The Default View has a `projects` toggle button that allows users to see which resources belong to projects, but there is nothing to indicate which project they belong to.

For this reason, a `project` column was added if the `projects` button is enabled, indicating the name of the project to which the resource belongs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created the resources that can be listed outside of a project (instance, guest network, VPC, etc.). Then, I enabled the `projects` button in the Default View and verified that the `project` column was filled with the name of the project that the resources belong to.