### PR TITLE
test: additional check to ensure hosts are left in up state

### DIFF
--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1011,7 +1011,8 @@ class TestSecuredVmMigration(cloudstackTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.ensure_all_hosts_are_up()
+        if cls.hypervisor.lower() in ["kvm"]:
+            cls.ensure_all_hosts_are_up()
         super(TestSecuredVmMigration, cls).tearDownClass()
 
     @classmethod

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1037,7 +1037,7 @@ class TestSecuredVmMigration(cloudstackTestCase):
                         hostid=host.id,
                         type='Routing'
                     )[0]
-                    if restarted_host.state == state:
+                    if restarted_host.state == 'Up':
                         break
                     retries = retries - 1
 

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1037,7 +1037,7 @@ class TestSecuredVmMigration(cloudstackTestCase):
                         hostid=host.id,
                         type='Routing'
                     )[0]
-                    if restarted_host.state == 'Up':
+                    if restarted_host.state == "Up":
                         break
                     retries = retries - 1
 

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -1011,7 +1011,35 @@ class TestSecuredVmMigration(cloudstackTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.ensure_all_hosts_are_up()
         super(TestSecuredVmMigration, cls).tearDownClass()
+
+    @classmethod
+    def ensure_all_hosts_are_up(cls):
+        hosts = Host.list(
+            cls.apiclient,
+            zoneid=cls.zone.id,
+            type='Routing',
+            hypervisor='KVM'
+        )
+        for host in hosts:
+            if host.state != "Up":
+                SshClient(host.ipaddress, port=22, user=cls.hostConfig["username"], passwd=cls.hostConfig["password"]) \
+                    .execute("service cloudstack-agent stop ; \
+                              sleep 10 ; \
+                              service cloudstack-agent start")
+                interval = 5
+                retries = 10
+                while retries > -1:
+                    time.sleep(interval)
+                    restarted_host = Host.list(
+                        cls.apiclient,
+                        hostid=host.id,
+                        type='Routing'
+                    )[0]
+                    if restarted_host.state == state:
+                        break
+                    retries = retries - 1
 
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()


### PR DESCRIPTION
### Description

With this change, a fix is added for failures seen with test_08_migrate_vm or other migration-related tests because the target host is in `Connecting` state,
https://github.com/apache/cloudstack/pull/8356#issuecomment-1865422925
https://github.com/apache/cloudstack/pull/8374#issuecomment-1865028605
and more

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
