### PR TITLE
xenserver: attach regular iso with configdrive

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -2710,7 +2710,7 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
                 String description = isoSR.getNameDescription(conn);
                 if (description.endsWith(ConfigDrive.CONFIGDRIVEDIR)) {
                     throw new CloudRuntimeException(String.format("VM %s already has %s ISO attached. Please " +
-                            "stop-start VM for allowing attaching both ISOs", vmName, ConfigDrive.CONFIGDRIVEDIR));
+                            "stop-start VM to allow attaching-detaching both ISOs", vmName, ConfigDrive.CONFIGDRIVEDIR));
                 }
             } catch (XenAPIException | XmlRpcException e) {
                 throw new CloudRuntimeException(String.format("Unable to retrieve name description for the already " +

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -62,6 +62,7 @@ import org.apache.cloudstack.diagnostics.DiagnosticsService;
 import org.apache.cloudstack.hypervisor.xenserver.ExtraConfigurationUtility;
 import org.apache.cloudstack.storage.command.browser.ListDataStoreObjectsAnswer;
 import org.apache.cloudstack.storage.command.browser.ListDataStoreObjectsCommand;
+import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.cloudstack.utils.security.ParserUtils;
@@ -221,6 +222,8 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
     private final static int USER_DEVICE_START_ID = 3;
 
     private final static String VM_NAME_ISO_SUFFIX = "-ISO";
+
+    private final static String VM_NAME_CONFIGDRIVE_ISO_SUFFIX = "-CONFIGDRIVE-ISO";
 
     private final static String VM_FILE_ISO_SUFFIX = ".iso";
     public final static int DEFAULTDOMRSSHPORT = 3922;
@@ -1020,12 +1023,13 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
     protected SR createIsoSRbyURI(final Connection conn, final URI uri, final String vmName, final boolean shared) {
         try {
             final Map<String, String> deviceConfig = new HashMap<String, String>();
+            final boolean isConfigDrive = uri.toString().endsWith(ConfigDrive.CONFIGDRIVEDIR);
             String path = uri.getPath();
             path = path.replace("//", "/");
             deviceConfig.put("location", uri.getHost() + ":" + path);
             final Host host = Host.getByUuid(conn, _host.getUuid());
             final SR sr = SR.create(conn, host, deviceConfig, new Long(0), uri.getHost() + path, "iso", "iso", "iso", shared, new HashMap<String, String>());
-            sr.setNameLabel(conn, vmName + "-ISO");
+            sr.setNameLabel(conn, vmName + (isConfigDrive ? VM_NAME_CONFIGDRIVE_ISO_SUFFIX: VM_NAME_ISO_SUFFIX));
             sr.setNameDescription(conn, deviceConfig.get("location"));
 
             sr.scan(conn);
@@ -2648,9 +2652,10 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
         return scsiid;
     }
 
-    public SR getISOSRbyVmName(final Connection conn, final String vmName) {
+    public SR getISOSRbyVmName(final Connection conn, final String vmName, boolean isConfigDrive) {
         try {
-            final Set<SR> srs = SR.getByNameLabel(conn, vmName + "-ISO");
+            final Set<SR> srs = SR.getByNameLabel(conn, vmName +
+                    (isConfigDrive ? VM_NAME_CONFIGDRIVE_ISO_SUFFIX : VM_NAME_ISO_SUFFIX));
             if (srs.size() == 0) {
                 return null;
             } else if (srs.size() == 1) {
@@ -2697,9 +2702,20 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
         } catch (final URISyntaxException e) {
             throw new CloudRuntimeException("isoURL is wrong: " + isoURL);
         }
-        isoSR = getISOSRbyVmName(conn, vmName);
+        isoSR = getISOSRbyVmName(conn, vmName, false);
         if (isoSR == null) {
             isoSR = createIsoSRbyURI(conn, uri, vmName, false);
+        } else {
+            try {
+                String description = isoSR.getNameDescription(conn);
+                if (description.endsWith(ConfigDrive.CONFIGDRIVEDIR)) {
+                    throw new CloudRuntimeException(String.format("VM %s already has %s ISO attached. Please " +
+                            "stop-start VM for allowing attaching both ISOs", vmName, ConfigDrive.CONFIGDRIVEDIR));
+                }
+            } catch (XenAPIException | XmlRpcException e) {
+                throw new CloudRuntimeException(String.format("Unable to retrieve name description for the already " +
+                        "attached ISO on VM %s", vmName));
+            }
         }
 
         final String isoName = isoURL.substring(index + 1);
@@ -5667,7 +5683,7 @@ public abstract class CitrixResourceBase extends ServerResourceBase implements S
             s_logger.debug("Attaching config drive iso device for the VM " + vmName + " In host " + ipAddr);
             Set<VM> vms = VM.getByNameLabel(conn, vmName);
 
-            SR sr = getSRByNameLabel(conn, vmName + VM_NAME_ISO_SUFFIX);
+            SR sr = getSRByNameLabel(conn, vmName + VM_NAME_CONFIGDRIVE_ISO_SUFFIX);
             //Here you will find only two vdis with the <vmname>.iso.
             //one is from source host and second from dest host
             Set<VDI> vdis = VDI.getByNameLabel(conn, vmName + VM_FILE_ISO_SUFFIX);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStopCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStopCommandWrapper.java
@@ -144,8 +144,10 @@ public final class CitrixStopCommandWrapper extends CommandWrapper<StopCommand, 
                                 networks.add(vif.getNetwork(conn));
                             }
                             vm.destroy(conn);
-                            final SR sr = citrixResourceBase.getISOSRbyVmName(conn, command.getVmName());
+                            final SR sr = citrixResourceBase.getISOSRbyVmName(conn, command.getVmName(), false);
                             citrixResourceBase.removeSR(conn, sr);
+                            final SR configDriveSR = citrixResourceBase.getISOSRbyVmName(conn, command.getVmName(), true);
+                            citrixResourceBase.removeSR(conn, configDriveSR);
                             // Disable any VLAN networks that aren't used
                             // anymore
                             for (final Network network : networks) {


### PR DESCRIPTION
### Description

Fixes #7902

This PR allows attaching a regular ISO to a VM when it already has the config drive ISO attached.
Config-drive ISO is now attached with the SR name-label `<VM-NAME>-CONFIGDRIVE-ISO`. While regular ISOs continue to attach with SR name-label `<VM-NAME>-ISO`. VM which already have the configdrive ISO attached before this fix will return an appropriate error and will need to be stopped-start.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- Deploy a network with configdrive for userdata service
- Deploy a VM for the network
- Try attaching an ISO to the VM

```
(localcloud) 🐱 > list networks id=9aa54302-2812-426e-bddb-654df195360b 
{
  "count": 1,
  "network": [
    {
      "account": "admin",
      "acltype": "Account",
      "broadcastdomaintype": "Vlan",
      "broadcasturi": "vlan://2158",
      "canusefordeploy": true,
      "created": "2024-06-11T07:03:14+0000",
      "details": {},
      "displaynetwork": true,
      "displaytext": "configdrive-l2",
      "dns1": "10.0.32.1",
      "dns2": "8.8.8.8",
      "domain": "ROOT",
      "domainid": "5a4b4766-1e62-11ef-b827-1e00120002d6",
      "hasannotations": false,
      "id": "9aa54302-2812-426e-bddb-654df195360b",
      "ispersistent": false,
      "issystem": false,
      "name": "configdrive-l2",
      "networkofferingavailability": "Optional",
      "networkofferingconservemode": true,
      "networkofferingdisplaytext": "Offering for L2 networks with config drive user data",
      "networkofferingid": "5f51a33c-e0cb-498b-812d-e9677556fdad",
      "networkofferingname": "DefaultL2NetworkOfferingConfigDrive",
      "physicalnetworkid": "19579c81-1bf9-4491-bbe9-769f87f9c903",
      "privatemtu": 1500,
      "publicmtu": 1500,
      "receivedbytes": 0,
      "redundantrouter": false,
      "related": "9aa54302-2812-426e-bddb-654df195360b",
      "restartrequired": false,
      "sentbytes": 0,
      "service": [
        {
          "capability": [],
          "name": "UserData",
          "provider": [
            {
              "name": "ConfigDrive"
            }
          ]
        }
      ],
      "specifyipranges": false,
      "state": "Implemented",
      "strechedl2subnet": false,
      "supportsvmautoscaling": false,
      "tags": [],
      "traffictype": "Guest",
      "type": "L2",
      "vlan": "2158",
      "zoneid": "87ab94de-5701-4aa0-8253-fcefac217440",
      "zonename": "ref-trl-6722-x-M7-abhishek-kumar"
    }
  ]
}
(localcloud) 🐱 > deploy virtualmachine zoneid=87ab94de-5701-4aa0-8253-fcefac217440 serviceofferingid=51ac121c-987b-446b-9e51-a383f30f8156 
💩 Missing required parameters:  templateid
(localcloud) 🐱 > deploy virtualmachine zoneid=87ab94de-5701-4aa0-8253-fcefac217440 serviceofferingid=51ac121c-987b-446b-9e51-a383f30f8156 templateid=a698f5ea-e51a-403c-a7be-22d5f6eaa11b networkids=9aa54302-2812-426e-bddb-654df195360b 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2024-06-12T12:14:56+0000",
    "details": {
      "cpuOvercommitRatio": "2.0",
      "hypervisortoolsversion": "false",
      "memoryOvercommitRatio": "1.0"
    },
    "displayname": "VM-45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "5a4b4766-1e62-11ef-b827-1e00120002d6",
    "guestosid": "8170a0ea-d54d-4cb9-b6a6-9d7652960164",
    "haenable": false,
    "hasannotations": false,
    "hostcontrolstate": "Enabled",
    "hostid": "d1b1d524-2445-4b23-aa24-0632d159e518",
    "hostname": "ref-trl-6722-x-M7-abhishek-kumar-xs1",
    "hypervisor": "XenServer",
    "id": "45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0",
    "instancename": "i-2-9-VM",
    "isdynamicallyscalable": false,
    "jobid": "67a99814-cbbf-4b50-a275-ff416a58ba0b",
    "jobstatus": 0,
    "lastupdated": "2024-06-12T12:15:10+0000",
    "memory": 512,
    "name": "VM-45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0",
    "nic": [
      {
        "broadcasturi": "vlan://2158",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "a85752da-bcc5-4ea2-80bc-0765c6b19ccf",
        "isdefault": true,
        "isolationuri": "vlan://2158",
        "macaddress": "02:01:00:ce:00:02",
        "networkid": "9aa54302-2812-426e-bddb-654df195360b",
        "networkname": "configdrive-l2",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "Debian GNU/Linux 12 (64-bit)",
    "ostypeid": "8170a0ea-d54d-4cb9-b6a6-9d7652960164",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "51ac121c-987b-446b-9e51-a383f30f8156",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "debian12-dummy",
    "templateformat": "VHD",
    "templateid": "a698f5ea-e51a-403c-a7be-22d5f6eaa11b",
    "templatename": "debian12-dummy",
    "templatetype": "USER",
    "userid": "78617ce4-1e62-11ef-b827-1e00120002d6",
    "username": "admin",
    "zoneid": "87ab94de-5701-4aa0-8253-fcefac217440",
    "zonename": "ref-trl-6722-x-M7-abhishek-kumar"
  }
}
(localcloud) 🐱 > list isos id=a42b25fc-cb1f-4447-b611-d3ccf015338c 
{
  "count": 1,
  "iso": [
    {
      "account": "admin",
      "bits": 64,
      "bootable": false,
      "checksum": "18a24183958339cb0508a9e27abd81494514469529bf1a4dd0cbc8a3c4d502a94400e6c58b6d54d5043eb2100946f6e85dd7032bc12642e4ab2e8907ed88dbcb",
      "created": "2024-06-11T09:11:40+0000",
      "crossZones": true,
      "directdownload": false,
      "displaytext": "tiny",
      "domain": "ROOT",
      "domainid": "5a4b4766-1e62-11ef-b827-1e00120002d6",
      "downloaddetails": [
        {
          "datastore": "NFS://10.0.32.4/acs/secondary/ref-trl-6722-x-M7-abhishek-kumar/ref-trl-6722-x-M7-abhishek-kumar-sec1",
          "datastoreId": "8d56f359-39a2-46f3-b429-5eb959c69d23",
          "datastoreRole": "Image",
          "downloadPercent": "100",
          "downloadState": "DOWNLOADED"
        }
      ],
      "hasannotations": false,
      "id": "a42b25fc-cb1f-4447-b611-d3ccf015338c",
      "isdynamicallyscalable": false,
      "isextractable": false,
      "isfeatured": true,
      "ispublic": true,
      "isready": true,
      "name": "tiny",
      "ostypeid": "5a6dadec-1e62-11ef-b827-1e00120002d6",
      "ostypename": "None",
      "passwordenabled": false,
      "size": 16777216,
      "status": "Successfully Installed",
      "tags": [],
      "url": "http://10.0.3.122/openvm/cloudstack/iso/TinyCore-8.0.iso",
      "zoneid": "87ab94de-5701-4aa0-8253-fcefac217440",
      "zonename": "ref-trl-6722-x-M7-abhishek-kumar"
    }
  ]
}
(localcloud) 🐱 > attach iso virtualmachineid=45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0 id=a42b25fc-cb1f-4447-b611-d3ccf015338c 
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "cpuused": "0%",
    "created": "2024-06-12T12:14:56+0000",
    "details": {
      "cpuOvercommitRatio": "2.0",
      "hypervisortoolsversion": "false",
      "memoryOvercommitRatio": "1.0"
    },
    "diskioread": 0,
    "diskiowrite": 0,
    "diskkbsread": 0,
    "diskkbswrite": 0,
    "displayname": "VM-45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "5a4b4766-1e62-11ef-b827-1e00120002d6",
    "guestosid": "8170a0ea-d54d-4cb9-b6a6-9d7652960164",
    "haenable": false,
    "hasannotations": false,
    "hostcontrolstate": "Enabled",
    "hostid": "d1b1d524-2445-4b23-aa24-0632d159e518",
    "hostname": "ref-trl-6722-x-M7-abhishek-kumar-xs1",
    "hypervisor": "XenServer",
    "id": "45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0",
    "instancename": "i-2-9-VM",
    "isdynamicallyscalable": false,
    "isodisplaytext": "tiny",
    "isoid": "a42b25fc-cb1f-4447-b611-d3ccf015338c",
    "isoname": "tiny",
    "jobid": "c65c5e10-7666-48df-88ba-fa46ffc946ef",
    "jobstatus": 0,
    "lastupdated": "2024-06-12T12:15:10+0000",
    "memory": 512,
    "memoryintfreekbs": 0,
    "memorykbs": 0,
    "memorytargetkbs": 0,
    "name": "VM-45ef2ec2-f890-4cb1-8a2f-27aa364c6cf0",
    "networkkbsread": 0,
    "networkkbswrite": 0,
    "nic": [
      {
        "broadcasturi": "vlan://2158",
        "deviceid": "0",
        "extradhcpoption": [],
        "id": "a85752da-bcc5-4ea2-80bc-0765c6b19ccf",
        "isdefault": true,
        "isolationuri": "vlan://2158",
        "macaddress": "02:01:00:ce:00:02",
        "networkid": "9aa54302-2812-426e-bddb-654df195360b",
        "networkname": "configdrive-l2",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "osdisplayname": "Debian GNU/Linux 12 (64-bit)",
    "ostypeid": "8170a0ea-d54d-4cb9-b6a6-9d7652960164",
    "passwordenabled": false,
    "pooltype": "NetworkFilesystem",
    "receivedbytes": 0,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "sentbytes": 0,
    "serviceofferingid": "51ac121c-987b-446b-9e51-a383f30f8156",
    "serviceofferingname": "Small Instance",
    "state": "Running",
    "tags": [],
    "templatedisplaytext": "debian12-dummy",
    "templateformat": "VHD",
    "templateid": "a698f5ea-e51a-403c-a7be-22d5f6eaa11b",
    "templatename": "debian12-dummy",
    "templatetype": "USER",
    "userid": "78617ce4-1e62-11ef-b827-1e00120002d6",
    "username": "admin",
    "zoneid": "87ab94de-5701-4aa0-8253-fcefac217440",
    "zonename": "ref-trl-6722-x-M7-abhishek-kumar"
  }
}
```

Checked CD list for VM on the hypervisor
```
[12:19 ref-trl-6722-x-M7-abhishek-kumar-xs1 ~]# xe vm-cd-list vm=i-2-9-VM 
CD 0 VBD:
uuid ( RO)             : 3954c440-fe40-4c88-305f-a98d337f842a
    vm-name-label ( RO): i-2-9-VM
            empty ( RO): false
       userdevice ( RW): 3


CD 0 VDI:
uuid ( RO)             : e0c92d6c-33ca-47a5-b87a-727aaab08693
       name-label ( RW): 204-2-fb774b79-018c-372a-92e5-ca89881d6989.iso
    sr-name-label ( RO): i-2-9-VM-ISO
     virtual-size ( RO): 16777216


CD 1 VBD:
uuid ( RO)             : d3602682-c29c-151e-16ef-5d466433a249
    vm-name-label ( RO): i-2-9-VM
            empty ( RO): false
       userdevice ( RW): 4


CD 1 VDI:
uuid ( RO)             : 610f40b1-155a-4a4c-be71-9b48326447b1
       name-label ( RW): i-2-9-VM.iso
    sr-name-label ( RO): i-2-9-VM-CONFIGDRIVE-ISO
     virtual-size ( RO): 405504
```
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
