### PR TITLE
UI: Fix missing locale strings for Status widget

### DIFF
--- a/ui/src/components/widgets/Status.vue
+++ b/ui/src/components/widgets/Status.vue
@@ -166,23 +166,24 @@ export default {
       if (!(state && this.displayText)) {
         return ''
       }
+      let result
       if (this.$route.path === '/vmsnapshot' || this.$route.path.includes('/vmsnapshot/')) {
-        return this.$t('message.vmsnapshot.state.' + state.toLowerCase())
+        result = this.$t('message.vmsnapshot.state.' + state.toLowerCase())
+      } else if (this.$route.path === '/vm' || this.$route.path.includes('/vm/')) {
+        result = this.$t('message.vm.state.' + state.toLowerCase())
+      } else if (this.$route.path === '/volume' || this.$route.path.includes('/volume/')) {
+        result = this.$t('message.volume.state.' + state.toLowerCase())
+      } else if (this.$route.path === '/guestnetwork' || this.$route.path.includes('/guestnetwork/')) {
+        result = this.$t('message.guestnetwork.state.' + state.toLowerCase())
+      } else if (this.$route.path === '/publicip' || this.$route.path.includes('/publicip/')) {
+        result = this.$t('message.publicip.state.' + state.toLowerCase())
       }
-      if (this.$route.path === '/vm' || this.$route.path.includes('/vm/')) {
-        return this.$t('message.vm.state.' + state.toLowerCase())
+
+      if (!result || (result.startsWith('message.') && result.endsWith('.state.' + state.toLowerCase()))) {
+        // Nothing for snapshots, vpcs, gateways, vnpnconn, vpnuser, kubectl, event, project, account, infra. They're all self explanatory
+        result = this.$t(state)
       }
-      if (this.$route.path === '/volume' || this.$route.path.includes('/volume/')) {
-        return this.$t('message.volume.state.' + state.toLowerCase())
-      }
-      if (this.$route.path === '/guestnetwork' || this.$route.path.includes('/guestnetwork/')) {
-        return this.$t('message.guestnetwork.state.' + state.toLowerCase())
-      }
-      if (this.$route.path === '/publicip' || this.$route.path.includes('/publicip/')) {
-        return this.$t('message.publicip.state.' + state.toLowerCase())
-      }
-      // Nothing for snapshots, vpcs, gateways, vnpnconn, vpnuser, kubectl, event, project, account, infra. They're all self explanatory
-      return this.$t(state)
+      return result
     },
     getStyle () {
       let styles = { display: 'inline-flex' }


### PR DESCRIPTION
### Description

This PR fixes #8783. Status widget changes the tooltip message based on the url. To fix this, before returning the tooltip message, we check if there is no string available in locale and set the message to state.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
