### PR TITLE
plugins/shutdown: fix triggerShutdown scheduling and response

### DIFF
--- a/plugins/shutdown/src/main/java/org/apache/cloudstack/shutdown/ShutdownManagerImpl.java
+++ b/plugins/shutdown/src/main/java/org/apache/cloudstack/shutdown/ShutdownManagerImpl.java
@@ -107,7 +107,10 @@ public class ShutdownManagerImpl extends ManagerBase implements ShutdownManager,
             this.shutdownTask = null;
         }
         this.shutdownTask = new ShutdownTask(this);
-        timer.scheduleAtFixedRate(shutdownTask, 0, 30L * 1000);
+        long period = 30L * 1000;
+        long delay = period / 2;
+        logger.debug(String.format("Scheduling shutdown task with delay: %d and period: %d", delay, period));
+        timer.scheduleAtFixedRate(shutdownTask, delay, period);
     }
 
     @Override


### PR DESCRIPTION
### Description

Earlier the triggerShutdown API would immediately shutdown the MS and if it is the same MS on which API is called and there are no pending jobs it would lead to error in the API call. This change adds a delay to the process so the MS would be able to send response to the API.

This should fix test failure seen in PR wrt test_safe_shutdown.py,
https://github.com/apache/cloudstack/pull/8601#issuecomment-2177437854https://github.com/apache/cloudstack/pull/8601#issuecomment-2177479552

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Without fix: 
```
localcloud) 🐱 > trigger shutdown managementserverid=1
🙈 Error: Get "http://1.2.3.4:8080/client/api?apiKey=LIN6rqXuaJwMPfGYFh13qDwYz5VNNz1J2J6qIOWcd3oLQOq0WtD4CwRundBL6rzXToa3lQOC_vKjI3nkHtiD8Q&command=triggerShutdown&managementserverid=1&response=json&signature=7PpZ8vp4jKIbTe41HqhNwfjVp4g%3D": dial tcp 1.2.3.4:8080: connect: connection refused
```

After fix:
```
(local) 🐱 > trigger shutdown managementserverid=1
{
  "triggershutdown": {
    "managementserverid": 1,
    "pendingjobscount": 0,
    "readyforshutdown": true,
    "shutdowntriggered": true
  }
}
```
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
