### PR TITLE
Fix cloudstack-ui package: bad directory permissions and missing WEB-INF

### DIFF
--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -320,6 +320,7 @@ rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/templates/systemvm/md5sum
 # UI
 mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
+cp -r client/target/classes/META-INF/webapp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui
 cp ui/dist/config.json ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui/
 cp -r ui/dist/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
 rm -f ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/config.json
@@ -658,7 +659,7 @@ pip3 install --upgrade urllib3
 
 %files ui
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/ui/config.json
-%attr(0644,root,root) %{_datadir}/%{name}-ui/*
+%{_datadir}/%{name}-ui/*
 %{_defaultdocdir}/%{name}-ui-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-ui-%{version}/NOTICE
 

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -320,7 +320,7 @@ rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/templates/systemvm/md5sum
 # UI
 mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
-cp -r client/target/classes/META-INF/webapp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui
+cp -r client/target/classes/META-INF/webapp/WEB-INF ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui
 cp ui/dist/config.json ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui/
 cp -r ui/dist/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
 rm -f ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/config.json

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -636,6 +636,10 @@ pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 
 %files ui
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/ui/config.json
+%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/assets
+%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/css
+%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/js
+%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/locales
 %attr(0644,root,root) %{_datadir}/%{name}-ui/*
 %{_defaultdocdir}/%{name}-ui-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-ui-%{version}/NOTICE

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -302,6 +302,7 @@ rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/templates/systemvm/md5sum
 # UI
 mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
+cp -r client/target/classes/META-INF/webapp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui
 cp ui/dist/config.json ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui/
 cp -r ui/dist/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
 rm -f ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/config.json
@@ -636,11 +637,7 @@ pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 
 %files ui
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/ui/config.json
-%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/assets
-%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/css
-%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/js
-%dir %attr(0755,root,root) %{_datadir}/%{name}-ui/locales
-%attr(0644,root,root) %{_datadir}/%{name}-ui/*
+%{_datadir}/%{name}-ui/*
 %{_defaultdocdir}/%{name}-ui-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-ui-%{version}/NOTICE
 

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -302,7 +302,7 @@ rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/templates/systemvm/md5sum
 # UI
 mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
-cp -r client/target/classes/META-INF/webapp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui
+cp -r client/target/classes/META-INF/webapp/WEB-INF ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui
 cp ui/dist/config.json ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ui/
 cp -r ui/dist/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/
 rm -f ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/config.json


### PR DESCRIPTION
### Description
The cloudstack-ui package contains a copy of the webapp. However, the package (for both CentOS 7 and CentOS 8) have two issues:
1. Bad permissions on directories. The 'cloud' user cannot read and serve assets from subdirectories
2. WEB-INF/web.xml is missing. This breaks the API as the web routes are not defined.

Fixes #8558

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [x] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Rebuilt the RPM packages under Rocky Linux 8 / CentOS 8 using Docker.

New cloudstack-ui packages now have the proper permissions:
```
# rpm2cpio  ../cloudstack-ui-4.18.2.0-SNAPSHOT.x86_64.rpm | cpio -idm                           
54793 blocks         
                                                                                       
# cd usr/share/cloudstack-ui/                                                                   

# ls -al
total 524                                                                                                   
drwxr-xr-x 7 root root    181 Jan 25 18:00 .                                                                
drwxr-xr-x 4 root root     38 Jan 25 18:00 ..                                                               
drwxr-xr-x 2 root root    175 Jan 25 18:00 assets                                                           
-rw-r--r-- 1 root root  14318 Jan 25 17:57 cloud.ico                                                        
-rw-r--r-- 1 root root 456667 Jan 25 17:57 color.less                                                       
lrwxrwxrwx 1 root root     30 Jan 25 17:57 config.json -> /etc/cloudstack/ui/config.json                    
drwxr-xr-x 2 root root   8192 Jan 25 18:00 css                                                              
-rw-r--r-- 1 root root   1228 Jan 25 17:57 error.html                                                       
-rw-r--r-- 1 root root   1220 Jan 25 17:57 example.html                                                     
-rw-r--r-- 1 root root  18123 Jan 25 17:57 index.html                                                       
drwxr-xr-x 2 root root  16384 Jan 25 18:00 js                                                               
drwxr-xr-x 2 root root    309 Jan 25 18:00 locales                                                          
drwxr-xr-x 2 root root     21 Jan 25 18:00 WEB-INF                                                          
```

#### How did you try to break this feature and the system with this change?
Affects only rpmbuild for the cloudstack-ui package. Extracted RPM package to verify change.