### PR TITLE
DRS: Ensure the destination host is part of the same cluster

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
@@ -467,7 +467,7 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
             Map<Host, Boolean> requiresStorageMotion = hostsForMigrationOfVM.third();
 
             for (Host destHost : compatibleDestinationHosts) {
-                if (!suitableDestinationHosts.contains(destHost)) {
+                if (!suitableDestinationHosts.contains(destHost) || cluster.getId() != destHost.getClusterId()) {
                     continue;
                 }
                 Ternary<Double, Double, Double> metrics = algorithm.getMetrics(cluster.getId(), vm,

--- a/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
@@ -73,6 +73,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterDrsServiceImplTest {
@@ -353,6 +354,7 @@ public class ClusterDrsServiceImplTest {
         Mockito.when(cluster.getId()).thenReturn(1L);
 
         HostVO destHost = Mockito.mock(HostVO.class);
+        Mockito.when(destHost.getClusterId()).thenReturn(1L);
 
         HostVO host = Mockito.mock(HostVO.class);
         Mockito.when(host.getId()).thenReturn(2L);
@@ -386,13 +388,9 @@ public class ClusterDrsServiceImplTest {
         }
 
         Mockito.when(managementServer.listHostsForMigrationOfVM(vm1, 0L, 500L, null, vmList)).thenReturn(
-                new Ternary<Pair<List<? extends Host>, Integer>, List<? extends Host>, Map<Host, Boolean>>(
-                        new Pair<>(List.of(destHost), 1), List.of(destHost), Map.of(destHost,
-                        false)));
+                new Ternary<>(new Pair<>(List.of(destHost), 1), List.of(destHost), Map.of(destHost, false)));
         Mockito.when(managementServer.listHostsForMigrationOfVM(vm2, 0L, 500L, null, vmList)).thenReturn(
-                new Ternary<Pair<List<? extends Host>, Integer>, List<? extends Host>, Map<Host, Boolean>>(
-                        new Pair<>(List.of(destHost), 1), List.of(destHost), Map.of(destHost,
-                        false)));
+                new Ternary<>(new Pair<>(List.of(destHost), 1), List.of(destHost), Map.of(destHost, false)));
         Mockito.when(balancedAlgorithm.getMetrics(cluster.getId(), vm1, serviceOffering, destHost, new HashMap<>(),
                 new HashMap<>(), false)).thenReturn(new Ternary<>(1.0, 0.5, 1.5));
 
@@ -404,6 +402,56 @@ public class ClusterDrsServiceImplTest {
 
         assertEquals(destHost, bestMigration.second());
         assertEquals(vm1, bestMigration.first());
+    }
+
+    @Test
+    public void testGetBestMigrationDifferentCluster() throws ConfigurationException {
+        ClusterVO cluster = Mockito.mock(ClusterVO.class);
+        Mockito.when(cluster.getId()).thenReturn(1L);
+
+        HostVO destHost = Mockito.mock(HostVO.class);
+        Mockito.when(destHost.getClusterId()).thenReturn(2L);
+
+        HostVO host = Mockito.mock(HostVO.class);
+        Mockito.when(host.getId()).thenReturn(2L);
+
+        VMInstanceVO vm1 = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm1.getId()).thenReturn(1L);
+        Mockito.when(vm1.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(vm1.getState()).thenReturn(VirtualMachine.State.Running);
+        Mockito.when(vm1.getDetails()).thenReturn(Collections.emptyMap());
+
+        VMInstanceVO vm2 = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm2.getId()).thenReturn(2L);
+        Mockito.when(vm2.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(vm2.getState()).thenReturn(VirtualMachine.State.Running);
+        Mockito.when(vm2.getDetails()).thenReturn(Collections.emptyMap());
+
+        List<VirtualMachine> vmList = new ArrayList<>();
+        vmList.add(vm1);
+        vmList.add(vm2);
+
+        Map<Long, List<VirtualMachine>> hostVmMap = new HashMap<>();
+        hostVmMap.put(host.getId(), new ArrayList<>());
+        hostVmMap.get(host.getId()).add(vm1);
+        hostVmMap.get(host.getId()).add(vm2);
+
+        Map<Long, ServiceOffering> vmIdServiceOfferingMap = new HashMap<>();
+
+        ServiceOffering serviceOffering = Mockito.mock(ServiceOffering.class);
+        for (VirtualMachine vm : vmList) {
+            vmIdServiceOfferingMap.put(vm.getId(), serviceOffering);
+        }
+
+        Mockito.when(managementServer.listHostsForMigrationOfVM(vm1, 0L, 500L, null, vmList)).thenReturn(
+                new Ternary<>(new Pair<>(List.of(destHost), 1), List.of(destHost), Map.of(destHost, false)));
+        Mockito.when(managementServer.listHostsForMigrationOfVM(vm2, 0L, 500L, null, vmList)).thenReturn(
+                new Ternary<>(new Pair<>(List.of(destHost), 1), List.of(destHost), Map.of(destHost, false)));
+        Pair<VirtualMachine, Host> bestMigration = clusterDrsService.getBestMigration(cluster, balancedAlgorithm,
+                vmList, vmIdServiceOfferingMap, new HashMap<>(), new HashMap<>());
+
+        assertNull(bestMigration.second());
+        assertNull(bestMigration.first());
     }
 
     @Test


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/cloudstack/issues/8629

This PR ensures that during a DRS run, the destination host is part of the same cluster for which migration is being run.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
