### PR TITLE
ui: change ipaddress tab label for shared networks

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1030,6 +1030,7 @@
 "label.ipv6.dns1": "IPv6 DNS1",
 "label.ipv6.dns2": "IPv6 DNS2",
 "label.ipv6.subnets": "IPv6 Subnets",
+"label.ip.addresses": "IP Addresses",
 "label.iqn": "Target IQN",
 "label.is.in.progress": "is in progress",
 "label.is.shared": "Is shared",

--- a/ui/src/components/view/ResourceView.vue
+++ b/ui/src/components/view/ResourceView.vue
@@ -44,7 +44,7 @@
           <template v-for="tab in tabs" :key="tab.name">
             <a-tab-pane
               :key="tab.name"
-              :tab="$t('label.' + tab.name)"
+              :tab="$t('label.' + tabName(tab))"
               v-if="showTab(tab)">
               <keep-alive>
                 <component
@@ -157,6 +157,12 @@ export default {
         }).join('&')
       )
       this.$emit('onTabChange', key)
+    },
+    tabName (tab) {
+      if (typeof tab.name === 'function') {
+        return tab.name(this.resource)
+      }
+      return tab.name
     },
     showTab (tab) {
       if (this.networkService && this.networkService.service && tab.networkServiceFilter) {

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -65,7 +65,7 @@ export default {
         component: shallowRef(defineAsyncComponent(() => import('@/views/network/Ipv6FirewallRulesTab.vue'))),
         show: (record, route, user) => { return record.type === 'Isolated' && ['IPv6', 'DualStack'].includes(record.internetprotocol) && !('vpcid' in record) && 'listIpv6FirewallRules' in store.getters.apis && (['Admin', 'DomainAdmin'].includes(user.roletype) || record.account === user.account || record.projectid) }
       }, {
-        name: 'public.ip.addresses',
+        name: (record) => { return record.type === 'Shared' ? 'ip.addresses' : 'public.ip.addresses' },
         component: shallowRef(defineAsyncComponent(() => import('@/views/network/IpAddressesTab.vue'))),
         show: (record, route, user) => { return 'listPublicIpAddresses' in store.getters.apis && (record.type === 'Shared' || (record.type === 'Isolated' && !('vpcid' in record) && (['Admin', 'DomainAdmin'].includes(user.roletype) || record.account === user.account || record.projectid))) }
       }, {


### PR DESCRIPTION
### Description

In UI, shared network IP addresses are shown in a tab named Public IP addresses inside the network view.

Public IP addresses have their own subsection in the UI. Network → Public IP address. Shared network IP addresses are not shown in this view.

This is confusing for users and Public IP addresses tab in the network view has been renamed as IP addresses for a shared network.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![image](https://github.com/apache/cloudstack/assets/153340/76d19202-97d0-4a81-94d9-fb7f7a9e9c7e)


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
