### PR TITLE
Fix KVM import unmanaged instance

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1320,7 +1320,6 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         ActionEventUtils.onStartedActionEvent(userId, owner.getId(), EventTypes.EVENT_VM_IMPORT,
                 cmd.getEventDescription(), null, null, true, 0);
 
-        //TODO: Placeholder for integration with KVM ingestion and KVM extend unmanage/manage VMs
         if (cmd instanceof ImportVmCmd) {
             ImportVmCmd importVmCmd = (ImportVmCmd) cmd;
             if (StringUtils.isBlank(importVmCmd.getImportSource())) {
@@ -1336,8 +1335,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                         details, importVmCmd, forced);
             }
         } else {
-            if (cluster.getHypervisorType() == Hypervisor.HypervisorType.VMware) {
-                userVm = importUnmanagedInstanceFromVmwareToVmware(zone, cluster, hosts, additionalNameFilters,
+            if (cluster.getHypervisorType() == Hypervisor.HypervisorType.VMware || cluster.getHypervisorType() == Hypervisor.HypervisorType.KVM) {
+                userVm = importUnmanagedInstanceFromHypervisor(zone, cluster, hosts, additionalNameFilters,
                         template, instanceName, displayName, hostName, caller, owner, userId,
                         serviceOffering, dataDiskOfferingMap,
                         nicNetworkMap, nicIpAddressMap,
@@ -1456,13 +1455,13 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }
     }
 
-    private UserVm importUnmanagedInstanceFromVmwareToVmware(DataCenter zone, Cluster cluster,
-                                                             List<HostVO> hosts, List<String> additionalNameFilters,
-                                                             VMTemplateVO template, String instanceName, String displayName,
-                                                             String hostName, Account caller, Account owner, long userId,
-                                                             ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap,
-                                                             Map<String, Long> nicNetworkMap, Map<String, Network.IpAddresses> nicIpAddressMap,
-                                                             Map<String, String> details, Boolean migrateAllowed, List<String> managedVms, boolean forced) {
+    private UserVm importUnmanagedInstanceFromHypervisor(DataCenter zone, Cluster cluster,
+                                                         List<HostVO> hosts, List<String> additionalNameFilters,
+                                                         VMTemplateVO template, String instanceName, String displayName,
+                                                         String hostName, Account caller, Account owner, long userId,
+                                                         ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap,
+                                                         Map<String, Long> nicNetworkMap, Map<String, Network.IpAddresses> nicIpAddressMap,
+                                                         Map<String, String> details, Boolean migrateAllowed, List<String> managedVms, boolean forced) {
         UserVm userVm = null;
         for (HostVO host : hosts) {
             HashMap<String, UnmanagedInstanceTO> unmanagedInstances = getUnmanagedInstancesForHost(host, instanceName, managedVms);


### PR DESCRIPTION
### Description

This PR fixes KVM manage/unmanage functionality on 4.19.0 RC1 - was introduced on https://github.com/apache/cloudstack/pull/7976 but the latest merge commits on the PR removed the execution for KVM

![image](https://github.com/apache/cloudstack/assets/5295080/211d8de8-d976-429c-8907-052ef7097e03)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Create KVM VM
- Unmanage VM
- Manage VM selecting the same template, network and service offering

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
