### PR TITLE
Change exception when orchestrating VM start

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -5418,7 +5418,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         try {
             orchestrateStart(vm.getUuid(), work.getParams(), work.getPlan(), _dpMgr.getDeploymentPlannerByName(work.getDeploymentPlanner()));
         } catch (CloudRuntimeException e){
-            logger.error(String.format("Unable to orchestrate start %s due to [%s].", vm, e.getMessage()));
+            logger.error("Unable to orchestrate start {} due to [{}].", vm, e.getMessage());
             CloudRuntimeException ex = new CloudRuntimeException(String.format("Unable to orchestrate the start of VM instance %s.",
                     ReflectionToStringBuilderUtils.reflectOnlySelectedFields(vm, "instanceName", "uuid")));
             return new Pair<>(JobInfo.Status.FAILED, JobSerializerHelper.toObjectSerializedString(ex));

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -93,6 +93,7 @@ import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.cloudstack.vm.UnmanagedVMsManager;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -5417,9 +5418,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         try {
             orchestrateStart(vm.getUuid(), work.getParams(), work.getPlan(), _dpMgr.getDeploymentPlannerByName(work.getDeploymentPlanner()));
         } catch (CloudRuntimeException e){
-            String message = String.format("Unable to orchestrate start %s due to [%s].", vm.toString(), e.getMessage());
-            logger.warn(message, e);
-            CloudRuntimeException ex = new CloudRuntimeException(message);
+            logger.error(String.format("Unable to orchestrate start %s due to [%s].", vm, e.getMessage()));
+            CloudRuntimeException ex = new CloudRuntimeException(String.format("Unable to orchestrate the start of VM instance %s.",
+                    ReflectionToStringBuilderUtils.reflectOnlySelectedFields(vm, "instanceName", "uuid")));
             return new Pair<>(JobInfo.Status.FAILED, JobSerializerHelper.toObjectSerializedString(ex));
         }
         return new Pair<>(JobInfo.Status.SUCCEEDED, null);


### PR DESCRIPTION
### Description

When attempting to start a VM, if an error occurs, the exception displayed to users is the same as what is being logged, which can expose information about the environment.

This PR addresses this issue by keeping the current message to be sent to the logs and adding a new one for the exception shown to users.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):


<details>
    <summary>Exception before the proposed changes</summary>

  ![old-exception](https://github.com/apache/cloudstack/assets/56271185/32498ee2-892e-403c-a862-fb8c875e1cc4)
</details>

<details>
    <summary>Exception after the proposed changes</summary>

  
![new-exception](https://github.com/apache/cloudstack/assets/56271185/39f8902c-8fc8-46c3-be33-11da49b3b842)

</details>

### How Has This Been Tested?

Using a stopped VM, I changed the _Compute Offering_ to a offering with `Host Tags` incompatible with every host in my environment in order to force the exception, then I tried to start the VM. An exception was thrown as shown in the screenshots above.

I also checked the logs in both cases and the only changes was log level and the removal of a duplicated message at the end of the log related to the exception.

Old log:

```
2024-05-06T19:19:34,582 WARN [c.c.v.ClusteredVirtualMachineManagerImpl] (Work-Job-Executor-35:[ctx-613c449f, job-326/job-327, ctx-6739b946]) (logid:c2b5e46f) Unable to orchestrate start VM instance {"id":32,"instanceName":"i-2-32-VM","type":"User","uuid":"0447f7cc-d6be-4999-875b-391ecf529fe4"} due to [No suitable host found.]. com.cloud.utils.exception.CloudRuntimeException: No suitable host found.
```

New log:

```
2024-05-07T18:26:38,697 ERROR [c.c.v.ClusteredVirtualMachineManagerImpl] (Work-Job-Executor-69:[ctx-73d78bb7, job-563/job-564, ctx-1b492476]) (logid:55146be5) Unable to orchestrate start VM instance {"id":47,"instanceName":"i-2-47-VM","type":"User","uuid":"e07b123d-51b2-4c5e-845c-880da28b7518"} due to [No suitable host found.].
```