### PR TITLE
Fix assignVirtualMachine template checkAccess

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -7221,10 +7221,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (template == null) {
             throw new InvalidParameterValueException(String.format("Template for VM: %s cannot be found", vm.getUuid()));
         }
-        if (!template.isPublicTemplate()) {
-            Account templateOwner = _accountMgr.getAccount(template.getAccountId());
-            _accountMgr.checkAccess(newAccount, null, true, templateOwner);
-        }
+        _accountMgr.checkAccess(newAccount, AccessType.UseEntry, true, template);
 
         // VV 5: check the new account can create vm in the domain
         DomainVO domain = _domainDao.findById(cmd.getDomainId());


### PR DESCRIPTION
### Description

This PR changes the checkAccess of when assigning a VM to check for the template itself instead of the account owner of the template. In this way, there is no need for checking if the template is public (it already does so inside checkAccess) and it gives a better message when the assigning fails because of it:

```
Failed to move vm due to Account [...] does not have permission to launch instances from template [...]
```

Instead of:
```
Failed to move vm due to Account [{"accountName":"[...]","id":[...],"uuid":"[...]"}] does not have permission to operate with resource
```

Also, current ACS lets you assign a VM with a public template of domain B to an account of domain A even if `share.public.templates.with.other.domains` is false. This also fixes it.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?

In a local lab with:
- In domain /A, a domain admin and a user. A private template of user A.
- In domain /A/AB, a user. A public template of user AB.
- In domain /B, a user. A public template of user B.

I then reproduced the following cases:
- Created a VM with userA and privateTemplateA. 
- With ROOT Admin, assign the VM to user B.
```
Failed to move vm due to Account usrb does not have permission to launch instances from template macha
```
- With Domain Admin A, assign the VM to user B through cmk.
```
🙈 Error: (HTTP 530, error code 9999) Failed to move vm due to Account doma does not have permission to operate within domain id=a453e418-f295-47c1-9728-c62121ae54f3
```

- With Domain Admin A, assign the VM to user AB.
```
Failed to move vm due to Account usrab does not have permission to launch instances from template macha
```

---
- Created a VM with userAB and publicTemplateAB. 
- With Domain Admin A, assign the VM to user A. Completed successfully.

---
- Created a VM with userA and privateTemplateA.
- With Root Admin, assign the VM to Root Admin. Completed successfully.

---
- Created a VM with userA and privateTemplateA.
- With Domain Admin A, assign the VM to Domain Admin A.
```
Failed to move vm due to Account doma does not have permission to launch instances from template macha
```
- With Root Admin, assign the VM to Domain Admin A.
```
Failed to move vm due to Account doma does not have permission to launch instances from template macha
```

---
- Created a VM with userB and publicTemplateB. (`share.public.templates.with.other.domains` true)
- With Root Admin, assign the VM to user A. Completed successfully.


---
- Created a VM with userB and publicTemplateB. (`share.public.templates.with.other.domains` false)
- With Root Admin, assign the VM to user A. 
```
Failed to move vm due to Account [{"accountName":"usra","id":4,"uuid":"01ebae51-0368-49d6-918c-6c6f2f4fb781"}]is not allowed to access the template Template {"format":"QCOW2","id":202,"uniqueName":"202-5-bd209989-477a-357d-8d6e-983f3d6052ae"}
```
