### PR TITLE
UI: Add Migrating state in volume filtering

### DIFF
--- a/ui/src/components/view/SearchView.vue
+++ b/ui/src/components/view/SearchView.vue
@@ -603,30 +603,35 @@ export default {
       return types
     },
     fetchState () {
-      const state = []
-      if (this.apiName.indexOf('listVolumes') > -1) {
-        state.push({
-          id: 'Allocated',
-          name: 'label.allocated'
-        })
-        state.push({
-          id: 'Ready',
-          name: 'label.isready'
-        })
-        state.push({
-          id: 'Destroy',
-          name: 'label.destroy'
-        })
-        state.push({
-          id: 'Expunging',
-          name: 'label.expunging'
-        })
-        state.push({
-          id: 'Expunged',
-          name: 'label.expunged'
-        })
+      if (this.apiName.includes('listVolumes')) {
+        return [
+          {
+            id: 'Allocated',
+            name: 'label.allocated'
+          },
+          {
+            id: 'Ready',
+            name: 'label.isready'
+          },
+          {
+            id: 'Destroy',
+            name: 'label.destroy'
+          },
+          {
+            id: 'Expunging',
+            name: 'label.expunging'
+          },
+          {
+            id: 'Expunged',
+            name: 'label.expunged'
+          },
+          {
+            id: 'Migrating',
+            name: 'label.migrating'
+          }
+        ]
       }
-      return state
+      return []
     },
     fetchEntityType () {
       const entityType = []


### PR DESCRIPTION
### Description

The GUI allows filtering volumes in several states; however, the `Migrating` state is not presented. For this reason, this PR adds the `Migrating` state to the volume filtering.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![Screenshot from 2024-02-08 15-04-57](https://github.com/apache/cloudstack/assets/39202678/d6752b43-fa14-42d6-9ef0-fabb012eef65)


### How Has This Been Tested?

I called the `migrateVolume` API, accessed the volumes tab in the UI and using the `Migrating` state filter all volumes in the `Migrating` state were returned.