### PR TITLE
Show menu section if user has access to at least one of its pages

### DIFF
--- a/ui/src/config/router.js
+++ b/ui/src/config/router.js
@@ -51,14 +51,13 @@ function generateRouterMap (section) {
       icon: section.icon,
       docHelp: vueProps.$applyDocHelpMappings(section.docHelp),
       searchFilters: section.searchFilters,
-      related: section.related
+      related: section.related,
+      section: true
     },
     component: shallowRef(RouteView)
   }
 
   if (section.children && section.children.length > 0) {
-    map.redirect = '/' + section.children[0].name
-    map.meta.permission = section.children[0].permission
     map.children = []
     for (const child of section.children) {
       if ('show' in child && !child.show()) {


### PR DESCRIPTION
### Description

As reported in https://github.com/apache/cloudstack/pull/8713#issuecomment-1969866705, the Storage section in the sidebar is not displayed to users when they do not have permission to the API `listVolumesMetrics`. However, roles can have permissions to other APIs, such as `listBackups` and `listSnapshots`, in which case the section should be displayed. This situation is not exclusive to the Storage section.

This PR fixes this issue by changing how the routes are filtered. Now, sections will be shown if they have at least one visible child. For other routes, the previous logic is still applied.

Closes #8730.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Here's how the menu looks like before (left) and after the changes (right) for a user that does not have permission for `listVolumesMetrics`:

![Screenshot from 2024-04-25 10-50-04](https://github.com/apache/cloudstack/assets/25729641/2eef414e-15d4-4391-97a2-8f190a168906)


### How Has This Been Tested?

1. I created a role `v`, based on the role `User`, that had access to `listSnapshots` and `listBuckets`, but did not have to `listVolumesMetrics`;
2. I created an account `v` using role `v`;
3. I accessed the UI using account `v`;
4. I verified that the Storage section was shown, having the Volume Snapshots and Buckets pages;
5. I verified that the other sections did not change;
6. I clicked the Storage section and verified that I was redirected to the Volume Snapshots page;
7. I denied `listSnaphots` and `listBuckets` for role `v`;
8. I logged out, cleared my cache and logged in again. I verified that the Storage section was not shown anymore.