### PR TITLE
User friendly name of Downloaded Templates Volumes and ISOs

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/storage/CreateEntityDownloadURLCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/storage/CreateEntityDownloadURLCommand.java
@@ -23,18 +23,19 @@ import com.cloud.agent.api.to.DataTO;
 
 public class CreateEntityDownloadURLCommand extends AbstractDownloadCommand {
 
-    public CreateEntityDownloadURLCommand(String parent, String installPath, String uuid, DataTO data) { // this constructor is for creating template download url
+    public CreateEntityDownloadURLCommand(String parent, String installPath, String fileName, String filePath, DataTO data) { // this constructor is for creating template download url
         super();
         this.parent = parent; // parent is required as not the template can be child of one of many parents
         this.installPath = installPath;
-        this.extractLinkUUID = uuid;
+        this.filenameInExtractURL = fileName;
+        this.filepathInExtractURL = filePath;
         this.data = data;
     }
 
-    public CreateEntityDownloadURLCommand(String installPath, String uuid) {
+    public CreateEntityDownloadURLCommand(String installPath, String filename) {
         super();
         this.installPath = installPath;
-        this.extractLinkUUID = uuid;
+        this.filenameInExtractURL = filename;
     }
 
     public CreateEntityDownloadURLCommand() {
@@ -42,7 +43,8 @@ public class CreateEntityDownloadURLCommand extends AbstractDownloadCommand {
 
     private String installPath;
     private String parent;
-    private String extractLinkUUID;
+    private String filenameInExtractURL;
+    private String filepathInExtractURL;
 
     public DataTO getData() {
         return data;
@@ -75,12 +77,19 @@ public class CreateEntityDownloadURLCommand extends AbstractDownloadCommand {
         this.parent = parent;
     }
 
-    public String getExtractLinkUUID() {
-        return extractLinkUUID;
+    public String getFilenameInExtractURL() {
+        return filenameInExtractURL;
     }
 
-    public void setExtractLinkUUID(String extractLinkUUID) {
-        this.extractLinkUUID = extractLinkUUID;
+    public void setFilenameInExtractURL(String filenameInExtractURL) {
+        this.filenameInExtractURL = filenameInExtractURL;
     }
 
+    public String getFilepathInExtractURL() {
+        return filepathInExtractURL;
+    }
+
+    public void setFilepathInExtractURL(String filepathInExtractURL) {
+        this.filepathInExtractURL = filepathInExtractURL;
+    }
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/DataObject.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/DataObject.java
@@ -50,4 +50,6 @@ public interface DataObject {
     void decRefCount();
 
     Long getRefCount();
+
+    String getName();
 }

--- a/plugins/storage/image/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackImageStoreDriverImpl.java
+++ b/plugins/storage/image/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackImageStoreDriverImpl.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand;
 import com.cloud.host.dao.HostDao;
 import com.cloud.storage.Upload;
+import com.cloud.utils.StringUtils;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
@@ -64,20 +65,42 @@ public class CloudStackImageStoreDriverImpl extends NfsImageStoreDriverImpl {
         return nfsTO;
     }
 
+    private String createObjectNameForExtractUrl(String installPath, ImageFormat format, DataObject dataObject) {
+        String objectNameInUrl = dataObject.getName();
+        try {
+            objectNameInUrl = cleanObjectName(objectNameInUrl);
+        } catch (Exception e) {
+            objectNameInUrl = UUID.randomUUID().toString();
+        }
+
+        if (format != null) {
+            objectNameInUrl = objectNameInUrl + "." + format.getFileExtension();
+        } else if (installPath.lastIndexOf(".") != -1) {
+            objectNameInUrl = objectNameInUrl + "." + installPath.substring(installPath.lastIndexOf(".") + 1);
+        }
+
+        return objectNameInUrl;
+    }
+
+    private String cleanObjectName(String objectName) {
+        if (StringUtils.isEmpty(objectName)) {
+            throw new IllegalArgumentException("Object name is empty or null");
+        }
+        return objectName.trim()
+                .replaceAll("[^a-zA-Z0-9]+", "-")
+                .replaceAll("-{2,}", "-")
+                .replaceAll("^-|-$", "");
+    }
+
     @Override
     public String createEntityExtractUrl(DataStore store, String installPath, ImageFormat format, DataObject dataObject) {
         // find an endpoint to send command
         EndPoint ep = _epSelector.select(store);
         // Create Symlink at ssvm
         String path = installPath;
-        String uuid = UUID.randomUUID().toString();
-        if (format != null) {
-            uuid = uuid + "." + format.getFileExtension();
-        } else if (path.lastIndexOf(".") != -1) {
-            uuid = uuid + "." + path.substring(path.lastIndexOf(".") + 1);
-        }
+        String objectNameInUrl = createObjectNameForExtractUrl(path, format, dataObject);
         CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)store).getMountPoint(),
-                                                                path, uuid, dataObject == null ? null: dataObject.getTO());
+                                                                path, objectNameInUrl, dataObject == null ? null: dataObject.getTO());
         Answer ans = null;
         if (ep == null) {
             String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
@@ -92,7 +115,7 @@ public class CloudStackImageStoreDriverImpl extends NfsImageStoreDriverImpl {
             throw new CloudRuntimeException(errorString);
         }
         // Construct actual URL locally now that the symlink exists at SSVM
-        return generateCopyUrl(ep.getPublicAddr(), uuid);
+        return generateCopyUrl(ep.getPublicAddr(), objectNameInUrl);
     }
 
     private String generateCopyUrl(String ipAddress, String uuid) {

--- a/plugins/storage/image/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackImageStoreDriverImpl.java
+++ b/plugins/storage/image/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackImageStoreDriverImpl.java
@@ -99,8 +99,9 @@ public class CloudStackImageStoreDriverImpl extends NfsImageStoreDriverImpl {
         // Create Symlink at ssvm
         String path = installPath;
         String objectNameInUrl = createObjectNameForExtractUrl(path, format, dataObject);
+        String objectPathInUrl = UUID.randomUUID().toString();
         CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)store).getMountPoint(),
-                                                                path, objectNameInUrl, dataObject == null ? null: dataObject.getTO());
+                                                                path, objectNameInUrl, objectPathInUrl, dataObject == null ? null: dataObject.getTO());
         Answer ans = null;
         if (ep == null) {
             String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
@@ -115,10 +116,10 @@ public class CloudStackImageStoreDriverImpl extends NfsImageStoreDriverImpl {
             throw new CloudRuntimeException(errorString);
         }
         // Construct actual URL locally now that the symlink exists at SSVM
-        return generateCopyUrl(ep.getPublicAddr(), objectNameInUrl);
+        return generateCopyUrl(ep.getPublicAddr(), objectNameInUrl, objectPathInUrl);
     }
 
-    private String generateCopyUrl(String ipAddress, String uuid) {
+    private String generateCopyUrl(String ipAddress, String fileName, String filePath) {
 
         String hostname = ipAddress;
         String scheme = "http";
@@ -141,7 +142,7 @@ public class CloudStackImageStoreDriverImpl extends NfsImageStoreDriverImpl {
             }
             scheme = "https";
         }
-        return scheme + "://" + hostname + "/userdata/" + uuid;
+        return scheme + "://" + hostname + "/userdata/" + filePath + "/" + fileName;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/storage/upload/UploadMonitorImpl.java
+++ b/server/src/main/java/com/cloud/storage/upload/UploadMonitorImpl.java
@@ -261,7 +261,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
             // Create Symlink at ssvm
             String path = vmTemplateHost.getInstallPath();
             String uuid = UUID.randomUUID().toString() + "." + template.getFormat().getFileExtension(); // adding "." + vhd/ova... etc.
-            CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)store).getMountPoint(), path, uuid, null);
+            CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)store).getMountPoint(), path, uuid, null, null);
             Answer ans = ep.sendMessage(cmd);
             if (ans == null || !ans.getResult()) {
                 errorString = "Unable to create a link for " + type + " id:" + template.getId() + "," + (ans == null ? "" : ans.getDetails());
@@ -317,7 +317,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
                 throw new CloudRuntimeException(errorString);
             }
 
