### PR TITLE
test: fix test_host_ping.py to restore original host state

### DIFF
--- a/test/integration/smoke/test_host_ping.py
+++ b/test/integration/smoke/test_host_ping.py
@@ -40,9 +40,14 @@ class TestHostPing(cloudstackTestCase):
         self.services = self.testClient.getParsedTestDataConfig()
         self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
         self.pod = get_pod(self.apiclient, self.zone.id)
+        self.original_host_state_map = {}
         self.cleanup = []
 
     def tearDown(self):
+        for host_id in self.original_host_state_map:
+            state = self.original_host_state_map[host_id]
+            sql_query = "UPDATE host SET status = '" + state + "' WHERE uuid = '" + host_id + "'"
+            self.dbConnection.execute(sql_query)
         super(TestHostPing, self).tearDown()
 
     def checkHostStateInCloudstack(self, state, host_id):
@@ -92,6 +97,7 @@ class TestHostPing(cloudstackTestCase):
             self.logger.debug('Hypervisor = {}'.format(host.id))
 
         hostToTest = listHost[0]
+        self.original_host_state_map[hostToTest.id] = hostToTest.state
         sql_query = "UPDATE host SET status = 'Alert' WHERE uuid = '" + hostToTest.id + "'"
         self.dbConnection.execute(sql_query)
 


### PR DESCRIPTION
### Description

Failures seen in #7344 were debugged and it was seen since one of the hosts is in Alert state. VM deployment fails with affinity group.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
