### PR TITLE
Option to create StorPool primary storage with a valid URL

### DIFF
--- a/plugins/storage/volume/storpool/README.md
+++ b/plugins/storage/volume/storpool/README.md
@@ -117,6 +117,8 @@ SP_API_HTTP - address of StorPool Api
 SP_AUTH_TOKEN - StorPool's token
 SP_TEMPLATE - name of StorPool's template
 
+> **NOTE:** You can use the alternative format option for the URL - storpool://{SP_AUTH_TOKEN}@{SP_API_HTTP}:{SP_API_HTTP_PORT}/{SP_TEMPLATE}
+
 Storage Tags: If left blank, the StorPool storage plugin will use the pool name to create a corresponding storage tag.
 This storage tag may be used later, when defining service or disk offerings.
 

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
@@ -172,6 +172,12 @@ public class StorPoolUtil {
         private String templateName;
 
         public SpConnectionDesc(String url) {
+            try {
+                extractUriParams(url);
+                return;
+            } catch (URISyntaxException e) {
+                log.debug("[ignore] the uri is not valid");
+            }
             String[] urlSplit = url.split(";");
             if (urlSplit.length == 1 && !urlSplit[0].contains("=")) {
                 this.templateName = url;
@@ -238,6 +244,13 @@ public class StorPoolUtil {
                     }
                 }
             }
+        }
+
+        private void extractUriParams(String url) throws URISyntaxException {
+            URI uri = new URI(url);
+            hostPort = uri.getHost() + ":" + uri.getPort();
+            authToken = uri.getUserInfo();
+            templateName = uri.getPath().replace("/", "");
         }
 
         public SpConnectionDesc(String host, String authToken2, String templateName2) {

--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/util/StorPoolUtil.java
@@ -248,6 +248,9 @@ public class StorPoolUtil {
 
         private void extractUriParams(String url) throws URISyntaxException {
             URI uri = new URI(url);
+            if (!StringUtils.equalsIgnoreCase(uri.getScheme(), "storpool")) {
+                throw new CloudRuntimeException("The scheme is invalid. The URL should be with a format storpool://{SP_AUTH_TOKEN}@{SP_API_HTTP}:{SP_API_HTTP_PORT}/{SP_TEMPLATE}");
+            }
             hostPort = uri.getHost() + ":" + uri.getPort();
             authToken = uri.getUserInfo();
             templateName = uri.getPath().replace("/", "");


### PR DESCRIPTION
### Description

This PR provides another option to create StorPool primary storage with a valid URL in cases the old format is not accepted. The user will be able to use the old and new format

Old format `SP_API_HTTP=address:port;SP_AUTH_TOKEN=token;SP_TEMPLATE=template_name`
New format `storpool://{SP_AUTH_TOKEN}@{SP_API_HTTP}:{SP_API_HTTP_PORT}/{SP_TEMPLATE}`



### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?
Manual and smoke tests
