### PR TITLE
Fix bootstrap exceptions

### DIFF
--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
@@ -101,9 +101,13 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
                     log.debug(String.format("Trying to obtain module [%s] context.", moduleDefinitionName));
                     ApplicationContext context = getApplicationContext(moduleDefinitionName);
                     try {
-                        Runnable runnable = context.getBean("moduleStartup", Runnable.class);
-                        log.info(String.format("Starting module [%s].", moduleDefinitionName));
-                        runnable.run();
+                        if (context.containsBean("moduleStartup")) {
+                            Runnable runnable = context.getBean("moduleStartup", Runnable.class);
+                            log.info(String.format("Starting module [%s].", moduleDefinitionName));
+                            runnable.run();
+                        } else {
+                            log.debug(String.format("Could not get module [%s] context bean.", moduleDefinitionName));
+                        }
                     } catch (BeansException e) {
                         log.warn(String.format("Failed to start module [%s] due to: [%s].", moduleDefinitionName, e.getMessage()));
                         if (log.isDebugEnabled()) {
@@ -126,6 +130,10 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
             public void with(ModuleDefinition def, Stack<ModuleDefinition> parents) {
                 try {
                     String moduleDefinitionName = def.getName();
+                    if (parents.isEmpty()) {
+                        log.debug(String.format("Could not find module [%s] context as they have no parents.", moduleDefinitionName));
+                        return;
+                    }
                     log.debug(String.format("Trying to obtain module [%s] context.", moduleDefinitionName));
                     ApplicationContext parent = getApplicationContext(parents.peek().getName());
                     log.debug(String.format("Trying to load module [%s] context.", moduleDefinitionName));


### PR DESCRIPTION
### Description

During management server initialization, some `EmptyStackException` and `BeansException` exceptions are always thrown; These exceptions do not affect ACS, however, they can cause confusion when observing the management server startup logs with DEBUG level on. The causes of the exceptions have been addressed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### How Has This Been Tested?

Without the change, I started the MGMT server with debug logs on and saw the exceptions being logged.
With the change, I started the MGMT server and saw that no exceptions were happening on bootstrap, furthermore, the MGMT server started correctly.