### PR TITLE
linstor: Do not pretend handling disconnect paths that are non Linstor

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -45,6 +45,7 @@ import com.linbit.linstor.api.model.ApiCallRc;
 import com.linbit.linstor.api.model.ApiCallRcList;
 import com.linbit.linstor.api.model.Properties;
 import com.linbit.linstor.api.model.ProviderKind;
+import com.linbit.linstor.api.model.Resource;
 import com.linbit.linstor.api.model.ResourceDefinition;
 import com.linbit.linstor.api.model.ResourceDefinitionModify;
 import com.linbit.linstor.api.model.ResourceGroup;
@@ -306,7 +307,7 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
     public boolean disconnectPhysicalDisk(String volumePath, KVMStoragePool pool)
     {
         s_logger.debug("Linstor: disconnectPhysicalDisk " + pool.getUuid() + ":" + volumePath);
-        return true;
+        return false;
     }
 
     @Override
@@ -342,40 +343,44 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
             s_logger.debug("Linstor: Using storpool: " + pool.getUuid());
             final DevelopersApi api = getLinstorAPI(pool);
 
-            try
-            {
+            Optional<ResourceWithVolumes> optRsc;
+            try {
                 List<ResourceWithVolumes> resources = api.viewResources(
-                    Collections.singletonList(localNodeName),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
+                        Collections.singletonList(localNodeName),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
 
-                Optional<ResourceWithVolumes> rsc = getResourceByPath(resources, localPath);
+                optRsc = getResourceByPath(resources, localPath);
+            } catch (ApiException apiEx) {
+                // couldn't query linstor controller
+                s_logger.error(apiEx.getBestMessage());
+                return false;
+            }
 
-                if (rsc.isPresent())
-                {
+            if (optRsc.isPresent()) {
+                try {
+                    Resource rsc = optRsc.get();
                     ResourceDefinitionModify rdm = new ResourceDefinitionModify();
                     rdm.deleteProps(Collections.singletonList("DrbdOptions/Net/allow-two-primaries"));
-                    ApiCallRcList answers = api.resourceDefinitionModify(rsc.get().getName(), rdm);
-                    if (answers.hasError())
-                    {
+                    ApiCallRcList answers = api.resourceDefinitionModify(rsc.getName(), rdm);
+                    if (answers.hasError()) {
                         s_logger.error(
                                 String.format("Failed to remove 'allow-two-primaries' on %s: %s",
-                                        rsc.get().getName(), LinstorUtil.getBestErrorMessage(answers)));
+                                        rsc.getName(), LinstorUtil.getBestErrorMessage(answers)));
                         // do not fail here as removing allow-two-primaries property isn't fatal
                     }
-
-                    return true;
+                } catch(ApiException apiEx){
+                    s_logger.error(apiEx.getBestMessage());
+                    // do not fail here as removing allow-two-primaries property isn't fatal
                 }
-                s_logger.warn("Linstor: Couldn't find resource for this path: " + localPath);
-            } catch (ApiException apiEx) {
-                s_logger.error(apiEx.getBestMessage());
-                // do not fail here as removing allow-two-primaries property isn't fatal
+                return true;
             }
         }
-        return true;
+        s_logger.info("Linstor: Couldn't find resource for this path: " + localPath);
+        return false;
     }
 
     @Override


### PR DESCRIPTION
### Description

Excerpt PR from #8790, that only fixes Linstor adaptor pretending handling paths that don't belong to Linstor.

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Manual with a Linstor cluster.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
