### PR TITLE
Fix API `moveUser` parameters descriptions

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
@@ -39,7 +39,7 @@ import com.cloud.user.User;
 import com.google.common.base.Preconditions;
 
 @APICommand(name = "moveUser",
-        description = "Moves a user to another account from the same domain",
+        description = "Moves a user to another account from the same domain.",
         responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
@@ -39,7 +39,7 @@ import com.cloud.user.User;
 import com.google.common.base.Preconditions;
 
 @APICommand(name = "moveUser",
-        description = "Moves a user to another account",
+        description = "Moves a user to another account from the same domain",
         responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false,
@@ -56,18 +56,18 @@ public class MoveUserCmd extends BaseCmd {
             type = CommandType.UUID,
             entityType = UserResponse.class,
             required = true,
-            description = "id of the user to be deleted")
+            description = "id of the user to be moved.")
     private Long id;
 
     @Parameter(name = ApiConstants.ACCOUNT,
             type = CommandType.STRING,
-            description = "Creates the user under the specified account. If no account is specified, the username will be used as the account name.")
+            description = "Moves the user under the specified account. If no account name is specified, it is necessary to provide an account id.")
     private String accountName;
 
     @Parameter(name = ApiConstants.ACCOUNT_ID,
             type = CommandType.UUID,
             entityType = AccountResponse.class,
-            description = "Creates the user under the specified domain. Has to be accompanied with the account parameter")
+            description = "Moves the user under the specified account. If no account id is specified, it is necessary to provide an account name.")
     private Long accountId;
 
     @Inject

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
@@ -39,7 +39,7 @@ import com.cloud.user.User;
 import com.google.common.base.Preconditions;
 
 @APICommand(name = "moveUser",
-        description = "Moves a user to another account from the same domain.",
+        description = "Moves a user to another account in the same domain.",
         responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false,


### PR DESCRIPTION
### Description

The description of the API `moveUser` parameters does not match its functionalities. Furthermore, the description of the API itself does not clearly state the limitation of only moving users between accounts within the same domain.

This PR addresses this issue by changing those descriptions to align with the API functionality.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

-  Before changes:
![old-moveuser](https://github.com/apache/cloudstack/assets/56271185/4229c954-5fc4-4b81-964c-aa067acf2761)

- After changes:
![new-moveuser](https://github.com/apache/cloudstack/assets/56271185/3c7568c7-e59c-4448-b684-cb6a7ca18cc0)


### How Has This Been Tested?

I tested by using CloudMonkey to list the command's description and its parameters.