### PR TITLE
Changes the value of config vm_memballoon_stats_period to 60

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -223,7 +223,7 @@ hypervisor.type=kvm
 
 # The time interval (in seconds) at which the balloon driver will get memory stats updates.
 # This is equivalent to Libvirt's --period parameter when using the dommemstat command.
-# vm.memballoon.stats.period=0
+# vm.memballoon.stats.period=60
 
 # Set to true to check disk activity on VM's disks before starting a VM. This only applies
 # to QCOW2 files, and ensures that there is no other running instance accessing

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -724,9 +724,9 @@ public class AgentProperties{
     /**
      * The time interval (in seconds) at which the balloon driver will get memory stats updates. This is equivalent to Libvirt's <code>--period</code> parameter when using the dommemstat command.
      * Data type: Integer.<br>
-     * Default value: <code>0</code>
+     * Default value: <code>60</code>
      */
-    public static final Property<Integer> VM_MEMBALLOON_STATS_PERIOD = new Property<>("vm.memballoon.stats.period", 0);
+    public static final Property<Integer> VM_MEMBALLOON_STATS_PERIOD = new Property<>("vm.memballoon.stats.period", 60);
 
     /**
      * The number of iothreads


### PR DESCRIPTION
### Description

Currently, the default value for the `vm_memballoon_stats_period` configuration is set to `0`. As a result, out of the box in ACS, memory metrics for Windows instances (with virtio drivers correctly installed and configured) is compromised when using KVM hypervisor. This pull request aims to propose setting the `vm_memballoon_stats_period` configuration value to `60`. This correction addresses situations such as the one reported through the issue: https://github.com/apache/cloudstack/issues/8453.

fixes: https://github.com/apache/cloudstack/issues/8453

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

-  Before changes:
![image](https://github.com/apache/cloudstack/assets/19981369/3ad3cac5-3890-4057-9d1c-171435c45af6)

- After changes:
![image](https://github.com/apache/cloudstack/assets/19981369/0a074d4b-636d-4b39-9a20-6f157ee0a46c)

### How Has This Been Tested?

A Windows VM was created, and it was confirmed that the VirtIO drivers were correctly installed. However, upon inspecting the metrics collected by ACS, it was observed that they did not align with the actual consumption of the VM. Subsequently, after changing the configuration value from `0` to `60`, the metrics collected by ACS matched the consumption values reported by the VM.