### PR TITLE
vm-import: kvm import and fix volume size when lesser than 1GiB

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
@@ -153,7 +153,7 @@ public interface VolumeOrchestrationService {
      * @param type Type of the volume - ROOT, DATADISK, etc
      * @param name Name of the volume
      * @param offering DiskOffering for the volume
-     * @param size DiskOffering for the volume
+     * @param sizeInBytes size of the volume in bytes
      * @param minIops minimum IOPS for the disk, if not passed DiskOffering value will be used
      * @param maxIops maximum IOPS for the disk, if not passed DiskOffering value will be used
      * @param vm VirtualMachine this volume is attached to
@@ -165,7 +165,7 @@ public interface VolumeOrchestrationService {
      * @param chainInfo chain info for the volume. Hypervisor specific.
      * @return  DiskProfile of imported volume
      */
-    DiskProfile importVolume(Type type, String name, DiskOffering offering, Long size, Long minIops, Long maxIops, VirtualMachine vm, VirtualMachineTemplate template,
+    DiskProfile importVolume(Type type, String name, DiskOffering offering, Long sizeInBytes, Long minIops, Long maxIops, VirtualMachine vm, VirtualMachineTemplate template,
                              Account owner, Long deviceId, Long poolId, String path, String chainInfo);
 
     DiskProfile updateImportedVolume(Type type, DiskOffering offering, VirtualMachine vm, VirtualMachineTemplate template,

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -2172,19 +2172,17 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
     }
 
     @Override
-    public DiskProfile importVolume(Type type, String name, DiskOffering offering, Long size, Long minIops, Long maxIops,
+    public DiskProfile importVolume(Type type, String name, DiskOffering offering, Long sizeInBytes, Long minIops, Long maxIops,
                                     VirtualMachine vm, VirtualMachineTemplate template, Account owner,
                                     Long deviceId, Long poolId, String path, String chainInfo) {
-        if (size == null) {
-            size = offering.getDiskSize();
-        } else {
-            size = (size * 1024 * 1024 * 1024);
+        if (sizeInBytes == null) {
+            sizeInBytes = offering.getDiskSize();
         }
 
         minIops = minIops != null ? minIops : offering.getMinIops();
         maxIops = maxIops != null ? maxIops : offering.getMaxIops();
 
-        VolumeVO vol = new VolumeVO(type, name, vm.getDataCenterId(), owner.getDomainId(), owner.getId(), offering.getId(), offering.getProvisioningType(), size, minIops, maxIops, null);
+        VolumeVO vol = new VolumeVO(type, name, vm.getDataCenterId(), owner.getDomainId(), owner.getId(), offering.getId(), offering.getProvisioningType(), sizeInBytes, minIops, maxIops, null);
         if (vm != null) {
             vol.setInstanceId(vm.getId());
         }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1172,7 +1172,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             }
             DiskOfferingVO diskOffering = diskOfferingDao.findById(serviceOffering.getDiskOfferingId());
             diskProfileStoragePoolList.add(importDisk(rootDisk, userVm, cluster, diskOffering, Volume.Type.ROOT, String.format("ROOT-%d", userVm.getId()),
-                    (rootDisk.getCapacity() / Resource.ResourceType.bytesToGiB), minIops, maxIops,
+                    rootDisk.getCapacity(), minIops, maxIops,
                     template, owner, null));
             long deviceId = 1L;
             for (UnmanagedInstanceTO.Disk disk : dataDisks) {
@@ -1181,7 +1181,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 }
                 DiskOffering offering = diskOfferingDao.findById(dataDiskOfferingMap.get(disk.getDiskId()));
                 diskProfileStoragePoolList.add(importDisk(disk, userVm, cluster, offering, Volume.Type.DATADISK, String.format("DATA-%d-%s", userVm.getId(), disk.getDiskId()),
-                        (disk.getCapacity() / Resource.ResourceType.bytesToGiB), offering.getMinIops(), offering.getMaxIops(),
+                        disk.getCapacity(), offering.getMinIops(), offering.getMaxIops(),
                         template, owner, deviceId));
                 deviceId++;
             }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1113,7 +1113,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }
         allDetails.put(VmDetailConstants.ROOT_DISK_CONTROLLER, rootDisk.getController());
         if (cluster.getHypervisorType() == Hypervisor.HypervisorType.KVM && isImportUnmanagedFromSameHypervisor) {
-            allDetails.put(VmDetailConstants.ROOT_DISK_SIZE, String.valueOf(rootDisk.getCapacity() / Resource.ResourceType.bytesToGiB));
+            long size = Double.valueOf(Math.ceil((double)rootDisk.getCapacity() / Resource.ResourceType.bytesToGiB)).longValue();
+            allDetails.put(VmDetailConstants.ROOT_DISK_SIZE, String.valueOf(size));
         }
 
         try {
@@ -1172,8 +1173,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             }
             DiskOfferingVO diskOffering = diskOfferingDao.findById(serviceOffering.getDiskOfferingId());
             diskProfileStoragePoolList.add(importDisk(rootDisk, userVm, cluster, diskOffering, Volume.Type.ROOT, String.format("ROOT-%d", userVm.getId()),
-                    rootDisk.getCapacity(), minIops, maxIops,
-                    template, owner, null));
+                    rootDisk.getCapacity(), minIops, maxIops, template, owner, null));
             long deviceId = 1L;
             for (UnmanagedInstanceTO.Disk disk : dataDisks) {
                 if (disk.getCapacity() == null || disk.getCapacity() == 0) {


### PR DESCRIPTION
### Description

This PR tries to deal with on of the leftovers from https://github.com/apache/cloudstack/pull/8465 as reported in https://github.com/apache/cloudstack/issues/8439

    when root size is 0 it is set to 1 to allow for creation of a disk.
Also, fixes the issue reported in https://github.com/apache/cloudstack/pull/8488#issuecomment-1886966407
Refactors importDisk methods to not do repeated byte to GiB and GiB to byte conversions.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->
Manually tested:

**KVM with advanced zone VM import**: https://github.com/apache/cloudstack/pull/8500#issuecomment-1888852070
1. VM with 50MiB root disk
2. VM with 8GiB root disk and a 20 GiB data disk

**VMware with advanced zone VM import**: https://github.com/apache/cloudstack/pull/8500#issuecomment-1888888777
1. VM with 50MiB root disk
2. VM with 8GiB root disk and a 20 GiB data disk

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
