### PR TITLE
Fix VR inheriting boot settings from user's VM

### DIFF
--- a/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
@@ -272,12 +272,15 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
             return false;
         }
 
+        Map<VirtualMachineProfile.Param, Object> params = new HashMap<>();
+        params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, Boolean.TRUE);
+
         final RouterDeploymentDefinition routerDeploymentDefinition =
                 routerDeploymentDefinitionBuilder.create()
                 .setGuestNetwork(network)
                 .setDeployDestination(dest)
                 .setAccountOwner(_accountMgr.getAccount(network.getAccountId()))
-                .setParams(vm.getParameters())
+                .setParams(params)
                 .build();
 
         final List<DomainRouterVO> routers = routerDeploymentDefinition.deployVirtualRouter();

--- a/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
@@ -219,7 +219,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
             return false;
         }
 
-        final Map<VirtualMachineProfile.Param, Object> params = new HashMap<VirtualMachineProfile.Param, Object>(1);
+        final Map<VirtualMachineProfile.Param, Object> params = new HashMap<>(1);
         params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, true);
 
         if (network.isRollingRestart()) {
@@ -264,30 +264,13 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
             return false;
         }
 
-        final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        if (offering.isSystemOnly()) {
-            return false;
-        }
         if (!_networkMdl.isProviderEnabledInPhysicalNetwork(_networkMdl.getPhysicalNetworkId(network), getProvider().getName())) {
             return false;
         }
 
-        Map<VirtualMachineProfile.Param, Object> params = new HashMap<>();
-        params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, Boolean.TRUE);
+        final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
+        implement(network, offering, dest, context);
 
-        final RouterDeploymentDefinition routerDeploymentDefinition =
-                routerDeploymentDefinitionBuilder.create()
-                .setGuestNetwork(network)
-                .setDeployDestination(dest)
-                .setAccountOwner(_accountMgr.getAccount(network.getAccountId()))
-                .setParams(params)
-                .build();
-
-        final List<DomainRouterVO> routers = routerDeploymentDefinition.deployVirtualRouter();
-
-        if (routers == null || routers.size() == 0) {
-            throw new ResourceUnavailableException("Can't find at least one running router!", DataCenter.class, network.getDataCenterId());
-        }
         return true;
     }
 


### PR DESCRIPTION
### Description

In a situation where there is a stopped user VM and this VM's network VR is also stopped, starting the user VM will also cause the VR to start. However, in this situation, the VR is inheriting the user VM's boot parameters, causing it to not start when the user VM has the UEFI boot type.

Because of this, the inheritance of user VM boot parameters has been removed from VR and other boot parameters have been defined in their place.

Fixes: #8734

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I followed the same steps from `How did you try to break this feature and the system with this change?` and verified that the user's VM and VR started correctly.

#### How did you try to break this feature and the system with this change?

1. Using VMware, I created an isolated network (`isolated`);
2. I deployed a VM (`test`) using the `isolated` network and started it;
3. After implementing the `isolated` network, I stopped the VM `test` and the VR of the `isolated` network;
4. I added the `UEFI=SECURE` setting to the `test` VM and started it again, causing the `isolated` network VR to start as well;
5. The VR could not start because it had the UEFI boot type.