### PR TITLE
server: skip password policies check on empty password

### DIFF
--- a/server/src/main/java/com/cloud/user/PasswordPolicy.java
+++ b/server/src/main/java/com/cloud/user/PasswordPolicy.java
@@ -78,8 +78,8 @@ public interface PasswordPolicy {
             "Advanced",
             String.class,
             "password.policy.regex",
-            ".+",
-            "A regular expression that the user's password must match. The default expression '.+' will match with any password.",
+            "",
+            "A regular expression that the user's password must match. By default no expression is used.",
             true,
             ConfigKey.Scope.Domain);
 

--- a/server/src/main/java/com/cloud/user/PasswordPolicy.java
+++ b/server/src/main/java/com/cloud/user/PasswordPolicy.java
@@ -78,8 +78,8 @@ public interface PasswordPolicy {
             "Advanced",
             String.class,
             "password.policy.regex",
-            "",
-            "A regular expression that the user's password must match. By default no expression is used.",
+            ".+",
+            "A regular expression that the user's password must match. The default expression '.+' will match with any password.",
             true,
             ConfigKey.Scope.Domain);
 

--- a/server/src/main/java/com/cloud/user/PasswordPolicyImpl.java
+++ b/server/src/main/java/com/cloud/user/PasswordPolicyImpl.java
@@ -188,12 +188,12 @@ public class PasswordPolicyImpl implements PasswordPolicy, Configurable {
         logger.trace(String.format("Validating if the new password for user [%s] matches regex [%s] defined in the configuration [%s].",
                 username, passwordPolicyRegex, PasswordPolicyRegex.key()));
 
-        if (passwordPolicyRegex == null){
+        if (StringUtils.isBlank(passwordPolicyRegex)) {
             logger.trace(String.format("Regex is null; therefore, we will not validate if the new password matches with regex for user [%s].", username));
             return;
         }
 
-        if (!password.matches(passwordPolicyRegex)){
+        if (!password.matches(passwordPolicyRegex)) {
             logger.error(String.format("User [%s] informed a new password that does not match with regex [%s]. Refusing the user's new password.", username, passwordPolicyRegex));
             throw new InvalidParameterValueException("User password does not match with password policy regex.");
         }

--- a/server/src/main/java/com/cloud/user/PasswordPolicyImpl.java
+++ b/server/src/main/java/com/cloud/user/PasswordPolicyImpl.java
@@ -27,6 +27,12 @@ public class PasswordPolicyImpl implements PasswordPolicy, Configurable {
     private Logger logger = Logger.getLogger(PasswordPolicyImpl.class);
 
     public void verifyIfPasswordCompliesWithPasswordPolicies(String password, String username, Long domainId) {
+        if (StringUtils.isEmpty(password)) {
+            logger.warn(String.format("User [%s] has an empty password, skipping password policy checks. " +
+                    "If this is not a LDAP user, there is something wrong.", username));
+            return;
+        }
+
         int numberOfSpecialCharactersInPassword = 0;
         int numberOfUppercaseLettersInPassword = 0;
         int numberOfLowercaseLettersInPassword = 0;
@@ -188,8 +194,8 @@ public class PasswordPolicyImpl implements PasswordPolicy, Configurable {
         logger.trace(String.format("Validating if the new password for user [%s] matches regex [%s] defined in the configuration [%s].",
                 username, passwordPolicyRegex, PasswordPolicyRegex.key()));
 
-        if (StringUtils.isBlank(passwordPolicyRegex)) {
-            logger.trace(String.format("Regex is null; therefore, we will not validate if the new password matches with regex for user [%s].", username));
+        if (StringUtils.isEmpty(passwordPolicyRegex)) {
+            logger.trace(String.format("Regex is empty; therefore, we will not validate if the new password matches with regex for user [%s].", username));
             return;
         }
 


### PR DESCRIPTION
### Description

This PR changes the `password.policy.regex` default value to empty. With an empty value for the configuration, it is skipped during the password policy check, only when the configuration is set to something different than a blank string, the regex will get checked.  
This way, when creating a user on `org.apache.cloudstack.ldap.LdapAuthenticator#authenticate()`  we won't get an error by default, as a empty value for the password is passed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