-            CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)secStore).getMountPoint(), path, uuid, null);
+            CreateEntityDownloadURLCommand cmd = new CreateEntityDownloadURLCommand(((ImageStoreEntity)secStore).getMountPoint(), path, uuid, null, null);
             Answer ans = ep.sendMessage(cmd);
             if (ans == null || !ans.getResult()) {
                 errorString = "Unable to create a link for " + type + " id:" + entityId + "," + (ans == null ? "" : ans.getDetails());

--- a/server/src/main/java/org/apache/cloudstack/diagnostics/to/DiagnosticsDataObject.java
+++ b/server/src/main/java/org/apache/cloudstack/diagnostics/to/DiagnosticsDataObject.java
@@ -99,4 +99,9 @@ public class DiagnosticsDataObject implements DataObject {
     public Long getRefCount() {
         return null;
     }
+
+    @Override
+    public String getName() {
+        return dataStore.getName();
+    }
 }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
@@ -268,6 +268,8 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         }
         // Create the directory structure so that its visible under apache server root
         String extractDir = "/var/www/html/userdata/";
+        extractDir = extractDir + cmd.getFilepathInExtractURL() + File.separator;
+        s_logger.info("HARI  " + extractDir);
         Script command = new Script("/bin/su", s_logger);
         command.add("-s");
         command.add("/bin/bash");
@@ -290,11 +292,11 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         }
 
         // Create a random file under the directory for security reasons.
-        String uuid = cmd.getExtractLinkUUID();
+        String filename = cmd.getFilenameInExtractURL();
         // Create a symbolic link from the actual directory to the template location. The entity would be directly visible under /var/www/html/userdata/cmd.getInstallPath();
         command = new Script("/bin/bash", s_logger);
         command.add("-c");
-        command.add("ln -sf /mnt/SecStorage/" + cmd.getParent() + File.separator + cmd.getInstallPath() + " " + extractDir + uuid);
+        command.add("ln -sf /mnt/SecStorage/" + cmd.getParent() + File.separator + cmd.getInstallPath() + " " + extractDir + filename);
         result = command.execute();
         if (result != null) {
             String errorString = "Error in linking  err=" + result;


### PR DESCRIPTION
### Description

This PR addresses the improvement #6949 

Previously when a template or volume or ISO is downloaded then the file name generated for the downloaded file is a random URL, with this PR we have improved to use the name of the object to set as the file name.

During the preparation of URL, MS uses only alphanumeric characters and replaces others with Hyphen (-).

For example 

![image](https://github.com/apache/cloudstack/assets/3348673/ec078817-893b-4857-8931-fb6ebe1483e5)


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor


### How Has This Been Tested?

Downloaded multiple templates, volumes with various names.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
