### PR TITLE
Change iops on offering change

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/VolumeDetailVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/VolumeDetailVO.java
@@ -80,4 +80,7 @@ public class VolumeDetailVO implements ResourceDetail {
         return display;
     }
 
+    public void setValue(String value) {
+        this.value = value;
+    }
 }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1512,6 +1512,14 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 volume.setDiskOfferingId(newDiskOfferingId);
             }
 
+            if (newMinIops != null) {
+                volume.setMinIops(newMinIops);
+            }
+
+            if (newMaxIops != null) {
+                volume.setMaxIops(newMaxIops);
+            }
+
             // Update size if volume has same size as before, else it is already updated
             final VolumeVO volumeNow = _volsDao.findById(volumeId);
             if (currentSize == volumeNow.getSize() && currentSize != newSize) {


### PR DESCRIPTION
### Description

This PR allows changing of IOPS on changing of disk offering via `changeOfferingForVolume` command.
As of now changing disk offering does change the size of the disk but doesn't update the IOPS for the volume.

This PR also updates the IOPS to unlimited while copying the template to the volume to speed up start up of a VM.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Tested with ScaleIO/powerflex.
1. Create two disk offerings with different IOPS
2. Launch a VM with the one of the above disk offerings
3. Check IOPS for the volume in powerflex dashboard
4. Change the offering for the volume
5. Recheck IOPS for the volume in powerflex dashboard

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
