### PR TITLE
Fix NPE when migrating a VM that had its template removed

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -1933,10 +1933,11 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 }
 
                 if (srcVolumeInfo.getTemplateId() != null) {
-                    LOGGER.debug(String.format("Copying template [%s] of volume [%s] from source storage pool [%s] to target storage pool [%s].", srcVolumeInfo.getTemplateId(), srcVolumeInfo.getId(), sourceStoragePool.getId(), destStoragePool.getId()));
-                    copyTemplateToTargetFilesystemStorageIfNeeded(srcVolumeInfo, sourceStoragePool, destDataStore, destStoragePool, destHost);
+                    copyTemplateIfNeeded(destHost, srcVolumeInfo, destDataStore, destStoragePool, sourceStoragePool);
                 } else {
-                    LOGGER.debug(String.format("Skipping copy template from source storage pool [%s] to target storage pool [%s] before migration due to volume [%s] does not have a template.", sourceStoragePool.getId(), destStoragePool.getId(), srcVolumeInfo.getId()));
+                    LOGGER.debug(String.format(
+                            "Skipping copy template from source storage pool [%s] to target storage pool [%s] before migration due to volume [%s] does not have a template.",
+                            sourceStoragePool.getId(), destStoragePool.getId(), srcVolumeInfo.getId()));
                 }
 
                 VolumeVO destVolume = duplicateVolumeOnAnotherStorage(srcVolume, destStoragePool);
@@ -2066,6 +2067,23 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         }
     }
 
+    /**
+     * Copies template to target File system storage in case needed.
+     * Also, must check for non null template, in case template has been (force) deleted but there are still VMs with it.
+     */
+    private void copyTemplateIfNeeded(Host destHost, VolumeInfo srcVolumeInfo, DataStore destDataStore, StoragePoolVO destStoragePool,
+            StoragePoolVO sourceStoragePool) {
+        VMTemplateVO vmTemplate = _vmTemplateDao.findById(srcVolumeInfo.getTemplateId());
+        if (vmTemplate != null) {
+            LOGGER.debug(String.format("Copying template [%s] of volume [%s] from source storage pool [%s] to target storage pool [%s].", srcVolumeInfo.getTemplateId(),
+                    srcVolumeInfo.getId(), sourceStoragePool.getId(), destStoragePool.getId()));
+            copyTemplateToTargetFilesystemStorageIfNeeded(srcVolumeInfo, sourceStoragePool, destDataStore, destStoragePool, destHost);
+        } else {
+            LOGGER.debug(String.format("Template [%s] has been (force) removed while there were VMs using it. Skipping step for copying Volume [%s] template.",
+                    srcVolumeInfo.getTemplateId(), srcVolumeInfo.getId()));
+        }
+    }
+
     protected String formatMigrationElementsAsJsonToDisplayOnLog(String objectName, Object object, Object from, Object to){
         return String.format("{%s: \"%s\", from: \"%s\", to:\"%s\"}", objectName, object, from, to);
     }
@@ -2151,7 +2169,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         if (srcVolumeInfo.getHypervisorType() == HypervisorType.KVM &&
                 srcVolumeInfo.getTemplateId() != null && srcVolumeInfo.getPoolId() != null) {
             VMTemplateVO template = _vmTemplateDao.findById(srcVolumeInfo.getTemplateId());
-            if (template.getFormat() != null && template.getFormat() != Storage.ImageFormat.ISO) {
+            if (template != null && template.getFormat() != null && template.getFormat() != Storage.ImageFormat.ISO) {
                 VMTemplateStoragePoolVO ref = templatePoolDao.findByPoolTemplate(srcVolumeInfo.getPoolId(), srcVolumeInfo.getTemplateId(), null);
                 return ref != null ? ref.getInstallPath() : null;
             }


### PR DESCRIPTION
### Description

This PR fixes an NPE when a VM had its template removed while the template still has running VMs.

Possibly fixes #8827 but not sure as I've not worked with imported VMs. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### How Has This Been Tested?

We have this currently running in our 4.16 environment and are bringing the change into a new release. 

#### How did you try to break this feature and the system with this change?

It does not break but instead resolves an issue.