### PR TITLE
ui: prevent scheduling readyforshutdown job when api inaccessible

### DIFF
--- a/ui/src/components/page/GlobalLayout.vue
+++ b/ui/src/components/page/GlobalLayout.vue
@@ -199,8 +199,10 @@ export default {
   created () {
     this.menus = this.mainMenu.find((item) => item.path === '/').children
     this.collapsed = !this.sidebarOpened
-    const readyForShutdownPollingJob = setInterval(this.checkShutdown, 5000)
-    this.$store.commit('SET_READY_FOR_SHUTDOWN_POLLING_JOB', readyForShutdownPollingJob)
+    if ('readyForShutdown' in this.$store.getters.apis) {
+      const readyForShutdownPollingJob = setInterval(this.checkShutdown, 5000)
+      this.$store.commit('SET_READY_FOR_SHUTDOWN_POLLING_JOB', readyForShutdownPollingJob)
+    }
   },
   mounted () {
     const layoutMode = this.$config.theme['@layout-mode'] || 'light'


### PR DESCRIPTION
### Description

Non-admin accounts may not have access to the readyForShutdown API therefore UI should not schedule the job.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Without fix errors can be seen for the readyForShutdown API call when logged in as normal account,
![Screenshot from 2024-01-05 11-57-55](https://github.com/apache/cloudstack/assets/153340/e12eafc6-51d2-404b-8779-33e3ce11b70e)



### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
