### PR TITLE
server: fix url check for storages without a valid url

### DIFF
--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -824,7 +824,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         Long zoneId = cmd.getZoneId();
 
         ScopeType scopeType = ScopeType.CLUSTER;
-        if ("file".equalsIgnoreCase(uriParams.get("scheme"))) {
+        if ("file".equals(uriParams.get("scheme"))) {
             scopeType = ScopeType.HOST;
         }
         String scope = cmd.getScope();
@@ -900,7 +900,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         DataStoreLifeCycle lifeCycle = storeProvider.getDataStoreLifeCycle();
         DataStore store = null;
         try {
-            if (params.get("scheme").toString().equals("file")) {
+            if ("file".equals(uriParams.get("scheme"))) {
                 store = createLocalStorage(params);
             } else {
                 store = lifeCycle.initialize(params);

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -685,19 +685,21 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         return true;
     }
 
+    protected String getValidatedPareForLocalStorage(Object obj, String paramName) {
+        String result = obj == null ? null : obj.toString();
+        if (StringUtils.isEmpty(result)) {
+            throw new InvalidParameterValueException(String.format("Invalid %s provided", paramName));
+        }
+        return result;
+    }
+
     protected DataStore createLocalStorage(Map<String, Object> poolInfos) throws ConnectionException{
         Object existingUuid = poolInfos.get("uuid");
         if( existingUuid == null ){
             poolInfos.put("uuid", UUID.randomUUID().toString());
         }
-        String hostAddress = poolInfos.get("host") == null ? null : poolInfos.get("host").toString();
-        if (StringUtils.isEmpty(hostAddress)) {
-            throw new InvalidParameterValueException("Invalid host provided");
-        }
-        String hostPath = poolInfos.get("hostPath") == null ? null : poolInfos.get("hostPath").toString();
-        if (StringUtils.isEmpty(hostPath)) {
-            throw new InvalidParameterValueException("Invalid path provided");
-        }
+        String hostAddress = getValidatedPareForLocalStorage(poolInfos.get("host"), "host");
+        String hostPath = getValidatedPareForLocalStorage(poolInfos.get("hostPath"), "path");
         Host host = _hostDao.findByName(hostAddress);
 
         if( host == null ) {

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -18,10 +18,12 @@ package com.cloud.storage;
 
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.sql.PreparedStatement;
@@ -132,9 +134,8 @@ import org.apache.cloudstack.storage.object.ObjectStore;
 import org.apache.cloudstack.storage.object.ObjectStoreEntity;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -255,8 +256,6 @@ import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.google.common.collect.Sets;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 
 
 @Component

--- a/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
+++ b/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
@@ -164,7 +164,7 @@ public class StorageManagerImplTest {
         String sfUrl = "MVIP=1.2.3.4;SVIP=6.7.8.9;clusterAdminUsername=admin;" +
                 "clusterAdminPassword=password;clusterDefaultMinIops=1000;" +
                 "clusterDefaultMaxIops=2000;clusterDefaultBurstIopsPercentOfMaxIops=2";
-        Map<String,String> uriParams = storageManagerImpl.extractUriParamsAsMap(sfUrl, true);
+        Map<String,String> uriParams = storageManagerImpl.extractUriParamsAsMap(sfUrl);
         Assert.assertTrue(MapUtils.isEmpty(uriParams));
     }
 
@@ -174,7 +174,7 @@ public class StorageManagerImplTest {
         String host = "HOST";
         String path = "/PATH";
         String sfUrl = String.format("%s://%s%s", scheme, host, path);
-        Map<String,String> uriParams = storageManagerImpl.extractUriParamsAsMap(sfUrl, false);
+        Map<String,String> uriParams = storageManagerImpl.extractUriParamsAsMap(sfUrl);
         Assert.assertTrue(MapUtils.isNotEmpty(uriParams));
         Assert.assertEquals(scheme, uriParams.get("scheme"));
         Assert.assertEquals(host, uriParams.get("host"));

--- a/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
+++ b/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
@@ -17,6 +17,8 @@
 package com.cloud.storage;
 
 import com.cloud.agent.api.StoragePoolInfo;
+import com.cloud.exception.ConnectionException;
+import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.host.Host;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.vm.VMInstanceVO;
@@ -34,6 +36,7 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -179,5 +182,28 @@ public class StorageManagerImplTest {
         Assert.assertEquals(scheme, uriParams.get("scheme"));
         Assert.assertEquals(host, uriParams.get("host"));
         Assert.assertEquals(path, uriParams.get("hostPath"));
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testCreateLocalStorageHostFailure() {
+        Map<String, Object> test = new HashMap<>();
+        test.put("host", null);
+        try {
+            storageManagerImpl.createLocalStorage(test);
+        } catch (ConnectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testCreateLocalStoragePathFailure() {
+        Map<String, Object> test = new HashMap<>();
+        test.put("host", "HOST");
+        test.put("hostPath", "");
+        try {
+            storageManagerImpl.createLocalStorage(test);
+        } catch (ConnectionException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
+++ b/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
@@ -23,6 +23,7 @@ import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.dao.VMInstanceDao;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.commons.collections.MapUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +35,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StorageManagerImplTest {
@@ -157,4 +159,25 @@ public class StorageManagerImplTest {
 
     }
 
+    @Test
+    public void testExtractUriParamsAsMapWithSolidFireUrl() {
+        String sfUrl = "MVIP=1.2.3.4;SVIP=6.7.8.9;clusterAdminUsername=admin;" +
+                "clusterAdminPassword=password;clusterDefaultMinIops=1000;" +
+                "clusterDefaultMaxIops=2000;clusterDefaultBurstIopsPercentOfMaxIops=2";
+        Map<String,String> uriParams = storageManagerImpl.extractUriParamsAsMap(sfUrl, true);
+        Assert.assertTrue(MapUtils.isEmpty(uriParams));
+    }
+
+    @Test
+    public void testExtractUriParamsAsMapWithNFSUrl() {
+        String scheme = "nfs";
+        String host = "HOST";
+        String path = "/PATH";
+        String sfUrl = String.format("%s://%s%s", scheme, host, path);
+        Map<String,String> uriParams = storageManagerImpl.extractUriParamsAsMap(sfUrl, false);
+        Assert.assertTrue(MapUtils.isNotEmpty(uriParams));
+        Assert.assertEquals(scheme, uriParams.get("scheme"));
+        Assert.assertEquals(host, uriParams.get("host"));
+        Assert.assertEquals(path, uriParams.get("hostPath"));
+    }
 }


### PR DESCRIPTION
### Description

Fixes #8352
Some managed storages may not need a valid URL to be passed. We can skip check and extraction of host or path from url of such storages.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
