### PR TITLE
Allow autoscale group and name override

### DIFF
--- a/server/src/main/java/com/cloud/network/as/AutoScaleManager.java
+++ b/server/src/main/java/com/cloud/network/as/AutoScaleManager.java
@@ -16,7 +16,10 @@
 // under the License.
 package com.cloud.network.as;
 
+import java.security.SecureRandom;
+
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public interface AutoScaleManager extends AutoScaleService {
 
@@ -55,4 +58,8 @@ public interface AutoScaleManager extends AutoScaleService {
     void checkIfVmActionAllowed(Long vmId);
 
     void removeVmFromVmGroup(Long vmId);
+
+    String getNextVmHostName(AutoScaleVmGroupVO asGroup);
+
+    void checkAutoScaleVmGroupName(String groupName);
 }

--- a/server/src/main/java/com/cloud/network/as/AutoScaleManager.java
+++ b/server/src/main/java/com/cloud/network/as/AutoScaleManager.java
@@ -16,11 +16,7 @@
 // under the License.
 package com.cloud.network.as;
 
-import java.security.SecureRandom;
-
 import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.commons.lang3.RandomStringUtils;
-
 public interface AutoScaleManager extends AutoScaleService {
 
     ConfigKey<Integer> AutoScaleStatsInterval = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Integer.class,

--- a/server/src/main/java/com/cloud/network/as/AutoScaleManager.java
+++ b/server/src/main/java/com/cloud/network/as/AutoScaleManager.java
@@ -17,6 +17,7 @@
 package com.cloud.network.as;
 
 import org.apache.cloudstack.framework.config.ConfigKey;
+
 public interface AutoScaleManager extends AutoScaleService {
 
     ConfigKey<Integer> AutoScaleStatsInterval = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Integer.class,

--- a/server/src/main/java/com/cloud/network/as/AutoScaleManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/as/AutoScaleManagerImpl.java
@@ -1938,7 +1938,8 @@ public class AutoScaleManagerImpl extends ManagerBase implements AutoScaleManage
         }
     }
 
-    private String getNextVmHostName(AutoScaleVmGroupVO asGroup) {
+    @Override
+    public String getNextVmHostName(AutoScaleVmGroupVO asGroup) {
         String vmHostNameSuffix = "-" + asGroup.getNextVmSeq() + "-" +
                 RandomStringUtils.random(VM_HOSTNAME_RANDOM_SUFFIX_LENGTH, 0, 0, true, false, (char[])null, new SecureRandom()).toLowerCase();
         // Truncate vm group name because max length of vm name is 63
@@ -1946,7 +1947,8 @@ public class AutoScaleManagerImpl extends ManagerBase implements AutoScaleManage
         return VM_HOSTNAME_PREFIX + asGroup.getName().substring(0, subStringLength) + vmHostNameSuffix;
     }
 
-    private void checkAutoScaleVmGroupName(String groupName) {
+    @Override
+    public void checkAutoScaleVmGroupName(String groupName) {
         String errorMessage = "";
         if (groupName == null || groupName.length() > 255 || groupName.length() < 1) {
             errorMessage = "AutoScale Vm Group name must be between 1 and 255 characters long";


### PR DESCRIPTION
… conventions

### Description
Updates AutoScaleManager/AutoScaleManagerImpl so that getNextVmHostName and checkAutoScaleVmGroupName can be overridden in derivative implementations to allow for custom naming conditions and restrictions.  If possible, would like to include this in 4.19 since it is a trivial change.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Extended implementation class with different VM names and tested for shorter auto-scale names.

#### How did you try to break this feature and the system with this change?

Use group names longer than the extended code allowed.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
