### PR TITLE
Fix link to removed volumes being shown in info card and list view

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -573,6 +573,7 @@ public class ApiConstants {
     public static final String AGGREGATE_NAME = "aggregatename";
     public static final String POOL_NAME = "poolname";
     public static final String VOLUME_NAME = "volumename";
+    public static final String VOLUME_STATE = "volumestate";
     public static final String SNAPSHOT_POLICY = "snapshotpolicy";
     public static final String SNAPSHOT_RESERVATION = "snapshotreservation";
     public static final String IP_NETWORK_LIST = "iptonetworklist";

--- a/api/src/main/java/org/apache/cloudstack/api/response/SnapshotResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SnapshotResponse.java
@@ -71,6 +71,10 @@ public class SnapshotResponse extends BaseResponseWithTagInformation implements 
     @Param(description = "type of the disk volume")
     private String volumeType;
 
+    @SerializedName(ApiConstants.VOLUME_STATE)
+    @Param(description = "state of the disk volume")
+    private String volumeState;
+
     @SerializedName(ApiConstants.CREATED)
     @Param(description = "  the date the snapshot was created")
     private Date created;
@@ -197,6 +201,10 @@ public class SnapshotResponse extends BaseResponseWithTagInformation implements 
 
     public void setVolumeType(String volumeType) {
         this.volumeType = volumeType;
+    }
+
+    public void setVolumeState(String volumeState) {
+        this.volumeState = volumeState;
     }
 
     public void setCreated(Date created) {

--- a/engine/schema/src/main/resources/META-INF/db/views/cloud.snapshot_view.sql
+++ b/engine/schema/src/main/resources/META-INF/db/views/cloud.snapshot_view.sql
@@ -48,6 +48,7 @@ SELECT
     `volumes`.`uuid` AS `volume_uuid`,
     `volumes`.`name` AS `volume_name`,
     `volumes`.`volume_type` AS `volume_type`,
+    `volumes`.`state` AS `volume_state`,
     `volumes`.`size` AS `volume_size`,
     `data_center`.`id` AS `data_center_id`,
     `data_center`.`uuid` AS `data_center_uuid`,

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -659,6 +659,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             snapshotResponse.setVolumeId(volume.getUuid());
             snapshotResponse.setVolumeName(volume.getName());
             snapshotResponse.setVolumeType(volume.getVolumeType().name());
+            snapshotResponse.setVolumeState(volume.getState().name());
             snapshotResponse.setVirtualSize(volume.getSize());
             DataCenter zone = ApiDBUtils.findZoneById(volume.getDataCenterId());
             if (zone != null) {

--- a/server/src/main/java/com/cloud/api/query/dao/SnapshotJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/SnapshotJoinDaoImpl.java
@@ -128,6 +128,7 @@ public class SnapshotJoinDaoImpl extends GenericDaoBaseWithTagInformation<Snapsh
             snapshotResponse.setVolumeId(snapshot.getVolumeUuid());
             snapshotResponse.setVolumeName(snapshot.getVolumeName());
             snapshotResponse.setVolumeType(snapshot.getVolumeType().name());
+            snapshotResponse.setVolumeState(snapshot.getVolumeState().name());
             snapshotResponse.setVirtualSize(snapshot.getVolumeSize());
             VolumeVO volume = ApiDBUtils.findVolumeById(snapshot.getVolumeId());
             if (volume != null && volume.getVolumeType() == Type.ROOT && volume.getInstanceId() != null) {

--- a/server/src/main/java/com/cloud/api/query/vo/SnapshotJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/SnapshotJoinVO.java
@@ -130,6 +130,10 @@ public class SnapshotJoinVO extends BaseViewWithTagInformationVO implements Cont
     @Enumerated(EnumType.STRING)
     Volume.Type volumeType = Volume.Type.UNKNOWN;
 
+    @Column(name = "volume_state")
+    @Enumerated(EnumType.STRING)
+    Volume.State volumeState;
+
     @Column(name = "volume_size")
     Long volumeSize;
 
@@ -295,6 +299,10 @@ public class SnapshotJoinVO extends BaseViewWithTagInformationVO implements Cont
 
     public Volume.Type getVolumeType() {
         return volumeType;
+    }
+
+    public Volume.State getVolumeState() {
+        return volumeState;
     }
 
     public Long getVolumeSize() {

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -454,7 +454,8 @@
           <div class="resource-detail-item__label">{{ $t('label.volume') }}</div>
           <div class="resource-detail-item__details">
             <hdd-outlined />
-            <router-link :to="{ path: '/volume/' + resource.volumeid }">{{ resource.volumename || resource.volume || resource.volumeid }} </router-link>
+            <router-link v-if="validLinks.volume" :to="{ path: '/volume/' + resource.volumeid }">{{ resource.volumename || resource.volume || resource.volumeid }} </router-link>
+            <span v-else>{{ resource.volumename || resource.volume || resource.volumeid }}</span>
           </div>
         </div>
         <div class="resource-detail-item" v-if="resource.associatednetworkid">
@@ -794,6 +795,7 @@
 <script>
 import { api } from '@/api'
 import { createPathBasedOnVmType } from '@/utils/plugins'
+import { validateLinks } from '@/utils/links'
 import Console from '@/components/widgets/Console'
 import OsLogo from '@/components/widgets/OsLogo'
 import Status from '@/components/widgets/Status'
@@ -859,7 +861,8 @@ export default {
         vpc: '',
         network: ''
       },
-      newResource: {}
+      newResource: {},
+      validLinks: {}
     }
   },
   watch: {
@@ -876,6 +879,7 @@ export default {
         this.newResource = newData
         this.showKeys = false
         this.setData()
+        this.validLinks = validateLinks(this.$router, this.isStatic, this.resource)
 
         if ('apikey' in this.resource) {
           this.getUserKeys()

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -167,7 +167,7 @@
         <router-link :to="{ path: getVmRouteUsingType(record) + record.virtualmachineid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'volumename'">
-        <router-link v-if="validLinks[record.id]?.volume" :to="{ path: '/volume/' + record.volumeid }">{{ text }}</router-link>
+        <router-link v-if="resourceIdToValidLinksMap[record.id]?.volume" :to="{ path: '/volume/' + record.volumeid }">{{ text }}</router-link>
         <span v-else>{{ text }}</span>
       </template>
       <template v-if="column.key === 'size'">
@@ -579,7 +579,7 @@ export default {
           disable: 'storageallocateddisablethreshold'
         }
       },
-      validLinks: {}
+      resourceIdToValidLinksMap: {}
     }
   },
   watch: {
@@ -588,7 +588,7 @@ export default {
       handler (newData, oldData) {
         if (newData === oldData) return
         this.items.forEach(record => {
-          this.validLinks[record.id] = validateLinks(this.$router, false, record)
+          this.resourceIdToValidLinksMap[record.id] = validateLinks(this.$router, false, record)
         })
       }
     }

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -167,7 +167,8 @@
         <router-link :to="{ path: getVmRouteUsingType(record) + record.virtualmachineid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'volumename'">
-        <router-link :to="{ path: '/volume/' + record.volumeid }">{{ text }}</router-link>
+        <router-link v-if="validLinks[record.id]?.volume" :to="{ path: '/volume/' + record.volumeid }">{{ text }}</router-link>
+        <span v-else>{{ text }}</span>
       </template>
       <template v-if="column.key === 'size'">
         <span v-if="text && $route.path === '/kubernetes'">
@@ -488,6 +489,7 @@ import TooltipButton from '@/components/widgets/TooltipButton'
 import ResourceIcon from '@/components/view/ResourceIcon'
 import ResourceLabel from '@/components/widgets/ResourceLabel'
 import { createPathBasedOnVmType } from '@/utils/plugins'
+import { validateLinks } from '@/utils/links'
 import cronstrue from 'cronstrue/i18n'
 import moment from 'moment-timezone'
 
@@ -576,6 +578,18 @@ export default {
           notification: 'storageallocatedthreshold',
           disable: 'storageallocateddisablethreshold'
         }
+      },
+      validLinks: {}
+    }
+  },
+  watch: {
+    items: {
+      deep: true,
+      handler (newData, oldData) {
+        if (newData === oldData) return
+        this.items.forEach(record => {
+          this.validLinks[record.id] = validateLinks(this.$router, false, record)
+        })
       }
     }
   },

--- a/ui/src/utils/links.js
+++ b/ui/src/utils/links.js
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export function validateLinks (router, isStatic, resource) {
+  const validLinks = {
+    volume: false
+  }
+
+  if (isStatic) {
+    return validLinks
+  }
+
+  if (resource.volumeid && router.resolve('/volume/' + resource.volumeid).matched[0].redirect !== '/exception/404') {
+    if (resource.volumestate) {
+      validLinks.volume = resource.volumestate !== 'Expunged'
+    } else {
+      validLinks.volume = true
+    }
+  }
+
+  return validLinks
+}


### PR DESCRIPTION
### Description

The volume snapshots and the snapshot details page show a link to the snapshotted volume. However, if the volume has been removed, it is not possible to access its page, resulting in a 404 when a user clicks the link.

This PR adds a validation in the UI in order to avoid showing this link when the volume has been removed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

<details>
<summary>
When the volume exists, a link is shown.
</summary>

![Screenshot from 2024-03-26 09-18-39](https://github.com/apache/cloudstack/assets/25729641/dde6d3bc-a1d1-4275-bfba-e2b4fa523aa9)

</details>

<details>
<summary>
If the volume has been removed, the link does not get shown.
</summary>

![Screenshot from 2024-03-26 09-18-54](https://github.com/apache/cloudstack/assets/25729641/c80951e2-bd3f-4218-ba96-b908ec6f0601)

</details>

### How Has This Been Tested?

1. I created a volume snapshot and verified that the volume snapshots and the snapshot details page showed a link to the volume;
2. I removed the volume and verified that the link was not shown anymore.