### PR TITLE
Refactor alert email generation method

### DIFF
--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -615,105 +615,81 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
 
         String msgSubject = null;
         String msgContent = null;
-        String totalStr;
-        String usedStr;
-        String pctStr = formatPercent(usedCapacity / totalCapacity);
+        String percentual = formatPercent(usedCapacity / totalCapacity);
+        String totalInMB = formatBytesToMegabytes(totalCapacity);
+        String usedInMB = formatBytesToMegabytes(usedCapacity);
+        String totalInString = String.valueOf(totalCapacity);
+        String usedInString = String.valueOf(usedCapacity);
         AlertType alertType = null;
         Long podId = pod == null ? null : pod.getId();
         Long clusterId = cluster == null ? null : cluster.getId();
+        String clusterName = cluster == null ? null : cluster.getName();
+        String podName = pod == null ? null : pod.getName();
+        String dataCenterName = dc.getName();
 
         switch (capacityType) {
-
-        //Cluster Level
-        case Capacity.CAPACITY_TYPE_MEMORY:
-            msgSubject = "System Alert: Low Available Memory in cluster " + cluster.getName() + " pod " + pod.getName() + " of availability zone " + dc.getName();
-            totalStr = formatBytesToMegabytes(totalCapacity);
-            usedStr = formatBytesToMegabytes(usedCapacity);
-            msgContent = "System memory is low, total: " + totalStr + " MB, used: " + usedStr + " MB (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_MEMORY;
-            break;
-        case Capacity.CAPACITY_TYPE_CPU:
-            msgSubject = "System Alert: Low Unallocated CPU in cluster " + cluster.getName() + " pod " + pod.getName() + " of availability zone " + dc.getName();
-            totalStr = DfWhole.format(totalCapacity);
-            usedStr = DfWhole.format(usedCapacity);
-            msgContent = "Unallocated CPU is low, total: " + totalStr + " Mhz, used: " + usedStr + " Mhz (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_CPU;
-            break;
-        case Capacity.CAPACITY_TYPE_STORAGE:
-            msgSubject = "System Alert: Low Available Storage in cluster " + cluster.getName() + " pod " + pod.getName() + " of availability zone " + dc.getName();
-            totalStr = formatBytesToMegabytes(totalCapacity);
-            usedStr = formatBytesToMegabytes(usedCapacity);
-            msgContent = "Available storage space is low, total: " + totalStr + " MB, used: " + usedStr + " MB (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_STORAGE;
-            break;
-        case Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED:
-            msgSubject = "System Alert: Remaining unallocated Storage is low in cluster " + cluster.getName() + " pod " + pod.getName() + " of availability zone " +
-                    dc.getName();
-            totalStr = formatBytesToMegabytes(totalCapacity);
-            usedStr = formatBytesToMegabytes(usedCapacity);
-            msgContent = "Unallocated storage space is low, total: " + totalStr + " MB, allocated: " + usedStr + " MB (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_STORAGE_ALLOCATED;
-            break;
-        case Capacity.CAPACITY_TYPE_LOCAL_STORAGE:
-            msgSubject = "System Alert: Remaining unallocated Local Storage is low in cluster " + cluster.getName() + " pod " + pod.getName() + " of availability zone " +
-                    dc.getName();
-            totalStr = formatBytesToMegabytes(totalCapacity);
-            usedStr = formatBytesToMegabytes(usedCapacity);
-            msgContent = "Unallocated storage space is low, total: " + totalStr + " MB, allocated: " + usedStr + " MB (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_LOCAL_STORAGE;
-            break;
-
-            //Pod Level
-        case Capacity.CAPACITY_TYPE_PRIVATE_IP:
-            msgSubject = "System Alert: Number of unallocated private IPs is low in pod " + pod.getName() + " of availability zone " + dc.getName();
-            totalStr = Double.toString(totalCapacity);
-            usedStr = Double.toString(usedCapacity);
-            msgContent = "Number of unallocated private IPs is low, total: " + totalStr + ", allocated: " + usedStr + " (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_PRIVATE_IP;
-            break;
-
-            //Zone Level
-        case Capacity.CAPACITY_TYPE_SECONDARY_STORAGE:
-            msgSubject = "System Alert: Low Available Secondary Storage in availability zone " + dc.getName();
-            totalStr = formatBytesToMegabytes(totalCapacity);
-            usedStr = formatBytesToMegabytes(usedCapacity);
-            msgContent = "Available secondary storage space is low, total: " + totalStr + " MB, used: " + usedStr + " MB (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_SECONDARY_STORAGE;
-            break;
-        case Capacity.CAPACITY_TYPE_VIRTUAL_NETWORK_PUBLIC_IP:
-            msgSubject = "System Alert: Number of unallocated virtual network public IPs is low in availability zone " + dc.getName();
-            totalStr = Double.toString(totalCapacity);
-            usedStr = Double.toString(usedCapacity);
-            msgContent = "Number of unallocated public IPs is low, total: " + totalStr + ", allocated: " + usedStr + " (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_VIRTUAL_NETWORK_PUBLIC_IP;
-            break;
-        case Capacity.CAPACITY_TYPE_DIRECT_ATTACHED_PUBLIC_IP:
-            msgSubject = "System Alert: Number of unallocated shared network IPs is low in availability zone " + dc.getName();
-            totalStr = Double.toString(totalCapacity);
-            usedStr = Double.toString(usedCapacity);
-            msgContent = "Number of unallocated shared network IPs is low, total: " + totalStr + ", allocated: " + usedStr + " (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_DIRECT_ATTACHED_PUBLIC_IP;
-            break;
-        case Capacity.CAPACITY_TYPE_VLAN:
-            msgSubject = "System Alert: Number of unallocated VLANs is low in availability zone " + dc.getName();
-            totalStr = Double.toString(totalCapacity);
-            usedStr = Double.toString(usedCapacity);
-            msgContent = "Number of unallocated VLANs is low, total: " + totalStr + ", allocated: " + usedStr + " (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_VLAN;
-            break;
-        case Capacity.CAPACITY_TYPE_VIRTUAL_NETWORK_IPV6_SUBNET:
-            msgSubject = "System Alert: Number of unallocated virtual network guest IPv6 subnets is low in availability zone " + dc.getName();
-            totalStr = Double.toString(totalCapacity);
-            usedStr = Double.toString(usedCapacity);
-            msgContent = "Number of unallocated virtual network guest IPv6 subnets is low, total: " + totalStr + ", allocated: " + usedStr + " (" + pctStr + "%)";
-            alertType = AlertManager.AlertType.ALERT_TYPE_VIRTUAL_NETWORK_IPV6_SUBNET;
-            break;
+            case Capacity.CAPACITY_TYPE_MEMORY:
+                msgSubject = String.format("System Alert: Low Available Memory in cluster [%s] pod [%s] of availability zone [%s].", clusterName, podName, dataCenterName);
+                msgContent = String.format("System memory is low, total: %s MB, used: %s MB (%s%%).", totalInMB, usedInMB, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_MEMORY;
+                break;
+            case Capacity.CAPACITY_TYPE_CPU:
+                msgSubject = String.format("System Alert: Low Unallocated CPU in cluster [%s] pod [%s] of availability zone [%s].", clusterName, podName, dataCenterName);
+                msgContent = String.format("Unallocated CPU is low, total: %s Mhz, used: %s Mhz (%s%%).", DfWhole.format(totalCapacity), DfWhole.format(usedCapacity), percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_CPU;
+                break;
+            case Capacity.CAPACITY_TYPE_STORAGE:
+                msgSubject = String.format("System Alert: Low Available Storage in cluster [%s] pod [%s] of availability zone [%s].", clusterName, podName, dataCenterName);
+                msgContent = String.format("Available storage space is low, total: %s MB, used: %s MB (%s%%).", totalInMB, usedInMB, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_STORAGE;
+                break;
+            case Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED:
+                msgSubject = String.format("System Alert: Remaining unallocated Storage is low in cluster [%s] pod [%s] of availability zone [%s].", clusterName, podName,
+                        dataCenterName);
+                msgContent = String.format("Unallocated storage space is low, total: %s MB, allocated: %s MB (%s%%)", totalInMB, usedInMB, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_STORAGE_ALLOCATED;
+                break;
+            case Capacity.CAPACITY_TYPE_LOCAL_STORAGE:
+                msgSubject = String.format("System Alert: Remaining unallocated Local Storage is low in cluster [%s] pod [%s] of availability zone [%s].", clusterName, podName,
+                        dataCenterName);
+                msgContent = String.format("Unallocated storage space is low, total: %s MB, allocated: %s MB (%s%%)", totalInMB, usedInMB, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_LOCAL_STORAGE;
+                break;
+            case Capacity.CAPACITY_TYPE_PRIVATE_IP:
+                msgSubject = String.format("System Alert: Number of unallocated private IPs is low in pod %s of availability zone [%s].", podName, dataCenterName);
+                msgContent = String.format("Number of unallocated private IPs is low, total: %s, allocated: %s (%s%%)", totalInString, usedInString, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_PRIVATE_IP;
+                break;
+            case Capacity.CAPACITY_TYPE_SECONDARY_STORAGE:
+                msgSubject = String.format("System Alert: Low Available Secondary Storage in availability zone [%s].", dataCenterName);
+                msgContent = String.format("Available secondary storage space is low, total: %s MB, used: %s MB (%s%%).", totalInMB, usedInMB, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_SECONDARY_STORAGE;
+                break;
+            case Capacity.CAPACITY_TYPE_VIRTUAL_NETWORK_PUBLIC_IP:
+                msgSubject = String.format("System Alert: Number of unallocated virtual network public IPs is low in availability zone [%s].", dataCenterName);
+                msgContent = String.format("Number of unallocated public IPs is low, total: %s, allocated: %s (%s%%).", totalInString, usedInString, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_VIRTUAL_NETWORK_PUBLIC_IP;
+                break;
+            case Capacity.CAPACITY_TYPE_DIRECT_ATTACHED_PUBLIC_IP:
+                msgSubject = String.format("System Alert: Number of unallocated shared network IPs is low in availability zone [%s].", dataCenterName);
+                msgContent = String.format("Number of unallocated shared network IPs is low, total: %s, allocated: %s (%s%%).", totalInString, usedInString, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_DIRECT_ATTACHED_PUBLIC_IP;
+                break;
+            case Capacity.CAPACITY_TYPE_VLAN:
+                msgSubject = String.format("System Alert: Number of unallocated VLANs is low in availability zone [%s].", dataCenterName);
+                msgContent = String.format("Number of unallocated VLANs is low, total: %s, allocated: %s (%s%%).", totalInString, usedInString, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_VLAN;
+                break;
+            case Capacity.CAPACITY_TYPE_VIRTUAL_NETWORK_IPV6_SUBNET:
+                msgSubject = String.format("System Alert: Number of unallocated virtual network guest IPv6 subnets is low in availability zone [%s].", dc.getName());
+                msgContent = String.format("Number of unallocated virtual network guest IPv6 subnets is low, total: [%s], allocated: [%s] (%s%%).", totalInString, usedInString, percentual);
+                alertType = AlertManager.AlertType.ALERT_TYPE_VIRTUAL_NETWORK_IPV6_SUBNET;
+                break;
         }
 
         try {
             if (logger.isDebugEnabled()) {
-                logger.debug(msgSubject);
-                logger.debug(msgContent);
+                logger.debug(String.format("Sending alert with subject [%s] and content [%s].", msgSubject, msgContent));
             }
             sendAlert(alertType, dc, pod, cluster, msgSubject, msgContent);
         } catch (Exception ex) {

--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -688,10 +688,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
         }
 
         try {
-            if (logger.isDebugEnabled()) {
-                logger.debug(String.format("Sending alert with subject [%s] and content [%s].", msgSubject, msgContent));
-            }
-            sendAlert(alertType, dc, pod, cluster, msgSubject, msgContent);
+            logger.debug("Sending alert with subject [{}] and content [{}].", msgSubject, msgContent);
+            sendAlert(alertType, dc.getId(), podId, clusterId, msgSubject, msgContent);
         } catch (Exception ex) {
             logger.error("Exception in CapacityChecker", ex);
         }


### PR DESCRIPTION
### Description

The method that generates the alert e-mail contains code repeated in many places and is not formatted properly.

This PR intends to refactor this method.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I changed the value of many  notification threshold  global settings to 0% (`zone.vlan.capacity.notificationthreshold` and `cluster.memory.allocated.capacity.notificationthreshold` for example). Then I checked through the logs that the messages were created correctly.

```
2024-03-25T18:22:03,626 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[4] dataCenterId=[1] podId=[null] clusterId=[null] message=[System Alert: Number of unallocated virtual network public IPs is low in availability zone [zn-test].].
2024-03-25T18:22:04,487 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Low Available Secondary Storage in availability zone [zn-test].] and content [Available secondary storage space is low, total: 60212 MB, used: 5476 MB (9.09%).].
2024-03-25T18:22:04,488 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[6] dataCenterId=[1] podId=[null] clusterId=[null] message=[System Alert: Low Available Secondary Storage in availability zone [zn-test].].
2024-03-25T18:22:04,503 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Number of unallocated VLANs is low in availability zone [zn-test].] and content [Number of unallocated VLANs is low, total: 101.0, allocated: 6.0 (5.94%).].
2024-03-25T18:22:04,504 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[18] dataCenterId=[1] podId=[null] clusterId=[null] message=[System Alert: Number of unallocated VLANs is low in availability zone [zn-test].].
2024-03-25T18:22:04,534 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Number of unallocated private IPs is low in pod Pod-zn-test of availability zone [zn-test].] and content [Number of unallocated private IPs is low, total: 10.0, allocated: 2.0 (20%)].
2024-03-25T18:22:04,534 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[5] dataCenterId=[1] podId=[1] clusterId=[null] message=[System Alert: Number of unallocated private IPs is low in pod Pod-zn-test of availability zone [zn-test].].
2024-03-25T18:22:06,243 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Low Unallocated CPU in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].] and content [Unallocated CPU is low, total: 30000 Mhz, used: 2500 Mhz (8.33%).].
2024-03-25T18:22:06,244 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[1] dataCenterId=[1] podId=[1] clusterId=[1] message=[System Alert: Low Unallocated CPU in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].].
2024-03-25T18:22:06,263 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Low Available Memory in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].] and content [System memory is low, total: 21914 MB, used: 2560 MB (11.68%).].
2024-03-25T18:22:06,263 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[0] dataCenterId=[1] podId=[1] clusterId=[1] message=[System Alert: Low Available Memory in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].].
2024-03-25T18:22:06,292 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Low Available Storage in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].] and content [Available storage space is low, total: 19019 MB, used: 4317 MB (22.7%).].
2024-03-25T18:22:06,293 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[2] dataCenterId=[1] podId=[1] clusterId=[1] message=[System Alert: Low Available Storage in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].].
2024-03-25T18:22:06,323 DEBUG [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) Sending alert with subject [System Alert: Remaining unallocated Storage is low in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].] and content [Unallocated storage space is low, total: 38037 MB, allocated: 20000 MB (52.58%)].
2024-03-25T18:22:06,324 WARN  [c.c.a.AlertManagerImpl] (CapacityChecker:[ctx-73e84063]) (logid:0ebef2c9) alertType=[3] dataCenterId=[1] podId=[1] clusterId=[1] message=[System Alert: Remaining unallocated Storage is low in cluster [Cluster-zn-test] pod [Pod-zn-test] of availability zone [zn-test].].
```
