### PR TITLE
ui: change reporting link to Github Discussions

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1613,7 +1613,7 @@
 "label.removing": "Removing",
 "label.replace.acl": "Replace ACL",
 "label.replace.acl.list": "Replace ACL list",
-"label.report.bug": "Report issue",
+"label.report.bug": "Ask a question or Report an issue",
 "label.required": "Required",
 "label.requireshvm": "HVM",
 "label.requiresupgrade": "Requires upgrade",

--- a/ui/src/components/page/GlobalFooter.vue
+++ b/ui/src/components/page/GlobalFooter.vue
@@ -23,7 +23,7 @@
     <div class="line" v-if="$store.getters.userInfo.roletype === 'Admin'">
       CloudStack {{ $store.getters.features.cloudstackversion }}
       <a-divider type="vertical" />
-      <a href="https://github.com/apache/cloudstack/issues/new" target="_blank">
+      <a href="https://github.com/apache/cloudstack/discussions" target="_blank">
         <github-outlined />
         {{ $t('label.report.bug') }}
       </a>


### PR DESCRIPTION
Many users are using the footer link to create Github issues about CloudStack that are usually discussed on the users@ mailing list. This created a large number of bogus issues that aren't bugs. We want to encourage engagement but not create non-issue issues.

This fixes that behaviour by diverting them to Github Discussions which are linked with the user@ ML, smart users can still report actual bugs/issues via the issues tab. Any user starting a discussions would encourage that interaction and such queries are sent to users@ ML for others to help the user.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial