### PR TITLE
Remove sensitive params (VmPassword, etc) from VMWork log

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/vm/VmWork.java
+++ b/engine/components-api/src/main/java/com/cloud/vm/VmWork.java
@@ -17,9 +17,21 @@
 package com.cloud.vm;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.cloud.serializer.GsonHelper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 
 public class VmWork implements Serializable {
     private static final long serialVersionUID = -6946320465729853589L;
+    private static final Gson gsonLogger = GsonHelper.getGsonLogger();
 
     long userId;
     long accountId;
@@ -55,5 +67,32 @@ public class VmWork implements Serializable {
 
     public String getHandlerName() {
         return handlerName;
+    }
+
+    @Override
+    public String toString() {
+        return gsonLogger.toJson(this);
+    }
+
+    protected String toStringAfterRemoveParams(String paramsObjName, List<String> params) {
+        String ObjJsonStr = gsonLogger.toJson(this);
+        if (StringUtils.isBlank(ObjJsonStr) || StringUtils.isBlank(paramsObjName) || CollectionUtils.isEmpty(params)) {
+            return ObjJsonStr;
+        }
+
+        try {
+            Map<String, Object> ObjMap = new ObjectMapper().readValue(ObjJsonStr, HashMap.class);
+            if (ObjMap != null && ObjMap.containsKey(paramsObjName)) {
+                for (String param : params) {
+                    ((Map<String, String>)ObjMap.get(paramsObjName)).remove(param);
+                }
+                String resultJson = new ObjectMapper().writeValueAsString(ObjMap);
+                return resultJson;
+            }
+        } catch (final JsonProcessingException e) {
+            // Ignore json exception
+        }
+
+        return ObjJsonStr;
     }
 }

--- a/engine/components-api/src/main/java/com/cloud/vm/VmWorkJobHandlerProxy.java
+++ b/engine/components-api/src/main/java/com/cloud/vm/VmWorkJobHandlerProxy.java
@@ -21,15 +21,13 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
-
-import com.google.gson.Gson;
-
 import org.apache.cloudstack.framework.jobs.impl.JobSerializerHelper;
 import org.apache.cloudstack.jobs.JobInfo;
+import org.apache.log4j.Logger;
 
 import com.cloud.serializer.GsonHelper;
 import com.cloud.utils.Pair;
+import com.google.gson.Gson;
 
 /**
  * VmWorkJobHandlerProxy can not be used as standalone due to run-time
@@ -102,12 +100,12 @@ public class VmWorkJobHandlerProxy implements VmWorkJobHandler {
 
             try {
                 if (s_logger.isDebugEnabled())
-                    s_logger.debug("Execute VM work job: " + work.getClass().getName() + _gsonLogger.toJson(work));
+                    s_logger.debug("Execute VM work job: " + work.getClass().getName() + work);
 
                 Object obj = method.invoke(_target, work);
 
                 if (s_logger.isDebugEnabled())
-                    s_logger.debug("Done executing VM work job: " + work.getClass().getName() + _gsonLogger.toJson(work));
+                    s_logger.debug("Done executing VM work job: " + work.getClass().getName() + work);
 
                 assert (obj instanceof Pair);
                 return (Pair<JobInfo.Status, String>)obj;

--- a/engine/orchestration/src/main/java/com/cloud/vm/VmWorkReboot.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VmWorkReboot.java
@@ -17,7 +17,9 @@
 package com.cloud.vm;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.cloudstack.framework.jobs.impl.JobSerializerHelper;
@@ -61,5 +63,12 @@ public class VmWorkReboot extends VmWork {
                     entry.getValue() instanceof Serializable ? (Serializable)entry.getValue() : entry.getValue().toString()));
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        List<String> params = new ArrayList<>();
+        params.add(VirtualMachineProfile.Param.VmPassword.getName());
+        return super.toStringAfterRemoveParams("rawParams", params);
     }
 }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VmWorkStart.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VmWorkStart.java
@@ -18,7 +18,9 @@
 package com.cloud.vm;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.cloudstack.context.CallContext;
@@ -134,5 +136,12 @@ public class VmWorkStart extends VmWork {
                         entry.getValue() instanceof Serializable ? (Serializable)entry.getValue() : entry.getValue().toString()));
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        List<String> params = new ArrayList<>();
+        params.add(VirtualMachineProfile.Param.VmPassword.getName());
+        return super.toStringAfterRemoveParams("rawParams", params);
     }
 }

--- a/engine/orchestration/src/test/java/com/cloud/vm/VmWorkRebootTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VmWorkRebootTest.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.vm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cloudstack.framework.jobs.impl.JobSerializerHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VmWorkRebootTest {
+
+    @Test
+    public void testToString() {
+        VmWork vmWork = new VmWork(1l, 1l, 1l, "testhandler");
+        Map<VirtualMachineProfile.Param, Object> params = new HashMap<>();
+        String lastHost = "rO0ABXQABHRydWU";
+        String lastHostSerialized = JobSerializerHelper.toObjectSerializedString(lastHost);
+        params.put(VirtualMachineProfile.Param.ConsiderLastHost, lastHost);
+        params.put(VirtualMachineProfile.Param.VmPassword, "rO0ABXQADnNhdmVkX3Bhc3N3b3Jk");
+        VmWorkReboot workInfo = new VmWorkReboot(vmWork, params);
+        String expectedVmWorkRebootStr = "{\"accountId\":1,\"vmId\":1,\"handlerName\":\"testhandler\",\"userId\":1,\"rawParams\":{\"ConsiderLastHost\":\"" + lastHostSerialized + "\"}}";
+
+        String vmWorkRebootStr = workInfo.toString();
+        Assert.assertEquals(expectedVmWorkRebootStr, vmWorkRebootStr);
+    }
+}

--- a/engine/orchestration/src/test/java/com/cloud/vm/VmWorkStartTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VmWorkStartTest.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.vm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cloudstack.framework.jobs.impl.JobSerializerHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VmWorkStartTest {
+
+    @Test
+    public void testToStringWithParams() {
+        VmWork vmWork = new VmWork(1l,  1l, 1l, "testhandler");
+        VmWorkStart workInfo = new VmWorkStart(vmWork);
+        Map<VirtualMachineProfile.Param, Object> params = new HashMap<>();
+        String lastHost = "rO0ABXQABHRydWU";
+        String lastHostSerialized = JobSerializerHelper.toObjectSerializedString(lastHost);
+        params.put(VirtualMachineProfile.Param.ConsiderLastHost, lastHost);
+        params.put(VirtualMachineProfile.Param.VmPassword, "rO0ABXQADnNhdmVkX3Bhc3N3b3Jk");
+        workInfo.setParams(params);
+        String expectedVmWorkStartStr = "{\"accountId\":1,\"dcId\":0,\"vmId\":1,\"handlerName\":\"testhandler\",\"userId\":1,\"rawParams\":{\"ConsiderLastHost\":\"" + lastHostSerialized + "\"}}";
+
+        String vmWorkStartStr = workInfo.toString();
+        Assert.assertEquals(expectedVmWorkStartStr, vmWorkStartStr);
+    }
+
+    @Test
+    public void testToStringWithRawParams() {
+        VmWork vmWork = new VmWork(1l,  1l, 1l, "testhandler");
+        VmWorkStart workInfo = new VmWorkStart(vmWork);
+        Map<String, String> rawParams = new HashMap<>();
+        rawParams.put(VirtualMachineProfile.Param.ConsiderLastHost.getName(), "rO0ABXQABHRydWU");
+        rawParams.put(VirtualMachineProfile.Param.VmPassword.getName(), "rO0ABXQADnNhdmVkX3Bhc3N3b3Jk");
+        workInfo.setRawParams(rawParams);
+        String expectedVmWorkStartStr = "{\"accountId\":1,\"dcId\":0,\"vmId\":1,\"handlerName\":\"testhandler\",\"userId\":1,\"rawParams\":{\"ConsiderLastHost\":\"rO0ABXQABHRydWU\"}}";
+
+        String vmWorkStartStr = workInfo.toString();
+        Assert.assertEquals(expectedVmWorkStartStr, vmWorkStartStr);
+    }
+}


### PR DESCRIPTION
### Description

The VM's password & other details sent via VM Details Map during VmWorkStart are logged as base64 encoded strings.

```
2024-01-22 11:22:53,879 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-4:ctx-8c25a1bb job-4690/job-4691 ctx-18a45cc5) (logid:76180ad6) Execute VM work job: com.cloud.vm.VmWorkStart{"dcId":1,"podId":1,"clusterId":1,"hostId":2,"rawParams":{"ConsiderLastHost":"rO0ABXQABHRydWU","VmPassword":"rO0ABXQADnNhdmVkX3Bhc3N3b3Jk"},"userId":2,"accountId":2,"vmId":415,"handlerName":"VirtualMachineManagerImpl"}
...
2024-01-22 11:22:59,456 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-4:ctx-8c25a1bb job-4690/job-4691 ctx-18a45cc5) (logid:76180ad6) Done executing VM work job: com.cloud.vm.VmWorkStart{"dcId":1,"podId":1,"clusterId":1,"hostId":2,"rawParams":{"ConsiderLastHost":"rO0ABXQABHRydWU","VmPassword":"rO0ABXQADnNhdmVkX3Bhc3N3b3Jk"},"userId":2,"accountId":2,"vmId":415,"handlerName":"VirtualMachineManagerImpl"}
```

This PR improves VMWork log to not include any sensitive params (VmPassword, etc).

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

Tested VM start and reboot operations, confirmed 'VmPassword' not shown in the log.

Log before changes =>

```
2024-01-22 11:22:53,879 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-4:ctx-8c25a1bb job-4690/job-4691 ctx-18a45cc5) (logid:76180ad6) Execute VM work job: com.cloud.vm.VmWorkStart{"dcId":1,"podId":1,"clusterId":1,"hostId":2,"rawParams":{"ConsiderLastHost":"rO0ABXQABHRydWU","VmPassword":"rO0ABXQADnNhdmVkX3Bhc3N3b3Jk"},"userId":2,"accountId":2,"vmId":415,"handlerName":"VirtualMachineManagerImpl"}


2024-01-22 11:22:59,456 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-4:ctx-8c25a1bb job-4690/job-4691 ctx-18a45cc5) (logid:76180ad6) Done executing VM work job: com.cloud.vm.VmWorkStart{"dcId":1,"podId":1,"clusterId":1,"hostId":2,"rawParams":{"ConsiderLastHost":"rO0ABXQABHRydWU","VmPassword":"rO0ABXQADnNhdmVkX3Bhc3N3b3Jk"},"userId":2,"accountId":2,"vmId":415,"handlerName":"VirtualMachineManagerImpl"}
```

Log after changes =>

```
2024-01-22 17:59:32,005 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-1:ctx-e027727c job-4730/job-4731 ctx-6c00584c) (logid:24c6cb7e) Execute VM work job: com.cloud.vm.VmWorkStart{"accountId":2,"dcId":1,"vmId":415,"hostId":2,"handlerName":"VirtualMachineManagerImpl","clusterId":1,"userId":2,"podId":1,"rawParams":{"ConsiderLastHost":"rO0ABXQABHRydWU"}}


2024-01-22 17:59:36,550 DEBUG [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-1:ctx-e027727c job-4730/job-4731 ctx-6c00584c) (logid:24c6cb7e) Done executing VM work job: com.cloud.vm.VmWorkStart{"accountId":2,"dcId":1,"vmId":415,"hostId":2,"handlerName":"VirtualMachineManagerImpl","clusterId":1,"userId":2,"podId":1,"rawParams":{"ConsiderLastHost":"rO0ABXQABHRydWU"}}
```

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
