### PR TITLE
Enable over provisioning for SharedMountPoint primary storages

### DIFF
--- a/api/src/main/java/com/cloud/storage/Storage.java
+++ b/api/src/main/java/com/cloud/storage/Storage.java
@@ -152,12 +152,12 @@ public class Storage {
         StorPool(true, true, true);
 
         private final boolean shared;
-        private final boolean overprovisioning;
+        private final boolean overProvisioning;
         private final boolean encryption;
 
-        StoragePoolType(boolean shared, boolean overprovisioning, boolean encryption) {
+        StoragePoolType(boolean shared, boolean overProvisioning, boolean encryption) {
             this.shared = shared;
-            this.overprovisioning = overprovisioning;
+            this.overProvisioning = overProvisioning;
             this.encryption = encryption;
         }
 
@@ -166,14 +166,16 @@ public class Storage {
         }
 
         public boolean supportsOverProvisioning() {
-            return overprovisioning;
+            return overProvisioning;
         }
 
-        public boolean supportsEncryption() { return encryption; }
+        public boolean supportsEncryption() {
+            return encryption;
+        }
     }
 
     public static List<StoragePoolType> getNonSharedStoragePoolTypes() {
-        List<StoragePoolType> nonSharedStoragePoolTypes = new ArrayList<StoragePoolType>();
+        List<StoragePoolType> nonSharedStoragePoolTypes = new ArrayList<>();
         for (StoragePoolType storagePoolType : StoragePoolType.values()) {
             if (!storagePoolType.isShared()) {
                 nonSharedStoragePoolTypes.add(storagePoolType);

--- a/api/src/main/java/com/cloud/storage/Storage.java
+++ b/api/src/main/java/com/cloud/storage/Storage.java
@@ -138,7 +138,7 @@ public class Storage {
         LVM(false, false, false), // XenServer local LVM SR
         CLVM(true, false, false),
         RBD(true, true, false), // http://libvirt.org/storage.html#StorageBackendRBD
-        SharedMountPoint(true, false, true),
+        SharedMountPoint(true, true, true),
         VMFS(true, true, false), // VMware VMFS storage
         PreSetup(true, true, false), // for XenServer, Storage Pool is set up by customers.
         EXT(false, true, false), // XenServer local EXT SR

--- a/api/src/test/java/com/cloud/storage/StorageTest.java
+++ b/api/src/test/java/com/cloud/storage/StorageTest.java
@@ -63,7 +63,7 @@ public class StorageTest {
         Assert.assertFalse(StoragePoolType.CLVM.supportsOverProvisioning());
         Assert.assertTrue(StoragePoolType.RBD.supportsOverProvisioning());
         Assert.assertTrue(StoragePoolType.PowerFlex.supportsOverProvisioning());
-        Assert.assertFalse(StoragePoolType.SharedMountPoint.supportsOverProvisioning());
+        Assert.assertTrue(StoragePoolType.SharedMountPoint.supportsOverProvisioning());
         Assert.assertTrue(StoragePoolType.VMFS.supportsOverProvisioning());
         Assert.assertTrue(StoragePoolType.PreSetup.supportsOverProvisioning());
         Assert.assertTrue(StoragePoolType.EXT.supportsOverProvisioning());

--- a/api/src/test/java/com/cloud/storage/StorageTest.java
+++ b/api/src/test/java/com/cloud/storage/StorageTest.java
@@ -52,7 +52,7 @@ public class StorageTest {
     }
 
     @Test
-    public void supportsOverprovisioningStoragePool() {
+    public void supportsOverProvisioningTestAllStoragePoolTypes() {
         Assert.assertTrue(StoragePoolType.Filesystem.supportsOverProvisioning());
         Assert.assertTrue(StoragePoolType.NetworkFilesystem.supportsOverProvisioning());
         Assert.assertFalse(StoragePoolType.IscsiLUN.supportsOverProvisioning());


### PR DESCRIPTION
### Description

ACS does not allow operators to set the configuration `storage.overprovisioning.factor` for `SharedMountPoint` primary storages, presenting the following message when one tries to change it:

![image](https://github.com/apache/cloudstack/assets/38945620/d27e9dec-1f1b-4b14-9b6c-e523708c9342)

Also, the global setting does not impact `SharedMoundPoint` primary storages, which means that the over-provisioning is not applied properly for this storage type. 

Furthermore, the metric presents that the `SharedMountPoint` has the global over-provisioning applied; however, in a scenario where the over-provision factor is 2, the allocation threshold is 80%, and the metrics show that storage has 40% allocated, one cannot allocate to it anymore.

This PR intends to enable over-provisioning for `SharedMountPoint` primary storages.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

In an environment where the global over-provision factor was 1, the allocation threshold was 80%, and the `SharedMountPoint` primary storage had 80% allocated, I was able to change the over-provisioning factor of the `SharedMountPoint` primary storage and allocate a new volume on it, as, with the over-provisioning, ACS considered it as having 40% allocated. 