### PR TITLE
server,test: fix resourceid for VOLUME.DESTROY in restore VM

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -7909,7 +7909,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
                 // Detach, destroy and create the usage event for the old root volume.
                 _volsDao.detachVolume(root.getId());
-                _volumeService.destroyVolume(root.getId(), caller, Volume.State.Allocated.equals(root.getState()) || expunge, false);
+                destroyVolumeInContext(vm, Volume.State.Allocated.equals(root.getState()) || expunge, root);
 
                 // For VMware hypervisor since the old root volume is replaced by the new root volume, force expunge old root volume if it has been created in storage
                 if (vm.getHypervisorType() == HypervisorType.VMware) {

--- a/test/integration/smoke/test_events_resource.py
+++ b/test/integration/smoke/test_events_resource.py
@@ -116,6 +116,7 @@ class TestEventsResource(cloudstackTestCase):
             self.services["domain"],
             parentdomainid=self.domain.id
         )
+        self.cleanup.append(domain1)
         self.services["domainid"] = domain1.id
 
         account = Account.create(
@@ -123,6 +124,7 @@ class TestEventsResource(cloudstackTestCase):
             self.services["account"],
             domainid=domain1.id
         )
+        self.cleanup.append(account)
 
         account_network = Network.create(
             self.apiclient,
@@ -130,6 +132,7 @@ class TestEventsResource(cloudstackTestCase):
             account.name,
             account.domainid
         )
+        self.cleanup.append(account_network)
         virtual_machine = VirtualMachine.create(
             self.apiclient,
             self.services,
@@ -138,6 +141,7 @@ class TestEventsResource(cloudstackTestCase):
             networkids=account_network.id,
             serviceofferingid=self.service_offering.id
         )
+        self.cleanup.append(virtual_machine)
         volume = Volume.create(
             self.apiclient,
             self.services,
@@ -146,6 +150,7 @@ class TestEventsResource(cloudstackTestCase):
             domainid=account.domainid,
             diskofferingid=self.disk_offering.id
         )
+        self.cleanup.append(volume)
         virtual_machine.attach_volume(
             self.apiclient,
             volume
@@ -157,15 +162,20 @@ class TestEventsResource(cloudstackTestCase):
         time.sleep(self.services["sleep"])
         virtual_machine.detach_volume(self.apiclient, volume)
         volume.delete(self.apiclient)
+        self.cleanup.remove(volume)
         ts = str(time.time())
         virtual_machine.update(self.apiclient, displayname=ts)
         virtual_machine.delete(self.apiclient)
+        self.cleanup.remove(virtual_machine)
         account_network.update(self.apiclient, name=account_network.name + ts)
         account_network.delete(self.apiclient)
+        self.cleanup.remove(account_network)
         account.update(self.apiclient, newname=account.name + ts)
         account.disable(self.apiclient)
         account.delete(self.apiclient)
+        self.cleanup.remove(account)
         domain1.delete(self.apiclient)
+        self.cleanup.remove(domain1)
 
         cmd = listEvents.listEventsCmd()
         cmd.startdate = start_time
@@ -185,8 +195,9 @@ class TestEventsResource(cloudstackTestCase):
         for event in events:
             if event.type.startswith("VM.") or (event.type.startswith("NETWORK.") and not event.type.startswith("NETWORK.ELEMENT")) or event.type.startswith("VOLUME.") or event.type.startswith("ACCOUNT.") or event.type.startswith("DOMAIN.") or event.type.startswith("TEMPLATE."):
                 if event.resourceid is None or event.resourcetype is None:
-                    self.debug("Failed event:: %s" % json.dumps(event, indent=2))
-                    self.fail("resourceid or resourcetype for the event not found!")
+                    event_json = json.dumps(event.__dict__, indent=2)
+                    self.debug("Failed event:: %s" % event_json)
+                    self.fail("resourceid or resourcetype not found for the event: %s" % event_json)
                 else:
                     self.debug("Event %s at %s:: Resource Type: %s, Resource ID: %s" % (event.type, event.created, event.resourcetype, event.resourceid))
 


### PR DESCRIPTION
### Description

Destroys old ROOT volume for the VM to be restored in its own context to allow event to be published with resourceid. Fixes exception in test_event_resources.py
Fixes failures seen in:
https://github.com/apache/cloudstack/pull/8601#issuecomment-2078654228
https://github.com/apache/cloudstack/pull/8601#issuecomment-2079018980
https://github.com/apache/cloudstack/pull/8601#issuecomment-2079141241

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
