### PR TITLE
ui: only deny option in project role permissions

### DIFF
--- a/ui/src/views/iam/PermissionEditable.vue
+++ b/ui/src/views/iam/PermissionEditable.vue
@@ -25,7 +25,7 @@
     :filterOption="(input, option) => {
       return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
     }" >
-    <a-select-option value="allow" :label="$t('label.allow')">{{ $t('label.allow') }}</a-select-option>
+    <a-select-option v-if="allowOptionAllowed" value="allow" :label="$t('label.allow')">{{ $t('label.allow') }}</a-select-option>
     <a-select-option value="deny" :label="$t('label.deny')">{{ $t('label.deny') }}</a-select-option>
   </a-select>
 </template>
@@ -36,6 +36,10 @@ export default {
     defaultValue: {
       type: String,
       required: true
+    },
+    allowOptionAllowed: {
+      type: Boolean,
+      default: true
     }
   },
   data () {

--- a/ui/src/views/project/iam/ProjectRolePermissionTab.vue
+++ b/ui/src/views/project/iam/ProjectRolePermissionTab.vue
@@ -40,6 +40,7 @@
         <div class="rules-table__col rules-table__col--permission">
           <permission-editable
             :defaultValue="newRulePermission"
+            :allowOptionAllowed="false"
             @onChange="onPermissionChange(null, $event)" />
         </div>
         <div class="rules-table__col rules-table__col--description">


### PR DESCRIPTION
### Description

Addresses #9071

As project roles are considered restrictive in nature than it is better to not provide an allow option in role permission to prevent confusion for the operator.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
