### PR TITLE
Decrypt account and domain configurations when needed

### DIFF
--- a/engine/schema/src/main/java/com/cloud/domain/dao/DomainDetailsDao.java
+++ b/engine/schema/src/main/java/com/cloud/domain/dao/DomainDetailsDao.java
@@ -31,4 +31,6 @@ public interface DomainDetailsDao extends GenericDao<DomainDetailVO, Long> {
     void deleteDetails(long domainId);
 
     void update(long domainId, Map<String, String> details);
+
+    String getActualValue(DomainDetailVO domainDetailVO);
 }

--- a/engine/schema/src/main/java/com/cloud/user/AccountDetailsDao.java
+++ b/engine/schema/src/main/java/com/cloud/user/AccountDetailsDao.java
@@ -34,4 +34,6 @@ public interface AccountDetailsDao extends GenericDao<AccountDetailVO, Long> {
      * they will get created
      */
     void update(long accountId, Map<String, String> details);
+
+    String getActualValue(AccountDetailVO accountDetailVO);
 }


### PR DESCRIPTION
### Description

This PR fixes an issue when using the LDAP integration with ACS. PR #6812 normalized the account and domain configurations to only encrypt the values with configurations in the `Hidden` and `Secure` categories. However, that PR failed to address the use of these configurations. This resulted in using the encrypted value of the configuration, when it should decrypt it first, as observed in issue #8637.

This problem was fixed by adding the method `getActualValue()` that checks if the configurations in the Account and Domain are in the `Hidden` and `Secure` categories, and decrypting it, if needed.

**NOTE:** For users that manually set the configurations `ldap.bind.password` and `ldap.truststore.password` to a plain value in order to fix the faulty behaviour, it is required to store them encrypted. It will not be possible to update the configuration via UI, as an exception will be thrown when ACS tries to decrypt the plain value. To fix this, it is required to set the password again for ACS to encrypt it. There are two options:

- Manually set the configuration via CloudMonkey, for example `update configuration domainid=<domain-uuid> name="ldap.bind.password" value="password"`;
- Or, removing the defined configuration through the database via the query `DELETE from cloud.domain_details WHERE name like "%ldap%password%"`, and setting the configuration via UI for the affected domains.

Fixes #8637 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
In a lab with version 4.19.0 installed, I configured an LDAP server and tried to create and LDAP account, which resulted in the following error `LDAP: error code 49 - Invalid Credentials`. After applying the changes in this patch, no exception was thrown, and the accounts in the LDAP server were correctly listed.