### PR TITLE
Update extraconfig for platform param in xen/xcpng

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
@@ -178,7 +178,7 @@ public class ExtraConfigurationUtility {
         }
     }
 
-    private static Pair<String, String> prepareKeyValuePair(String cfg) {
+    protected static Pair<String, String> prepareKeyValuePair(String cfg) {
         // cfg is either param=value or map-param:key=value
         int indexOfEqualSign = cfg.indexOf("=");
         if (indexOfEqualSign <= 0) {

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
@@ -16,13 +16,13 @@
 // under the License.
 package org.apache.cloudstack.hypervisor.xenserver;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
 import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Types;
@@ -35,16 +35,22 @@ public class ExtraConfigurationUtility {
         Map<String, Object> recordMap = vmr.toMap();
         for (String key : extraConfig.keySet()) {
             String cfg = extraConfig.get(key);
-            Map<String, String> configParams = prepareKeyValuePair(cfg);
+            // cfg is either param=value or map-param:key=value
+            Pair<String, String> configParam = prepareKeyValuePair(cfg);
+            if (configParam == null) {
+                LOG.warn("Invalid extra config passed: " + cfg);
+                continue;
+            }
 
-            // paramKey is either param or param:key for map parameters
-            String paramKey = configParams.keySet().toString().replaceAll("[\\[\\]]", "");
-            String paramValue = configParams.get(paramKey);
+            // paramKey is either param or map-param:key for map parameters
+            String paramKey = configParam.first();
+            String paramValue = configParam.second();
 
-            //Map params
             if (paramKey.contains(":")) {
+                // Map params - paramKey is map-param:key
                 applyConfigWithNestedKeyValue(conn, vm, recordMap, paramKey, paramValue);
             } else {
+                // Params - paramKey is param
                 applyConfigWithKeyValue(conn, vm, recordMap, paramKey, paramValue);
             }
         }
@@ -58,6 +64,7 @@ public class ExtraConfigurationUtility {
      * Nested keys contain ":" between the paramKey and need to split into operation param and key
      * */
     private static void applyConfigWithNestedKeyValue(Connection conn, VM vm, Map<String, Object> recordMap, String paramKey, String paramValue) {
+        // paramKey is map-param:key
         int i = paramKey.indexOf(":");
         String actualParam = paramKey.substring(0, i);
         String keyName = paramKey.substring(i + 1);
@@ -68,6 +75,7 @@ public class ExtraConfigurationUtility {
         }
 
         try {
+            // map-param param with '_'
             switch (actualParam) {
                 case "VCPUs_params":
                     vm.addToVCPUsParams(conn, keyName, paramValue);
@@ -101,6 +109,7 @@ public class ExtraConfigurationUtility {
         }
 
         try {
+            // param with '_'
             switch (paramKey) {
                 case "HVM_boot_policy":
                     vm.setHVMBootPolicy(conn, paramValue);
@@ -144,7 +153,7 @@ public class ExtraConfigurationUtility {
                 case "VCPUs_at_startup":
                     vm.setVCPUsAtStartup(conn, Long.valueOf(paramValue));
                     break;
-                case "is-a-template":
+                case "is_a_template":
                     vm.setIsATemplate(conn, Boolean.valueOf(paramValue));
                     break;
                 case "memory_static_max":
@@ -169,12 +178,28 @@ public class ExtraConfigurationUtility {
         }
     }
 
-    private static Map<String, String> prepareKeyValuePair(String cfg) {
-        Map<String, String> configKeyPair = new HashMap<>();
+    private static Pair<String, String> prepareKeyValuePair(String cfg) {
+        // cfg is either param=value or map-param:key=value
         int indexOfEqualSign = cfg.indexOf("=");
-        String key = cfg.substring(0, indexOfEqualSign).replace("-", "_");
+        if (indexOfEqualSign <= 0) {
+            return null;
+        }
+
+        String key;
+        // Replace '-' with '_' in param / map-param only
+        if (cfg.contains(":")) {
+            int indexOfColon = cfg.indexOf(":");
+            if (indexOfColon <= 0 || indexOfEqualSign < indexOfColon) {
+                return null;
+            }
+            String mapParam = cfg.substring(0, indexOfColon).replace("-", "_");
+            String paramKey = cfg.substring(indexOfColon + 1, indexOfEqualSign);
+            key = mapParam + ":" + paramKey;
+        } else {
+            key = cfg.substring(0, indexOfEqualSign).replace("-", "_");
+        }
+
         String value = cfg.substring(indexOfEqualSign + 1);
-        configKeyPair.put(key, value);
-        return configKeyPair;
+        return new Pair<>(key, value);
     }
 }

--- a/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
+++ b/plugins/hypervisors/xenserver/src/main/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtility.java
@@ -73,7 +73,7 @@ public class ExtraConfigurationUtility {
                     vm.addToVCPUsParams(conn, keyName, paramValue);
                     break;
                 case "platform":
-                    vm.addToOtherConfig(conn, keyName, paramValue);
+                    vm.addToPlatform(conn, keyName, paramValue);
                     break;
                 case "HVM_boot_params":
                     vm.addToHVMBootParams(conn, keyName, paramValue);

--- a/plugins/hypervisors/xenserver/src/test/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtilityTest.java
+++ b/plugins/hypervisors/xenserver/src/test/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtilityTest.java
@@ -1,0 +1,33 @@
+package org.apache.cloudstack.hypervisor.xenserver;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.utils.Pair;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExtraConfigurationUtilityTest {
+
+    @Test
+    public void prepareKeyValuePairTest() {
+        // Map params
+        verifyKeyValuePairForConfigParam("platform:exp-nested-hvm=true", "platform:exp-nested-hvm", "true");
+        verifyKeyValuePairForConfigParam("other_config:my_key=my_value", "other_config:my_key", "my_value");
+        verifyKeyValuePairForConfigParam("test-config:test-key=test-value", "test_config:test-key", "test-value");
+
+        // Params
+        verifyKeyValuePairForConfigParam("is_a_template=true", "is_a_template", "true");
+        verifyKeyValuePairForConfigParam("is-a-template=true", "is_a_template", "true");
+        verifyKeyValuePairForConfigParam("memory_dynamic_min=536870912", "memory_dynamic_min", "536870912");
+        verifyKeyValuePairForConfigParam("VCPUs_at_startup=2", "VCPUs_at_startup", "2");
+        verifyKeyValuePairForConfigParam("VCPUs-max=4", "VCPUs_max", "4");
+    }
+
+    private void verifyKeyValuePairForConfigParam(String cfg, String expectedKey, String expectedValue) {
+        Pair<String, String> keyValuePair = ExtraConfigurationUtility.prepareKeyValuePair(cfg);
+        Assert.assertEquals(expectedKey, keyValuePair.first());
+        Assert.assertEquals(expectedValue, keyValuePair.second());
+    }
+}

--- a/plugins/hypervisors/xenserver/src/test/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtilityTest.java
+++ b/plugins/hypervisors/xenserver/src/test/java/org/apache/cloudstack/hypervisor/xenserver/ExtraConfigurationUtilityTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.cloudstack.hypervisor.xenserver;
 
 import org.junit.Assert;


### PR DESCRIPTION
### Description

This PR updates extraconfig for platform param in xen/xcpng. Also, fixed map param key, not to replace '-' with '_' (replace only applicable to param / map-param).

Fixes #8847 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Before Fix:

<img width="1035" alt="XCPNG-VM-PlatformConfig-BeforeFix" src="https://github.com/apache/cloudstack/assets/12028987/f317d2fe-0f36-4433-80a5-08e594615fb4">

After Fix:

<img width="1040" alt="XCPNG-VM-PlatformConfig-AfterFix-Updated" src="https://github.com/apache/cloudstack/assets/12028987/0fa3294b-f1d3-44c7-86ac-2641bc0dadd8">

[Dev] VM is_a_template param check (in recordMap):

<img width="623" alt="vm-param-is_a_template" src="https://github.com/apache/cloudstack/assets/12028987/651d40cc-7e74-4603-a4fb-5c34d70f65f5">


### How Has This Been Tested?

Deployed VM with platform extraconfig after setting the global config.

- **enable.additional.vm.configuration** to **true**
- **allow.additional.vm.configuration.list.xenserver** to **platform:exp-nested-hvm**

```
(testenv) 🐱 > deploy virtualmachine templateid=da64d661-2991-11ef-81fa-1e001600014a serviceofferingid=3c6ff3e9-4cb2-4aa6-81a1-5733272a5a4f zoneid=e6ff5d2b-46b4-4d41-b28b-704365edcf3b name=TestVM04 extraconfig=platform%3Aexp-nested-hvm%3Dtrue
```

```
[ref-trl-6837-x-M7-suresh-anaparti-xs1 ~]# xe vm-list params=platform uuid=44d17a76-b4fa-209f-0ee9-171fe098e144
platform (MRW)    : timeoffset: 0; device-model: qemu-upstream-compat; vga: std; videoram: 8; apic: true; viridian: false; pae: true; acpi: 1; hpet: true; secureboot: false; exp-nested-hvm: true; nx: true
```

```
(testenv) 🐱 > list virtualmachines id=353ef820-e83e-455a-b2e2-1003cb1bd459 
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "admin",
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 500,
      "created": "2024-06-13T20:38:25+0000",
      "details": {
        "cpuOvercommitRatio": "2.0",
        "extraconfig-1": "platform:exp-nested-hvm=true",
        "hypervisortoolsversion": "xenserver56",
        "memoryOvercommitRatio": "1.0",
        "platform": "device-model:qemu-upstream-compat;vga:std;videoram:8;apic:true;viridian:false;pae:true;acpi:1;hpet:true;secureboot:false;exp-nested-hvm:true;nx:true"
      },
      "displayname": "TestVM04",
      "displayvm": true,
      "domain": "ROOT",
      "domainid": "da608984-2991-11ef-81fa-1e001600014a",
      "guestosid": "da857fa2-2991-11ef-81fa-1e001600014a",
      "haenable": false,
      "hasannotations": false,
      "hostcontrolstate": "Enabled",
      "hostid": "cf3eb7da-3721-4ea4-8112-63a736690db3",
      "hostname": "ref-trl-6837-x-M7-suresh-anaparti-xs1",
      "hypervisor": "XenServer",
      "id": "353ef820-e83e-455a-b2e2-1003cb1bd459",
      "instancename": "i-2-7-VM",
      "isdynamicallyscalable": false,
      "lastupdated": "2024-06-13T20:42:33+0000",
      "memory": 512,
      "name": "TestVM04",
      "nic": [
        {
          "broadcasturi": "vlan://2534",
          "deviceid": "0",
          "extradhcpoption": [],
          "gateway": "10.1.1.1",
          "id": "9d1ac630-744e-4276-9199-f168b22850a5",
          "ipaddress": "10.1.1.80",
          "isdefault": true,
          "isolationuri": "vlan://2534",
          "macaddress": "02:01:00:cc:00:05",
          "netmask": "255.255.255.0",
          "networkid": "c0d9b84f-eddc-4af8-b918-a42f9b04512f",
          "networkname": "TestNW01",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "Isolated"
        }
      ],
      "osdisplayname": "CentOS 5.6 (64-bit)",
      "ostypeid": "da857fa2-2991-11ef-81fa-1e001600014a",
      "passwordenabled": false,
      "pooltype": "NetworkFilesystem",
      "receivedbytes": 0,
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "sentbytes": 0,
      "serviceofferingid": "3c6ff3e9-4cb2-4aa6-81a1-5733272a5a4f",
      "serviceofferingname": "Small Instance",
      "state": "Running",
      "tags": [],
      "templatedisplaytext": "CentOS 5.6(64-bit) no GUI (XenServer)",
      "templateid": "da64d661-2991-11ef-81fa-1e001600014a",
      "templatename": "CentOS 5.6(64-bit) no GUI (XenServer)",
      "userid": "fb8a8caa-2991-11ef-81fa-1e001600014a",
      "username": "admin",
      "zoneid": "e6ff5d2b-46b4-4d41-b28b-704365edcf3b",
      "zonename": "ref-trl-6837-x-M7-suresh-anaparti"
    }
  ]
}
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
