### PR TITLE
Fix null host tags while creating a zone

### DIFF
--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -1358,7 +1358,7 @@ export default {
       hostData.clusterid = this.stepData.clusterReturned.id
       hostData.hypervisor = this.stepData.clusterReturned.hypervisortype
       hostData.clustertype = this.stepData.clusterReturned.clustertype
-      hostData.hosttags = this.prefillContent?.hostTags || null
+      hostData.hosttags = this.prefillContent?.hostTags || ''
       hostData.username = this.prefillContent?.hostUserName || null
       hostData.password = hostPassword
       const hostname = this.prefillContent?.hostName || null


### PR DESCRIPTION
### Description

In the UI, during zone creation, if a new host is created without specifying host tags, ACS adds the `null` tag to it automatically.

This behaviour has been fixed, making it so that no host tags are added in this situation 


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### How Has This Been Tested?

I created a zone through the UI without specifying host tags and verified that no tags were added.

I also created while specifying host tags and verified that they were added accordingly 
