### PR TITLE
Fix permission to manipulate VMs and templates settings through UI

### DIFF
--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -194,7 +194,6 @@ export default {
         return
       }
       this.resourceType = this.$route.meta.resourceType
-      console.log(this.resourceType)
       if (resource.details) {
         this.details = Object.keys(resource.details).map(k => {
           return { name: k, value: resource.details[k], edit: false }

--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// :disabled="!('updateTemplate' in $store.getters.apis && 'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner())"
-// :disabled="!(isAdminOrOwner() && ((resourceType === 'Template' && 'updateTemplate' in $store.getters.apis) || (resourceType === 'UserVm' && 'updateVirtualMachine' in $store.getters.apis)))"
-
 <template>
   <a-spin :spinning="loading">
     <a-alert

--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -26,7 +26,7 @@
         <a-button
           type="dashed"
           style="width: 100%"
-          :disabled="!(isAdminOrOwner() && hasAPIPermission())"
+          :disabled="!(isAdminOrOwner() && hasSettingUpdatePermission())"
           @click="onShowAddDetail">
           <template #icon><plus-outlined /></template>
           {{ $t('label.add.setting') }}
@@ -96,7 +96,7 @@
         </a-list-item-meta>
         <template #actions>
           <div
-            v-if="!disableSettings && isAdminOrOwner() && allowEditOfDetail(item.name) && hasAPIPermission()">
+            v-if="!disableSettings && isAdminOrOwner() && allowEditOfDetail(item.name) && hasSettingUpdatePermission()">
             <tooltip-button
               :tooltip="$t('label.edit')"
               icon="edit-outlined"
@@ -105,7 +105,7 @@
               @onClick="showEditDetail(index)" />
           </div>
           <div
-            v-if="!disableSettings && isAdminOrOwner() && allowEditOfDetail(item.name) && hasAPIPermission()">
+            v-if="!disableSettings && isAdminOrOwner() && allowEditOfDetail(item.name) && hasSettingUpdatePermission()">
             <a-popconfirm
               :title="`${$t('label.delete.setting')}?`"
               @confirm="deleteDetail(index)"
@@ -332,7 +332,7 @@ export default {
       this.error = false
       this.showAddDetail = false
     },
-    hasAPIPermission () {
+    hasSettingUpdatePermission () {
       return (
         (this.resourceType === 'Template' && 'updateTemplate' in this.$store.getters.apis) ||
         (this.resourceType === 'UserVm' && 'updateVirtualMachine' in this.$store.getters.apis)

--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// :disabled="!('updateTemplate' in $store.getters.apis && 'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner())"
+// :disabled="!(isAdminOrOwner() && ((resourceType === 'Template' && 'updateTemplate' in $store.getters.apis) || (resourceType === 'UserVm' && 'updateVirtualMachine' in $store.getters.apis)))"
+
 <template>
   <a-spin :spinning="loading">
     <a-alert
@@ -26,7 +29,7 @@
         <a-button
           type="dashed"
           style="width: 100%"
-          :disabled="!('updateTemplate' in $store.getters.apis && 'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner())"
+          :disabled="!(isAdminOrOwner() && hasAPIPermission())"
           @click="onShowAddDetail">
           <template #icon><plus-outlined /></template>
           {{ $t('label.add.setting') }}
@@ -96,8 +99,7 @@
         </a-list-item-meta>
         <template #actions>
           <div
-            v-if="!disableSettings && 'updateTemplate' in $store.getters.apis &&
-              'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner() && allowEditOfDetail(item.name)">
+            v-if="!disableSettings && isAdminOrOwner() && allowEditOfDetail(item.name) && hasAPIPermission()">
             <tooltip-button
               :tooltip="$t('label.edit')"
               icon="edit-outlined"
@@ -106,8 +108,7 @@
               @onClick="showEditDetail(index)" />
           </div>
           <div
-            v-if="!disableSettings && 'updateTemplate' in $store.getters.apis &&
-              'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner() && allowEditOfDetail(item.name)">
+            v-if="!disableSettings && isAdminOrOwner() && allowEditOfDetail(item.name) && hasAPIPermission()">
             <a-popconfirm
               :title="`${$t('label.delete.setting')}?`"
               @confirm="deleteDetail(index)"
@@ -196,6 +197,7 @@ export default {
         return
       }
       this.resourceType = this.$route.meta.resourceType
+      console.log(this.resourceType)
       if (resource.details) {
         this.details = Object.keys(resource.details).map(k => {
           return { name: k, value: resource.details[k], edit: false }
@@ -333,6 +335,12 @@ export default {
       this.newValue = ''
       this.error = false
       this.showAddDetail = false
+    },
+    hasAPIPermission () {
+      return (
+        (this.resourceType === 'Template' && 'updateTemplate' in this.$store.getters.apis) ||
+        (this.resourceType === 'UserVm' && 'updateVirtualMachine' in this.$store.getters.apis)
+      )
     }
   }
 }


### PR DESCRIPTION
### Description

VMs and templates settings can only be manipulated through UI if the user's account role has permission to `updateVirtualMachine` and `updateTemplate` APIs. If the role does not have permission to both APIs simultaneously the interface blocks the manipulation of VMs and templates settings.

This PR addresses this issue by making those APIs permissions independent from each other.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I've manipulated `updateVirtualMachine` and `updateTemplate` APIs permissions and I've gathered the following results:

| Test number | `updateVirtualMachine` | `updateTemplate` | Can manipulate VM settings? (Y/N) | Can manipulate template settings? (Y/N) | Expected results? (Y/N) | 
| :---: | :---: | :---: | :---: | :---: | :---: |
| 1 | `Allow` | `Allow` | Y | Y | Y |
| 2 | `Allow` | `Deny`  | Y | N | Y |
| 3 | `Deny`  | `Allow` | N | Y | Y |
| 4 | `Deny`  | `Deny`  | N | N | Y |

