### PR TITLE
Differentiate between instalation ISO and attached ISO

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -520,7 +520,7 @@
           </span>
         </div>
         <div class="resource-detail-item" v-if="resource.templateid">
-          <div class="resource-detail-item__label">{{ $t('label.templatename') }}</div>
+          <div class="resource-detail-item__label">{{ resource.templateformat === 'ISO'? $t('label.iso') : $t('label.templatename') }}</div>
           <div class="resource-detail-item__details">
             <resource-icon v-if="resource.icon" :image="getImage(resource.icon.base64image)" size="1x" style="margin-right: 5px"/>
             <SaveOutlined v-else />
@@ -528,7 +528,7 @@
           </div>
         </div>
         <div class="resource-detail-item" v-if="resource.isoid">
-          <div class="resource-detail-item__label">{{ $t('label.iso') }}</div>
+          <div class="resource-detail-item__label">{{ $t('label.isoname') }}</div>
           <div class="resource-detail-item__details">
             <resource-icon v-if="resource.icon" :image="getImage(resource.icon.base64image)" size="1x" style="margin-right: 5px"/>
             <UsbOutlined v-else />


### PR DESCRIPTION
### Description

When a VM has been created using an ISO, its infocard will label the ISO as `Template`. Additionally, any ISO attached to it will be labeled as `ISO`. This behaviour may cause confusion, causing users to believe the installation ISO is a template, or the attached ISO was the installation media.

To solve this, the label of the installation media has been edited to be either `Template` or `ISO` depending on its format and the label of the attached ISO has been modified to `Attached ISO`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):


<details><summary>Before</summary>

![image](https://github.com/apache/cloudstack/assets/49285692/3d6066b1-b99a-420f-8249-93cf1ffd80c2)

![image](https://github.com/apache/cloudstack/assets/49285692/e3b1ab5e-89ec-4dc5-8603-df6504fbfb04)


</details>


<details><summary>After</summary>

![image](https://github.com/apache/cloudstack/assets/49285692/14920c57-9153-4457-be4f-d9cdd7f8c7f8)

![image](https://github.com/apache/cloudstack/assets/49285692/db7c3323-cc8a-4a3d-8237-6b1a691a21b2)

</details>
