### PR TITLE
Fix `deleteUser` API to prevent deletion of the caller

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/user/DeleteUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/user/DeleteUserCmd.java
@@ -84,11 +84,10 @@ public class DeleteUserCmd extends BaseCmd {
     public void execute() {
         CallContext.current().setEventDetails("UserId: " + getId());
         boolean result = _regionService.deleteUser(this);
-        if (result) {
-            SuccessResponse response = new SuccessResponse(getCommandName());
-            this.setResponseObject(response);
-        } else {
+        if (!result) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to delete user");
         }
+        SuccessResponse response = new SuccessResponse(getCommandName());
+        this.setResponseObject(response);
     }
 }

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2152,7 +2152,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         }
     }
 
-    private void checkAccountAndAccess(UserVO user, Account account) {
+    protected void checkAccountAndAccess(UserVO user, Account account) {
         // don't allow to delete the user from the account of type Project
         if (account.getType() == Account.Type.PROJECT) {
             throw new InvalidParameterValueException("Project users cannot be deleted or moved.");
@@ -2162,7 +2162,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         CallContext.current().putContextParameter(User.class, user.getUuid());
     }
 
-    private UserVO getValidUserVO(long id) {
+    protected UserVO getValidUserVO(long id) {
         UserVO user = _userDao.findById(id);
 
         if (user == null || user.getRemoved() != null) {

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2064,13 +2064,20 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_USER_DELETE, eventDescription = "deleting User")
     public boolean deleteUser(DeleteUserCmd deleteUserCmd) {
-        UserVO user = getValidUserVO(deleteUserCmd.getId());
-
+        final Long id = deleteUserCmd.getId();
+        User caller = CallContext.current().getCallingUser();
+        UserVO user = getValidUserVO(id);
         Account account = _accountDao.findById(user.getAccountId());
+
+        if (caller.getId() == id) {
+            Domain domain = _domainDao.findById(account.getDomainId());
+            throw new InvalidParameterValueException(String.format("The caller is requesting to delete itself. As a security measure, ACS will not allow this operation." +
+                    " To delete user %s (ID: %s, Domain: %s), request to another user with permission to execute the operation.", user.getUsername(), user.getUuid(), domain.getUuid()));
+        }
 
         // don't allow to delete the user from the account of type Project
         checkAccountAndAccess(user, account);
-        return _userDao.remove(deleteUserCmd.getId());
+        return _userDao.remove(id);
     }
 
     @Override


### PR DESCRIPTION
### Description

Currently, ACS allows users to delete themselves by calling the `deleteUser` API via CLI. Fixing this behavior has been previously suggested in this [comment](https://github.com/apache/cloudstack/pull/7242#issuecomment-1433260909), as it leaves room for errors if users don't pay enough attention (e.g., when using the console's autocomplete feature), since the parameter passed is the user's `UUID` and it's not easily identifiable to whom this `UUID` belongs. Furthermore, there's already a feature to prevent a user from deleting themselves via the UI; however, slower environments create a small window where it's possible for the user to click the button before it's disabled, allowing deletion even through the UI (see this [comment](https://github.com/apache/cloudstack/pull/7242#issuecomment-1444300925)).

This pull request addresses this issue by adding a validation that checks the caller's `UUID` and compares it with the `UUID` of the user they are trying to delete. If they are the same, an exception is thrown.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![delete-user](https://github.com/apache/cloudstack/assets/56271185/2d271e4a-169f-455b-9abf-9e5218cfba6a)

### How Has This Been Tested?

I tested by creating a new user (Temp) and attempted to delete it using the same user via CloudMonkey.

An exception was thrown, and the user was not deleted.

Next, I attempted to delete the user via the UI by rapidly clicking the delete icon before being disabled. Once again, an exception was thrown without deleting the user as shown in the screenshot above.

```(Temp) 🐱 > delete user id=02392623-cd84-4695-ba49-ec187742b2cd 
🙈 Error: (HTTP 431, error code 4350) The caller is requesting to delete itself. As a security measure, ACS will not allow this operation. To delete user Temp (ID: 02392623-cd84-4695-ba49-ec187742b2cd, Domain: d57f818f-efe2-44e4-810c-820f048c3129), request to another user with permission to execute the operation. ```