### PR TITLE
Fix `deleteAccount` API to prevent deletion of the caller

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/account/DeleteAccountCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/account/DeleteAccountCmd.java
@@ -89,12 +89,11 @@ public class DeleteAccountCmd extends BaseAsyncCmd {
         CallContext.current().setEventDetails("Account ID: " + (account != null ? account.getUuid() : getId())); // Account not found is already handled by service
 
         boolean result = _regionService.deleteUserAccount(this);
-        if (result) {
-            SuccessResponse response = new SuccessResponse(getCommandName());
-            setResponseObject(response);
-        } else {
+        if (!result) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to delete user account and all corresponding users");
         }
+        SuccessResponse response = new SuccessResponse(getCommandName());
+        setResponseObject(response);
     }
 
     @Override

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1838,7 +1838,6 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             throw new InvalidParameterValueException("The account id=" + accountId + " manages project(s) with ids " + projectIds + "and can't be removed");
         }
 
-
         CallContext.current().putContextParameter(Account.class, account.getUuid());
 
         return deleteAccount(account, callerUserId, caller);

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1815,7 +1815,15 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         // If the user is a System user, return an error. We do not allow this
         AccountVO account = _accountDao.findById(accountId);
 
-        if (! isDeleteNeeded(account, accountId, caller)) {
+        if (caller.getId() == accountId) {
+            Domain domain = _domainDao.findById(account.getDomainId());
+            throw new InvalidParameterValueException(String.format("The caller is requesting to delete their own account. As a security measure, ACS will not allow this " +
+                            "operation." +
+                            "To delete account %s (ID: %s, Domain: %s), request to another user with permission to execute the operation.",
+                    account.getAccountName(), account.getUuid(), domain.getUuid()));
+        }
+
+        if (!isDeleteNeeded(account, accountId, caller)) {
             return true;
         }
 
@@ -1829,6 +1837,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
             throw new InvalidParameterValueException("The account id=" + accountId + " manages project(s) with ids " + projectIds + "and can't be removed");
         }
+
 
         CallContext.current().putContextParameter(Account.class, account.getUuid());
 

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1817,9 +1817,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
         if (caller.getId() == accountId) {
             Domain domain = _domainDao.findById(account.getDomainId());
-            throw new InvalidParameterValueException(String.format("The caller is requesting to delete their own account. As a security measure, ACS will not allow this " +
-                            "operation." +
-                            "To delete account %s (ID: %s, Domain: %s), request to another user with permission to execute the operation.",
+            throw new InvalidParameterValueException(String.format("Deletion of your own account is not allowed. To delete account %s (ID: %s, Domain: %s), " +
+                            "request to another user with permissions to perform the operation.",
                     account.getAccountName(), account.getUuid(), domain.getUuid()));
         }
 
@@ -1843,7 +1842,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return deleteAccount(account, callerUserId, caller);
     }
 
-    private boolean isDeleteNeeded(AccountVO account, long accountId, Account caller) {
+    protected boolean isDeleteNeeded(AccountVO account, long accountId, Account caller) {
         if (account == null) {
             logger.info(String.format("The account, identified by id %d, doesn't exist", accountId ));
             return false;

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -217,7 +217,7 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
     public void deleteUserAccountTestIfAccountIdIsNotEqualToCallerAccountIdShouldNotThrowException() {
         try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)) {
             CallContext callContextMock = Mockito.mock(CallContext.class);
-            callContextMocked.when((CallContext::current)).thenReturn(callContextMock);
+            callContextMocked.when(CallContext::current).thenReturn(callContextMock);
             long accountId = 1L;
 
             Mockito.doReturn(accountVoMock).when(callContextMock).getCallingAccount();

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -213,6 +213,7 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
             accountManagerImpl.deleteUserAccount(accountId);
         }
     }
+
     @Test
     public void deleteUserAccountTestIfAccountIdIsNotEqualToCallerAccountIdShouldNotThrowException() {
         try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)) {

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -215,7 +215,7 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
     }
     @Test
     public void deleteUserAccountTestIfAccountIdIsNotEqualToCallerAccountIdShouldNotThrowException() {
-        try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)){
+        try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)) {
             CallContext callContextMock = Mockito.mock(CallContext.class);
             callContextMocked.when((CallContext::current)).thenReturn(callContextMock);
             long accountId = 1L;

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -199,6 +199,38 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
     }
 
     @Test (expected = InvalidParameterValueException.class)
