### PR TITLE
Fix libvirt domain event listener by properly processing events

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtConnection.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtConnection.java
@@ -114,8 +114,12 @@ public class LibvirtConnection {
         return "qemu:///system";
     }
 
-    // stand up libvirt event handling and polling. This is not specific to a connection object instance, but needs to
-    // exist prior to creating connections.
+    /**
+     * Set up Libvirt event handling and polling. This is not specific to a connection object instance, but needs
+     * to be done prior to creating connections. See the Libvirt documentation for virEventRegisterDefaultImpl and
+     * virEventRunDefaultImpl or the libvirt-java Library Javadoc for more information.
+     * @throws LibvirtException
+     */
     private static synchronized void setupEventListener() throws LibvirtException {
         if (libvirtEventThread == null || !libvirtEventThread.isAlive()) {
             // Registers a default event loop, must be called before connecting to hypervisor

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtConnection.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtConnection.java
@@ -23,6 +23,7 @@ import com.cloud.agent.properties.AgentProperties;
 import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import org.apache.log4j.Logger;
 import org.libvirt.Connect;
+import org.libvirt.Library;
 import org.libvirt.LibvirtException;
 
 import com.cloud.hypervisor.Hypervisor;
@@ -34,6 +35,7 @@ public class LibvirtConnection {
 
     static private Connect s_connection;
     static private String s_hypervisorURI;
+    static private Thread libvirtEventThread;
 
     static public Connect getConnection() throws LibvirtException {
         return getConnection(s_hypervisorURI);
@@ -45,6 +47,8 @@ public class LibvirtConnection {
 
         if (conn == null) {
             s_logger.info("No existing libvirtd connection found. Opening a new one");
+
+            setupEventListener();
             conn = new Connect(hypervisorURI, false);
             s_logger.debug("Successfully connected to libvirt at: " + hypervisorURI);
             s_connections.put(hypervisorURI, conn);
@@ -53,7 +57,15 @@ public class LibvirtConnection {
                 conn.getVersion();
             } catch (LibvirtException e) {
                 s_logger.error("Connection with libvirtd is broken: " + e.getMessage());
+
+                try {
+                    conn.close();
+                } catch (LibvirtException closeEx) {
+                    s_logger.debug("Ignoring error while trying to close broken connection:" + closeEx.getMessage());
+                }
+
                 s_logger.debug("Opening a new libvirtd connection to: " + hypervisorURI);
+                setupEventListener();
                 conn = new Connect(hypervisorURI, false);
                 s_connections.put(hypervisorURI, conn);
             }
@@ -100,5 +112,30 @@ public class LibvirtConnection {
         }
 
         return "qemu:///system";
+    }
+
+    // stand up libvirt event handling and polling. This is not specific to a connection object instance, but needs to
+    // exist prior to creating connections.
+    private static synchronized void setupEventListener() throws LibvirtException {
+        if (libvirtEventThread == null || !libvirtEventThread.isAlive()) {
+            // Registers a default event loop, must be called before connecting to hypervisor
+            Library.initEventLoop();
+            libvirtEventThread = new Thread(() -> {
+                while (true) {
+                    try {
+                        // This blocking call contains a loop of its own that will process events until the event loop is stopped or exception is thrown.
+                        Library.runEventLoop();
+                    } catch (LibvirtException e) {
+                        s_logger.error("LibvirtException was thrown in event loop: ", e);
+                    } catch (InterruptedException e) {
+                        s_logger.error("Libvirt event loop was interrupted: ", e);
+                    }
+                }
+            });
+
+            // Process events in separate thread. Failure to run event loop regularly will cause connections to close due to keepalive timeout.
+            libvirtEventThread.setDaemon(true);
+            libvirtEventThread.start();
+        }
     }
 }


### PR DESCRIPTION
### Description

This PR fixes the libvirt event processing to handle changes in Libvirt domains (and other events if registered).

There is some history around this. Initially it seems there was an event loop initialization added in an earlier [PR](https://github.com/apache/cloudstack/pull/7408) that supports live block copy. This introduced `Library.initEventLoop();` to `LibvirtConnection`, however it never polled for events, and this caused the keepalive issue warned about by libvirt doc [here](https://libvirt.org/html/libvirt-libvirt-event.html#virEventRegisterDefaultImpl):

```
For proper event handling, it is important that the event implementation is registered before a connection to the Hypervisor is opened.

Once registered, the application has to invoke [virEventRunDefaultImpl](https://libvirt.org/html/libvirt-libvirt-event.html#virEventRunDefaultImpl)() in a loop to process events. Failure to do so may result in connections being closed unexpectedly as a result of keepalive timeout.
```

Thus it was found that long running VM migrations would fail due to keep alive issues, which resulted in https://github.com/apache/cloudstack/pull/7945

In the meantime, [support for detecting out of band VM shutdowns](https://github.com/apache/cloudstack/pull/7963) was being developed to also utilize events, and in parallel was relying on the above `Library.initEventLoop();` in `LibvirtConnection`.  This new feature added the missing polling, but ultimately doesn't work (fails gracefully to provide new event handling) because `Library.initEventLoop()` was lost in parallel.

This PR moves the thread responsible for running the Libvirt event loop out of LibvirtComputingResource and into LibvirtConnection, and reintroduces `Library.initEventLoop()`, which shouldn't result in keep alive errors now that we are properly polling for events. It also sets up the event loop before any Libvirt connection as documentation requires.

Finally, when a connection is tested using `conn.getVersion()`, if an exception is thrown we simply create a new connection (but no attempt is made to clean up the old connection). This was resulting in file handle leaks in cases such as the keep alive timeout that was causing connections to go stale, so now we try to close the connection before creating a new one.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested with main by deleting VMs out of band, also checking for file handle leaks that were apparent in the previous observed introduction of `Library.initEventLoop()` using `lsof +E -aUc java` on the hypervisor hosts.