### PR TITLE
framework/config: make logic in ::value() defensive

### DIFF
--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -211,7 +211,7 @@ public class ConfigKey<T> {
 
     public T value() {
         if (_value == null || isDynamic()) {
-            ConfigurationVO vo = s_depot != null ? s_depot.global().findById(key()) : null;
+            ConfigurationVO vo = (s_depot != null && s_depot.global() != null) ? s_depot.global().findById(key()) : null;
             final String value = (vo != null && vo.getValue() != null) ? vo.getValue() : defaultValue();
             _value = ((value == null) ? (T)defaultValue() : valueOf(value));
         }

--- a/framework/config/src/test/java/org/apache/cloudstack/framework/config/ConfigKeyScheduledExecutionWrapperTest.java
+++ b/framework/config/src/test/java/org/apache/cloudstack/framework/config/ConfigKeyScheduledExecutionWrapperTest.java
@@ -20,7 +20,6 @@ import com.cloud.utils.concurrency.NamedThreadFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.concurrent.Executors;
@@ -59,8 +58,8 @@ public class ConfigKeyScheduledExecutionWrapperTest {
     @Test(expected = IllegalArgumentException.class)
     public void invalidConfigKeyTest() {
         TestRunnable runnable = new TestRunnable();
-        ConfigKey<String> configKey = Mockito.mock(ConfigKey.class);
-        when(configKey.value()).thenReturn("test");
+        ConfigKey<String> configKey = new ConfigKey<>(String.class, "test", "test", "test", "test", true,
+                ConfigKey.Scope.Global, null, null, null, null, null, ConfigKey.Kind.CSV, null);
         ConfigKeyScheduledExecutionWrapper runner = new ConfigKeyScheduledExecutionWrapper(executorService, runnable, configKey, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
### Description

This adds a NPE check on the s_depot.global() which can cause NPE in
case of unit tests, where s_depot is not null but the underlying config
dao is null (not mocked or initialised) via `s_depot.global()` becomes
null.

Related to:
#9103
#8916

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [x] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial