### PR TITLE
[Quota] Update pre-populated Quota tariffs' type

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -85,6 +85,7 @@ import com.cloud.upgrade.dao.Upgrade41710to41720;
 import com.cloud.upgrade.dao.Upgrade41720to41800;
 import com.cloud.upgrade.dao.Upgrade41800to41810;
 import com.cloud.upgrade.dao.Upgrade41810to41900;
+import com.cloud.upgrade.dao.Upgrade41900to41910;
 import com.cloud.upgrade.dao.Upgrade420to421;
 import com.cloud.upgrade.dao.Upgrade421to430;
 import com.cloud.upgrade.dao.Upgrade430to440;
@@ -224,6 +225,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.17.2.0", new Upgrade41720to41800())
                 .next("4.18.0.0", new Upgrade41800to41810())
                 .next("4.18.1.0", new Upgrade41810to41900())
+                .next("4.19.0.0", new Upgrade41900to41910())
                 .build();
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41900to41910.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41900to41910.java
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade.dao;
+
+import com.cloud.utils.exception.CloudRuntimeException;
+
+import java.io.InputStream;
+import java.sql.Connection;
+
+public class Upgrade41900to41910 implements DbUpgrade {
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[] {"4.19.0.0", "4.19.1.0"};
+    }
+
+    @Override
+    public String getUpgradedVersion() {
+        return "4.19.1.0";
+    }
+
+    @Override
+    public boolean supportsRollingUpgrade() {
+        return false;
+    }
+
+    @Override
+    public InputStream[] getPrepareScripts() {
+        final String scriptFile = "META-INF/db/schema-41900to41910.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
+    }
+
+    @Override
+    public void performDataMigration(Connection conn) {
+    }
+
+    @Override
+    public InputStream[] getCleanupScripts() {
+        final String scriptFile = "META-INF/db/schema-41900to41910-cleanup.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
+    }
+}

--- a/engine/schema/src/main/resources/META-INF/db/schema-41900to41910-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41900to41910-cleanup.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade cleanup from 4.19.0.0 to 4.19.1.0
+--;

--- a/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
@@ -1,0 +1,32 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.19.0.0 to 4.19.1.0
+--;
+
+-- Updates the populated Quota tariff's types VM_DISK_BYTES_READ, VM_DISK_BYTES_WRITE, VM_DISK_IO_READ and VM_DISK_IO_WRITE to the correct unit.
+
+UPDATE cloud_usage.quota_tariff
+SET usage_unit = 'Bytes', updated_on = NOW()
+WHERE effective_on = '2010-05-04 00:00:00'
+AND name IN ('VM_DISK_BYTES_READ', 'VM_DISK_BYTES_WRITE');
+
+UPDATE cloud_usage.quota_tariff
+SET usage_unit = 'IOPS', updated_on = NOW()
+WHERE effective_on = '2010-05-04 00:00:00'
+AND name IN ('VM_DISK_IO_READ', 'VM_DISK_IO_WRITE');


### PR DESCRIPTION
### Description

The PR #7152 changed the unit of the Quota types `VM_DISK_IO_READ`, `VM_DISK_IO_WRITE`, `VM_DISK_BYTES_READ` and `VM_DISK_BYTES_WRITE`. However, the pre-populated tariffs were not considered, and their unit type is still with the old value. The unit was only displayed incorrectly, as the calculation utilizes the correct unit. Their unit types were updated to the correct ones.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

<details><summary>Update script</summary>

