### PR TITLE
Removed unnecessary migration of `ROOT` volumes with KVM

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3099,7 +3099,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             executeManagedStorageChecksWhenTargetStoragePoolNotProvided(targetHost, currentPool, volume);
             if (ScopeType.HOST.equals(currentPool.getScope()) || isStorageCrossClusterMigration(plan.getClusterId(), currentPool)) {
                 createVolumeToStoragePoolMappingIfPossible(profile, plan, volumeToPoolObjectMap, volume, currentPool);
-            } else if (shouldMapVolume(profile, volume, currentPool)){
+            } else if (shouldMapVolume(profile, currentPool)){
                 volumeToPoolObjectMap.put(volume, currentPool);
             }
         }
@@ -3111,11 +3111,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
      * Some context: VMware migration workflow requires all volumes to be mapped (even if volume stays on its current pool);
      *  however, this is not necessary/desirable for the KVM flow.
      */
-    protected boolean shouldMapVolume(VirtualMachineProfile profile, Volume volume, StoragePoolVO currentPool) {
+    protected boolean shouldMapVolume(VirtualMachineProfile profile, StoragePoolVO currentPool) {
         boolean isManaged = currentPool.isManaged();
         boolean isNotKvm = HypervisorType.KVM != profile.getHypervisorType();
-        boolean isNotDatadisk = Type.DATADISK != volume.getVolumeType();
-        return isNotKvm || isNotDatadisk || isManaged;
+        return isNotKvm || isManaged;
     }
 
     /**


### PR DESCRIPTION
### Description

Using KVM as a hypervisor, when performing a live migration of a VM with its datadisks, the ROOT volume is also migrated, even if the user has not requested this action. Since this migration of the root volume is unnecessary and causes greater latency for the live migrate process, this behavior has been changed. Now, when migrating a VM and its datadisks, only the volumes selected for migration will actually be migrated.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

### Description of tests

A new VM was created with a root and a data volume for testing; Several live migration scenarios were tested. The cases are described below.

The following migrations occurred successfully, in each case, when only the datadisk was moved, a dump of the VM XML was performed to verify that the ROOT volume had not been moved.

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | iSCSI2 |
| DATA1 | iSCSI1 | --- |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | --- |
| DATA1 | iSCSI1 | iSCSI2 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | iSCSI2 |
| DATA1 | iSCSI1 | iSCSI2 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | Local |
| DATA1 | iSCSI1 | Local |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | Local | iSCSI1 |
| DATA1 | Local | iSCSI1 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | NFS1 |
| DATA1 | iSCSI1 | NFS1 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | NFS1 |
| DATA1 | iSCSI1 | --- |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | iSCSI1 | --- |
| DATA1 | iSCSI1 | NFS1 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | NFS2 |
| DATA1 | NFS1 | NFS2 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | Local |
| DATA1 | NFS1 | Local |

The following migrations ended in error. However, the error is expected, because, as described in #8907, when migrating the VM + volume and not migrating all NFS volumes, an error occurs. This error will be fixed in another PR.

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | Local |
| DATA1 | NFS1 | --- |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | --- |
| DATA1 | NFS1 | Local |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | NFS2 |
| DATA1 | NFS1 | --- |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | NFS2 |
| DATA1 | NFS1 | --- |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | ISCSI1 | --- |
| DATA1 | NFS1 | ISCSI1 |

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | NFS1 | --- |
| DATA1 | ISCSI1 | NFS1 |

The following migration ended in error; however, this case is due to another bug that was also described in #8907: when migrating to an NFS storage, ACS will validate if the destination host has access to the source storage. This causes an issue when migrating from local storage to NFS storage, as the destination host will never have direct access to the source host's local storage. This bug will be fixed in another PR.

| Volume | Origin | Destination |
| ------ | ------ | ------ |
| ROOT | Local | NFS1 |
| DATA1 | Local | NFS1 |
