### PR TITLE
Show network metrics for System VMs

### DIFF
--- a/ui/src/components/view/StatsTab.vue
+++ b/ui/src/components/view/StatsTab.vue
@@ -204,7 +204,7 @@
             />
           </a-col>
         </a-row>
-        <a-row class="chart-row" v-if="resourceType === 'VirtualMachine'">
+        <a-row class="chart-row" v-if="resourceIsVirtualMachine">
           <a-col>
             <strong>{{ $t('label.network') }}</strong>
             <InfoCircleOutlined class="info-icon" :title="$t('label.see.more.info.network.usage')" @click="onClickShowResourceInfoModal('NET')"/>


### PR DESCRIPTION
### Description

The Network metrics segment of the UI displays the amount of data downloaded/uploaded by a specific instance. However, when the instance is a system VM (VR, CPVM or SSVM), this segment is not shown.

This behaviour has been fixed, allowing network metrics for System VMs to be viewed via UI.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


<details><summary>Before</summary>

Console Proxy:
![consoleProxyBefore](https://github.com/apache/cloudstack/assets/49285692/7f1a3a11-dab6-43f1-b6c4-e80755aeae0d)

Secondary Storage:
![SecondaryStorageBefore](https://github.com/apache/cloudstack/assets/49285692/3f175a49-217a-4f99-8975-3ae62d9579b9)

Virtual Router:
![routerBefore](https://github.com/apache/cloudstack/assets/49285692/9326ec67-cbae-4338-a367-a09a3fdb86a2)

</details>



<details><summary>After</summary>

Console Proxy:
![consoleProxyAfter](https://github.com/apache/cloudstack/assets/49285692/74380dd0-3df0-4af3-9cb7-cc4405bc1a62)

Secondary Storage:
![secondaryStorageAfter](https://github.com/apache/cloudstack/assets/49285692/d60b4655-0c6a-4537-87e6-eb18674e350b)

Virtual Router:
![routerAfter](https://github.com/apache/cloudstack/assets/49285692/2133e197-cac7-476e-8cea-efe029bccdbf)

</details>


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
