### PR TITLE
Prevent network disruption on adding a VPC tier for redundant VRs

### DIFF
--- a/api/src/main/java/com/cloud/network/VpcVirtualNetworkApplianceService.java
+++ b/api/src/main/java/com/cloud/network/VpcVirtualNetworkApplianceService.java
@@ -29,7 +29,6 @@ public interface VpcVirtualNetworkApplianceService extends VirtualNetworkApplian
     /**
      * @param router
      * @param network
-     * @param isRedundant
      * @param params TODO
      * @return
      * @throws ConcurrentOperationException
@@ -42,11 +41,30 @@ public interface VpcVirtualNetworkApplianceService extends VirtualNetworkApplian
     /**
      * @param router
      * @param network
-     * @param isRedundant
      * @return
      * @throws ConcurrentOperationException
      * @throws ResourceUnavailableException
      */
     boolean removeVpcRouterFromGuestNetwork(VirtualRouter router, Network network) throws ConcurrentOperationException, ResourceUnavailableException;
+
+
+    /**
+     * @param router
+     * @param network
+     * @return
+     * @throws ConcurrentOperationException
+     * @throws ResourceUnavailableException
+     */
+    boolean stopKeepAlivedOnRouter(VirtualRouter router, Network network) throws ConcurrentOperationException, ResourceUnavailableException;
+
+
+    /**
+     * @param router
+     * @param network
+     * @return
+     * @throws ConcurrentOperationException
+     * @throws ResourceUnavailableException
+     */
+    boolean startKeepAlivedOnRouter(VirtualRouter router, Network network) throws ConcurrentOperationException, ResourceUnavailableException;
 
 }

