### PR TITLE
[WIP] framework/db: introduce a new MySQL table based distributed lock

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 
 import com.cloud.utils.FileUtil;
 import org.apache.cloudstack.utils.CloudStackVersion;
+import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -398,6 +399,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
 
     @Override
     public void check() {
+        initDistributedLock();
         GlobalLock lock = GlobalLock.getInternLock("DatabaseUpgrade");
         try {
             s_logger.info("Grabbing lock to check for database upgrade.");
@@ -438,6 +440,39 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
             }
         } finally {
             lock.releaseRef();
+        }
+    }
+
+    private void initDistributedLock() {
+        s_logger.info("Setting up distributed lock table if not created.");
+        TransactionLegacy txn = TransactionLegacy.open("initDistributedLock");
+        txn.start();
+        String errorMessage = "Unable to get the database connections";
+        try {
+            Connection conn = txn.getConnection();
+            errorMessage = "Unable to create distributed_lock table in the 'cloud' database ";
+            String sql = "CREATE TABLE IF NOT EXISTS `cloud`.`distributed_lock` (" +
+                         "  `name` varchar(1024) NOT NULL," +
+                         "  `thread` varchar(1024) NOT NULL," +
+                         "  `ms_id` bigint NOT NULL, `pid` int NOT NULL," +
+                         "  `created` datetime DEFAULT NULL," +
+                         "  PRIMARY KEY (`name`)," +
+                         "  UNIQUE KEY `name` (`name`)" +
+                         ") ENGINE=InnoDB DEFAULT CHARSET=utf8";
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                pstmt.execute();
+            }
+            try (PreparedStatement pstmt = conn.prepareStatement("DELETE FROM cloud.distributed_lock WHERE ms_id=?")) {
+                pstmt.setLong(1, ManagementServerNode.getManagementServerId());
+                pstmt.execute();
+            }
+            txn.commit();
+        } catch (CloudRuntimeException | SQLException e) {
+            s_logger.error(e.getMessage());
+            errorMessage = String.format("%s due to %s.", errorMessage, e.getMessage());
+            throw new CloudRuntimeException(errorMessage, e);
+        } finally {
+            txn.close();
         }
     }
 

--- a/framework/db/src/main/java/com/cloud/utils/db/DbUtil.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/DbUtil.java
@@ -41,6 +41,7 @@ import javax.persistence.SecondaryTables;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
+import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.log4j.Logger;
 
 import static com.cloud.utils.AutoCloseableUtil.closeAutoCloseable;
