### PR TITLE
add The name of the Qemu binary to look for.

### DIFF
--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -22,6 +22,7 @@
         "<enter><wait>"
       ],
       "boot_wait": "5s",
+      "qemu_binary": "qemu-system-x86_64",
       "disk_interface": "virtio",
       "disk_size": "5000M",
       "format": "qcow2",


### PR DESCRIPTION
### Description
This PR adds the qemu'binary option for building SystemVM and provides an option for building Arm64 architecture
By default, Packer only looks for programs with a binary name of qemu-system-x86_64, while on arm64, the name is qemu-kvm. Running the script directly on arm64 will result in a build failure

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):
Before adding options
![PixPin_2024-04-01_11-01-21](https://github.com/apache/cloudstack/assets/32887476/4c92caa0-838a-491d-a8d6-ca39efa38172)

After adding options
![PixPin_2024-04-01_11-00-21](https://github.com/apache/cloudstack/assets/32887476/828e869c-4450-4ac0-bafd-8ceabf57f3c3)
### How Has This Been Tested?
An error occurred when using the build script to build. Upon checking the template file, it was found that the system virtual machine image file points to the x86_64 download address. After changing the download address and checksum, the build script was run again and it was found that it still cannot be built normally. When checking the build configuration of the packer, it was found that by default, the qemu component of the packer looks for the qemu-system-x86_64 binary program, which does not exist on the arm64 server. After adding this option and modifying it to qemu-kvm, the script can be built normally

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?
Ignore this section
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
