### PR TITLE
Change the check for the existence of `cryptsetup` command

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/cryptsetup/CryptSetup.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/cryptsetup/CryptSetup.java
@@ -108,7 +108,7 @@ public class CryptSetup {
 
     public boolean isSupported() {
         final Script script = new Script(commandPath);
-        script.add("--usage");
+        script.add("--version");
         final String result = script.execute();
         return result == null;
     }


### PR DESCRIPTION
### Description

Currently, when starting the Agent, ACS checks if the `cryptsetup` command can be used by using the command's `help`; the output of the command is printed in the logs. However, this output is too verbose and can be confusing.

This PR addresses this issue by using the utility version to check the command, instead of `help`, which is much less verbose.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

-  Before changes:
  
![grep_usage_host-1](https://github.com/apache/cloudstack/assets/56271185/260ceae6-fad0-46fb-96c1-ffc6f55294b5)

-  After changes:

![grep_version_host-1](https://github.com/apache/cloudstack/assets/56271185/90c68e98-3f0b-4daf-805a-483902b57842)


### How Has This Been Tested?

I checked the logs before and after changes. As shown in the screenshots above, the logs became more intuitive.
