### PR TITLE
Linstor 4.19 fix script alllines

### DIFF
--- a/utils/src/main/java/com/cloud/utils/script/OutputInterpreter.java
+++ b/utils/src/main/java/com/cloud/utils/script/OutputInterpreter.java
@@ -137,6 +137,11 @@ public abstract class OutputInterpreter {
         public String getLines() {
             return allLines;
         }
+
+        @Override
+        public boolean drain() {
+            return true;
+        }
     }
 
     public static class LineByLineOutputLogger extends OutputInterpreter {

--- a/utils/src/test/java/com/cloud/utils/ScriptTest.java
+++ b/utils/src/test/java/com/cloud/utils/ScriptTest.java
@@ -112,6 +112,20 @@ public class ScriptTest {
     }
 
     @Test
+    public void executeWithOutputInterpreterAllLinesParserLargeOutput() {
+        Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
+        OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
+        Script script = new Script("seq");
+        script.add("-f");
+        script.add("my text to test cloudstack %g");
+        script.add("4096"); // AllLinesParser doesn't work with that amount of data
+        String value = script.execute(parser);
+        // it is a stack trace in this case as string
+        Assert.assertNull(value);
+        Assert.assertEquals(129965, parser.getLines().length());
+    }
+
+    @Test
     public void runSimpleBashScriptNotExisting() {
         Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
         String output = Script.runSimpleBashScript("/not/existing/scripts/"


### PR DESCRIPTION
### Description

This PR enabled draining on the `AllLinesParser` so `Script.execute()` doesn't timeout if it has to read larger data.
Right now commands with larger output and `AllLinesParser` won't finish, because noone is emptying the stdout buffer
and the process will never exit until killed by the timeout "interrupt".

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested with local `Script` executions and an added unittest.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
