### PR TITLE
ui: add support to change Account role for admins

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1767,6 +1767,7 @@
 "label.restore.volume.attach": "Restore volume and attach",
 "label.review": "Review",
 "label.role": "Role",
+"label.roleid": "Role",
 "label.rolename": "Role",
 "label.roles": "Roles",
 "label.roletype": "Role Type",

--- a/ui/src/config/section/account.js
+++ b/ui/src/config/section/account.js
@@ -91,7 +91,7 @@ export default {
       icon: 'edit-outlined',
       label: 'label.action.edit.account',
       dataView: true,
-      args: ['newname', 'account', 'domainid', 'networkdomain'],
+      args: ['newname', 'account', 'domainid', 'networkdomain', 'roleid'],
       mapping: {
         account: {
           value: (record) => { return record.name }


### PR DESCRIPTION
This allow admins to change role of an account via UI by changing the `roleid` param to the updateAccount API/form.

This fixes #7756 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<img width="593" alt="Screenshot 2024-04-30 at 4 48 32 PM" src="https://github.com/apache/cloudstack/assets/95203/c2f050e4-ef5c-4430-b1d6-7d984552b27c">