### PR TITLE
Fix NPE when sending copy command to least busy SSVM

### DIFF
--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -536,7 +536,7 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
 
     private List<Long> ssvmWithLeastMigrateJobs() {
         logger.debug("Picking ssvm from the pool with least commands running on it");
-        String query = "select host_id, count(*) from cmd_exec_log group by host_id order by 2;";
+        String query = "select cel.host_id, count(*) from cmd_exec_log cel join host h on cel.host_id = h.id where h.removed is NULL group by cel.host_id order by 2;";
         TransactionLegacy txn = TransactionLegacy.currentTxn();
 
         List<Long> result = new ArrayList<Long>();


### PR DESCRIPTION
### Description

In order to copy an object from a secondary storage to another, the MS sends a copy command to the least busy SSVM; however, removed SSVMs are considered when listing the SSVMs ordered by the quantity of commands being executed. This way, if there are commands that have not finished properly in a removed SSVM, a NPE occurs when sending the copy command if the "least busy" SSVM has been removed.

This PRs fixes the NPE.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?

1. I initiated a data migration between secondary storages;
2. I verified that the `cmd_exec_log` table had one entry for a command sent to the SSVM;
3. Before the data migration finished, I deleted the SSVM;
4. I verified that the `cmd_exec_log` still had one entry for the removed SSVM;
5. I waited until another SSVM was created;
6. I initiated another data migration between secondary storages.

Before the changes, step 6 would result in a NPE, as the removed SSVM was sometimes chosen as the least busy SSVM.

```bash
2024-05-24T12:41:47,662 DEBUG [o.a.c.s.i.SecondaryStorageServiceImpl] (pool-19-thread-2:[]) (logid:) Failed to copy Data java.lang.NullPointerException: Cannot invoke "com.cloud.host.Host.getId()" because "host" is null
	at org.apache.cloudstack.storage.RemoteHostEndPoint.configure(RemoteHostEndPoint.java:76)
	at org.apache.cloudstack.storage.RemoteHostEndPoint.getHypervisorHostEndPoint(RemoteHostEndPoint.java:90)
	at org.apache.cloudstack.storage.endpoint.DefaultEndPointSelector.getEndPointFromHostId(DefaultEndPointSelector.java:454)
	at org.apache.cloudstack.storage.image.BaseImageStoreDriverImpl.sendToLeastBusyEndpoint(BaseImageStoreDriverImpl.java:439)
	at org.apache.cloudstack.storage.image.BaseImageStoreDriverImpl.copyAsync(BaseImageStoreDriverImpl.java:413)
	at org.apache.cloudstack.storage.image.BaseImageStoreDriverImpl.copyAsync(BaseImageStoreDriverImpl.java:422)
	at org.apache.cloudstack.storage.motion.DataMotionServiceImpl.copyAsync(DataMotionServiceImpl.java:70)
	at org.apache.cloudstack.storage.motion.DataMotionServiceImpl.copyAsync(DataMotionServiceImpl.java:117)
	at org.apache.cloudstack.storage.image.SecondaryStorageServiceImpl.migrateJob(SecondaryStorageServiceImpl.java:167)
	at org.apache.cloudstack.storage.image.SecondaryStorageServiceImpl.migrateData(SecondaryStorageServiceImpl.java:124)
	at org.apache.cloudstack.engine.orchestration.StorageOrchestrator$MigrateDataTask.call(StorageOrchestrator.java:560)
	at org.apache.cloudstack.engine.orchestration.StorageOrchestrator$MigrateDataTask.call(StorageOrchestrator.java:529)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

After applying the changes, step 6 does not throw a NPE, as the removed SSVM is not considered when listing the SSVMs anymore.