### PR TITLE
Add ReservationDao as dependency for the Usage Server

### DIFF
--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-common-daos-between-management-and-usage-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-common-daos-between-management-and-usage-context.xml
@@ -68,5 +68,6 @@
 	<bean id="vMSnapshotDaoImpl" class="com.cloud.vm.snapshot.dao.VMSnapshotDaoImpl" />
 	<bean id="VmTemplateDaoImpl" class="org.apache.cloudstack.quota.dao.VmTemplateDaoImpl" />
 	<bean id="volumeDaoImpl" class="com.cloud.storage.dao.VolumeDaoImpl" />
+  <bean id="reservationDao" class="org.apache.cloudstack.reservation.dao.ReservationDaoImpl" />
     <bean id="backupOfferingDaoImpl" class="org.apache.cloudstack.backup.dao.BackupOfferingDaoImpl" />
 </beans>

--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -158,7 +158,6 @@
   <bean id="projectJoinDaoImpl" class="com.cloud.api.query.dao.ProjectJoinDaoImpl" />
   <bean id="regionDaoImpl" class="org.apache.cloudstack.region.dao.RegionDaoImpl" />
   <bean id="remoteAccessVpnDaoImpl" class="com.cloud.network.dao.RemoteAccessVpnDaoImpl" />
-  <bean id="reservationDao" class="org.apache.cloudstack.reservation.dao.ReservationDaoImpl" />
   <bean id="resourceCountDaoImpl" class="com.cloud.configuration.dao.ResourceCountDaoImpl" />
   <bean id="resourceIconDaoImpl" class="com.cloud.resource.icon.dao.ResourceIconDaoImpl" />
   <bean id="resourceLimitDaoImpl" class="com.cloud.configuration.dao.ResourceLimitDaoImpl" />


### PR DESCRIPTION
### Description

The Quota processing occurs on the Management Server (via API) and Usage Server (via task). It uses the class `PresetVariableHelper` to retrieve data from the database and inject it into the Quota tariff's activation rules. To retrieve the data, some DAOs are mapped as dependencies for the Usage Server and injected in that class. 

PR #8302 injected `org.apache.cloudstack.reservation.dao.ReservationDao` in `com.cloud.storage.dao.VolumeDao` (which is also injected in `PresetVariableHelper`); however, `org.apache.cloudstack.reservation.dao.ReservationDao` was not added as dependency for the Usage Server, causing errors to start the Usage Server: 

<details><summary>Logs</summary>

```
04:51:35,224  INFO Transaction:1030 - Is Data Base High Availiability enabled? Ans : false
04:51:35,224  INFO Transaction:1158 - Using the following URI to connect to cloud database [jdbc:mysql://localhost:3306/cloud?autoReconnect=true&prepStmtCacheSize=517&cachePrepStmts=true&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'&serverTimezone=UTC&scrollTolerantForwardOnly=true].
04:51:35,245  INFO Transaction:1158 - Using the following URI to connect to usage database [jdbc:mysql://localhost:3306/cloud_usage?autoReconnect=true&serverTimezone=UTC&scrollTolerantForwardOnly=true].
04:51:37,470  INFO ComponentContext:61 - Setup Spring Application context
04:51:38,677 ERROR ComponentContext:81 - Could not load bean due to: [Error creating bean with name 'volumeDaoImpl': Unsatisfied dependency expressed through field 'reservationDao'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.cloudstack.reservation.dao.ReservationDao' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@javax.inject.Inject()}]. The service will be stopped. Please investigate the cause of the error or contact your support team. org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'volumeDaoImpl': Unsatisfied dependency expressed through field 'reservationDao'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.cloudstack.reservation.dao.ReservationDao' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@javax.inject.Inject()}
  at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:660)
  at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:640)
  at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:119)
  at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:399)
  at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1431)
  at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.configureBean(AbstractAutowireCapableBeanFactory.java:364)
  at com.cloud.utils.component.ComponentContext.initComponentsLifeCycle(ComponentContext.java:79)
  at com.cloud.usage.UsageServer.start(UsageServer.java:55)
  at com.cloud.usage.UsageServer.main(UsageServer.java:42)
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.cloudstack.reservation.dao.ReservationDao' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@javax.inject.Inject()}
  at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1801)
  at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1357)
  at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1311)
  at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:657)
  ... 8 more
``` 
</details>

This PR adds the `org.apache.cloudstack.reservation.dao.ReservationDao` as dependency for the Usage Server.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I applied the changes and tried to start the Usage Server:

<details><summary>Logs</summary>

```
04:53:02,726  INFO LogUtils:59 - log4j configuration found at /etc/cloudstack/usage/log4j-cloud.xml
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
04:53:03,333  INFO Transaction:1030 - Is Data Base High Availiability enabled? Ans : false
04:53:03,334  INFO Transaction:1158 - Using the following URI to connect to cloud database [jdbc:mysql://localhost:3306/cloud?autoReconnect=true&prepStmtCacheSize=517&cachePrepStmts=true&sessionVariables=sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'&serverTimezone=UTC&scrollTolerantForwardOnly=true].
04:53:03,346  INFO Transaction:1158 - Using the following URI to connect to usage database [jdbc:mysql://localhost:3306/cloud_usage?autoReconnect=true&serverTimezone=UTC&scrollTolerantForwardOnly=true].
04:53:04,288  INFO ComponentContext:61 - Setup Spring Application context
04:53:04,873  INFO ComponentContext:116 - Configuring org.apache.cloudstack.framework.config.dao.ConfigurationDaoImpl_EnhancerByCloudStack_2634113
04:53:04,875  INFO ComponentContext:116 - Configuring com.cloud.storage.dao.SnapshotDaoImpl_EnhancerByCloudStack_569da26d
04:53:04,875  INFO ComponentContext:116 - Configuring org.apache.cloudstack.quota.dao.QuotaEmailConfigurationDaoImpl_EnhancerByCloudStack_8006895b
04:53:04,875  INFO ComponentContext:116 - Configuring com.cloud.usage.dao.UsageVMSnapshotDaoImpl_EnhancerByCloudStack_c98c579
04:53:04,875  INFO ComponentContext:116 - Configuring com.cloud.storage.dao.VolumeDaoImpl_EnhancerByCloudStack_ace675e7
```
</details>