+    public void deleteUserAccountTestIfAccountIdIsEqualToCallerIdShouldThrowException() {
+        try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)) {
+            CallContext callContextMock = Mockito.mock(CallContext.class);
+            callContextMocked.when(CallContext::current).thenReturn(callContextMock);
+            long accountId = 1L;
+
+            Mockito.doReturn(accountVoMock).when(callContextMock).getCallingAccount();
+            Mockito.doReturn(accountVoMock).when(_accountDao).findById(Mockito.anyLong());
+            Mockito.doReturn(domainVoMock).when(_domainDao).findById(Mockito.anyLong());
+            Mockito.doReturn(1L).when(accountVoMock).getId();
+
+            accountManagerImpl.deleteUserAccount(accountId);
+        }
+    }
+    @Test
+    public void deleteUserAccountTestIfAccountIdIsNotEqualToCallerAccountIdShouldNotThrowException() {
+        try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)){
+            CallContext callContextMock = Mockito.mock(CallContext.class);
+            callContextMocked.when((CallContext::current)).thenReturn(callContextMock);
+            long accountId = 1L;
+
+            Mockito.doReturn(accountVoMock).when(callContextMock).getCallingAccount();
+            Mockito.doReturn(accountVoMock).when(_accountDao).findById(Mockito.anyLong());
+            Mockito.doReturn(2L).when(accountVoMock).getId();
+            Mockito.doReturn(true).when(accountManagerImpl).isDeleteNeeded(Mockito.any(), Mockito.anyLong(), Mockito.any());
+            Mockito.doReturn(new ArrayList<Long>()).when(_projectAccountDao).listAdministratedProjectIds(Mockito.anyLong());
+
+            accountManagerImpl.deleteUserAccount(accountId);
+        }
+    }
+
+    @Test (expected = InvalidParameterValueException.class)
     public void deleteUserTestIfUserIdIsEqualToCallerIdShouldThrowException() {
         try (MockedStatic<CallContext> callContextMocked = Mockito.mockStatic(CallContext.class)) {
             DeleteUserCmd cmd = Mockito.mock(DeleteUserCmd.class);


### PR DESCRIPTION
### Description

ACS allows users to delete their own account by calling the `deleteAccount` API via CLI. Fixing this behavior has been previously suggested in this [comment](https://github.com/apache/cloudstack/pull/7242#issuecomment-1433260909). Furthermore, there's already a feature to prevent a user from deleting their own account via UI; however, slower environments create a small window where it's possible for the user to click the button before it's disabled, allowing deletion even through the UI (see this [comment](https://github.com/apache/cloudstack/pull/7242#issuecomment-1444300925)).

This pull request addresses this issue by adding a validation that checks the `UUID` of the caller's account and compares it with the `UUID` of the account they are trying to delete. If they are the same, an exception is thrown.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):

![delete-account](https://github.com/apache/cloudstack/assets/56271185/09a6bfdf-65ca-42dd-a249-0539492d505e)

### How Has This Been Tested?

I tested by creating a new account (Temp) and attempted to delete it using a user in this same account via CloudMonkey.
As expected, an exception was thrown.

Next, I attempted to delete the account via the UI by rapidly clicking the delete icon. Once again, an exception was thrown without deleting the account.

```
"errortext": "The caller is requesting to delete their own account. As a security measure, ACS will not allow this operation.To delete account Temp (ID: 510c8c3a-f2ab-4e42-8e52-55ac968b7291, Domain: ab95574f-7857-4a44-9510-2c72ccc770fe), request to another user with permission to execute the operation."
```