### PR TITLE
Go back to previous timestamp on logging

### DIFF
--- a/agent/conf/log4j-cloud.xml.in
+++ b/agent/conf/log4j-cloud.xml.in
@@ -30,7 +30,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%ex%n"/>
       </RollingFile>
 
       <!-- ============================== -->

--- a/client/conf/log4j-cloud.xml.in
+++ b/client/conf/log4j-cloud.xml.in
@@ -34,7 +34,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
       </RollingFile>
 
 
@@ -43,7 +43,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
       </RollingFile>
 
       <!-- ============================== -->
@@ -52,7 +52,7 @@ under the License.
 
       <Syslog name="SYSLOG" host="localhost" facility="LOCAL6">
          <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
       </Syslog>
 
       <!-- ============================== -->
@@ -61,7 +61,7 @@ under the License.
 
       <AlertSyslogAppender name="ALERTSYSLOG" syslogHosts="" facility="LOCAL6">
          <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex{filters(${filters})}%n"/>
       </AlertSyslogAppender>
 
       <!-- ============================== -->

--- a/plugins/hypervisors/hyperv/conf/log4j-cloud.xml.in
+++ b/plugins/hypervisors/hyperv/conf/log4j-cloud.xml.in
@@ -30,7 +30,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{3}] (%t:%x) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{3}] (%t:%x) %m%ex%n"/>
       </RollingFile>
 
       <!-- ============================== -->
@@ -39,7 +39,7 @@ under the License.
 
       <Console name="CONSOLE" target="SYSTEM_OUT">
          <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
-         <PatternLayout pattern="%d{ISO8601}{GMT} %-5p [%c{3}] (%t:%x) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT}{GMT} %-5p [%c{3}] (%t:%x) %m%ex%n"/>
       </Console>
 
    </Appenders>

--- a/plugins/user-authenticators/ldap/src/test/resources/log4j.xml
+++ b/plugins/user-authenticators/ldap/src/test/resources/log4j.xml
@@ -32,7 +32,7 @@
 
       <Console name="CONSOLE" target="SYSTEM_OUT">
          <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{3}] (%t:%x) %m%xEx{filters(${filters})}%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{3}] (%t:%x) %m%xEx{filters(${filters})}%n"/>
       </Console>
    </Appenders>
 

--- a/server/conf/log4j-cloud.xml.in
+++ b/server/conf/log4j-cloud.xml.in
@@ -31,7 +31,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) %m%ex%n"/>
       </RollingFile>
 
 
@@ -40,7 +40,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) (logid:%X{logcontextid}) %m%ex%n"/>
       </RollingFile>
 
 
@@ -49,7 +49,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{1.}] (%t:%x) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{1.}] (%t:%x) %m%ex%n"/>
       </RollingFile>
 
       <!-- ============================== -->

--- a/usage/conf/log4j-cloud_usage.xml.in
+++ b/usage/conf/log4j-cloud_usage.xml.in
@@ -39,7 +39,7 @@ under the License.
          <Policies>
             <TimeBasedTriggeringPolicy/>
          </Policies>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%ex%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%ex%n"/>
       </RollingFile>
    </Appenders>
 

--- a/utils/src/test/resources/log4j.xml
+++ b/utils/src/test/resources/log4j.xml
@@ -33,7 +33,7 @@
 
       <Console name="CONSOLE" target="SYSTEM_OUT">
          <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
-         <PatternLayout pattern="%d{ISO8601} %-5p [%c{3}] (%t:%x) %m%xEx{filters(${filters})}%n"/>
+         <PatternLayout pattern="%d{DEFAULT} %-5p [%c{3}] (%t:%x) %m%xEx{filters(${filters})}%n"/>
       </Console>
    </Appenders>
 


### PR DESCRIPTION
### Description

Before #7131, the logs' timestamp was in the `2024-04-02 22:04:28,617`, with the upgrade to log4j2, the logs' timestamp was changed to the `2024-04-02T21:55:12,724` format. This PR changes the timestamp back to the previous format.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

