### PR TITLE
Fix XenServer nested extra configuration

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1972,7 +1972,7 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
         // Add configuration settings VM record for User VM instances before creating VM
         Map<String, String> extraConfig = vmSpec.getExtraConfig();
         if (vmSpec.getType().equals(VirtualMachine.Type.User) && MapUtils.isNotEmpty(extraConfig)) {
-            logger.info("Appending user extra configuration settings [{}] to [{}].", extraConfig, vmSpec));
+            logger.info("Appending user extra configuration settings [{}] to [{}].", extraConfig, vmSpec);
             ExtraConfigurationUtility.setExtraConfigurationToVm(conn,vmr, vm, extraConfig);
         }
     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1972,7 +1972,7 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
         // Add configuration settings VM record for User VM instances before creating VM
         Map<String, String> extraConfig = vmSpec.getExtraConfig();
         if (vmSpec.getType().equals(VirtualMachine.Type.User) && MapUtils.isNotEmpty(extraConfig)) {
-            logger.info("Appending user extra configuration settings to VM");
+            logger.info(String.format("Appending user extra configuration settings [%s] to [%s].", extraConfig, vmSpec));
             ExtraConfigurationUtility.setExtraConfigurationToVm(conn,vmr, vm, extraConfig);
         }
     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1972,7 +1972,7 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
         // Add configuration settings VM record for User VM instances before creating VM
         Map<String, String> extraConfig = vmSpec.getExtraConfig();
         if (vmSpec.getType().equals(VirtualMachine.Type.User) && MapUtils.isNotEmpty(extraConfig)) {
-            logger.info(String.format("Appending user extra configuration settings [%s] to [%s].", extraConfig, vmSpec));
+            logger.info("Appending user extra configuration settings [{}] to [{}].", extraConfig, vmSpec));
             ExtraConfigurationUtility.setExtraConfigurationToVm(conn,vmr, vm, extraConfig);
         }
     }

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
@@ -43,7 +43,7 @@ public class ExtraConfigurationUtility {
             String paramValue = configParams.get(paramKey);
 
             //Map params
-            LOGGER.debug(String.format("Applying [%s] configuration as [%s].", paramKey, paramValue));
+            LOGGER.debug("Applying [{}] configuration as [{}].", paramKey, paramValue);
             if (paramKey.contains(":")) {
                 applyConfigWithNestedKeyValue(conn, vm, recordMap, paramKey, paramValue);
             } else {
@@ -96,7 +96,8 @@ public class ExtraConfigurationUtility {
                     LOGGER.warn(msg);
             }
         } catch (XmlRpcException | Types.XenAPIException e) {
-            LOGGER.error(String.format("Exception caught while setting VM configuration: [%s]", e.getMessage() == null ? e.toString() : e.getMessage()), e);
+            LOGGER.error("Exception caught while setting VM configuration: [{}]", e.getMessage() == null ? e.toString() : e.getMessage());
+            LOGGER.debug("Exception caught while setting VM configuration", e);
             throw new CloudRuntimeException("Exception caught while setting VM configuration", e);
         }
     }

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
@@ -43,6 +43,7 @@ public class ExtraConfigurationUtility {
             String paramValue = configParams.get(paramKey);
 
             //Map params
+            LOGGER.debug(String.format("Applying [%s] configuration as [%s].", paramKey, paramValue));
             if (paramKey.contains(":")) {
                 applyConfigWithNestedKeyValue(conn, vm, recordMap, paramKey, paramValue);
             } else {
@@ -53,6 +54,11 @@ public class ExtraConfigurationUtility {
 
     private static boolean isValidOperation(Map<String, Object> recordMap, String actualParam) {
         return recordMap.containsKey(actualParam);
+    }
+
+    private static Map<String, String> putInMap(Map<String, String> map, String key, String value) {
+        map.put(key, value);
+        return map;
     }
 
     /**
@@ -71,26 +77,26 @@ public class ExtraConfigurationUtility {
         try {
             switch (actualParam) {
                 case "VCPUs_params":
-                    vm.addToVCPUsParams(conn, keyName, paramValue);
+                    vm.setVCPUsParams(conn, putInMap(vm.getVCPUsParams(conn), keyName, paramValue));
                     break;
                 case "platform":
-                    vm.addToOtherConfig(conn, keyName, paramValue);
+                    vm.setOtherConfig(conn, putInMap(vm.getOtherConfig(conn), keyName, paramValue));
                     break;
                 case "HVM_boot_params":
-                    vm.addToHVMBootParams(conn, keyName, paramValue);
+                    vm.setHVMBootParams(conn, putInMap(vm.getHVMBootParams(conn), keyName, paramValue));
                     break;
                 case "other_config":
-                    vm.addToOtherConfig(conn, keyName, paramValue);
+                    vm.setOtherConfig(conn, putInMap(vm.getOtherConfig(conn), keyName, paramValue));
                     break;
                 case "xenstore_data":
-                    vm.addToXenstoreData(conn, keyName, paramValue);
+                    vm.setXenstoreData(conn, putInMap(vm.getXenstoreData(conn), keyName, paramValue));
                     break;
                 default:
                     String msg = String.format("Passed configuration %s is not supported", paramKey);
                     LOGGER.warn(msg);
             }
         } catch (XmlRpcException | Types.XenAPIException e) {
-            LOGGER.error("Exception caught while setting VM configuration. exception: " + e.getMessage());
+            LOGGER.error(String.format("Exception caught while setting VM configuration: [%s]", e.getMessage() == null ? e.toString() : e.getMessage()), e);
             throw new CloudRuntimeException("Exception caught while setting VM configuration", e);
         }
     }


### PR DESCRIPTION
### Description

This PR fixes a problem when trying to boot up a XenServer VM with a template through an ISO. 

Steps to reproduce:
- Enable `enable.additional.vm.configuration` and add `HVM-boot-params:order` to `allow.additional.vm.configuration.list.xen`.
- Create a XenServer VM with a template.
- Attach an ISO to it.
- Call `updateVirtualMachine` with parameter `extraconfig=HVM-boot-params:order%3Ddcn`
- Start up the VM.

It will not finish, with the following log message:
```
INFO  [c.c.h.x.r.XenServer650Resource] (DirectAgent-71:[ctx-6c7bfe3d]) (logid:faabbafa) Appending user extra configuration settings to VM
ERROR [o.a.c.h.x.ExtraConfigurationUtility] (DirectAgent-71:[ctx-6c7bfe3d]) (logid:faabbafa) Exception caught while setting VM configuration. exception: null
```

After fixing the exception message, we get:

```
ERROR [o.a.c.h.x.ExtraConfigurationUtility] (DirectAgent-25:ctx-0d31d123) (logid:aa40d07d) Exception caught while setting VM configuration: [You tried to add a key-value pair to a map, but that key is already there.]
```

This PR fixes the exception message and changes the Xen API method called from `addTo` to `set` with `get`, letting Java substitute any duplicates in the HashMap.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
I repeated the steps to reproduce the error and verified the VM with template started up sucessfully, booting the ISO.