### PR TITLE
Fix columns in VM details tabs

### DIFF
--- a/ui/src/components/view/ListResourceTable.vue
+++ b/ui/src/components/view/ListResourceTable.vue
@@ -41,21 +41,20 @@
           <template v-if="column.key === col">
             <router-link :set="routerlink = routerlinks(record)" :to="{ path: routerlink[col] }" >{{ text }}</router-link>
           </template>
+
+          <template v-else-if="['state', 'status'].includes(column.key)">
+            <status :text="text ? text : ''" />{{ text }}
+          </template>
+
+          <template v-else-if="column.key === 'created'">
+            {{ $toLocaleDate(text) }}
+          </template>
+
+          <template v-else>
+            {{ text }}
+          </template>
         </div>
-
-        <template v-if="column.key === 'state'">
-          <status :text="text ? text : ''" />{{ text }}
-        </template>
-
-        <template v-if="column.key === 'status'">
-          <status :text="text ? text : ''" />{{ text }}
-        </template>
       </template>
-
-      <template v-slot:created="{ item }">
-        {{ $toLocaleDate(item) }}
-      </template>
-
     </a-table>
 
     <div v-if="!defaultPagination" style="display: block; text-align: right; margin-top: 10px;">


### PR DESCRIPTION
### Description
When accessing the `Backups` or `Instance snapshots` tabs through the VM details, there are some columns that show no data (created column for example).

This PR aims to fix this and populate these columns with their respective data.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![Screenshot from 2024-05-09 17-42-48](https://github.com/apache/cloudstack/assets/39202678/0714c84c-1c80-48c8-bc8e-cac6334f44f5)

![Screenshot from 2024-05-09 17-43-03](https://github.com/apache/cloudstack/assets/39202678/c921784d-e864-4736-904f-29f6e32036c7)

### How Has This Been Tested?
I followed the same steps from `How did you try to break this feature and the system with this change?` then I verified that all columns presented data.

#### How did you try to break this feature and the system with this change?

1. In the UI, create a backup and a VM snapshot to a VM;
2. Access the `Backups` and `Instance snapshots` tabs in the VM page;
3. Some columns in these tabs will be blank.