### PR TITLE
Fix 404 when moving a VM to out of a project

### DIFF
--- a/ui/src/views/compute/AssignInstance.vue
+++ b/ui/src/views/compute/AssignInstance.vue
@@ -306,7 +306,11 @@ export default {
           message: this.$t('label.loadbalancerinstance')
         })
         this.$emit('close-action')
-        this.parentFetchData()
+        if (this.$store.getters.project?.id) {
+          this.$router.push({ path: '/vm' })
+        } else {
+          this.parentFetchData()
+        }
       }).catch(error => {
         this.$notifyError(error)
       }).finally(() => {


### PR DESCRIPTION
### Description

In a project's view, after assigning an instance belonging to the project to a user account through the instance's page, the UI tries to refresh the information about the instance. However, as the project does not have permission to view instances from other accounts, the user is redirected to a 404.

This PR adds a check in the UI to avoid showing this 404.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

In the root admin account, I made the following tests:

| Number | Test | Previous result | New result | Expected result? (Y/N) |
| - | - | - | - | - |
| 1 | In a project's view, I assigned an instance belonging to the project to a user account | UI gets redirected to a 404 | UI gets redirected to the instance listing | Y |
| 2 | In a project's view, I tried to assign an instance belonging to the project to the project itself | An error is shown, as the previous and the new owner are the same. The UI stays in the same page | An error is shown, as the previous and the new owner are the same. The UI stays in the same page | Y |
| 3 | In a project's view, I assigned an instance belonging to the project to another project in the same domain | UI gets redirected to a 404 | UI gets redirected to the instance listing | Y |
| 4 | In a project's view, I assigned an instance belonging to the project to another project in a subdomain | UI gets redirected to a 404 | UI gets redirected to the instance listing | Y |
| 5 | In the default view, I assigned an instance belonging to account A to account B | The UI refreshes the information about the instance | The UI refreshes the information about the instance | Y |