### PR TITLE
UI: Fix Userdata registration from UI

### DIFF
--- a/ui/src/utils/plugins.js
+++ b/ui/src/utils/plugins.js
@@ -482,6 +482,15 @@ export const fileSizeUtilPlugin = {
   }
 }
 
+function isBase64 (str) {
+  try {
+    const decoded = new TextDecoder().decode(Uint8Array.from(atob(str), c => c.charCodeAt(0)))
+    return btoa(decoded) === str
+  } catch (err) {
+    return false
+  }
+}
+
 export const genericUtilPlugin = {
   install (app) {
     app.config.globalProperties.$isValidUuid = function (uuid) {
@@ -490,8 +499,7 @@ export const genericUtilPlugin = {
     }
 
     app.config.globalProperties.$toBase64AndURIEncoded = function (text) {
-      const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/
-      if (base64regex.test(text)) {
+      if (isBase64(text)) {
         return text
       }
       return encodeURIComponent(btoa(unescape(encodeURIComponent(text))))


### PR DESCRIPTION
### Description

This PR fixes: https://github.com/apache/cloudstack/issues/8736
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

1. When "haha" is passed as userdata:

Userdata is base64 encoded:
![image](https://github.com/apache/cloudstack/assets/10495417/cd161124-537f-49c8-bb77-352690c3354d)

Response:
![image](https://github.com/apache/cloudstack/assets/10495417/f037d684-2ec4-4fcc-89f1-7fdcedeff69e)


2. When "haha" is base64 encoded and provided as userdata input:

![image](https://github.com/apache/cloudstack/assets/10495417/0b43a725-d604-4430-bcc6-8ee9cbf1e237)

Response:
![image](https://github.com/apache/cloudstack/assets/10495417/672fe884-e805-4926-9f0f-b0e454310be8)


#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
