### PR TITLE
Improvements on information about disks size and offering in VM deployment wizard's InfoCard

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -550,12 +550,19 @@
             <span v-else>{{ resource.serviceofferingname || resource.serviceofferingid }}</span>
           </div>
         </div>
-        <div class="resource-detail-item" v-if="resource.diskofferingname && resource.diskofferingid">
+        <div class="resource-detail-item" v-if="resource.rootdiskofferingid && resource.rootdiskofferingdisplaytext || resource.datadiskofferingid && resource.datadiskofferingdisplaytext">
           <div class="resource-detail-item__label">{{ $t('label.diskoffering') }}</div>
           <div class="resource-detail-item__details">
             <hdd-outlined />
-            <router-link v-if="!isStatic && $router.resolve('/diskoffering/' + resource.diskofferingid).matched[0].redirect !== '/exception/404'" :to="{ path: '/diskoffering/' + resource.diskofferingid }">{{ resource.diskofferingname || resource.diskofferingid }} </router-link>
-            <span v-else>{{ resource.diskofferingname || resource.diskofferingid }}</span>
+            <div v-if="resource.rootdiskofferingid">
+              <router-link v-if="!isStatic && $router.resolve('/diskoffering/' + resource.rootdiskofferingid).matched[0].redirect !== '/exception/404'" :to="{ path: '/diskoffering/' + resource.rootdiskofferingid }">{{ resource.rootdiskofferingdisplaytext }}</router-link>
+              <span v-else>{{ resource.rootdiskofferingdisplaytext }}</span>
+            </div>
+            <span v-if="resource.rootdiskofferingid && resource.datadiskofferingid">&nbsp;|&nbsp;</span>
+            <div v-if="resource.datadiskofferingid">
+              <router-link v-if="!isStatic && $router.resolve('/diskoffering/' + resource.datadiskofferingid).matched[0].redirect !== '/exception/404'" :to="{ path: '/diskoffering/' + resource.datadiskofferingid }">{{ resource.datadiskofferingdisplaytext }}</router-link>
+              <span v-else>{{ resource.datadiskofferingdisplaytext }}</span>
+            </div>
           </div>
         </div>
         <div class="resource-detail-item" v-if="resource.backupofferingid">


### PR DESCRIPTION
### Description

The VM deployment wizard only shows one of the disk offerings that will be used to create the VM's volumes, which corresponds to the data disk if using a template, and the root disk if using a ISO. The disk offering that will be used to create the root disk is not shown when deploying through a template. This confuses users, since the wizard does not explicitly show what offering will be used for each disk. Furthermore, the instance summary often presents an incorrect value for the size of the disks.

This PR makes some changes in the deployment wizard in order to explicitly show what offerings will be used for the root and data disks, and to display their correct size. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):

![image](https://github.com/apache/cloudstack/assets/25729641/ea6a1260-44ab-4aac-ac85-e9ad42231563)

### How Has This Been Tested?

I created one disk offering:
1. Name and description: Associated. Custom disk size: false. Disk size (in GB): 10.

And two compute offerings:
1. Name and description: Associated. Compute only disk offering: false: Disk offerings: Associated.
2. Name and description: Custom. Compute only disk offering: false: Disk offerings: Custom Disk.

In every test described below, I deployed the VM and verified that the VM's volumes were created using the disk offerings and the sizes displayed in the UI.

### Tests deploying from a template:

- I selected the compute offering Small Instance;
- I selected the compute offering Small Instance, enabled root disk offering override and selected Medium;
- I selected the compute offering Small Instance, enabled root disk offering override, selected Custom and set the size to 10 GB;
- I selected the compute offering Custom and set the size to 11 GB;
- I selected the compute offering Custom, set the size to 12 GB, enabled override and selected Medium;
- I selected the compute offering Associated;
- I selected the compute offering Associated, enabled override and selected Medium;
- I selected the compute offering Associated, enabled override, selected Custom and set the size to 13 GB;
- I selected the compute offering Small Instance and a Small data disk;
- I selected the compute offering Small Instance, enabled root disk override, selected Medium and a Small data disk;
- I selected the compute offering Small Instance, enabled root disk override, selected the Custom root disk, set the size to 11 GB, selected the Custom Disk data disk and set the size to 12 GB.

### Tests deploying from an ISO:

- I selected the compute offering Small Instance and Medium disk size;
- I selected the compute offering Custom and Medium disk size;
- I selected the compute offering Associated and Medium disk size;
- I selected the compute offering Associated, Custom disk size and set the size to 13 GB.