### PR TITLE
Add IOPS to disk offerings details

### DIFF
--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -155,7 +155,7 @@ export default {
       },
       columns: ['name', 'displaytext', 'disksize', 'domain', 'zone', 'order'],
       details: () => {
-        var fields = ['name', 'id', 'displaytext', 'disksize', 'provisioningtype', 'storagetype', 'iscustomized', 'disksizestrictness', 'iscustomizediops', 'tags', 'domain', 'zone', 'created', 'encrypt']
+        var fields = ['name', 'id', 'displaytext', 'disksize', 'provisioningtype', 'storagetype', 'iscustomized', 'disksizestrictness', 'iscustomizediops', 'diskIopsReadRate', 'diskIopsWriteRate', 'diskBytesReadRate', 'diskBytesWriteRate', 'maxiops', 'tags', 'domain', 'zone', 'created', 'encrypt']
         if (store.getters.apis.createDiskOffering &&
           store.getters.apis.createDiskOffering.params.filter(x => x.name === 'storagepolicy').length > 0) {
           fields.splice(6, 0, 'vspherestoragepolicy')

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -155,7 +155,7 @@ export default {
       },
       columns: ['name', 'displaytext', 'disksize', 'domain', 'zone', 'order'],
       details: () => {
-        var fields = ['name', 'id', 'displaytext', 'disksize', 'provisioningtype', 'storagetype', 'iscustomized', 'disksizestrictness', 'iscustomizediops', 'diskIopsReadRate', 'diskIopsWriteRate', 'diskBytesReadRate', 'diskBytesWriteRate', 'maxiops', 'tags', 'domain', 'zone', 'created', 'encrypt']
+        var fields = ['name', 'id', 'displaytext', 'disksize', 'provisioningtype', 'storagetype', 'iscustomized', 'disksizestrictness', 'iscustomizediops', 'diskIopsReadRate', 'diskIopsWriteRate', 'diskBytesReadRate', 'diskBytesWriteRate', 'miniops', 'maxiops', 'tags', 'domain', 'zone', 'created', 'encrypt']
         if (store.getters.apis.createDiskOffering &&
           store.getters.apis.createDiskOffering.params.filter(x => x.name === 'storagepolicy').length > 0) {
           fields.splice(6, 0, 'vspherestoragepolicy')


### PR DESCRIPTION
### Description

When listing disk offerings through the UI, IOPS and read/write data for these offerings is not presented, making it difficult to access information about them.

For this reason, `Disk Read Rate (IOPS)`, `Disk Write Rate (IOPS)`, `Disk Read Rate (BPS)`, `Disk Write Rate (BPS)` and `Max IOPS` data has been added to the disk offering details.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

1. I created a disk offering with customized write and read rate values using the `hypervisor` QoS type in the creation form;
2. I created a disk offering with max IOPS using the `storage` QoS type in the creation form;
3. I accessed these disk offerings and verified that the `Disk Read Rate (IOPS)`, `Disk Write Rate (IOPS)`, `Disk Read Rate (BPS)`, `Disk Write Rate (BPS)` data were in the disk offering created in the step 1 and the `Max IOPS` data was in the disk offering created in the step 2.