### PR TITLE
VMware: Improve error messaging / logs when starting non-user VMs, and secondary storage not available or doesn't have enough capacity

### DIFF
--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/manager/ImageStoreProviderManagerImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/manager/ImageStoreProviderManagerImpl.java
@@ -201,7 +201,7 @@ public class ImageStoreProviderManagerImpl implements ImageStoreProviderManager,
 
         // No store with space found
         s_logger.error(String.format("Can't find an image storage in zone with less than %d usage",
-                Math.round(_statsCollector.getImageStoreCapacityThreshold()*100)));
+                Math.round(_statsCollector.getImageStoreCapacityThreshold() * 100)));
         return null;
     }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -562,7 +562,6 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
 
     @Override
     public Pair<String, Long> getSecondaryStorageStoreUrlAndId(long dcId) {
-
         String secUrl = null;
         Long secId = null;
         DataStore secStore = _dataStoreMgr.getImageStoreWithFreeCapacity(dcId);
@@ -572,18 +571,18 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         }
 
         if (secUrl == null) {
-            // we are using non-NFS image store, then use cache storage instead
-            s_logger.info("Secondary storage is not NFS, we need to use staging storage");
+            // image stores doesn't have enough capacity or we are using non-NFS image store, then use cache storage instead
+            s_logger.info("Secondary storage is either not having free capacity or not NFS, we need to use staging storage");
             DataStore cacheStore = _dataStoreMgr.getImageCacheStore(dcId);
             if (cacheStore != null) {
                 secUrl = cacheStore.getUri();
                 secId = cacheStore.getId();
             } else {
-                s_logger.warn("No staging storage is found when non-NFS secondary storage is used");
+                s_logger.warn("No staging storage is found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used");
             }
         }
 
-        return new Pair<String, Long>(secUrl, secId);
+        return new Pair<>(secUrl, secId);
     }
 
     @Override
@@ -599,13 +598,13 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         }
 
         if (urlIdList.isEmpty()) {
-            // we are using non-NFS image store, then use cache storage instead
-            s_logger.info("Secondary storage is not NFS, we need to use staging storage");
+            // image stores doesn't have enough capacity or we are using non-NFS image store, then use cache storage instead
+            s_logger.info("Secondary storage is either not having free capacity or not NFS, we need to use staging storage");
             DataStore cacheStore = _dataStoreMgr.getImageCacheStore(dcId);
             if (cacheStore != null) {
                 urlIdList.add(new Pair<>(cacheStore.getUri(), cacheStore.getId()));
             } else {
-                s_logger.warn("No staging storage is found when non-NFS secondary storage is used");
+                s_logger.warn("No staging storage is found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used");
             }
         }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -571,14 +571,13 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         }
 
         if (secUrl == null) {
-            // image stores doesn't have enough capacity or we are using non-NFS image store, then use cache storage instead
-            s_logger.info("Secondary storage is either not having free capacity or not NFS, we need to use staging storage");
+            s_logger.info("Secondary storage is either not having free capacity or not NFS, then use cache/staging storage instead");
             DataStore cacheStore = _dataStoreMgr.getImageCacheStore(dcId);
             if (cacheStore != null) {
                 secUrl = cacheStore.getUri();
                 secId = cacheStore.getId();
             } else {
-                s_logger.warn("No staging storage is found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used");
+                s_logger.warn("No cache/staging storage found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used");
             }
         }
 
@@ -598,13 +597,12 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         }
 
         if (urlIdList.isEmpty()) {
-            // image stores doesn't have enough capacity or we are using non-NFS image store, then use cache storage instead
-            s_logger.info("Secondary storage is either not having free capacity or not NFS, we need to use staging storage");
+            s_logger.info("Secondary storage is either not having free capacity or not NFS, then use cache/staging storage instead");
             DataStore cacheStore = _dataStoreMgr.getImageCacheStore(dcId);
             if (cacheStore != null) {
                 urlIdList.add(new Pair<>(cacheStore.getUri(), cacheStore.getId()));
             } else {
-                s_logger.warn("No staging storage is found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used");
+                s_logger.warn("No cache/staging storage found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used");
             }
         }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2281,7 +2281,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 Pair<String, Long> secStoreUrlAndId = mgr.getSecondaryStorageStoreUrlAndId(Long.parseLong(_dcId));
                 String secStoreUrl = secStoreUrlAndId.first();
                 if (secStoreUrl == null) {
-                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (less than %d usage) or not ready yet, or non-NFS secondary storage is used",
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d usage threshold) or not ready yet, or non-NFS secondary storage is used",
                             _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