--- a/core/src/main/java/com/cloud/agent/api/ManageServiceCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/ManageServiceCommand.java
@@ -1,0 +1,49 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.agent.api;
+
+import com.cloud.agent.api.routing.NetworkElementCommand;
+
+public class ManageServiceCommand extends NetworkElementCommand {
+
+    String serviceName;
+    String action;
+
+    @Override
+    public boolean executeInSequence() {
+        return true;
+    }
+
+    protected ManageServiceCommand() {
+    }
+
+    public ManageServiceCommand(String serviceName, String action) {
+        this.serviceName = serviceName;
+        this.action = action;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getAction() {
+        return action;
+    }
+}

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/VRScripts.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/VRScripts.java
@@ -81,4 +81,5 @@ public class VRScripts {
     public static final String VR_UPDATE_INTERFACE_CONFIG = "update_interface_config.sh";
 
     public static final String ROUTER_FILESYSTEM_WRITABLE_CHECK = "filesystem_writable_check.py";
+    public static final String MANAGE_SERVICE = "manage_service.sh";
 }

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
@@ -34,6 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.naming.ConfigurationException;
 
+import com.cloud.agent.api.ManageServiceCommand;
 import com.cloud.agent.api.routing.UpdateNetworkCommand;
 import com.cloud.agent.api.to.IpAddressTO;
 import com.cloud.network.router.VirtualRouter;
@@ -141,6 +142,10 @@ public class VirtualRoutingResource {
 
             if (cmd instanceof UpdateNetworkCommand) {
                 return execute((UpdateNetworkCommand) cmd);
+            }
+
+            if (cmd instanceof ManageServiceCommand) {
+                return execute((ManageServiceCommand) cmd);
             }
 
             if (_vrAggregateCommandsSet.containsKey(routerName)) {
@@ -268,6 +273,17 @@ public class VirtualRoutingResource {
             return new Answer(cmd, true, null);
         }
         return new Answer(cmd, new CloudRuntimeException("Failed to update interface mtu"));
+    }
+
+    private Answer execute(ManageServiceCommand cmd) {
+        String routerIp = cmd.getAccessDetail(NetworkElementCommand.ROUTER_IP);
+        String args = cmd.getAction() + " " + cmd.getServiceName();
+        ExecutionResult result = _vrDeployer.executeInVR(routerIp, VRScripts.MANAGE_SERVICE, args);
+        if (result.isSuccess()) {
+            return new Answer(cmd, true, "Keepalived stopped successfully. Details: " + result.getDetails());
+        } else {
+            return new Answer(cmd, false, "Failed to stop keepalived. Detail: " + result.getDetails());
+        }
     }
 
     private ExecutionResult applyConfigToVR(String routerAccessIp, ConfigItem c) {

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.naming.ConfigurationException;
 
-import com.cloud.agent.api.ManageServiceCommand;
+import org.apache.cloudstack.agent.routing.ManageServiceCommand;
 import com.cloud.agent.api.routing.UpdateNetworkCommand;
 import com.cloud.agent.api.to.IpAddressTO;
 import com.cloud.network.router.VirtualRouter;
@@ -280,9 +280,12 @@ public class VirtualRoutingResource {
         String args = cmd.getAction() + " " + cmd.getServiceName();
         ExecutionResult result = _vrDeployer.executeInVR(routerIp, VRScripts.MANAGE_SERVICE, args);
         if (result.isSuccess()) {
-            return new Answer(cmd, true, "Keepalived stopped successfully. Details: " + result.getDetails());
+            return new Answer(cmd, true,
+                    String.format("Successfully executed action: %s on service: %s. Details: %s",
+                            cmd.getAction(), cmd.getServiceName(), result.getDetails()));
         } else {
-            return new Answer(cmd, false, "Failed to stop keepalived. Detail: " + result.getDetails());
+            return new Answer(cmd, false, String.format("Failed to execute action: %s on service: %s. Details: %s",
+                    cmd.getAction(), cmd.getServiceName(), result.getDetails()));
         }
     }
 

--- a/core/src/main/java/org/apache/cloudstack/agent/routing/ManageServiceCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/routing/ManageServiceCommand.java
@@ -17,7 +17,7 @@
 // under the License.
 //
 
-package com.cloud.agent.api;
+package org.apache.cloudstack.agent.routing;
 
 import com.cloud.agent.api.routing.NetworkElementCommand;
 

--- a/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.agent.api.ManageServiceCommand;
+import com.cloud.agent.api.routing.NetworkElementCommand;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -223,6 +225,53 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             }
         }
 
+        return result;
+    }
+
+    @Override
+    public boolean stopKeepAlivedOnRouter(VirtualRouter router,
+            Network network) throws ConcurrentOperationException, ResourceUnavailableException {
+        return manageKeepalivedServiceOnRouter(router, network, "stop");
+    }
+
+    @Override
+    public boolean startKeepAlivedOnRouter(VirtualRouter router,
+            Network network) throws ConcurrentOperationException, ResourceUnavailableException {
+        return manageKeepalivedServiceOnRouter(router, network, "start");
+    }
+
+    private boolean manageKeepalivedServiceOnRouter(VirtualRouter router,
+            Network network, String action) throws ConcurrentOperationException, ResourceUnavailableException {
+        if (network.getTrafficType() != TrafficType.Guest) {
+            s_logger.warn("Network " + network + " is not of type " + TrafficType.Guest);
+            return false;
+        }
+        boolean result = true;
+        try {
+            if (router.getState() == State.Running) {
+                final ManageServiceCommand stopCommand = new ManageServiceCommand("keepalived", action);
+                stopCommand.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
+
+                final Commands cmds = new Commands(Command.OnError.Stop);
+                cmds.addCommand("manageKeepalived", stopCommand);
+                _nwHelper.sendCommandsToRouter(router, cmds);
+
+                final Answer setupAnswer = cmds.getAnswer("manageKeepalived");
+                if (!(setupAnswer != null && setupAnswer.getResult())) {
+                    s_logger.warn("Unable to " + action + " keepalived on router " + router);
+                    result = false;
+                }
+            } else if (router.getState() == State.Stopped || router.getState() == State.Stopping) {
+                s_logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending command to the backend");
+            } else {
+                String message = "Unable to " + action + " keepalived on virtual router [" + router + "] is not in the right state " + router.getState();
+                s_logger.warn(message);
+                throw new ResourceUnavailableException(message, DataCenter.class, router.getDataCenterId());
+            }
+        } catch (final Exception ex) {
+            s_logger.warn("Failed to " + action + "  keepalived on router " + router + " to network " + network + " due to ", ex);
+            result = false;
+        }
         return result;
     }
 