@@ -198,28 +199,36 @@ public class DbUtil {
     public static boolean getGlobalLock(String name, int timeoutSeconds) {
         Connection conn = getConnectionForGlobalLocks(name, true);
         if (conn == null) {
-            LOGGER.error("Unable to acquire DB connection for global lock system");
+            LOGGER.error("Unable to acquire DB connection for distributed lock: " + name);
             return false;
         }
 
-        try (PreparedStatement pstmt = conn.prepareStatement("SELECT COALESCE(GET_LOCK(?, ?),0)");) {
-            pstmt.setString(1, name);
-            pstmt.setInt(2, timeoutSeconds);
-
-            try (ResultSet rs = pstmt.executeQuery();) {
-                if (rs != null && rs.first()) {
-                    if (rs.getInt(1) > 0) {
-                        return true;
-                    } else {
-                        if (LOGGER.isDebugEnabled())
-                            LOGGER.debug("GET_LOCK() timed out on lock : " + name);
-                    }
+        int remainingTime = timeoutSeconds;
+        while (remainingTime > 0) {
+            try (PreparedStatement pstmt = conn.prepareStatement(
+                    "INSERT INTO cloud.distributed_lock (name, thread, ms_id, pid, created) " +
+                    "VALUES (?, ?, ?, ?, now()) ON DUPLICATE KEY UPDATE name=name")) {
+                pstmt.setString(1, name);
+                pstmt.setString(2, Thread.currentThread().getName());
+                pstmt.setLong(3, ManagementServerNode.getManagementServerId());
+                pstmt.setLong(4, ProcessHandle.current().pid());
+                if (pstmt.executeUpdate() > 0) {
+                    return true;
                 }
+            } catch (SQLException e) {
+                LOGGER.error("Inserting to cloud.distributed_lock query threw exception ", e);
+            } catch (Throwable e) {
+                LOGGER.error("Inserting to cloud.distributed_lock query threw exception  ", e);
             }
-        } catch (SQLException e) {
-            LOGGER.error("GET_LOCK() throws exception ", e);
-        } catch (Throwable e) {
-            LOGGER.error("GET_LOCK() throws exception ", e);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Waiting, cloud.distributed_lock already has the lock: " + name);
+            }
+            remainingTime = remainingTime - 1;
+            try {
+                Thread.sleep(1000L);
+            } catch (InterruptedException ignore) {
+            }
         }
 
         removeConnectionForGlobalLocks(name);
@@ -234,24 +243,20 @@ public class DbUtil {
     public static boolean releaseGlobalLock(String name) {
         try (Connection conn = getConnectionForGlobalLocks(name, false);) {
             if (conn == null) {
-                LOGGER.error("Unable to acquire DB connection for global lock system");
+                LOGGER.error("Unable to acquire DB connection for distributed lock: " + name);
                 assert (false);
                 return false;
             }
 
-            try (PreparedStatement pstmt = conn.prepareStatement("SELECT COALESCE(RELEASE_LOCK(?), 0)");) {
+            try (PreparedStatement pstmt = conn.prepareStatement("DELETE FROM cloud.distributed_lock WHERE name=?")) {
                 pstmt.setString(1, name);
-                try (ResultSet rs = pstmt.executeQuery();) {
-                    if (rs != null && rs.first()) {
-                        return rs.getInt(1) > 0;
-                    }
-                    LOGGER.error("releaseGlobalLock:RELEASE_LOCK() returns unexpected result");
+                if (pstmt.executeUpdate() > 0) {
+                    return true;
                 }
+                LOGGER.warn("releaseGlobalLock: failed to remove cloud.distributed_lock lock which does not exist: " + name);
             }
-        } catch (SQLException e) {
-            LOGGER.error("RELEASE_LOCK() throws exception ", e);
         } catch (Throwable e) {
-            LOGGER.error("RELEASE_LOCK() throws exception ", e);
+            LOGGER.error("Removing cloud.distributed_lock lock threw exception ", e);
         }
         return false;
     }

--- a/setup/db/create-schema.sql
+++ b/setup/db/create-schema.sql
@@ -195,6 +195,7 @@ DROP TABLE IF EXISTS `cloud`.`image_data_store`;
 DROP TABLE IF EXISTS `cloud`.`vm_compute_tags`;
 DROP TABLE IF EXISTS `cloud`.`vm_root_disk_tags`;
 DROP TABLE IF EXISTS `cloud`.`vm_network_map`;
+DROP TABLE IF EXISTS `cloud`.`distributed_lock`;
 
 CREATE TABLE `cloud`.`version` (
   `id` bigint unsigned NOT NULL UNIQUE AUTO_INCREMENT COMMENT 'id',

--- a/utils/src/main/java/com/cloud/utils/net/MacAddress.java
+++ b/utils/src/main/java/com/cloud/utils/net/MacAddress.java
@@ -19,25 +19,18 @@
 
 package com.cloud.utils.net;
 
-import static com.cloud.utils.AutoCloseableUtil.closeAutoCloseable;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Enumeration;
 import java.util.Formatter;
-
-import org.apache.log4j.Logger;
 
 /**
  * This class retrieves the (first) MAC address for the machine is it is loaded on and stores it statically for retrieval.
  * It can also be used for formatting MAC addresses.
- * copied fnd addpeted rom the public domain utility from John Burkard.
  **/
 public class MacAddress {
-    private static final Logger s_logger = Logger.getLogger(MacAddress.class);
     private long _addr = 0;
 
     protected MacAddress() {
@@ -79,209 +72,45 @@ public class MacAddress {
     static {
         String macAddress = null;
 
-        Process p = null;
-        BufferedReader in = null;
-
         try {
-            String osname = System.getProperty("os.name");
-
-            if (osname.startsWith("Windows")) {
-                p = Runtime.getRuntime().exec(new String[] {"ipconfig", "/all"}, null);
-            } else if (osname.startsWith("Solaris") || osname.startsWith("SunOS")) {
-                // Solaris code must appear before the generic code
-                String hostName = MacAddress.getFirstLineOfCommand(new String[] {"uname", "-n"});
-                if (hostName != null) {
-                    p = Runtime.getRuntime().exec(new String[] {"/usr/sbin/arp", hostName}, null);
-                }
-            } else if (new File("/usr/sbin/lanscan").exists()) {
-                p = Runtime.getRuntime().exec(new String[] {"/usr/sbin/lanscan"}, null);
-            } else if (new File("/sbin/ifconfig").exists()) {
-                p = Runtime.getRuntime().exec(new String[] {"/sbin/ifconfig", "-a"}, null);
-            }
-
-            if (p != null) {
-                in = new BufferedReader(new InputStreamReader(p.getInputStream()), 128);
-                String l = null;
-                while ((l = in.readLine()) != null) {
-                    macAddress = MacAddress.parse(l);
-                    if (macAddress != null) {
-                        short parsedShortMacAddress = MacAddress.parseShort(macAddress);
-                        if (parsedShortMacAddress != 0xff && parsedShortMacAddress != 0x00)
-                            break;
-                    }
-                    macAddress = null;
-                }
-            }
-
-        } catch (SecurityException ex) {
-            s_logger.info("[ignored] security exception in static initializer of MacAddress", ex);
-        } catch (IOException ex) {
-            s_logger.info("[ignored] io exception in static initializer of MacAddress");
-        } finally {
-            if (p != null) {
-                closeAutoCloseable(in, "closing init process input stream");
-                closeAutoCloseable(p.getErrorStream(), "closing init process error output stream");
-                closeAutoCloseable(p.getOutputStream(), "closing init process std output stream");
-                p.destroy();
-            }
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements()) {
+                 NetworkInterface network = networkInterfaces.nextElement();
+                 final byte [] mac = network.getHardwareAddress();
+                 if (mac != null && !network.isVirtual() &&
+                         !network.getName().startsWith("br-") &&
+                         !network.getName().startsWith("veth") &&
+                         !network.getName().startsWith("vnet")) {
+                     StringBuilder macAddressBuilder = new StringBuilder();
+                     for (byte b : mac) {
+                         macAddressBuilder.append(String.format("%02X", b));
+                     }
+                     macAddress = macAddressBuilder.toString();
+                 }
+             }
+        } catch (SocketException ignore) {
         }
 
-        long clockSeqAndNode = 0;
+        long macAddressInLong = 0;
 
         if (macAddress != null) {
-            if (macAddress.indexOf(':') != -1) {
-                clockSeqAndNode |= MacAddress.parseLong(macAddress);
-            } else if (macAddress.startsWith("0x")) {
-                clockSeqAndNode |= MacAddress.parseLong(macAddress.substring(2));
-            }
+            macAddressInLong = Long.parseLong(macAddress, 16);
         } else {
             try {
                 byte[] local = InetAddress.getLocalHost().getAddress();
-                clockSeqAndNode |= (local[0] << 24) & 0xFF000000L;
-                clockSeqAndNode |= (local[1] << 16) & 0xFF0000;
-                clockSeqAndNode |= (local[2] << 8) & 0xFF00;
-                clockSeqAndNode |= local[3] & 0xFF;
+                macAddressInLong |= (local[0] << 24) & 0xFF000000L;
+                macAddressInLong |= (local[1] << 16) & 0xFF0000;
+                macAddressInLong |= (local[2] << 8) & 0xFF00;
+                macAddressInLong |= local[3] & 0xFF;
             } catch (UnknownHostException ex) {
-                clockSeqAndNode |= (long)(Math.random() * 0x7FFFFFFF);
+                macAddressInLong |= (long)(Math.random() * 0x7FFFFFFF);
             }
         }
 
-        s_address = new MacAddress(clockSeqAndNode);
+        s_address = new MacAddress(macAddressInLong);
     }
 
     public static MacAddress getMacAddress() {
         return s_address;
-    }
-
-    private static String getFirstLineOfCommand(String[] commands) throws IOException {
-
-        Process p = null;
-        BufferedReader reader = null;
-
-        try {
-            p = Runtime.getRuntime().exec(commands);
-            reader = new BufferedReader(new InputStreamReader(p.getInputStream()), 128);
-
-            return reader.readLine();
-        } finally {
-            if (p != null) {
-                closeAutoCloseable(reader, "closing process input stream");
-                closeAutoCloseable(p.getErrorStream(), "closing process error output stream");
-                closeAutoCloseable(p.getOutputStream(), "closing process std output stream");
-                p.destroy();
-            }
-        }
-
-    }
-
-    /**
-     * The MAC address parser attempts to find the following patterns:
-     * <ul>
-     * <li>.{1,2}:.{1,2}:.{1,2}:.{1,2}:.{1,2}:.{1,2}</li>
-     * <li>.{1,2}-.{1,2}-.{1,2}-.{1,2}-.{1,2}-.{1,2}</li>
-     * </ul>
-     *
-     * This is copied from the author below.  The author encouraged copying
-     * it.
-     *
-     */
-    static String parse(String in) {
-
-        // lanscan
-
-        int hexStart = in.indexOf("0x");
-        if (hexStart != -1) {
-            int hexEnd = in.indexOf(' ', hexStart);
-            if (hexEnd != -1) {
-                return in.substring(hexStart, hexEnd);
-            }
-        }
-
-        int octets = 0;
-        int lastIndex, old, end;
-
-        if (in.indexOf('-') > -1) {
-            in = in.replace('-', ':');
-        }
-
-        lastIndex = in.lastIndexOf(':');
-
-        if (lastIndex > in.length() - 2)
-            return null;
-
-        end = Math.min(in.length(), lastIndex + 3);
-
-        ++octets;
-        old = lastIndex;
-        while (octets != 5 && lastIndex != -1 && lastIndex > 1) {
-            lastIndex = in.lastIndexOf(':', --lastIndex);
-            if (old - lastIndex == 3 || old - lastIndex == 2) {
-                ++octets;
-                old = lastIndex;
-            }
-        }
-
-        if (octets == 5 && lastIndex > 1) {
-            return in.substring(lastIndex - 2, end).trim();
-        }
-        return null;
-    }
-
-    /**
-     * Parses a <code>long</code> from a hex encoded number. This method will skip
-     * all characters that are not 0-9 and a-f (the String is lower cased first).
-     * Returns 0 if the String does not contain any interesting characters.
-     *
-     * @param s the String to extract a <code>long</code> from, may not be <code>null</code>
-     * @return a <code>long</code>
-     * @throws NullPointerException if the String is <code>null</code>
-     */
-    private static long parseLong(String s) throws NullPointerException {
-        s = s.toLowerCase();
-        long out = 0;
-        byte shifts = 0;
-        char c;
-        for (int i = 0; i < s.length() && shifts < 16; i++) {
-            c = s.charAt(i);
-            if ((c > 47) && (c < 58)) {
-                out <<= 4;
-                ++shifts;
-                out |= c - 48;
-            } else if ((c > 96) && (c < 103)) {
-                ++shifts;
-                out <<= 4;
-                out |= c - 87;
-            }
-        }
-        return out;
-    }
-
-    /**
-     * Parses a <code>short</code> from a hex encoded number. This method will skip
-     * all characters that are not 0-9 and a-f (the String is lower cased first).
-     * Returns 0 if the String does not contain any interesting characters.
-     *
-     * @param s the String to extract a <code>short</code> from, may not be <code>null</code>
-     * @return a <code>short</code>
-     * @throws NullPointerException if the String is <code>null</code>
-     */
-    private static short parseShort(String s) throws NullPointerException {
-        s = s.toLowerCase();
-        short out = 0;
-        byte shifts = 0;
-        char c;
-        for (int i = 0; i < s.length() && shifts < 4; i++) {
-            c = s.charAt(i);
-            if ((c > 47) && (c < 58)) {
-                out <<= 4;
-                ++shifts;
-                out |= c - 48;
-            } else if ((c > 96) && (c < 103)) {
-                ++shifts;
-                out <<= 4;
-                out |= c - 87;
-            }
-        }
-        return out;
     }
 }

--- a/utils/src/test/java/com/cloud/utils/net/MacAddressTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/MacAddressTest.java
@@ -41,14 +41,14 @@ public class MacAddressTest {
     public final void testMacAddressToLong() throws Exception {
         // TODO this test should fail this address is beyond the acceptable range for macaddresses
         MacAddress mac = new MacAddress(Long.MAX_VALUE);
-        assertEquals(Long.MAX_VALUE,mac.toLong());
+        assertEquals(Long.MAX_VALUE, mac.toLong());
         System.out.println(mac.toString());
     }
 
-    // TODO    public final void testToLong() throws Exception {
-    // TODO    public final void testToByteArray() throws Exception {
-    // TODO    public final void testToStringString() throws Exception {
-    // TODO    public final void testToString() throws Exception {
-    // TODO    public final void testGetMacAddress() throws Exception {
-    // TODO    public final void testParse() throws Exception {
+    @Test
+    public final void testSpecificMacAddress() throws Exception {
+        // Test specific mac address 76:3F:76:EB:02:81
+        MacAddress mac = new MacAddress(130014950130305L);
+        assertEquals("76:3f:76:eb:02:81", mac.toString());
+    }
 }


### PR DESCRIPTION
This introduces a MySQL innodb table based distributed lock which can be used by one or more management server and its threads. This removes usage of MySQL server provided locking functions (GET_LOCK, RELEASE_LOCK) which are not replicated or [not supported](https://docs.percona.com/percona-xtradb-cluster/8.0/limitation.html) currently by any MySQL clustering solutions. This would be the first main step in having CloudStack to work with a MySQL clustering solution such as InnoDB cluster, Percona Xtradb cluster, MariaDB galera cluster. There may be other changes required which can be found in due course if this feature works at scale.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

In a local setup against simulator & mvn, in a single management server no exception were seen. Most tests need to be done such as:

- simulator based smoketests which is one mvn-run of mgmt server + one mysql db server
- smoketests (test matrix) which tests largely one mgmt server + one mysql db server
- multiple (say 3) mgmt servers + one mysql db server
- multiple (say 3) mgmt servers + mysql db cluster with say 3 nodes