### PR TITLE
minio: fix store user creation

### DIFF
--- a/plugins/storage/object/minio/src/main/java/org/apache/cloudstack/storage/datastore/driver/MinIOObjectStoreDriverImpl.java
+++ b/plugins/storage/object/minio/src/main/java/org/apache/cloudstack/storage/datastore/driver/MinIOObjectStoreDriverImpl.java
@@ -298,6 +298,11 @@ public class MinIOObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
         } catch (NoSuchAlgorithmException | IOException | InvalidKeyException e) {
             s_logger.error(String.format("Error encountered while retrieving user: %s for existing MinIO store user check", accessKey), e);
             return false;
+        } catch (RuntimeException e) { // MinIO lib may throw RuntimeException with code: XMinioAdminNoSuchUser
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("Ignoring error encountered while retrieving user: %s for existing MinIO store user check", accessKey));
+            }
+            s_logger.trace("Exception during MinIO user check", e);
         }
         if (s_logger.isDebugEnabled()) {
             s_logger.debug(String.format("MinIO store user does not exist. Creating user: %s", accessKey));

--- a/plugins/storage/object/minio/src/main/java/org/apache/cloudstack/storage/datastore/driver/MinIOObjectStoreDriverImpl.java
+++ b/plugins/storage/object/minio/src/main/java/org/apache/cloudstack/storage/datastore/driver/MinIOObjectStoreDriverImpl.java
@@ -279,7 +279,7 @@ public class MinIOObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
                 return true;
             }
         } catch (Exception e) {
-            s_logger.debug("User does not exist. Creating user: " + accessKey);
+            s_logger.debug(String.format("User does not exist. Creating user: %s", accessKey));
         }
 
         KeyGenerator generator = null;

--- a/plugins/storage/object/minio/src/main/java/org/apache/cloudstack/storage/datastore/driver/MinIOObjectStoreDriverImpl.java
+++ b/plugins/storage/object/minio/src/main/java/org/apache/cloudstack/storage/datastore/driver/MinIOObjectStoreDriverImpl.java
@@ -65,7 +65,7 @@ import io.minio.messages.VersioningConfiguration;
 
 public class MinIOObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
     private static final Logger s_logger = Logger.getLogger(MinIOObjectStoreDriverImpl.class);
-    private static final String ACS_PREFIX = "acs";
+    protected static final String ACS_PREFIX = "acs";
 
     @Inject
     AccountDao _accountDao;
@@ -85,8 +85,8 @@ public class MinIOObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
     private static final String ACCESS_KEY = "accesskey";
     private static final String SECRET_KEY = "secretkey";
 
-    private static final String MINIO_ACCESS_KEY = "minio-accesskey";
-    private static final String MINIO_SECRET_KEY = "minio-secretkey";
+    protected static final String MINIO_ACCESS_KEY = "minio-accesskey";
+    protected static final String MINIO_SECRET_KEY = "minio-secretkey";
 
     @Override
     public DataStoreTO getStoreTO(DataStore store) {


### PR DESCRIPTION
### Description

To prevent error during multi-user access, use account UUID to create/access user on the procider side. Also, update existing secret key for a user that already exist.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

1. Create a new account `testuser`
2. Create a minio bucket for the account
3. Delete the account
4. Again create account with the same name
5. Try creating a minio bucket and observe the failure,
```
2024-01-03 12:34:27,976 DEBUG [o.a.c.s.o.BucketApiServiceImpl] (API-Job-Executor-83:ctx-8824ed0d job-95 ctx-1ec9d7a6) (logid:5741e607) Failed to create bucket with name: bucket2
com.cloud.utils.exception.CloudRuntimeException: Bucket access credentials unavailable for account: testuser
	at org.apache.cloudstack.storage.datastore.driver.MinIOObjectStoreDriverImpl.createBucket(MinIOObjectStoreDriverImpl.java:103)
	at org.apache.cloudstack.storage.object.store.ObjectStoreImpl.createBucket(ObjectStoreImpl.java:108)
	at org.apache.cloudstack.storage.object.BucketApiServiceImpl.createBucket(BucketApiServiceImpl.java:147)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.apache.cloudstack.network.contrail.management.EventUtils$EventInterceptor.invoke(EventUtils.java:107)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at com.cloud.event.ActionEventInterceptor.invoke(ActionEventInterceptor.java:52)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy394.createBucket(Unknown Source)
	at org.apache.cloudstack.api.command.user.bucket.CreateBucketCmd.execute(CreateBucketCmd.java:190)
	at com.cloud.api.ApiDispatcher.dispatch(ApiDispatcher.java:172)
	at com.cloud.api.ApiAsyncJobDispatcher.runJob(ApiAsyncJobDispatcher.java:112)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.runInContext(AsyncJobManagerImpl.java:632)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.run(AsyncJobManagerImpl.java:580)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
![Screenshot from 2024-01-03 18-07-07](https://github.com/apache/cloudstack/assets/153340/86af9c67-6f9a-4dd5-b77a-4071f133a7f8)

6. Upgrade to PR packages and bucket creation works without any error. On MinIO dashboard user created with uuid can be seen,
![Screenshot from 2024-01-03 18-48-12](https://github.com/apache/cloudstack/assets/153340/9d72ad7d-ab62-4f5b-8b2c-c23848bdf0fb)



#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
