### PR TITLE
api: listApis should return params based on caller

### DIFF
--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/response/ApiDiscoveryResponse.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/response/ApiDiscoveryResponse.java
@@ -16,13 +16,14 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.cloud.serializer.Param;
-import com.google.gson.annotations.SerializedName;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 
-import java.util.HashSet;
-import java.util.Set;
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 @SuppressWarnings("unused")
 public class ApiDiscoveryResponse extends BaseResponse {
@@ -62,6 +63,18 @@ public class ApiDiscoveryResponse extends BaseResponse {
         params = new HashSet<ApiParameterResponse>();
         apiResponse = new HashSet<ApiResponseResponse>();
         isAsync = false;
+    }
+
+    public ApiDiscoveryResponse(ApiDiscoveryResponse another) {
+        this.name = another.getName();
+        this.description = another.getDescription();
+        this.since = another.getSince();
+        this.isAsync = another.getAsync();
+        this.related = another.getRelated();
+        this.params = new HashSet<>(another.getParams());
+        this.apiResponse = new HashSet<>(another.getApiResponse());
+        this.type = another.getType();
+        this.setObjectName(another.getObjectName());
     }
 
     public void setName(String name) {
@@ -122,5 +135,9 @@ public class ApiDiscoveryResponse extends BaseResponse {
 
     public Set<ApiResponseResponse> getApiResponse() {
         return apiResponse;
+    }
+
+    public String getType() {
+        return type;
     }
 }

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/response/ApiParameterResponse.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/api/response/ApiParameterResponse.java
@@ -16,12 +16,14 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 
 import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 public class ApiParameterResponse extends BaseResponse {
     @SerializedName(ApiConstants.NAME)
@@ -51,6 +53,8 @@ public class ApiParameterResponse extends BaseResponse {
     @SerializedName("related")
     @Param(description = "comma separated related apis to get the parameter")
     private String related;
+
+    private transient List<RoleType> authorizedRoleTypes = null;
 
     public ApiParameterResponse() {
     }
@@ -87,4 +91,11 @@ public class ApiParameterResponse extends BaseResponse {
         this.related = related;
     }
 
+    public void setAuthorizedRoleTypes(List<RoleType> authorizedRoleTypes) {
+        this.authorizedRoleTypes = authorizedRoleTypes;
+    }
+
+    public List<RoleType> getAuthorizedRoleTypes() {
+        return authorizedRoleTypes;
+    }
 }

--- a/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/main/java/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -18,8 +18,10 @@ package org.apache.cloudstack.discovery;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,21 +30,22 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.acl.APIChecker;
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RoleService;
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.BaseAsyncCmd;
 import org.apache.cloudstack.api.BaseAsyncCreateCmd;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.Parameter;
-import org.apache.cloudstack.acl.Role;
-import org.apache.cloudstack.acl.RoleService;
-import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.command.user.discovery.ListApisCmd;
 import org.apache.cloudstack.api.response.ApiDiscoveryResponse;
 import org.apache.cloudstack.api.response.ApiParameterResponse;
 import org.apache.cloudstack.api.response.ApiResponseResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.reflections.ReflectionUtils;
@@ -217,6 +220,9 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
                     paramResponse.setSince(parameterAnnotation.since());
                 }
                 paramResponse.setRelated(parameterAnnotation.entityType()[0].getName());
+                if (parameterAnnotation.authorized() != null) {
+                    paramResponse.setAuthorizedRoleTypes(Arrays.asList(parameterAnnotation.authorized()));
+                }
                 response.addParam(paramResponse);
             }
         }
@@ -249,6 +255,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
 
         if (user == null)
             return null;
+        Account account = accountService.getAccount(user.getAccountId());
 
         if (name != null) {
             if (!s_apiNameDiscoveryResponseMap.containsKey(name))
@@ -262,10 +269,9 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
                     return null;
                 }
             }
-            responseList.add(s_apiNameDiscoveryResponseMap.get(name));
+            responseList.add(getApiDiscoveryResponseWithAccessibleParams(name, account));
 
         } else {
-            Account account = accountService.getAccount(user.getAccountId());
             if (account == null) {
                 throw new PermissionDeniedException(String.format("The account with id [%s] for user [%s] is null.", user.getAccountId(), user));
             }
@@ -286,11 +292,31 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
             }
 
             for (String apiName: apisAllowed) {
-                responseList.add(s_apiNameDiscoveryResponseMap.get(apiName));
+                responseList.add(getApiDiscoveryResponseWithAccessibleParams(apiName, account));
             }
         }
         response.setResponses(responseList);
         return response;
