### PR TITLE
Linstor 4.19 fix selecting non enabled hosts

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -958,9 +958,12 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             }
             else {
                 answer = new Answer(cmd, false, "Unable to get matching Linstor endpoint.");
+                deleteResourceDefinition(pool, rscName);
             }
         } catch (ApiException exc) {
             s_logger.error("copy template failed: ", exc);
+            s_logger.info(String.format("deleting failed template resource: %s", rscName));
+            deleteResourceDefinition(pool, rscName);
             throw new CloudRuntimeException(exc.getBestMessage());
         }
         return answer;

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -59,6 +59,7 @@ import com.cloud.api.storage.LinstorRevertBackupSnapshotCommand;
 import com.cloud.configuration.Config;
 import com.cloud.host.Host;
 import com.cloud.host.dao.HostDao;
+import com.cloud.resource.ResourceState;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.ResizeVolumePayload;
 import com.cloud.storage.SnapshotVO;
@@ -214,6 +215,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                 }
                 throw new CloudRuntimeException("Linstor: Unable to delete resource definition: " + rscDefName);
             }
+            s_logger.info(String.format("Linstor: Deleted resource %s", rscDefName));
         } catch (ApiException apiEx)
         {
             s_logger.error("Linstor: ApiEx - " + apiEx.getMessage());
@@ -865,7 +867,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         Host host = null;
         for (String nodeName : linstorNodeNames) {
             host = _hostDao.findByName(nodeName);
-            if (host != null) {
+            if (host != null && host.getResourceState() == ResourceState.Enabled) {
                 s_logger.info(String.format("Linstor: Make resource %s available on node %s ...", rscName, nodeName));
                 ApiCallRcList answers = api.resourceMakeAvailableOnNode(rscName, nodeName, new ResourceMakeAvailable());
                 if (!answers.hasError()) {
@@ -892,21 +894,16 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
     }
 
     private Optional<RemoteHostEndPoint> getDiskfullEP(DevelopersApi api, String rscName) throws ApiException {
-        com.linbit.linstor.api.model.StoragePool linSP =
-            LinstorUtil.getDiskfulStoragePool(api, rscName);
-        if (linSP != null)
-        {
-            Host host = _hostDao.findByName(linSP.getNodeName());
-            if (host == null)
-            {
-                s_logger.error("Linstor: Host '" + linSP.getNodeName() + "' not found.");
-                return Optional.empty();
-            }
-            else
-            {
-                return Optional.of(RemoteHostEndPoint.getHypervisorHostEndPoint(host));
+        List<com.linbit.linstor.api.model.StoragePool> linSPs = LinstorUtil.getDiskfulStoragePools(api, rscName);
+        if (linSPs != null) {
+            for (com.linbit.linstor.api.model.StoragePool sp : linSPs) {
+                Host host = _hostDao.findByName(sp.getNodeName());
+                if (host != null && host.getResourceState() == ResourceState.Enabled) {
+                    return Optional.of(RemoteHostEndPoint.getHypervisorHostEndPoint(host));
+                }
             }
         }
+        s_logger.error("Linstor: No diskfull host found.");
         return Optional.empty();
     }
 
@@ -962,7 +959,6 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             }
         } catch (ApiException exc) {
             s_logger.error("copy template failed: ", exc);
-            s_logger.info(String.format("deleting failed template resource: %s", rscName));
             deleteResourceDefinition(pool, rscName);
             throw new CloudRuntimeException(exc.getBestMessage());
         }

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -77,16 +77,16 @@ public class LinstorUtil {
         return nodes.stream().map(Node::getName).collect(Collectors.toList());
     }
 
-    public static com.linbit.linstor.api.model.StoragePool
-    getDiskfulStoragePool(@Nonnull DevelopersApi api, @Nonnull String rscName) throws ApiException
+    public static List<com.linbit.linstor.api.model.StoragePool>
+    getDiskfulStoragePools(@Nonnull DevelopersApi api, @Nonnull String rscName) throws ApiException
     {
         List<ResourceWithVolumes> resources = api.viewResources(
-            Collections.emptyList(),
-            Collections.singletonList(rscName),
-            Collections.emptyList(),
-            Collections.emptyList(),
-            null,
-            null);
+                Collections.emptyList(),
+                Collections.singletonList(rscName),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null,
+                null);
 
         String nodeName = null;
         String storagePoolName = null;
@@ -107,13 +107,23 @@ public class LinstorUtil {
         }
 
         List<com.linbit.linstor.api.model.StoragePool> sps = api.viewStoragePools(
-            Collections.singletonList(nodeName),
-            Collections.singletonList(storagePoolName),
-            Collections.emptyList(),
-            null,
-            null
+                Collections.singletonList(nodeName),
+                Collections.singletonList(storagePoolName),
+                Collections.emptyList(),
+                null,
+                null
         );
-        return !sps.isEmpty() ? sps.get(0) : null;
+        return sps != null ? sps : Collections.emptyList();
+    }
+
+    public static com.linbit.linstor.api.model.StoragePool
+    getDiskfulStoragePool(@Nonnull DevelopersApi api, @Nonnull String rscName) throws ApiException
+    {
+        List<com.linbit.linstor.api.model.StoragePool> sps = getDiskfulStoragePools(api, rscName);
+        if (sps != null) {
+            return !sps.isEmpty() ? sps.get(0) : null;
+        }
+        return null;
     }
 
     public static String getSnapshotPath(com.linbit.linstor.api.model.StoragePool sp, String rscName, String snapshotName) {


### PR DESCRIPTION
### Description

This PR fixes template copy and other operations while there are nodes in the cluster under maintenance or disabled.

It was simply forgotten to check the host state is not in any none enabled state.
Additionally delete the created resource definition from Linstor if something went wrong copying.

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Linstor cluster, copying a new template into primary storage and also do volume snapshots (with maintenance hosts)

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
