### PR TITLE
Add password enabled during ISO register and update

### DIFF
--- a/ui/src/config/section/image.js
+++ b/ui/src/config/section/image.js
@@ -231,7 +231,7 @@ export default {
         }
         return fields
       },
-      details: ['name', 'id', 'displaytext', 'checksum', 'ostypename', 'size', 'bootable', 'isready', 'directdownload', 'isextractable', 'ispublic', 'isfeatured', 'crosszones', 'account', 'domain', 'created', 'userdatadetails', 'userdatapolicy', 'url'],
+      details: ['name', 'id', 'displaytext', 'checksum', 'ostypename', 'size', 'bootable', 'isready', 'passwordenabled', 'directdownload', 'isextractable', 'ispublic', 'isfeatured', 'crosszones', 'account', 'domain', 'created', 'userdatadetails', 'userdatapolicy', 'url'],
       searchFilters: () => {
         var filters = ['name', 'zoneid', 'tags']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {

--- a/ui/src/views/image/RegisterOrUploadIso.vue
+++ b/ui/src/views/image/RegisterOrUploadIso.vue
@@ -250,6 +250,12 @@
           </template>
           <a-switch v-model:checked="form.isfeatured" />
         </a-form-item>
+        <a-form-item ref="passwordenabled" name="passwordenabled" v-if="currentForm === 'Create'">
+          <template #label>
+            <tooltip-label :title="$t('label.passwordenabled')" :tooltip="apiParams.passwordenabled.description"/>
+          </template>
+          <a-switch v-model:checked="form.passwordenabled" />
+        </a-form-item>
 
         <div :span="24" class="action-button">
           <a-button @click="closeAction">{{ $t('label.cancel') }}</a-button>
@@ -332,7 +338,8 @@ export default {
       this.form = reactive({
         bootable: true,
         isextractable: false,
-        ispublic: false
+        ispublic: false,
+        passwordenabled: false
       })
       this.rules = reactive({
         url: [{ required: true, message: this.$t('label.upload.iso.from.local') }],

--- a/ui/src/views/image/UpdateISO.vue
+++ b/ui/src/views/image/UpdateISO.vue
@@ -42,6 +42,12 @@
             :placeholder="apiParams.displaytext.description"
             autoFocus />
         </a-form-item>
+        <a-form-item name="passwordenabled" ref="passwordenabled">
+          <template #label>
+            <tooltip-label :title="$t('label.passwordenabled')" :tooltip="apiParams.passwordenabled.description"/>
+          </template>
+          <a-switch v-model:checked="form.passwordenabled" />
+        </a-form-item>
 
         <a-form-item name="ostypeid" ref="ostypeid" :label="$t('label.ostypeid')">
           <a-select
@@ -162,7 +168,7 @@ export default {
         displaytext: [{ required: true, message: this.$t('message.error.required.input') }],
         ostypeid: [{ required: true, message: this.$t('message.error.select') }]
       })
-      const resourceFields = ['name', 'displaytext', 'ostypeid', 'userdataid', 'userdatapolicy']
+      const resourceFields = ['name', 'displaytext', 'passwordenabled', 'ostypeid', 'userdataid', 'userdatapolicy']
 
       for (var field of resourceFields) {
         var fieldValue = this.resource[field]


### PR DESCRIPTION
### Description

The parameter `passwordenabled` is available on the APIs that register and update ISOs, however, it had not been added to the UI yet.

This parameter was added to the UI, making it possible to specify it when registering/updating ISOs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details><summary>Before</summary>

![image](https://github.com/apache/cloudstack/assets/49285692/0255b9af-84b3-43c6-82c1-547ec76e6361)

![image](https://github.com/apache/cloudstack/assets/49285692/3b21042e-1c24-4a35-8939-fa14825c808e)

</details>


<details><summary>After</summary>

![image](https://github.com/apache/cloudstack/assets/49285692/c7116516-cf5b-4f97-98a3-028e452ce222)

![image](https://github.com/apache/cloudstack/assets/49285692/4ef3b5a9-78aa-4e03-bd72-9f189d25198c)

</details>





### How Has This Been Tested?

