### PR TITLE
Change available fields when editing a default role in the UI

### DIFF
--- a/ui/src/config/section/role.js
+++ b/ui/src/config/section/role.js
@@ -53,7 +53,7 @@ export default {
       icon: 'edit-outlined',
       label: 'label.edit.role',
       dataView: true,
-      args: ['name', 'description', 'type', 'ispublic'],
+      args: (record) => record.isdefault ? ['ispublic'] : ['name', 'description', 'type', 'ispublic'],
       mapping: {
         type: {
           options: ['Admin', 'DomainAdmin', 'User']


### PR DESCRIPTION
### Description

This PR addresses the problem of not being possible to edit the Public property of a default role through the UI, since it sets the other fields as parameters of the API call and results in a `Default roles cannot be updated (with the exception of making it private/public).` error. 

It solves this by simply limiting the available fields for default roles, since they are not possible to be edited in the first place and should not show up anyway. It does not change the window for non-default roles.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

In the User default role, I verified that only the Public field showed up. I unchecked it and verified `ispublic` became false. 

I created a new role. In its editing window, I verified all the original fields were there (Name, Description, Type and Public). I changed the fields and verified they took place.
