### PR TITLE
Fix radio buttons in instance migration pop-up

### DIFF
--- a/ui/src/views/compute/MigrateVMStorage.vue
+++ b/ui/src/views/compute/MigrateVMStorage.vue
@@ -24,7 +24,7 @@
     </a-alert>
     <a-radio-group
       v-if="migrateVmWithVolumeAllowed"
-      :defaultValue="migrateMode"
+      v-model:value="migrateMode"
       @change="e => { handleMigrateModeChange(e.target.value) }">
       <a-radio class="radio-style" :value="1">
         {{ $t('label.migrate.instance.single.storage') }}


### PR DESCRIPTION
### Description

When an operator selects the migration mode in the instance migration pop-up, the corresponding radio button does not get checked. This PR fixes this issue. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

<details>
<summary>
Before the changes
</summary>

![Screenshot from 2024-03-26 11-11-45](https://github.com/apache/cloudstack/assets/25729641/e66ee94e-3202-46d5-8777-bf65b225039b)

</details>

<details>
<summary>
After applying these changes
</summary>

![Screenshot from 2024-03-26 11-11-12](https://github.com/apache/cloudstack/assets/25729641/67c95c7e-3426-4ef1-b8f2-f4ef9b84702e)

</details>

### How Has This Been Tested?

1. I created a stopped instance and accessed its page.
2. I opened the migration pop-up and verified that the first option was selected by default.
3. I clicked on the second option and verified that its radio button got selected.
4. I clicked on the first option and verified that its radio button got selected.