@@ -4615,7 +4615,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             for (Pair<String, Long> secStoreUrlAndId : secStoreUrlAndIdList) {
                 String secStoreUrl = secStoreUrlAndId.first();
                 if (secStoreUrl == null) {
-                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (less than %d usage) or not ready yet, or non-NFS secondary storage is used",
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d usage threshold) or not ready yet, or non-NFS secondary storage is used",
                             _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
@@ -7344,7 +7344,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 Pair<String, Long> secStoreUrlAndId = mgr.getSecondaryStorageStoreUrlAndId(Long.parseLong(_dcId));
                 String secStoreUrl = secStoreUrlAndId.first();
                 if (secStoreUrl == null) {
-                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (less than %d usage) or not ready yet, or non-NFS secondary storage is used",
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d usage threshold) or not ready yet, or non-NFS secondary storage is used",
                             _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import javax.naming.ConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import com.cloud.capacity.CapacityManager;
 import com.cloud.hypervisor.vmware.mo.HostDatastoreBrowserMO;
 import com.vmware.vim25.FileInfo;
 import com.vmware.vim25.FileQueryFlags;
@@ -2279,15 +2280,15 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 // attach ISO (for patching of system VM)
                 Pair<String, Long> secStoreUrlAndId = mgr.getSecondaryStorageStoreUrlAndId(Long.parseLong(_dcId));
                 String secStoreUrl = secStoreUrlAndId.first();
-                Long secStoreId = secStoreUrlAndId.second();
                 if (secStoreUrl == null) {
-                    String msg = "secondary storage for dc " + _dcId + " is not ready yet?";
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (less than %d usage) or not ready yet, or non-NFS secondary storage is used",
+                            _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
 
                 ManagedObjectReference morSecDs = prepareSecondaryDatastoreOnHost(secStoreUrl);
                 if (morSecDs == null) {
-                    String msg = "Failed to prepare secondary storage on host, secondary store url: " + secStoreUrl;
+                    String msg = "Failed to prepare secondary storage on host, NFS secondary or cache store url: " + secStoreUrl + " in dc "+ _dcId;
                     throw new Exception(msg);
                 }
                 DatastoreMO secDsMo = new DatastoreMO(hyperHost.getContext(), morSecDs);
@@ -4613,15 +4614,15 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             List<Pair<String, Long>> secStoreUrlAndIdList = mgr.getSecondaryStorageStoresUrlAndIdList(Long.parseLong(_dcId));
             for (Pair<String, Long> secStoreUrlAndId : secStoreUrlAndIdList) {
                 String secStoreUrl = secStoreUrlAndId.first();
-                Long secStoreId = secStoreUrlAndId.second();
                 if (secStoreUrl == null) {
-                    String msg = String.format("Secondary storage for dc %s is not ready yet?", _dcId);
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (less than %d usage) or not ready yet, or non-NFS secondary storage is used",
+                            _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
 
                 ManagedObjectReference morSecDs = prepareSecondaryDatastoreOnHost(secStoreUrl);
                 if (morSecDs == null) {
-                    String msg = "Failed to prepare secondary storage on host, secondary store url: " + secStoreUrl;
+                    String msg = "Failed to prepare secondary storage on host, NFS secondary or cache store url: " + secStoreUrl + " in dc "+ _dcId;
                     throw new Exception(msg);
                 }
             }
@@ -7342,14 +7343,14 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 VmwareManager mgr = targetHyperHost.getContext().getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
                 Pair<String, Long> secStoreUrlAndId = mgr.getSecondaryStorageStoreUrlAndId(Long.parseLong(_dcId));
                 String secStoreUrl = secStoreUrlAndId.first();
-                Long secStoreId = secStoreUrlAndId.second();
                 if (secStoreUrl == null) {
-                    String msg = "secondary storage for dc " + _dcId + " is not ready yet?";
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (less than %d usage) or not ready yet, or non-NFS secondary storage is used",
+                            _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
                 ManagedObjectReference morSecDs = prepareSecondaryDatastoreOnSpecificHost(secStoreUrl, targetHyperHost);
                 if (morSecDs == null) {
-                    throw new Exception(String.format("Failed to prepare secondary storage on host, secondary store url: %s", secStoreUrl));
+                    throw new Exception(String.format("Failed to prepare secondary storage on host, NFS secondary or cache store url: %s in dc %s", secStoreUrl, _dcId));
                 }
             }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2281,7 +2281,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 Pair<String, Long> secStoreUrlAndId = mgr.getSecondaryStorageStoreUrlAndId(Long.parseLong(_dcId));
                 String secStoreUrl = secStoreUrlAndId.first();
                 if (secStoreUrl == null) {
-                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d usage threshold) or not ready yet, or non-NFS secondary storage is used",
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d%% usage threshold) or not ready yet, or non-NFS secondary storage is used",
                             _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
@@ -4615,7 +4615,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             for (Pair<String, Long> secStoreUrlAndId : secStoreUrlAndIdList) {
                 String secStoreUrl = secStoreUrlAndId.first();
                 if (secStoreUrl == null) {
-                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d usage threshold) or not ready yet, or non-NFS secondary storage is used",
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d%% usage threshold) or not ready yet, or non-NFS secondary storage is used",
                             _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }
@@ -7344,7 +7344,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 Pair<String, Long> secStoreUrlAndId = mgr.getSecondaryStorageStoreUrlAndId(Long.parseLong(_dcId));
                 String secStoreUrl = secStoreUrlAndId.first();
                 if (secStoreUrl == null) {
-                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d usage threshold) or not ready yet, or non-NFS secondary storage is used",
+                    String msg = String.format("NFS secondary or cache storage of dc %s either doesn't have enough capacity (has reached %d%% usage threshold) or not ready yet, or non-NFS secondary storage is used",
                             _dcId, Math.round(CapacityManager.SecondaryStorageCapacityThreshold.value() * 100));
                     throw new Exception(msg);
                 }


