### PR TITLE
Limit `listRoles` API visibility

### DIFF
--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
@@ -347,6 +347,11 @@ public class MockAccountManager extends ManagerBase implements AccountManager {
     }
 
     @Override
+    public List<String> getApiNameList() {
+        return null;
+    }
+
+    @Override
     public boolean deleteUserAccount(long arg0) {
         // TODO Auto-generated method stub
         return false;

--- a/server/src/main/java/com/cloud/user/AccountManager.java
+++ b/server/src/main/java/com/cloud/user/AccountManager.java
@@ -195,6 +195,8 @@ public interface AccountManager extends AccountService, Configurable {
     UserTwoFactorAuthenticator getUserTwoFactorAuthenticator(final Long domainId, final Long userAccountId);
 
     void verifyUsingTwoFactorAuthenticationCode(String code, Long domainId, Long userAccountId);
+
     UserTwoFactorAuthenticationSetupResponse setupUserTwoFactorAuthentication(SetupUserTwoFactorAuthenticationCmd cmd);
 
+    List<String> getApiNameList();
 }

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -426,6 +426,11 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
+    public List<String> getApiNameList() {
+        return apiNameList;
+    }
+
+    @Override
     public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
         _systemAccount = _accountDao.findById(Account.ACCOUNT_ID_SYSTEM);
         if (_systemAccount == null) {

--- a/server/src/main/java/org/apache/cloudstack/acl/RoleManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/acl/RoleManagerImpl.java
@@ -420,15 +420,15 @@ public class RoleManagerImpl extends ManagerBase implements RoleService, Configu
 
     /**
      * Checks if the role of the caller account has compatible permissions of the specified role.
-     * For each permission of the role of the caller, the roleToAccess needs to contain the same permission.
+     * For each permission of the role of the caller, the target role needs to contain the same permission.
      *
-     * @param rolePermissions the permissions of the caller role.
-     * @param roleToAccess the role that the caller role wants to access.
+     * @param sourceRolePermissions the permissions of the caller role.
+     * @param targetRole the role that the caller role wants to access.
      * @return True if the role can be accessed with the given permissions; false otherwise.
      */
-    protected boolean roleHasPermission(Map<String, Permission> rolePermissions, Role roleToAccess) {
+    protected boolean roleHasPermission(Map<String, Permission> sourceRolePermissions, Role targetRole) {
         Set<String> rulesAlreadyCompared = new HashSet<>();
-        for (RolePermission rolePermission : findAllPermissionsBy(roleToAccess.getId())) {
+        for (RolePermission rolePermission : findAllPermissionsBy(targetRole.getId())) {
             boolean permissionIsRegex = rolePermission.getRule().getRuleString().contains("*");
 
             for (String apiName : accountManager.getApiNameList()) {
@@ -436,7 +436,7 @@ public class RoleManagerImpl extends ManagerBase implements RoleService, Configu
                     continue;
                 }
 
-                if (rolePermission.getPermission() == Permission.ALLOW && (!rolePermissions.containsKey(apiName) || rolePermissions.get(apiName) == Permission.DENY)) {
+                if (rolePermission.getPermission() == Permission.ALLOW && (!sourceRolePermissions.containsKey(apiName) || sourceRolePermissions.get(apiName) == Permission.DENY)) {
                     return false;
                 }
 

--- a/server/src/main/java/org/apache/cloudstack/acl/RoleManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/acl/RoleManagerImpl.java
@@ -18,9 +18,12 @@ package org.apache.cloudstack.acl;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -382,40 +385,98 @@ public class RoleManagerImpl extends ManagerBase implements RoleService, Configu
     public Pair<List<Role>, Integer> findRolesByName(String name, String keyword, Long startIndex, Long limit) {
         if (StringUtils.isNotBlank(name) || StringUtils.isNotBlank(keyword)) {
             Pair<List<RoleVO>, Integer> data = roleDao.findAllByName(name, keyword, startIndex, limit, isCallerRootAdmin());
-            int removed = removeRootAdminRolesIfNeeded(data.first());
+            int removed = removeRolesIfNeeded(data.first());
             return new Pair<List<Role>,Integer>(ListUtils.toListOfInterface(data.first()), Integer.valueOf(data.second() - removed));
         }
         return new Pair<List<Role>, Integer>(new ArrayList<Role>(), 0);
     }
 
     /**
-     *  Removes roles of the given list that have the type '{@link RoleType#Admin}' if the user calling the method is not a 'root admin'.
-     *  The actual removal is executed via {@link #removeRootAdminRoles(List)}. Therefore, if the method is called by a 'root admin', we do nothing here.
+     *  Removes roles from the given list if the role has different or more permissions than the user's calling the method role
      */
-    protected int removeRootAdminRolesIfNeeded(List<? extends Role> roles) {
-        if (!isCallerRootAdmin()) {
-            return removeRootAdminRoles(roles);
+    protected int removeRolesIfNeeded(List<? extends Role> roles) {
+        if (roles.isEmpty()) {
+            return 0;
         }
-        return 0;
+
+        Long callerRoleId = getCurrentAccount().getRoleId();
+        Map<String, Permission> callerRolePermissions = getRoleRulesAndPermissions(callerRoleId);
+
+        int count = 0;
+        Iterator<? extends Role> rolesIterator = roles.iterator();
+        while (rolesIterator.hasNext()) {
+            Role role = rolesIterator.next();
+
+            if (role.getId() == callerRoleId || roleHasPermission(callerRolePermissions, role)) {
+                continue;
+            }
+
+            count++;
+            rolesIterator.remove();
+        }
+
+        return count;
     }
 
     /**
-     * Remove all roles that have the {@link RoleType#Admin}.
+     * Checks if the role of the caller account has compatible permissions of the specified role.
+     * For each permission of the role of the caller, the roleToAccess needs to contain the same permission.
+     *
+     * @param rolePermissions the permissions of the caller role.
+     * @param roleToAccess the role that the caller role wants to access.
+     * @return True if the role can be accessed with the given permissions; false otherwise.
      */
-    protected int removeRootAdminRoles(List<? extends Role> roles) {
-        if (CollectionUtils.isEmpty(roles)) {
-            return 0;
-        }
-        Iterator<? extends Role> rolesIterator = roles.iterator();
-        int count = 0;
-        while (rolesIterator.hasNext()) {
-            Role role = rolesIterator.next();
-            if (RoleType.Admin == role.getRoleType()) {
-                count++;
-                rolesIterator.remove();
+    protected boolean roleHasPermission(Map<String, Permission> rolePermissions, Role roleToAccess) {
+        Set<String> rulesAlreadyCompared = new HashSet<>();
+        for (RolePermission rolePermission : findAllPermissionsBy(roleToAccess.getId())) {
+            boolean permissionIsRegex = rolePermission.getRule().getRuleString().contains("*");
+
+            for (String apiName : accountManager.getApiNameList()) {
+                if (!rolePermission.getRule().matches(apiName) || rulesAlreadyCompared.contains(apiName)) {
+                    continue;
+                }
+
+                if (rolePermission.getPermission() == Permission.ALLOW && (!rolePermissions.containsKey(apiName) || rolePermissions.get(apiName) == Permission.DENY)) {
+                    return false;
+                }
+
+                rulesAlreadyCompared.add(apiName);
+
+                if (!permissionIsRegex) {
+                    break;
+                }
             }
         }
-        return count;
+
+        return true;
+    }
+
+    /**
+     * Given a role ID, returns a {@link Map} containing the API name as the key and the {@link Permission} for the API as the value.
+     *
+     * @param roleId ID from role.
+     */
+    public Map<String, Permission> getRoleRulesAndPermissions(Long roleId) {
+        Map<String, Permission> roleRulesAndPermissions = new HashMap<>();
+
+        for (RolePermission rolePermission : findAllPermissionsBy(roleId)) {
+            boolean permissionIsRegex = rolePermission.getRule().getRuleString().contains("*");
+
+            for (String apiName : accountManager.getApiNameList()) {
+                if (!rolePermission.getRule().matches(apiName)) {
+                    continue;
+                }
+
+                if (!roleRulesAndPermissions.containsKey(apiName)) {
+                    roleRulesAndPermissions.put(apiName, rolePermission.getPermission());
+                }
+
+                if (!permissionIsRegex) {
+                    break;
+                }
+            }
+        }
+        return roleRulesAndPermissions;
     }
 
     @Override
@@ -435,14 +496,14 @@ public class RoleManagerImpl extends ManagerBase implements RoleService, Configu
     @Override
     public List<Role> listRoles() {
         List<? extends Role> roles = roleDao.listAll();
-        removeRootAdminRolesIfNeeded(roles);
+        removeRolesIfNeeded(roles);
         return ListUtils.toListOfInterface(roles);
     }
 
     @Override
     public Pair<List<Role>, Integer> listRoles(Long startIndex, Long limit) {
         Pair<List<RoleVO>, Integer> data = roleDao.listAllRoles(startIndex, limit, isCallerRootAdmin());
-        int removed = removeRootAdminRolesIfNeeded(data.first());
+        int removed = removeRolesIfNeeded(data.first());
         return new Pair<List<Role>,Integer>(ListUtils.toListOfInterface(data.first()), Integer.valueOf(data.second() - removed));
     }
 

--- a/server/src/test/java/com/cloud/user/MockAccountManagerImpl.java
+++ b/server/src/test/java/com/cloud/user/MockAccountManagerImpl.java
@@ -479,4 +479,8 @@ public class MockAccountManagerImpl extends ManagerBase implements Manager, Acco
         return null;
     }
 
+    @Override
+    public List<String> getApiNameList() {
+        return null;
+    }
 }

--- a/server/src/test/java/org/apache/cloudstack/acl/RoleManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/acl/RoleManagerImplTest.java
@@ -20,7 +20,10 @@ package org.apache.cloudstack.acl;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.utils.Pair;
+
+import org.apache.cloudstack.acl.RolePermissionEntity.Permission;
 import org.apache.cloudstack.acl.dao.RoleDao;
+import org.apache.cloudstack.acl.dao.RolePermissionsDao;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,7 +36,10 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RoleManagerImplTest {
@@ -45,6 +51,22 @@ public class RoleManagerImplTest {
     private AccountManager accountManagerMock;
     @Mock
     private RoleDao roleDaoMock;
+    @Mock
+    private RolePermissionsDao rolePermissionsDaoMock;
+    @Mock
+    private RolePermission rolePermission1Mock;
+    @Mock
+    private RolePermission rolePermission2Mock;
+    @Mock
+    private Account callerAccountMock;
+    @Mock
+    private Role callerAccountRoleMock;
+    @Mock
+    private Role lessPermissionsRoleMock;
+    @Mock
+    private Role morePermissionsRoleMock;
+    @Mock
+    private Role differentPermissionsRoleMock;
 
     @Mock
     private Account accountMock;
@@ -53,6 +75,33 @@ public class RoleManagerImplTest {
     @Mock
     private RoleVO roleVoMock;
     private long roleMockId = 1l;
+
+    private Map<String, Permission> rolePermissions = new HashMap<>();
+
+    public void setUpRoleVisibilityTests() {
+        Mockito.doReturn(List.of("api1", "api2", "api3")).when(accountManagerMock).getApiNameList();
+
+        Mockito.doReturn(1L).when(callerAccountRoleMock).getId();
+        Mockito.doReturn(callerAccountMock).when(roleManagerImpl).getCurrentAccount();
+        Mockito.doReturn(callerAccountRoleMock.getId()).when(callerAccountMock).getRoleId();
+
+        Mockito.when(rolePermission1Mock.getRule()).thenReturn(new Rule("api1"));
+        Mockito.when(rolePermission2Mock.getRule()).thenReturn(new Rule("api2"));
+        Mockito.doReturn(RolePermissionEntity.Permission.ALLOW).when(rolePermission1Mock).getPermission();
+        Mockito.doReturn(RolePermissionEntity.Permission.ALLOW).when(rolePermission2Mock).getPermission();
+
+        List<RolePermission> lessPermissionsRolePermissions = Collections.singletonList(rolePermission1Mock);
+        Mockito.doReturn(1L).when(lessPermissionsRoleMock).getId();
+        Mockito.when(roleManagerImpl.findAllPermissionsBy(1L)).thenReturn(lessPermissionsRolePermissions);
+
+        List<RolePermission> morePermissionsRolePermissions = List.of(rolePermission1Mock, rolePermission2Mock);
+        Mockito.doReturn(2L).when(morePermissionsRoleMock).getId();
+        Mockito.when(roleManagerImpl.findAllPermissionsBy(morePermissionsRoleMock.getId())).thenReturn(morePermissionsRolePermissions);
+
+        List<RolePermission> differentPermissionsRolePermissions = Collections.singletonList(rolePermission2Mock);
+        Mockito.doReturn(3L).when(differentPermissionsRoleMock).getId();
+        Mockito.when(roleManagerImpl.findAllPermissionsBy(differentPermissionsRoleMock.getId())).thenReturn(differentPermissionsRolePermissions);
+    }
 
     @Before
     public void beforeTest() {
@@ -168,57 +217,104 @@ public class RoleManagerImplTest {
         Mockito.doReturn(toBeReturned).when(roleDaoMock).findAllByName(roleName, null, null, null, false);
 
         roleManagerImpl.findRolesByName(roleName);
-        Mockito.verify(roleManagerImpl).removeRootAdminRolesIfNeeded(roles);
+        Mockito.verify(roleManagerImpl).removeRolesIfNeeded(roles);
     }
 
     @Test
-    public void removeRootAdminRolesIfNeededTestRootAdmin() {
-        Mockito.doReturn(accountMock).when(roleManagerImpl).getCurrentAccount();
-        Mockito.doReturn(true).when(accountManagerMock).isRootAdmin(accountMockId);
-
+    public void removeRolesIfNeededTestRoleWithMoreAndSamePermissionsKeepRoles() {
+        setUpRoleVisibilityTests();
         List<Role> roles = new ArrayList<>();
-        roleManagerImpl.removeRootAdminRolesIfNeeded(roles);
 
-        Mockito.verify(roleManagerImpl, Mockito.times(0)).removeRootAdminRoles(roles);
+        List<RolePermission> callerAccountRolePermissions = List.of(rolePermission1Mock, rolePermission2Mock);
+        Mockito.when(roleManagerImpl.findAllPermissionsBy(callerAccountRoleMock.getId())).thenReturn(callerAccountRolePermissions);
+
+        roles.add(callerAccountRoleMock);
+        roles.add(lessPermissionsRoleMock);
+
+        roleManagerImpl.removeRolesIfNeeded(roles);
+
+        Assert.assertEquals(2, roles.size());
+        Assert.assertEquals(callerAccountRoleMock, roles.get(0));
+        Assert.assertEquals(lessPermissionsRoleMock, roles.get(1));
     }
 
     @Test
-    public void removeRootAdminRolesIfNeededTestNonRootAdminUser() {
-        Mockito.doReturn(accountMock).when(roleManagerImpl).getCurrentAccount();
-        Mockito.doReturn(false).when(accountManagerMock).isRootAdmin(accountMockId);
-
+    public void removeRolesIfNeededTestRoleWithLessPermissionsRemoveRoles() {
+        setUpRoleVisibilityTests();
         List<Role> roles = new ArrayList<>();
-        roleManagerImpl.removeRootAdminRolesIfNeeded(roles);
 
-        Mockito.verify(roleManagerImpl, Mockito.times(1)).removeRootAdminRoles(roles);
+        List<RolePermission> callerAccountRolePermissions = Collections.singletonList(rolePermission1Mock);
+        Mockito.when(roleManagerImpl.findAllPermissionsBy(callerAccountRoleMock.getId())).thenReturn(callerAccountRolePermissions);
+
+
+        roles.add(callerAccountRoleMock);
+        roles.add(morePermissionsRoleMock);
+
+        roleManagerImpl.removeRolesIfNeeded(roles);
+
+        Assert.assertEquals(1, roles.size());
+        Assert.assertEquals(callerAccountRoleMock, roles.get(0));
     }
 
     @Test
-    public void removeRootAdminRolesTest() {
+    public void removeRolesIfNeededTestRoleWithDifferentPermissionsRemoveRoles() {
+        setUpRoleVisibilityTests();
         List<Role> roles = new ArrayList<>();
-        Role roleRootAdmin = Mockito.mock(Role.class);
-        Mockito.doReturn(RoleType.Admin).when(roleRootAdmin).getRoleType();
 
-        Role roleDomainAdmin = Mockito.mock(Role.class);
-        Mockito.doReturn(RoleType.DomainAdmin).when(roleDomainAdmin).getRoleType();
+        List<RolePermission> callerAccountRolePermissions = Collections.singletonList(rolePermission1Mock);
+        Mockito.when(roleManagerImpl.findAllPermissionsBy(callerAccountRoleMock.getId())).thenReturn(callerAccountRolePermissions);
 
-        Role roleResourceAdmin = Mockito.mock(Role.class);
-        Mockito.doReturn(RoleType.ResourceAdmin).when(roleResourceAdmin).getRoleType();
+        roles.add(callerAccountRoleMock);
+        roles.add(differentPermissionsRoleMock);
 
-        Role roleUser = Mockito.mock(Role.class);
-        Mockito.doReturn(RoleType.User).when(roleUser).getRoleType();
+        roleManagerImpl.removeRolesIfNeeded(roles);
 
-        roles.add(roleRootAdmin);
-        roles.add(roleDomainAdmin);
-        roles.add(roleResourceAdmin);
-        roles.add(roleUser);
+        Assert.assertEquals(1, roles.size());
+        Assert.assertEquals(callerAccountRoleMock, roles.get(0));
+    }
 
-        roleManagerImpl.removeRootAdminRoles(roles);
+    @Test
+    public void roleHasPermissionTestRoleWithMoreAndSamePermissionsReturnsTrue() {
+        setUpRoleVisibilityTests();
+        rolePermissions.put("api1", Permission.ALLOW);
+        rolePermissions.put("api2", Permission.ALLOW);
 
-        Assert.assertEquals(3, roles.size());
-        Assert.assertEquals(roleDomainAdmin, roles.get(0));
-        Assert.assertEquals(roleResourceAdmin, roles.get(1));
-        Assert.assertEquals(roleUser, roles.get(2));
+        boolean result = roleManagerImpl.roleHasPermission(rolePermissions, lessPermissionsRoleMock);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void roleHasPermissionTestRoleAllowedApisDoesNotContainRoleToAccessAllowedApiReturnsFalse() {
+        setUpRoleVisibilityTests();
+        rolePermissions.put("api2", Permission.ALLOW);
+        rolePermissions.put("api3", Permission.ALLOW);
+
+        boolean result = roleManagerImpl.roleHasPermission(rolePermissions, morePermissionsRoleMock);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void roleHasPermissionTestRolePermissionsDeniedApiContainRoleToAccessAllowedApiReturnsFalse() {
+        setUpRoleVisibilityTests();
+        rolePermissions.put("api1", Permission.ALLOW);
+        rolePermissions.put("api2", Permission.DENY);
+
+        boolean result = roleManagerImpl.roleHasPermission(rolePermissions, morePermissionsRoleMock);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void getRolePermissionsTestRoleReturnsRolePermissions() {
+        setUpRoleVisibilityTests();
+
+        Map<String, Permission> roleRulesAndPermissions = roleManagerImpl.getRoleRulesAndPermissions(morePermissionsRoleMock.getId());
+
+        Assert.assertEquals(2, roleRulesAndPermissions.size());
+        Assert.assertEquals(roleRulesAndPermissions.get("api1"), Permission.ALLOW);
+        Assert.assertEquals(roleRulesAndPermissions.get("api2"), Permission.ALLOW);
     }
 
     @Test
@@ -277,12 +373,12 @@ public class RoleManagerImplTest {
         roles.add(Mockito.mock(Role.class));
 
         Mockito.doReturn(roles).when(roleDaoMock).listAll();
-        Mockito.doReturn(0).when(roleManagerImpl).removeRootAdminRolesIfNeeded(roles);
+        Mockito.doReturn(0).when(roleManagerImpl).removeRolesIfNeeded(roles);
 
         List<Role> returnedRoles = roleManagerImpl.listRoles();
 
         Assert.assertEquals(roles.size(), returnedRoles.size());
         Mockito.verify(roleDaoMock).listAll();
-        Mockito.verify(roleManagerImpl).removeRootAdminRolesIfNeeded(roles);
+        Mockito.verify(roleManagerImpl).removeRolesIfNeeded(roles);
     }
 }


### PR DESCRIPTION
### Description

When calling the `listRoles` API, users can see roles with more permissions than theirs.

Therefore, the behavior of the `listRoles` API was changed so that users can only see roles that their role has permission to access (roles with same and less permissions).


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

1. I created a custom role based on User role and added the `listRoles` API to it.
2. I created an account using the role from step 1 and logged into it.
3. I called the `listRoles` API via CloudMonkey and verfied that the roles with more permissions than mine were not listed, such as default admin roles.