### PR TITLE
Allow deletion of system VM templates

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/DeleteTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/DeleteTemplateCmd.java
@@ -55,6 +55,9 @@ public class DeleteTemplateCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.FORCED, type = CommandType.BOOLEAN, required = false, description = "Force delete a template.", since = "4.9+")
     private Boolean forced;
 
+    @Parameter(name = ApiConstants.IS_SYSTEM, type = CommandType.BOOLEAN, required = false, description = "Necessary if the template's type is system.", since = "4.20.0")
+    private Boolean isSystem;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -69,6 +72,10 @@ public class DeleteTemplateCmd extends BaseAsyncCmd {
 
     public boolean isForced() {
         return BooleanUtils.toBooleanDefaultIfNull(forced, false);
+    }
+
+    public boolean getIsSystem() {
+        return BooleanUtils.toBooleanDefaultIfNull(isSystem, false);
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/DeleteTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/DeleteTemplateCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.user.template;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.log4j.Logger;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
@@ -55,7 +56,7 @@ public class DeleteTemplateCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.FORCED, type = CommandType.BOOLEAN, required = false, description = "Force delete a template.", since = "4.9+")
     private Boolean forced;
 
-    @Parameter(name = ApiConstants.IS_SYSTEM, type = CommandType.BOOLEAN, required = false, description = "Necessary if the template's type is system.", since = "4.20.0")
+    @Parameter(name = ApiConstants.IS_SYSTEM, type = CommandType.BOOLEAN, required = false, description = "Necessary if the template's type is system.", since = "4.20.0", authorized = {RoleType.Admin})
     private Boolean isSystem;
 
     /////////////////////////////////////////////////////

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -748,9 +748,6 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
     public TemplateProfile prepareDelete(DeleteTemplateCmd cmd) {
         TemplateProfile profile = super.prepareDelete(cmd);
         VMTemplateVO template = profile.getTemplate();
-        if (template.getTemplateType() == TemplateType.SYSTEM) {
-            throw new InvalidParameterValueException("The DomR template cannot be deleted.");
-        }
         checkZoneImageStores(profile.getTemplate(), profile.getZoneIdList());
         return profile;
     }

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -748,6 +748,9 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
     public TemplateProfile prepareDelete(DeleteTemplateCmd cmd) {
         TemplateProfile profile = super.prepareDelete(cmd);
         VMTemplateVO template = profile.getTemplate();
+        if (template.getTemplateType() == TemplateType.SYSTEM && !cmd.getIsSystem()) {
+            throw new InvalidParameterValueException("Could not delete template as it is a SYSTEM template and isSystem is set to false.");
+        }
         checkZoneImageStores(profile.getTemplate(), profile.getZoneIdList());
         return profile;
     }


### PR DESCRIPTION
### Description

Currently, ACS does not allow the deletion of system VM templates. However, it might be of interest to the operator to delete templates from older versions that are no longer in use.

A change was applied to remove the restriction on the deletion of system VM templates, allowing operators to delete such templates.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### How Has This Been Tested?

I applied the changes and successfully deleted old system VM templates