```log
2024-02-05 14:42:03,890 INFO  [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) DB version = 4.19.0.0 Code Version = 4.19.1.0
2024-02-05 14:42:03,894 INFO  [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Database upgrade must be performed from 4.19.0.0 to 4.19.1.0
2024-02-05 14:42:03,949 DEBUG [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Running upgrade Upgrade41900to41910 to upgrade from 4.19.0.0-4.19.1.0 to 4.19.1.0
2024-02-05 14:42:03,957 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Licensed to the Apache Software Foundation (ASF) under one
2024-02-05 14:42:03,958 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- or more contributor license agreements.  See the NOTICE file
2024-02-05 14:42:03,958 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- distributed with this work for additional information
2024-02-05 14:42:03,958 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- regarding copyright ownership.  The ASF licenses this file
2024-02-05 14:42:03,959 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- to you under the Apache License, Version 2.0 (the
2024-02-05 14:42:03,959 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- "License"); you may not use this file except in compliance
2024-02-05 14:42:03,959 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- with the License.  You may obtain a copy of the License at
2024-02-05 14:42:03,959 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --
2024-02-05 14:42:03,959 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --   http://www.apache.org/licenses/LICENSE-2.0
2024-02-05 14:42:03,960 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --
2024-02-05 14:42:03,960 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Unless required by applicable law or agreed to in writing,
2024-02-05 14:42:03,960 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- software distributed under the License is distributed on an
2024-02-05 14:42:03,960 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
2024-02-05 14:42:03,963 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- KIND, either express or implied.  See the License for the
2024-02-05 14:42:03,963 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- specific language governing permissions and limitations
2024-02-05 14:42:03,963 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- under the License.
2024-02-05 14:42:03,964 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --;
2024-02-05 14:42:03,964 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Schema upgrade from 4.19.0.0 to 4.19.1.0
2024-02-05 14:42:03,965 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --;
2024-02-05 14:42:03,965 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Updates the populated Quota tariff's types VM_DISK_BYTES_READ, VM_DISK_BYTES_WRITE, VM_DISK_IO_READ and VM_DISK_IO_WRITE to the correct unit.
2024-02-05 14:42:03,966 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) UPDATE cloud_usage.quota_tariff SET usage_unit = 'Bytes', updated_on = NOW() WHERE effective_on = '2010-05-04 00:00:00' AND name IN ('VM_DISK_BYTES_READ', 'VM_DISK_BYTES_WRITE') 
2024-02-05 14:42:03,976 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) UPDATE cloud_usage.quota_tariff SET usage_unit = 'IOPS', updated_on = NOW() WHERE effective_on = '2010-05-04 00:00:00' AND name IN ('VM_DISK_IO_READ', 'VM_DISK_IO_WRITE') 
2024-02-05 14:42:04,091 INFO  [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Cleanup upgrade Upgrade41900to41910 to upgrade from 4.19.0.0-4.19.1.0 to 4.19.1.0
2024-02-05 14:42:04,103 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Licensed to the Apache Software Foundation (ASF) under one
2024-02-05 14:42:04,103 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- or more contributor license agreements.  See the NOTICE file
2024-02-05 14:42:04,103 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- distributed with this work for additional information
2024-02-05 14:42:04,104 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- regarding copyright ownership.  The ASF licenses this file
2024-02-05 14:42:04,104 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- to you under the Apache License, Version 2.0 (the
2024-02-05 14:42:04,104 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- "License"); you may not use this file except in compliance
2024-02-05 14:42:04,105 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- with the License.  You may obtain a copy of the License at
2024-02-05 14:42:04,105 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --
2024-02-05 14:42:04,105 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --   http://www.apache.org/licenses/LICENSE-2.0
2024-02-05 14:42:04,105 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --
2024-02-05 14:42:04,105 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Unless required by applicable law or agreed to in writing,
2024-02-05 14:42:04,106 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- software distributed under the License is distributed on an
2024-02-05 14:42:04,106 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
2024-02-05 14:42:04,106 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- KIND, either express or implied.  See the License for the
2024-02-05 14:42:04,106 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- specific language governing permissions and limitations
2024-02-05 14:42:04,106 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- under the License.
2024-02-05 14:42:04,107 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --;
2024-02-05 14:42:04,107 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) -- Schema upgrade cleanup from 4.19.0.0 to 4.19.1.0
2024-02-05 14:42:04,108 DEBUG [c.c.u.d.ScriptRunner] (main:null) (logid:) --;
2024-02-05 14:42:04,115 DEBUG [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Cleanup script Upgrade41900to41910 is executed successfully
2024-02-05 14:42:04,225 DEBUG [c.c.u.DatabaseUpgradeChecker] (main:null) (logid:) Upgrade completed for version 4.19.1.0
```
</details>

After the update script, the usage units were updated accordingly.

```markdown
|id|usage_type|usage_name|usage_unit|usage_discriminator|currency_value|effective_on|updated_on|updated_by|uuid|name|description|activation_rule|removed|end_date|
|--|----------|----------|----------|-------------------|--------------|------------|----------|----------|----|----|-----------|---------------|-------|--------|
|18|21|VM_DISK_IO_READ|IOPS|1|0.00000|2010-05-04 00:00:00|2024-01-31 20:51:49|1|9f3f2dc7-771e-11ee-8e59-5254003754dc|VM_DISK_IO_READ|||||
|19|22|VM_DISK_IO_WRITE|IOPS|1|0.00000|2010-05-04 00:00:00|2024-01-31 20:51:49|1|9f3f2ead-771e-11ee-8e59-5254003754dc|VM_DISK_IO_WRITE|||||
|20|23|VM_DISK_BYTES_READ|Bytes|1|0.00000|2010-05-04 00:00:00|2024-01-31 20:51:49|1|9f3f2f84-771e-11ee-8e59-5254003754dc|VM_DISK_BYTES_READ|||||
|21|24|VM_DISK_BYTES_WRITE|Bytes|1|0.00000|2010-05-04 00:00:00|2024-01-31 20:51:49|1|9f3f304f-771e-11ee-8e59-5254003754dc|VM_DISK_BYTES_WRITE|||||
```

#### How did you try to break this feature and the system with this change?