### PR TITLE
Fix unmanage VM marvin tests and small UI fixes for import

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -54,6 +54,7 @@ import com.vmware.vim25.FileQueryFlags;
 import com.vmware.vim25.FolderFileInfo;
 import com.vmware.vim25.HostDatastoreBrowserSearchResults;
 import com.vmware.vim25.HostDatastoreBrowserSearchSpec;
+import com.vmware.vim25.VirtualMachineConfigSummary;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
@@ -7154,7 +7155,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
                 UnmanagedInstanceTO instance = VmwareHelper.getUnmanagedInstance(hyperHost, vmMo);
                 if (instance != null) {
-                    instance.setCpuSpeed(vmMo.getConfigSummary().getCpuReservation());
+                    VirtualMachineConfigSummary configSummary = vmMo.getConfigSummary();
+                    instance.setCpuSpeed(configSummary != null ? configSummary.getCpuReservation() : 0);
                     unmanagedInstances.put(instance.getName(), instance);
                 }
             }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -7154,6 +7154,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
                 UnmanagedInstanceTO instance = VmwareHelper.getUnmanagedInstance(hyperHost, vmMo);
                 if (instance != null) {
+                    instance.setCpuSpeed(vmMo.getConfigSummary().getCpuReservation());
                     unmanagedInstances.put(instance.getName(), instance);
                 }
             }

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -266,12 +266,12 @@
                   </template>
                   <span>{{ $t('message.ip.address.changes.effect.after.vm.restart') }}</span>
                 </a-form-item>
-                <a-row :gutter="12" justify="end">
+                <a-row v-if="selectedVmwareVcenter" :gutter="12" justify="end">
                   <a-col style="text-align: right">
                     <a-form-item name="forced" ref="forced">
                       <template #label>
                         <tooltip-label
-                          :title="selectedVmwareVcenter ? $t('label.allow.duplicate.macaddresses') : $t('label.forced')"
+                          :title="$t('label.allow.duplicate.macaddresses')"
                           :tooltip="apiParams.forced.description"/>
                       </template>
                       <a-switch v-model:checked="form.forced" @change="val => { switches.forced = val }" />
@@ -294,13 +294,23 @@
                   </template>
                 </a-alert>
               </a-row>
-              <a-row :gutter="12">
+              <a-row v-if="!selectedVmwareVcenter" :gutter="12">
                 <a-col :md="24" :lg="12">
-                  <a-form-item name="migrateallowed" ref="migrateallowed" v-if="!selectedVmwareVcenter">
+                  <a-form-item name="migrateallowed" ref="migrateallowed">
                     <template #label>
                       <tooltip-label :title="$t('label.migrate.allowed')" :tooltip="apiParams.migrateallowed.description"/>
                     </template>
                     <a-switch v-model:checked="form.migrateallowed" @change="val => { switches.migrateAllowed = val }" />
+                  </a-form-item>
+                </a-col>
+                <a-col>
+                  <a-form-item name="forced" ref="forced">
+                    <template #label>
+                      <tooltip-label
+                        :title="$t('label.forced')"
+                        :tooltip="apiParams.forced.description"/>
+                    </template>
+                    <a-switch v-model:checked="form.forced" @change="val => { switches.forced = val }" />
                   </a-form-item>
                 </a-col>
               </a-row>


### PR DESCRIPTION
### Description

This PR fixes the failing smoke test for `test_vm_lifecycle_unmanage_import.py` for Vmware and adds a small UI fix on the import wizard

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
