### PR TITLE
Fix KVM imported unmanaged VMs disks path

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapper.java
@@ -197,7 +197,6 @@ public final class LibvirtGetUnmanagedInstancesCommandWrapper extends CommandWra
             disk.setLabel(diskDef.getDiskLabel());
             disk.setController(diskDef.getBusType().toString());
 
-
             Pair<String, String> sourceHostPath = getSourceHostPath(libvirtComputingResource, diskDef.getSourcePath());
             if (sourceHostPath != null) {
                 disk.setDatastoreHost(sourceHostPath.first());
@@ -211,9 +210,20 @@ public final class LibvirtGetUnmanagedInstancesCommandWrapper extends CommandWra
             disk.setDatastorePort(diskDef.getSourceHostPort());
             disk.setImagePath(imagePath);
             disk.setDatastoreName(imagePath.substring(imagePath.lastIndexOf("/")));
+            disk.setFileBaseName(getDiskRelativePath(imagePath));
             disks.add(disk);
         }
         return disks;
+    }
+
+    protected String getDiskRelativePath(String imagePath) {
+        if (StringUtils.isBlank(imagePath)) {
+            return null;
+        }
+        if (!imagePath.contains("/")) {
+            return imagePath;
+        }
+        return imagePath.substring(imagePath.lastIndexOf("/") + 1);
     }
 
     private Pair<String, String> getSourceHostPath(LibvirtComputingResource libvirtComputingResource, String diskPath) {

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapperTest.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LibvirtGetUnmanagedInstancesCommandWrapperTest {
+
+    @Spy
+    private LibvirtGetUnmanagedInstancesCommandWrapper wrapper = new LibvirtGetUnmanagedInstancesCommandWrapper();
+
+    @Test
+    public void testGetDiskRelativePathNullPath() {
+        Assert.assertNull(wrapper.getDiskRelativePath(null));
+    }
+
+    @Test
+    public void testGetDiskRelativePathWithoutSlashes() {
+        String imagePath = UUID.randomUUID().toString();
+        Assert.assertEquals(imagePath, wrapper.getDiskRelativePath(imagePath));
+    }
+
+    @Test
+    public void testGetDiskRelativePathFullPath() {
+        String relativePath = "ea4b2296-d349-4968-ab72-c8eb523b556e";
+        String imagePath = String.format("/mnt/97e4c9ed-e3bc-3e26-b103-7967fc9feae1/%s", relativePath);
+        Assert.assertEquals(relativePath, wrapper.getDiskRelativePath(imagePath));
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes the volumes path on KVM import unmanaged instances

Fixes: #8479 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Create VM on KVM
- Unmanage VM
- Import unmanaged VM from the same template
- Verify disks path
- Destroy/expunge VM and verify there are no leftover disks

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
