### PR TITLE
Speedup resource count calculation

### DIFF
--- a/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDao.java
+++ b/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDao.java
@@ -49,11 +49,14 @@ public interface ResourceCountDao extends GenericDao<ResourceCountVO, Long> {
 
     ResourceCountVO findByOwnerAndTypeAndTag(long ownerId, ResourceOwnerType ownerType, ResourceType type, String tag);
 
+    List<ResourceCountVO> findByOwnersAndTypeAndTag(List<Long> ownerIdList, ResourceOwnerType ownerType,
+            ResourceType type, String tag);
+
     List<ResourceCountVO> listResourceCountByOwnerType(ResourceOwnerType ownerType);
 
     Set<Long> listAllRowsToUpdate(long ownerId, ResourceOwnerType ownerType, ResourceType type, String tag);
 
-    boolean incrementCountByIds(Set<Long> ids, boolean increment, long delta);
+    boolean updateCountByDeltaForIds(List<Long> ids, boolean increment, long delta);
 
     Set<Long> listRowsToUpdateForDomain(long domainId, ResourceType type, String tag);
 
@@ -74,4 +77,6 @@ public interface ResourceCountDao extends GenericDao<ResourceCountVO, Long> {
     long countMemoryAllocatedToAccount(long accountId);
 
     void removeResourceCountsForNonMatchingTags(Long ownerId, ResourceOwnerType ownerType, List<ResourceType> types, List<String> tags);
+
+    List<ResourceCountVO> lockRows(Set<Long> ids);
 }

--- a/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDao.java
+++ b/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDao.java
@@ -53,6 +53,8 @@ public interface ResourceCountDao extends GenericDao<ResourceCountVO, Long> {
 
     Set<Long> listAllRowsToUpdate(long ownerId, ResourceOwnerType ownerType, ResourceType type, String tag);
 
+    boolean incrementCountByIds(Set<Long> ids, boolean increment, long delta);
+
     Set<Long> listRowsToUpdateForDomain(long domainId, ResourceType type, String tag);
 
     long removeEntriesByOwner(long ownerId, ResourceOwnerType ownerType);

--- a/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/configuration/dao/ResourceCountDaoImpl.java
@@ -185,12 +185,10 @@ public class ResourceCountDaoImpl extends GenericDaoBase<ResourceCountVO, Long> 
         String poolIdsInStr = ids.stream().map(String::valueOf).collect(Collectors.joining(",", "(", ")"));
         String sql = updateSql.replace("(?)", poolIdsInStr);
 
-        try (TransactionLegacy txn = TransactionLegacy.currentTxn();
-             PreparedStatement pstmt = txn.prepareAutoCloseStatement(sql)
-        ) {
+        final TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try(PreparedStatement pstmt = txn.prepareStatement(sql);) {
             pstmt.setLong(1, delta);
             pstmt.executeUpdate();
-            txn.commit();
             return true;
         } catch (SQLException e) {
             throw new CloudRuntimeException(e);

--- a/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDao.java
@@ -31,4 +31,6 @@ public interface ReservationDao extends GenericDao<ReservationVO, Long> {
     void setResourceId(Resource.ResourceType type, Long resourceId);
     List<Long> getResourceIds(long accountId, Resource.ResourceType type);
     List<ReservationVO> getReservationsForAccount(long accountId, Resource.ResourceType type, String tag);
+
+    void removeByIds(List<Long> reservationIds);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDao.java
@@ -31,6 +31,5 @@ public interface ReservationDao extends GenericDao<ReservationVO, Long> {
     void setResourceId(Resource.ResourceType type, Long resourceId);
     List<Long> getResourceIds(long accountId, Resource.ResourceType type);
     List<ReservationVO> getReservationsForAccount(long accountId, Resource.ResourceType type, String tag);
-
     void removeByIds(List<Long> reservationIds);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDaoImpl.java
@@ -49,9 +49,7 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
     private final SearchBuilder<ReservationVO> listDomainAndTypeSearch;
     private final SearchBuilder<ReservationVO> listDomainAndTypeAndNoTagSearch;
     private final SearchBuilder<ReservationVO> listResourceByAccountAndTypeAndNoTagSearch;
-
     private final SearchBuilder<ReservationVO> listIdsSearch;
-
 
     public ReservationDaoImpl() {
 
@@ -173,12 +171,10 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
 
     @Override
     public void removeByIds(List<Long> reservationIds) {
-        if (CollectionUtils.isEmpty(reservationIds)) {
-            return;
+        if (CollectionUtils.isNotEmpty(reservationIds)) {
+            SearchCriteria<ReservationVO> sc = listIdsSearch.create();
+            sc.setParameters(IDS, reservationIds.toArray());
+            remove(sc);
         }
-
-        SearchCriteria<ReservationVO> sc = listIdsSearch.create();
-        sc.setParameters(IDS, reservationIds.toArray());
-        remove(sc);
     }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/reservation/dao/ReservationDaoImpl.java
@@ -29,6 +29,7 @@ import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import org.apache.cloudstack.user.ResourceReservation;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,6 +41,7 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
     private static final String RESOURCE_ID = "resourceId";
     private static final String ACCOUNT_ID = "accountId";
     private static final String DOMAIN_ID = "domainId";
+    private static final String IDS = "ids";
     private final SearchBuilder<ReservationVO> listResourceByAccountAndTypeSearch;
     private final SearchBuilder<ReservationVO> listAccountAndTypeSearch;
     private final SearchBuilder<ReservationVO> listAccountAndTypeAndNoTagSearch;
@@ -47,6 +49,9 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
     private final SearchBuilder<ReservationVO> listDomainAndTypeSearch;
     private final SearchBuilder<ReservationVO> listDomainAndTypeAndNoTagSearch;
     private final SearchBuilder<ReservationVO> listResourceByAccountAndTypeAndNoTagSearch;
+
+    private final SearchBuilder<ReservationVO> listIdsSearch;
+
 
     public ReservationDaoImpl() {
 
@@ -87,6 +92,10 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
         listDomainAndTypeAndNoTagSearch.and(RESOURCE_TYPE, listDomainAndTypeAndNoTagSearch.entity().getResourceType(), SearchCriteria.Op.EQ);
         listDomainAndTypeAndNoTagSearch.and(RESOURCE_TAG, listDomainAndTypeAndNoTagSearch.entity().getTag(), SearchCriteria.Op.NULL);
         listDomainAndTypeAndNoTagSearch.done();
+
+        listIdsSearch = createSearchBuilder();
+        listIdsSearch.and(IDS, listIdsSearch.entity().getId(), SearchCriteria.Op.IN);
+        listIdsSearch.done();
     }
 
     @Override
@@ -160,5 +169,16 @@ public class ReservationDaoImpl extends GenericDaoBase<ReservationVO, Long> impl
             sc.setParameters(RESOURCE_TAG, tag);
         }
         return listBy(sc);
+    }
+
+    @Override
+    public void removeByIds(List<Long> reservationIds) {
+        if (CollectionUtils.isEmpty(reservationIds)) {
+            return;
+        }
+
+        SearchCriteria<ReservationVO> sc = listIdsSearch.create();
+        sc.setParameters(IDS, reservationIds.toArray());
+        remove(sc);
     }
 }


### PR DESCRIPTION
### Description

This PR fixes the issues which occur when increment/decrement methods are waiting for a lock on domain tables and `ResourceCountCheckTask` is running at the same time. This issue appears when innodb_lock_wait_timeout is many times less than the time it takes for `recalculateDomainResourceCount` to complete. (Check steps below on how to reproduce the error).
```java
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: com.mysql.cj.jdbc.ClientPreparedStatement: SELECT resource_count.id, resource_count.type, resource_count.account_i
d, resource_count.domain_id, resource_count.count, resource_count.tag FROM resource_count WHERE resource_count.id IN (33,4785,3513,4845)  FOR UPDATE 
        at com.cloud.utils.db.GenericDaoBase.searchIncludingRemoved(GenericDaoBase.java:438)
        at com.cloud.utils.db.GenericDaoBase.searchIncludingRemoved(GenericDaoBase.java:366)
        at com.cloud.utils.db.GenericDaoBase.search(GenericDaoBase.java:355)
        at com.cloud.utils.db.GenericDaoBase.lockRows(GenericDaoBase.java:341)
        .....

```

We do this by removing unnecessary locks and simplifying count updates.

As of now, to calculate the resource count for root domain, we are taking the lock on the entire table.
This PR also splits the domain count calculation transaction into multiple transactions locks. This is done by breaking up the domain count calculation process by:
1. Calculate resource count for all accounts in a domain
2. Calculate resource count for all child domains in a domain
3. In a transaction, fetch the child domain & accounts count and update the count if required

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Setup multiple domains & networks. And update their limits. I used the below command.
```bash
csbench -create -domain -network -limits
```
```
# csbench-config
numdomains = 10
numnetworks = 1
numvms = 100
startvm = false  # For faster creation of VMs
```
2. Check the time it takes for resource count calculation to run. To manually trigger resource count calculation, run this command:
```bash
time cmk update resourcecount domainid=1
```
3. Update `innodb_lock_wait_timeout` to a value less than by a few seconds it took for the above request to complete.
```sql
SET GLOBAL innodb_lock_wait_timeout=3;
```
4. Restart the management server for `innodb_lock_wait_timeout` change to take effect.
5. Run the below commands.
```
csbench -create -vm -workers=50
csbench -teardown -vm -workers=50
```
In parallel to above requests, execute `cmk update resourcecount domainid=1` to trigger resource count recalculation while VMs are getting created or destroyed.

6. Check logs for `ClientPreparedStatement`.
```bash
grep "ClientPreparedStatement" vmops.log
```

#### Results

##### With patch - creation of VM in stopped state

```
+----------+-------+-------+--------+-------+--------+-----------------+-----------------+-----------------+
| TYPE     | COUNT |   MIN |    MAX |   AVG | MEDIAN | 90TH PERCENTILE | 95TH PERCENTILE | 99TH PERCENTILE |
+----------+-------+-------+--------+-------+--------+-----------------+-----------------+-----------------+
| vm - All |  1000 | 1.475 | 13.879 | 4.012 |  2.955 |           8.397 |           9.648 |          12.616 |
+----------+-------+-------+--------+-------+--------+-----------------+-----------------+-----------------+
```
```
+------------------+-------+--------+-------+--------+--------+-----------------+-----------------+-----------------+
| TYPE             | COUNT |    MIN |   MAX |    AVG | MEDIAN | 90TH PERCENTILE | 95TH PERCENTILE | 99TH PERCENTILE |
+------------------+-------+--------+-------+--------+--------+-----------------+-----------------+-----------------+
| vm-destroy - All |  1000 | 15.301 | 29.74 | 20.129 | 21.438 |          21.625 |          22.681 |          28.547 |
+------------------+-------+--------+-------+--------+--------+-----------------+-----------------+-----------------+
```
##### Without patch
```
+-----------------+-------+-------+--------+-------+--------+-----------------+-----------------+-----------------+
| TYPE            | COUNT |   MIN |    MAX |   AVG | MEDIAN | 90TH PERCENTILE | 95TH PERCENTILE | 99TH PERCENTILE |
+-----------------+-------+-------+--------+-------+--------+-----------------+-----------------+-----------------+
| vm - All        |  1000 | 2.039 | 17.463 | 5.656 |   4.77 |          10.484 |          11.758 |          13.645 |
| vm - Successful |   988 | 2.039 | 17.463 |  5.67 |  4.773 |          10.489 |          11.791 |          13.753 |
| vm - Failed     |    12 | 3.181 |  5.414 | 4.493 |  4.679 |            5.21 |           5.313 |           5.313 |
+-----------------+-------+-------+--------+-------+--------+-----------------+-----------------+-----------------+
```
```
+------------------+-------+--------+--------+--------+--------+-----------------+-----------------+-----------------+
| TYPE             | COUNT |    MIN |    MAX |    AVG | MEDIAN | 90TH PERCENTILE | 95TH PERCENTILE | 99TH PERCENTILE |
+------------------+-------+--------+--------+--------+--------+-----------------+-----------------+-----------------+
| vm-destroy - All |   996 | 10.295 | 29.176 | 20.111 | 21.417 |          21.655 |           22.27 |          28.691 |
+------------------+-------+--------+--------+--------+--------+-----------------+-----------------+-----------------+
```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
