### PR TITLE
Refactor KubernetesClusterResourceModifierActionWorker

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/firewall/CreateFirewallRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/firewall/CreateFirewallRuleCmd.java
@@ -94,9 +94,33 @@ public class CreateFirewallRuleCmd extends BaseAsyncCreateCmd implements Firewal
         return ipAddressId;
     }
 
+    public void setIpAddressId(Long ipAddressId) {
+        this.ipAddressId = ipAddressId;
+    }
+
     @Override
     public String getProtocol() {
         return protocol.trim();
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public Integer getPublicStartPort() {
+        return publicStartPort;
+    }
+
+    public void setPublicStartPort(Integer publicStartPort) {
+        this.publicStartPort = publicStartPort;
+    }
+
+    public Integer getPublicEndPort() {
+        return publicEndPort;
+    }
+
+    public void setPublicEndPort(Integer publicEndPort) {
+        this.publicEndPort = publicEndPort;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkACLCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkACLCmd.java
@@ -113,6 +113,10 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
         return p;
     }
 
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
     public List<String> getSourceCidrList() {
         if (cidrlist != null) {
             return cidrlist;
@@ -136,6 +140,9 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
         throw new InvalidParameterValueException("Invalid traffic type " + trafficType);
     }
 
+    public void setTrafficType(String trafficType) {
+        this.trafficType = trafficType;
+    }
     // ///////////////////////////////////////////////////
     // ///////////// API Implementation///////////////////
     // ///////////////////////////////////////////////////
@@ -144,15 +151,23 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
         return action;
     }
 
+    public void setAction(String action) {
+        this.action = action;
+    }
+
     public Integer getNumber() {
         return number;
     }
 
-    public Integer getSourcePortStart() {
+    public Integer getPublicStartPort() {
         return publicStartPort;
     }
 
-    public Integer getSourcePortEnd() {
+    public void setPublicStartPort(Integer publicStartPort) {
+        this.publicStartPort = publicStartPort;
+    }
+
+    public Integer getPublicEndPort() {
         if (publicEndPort == null) {
             if (publicStartPort != null) {
                 return publicStartPort;
@@ -164,8 +179,16 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
         return null;
     }
 
+    public void setPublicEndPort(Integer publicEndPort) {
+        this.publicEndPort = publicEndPort;
+    }
+
     public Long getNetworkId() {
         return networkId;
+    }
+
+    public void setNetworkId(Long networkId) {
+        this.networkId = networkId;
     }
 
     @Override
@@ -205,6 +228,10 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
 
     public Long getACLId() {
         return aclId;
+    }
+
+    public void setAclId(Long aclId) {
+        this.aclId = aclId;
     }
 
     public String getReason() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/StartVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/StartVMCmd.java
@@ -102,6 +102,10 @@ public class StartVMCmd extends BaseAsyncCmd implements UserCmd {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public Long getHostId() {
         return hostId;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
@@ -101,6 +101,10 @@ public class ResizeVolumeCmd extends BaseAsyncCmd implements UserCmd {
         return getEntityId();
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public Long getMinIops() {
         return minIops;
     }
@@ -111,6 +115,10 @@ public class ResizeVolumeCmd extends BaseAsyncCmd implements UserCmd {
 
     public Long getSize() {
         return size;
+    }
+
+    public void setSize(Long size) {
+        this.size = size;
     }
 
     public boolean isShrinkOk() {

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -836,7 +836,6 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
     }
 
 
-
     private KubernetesClusterVO updateKubernetesClusterEntry(final Boolean autoscaleEnabled, final Long minSize, final Long maxSize) throws CloudRuntimeException {
         KubernetesClusterVO kubernetesClusterVO = updateKubernetesClusterEntry(null, null, null, null, autoscaleEnabled, minSize, maxSize);
         if (kubernetesClusterVO == null) {

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -58,6 +58,7 @@ import com.cloud.exception.ManagementServerException;
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.exception.PermissionDeniedException;
+import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
@@ -103,7 +104,6 @@ import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionCallbackWithException;
-import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.Ip;
 import com.cloud.utils.net.NetUtils;
@@ -113,7 +113,28 @@ import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.command.user.firewall.CreateFirewallRuleCmd;
+import org.apache.cloudstack.api.command.user.network.CreateNetworkACLCmd;
+import org.apache.cloudstack.api.command.user.vm.StartVMCmd;
+import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 public class KubernetesClusterResourceModifierActionWorker extends KubernetesClusterActionWorker {
 

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -567,7 +567,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
         for (PortForwardingRuleVO pfRule : pfRules) {
             if (startPort <= pfRule.getSourcePortStart() && pfRule.getSourcePortStart() <= endPort) {
                 portForwardingRulesDao.remove(pfRule.getId());
-                logger.debug(String.format("The Port forwarding rule [%s] with the id [%s] was removed.", pfRule.getName(), pfRule.getId()));
+                logger.debug("The Port forwarding rule [{}] with the id [{}] was removed.", pfRule.getName(), pfRule.getId());
             }
         }
         rulesService.applyPortForwardingRules(publicIp.getId(), account);
@@ -579,7 +579,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
         loadBalancerRules.stream().filter(lbRules -> lbRules.getNetworkId() == network.getId() && lbRules.getAccountId() == account.getId() && lbRules.getSourcePortStart() == CLUSTER_API_PORT
         && lbRules.getSourcePortEnd() == CLUSTER_API_PORT).forEach(lbRule -> {
             lbService.deleteLoadBalancerRule(lbRule.getId(), true);
-            logger.debug(String.format("The load balancing rule with the Id: %s was removed",lbRule.getId()));
+            logger.debug("The load balancing rule with the Id: {} was removed",lbRule.getId());
         });
     }
 

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -835,7 +835,6 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
         });
     }
 
-
     private KubernetesClusterVO updateKubernetesClusterEntry(final Boolean autoscaleEnabled, final Long minSize, final Long maxSize) throws CloudRuntimeException {
         KubernetesClusterVO kubernetesClusterVO = updateKubernetesClusterEntry(null, null, null, null, autoscaleEnabled, minSize, maxSize);
         if (kubernetesClusterVO == null) {

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -796,31 +796,31 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
 
     protected KubernetesClusterVO updateKubernetesClusterEntry(final Long cores, final Long memory, final Long size,
                final Long serviceOfferingId, final Boolean autoscaleEnabled, final Long minSize, final Long maxSize) {
-        return Transaction.execute(new TransactionCallback<KubernetesClusterVO>() {
-                @Override
-                public KubernetesClusterVO doInTransaction(TransactionStatus status) {
-                KubernetesClusterVO updatedCluster = kubernetesClusterDao.findById(kubernetesCluster.getId());
-                if (cores != null) {
-                    updatedCluster.setCores(cores);
-                }
-                if (memory != null) {
-                    updatedCluster.setMemory(memory);
-                }
-                if (size != null) {
-                    updatedCluster.setNodeCount(size);
-                }
-                if (serviceOfferingId != null) {
-                    updatedCluster.setServiceOfferingId(serviceOfferingId);
-                }
-                if (autoscaleEnabled != null) {
-                    updatedCluster.setAutoscalingEnabled(autoscaleEnabled.booleanValue());
-                }
-                updatedCluster.setMinSize(minSize);
-                updatedCluster.setMaxSize(maxSize);
-                return kubernetesClusterDao.persist(updatedCluster);
+        return Transaction.execute((TransactionCallback<KubernetesClusterVO>) status -> {
+            KubernetesClusterVO updatedCluster = kubernetesClusterDao.createForUpdate(kubernetesCluster.getId());
+
+            if (cores != null) {
+                updatedCluster.setCores(cores);
             }
+            if (memory != null) {
+                updatedCluster.setMemory(memory);
+            }
+            if (size != null) {
+                updatedCluster.setNodeCount(size);
+            }
+            if (serviceOfferingId != null) {
+                updatedCluster.setServiceOfferingId(serviceOfferingId);
+            }
+            if (autoscaleEnabled != null) {
+                updatedCluster.setAutoscalingEnabled(autoscaleEnabled.booleanValue());
+            }
+            updatedCluster.setMinSize(minSize);
+            updatedCluster.setMaxSize(maxSize);
+            return kubernetesClusterDao.persist(updatedCluster);
         });
     }
+
+
 
     private KubernetesClusterVO updateKubernetesClusterEntry(final Boolean autoscaleEnabled, final Long minSize, final Long maxSize) throws CloudRuntimeException {
         KubernetesClusterVO kubernetesClusterVO = updateKubernetesClusterEntry(null, null, null, null, autoscaleEnabled, minSize, maxSize);

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -551,7 +551,6 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
             }
         }
         rulesService.applyPortForwardingRules(publicIp.getId(), account);
-
     }
 
     protected void removeLoadBalancingRule(final IpAddress publicIp, final Network network,

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -17,32 +17,6 @@
 
 package com.cloud.kubernetes.cluster.actionworkers;
 
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
-
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-
-import com.cloud.exception.ResourceAllocationException;
-import org.apache.cloudstack.api.ApiCommandResourceType;
-import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseCmd;
-import org.apache.cloudstack.api.command.user.firewall.CreateFirewallRuleCmd;
-import org.apache.cloudstack.api.command.user.network.CreateNetworkACLCmd;
-import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-
 import com.cloud.capacity.CapacityManager;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterDetailsVO;
@@ -113,12 +87,13 @@ import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.command.user.firewall.CreateFirewallRuleCmd;
 import org.apache.cloudstack.api.command.user.network.CreateNetworkACLCmd;
-import org.apache.cloudstack.api.command.user.vm.StartVMCmd;
 import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
+import org.apache.cloudstack.context.CallContext;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -532,7 +532,6 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
                     if (pfRule.getVirtualMachineId() == vmId) {
                         portForwardingRulesDao.remove(pfRule.getId());
                         logger.debug(String.format("The Port forwarding rule [%s] with the id [%s] was removed.", pfRule.getName(), pfRule.getId()));
-
                         break;
                     }
                 }

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -431,30 +431,23 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
         List<String> sourceCidrList = new ArrayList<String>();
         sourceCidrList.add("0.0.0.0/0");
 
-        CreateFirewallRuleCmd rule = new CreateFirewallRuleCmd();
-        rule = ComponentContext.inject(rule);
+        CreateFirewallRuleCmd firewallRule = new CreateFirewallRuleCmd();
+        firewallRule = ComponentContext.inject(firewallRule);
 
-        Field addressField = rule.getClass().getDeclaredField("ipAddressId");
-        addressField.setAccessible(true);
-        addressField.set(rule, publicIp.getId());
+        firewallRule.setIpAddressId(publicIp.getId());
 
-        Field protocolField = rule.getClass().getDeclaredField("protocol");
-        protocolField.setAccessible(true);
-        protocolField.set(rule, "TCP");
+        firewallRule.setProtocol("TCP");
 
-        Field startPortField = rule.getClass().getDeclaredField("publicStartPort");
-        startPortField.setAccessible(true);
-        startPortField.set(rule, startPort);
+        firewallRule.setPublicStartPort(startPort);
 
-        Field endPortField = rule.getClass().getDeclaredField("publicEndPort");
-        endPortField.setAccessible(true);
-        endPortField.set(rule, endPort);
+        firewallRule.setPublicEndPort(endPort);
 
-        Field cidrField = rule.getClass().getDeclaredField("cidrlist");
+        firewallRule.setSourceCidrList(sourceCidrList);
+        Field cidrField = firewallRule.getClass().getDeclaredField("cidrlist");
         cidrField.setAccessible(true);
-        cidrField.set(rule, sourceCidrList);
+        cidrField.set(firewallRule, sourceCidrList);
 
-        firewallService.createIngressFirewallRule(rule);
+        firewallService.createIngressFirewallRule(firewallRule);
         firewallService.applyIngressFwRules(publicIp.getId(), account);
     }
 

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -597,13 +597,13 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
     protected void removeVpcTierAllowPortACLRule(final Network network, int startPort, int endPort) throws NoSuchFieldException,
             IllegalAccessException, ResourceUnavailableException {
         List<NetworkACLItemVO> aclItems = networkACLItemDao.listByACL(network.getNetworkACLId());
-        aclItems = aclItems.stream().filter(x -> (x.getProtocol() != null &&
-                        x.getProtocol().equals("TCP") &&
-                        x.getSourcePortStart() != null &&
-                        x.getSourcePortStart().equals(startPort) &&
-                        x.getSourcePortEnd() != null &&
-                        x.getSourcePortEnd().equals(endPort) &&
-                        x.getAction().equals(NetworkACLItem.Action.Allow)))
+        aclItems = aclItems.stream().filter(networkACLItem -> (networkACLItem.getProtocol() != null &&
+                        networkACLItem.getProtocol().equals("TCP") &&
+                        networkACLItem.getSourcePortStart() != null &&
+                        networkACLItem.getSourcePortStart().equals(startPort) &&
+                        networkACLItem.getSourcePortEnd() != null &&
+                        networkACLItem.getSourcePortEnd().equals(endPort) &&
+                        networkACLItem.getAction().equals(NetworkACLItem.Action.Allow)))
                 .collect(Collectors.toList());
 
         for (NetworkACLItemVO aclItem : aclItems) {

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -571,7 +571,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
     protected void provisionVpcTierAllowPortACLRule(final Network network, int startPort, int endPorts) throws NoSuchFieldException,
             IllegalAccessException, ResourceUnavailableException {
         List<NetworkACLItemVO> aclItems = networkACLItemDao.listByACL(network.getNetworkACLId());
-        aclItems = aclItems.stream().filter(x -> !NetworkACLItem.State.Revoke.equals(x.getState())).collect(Collectors.toList());
+        aclItems = aclItems.stream().filter(networkACLItem -> !NetworkACLItem.State.Revoke.equals(networkACLItem.getState())).collect(Collectors.toList());
         CreateNetworkACLCmd networkACLRule = new CreateNetworkACLCmd();
         networkACLRule = ComponentContext.inject(networkACLRule);
 

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -524,7 +524,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
                     firewallRule.getSourcePortEnd() == CLUSTER_API_PORT) {
                 rule = firewallRule;
                 firewallService.revokeIngressFwRule(firewallRule.getId(), true);
-                logger.debug(String.format("The API firewall rule [%s] with the id [%s] was revoked",firewallRule.getName(),firewallRule.getId()));
+                logger.debug("The API firewall rule [%s] with the id [%s] was revoked",firewallRule.getName(),firewallRule.getId());
                 break;
             }
         }
@@ -538,7 +538,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
             if (firewallRule.getSourcePortStart() == CLUSTER_NODES_DEFAULT_START_SSH_PORT) {
                 rule = firewallRule;
                 firewallService.revokeIngressFwRule(firewallRule.getId(), true);
-                logger.debug(String.format("The SSH firewall rule [%s] with the id [%s] was revoked",firewallRule.getName(),firewallRule.getId()));
+                logger.debug("The SSH firewall rule [%s] with the id [%s] was revoked",firewallRule.getName(),firewallRule.getId());
                 break;
             }
         }
@@ -552,7 +552,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
                 for (PortForwardingRuleVO pfRule : pfRules) {
                     if (pfRule.getVirtualMachineId() == vmId) {
                         portForwardingRulesDao.remove(pfRule.getId());
-                        logger.debug(String.format("The Port forwarding rule [%s] with the id [%s] was removed.", pfRule.getName(), pfRule.getId()));
+                        logger.debug("The Port forwarding rule [%s] with the id [%s] was removed.", pfRule.getName(), pfRule.getId());
                         break;
                     }
                 }

--- a/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -325,8 +325,8 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     public NetworkACLItem createNetworkACLItem(CreateNetworkACLCmd createNetworkACLCmd) {
         Long aclId = createAclListIfNeeded(createNetworkACLCmd);
 
-        Integer sourcePortStart = createNetworkACLCmd.getSourcePortStart();
-        Integer sourcePortEnd = createNetworkACLCmd.getSourcePortEnd();
+        Integer sourcePortStart = createNetworkACLCmd.getPublicStartPort();
+        Integer sourcePortEnd = createNetworkACLCmd.getPublicEndPort();
         String protocol = createNetworkACLCmd.getProtocol();
         List<String> sourceCidrList = createNetworkACLCmd.getSourceCidrList();
         Integer icmpCode = createNetworkACLCmd.getIcmpCode();


### PR DESCRIPTION
### Description

This PR aims to refactor the class `KubernetesClusterResourceModifierActionWorker`. The main goal is to improve the adherence to object-oriented programming principles, specifically encapsulation. In this class, there were a couple of methods that were using reflection, such as `Field.setAccessible()`, to modify object fields directly, which can be seen as a violation of encapsulation, one of the fundamental principles of object-oriented programming. This issue was fixed by creating setters in the respective classes belonging to the objects where this behavior occurred.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
I ran all the tests related to the class `KubernetesClusterResourceModifierActionWorker` and certified none of them were broken.