### PR TITLE
cks: fix list apis response count

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -1486,13 +1486,13 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         if (clusterType != null) {
             sc.setParameters("cluster_type", clusterType);
         }
-        List<KubernetesClusterVO> kubernetesClusters = kubernetesClusterDao.search(sc, searchFilter);
-        for (KubernetesClusterVO cluster : kubernetesClusters) {
+        Pair<List<KubernetesClusterVO>, Integer> kubernetesClustersAndCount = kubernetesClusterDao.searchAndCount(sc, searchFilter);
+        for (KubernetesClusterVO cluster : kubernetesClustersAndCount.first()) {
             KubernetesClusterResponse clusterResponse = createKubernetesClusterResponse(cluster.getId());
             responsesList.add(clusterResponse);
         }
-        ListResponse<KubernetesClusterResponse> response = new ListResponse<KubernetesClusterResponse>();
-        response.setResponses(responsesList);
+        ListResponse<KubernetesClusterResponse> response = new ListResponse<>();
+        response.setResponses(responsesList, kubernetesClustersAndCount.second());
         return response;
     }
 

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/version/KubernetesVersionManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/version/KubernetesVersionManagerImpl.java
@@ -52,6 +52,7 @@ import com.cloud.storage.dao.VMTemplateZoneDao;
 import com.cloud.template.TemplateApiService;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.user.AccountManager;
+import com.cloud.utils.Pair;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.db.Filter;
@@ -111,13 +112,14 @@ public class KubernetesVersionManagerImpl extends ManagerBase implements Kuberne
         return response;
     }
 
-    private ListResponse<KubernetesSupportedVersionResponse> createKubernetesSupportedVersionListResponse(List<KubernetesSupportedVersionVO> versions) {
+    private ListResponse<KubernetesSupportedVersionResponse> createKubernetesSupportedVersionListResponse(
+            List<KubernetesSupportedVersionVO> versions, Integer count) {
         List<KubernetesSupportedVersionResponse> responseList = new ArrayList<>();
         for (KubernetesSupportedVersionVO version : versions) {
             responseList.add(createKubernetesSupportedVersionResponse(version));
         }
         ListResponse<KubernetesSupportedVersionResponse> response = new ListResponse<>();
-        response.setResponses(responseList);
+        response.setResponses(responseList, count);
         return response;
     }
 
@@ -272,10 +274,12 @@ public class KubernetesVersionManagerImpl extends ManagerBase implements Kuberne
         if(keyword != null){
             sc.setParameters("keyword", "%" + keyword + "%");
         }
-        List <KubernetesSupportedVersionVO> versions = kubernetesSupportedVersionDao.search(sc, searchFilter);
-        versions = filterKubernetesSupportedVersions(versions, minimumSemanticVersion);
+        Pair<List<KubernetesSupportedVersionVO>, Integer> versionsAndCount =
+                kubernetesSupportedVersionDao.searchAndCount(sc, searchFilter);
+        List<KubernetesSupportedVersionVO> versions =
+                filterKubernetesSupportedVersions(versionsAndCount.first(), minimumSemanticVersion);
 
-        return createKubernetesSupportedVersionListResponse(versions);
+        return createKubernetesSupportedVersionListResponse(versions, versionsAndCount.second());
     }
 
     @Override

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/version/KubernetesVersionServiceTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/version/KubernetesVersionServiceTest.java
@@ -35,6 +35,7 @@ import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,6 +67,7 @@ import com.cloud.user.AccountManager;
 import com.cloud.user.AccountVO;
 import com.cloud.user.User;
 import com.cloud.user.UserVO;
+import com.cloud.utils.Pair;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.SearchBuilder;
@@ -142,14 +144,13 @@ public class KubernetesVersionServiceTest {
         when(versionVO.getSemanticVersion()).thenReturn(KubernetesVersionService.MIN_KUBERNETES_VERSION);
         versionVOs.add(versionVO);
         when(kubernetesSupportedVersionDao.findById(Mockito.anyLong())).thenReturn(versionVO);
-        when(kubernetesSupportedVersionDao.search(Mockito.any(SearchCriteria.class), Mockito.any(Filter.class))).thenReturn(versionVOs);
-        ListResponse<KubernetesSupportedVersionResponse> response =
-                kubernetesVersionService.listKubernetesSupportedVersions(
-                cmd);
-        Assert.assertNotNull(response);
-        Assert.assertEquals(Integer.valueOf(1), response.getCount());
-        Assert.assertEquals(1, response.getResponses().size());
-        Assert.assertEquals(KubernetesVersionService.MIN_KUBERNETES_VERSION, response.getResponses().get(0).getSemanticVersion());
+        when(kubernetesSupportedVersionDao.searchAndCount(Mockito.any(SearchCriteria.class),
+                Mockito.any(Filter.class))).thenReturn(new Pair<>(versionVOs, versionVOs.size()));
+        ListResponse<KubernetesSupportedVersionResponse> versionsResponse =
+                kubernetesVersionService.listKubernetesSupportedVersions(cmd);
+        Assert.assertEquals(versionVOs.size(), versionsResponse.getCount().intValue());
+        Assert.assertTrue(CollectionUtils.isNotEmpty(versionsResponse.getResponses()));
+        Assert.assertEquals(versionVOs.size(), versionsResponse.getResponses().size());
     }
 
     @Test(expected = InvalidParameterValueException.class)


### PR DESCRIPTION
### Description

Fixes count value in listKubernetesClusters and listSupportedKubernetesVersions APIs response.
Currently, it returns items count of the response

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
