### PR TITLE
fix: domain limits tab ui is now able to present 0 to the user

### DIFF
--- a/ui/src/components/view/ResourceLimitTab.vue
+++ b/ui/src/components/view/ResourceLimitTab.vue
@@ -112,7 +112,7 @@ export default {
         this.formLoading = true
         this.dataResource = await this.listResourceLimits(params)
         this.dataResource.forEach(item => {
-          form[item.resourcetype] = item.max || -1
+          form[item.resourcetype] = item.max == null ? -1 : item.max 
         })
         this.form = form
         this.formRef.value.resetFields()

--- a/ui/src/components/view/ResourceLimitTab.vue
+++ b/ui/src/components/view/ResourceLimitTab.vue
@@ -112,7 +112,7 @@ export default {
         this.formLoading = true
         this.dataResource = await this.listResourceLimits(params)
         this.dataResource.forEach(item => {
-          form[item.resourcetype] = item.max == null ? -1 : item.max 
+          form[item.resourcetype] = item.max == null ? -1 : item.max
         })
         this.form = form
         this.formRef.value.resetFields()


### PR DESCRIPTION
### Description

If the user configured a limit to 0 on the Domain's "Configure Limits" tab,  after submitting, the value would return to -1. This was only a bug in the UI as the value was actually saved in the back-end.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):
Before the changes:
![Screenshot from 2024-06-03 11-36-35](https://github.com/apache/cloudstack/assets/55457416/1ccdb2ed-e439-4844-bebe-ac75ebcfc4fc)
After changing the value to 0 and submitting, the value returned to -1:
![Screenshot from 2024-06-03 11-36-42](https://github.com/apache/cloudstack/assets/55457416/0bf3fb03-d87d-4ca5-966c-07e463c130e6)

After the UI fix, the value 0 keeps being shown after submission:
![Screenshot from 2024-06-03 12-31-52](https://github.com/apache/cloudstack/assets/55457416/d8504424-577f-41cb-97d3-91929b450fa8)




### How Has This Been Tested?

Before the changes made, after creating a test domain and accessing the limit settings in the Configure limits tab, when changing some default setting from -1 to 0 and clicking the submit button, the resource limit would return to -1 on the UI.
With the changes, changing a limit value from -1 to 0 and pressing the Submit button, 0 was shown in the UI. The information in the resource preview tab was also checked, confirming that the changes had taken effect on the back end.