### PR TITLE
Fix the removal of network offering tags

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -7186,7 +7186,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     }
                 }
 
-                if (tags.isEmpty()) {
+                if (StringUtils.isBlank(tags)) {
                     offering.setTags(null);
                 } else {
                     offering.setTags(tags);

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -7186,7 +7186,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     }
                 }
 
-                offering.setTags(tags);
+                if (tags.isEmpty()) {
+                    offering.setTags(null);
+                } else {
+                    offering.setTags(tags);
+                }
             }
 
             // Verify availability


### PR DESCRIPTION
### Description

When removing tags from a network offering, whether through the UI or API, they are currently defined as an empty string (`""`) instead of being definitively deleted.

This PR addresses this issue by enabling the complete removal of network offering tags.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):

### How Has This Been Tested?

Through CloudMonkey:

I removed a network offering's tag using the `updateNetworkOffering` API. Then, I verified that the `tags` field, which previously held an empty string (`""`), had completely disappeared.
```bash
> updateNetworkOffering id=bdf5fb44-916d-4ba8-971f-f52d76ab3bc5 tags=
{
  "networkoffering": {
    "availability": "Optional",
    "conservemode": true,
    "created": "2024-02-19T16:58:53+0000",
    "details": {
      "internetProtocol": "IPv4"
    },
    "displaytext": "description",
    "egressdefaultpolicy": true,
    "fortungsten": false,
    "forvpc": false,
    "guestiptype": "Isolated",
    "hasannotations": false,
    "id": "bdf5fb44-916d-4ba8-971f-f52d76ab3bc5",
    "internetprotocol": "IPv4",
    "isdefault": false,
    "ispersistent": false,
    "name": "NetworkOffering",
    "networkrate": 200,
    "service": [],
    "serviceofferingid": "6d259955-2afa-428c-898f-f2bfa425f3dc",
    "specifyipranges": false,
    "specifyvlan": true,
    "state": "Disabled",
    "supportspublicaccess": false,
    "supportsstrechedl2subnet": false,
    "traffictype": "Guest"
  }
}
```

Through UI:

I updated a network offering, removing its tag. Afterwards, I verified that the `Tags` field, which previously held a blank value, had completely disappeared.