### PR TITLE
Limit infrastructure details revealed to the end user after a failed migration on KVM

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -308,7 +308,8 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             logger.error(String.format("Can't migrate domain [%s] due to: [%s].", vmName, e.getMessage()), e);
             result = e.getMessage();
             if (result.startsWith("unable to connect to server") && result.endsWith("refused")) {
-                result = String.format("Migration was refused connection to destination: %s. Please check libvirt configuration compatibility and firewall rules on the source and destination hosts.", destinationUri);
+                logger.debug(String.format("Migration failed as connection to destination [%s] was refused. Please check libvirt configuration compatibility and firewall rules on the source and destination hosts.", destinationUri));
+                result = String.format("Failed to migrate domain [%s].", vmName);
             }
         } catch (final InterruptedException
             | ExecutionException

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -308,7 +308,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             logger.error(String.format("Can't migrate domain [%s] due to: [%s].", vmName, e.getMessage()), e);
             result = e.getMessage();
             if (result.startsWith("unable to connect to server") && result.endsWith("refused")) {
-                logger.debug(String.format("Migration failed as connection to destination [%s] was refused. Please check libvirt configuration compatibility and firewall rules on the source and destination hosts.", destinationUri));
+                logger.debug("Migration failed as connection to destination [{}] was refused. Please check libvirt configuration compatibility and firewall rules on the source and destination hosts.", destinationUri);
                 result = String.format("Failed to migrate domain [%s].", vmName);
             }
         } catch (final InterruptedException


### PR DESCRIPTION
### Description

When a migration error occurs on KVM, the message `Migration was refused connection to destination: <destination Uri>. Please check libvirt configuration compatibility and firewall rules on the source and destination hosts.` is presented to the user. This discloses infrastructure information which should not be available to the end user.

This message was substituted by a generic message, to avoid exposing infrastructure information. A new log was also added, containing the previous content of the message, in order to enable debugging.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor
