### PR TITLE
Add autofocus to input in the 2FA screen

### DIFF
--- a/ui/src/views/dashboard/VerifyTwoFa.vue
+++ b/ui/src/views/dashboard/VerifyTwoFa.vue
@@ -71,6 +71,11 @@ export default {
   created () {
     this.initForm()
   },
+  mounted () {
+    this.$nextTick(() => {
+      this.focusInput()
+    })
+  },
   methods: {
     initForm () {
       this.formRef = ref()
@@ -78,6 +83,12 @@ export default {
       this.rules = reactive({
         code: [{ required: true, message: this.$t('message.error.authentication.code') }]
       })
+    },
+    focusInput () {
+      const inputElement = this.$refs.code.$el.querySelector('input[type=password]')
+      if (inputElement) {
+        inputElement.focus()
+      }
     },
     handleSubmit () {
       this.formRef.value.validate().then(() => {


### PR DESCRIPTION
### Description

Every time a user is redirected to the 2FA screen, the input lacks `autofocus` and the user has to click in the input before being able to type the authentication PIN.

This pull request addresses this issue by adding the `autofocus` whenever the user is redirected to the 2FA page.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

By using a user with 2FA enabled, I made the following tests:

By opening the UI for the first time, I logged in. Then, I logged off and logged in again. After being redirected to the 2FA screen, I returned to the login screen and logged in again.

After each login, I was redirected to the 2FA screen and the `autofocus` worked as expected.