### PR TITLE
Hide volumes tab in instance page when user does not have permission to list volumes

### DIFF
--- a/ui/src/views/compute/InstanceTab.vue
+++ b/ui/src/views/compute/InstanceTab.vue
@@ -33,7 +33,7 @@
         <router-link :to="{ path: '/iso/' + vm.isoid }">{{ vm.isoname }}</router-link> <br/>
         <barcode-outlined /> {{ vm.isoid }}
       </a-tab-pane>
-      <a-tab-pane :tab="$t('label.volumes')" key="volumes">
+      <a-tab-pane :tab="$t('label.volumes')" key="volumes" v-if="'listVolumes' in $store.getters.apis">
         <a-button
           type="primary"
           style="width: 100%; margin-bottom: 10px"


### PR DESCRIPTION
### Description

In any instance's page, the volumes tab always gets shown, even if the account does not have permission to list the instance's volumes.

This PR adds a check in the UI in order to hide the volumes tab if the current account does not have permission to use the `listVolumes` API.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):

Before, a user without permission could access the volumes tab, but the volumes would not get listed. With these changes, the volumes tab does not get shown.

![Screenshot from 2024-02-27 16-07-56](https://github.com/apache/cloudstack/assets/25729641/b4c5d45f-5ff1-42ab-9dcd-d61bc38250af)

### How Has This Been Tested?

1. I created a role that had access to `listVolumes`;
2. I created an account using the role;
3. I created a VM using the account;
4. In the created account, I accessed the VM's page and verified that the volumes tab was shown;
5. I removed the access to `listVolumes` from the role created in step 1;
6. In the created account, I accessed the VM's page again and verified that the volumes tab was not shown.