### PR TITLE
[UI] Add option to select owner of volume when creating it

### DIFF
--- a/ui/src/views/storage/CreateVolume.vue
+++ b/ui/src/views/storage/CreateVolume.vue
@@ -17,6 +17,9 @@
 
 <template>
   <a-spin :spinning="loading">
+    <div v-if="!isNormalUserOrProject">
+      <ownership-selection @fetch-owner="fetchOwnerOptions" />
+    </div>
     <a-form
       class="form"
       layout="vertical"
@@ -127,11 +130,14 @@ import { api } from '@/api'
 import { mixinForm } from '@/utils/mixin'
 import ResourceIcon from '@/components/view/ResourceIcon'
 import TooltipLabel from '@/components/widgets/TooltipLabel'
+import OwnershipSelection from '@/views/compute/wizard/OwnershipSelection.vue'
+import store from '@/store'
 
 export default {
   name: 'CreateVolume',
   mixins: [mixinForm],
   components: {
+    OwnershipSelection,
     ResourceIcon,
     TooltipLabel
   },
@@ -143,6 +149,11 @@ export default {
   },
   data () {
     return {
+      owner: {
+        projectid: store.getters.project?.id,
+        domainid: store.getters.project?.id ? null : store.getters.userInfo.domainid,
+        account: store.getters.project?.id ? null : store.getters.userInfo.account
+      },
       snapshotZoneIds: [],
       zones: [],
       offerings: [],
@@ -154,6 +165,9 @@ export default {
   computed: {
     createVolumeFromVM () {
       return this.$route.path.startsWith('/vm/')
+    },
+    isNormalUserOrProject () {
+      return ['User'].includes(this.$store.getters.userInfo.roletype) || store.getters.project?.id
     },
     createVolumeFromSnapshot () {
       return this.$route.path.startsWith('/snapshot')
@@ -194,6 +208,22 @@ export default {
         this.rules.name = [{ required: true, message: this.$t('message.error.volume.name') }]
         this.rules.diskofferingid = [{ required: true, message: this.$t('message.error.select') }]
       }
+    },
+    fetchOwnerOptions (OwnerOptions) {
+      this.owner = {}
+      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+        if (!OwnerOptions.selectedAccount) {
+          return
+        }
+        this.owner.account = OwnerOptions.selectedAccount
+        this.owner.domainid = OwnerOptions.selectedDomain
+      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+        if (!OwnerOptions.selectedProject) {
+          return
+        }
+        this.owner.projectid = OwnerOptions.selectedProject
+      }
+      this.fetchData()
     },
     fetchData () {
       if (this.createVolumeFromSnapshot) {
@@ -246,10 +276,16 @@ export default {
       this.loading = true
       var params = {
         zoneid: zoneId,
-        listall: true
+        listall: true,
+        domainid: this.owner.domainid
       }
       if (this.createVolumeFromVM) {
         params.virtualmachineid = this.resource.id
+      }
+      if (this.owner.projectid) {
+        params.projectid = this.owner.projectid
+      } else {
+        params.account = this.owner.account
       }
       api('listDiskOfferings', params).then(json => {
         this.offerings = json.listdiskofferingsresponse.diskoffering || []
@@ -278,6 +314,12 @@ export default {
         }
         if (this.createVolumeFromSnapshot) {
           values.snapshotid = this.resource.id
+        }
+        values.domainid = this.owner.domainid
+        if (this.owner.projectid) {
+          values.projectid = this.owner.projectid
+        } else {
+          values.account = this.owner.account
         }
         this.loading = true
         api('createVolume', values).then(response => {


### PR DESCRIPTION
### Description

This PR allows selecting a target account (or project) during volume creation through the UI, using #8919's `OwnershipSelection`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### Screenshots (if appropriate):
![image](https://github.com/apache/cloudstack/assets/22242548/bfa64b8e-2864-4f19-ba68-402b6ed8404d)


### How Has This Been Tested?
**Environment with one domain (`dom`), besides `root`, and a domain admin and an user accounts in both `root` and `dom`, as well as the Root Admin. Every account created one project each.**

Table lists all options shown in UI, when logged as each of the accounts:
(User accounts did not show the selection fields Owner type, Domain and Account/Project. Neither did any of the projects.)

| Logged in as  | Listed domains | Listed accounts | Listed projects |
| ------------- | ------------- | ------------- | ------------- |
| ROOT Admin (`admin`) | - ROOT<br>- ROOT/dom  | - admin, dadm, usr<br>- dom-adm, dom-usr | - admin-proj, dadm-proj, usr-proj<br>- dom-adm-proj, dom-usr-proj|
| ROOT Domain Admin (`dadm`) | - ROOT<br>- ROOT/dom  | - admin, dadm, usr<br>- dom-adm, dom-usr | - admin-proj, dadm-proj, usr-proj<br>- * |
| ROOT User  (`usr`) | ---  | ---  | ---  |
| ROOT/dom Domain Admin (`dom-adm`)  | - ROOT/dom  | - dom-adm, dom-usr   | - dom-adm-proj, dom-usr-proj  |
| ROOT/dom User (`dom-usr`)  | ---  | ---  | ---  |


#### Testing this, I found a bug on listProjects. A domain admin can't list a subdomain's projects, with `isrecursive` or not.
I'm still working on the best way to go about it and will open a PR to fix it, but it's not ready yet.