--- a/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.agent.api.ManageServiceCommand;
+import org.apache.cloudstack.agent.routing.ManageServiceCommand;
 import com.cloud.agent.api.routing.NetworkElementCommand;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;

--- a/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
+++ b/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
@@ -204,6 +204,20 @@ public class MockVpcVirtualNetworkApplianceManager extends ManagerBase implement
         return false;
     }
 
+    @Override
+    public boolean stopKeepAlivedOnRouter(VirtualRouter router,
+            Network network) throws ConcurrentOperationException, ResourceUnavailableException {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean startKeepAlivedOnRouter(VirtualRouter router,
+            Network network) throws ConcurrentOperationException, ResourceUnavailableException {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
     /* (non-Javadoc)
      * @see com.cloud.network.router.VpcVirtualNetworkApplianceManager#destroyPrivateGateway(com.cloud.network.vpc.PrivateGateway, com.cloud.network.router.VirtualRouter)
      */

--- a/systemvm/debian/opt/cloud/bin/manage_service.sh
+++ b/systemvm/debian/opt/cloud/bin/manage_service.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+systemctl $1 $2


### PR DESCRIPTION
### Description

This PR fixes https://github.com/apache/cloudstack/issues/8108

As of now, on adding a new network tier to a VPC, results in a small network disruption because of keepalived's config reload on both the VRs. This patch fixes this by doing operations in this order:
1. Stop keepalived on all the backup VRs. This prevents the backup VR from becoming master when keepalived on the PRIMARY VR is getting reloaded.
2. Update the config and reload on all primary VRs.
3. Update the config and restart on all backup VRs.

Logs before patch on Primary VR
```
tail -f /var/log/messages | grep keepalived
Jun 13 11:53:31 systemvm Keepalived_vrrp[10528]: (inside_network) Entering BACKUP STATE
Jun 13 11:54:55 systemvm Keepalived_vrrp[10528]: (inside_network) Backup received priority 0 advertisement
Jun 13 11:54:56 systemvm Keepalived_vrrp[10528]: (inside_network) Entering MASTER STATE
Jun 13 12:14:00 systemvm Keepalived[10527]: Reloading ...
Jun 13 12:14:00 systemvm Keepalived[10527]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 13 12:14:00 systemvm Keepalived_vrrp[10528]: Reloading
Jun 13 12:14:00 systemvm Keepalived_vrrp[10528]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 13 12:14:00 systemvm Keepalived_vrrp[10528]: VRRP_Script(heartbeat) considered successful on reload
Jun 13 12:14:00 systemvm Keepalived_vrrp[10528]: SECURITY VIOLATION - scripts are being executed but script_security not enabled.
Jun 13 12:14:03 systemvm Keepalived_vrrp[10528]: (inside_network) received an unexpected ip number count 2, expected 3!
Jun 13 12:14:04 systemvm Keepalived_vrrp[10528]: (inside_network) received an unexpected ip number count 2, expected 3!
Jun 13 12:14:05 systemvm Keepalived_vrrp[10528]: (inside_network) IPSEC-AH : sequence number 4009 already processed. Packet dropped. Local(4009)
Jun 13 12:14:07 systemvm Keepalived_vrrp[10528]: (inside_network) received an unexpected ip number count 2, expected 3!
Jun 13 12:14:07 systemvm Keepalived_vrrp[10528]: (inside_network) Received advert from 172.31.1.88 with lower priority 100, ours 100, forcing new election
Jun 13 12:14:07 systemvm Keepalived_vrrp[10528]: (inside_network) IPSEC-AH : Syncing seq_num - Increment seq

```

Logs before patch on Backup VR
```
Jun 13 11:54:56 systemvm Keepalived_vrrp[10628]: (inside_network) Entering BACKUP STATE
Jun 13 12:05:18 systemvm Keepalived_vrrp[10628]: (inside_network) IPSEC-AH : sequence number 3479 already processed. Packet dropped. Local(3479)
Jun 13 12:14:00 systemvm Keepalived_vrrp[10628]: (inside_network) received an unexpected ip number count 3, expected 2!
Jun 13 12:14:01 systemvm Keepalived_vrrp[10628]: (inside_network) received an unexpected ip number count 3, expected 2!
Jun 13 12:14:02 systemvm Keepalived_vrrp[10628]: (inside_network) received an unexpected ip number count 3, expected 2!
Jun 13 12:14:03 systemvm Keepalived_vrrp[10628]: (inside_network) received an unexpected ip number count 3, expected 2!
Jun 13 12:14:03 systemvm Keepalived_vrrp[10628]: (inside_network) Entering MASTER STATE
Jun 13 12:14:05 systemvm Keepalived_vrrp[10628]: (inside_network) IPSEC-AH : sequence number 4009 already processed. Packet dropped. Local(4009)
Jun 13 12:14:06 systemvm Keepalived_vrrp[10628]: (inside_network) received an unexpected ip number count 3, expected 2!
Jun 13 12:14:07 systemvm Keepalived[10627]: Reloading ...
Jun 13 12:14:07 systemvm Keepalived[10627]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 13 12:14:07 systemvm Keepalived_vrrp[10628]: Reloading
Jun 13 12:14:07 systemvm Keepalived_vrrp[10628]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 13 12:14:07 systemvm Keepalived_vrrp[10628]: VRRP_Script(heartbeat) considered successful on reload
Jun 13 12:14:07 systemvm Keepalived_vrrp[10628]: SECURITY VIOLATION - scripts are being executed but script_security not enabled.
Jun 13 12:14:07 systemvm Keepalived_vrrp[10628]: (inside_network) Master received advert from 172.31.1.236 with same priority 100 but higher IP address than ours
Jun 13 12:14:07 systemvm Keepalived_vrrp[10628]: (inside_network) Entering BACKUP STATE
```

Logs after patch on Primary VR
```
Jun 14 10:23:04 systemvm Keepalived[116549]: Reloading ...
Jun 14 10:23:04 systemvm Keepalived[116549]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 14 10:23:04 systemvm Keepalived_vrrp[116550]: Reloading
Jun 14 10:23:04 systemvm Keepalived_vrrp[116550]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 14 10:23:04 systemvm Keepalived_vrrp[116550]: VRRP_Script(heartbeat) considered successful on reload
Jun 14 10:23:04 systemvm Keepalived_vrrp[116550]: SECURITY VIOLATION - scripts are being executed but script_security not enabled.
```
Logs after patch on Backup VR
```
Jun 14 10:23:00 systemvm Keepalived[133456]: Stopping
Jun 14 10:23:01 systemvm Keepalived_vrrp[133462]: Stopped
Jun 14 10:23:01 systemvm Keepalived[133456]: Stopped Keepalived v2.1.5 (07/13,2020)
Jun 14 10:23:08 systemvm Keepalived[134884]: Starting Keepalived v2.1.5 (07/13,2020)
Jun 14 10:23:08 systemvm Keepalived[134884]: WARNING - keepalived was build for newer Linux 5.10.70, running on Linux 5.10.0-26-amd64 #1 SMP Debian 5.10.197-1 (2023-09-29)
Jun 14 10:23:08 systemvm Keepalived[134884]: Command line: '/usr/sbin/keepalived' '--dont-fork'
Jun 14 10:23:08 systemvm Keepalived[134884]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 14 10:23:08 systemvm Keepalived[134884]: NOTICE: setting config option max_auto_priority should result in better keepalived performance
Jun 14 10:23:08 systemvm Keepalived[134884]: Starting VRRP child process, pid=134885
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: Registering Kernel netlink reflector
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: Registering Kernel netlink command channel
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: WARNING - default user 'keepalived_script' for script execution does not exist - please create.
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: SECURITY VIOLATION - scripts are being executed but script_security not enabled.
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: Registering gratuitous ARP shared channel
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: VRRP_Script(heartbeat) succeeded
Jun 14 10:23:08 systemvm Keepalived_vrrp[134885]: (inside_network) Entering BACKUP STATE
```


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
