### PR TITLE
Import VM logging improvements

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
@@ -203,8 +203,8 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
             for (Map<String, String> entry : (Collection<Map<String, String>>)nicNetworkList.values()) {
                 String nic = entry.get(VmDetailConstants.NIC);
                 String networkUuid = entry.get(VmDetailConstants.NETWORK);
-                if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace(String.format("nic, '%s', goes on net, '%s'", nic, networkUuid));
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(String.format("nic, '%s', goes on net, '%s'", nic, networkUuid));
                 }
                 if (StringUtils.isAnyEmpty(nic, networkUuid) || _entityMgr.findByUuid(Network.class, networkUuid) == null) {
                     throw new InvalidParameterValueException(String.format("Network ID: %s for NIC ID: %s is invalid", networkUuid, nic));
@@ -221,8 +221,8 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
             for (Map<String, String> entry : (Collection<Map<String, String>>)nicIpAddressList.values()) {
                 String nic = entry.get(VmDetailConstants.NIC);
                 String ipAddress = StringUtils.defaultIfEmpty(entry.get(VmDetailConstants.IP4_ADDRESS), null);
-                if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace(String.format("nic, '%s', gets ip, '%s'", nic, ipAddress));
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(String.format("nic, '%s', gets ip, '%s'", nic, ipAddress));
                 }
                 if (StringUtils.isEmpty(nic)) {
                     throw new InvalidParameterValueException(String.format("NIC ID: '%s' is invalid for IP address mapping", nic));

--- a/core/src/main/java/com/cloud/agent/api/CheckVolumeAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/CheckVolumeAnswer.java
@@ -17,7 +17,6 @@
 
 package com.cloud.agent.api;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class CheckVolumeAnswer extends Answer {
 
     private long size;

--- a/core/src/main/java/com/cloud/agent/api/CheckVolumeCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/CheckVolumeCommand.java
@@ -21,7 +21,6 @@ package com.cloud.agent.api;
 
 import com.cloud.agent.api.to.StorageFilerTO;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class CheckVolumeCommand extends Command {
 
     String srcFile;

--- a/core/src/main/java/com/cloud/agent/api/CopyRemoteVolumeAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/CopyRemoteVolumeAnswer.java
@@ -17,7 +17,6 @@
 
 package com.cloud.agent.api;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class CopyRemoteVolumeAnswer extends Answer {
 
     private String remoteIp;

--- a/core/src/main/java/com/cloud/agent/api/CopyRemoteVolumeCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/CopyRemoteVolumeCommand.java
@@ -21,10 +21,10 @@ package com.cloud.agent.api;
 
 import com.cloud.agent.api.to.StorageFilerTO;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class CopyRemoteVolumeCommand extends Command {
     String remoteIp;
     String username;
+    @LogLevel(LogLevel.Log4jLevel.Off)
     String password;
     String srcFile;
     String tmpPath;

--- a/core/src/main/java/com/cloud/agent/api/GetRemoteVmsAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/GetRemoteVmsAnswer.java
@@ -22,10 +22,10 @@ import org.apache.cloudstack.vm.UnmanagedInstanceTO;
 import java.util.HashMap;
 import java.util.List;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class GetRemoteVmsAnswer extends Answer {
 
     private String remoteIp;
+    @LogLevel(LogLevel.Log4jLevel.Trace)
     private HashMap<String, UnmanagedInstanceTO> unmanagedInstances;
 
     List<String> vmNames;

--- a/core/src/main/java/com/cloud/agent/api/GetRemoteVmsCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/GetRemoteVmsCommand.java
@@ -19,11 +19,11 @@
 
 package com.cloud.agent.api;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class GetRemoteVmsCommand extends Command {
 
     String remoteIp;
     String username;
+    @LogLevel(LogLevel.Log4jLevel.Off)
     String password;
 
     public GetRemoteVmsCommand(String remoteIp, String username, String password) {

--- a/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesAnswer.java
@@ -21,10 +21,10 @@ import java.util.HashMap;
 
 import org.apache.cloudstack.vm.UnmanagedInstanceTO;
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class GetUnmanagedInstancesAnswer extends Answer {
 
     private String instanceName;
+    @LogLevel(LogLevel.Log4jLevel.Trace)
     private HashMap<String, UnmanagedInstanceTO> unmanagedInstances;
 
     GetUnmanagedInstancesAnswer() {

--- a/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesCommand.java
@@ -28,10 +28,10 @@ import org.apache.commons.collections.CollectionUtils;
  * All managed instances will be filtered while trying to find unmanaged instances.
  */
 
-@LogLevel(LogLevel.Log4jLevel.Trace)
 public class GetUnmanagedInstancesCommand extends Command {
 
     String instanceName;
+    @LogLevel(LogLevel.Log4jLevel.Trace)
     List<String> managedInstancesNames;
 
     public GetUnmanagedInstancesCommand() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3771,14 +3771,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     }
 
     public List<String> getAllVmNames(final Connect conn) {
-        final ArrayList<String> la = new ArrayList<String>();
+        final ArrayList<String> domainNames = new ArrayList<String>();
         try {
             final String names[] = conn.listDefinedDomains();
             for (int i = 0; i < names.length; i++) {
-                la.add(names[i]);
+                domainNames.add(names[i]);
             }
         } catch (final LibvirtException e) {
-            s_logger.warn("Failed to list Defined domains", e);
+            s_logger.warn("Failed to list defined domains", e);
         }
 
         int[] ids = null;
@@ -3786,14 +3786,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             ids = conn.listDomains();
         } catch (final LibvirtException e) {
             s_logger.warn("Failed to list domains", e);
-            return la;
+            return domainNames;
         }
 
         Domain dm = null;
         for (int i = 0; i < ids.length; i++) {
             try {
                 dm = conn.domainLookupByID(ids[i]);
-                la.add(dm.getName());
+                domainNames.add(dm.getName());
             } catch (final LibvirtException e) {
                 s_logger.warn("Unable to get vms", e);
             } finally {
@@ -3807,7 +3807,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
         }
 
-        return la;
+        return domainNames;
     }
 
     private HashMap<String, HostVmStateReportEntry> getHostVmStateReport() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapper.java
@@ -48,7 +48,7 @@ public final class LibvirtGetUnmanagedInstancesCommandWrapper extends CommandWra
 
     @Override
     public GetUnmanagedInstancesAnswer execute(GetUnmanagedInstancesCommand command, LibvirtComputingResource libvirtComputingResource) {
-        LOGGER.info("Fetching unmanaged instance on host");
+        LOGGER.info("Fetching unmanaged instances on host");
 
         HashMap<String, UnmanagedInstanceTO> unmanagedInstances = new HashMap<>();
         try {

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -800,6 +800,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }
         int copyTimeoutInSecs = copyTimeout * 60;
         copyRemoteVolumeCommand.setWait(copyTimeoutInSecs);
+        LOGGER.error(String.format("Initiating copy remote volume %s from %s, timeout %d secs", path, remoteUrl, copyTimeoutInSecs));
         Answer answer = agentManager.easySend(dest.getHost().getId(), copyRemoteVolumeCommand);
         if (!(answer instanceof CopyRemoteVolumeAnswer)) {
             throw new CloudRuntimeException("Error while copying volume of remote instance: " + answer.getDetails());
@@ -2434,7 +2435,6 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         return defaultNetwork;
     }
 
-    //generate unit test
     public ListResponse<UnmanagedInstanceResponse> listVmsForImport(ListVmsForImportCmd cmd) {
         final Account caller = CallContext.current().getCallingAccount();
         if (caller.getType() != Account.Type.ADMIN) {
@@ -2474,8 +2474,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     private HashMap<String, UnmanagedInstanceTO> getRemoteVmsOnKVMHost(long zoneId, String remoteHostUrl, String username, String password) {
         //ToDo: add option to list one Vm by name
         List<HostVO> hosts = resourceManager.listAllUpAndEnabledHostsInOneZoneByHypervisor(Hypervisor.HypervisorType.KVM, zoneId);
-        if(hosts.size() < 1) {
-            throw new CloudRuntimeException("No hosts available for VM import");
+        if (hosts.size() < 1) {
+            throw new CloudRuntimeException("No hosts available to list VMs on remote host " + remoteHostUrl);
         }
         HostVO host = hosts.get(0);
         GetRemoteVmsCommand getRemoteVmsCommand = new GetRemoteVmsCommand(remoteHostUrl, username, password);


### PR DESCRIPTION
### Description

This PR improves logs while importing vm from remote/external KVM host.

Fixes #8779 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Manually tested import vm operation and checked the import logs in MS / KVM host.

**MS logs =>**

```
2024-06-21 19:45:11,411 DEBUG [c.c.a.t.Request] (qtp1866850137-19:ctx-7f9bf2bb ctx-a94593d9) (logid:a066305c) Seq 1-168603511049682964: Sending  { Cmd , MgmtId: 32986204471710, via: 1(ref-trl-6881-k-M7-suresh-anaparti-kvm1), Ver: v1, Flags: 100011, [{"com.cloud.agent.api.GetRemoteVmsCommand":{"remoteIp":"10.x.x.x","username":"root","wait":"0","bypassHostMaintenance":"false"}}] }
2024-06-21 19:45:11,467 DEBUG [c.c.a.t.Request] (AgentManager-Handler-15:null) (logid:) Seq 1-168603511049682964: Processing:  { Ans: , MgmtId: 32986204471710, via: 1, Ver: v1, Flags: 10, [{"com.cloud.agent.api.GetRemoteVmsAnswer":{"remoteIp":"10.x.x.x","result":"true","details":"","wait":"0","bypassHostMaintenance":"false"}}] }
2024-06-21 19:45:11,467 DEBUG [c.c.a.t.Request] (qtp1866850137-19:ctx-7f9bf2bb ctx-a94593d9) (logid:a066305c) Seq 1-168603511049682964: Received:  { Ans: , MgmtId: 32986204471710, via: 1(ref-trl-6881-k-M7-suresh-anaparti-kvm1), Ver: v1, Flags: 10, { GetRemoteVmsAnswer } }
...
2024-06-21 19:46:11,369 ERROR [o.a.c.v.UnmanagedVMsManagerImpl] (API-Job-Executor-1:ctx-b1fc397c job-43 ctx-8e262883) (logid:f12d765a) Initiating copy remote volume /root/kvm.qcow2 from 10.x.x.x, timeout 900 secs
2024-06-21 19:46:11,371 DEBUG [c.c.a.t.Request] (API-Job-Executor-1:ctx-b1fc397c job-43 ctx-8e262883) (logid:f12d765a) Seq 2-521854606821556251: Sending  { Cmd , MgmtId: 32986204471710, via: 2(ref-trl-6881-k-M7-suresh-anaparti-kvm2), Ver: v1, Flags: 100011, [{"com.cloud.agent.api.CopyRemoteVolumeCommand":{"remoteIp":"10.x.x.x","username":"root","srcFile":"/root/kvm.qcow2","tmpPath":"/tmp/","storageFilerTO":{"id":"2","uuid":"f860203f-18b5-3ef8-ad58-66f40316f09d","host":"10.x.x.x","path":"/acs/primary/ref-trl-6881-k-M7-suresh-anaparti/ref-trl-6881-k-M7-suresh-anaparti-kvm-pri2","port":"2049","type":"NetworkFilesystem"},"wait":"900","bypassHostMaintenance":"false"}}] }
2024-06-21 19:46:12,151 DEBUG [c.c.a.t.Request] (AgentManager-Handler-15:null) (logid:) Seq 2-521854606821556251: Processing:  { Ans: , MgmtId: 32986204471710, via: 2, Ver: v1, Flags: 10, [{"com.cloud.agent.api.CopyRemoteVolumeAnswer":{"remoteIp":"10.x.x.x","filename":"f1779731-5b6a-4006-96c6-431143929fd8","size":"(1.00 GB) 1073741824","result":"true","details":"","wait":"0","bypassHostMaintenance":"false"}}] }
2024-06-21 19:46:12,152 DEBUG [c.c.a.t.Request] (API-Job-Executor-1:ctx-b1fc397c job-43 ctx-8e262883) (logid:f12d765a) Seq 2-521854606821556251: Received:  { Ans: , MgmtId: 32986204471710, via: 2(ref-trl-6881-k-M7-suresh-anaparti-kvm2), Ver: v1, Flags: 10, { CopyRemoteVolumeAnswer } }
```

**KVM host logs =>**

```
2024-06-21 19:45:11,421 DEBUG [cloud.agent.Agent] (agentRequest-Handler-3:null) (logid:a066305c) Request:Seq 1-168603511049682964:  { Cmd , MgmtId: 32986204471710, via: 1, Ver: v1, Flags: 100011, [{"com.cloud.agent.api.GetRemoteVmsCommand":{"remoteIp":"10.x.x.x","username":"root","wait":"0","bypassHostMaintenance":"false"}}] }
2024-06-21 19:45:11,421 DEBUG [cloud.agent.Agent] (agentRequest-Handler-3:null) (logid:a066305c) Processing command: com.cloud.agent.api.GetRemoteVmsCommand
2024-06-21 19:45:11,422 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-3:null) (logid:a066305c) Looking for libvirtd connection at: qemu+tcp://10.x.x.x/system
2024-06-21 19:45:11,422 INFO  [kvm.resource.LibvirtConnection] (agentRequest-Handler-3:null) (logid:a066305c) No existing libvirtd connection found. Opening a new one
2024-06-21 19:45:11,427 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-3:null) (logid:a066305c) Successfully connected to libvirt at: qemu+tcp://10.x.x.x/system
2024-06-21 19:45:11,436 INFO  [resource.wrapper.LibvirtGetRemoteVmsCommandWrapper] (agentRequest-Handler-3:null) (logid:a066305c) Found 3 VMs on the remote host 10.x.x.x
2024-06-21 19:45:11,437 DEBUG [resource.wrapper.LibvirtGetRemoteVmsCommandWrapper] (agentRequest-Handler-3:null) (logid:a066305c) Remote VM guest1-rhel7 - powerstate: VIR_DOMAIN_SHUTOFF, state: PowerOff
2024-06-21 19:45:11,461 DEBUG [resource.wrapper.LibvirtGetRemoteVmsCommandWrapper] (agentRequest-Handler-3:null) (logid:a066305c) Remote VM i-2-7-VM - powerstate: VIR_DOMAIN_RUNNING, state: PowerOn
2024-06-21 19:45:11,462 DEBUG [resource.wrapper.LibvirtGetRemoteVmsCommandWrapper] (agentRequest-Handler-3:null) (logid:a066305c) Remote VM i-2-6-VM - powerstate: VIR_DOMAIN_RUNNING, state: PowerOn
2024-06-21 19:45:11,464 DEBUG [resource.wrapper.LibvirtGetRemoteVmsCommandWrapper] (agentRequest-Handler-3:null) (logid:a066305c) Found 1 stopped VMs on remote host 10.x.x.x
2024-06-21 19:45:11,466 DEBUG [cloud.agent.Agent] (agentRequest-Handler-3:null) (logid:a066305c) Seq 1-168603511049682964:  { Ans: , MgmtId: 32986204471710, via: 1, Ver: v1, Flags: 10, [{"com.cloud.agent.api.GetRemoteVmsAnswer":{"remoteIp":"10.x.x.x","result":"true","details":"","wait":"0","bypassHostMaintenance":"false"}}] }
...
2024-06-21 19:46:11,422 DEBUG [cloud.agent.Agent] (agentRequest-Handler-1:null) (logid:f12d765a) Request:Seq 2-521854606821556251:  { Cmd , MgmtId: 32986204471710, via: 2, Ver: v1, Flags: 100011, [{"com.cloud.agent.api.CopyRemoteVolumeCommand":{"remoteIp":"10.x.x.x","username":"root","srcFile":"/root/kvm.qcow2","tmpPath":"/tmp/","storageFilerTO":{"id":"2","uuid":"f860203f-18b5-3ef8-ad58-66f40316f09d","host":"10.x.x.x","path":"/acs/primary/ref-trl-6881-k-M7-suresh-anaparti/ref-trl-6881-k-M7-suresh-anaparti-kvm-pri2","port":"2049","type":"NetworkFilesystem"},"wait":"900","bypassHostMaintenance":"false"}}] }
2024-06-21 19:46:11,431 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:f12d765a) Successfully refreshed pool f860203f-18b5-3ef8-ad58-66f40316f09d Capacity: (1.9990 TB) 2197949513728 Used: (1.2908 TB) 1419287461888 Available: (725.19 GB) 778662051840
2024-06-21 19:46:11,432 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-1:null) (logid:f12d765a) Converting remote disk file: /root/kvm.qcow2, output file: /tmp/f1779731-5b6a-4006-96c6-431143929fd8 (timeout: 900 secs)
2024-06-21 19:46:11,871 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-1:null) (logid:f12d765a) Copying converted remote disk file f1779731-5b6a-4006-96c6-431143929fd8 to: /mnt/f860203f-18b5-3ef8-ad58-66f40316f09d
2024-06-21 19:46:12,104 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-1:null) (logid:f12d765a) Successfully copied converted remote disk file to: /mnt/f860203f-18b5-3ef8-ad58-66f40316f09d/f1779731-5b6a-4006-96c6-431143929fd8
2024-06-21 19:46:12,105 DEBUG [resource.wrapper.LibvirtCopyRemoteVolumeCommandWrapper] (agentRequest-Handler-1:null) (logid:f12d765a) Volume /root/kvm.qcow2 copy successful, copied to file: f1779731-5b6a-4006-96c6-431143929fd8
2024-06-21 19:46:12,111 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:f12d765a) Could not find volume f1779731-5b6a-4006-96c6-431143929fd8: Storage volume not found: no storage vol with matching name 'f1779731-5b6a-4006-96c6-431143929fd8'
2024-06-21 19:46:12,112 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:f12d765a) Refreshing storage pool f860203f-18b5-3ef8-ad58-66f40316f09d
2024-06-21 19:46:12,128 DEBUG [kvm.storage.LibvirtStorageAdaptor] (agentRequest-Handler-1:null) (logid:f12d765a) Found volume f1779731-5b6a-4006-96c6-431143929fd8 in storage pool f860203f-18b5-3ef8-ad58-66f40316f09d after refreshing the pool
2024-06-21 19:46:12,156 DEBUG [cloud.agent.Agent] (agentRequest-Handler-1:null) (logid:f12d765a) Seq 2-521854606821556251:  { Ans: , MgmtId: 32986204471710, via: 2, Ver: v1, Flags: 10, [{"com.cloud.agent.api.CopyRemoteVolumeAnswer":{"remoteIp":"10.x.x.x","filename":"f1779731-5b6a-4006-96c6-431143929fd8","size":"(1.00 GB) 1073741824","result":"true","details":"","wait":"0","bypassHostMaintenance":"false"}}] }
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
