### PR TITLE
Fix  deleting backups through the UI using `forced`

### DIFF
--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -509,7 +509,15 @@ export default {
           label: 'label.delete.backup',
           message: 'message.delete.backup',
           dataView: true,
-          show: (record) => { return record.state !== 'Destroyed' }
+          show: (record) => { return record.state !== 'Destroyed' },
+          args: ['forced'],
+          mapping: {
+            forced: {
+              value: false,
+              toggle: true
+            }
+          }
+
         }
       ]
     },


### PR DESCRIPTION
### Description

In the PR #6580, a new parameter called `forced` was added to the API `deleteBackup`; however, these changes were not implemented in the UI; therefore, this PR aims to do so by creating a switch to allow the user to send a request to this API with the `forced` parameter set to true through the UI.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

Before:
![image](https://github.com/apache/cloudstack/assets/124818914/92cd99fd-ca23-4117-9263-94ccc988e109)

After:
![image](https://github.com/apache/cloudstack/assets/124818914/123d6990-f5c2-44b9-9b8a-7645a821cc6f)



### How Has This Been Tested?
First, I implemented the modifications and set ACS up in a local environment. Subsequently, I used the browser's dev tool to check if the request being sent had the forced parameter set to true when the switch was toggled, which it did. At last, I created a couple of backups and removed them successfully with the new switch toggled on.