### PR DESCRIPTION
### Description

This PR improves error messaging / logs when starting non-user VMs in VMware, and secondary storage not available or doesn't have enough capacity. It addresses inappropriate messages part 2, 3 in #8390.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Set the config `secondary.storage.capacity.threshold`to below the available secondary storage capacity, stop SSVM and start it. SSVM will fail to start with the below logs.

<img width="965" alt="SSVMStartFailed_NoSecStorageCapacity" src="https://github.com/apache/cloudstack/assets/12028987/071b6bdd-fe96-4d3d-b3bd-30f0c1518779">

```
2024-06-24 21:24:59,152 WARN  [c.c.s.StatsCollector] (DirectAgent-35:ctx-1a4ece48 10.0.35.32, job-65/job-66, cmd: StartCommand) (logid:1c0be4ca) Image storage [1] has not enough capacity. Capacity: total=[1 TB], used=[1 TB], threshold=[20.000000298023224%].
2024-06-24 21:24:59,152 INFO  [c.c.h.v.m.VmwareManagerImpl] (DirectAgent-35:ctx-1a4ece48 10.0.35.32, job-65/job-66, cmd: StartCommand) (logid:1c0be4ca) Secondary storage is either not having free capacity or not NFS, then use cache/staging storage instead
2024-06-24 21:24:59,154 WARN  [c.c.h.v.m.VmwareManagerImpl] (DirectAgent-35:ctx-1a4ece48 10.0.35.32, job-65/job-66, cmd: StartCommand) (logid:1c0be4ca) No cache/staging storage found when NFS secondary storage with free capacity not available or non-NFS secondary storage is used
2024-06-24 21:24:59,155 INFO  [c.c.h.v.u.VmwareHelper] (DirectAgent-35:ctx-1a4ece48 10.0.35.32, job-65/job-66, cmd: StartCommand) (logid:1c0be4ca) [ignored]failed to get message for exception: NFS secondary or cache storage of dc 1 either doesn't have enough capacity (has reached 20% usage threshold) or not ready yet, or non-NFS secondary storage is used
2024-06-24 21:24:59,155 ERROR [c.c.h.v.r.VmwareResource] (DirectAgent-35:ctx-1a4ece48 10.0.35.32, job-65/job-66, cmd: StartCommand) (logid:1c0be4ca) StartCommand failed due to [Exception: java.lang.Exception
Message: NFS secondary or cache storage of dc 1 either doesn't have enough capacity (has reached 20% usage threshold) or not ready yet, or non-NFS secondary storage is used
].
java.lang.Exception: NFS secondary or cache storage of dc 1 either doesn't have enough capacity (has reached 20% usage threshold) or not ready yet, or non-NFS secondary storage is used
	at com.cloud.hypervisor.vmware.resource.VmwareResource.execute(VmwareResource.java:2286)
	at com.cloud.hypervisor.vmware.resource.VmwareResource.executeRequest(VmwareResource.java:566)

```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