+    }
+
+    private static ApiDiscoveryResponse getApiDiscoveryResponseWithAccessibleParams(String name, Account account) {
+        if (Account.Type.ADMIN.equals(account.getType())) {
+            return s_apiNameDiscoveryResponseMap.get(name);
+        }
+        ApiDiscoveryResponse apiDiscoveryResponse =
+                new ApiDiscoveryResponse(s_apiNameDiscoveryResponseMap.get(name));
+        Iterator<ApiParameterResponse> iterator = apiDiscoveryResponse.getParams().iterator();
+        while (iterator.hasNext()) {
+            ApiParameterResponse parameterResponse = iterator.next();
+            List<RoleType> authorizedRoleTypes = parameterResponse.getAuthorizedRoleTypes();
+            RoleType accountRoleType = RoleType.getByAccountType(account.getType());
+            if (CollectionUtils.isNotEmpty(parameterResponse.getAuthorizedRoleTypes()) &&
+                    accountRoleType != null &&
+                    !authorizedRoleTypes.contains(accountRoleType)) {
+                iterator.remove();
+            }
+        }
+        return apiDiscoveryResponse;
     }
 
     @Override


### PR DESCRIPTION
### Description

API params can be marked accessible to selected role types using  `authorized` values in API command class.
The existing behaviour of lisApis API was to return all parameters of the API irrespective of the caller's role type. This PR fixes it by adding checks to filter params.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->

Tested by setting an API param as,
```
    @Parameter(name = ApiConstants.SCOPE, type = BaseCmd.CommandType.STRING, description = "Scope of the Webhook",
        authorized = {RoleType.Admin, RoleType.DomainAdmin})
    private String scope;
```

Using cmk,

```
(localcloud) 🐱 > set username admin
(localcloud) 🐱 > sync
Discovered 766 APIs
(localcloud) 🐱 > list apis name=createWebhook filter=name,params
{
  "api": [
    {
      "name": "createWebhook",
      "params": [
        {
          "description": "an optional domainId for the Webhook. If the account parameter is used, domainId must also be used.",
          "length": 255,
          "name": "domainid",
          "related": "listDomainChildren,listDomains",
          "required": false,
          "type": "uuid"
        },
        {
          "description": "Project for the Webhook",
          "length": 255,
          "name": "projectid",
          "related": "activateProject,suspendProject",
          "required": false,
          "type": "uuid"
        },
        {
          "description": "An optional account for the Webhook. Must be used with domainId.",
          "length": 255,
          "name": "account",
          "required": false,
          "type": "string"
        },
        {
          "description": "Scope of the Webhook",
          "length": 255,
          "name": "scope",
          "required": false,
          "type": "string"
        },
        {
          "description": "Secret key of the Webhook",
          "length": 255,
          "name": "secretkey",
          "required": false,
          "type": "string"
        },
        {
          "description": "If set to true then SSL verification will be done for the Webhook otherwise not",
          "length": 255,
          "name": "sslverification",
          "required": false,
          "type": "boolean"
        },
        {
          "description": "Payload URL of the Webhook",
          "length": 255,
          "name": "payloadurl",
          "required": true,
          "type": "string"
        },
        {
          "description": "State of the Webhook",
          "length": 255,
          "name": "state",
          "required": false,
          "type": "string"
        },
        {
          "description": "Name for the Webhook",
          "length": 255,
          "name": "name",
          "required": true,
          "type": "string"
        },
        {
          "description": "Description for the Webhook",
          "length": 255,
          "name": "description",
          "required": false,
          "type": "string"
        }
      ]
    }
  ],
  "count": 1
}
(localcloud) 🐱 > set username user
(localcloud) 🐱 > sync
Discovered 340 APIs
(localcloud) 🐱 > list apis name=createWebhook filter=name,params
{
  "api": [
    {
      "name": "createWebhook",
      "params": [
        {
          "description": "an optional domainId for the Webhook. If the account parameter is used, domainId must also be used.",
          "length": 255,
          "name": "domainid",
          "related": "listDomainChildren,listDomains",
          "required": false,
          "type": "uuid"
        },
        {
          "description": "Project for the Webhook",
          "length": 255,
          "name": "projectid",
          "related": "activateProject,suspendProject",
          "required": false,
          "type": "uuid"
        },
        {
          "description": "An optional account for the Webhook. Must be used with domainId.",
          "length": 255,
          "name": "account",
          "required": false,
          "type": "string"
        },
        {
          "description": "Secret key of the Webhook",
          "length": 255,
          "name": "secretkey",
          "required": false,
          "type": "string"
        },
        {
          "description": "If set to true then SSL verification will be done for the Webhook otherwise not",
          "length": 255,
          "name": "sslverification",
          "required": false,
          "type": "boolean"
        },
        {
          "description": "Payload URL of the Webhook",
          "length": 255,
          "name": "payloadurl",
          "required": true,
          "type": "string"
        },
        {
          "description": "State of the Webhook",
          "length": 255,
          "name": "state",
          "required": false,
          "type": "string"
        },
        {
          "description": "Name for the Webhook",
          "length": 255,
          "name": "name",
          "required": true,
          "type": "string"
        },
        {
          "description": "Description for the Webhook",
          "length": 255,
          "name": "description",
          "required": false,
          "type": "string"
        }
      ]
    }
  ],
  "count": 1
}

```