### PR TITLE
Add support for network data in Config Drive

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.cloud.dc.DataCenter;
+import com.cloud.hypervisor.Hypervisor;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.ConfigKey.Scope;
@@ -143,6 +144,8 @@ public interface NetworkOrchestrationService {
     void removeNics(VirtualMachineProfile vm);
 
     List<NicProfile> getNicProfiles(VirtualMachine vm);
+
+    List<NicProfile> getNicProfiles(Long vmId, Hypervisor.HypervisorType hypervisorType);
 
     Map<String, String> getSystemVMAccessDetails(VirtualMachine vm);
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1798,7 +1798,6 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                                      final ReservationContext context) throws InsufficientCapacityException, ConcurrentOperationException, ResourceUnavailableException {
         element.prepare(network, profile, vmProfile, dest, context);
         if (vmProfile.getType() == Type.User && element.getProvider() != null) {
-            boolean buildConfigDrive = false;
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dhcp)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dhcp, element.getProvider()) && element instanceof DhcpServiceProvider) {
                 final DhcpServiceProvider sp = (DhcpServiceProvider) element;
@@ -1810,7 +1809,6 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (!sp.addDhcpEntry(network, profile, vmProfile, dest, context)) {
                     return false;
                 }
-                buildConfigDrive = true;
             }
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dns)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dns, element.getProvider()) && element instanceof DnsServiceProvider) {
@@ -1823,7 +1821,6 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (!sp.addDnsEntry(network, profile, vmProfile, dest, context)) {
                     return false;
                 }
-                buildConfigDrive = true;
             }
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.UserData)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.UserData, element.getProvider()) && element instanceof UserDataServiceProvider) {
@@ -1831,9 +1828,17 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (!sp.addPasswordAndUserdata(network, profile, vmProfile, dest, context)) {
                     return false;
                 }
-                buildConfigDrive = true;
             }
-            if (buildConfigDrive && element instanceof ConfigDriveNetworkElement) {
+            if (element instanceof ConfigDriveNetworkElement && ((
+                    _networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dhcp) &&
+                            _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dhcp, element.getProvider())
+            ) || (
+                    _networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dns) &&
+                            _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dns, element.getProvider())
+            ) || (
+                    _networkModel.areServicesSupportedInNetwork(network.getId(), Service.UserData) &&
+                            _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.UserData, element.getProvider())
+            ))) {
                 final ConfigDriveNetworkElement sp = (ConfigDriveNetworkElement) element;
                 return sp.createConfigDriveIso(profile, vmProfile, dest, null);
             }
@@ -4445,23 +4450,28 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     }
 
     @Override
-    public List<NicProfile> getNicProfiles(final VirtualMachine vm) {
-        final List<NicVO> nics = _nicDao.listByVmId(vm.getId());
+    public List<NicProfile> getNicProfiles(final Long vmId, HypervisorType hypervisorType) {
+        final List<NicVO> nics = _nicDao.listByVmId(vmId);
         final List<NicProfile> profiles = new ArrayList<NicProfile>();
 
         if (nics != null) {
             for (final Nic nic : nics) {
                 final NetworkVO network = _networksDao.findById(nic.getNetworkId());
-                final Integer networkRate = _networkModel.getNetworkRate(network.getId(), vm.getId());
+                final Integer networkRate = _networkModel.getNetworkRate(network.getId(), vmId);
 
                 final NetworkGuru guru = AdapterBase.getAdapterByName(networkGurus, network.getGuruName());
                 final NicProfile profile = new NicProfile(nic, network, nic.getBroadcastUri(), nic.getIsolationUri(), networkRate,
-                        _networkModel.isSecurityGroupSupportedInNetwork(network), _networkModel.getNetworkTag(vm.getHypervisorType(), network));
+                        _networkModel.isSecurityGroupSupportedInNetwork(network), _networkModel.getNetworkTag(hypervisorType, network));
                 guru.updateNicProfile(profile, network);
                 profiles.add(profile);
             }
         }
         return profiles;
+    }
+
+    @Override
+    public List<NicProfile> getNicProfiles(final VirtualMachine vm) {
+        return getNicProfiles(vm.getId(), vm.getHypervisorType());
     }
 
     @Override

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1798,6 +1798,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                                      final ReservationContext context) throws InsufficientCapacityException, ConcurrentOperationException, ResourceUnavailableException {
         element.prepare(network, profile, vmProfile, dest, context);
         if (vmProfile.getType() == Type.User && element.getProvider() != null) {
+            boolean buildConfigDrive = false;
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dhcp)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dhcp, element.getProvider()) && element instanceof DhcpServiceProvider) {
                 final DhcpServiceProvider sp = (DhcpServiceProvider) element;
@@ -1809,6 +1810,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (!sp.addDhcpEntry(network, profile, vmProfile, dest, context)) {
                     return false;
                 }
+                buildConfigDrive = true;
             }
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dns)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dns, element.getProvider()) && element instanceof DnsServiceProvider) {
@@ -1821,6 +1823,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (!sp.addDnsEntry(network, profile, vmProfile, dest, context)) {
                     return false;
                 }
+                buildConfigDrive = true;
             }
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.UserData)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.UserData, element.getProvider()) && element instanceof UserDataServiceProvider) {
@@ -1828,6 +1831,11 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (!sp.addPasswordAndUserdata(network, profile, vmProfile, dest, context)) {
                     return false;
                 }
+                buildConfigDrive = true;
+            }
+            if (buildConfigDrive && element instanceof ConfigDriveNetworkElement) {
+                final ConfigDriveNetworkElement sp = (ConfigDriveNetworkElement) element;
+                return sp.createConfigDriveIso(profile, vmProfile, dest, null);
             }
         }
         return true;

--- a/engine/storage/configdrive/src/main/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
+++ b/engine/storage/configdrive/src/main/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
@@ -37,7 +37,6 @@ import java.util.Set;
 
 import com.cloud.network.Network;
 import com.cloud.vm.NicProfile;
-import com.google.gson.JsonParser;
 import com.googlecode.ipv6.IPv6Network;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.MapUtils;
@@ -54,13 +53,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import javax.inject.Inject;
-
 public class ConfigDriveBuilder {
 
     protected static Logger LOGGER = LogManager.getLogger(ConfigDriveBuilder.class);
-    @Inject
-    NetworkModel _networkModel;
 
     /**
      * This is for mocking the File class. We cannot mock the File class directly because Mockito uses it internally.
@@ -227,23 +222,6 @@ public class ConfigDriveBuilder {
         writeFile(openStackFolder, "meta_data.json", metaData.toString());
     }
 
-    static JsonObject getExistingNetworkData(File openStackFolder) {
-        if (openStackFolder.exists()) {
-            File networkDataFile = getFile(openStackFolder.getAbsolutePath(), "network_data.json");
-            if (networkDataFile.exists()) {
-                try {
-                    String networkDataFileContent = FileUtils.readFileToString(networkDataFile, com.cloud.utils.StringUtils.getPreferredCharset());
-                    if (StringUtils.isNotBlank(networkDataFileContent)) {
-                        return new JsonParser().parse(networkDataFileContent).getAsJsonObject();
-                    }
-                } catch (IOException e) {
-                    LOGGER.warn("Failed to read existing network data file: {}", networkDataFile.getAbsolutePath(), e);
-                }
-            }
-        }
-        return new JsonObject();
-    }
-
     /**
      * First we generate a JSON object using {@link #getNetworkDataJsonObjectForNic(NicProfile, List)}, then we write it to a file called "network_data.json".
      */
@@ -394,7 +372,7 @@ public class ConfigDriveBuilder {
             ipv6Network.addProperty("ip_address", nic.getIPv6Address());
             ipv6Network.addProperty("link", String.format("eth%d", nic.getDeviceId()));
             ipv6Network.addProperty("netmask", IPv6Network.fromString(nic.getIPv6Cidr()).getNetmask().toString());
-            ipv6Network.addProperty("network_id", nic.getNetworkId());
+            ipv6Network.addProperty("network_id", nic.getUuid());
             ipv6Network.addProperty("type", "ipv6");
 
             JsonArray ipv6RouteArray = new JsonArray();

--- a/engine/storage/configdrive/src/main/java/org/apache/cloudstack/storage/configdrive/ConfigDriveUtils.java
+++ b/engine/storage/configdrive/src/main/java/org/apache/cloudstack/storage/configdrive/ConfigDriveUtils.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.storage.configdrive;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ConfigDriveUtils {
+
+    static void mergeJsonArraysAndUpdateObject(JsonObject finalObject, JsonObject newObj, String memberName, String... keys) {
+        JsonArray existingMembers = finalObject.has(memberName) ? finalObject.get(memberName).getAsJsonArray() : new JsonArray();
+        JsonArray newMembers = newObj.has(memberName) ? newObj.get(memberName).getAsJsonArray() : new JsonArray();
+
+        if (existingMembers.size() > 0 || newMembers.size() > 0) {
+            JsonArray finalMembers = new JsonArray();
+            Set<String> idSet = new HashSet<>();
+            for (JsonElement element : existingMembers.getAsJsonArray()) {
+                JsonObject elementObject = element.getAsJsonObject();
+                String key = Arrays.stream(keys).map(elementObject::get).map(JsonElement::getAsString).reduce((a, b) -> a + "-" + b).orElse("");
+                idSet.add(key);
+                finalMembers.add(element);
+            }
+            for (JsonElement element : newMembers.getAsJsonArray()) {
+                JsonObject elementObject = element.getAsJsonObject();
+                String key = Arrays.stream(keys).map(elementObject::get).map(JsonElement::getAsString).reduce((a, b) -> a + "-" + b).orElse("");
+                if (!idSet.contains(key)) {
+                    finalMembers.add(element);
+                }
+            }
+            finalObject.add(memberName, finalMembers);
+        }
+    }
+
+}

--- a/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
+++ b/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
@@ -113,15 +113,15 @@ public class ConfigDriveBuilderTest {
 
     @Test(expected = CloudRuntimeException.class)
     public void buildConfigDriveTestNoVmData() {
-        ConfigDriveBuilder.buildConfigDrive(null, "teste", "C:", null);
+        ConfigDriveBuilder.buildConfigDrive(null, null, "teste", "C:", null);
     }
 
     @Test(expected = CloudRuntimeException.class)
     public void buildConfigDriveTestIoException() {
         try (MockedStatic<ConfigDriveBuilder> configDriveBuilderMocked = Mockito.mockStatic(ConfigDriveBuilder.class)) {
             configDriveBuilderMocked.when(() -> ConfigDriveBuilder.writeVendorAndNetworkEmptyJsonFile(nullable(File.class))).thenThrow(CloudRuntimeException.class);
-            Mockito.when(ConfigDriveBuilder.buildConfigDrive(new ArrayList<>(), "teste", "C:", null)).thenCallRealMethod();
-            ConfigDriveBuilder.buildConfigDrive(new ArrayList<>(), "teste", "C:", null);
+            Mockito.when(ConfigDriveBuilder.buildConfigDrive(null, new ArrayList<>(), "teste", "C:", null)).thenCallRealMethod();
+            ConfigDriveBuilder.buildConfigDrive(null, new ArrayList<>(), "teste", "C:", null);
         }
     }
 
@@ -137,9 +137,9 @@ public class ConfigDriveBuilderTest {
 
             configDriveBuilderMocked.when(() -> ConfigDriveBuilder.generateAndRetrieveIsoAsBase64Iso(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenAnswer(invocation -> "mockIsoDataBase64");
             //force execution of real method
-            Mockito.when(ConfigDriveBuilder.buildConfigDrive(new ArrayList<>(), "teste", "C:", null)).thenCallRealMethod();
+            Mockito.when(ConfigDriveBuilder.buildConfigDrive(null, new ArrayList<>(), "teste", "C:", null)).thenCallRealMethod();
 
-            String returnedIsoData = ConfigDriveBuilder.buildConfigDrive(new ArrayList<>(), "teste", "C:", null);
+            String returnedIsoData = ConfigDriveBuilder.buildConfigDrive(null, new ArrayList<>(), "teste", "C:", null);
 
             Assert.assertEquals("mockIsoDataBase64", returnedIsoData);
 

--- a/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
+++ b/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 
 import com.cloud.network.Network;
 import com.cloud.vm.NicProfile;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -636,8 +635,6 @@ public class ConfigDriveBuilderTest {
     public void testWriteNetworkDataEmptyJson() throws Exception {
         // Setup
         NicProfile nicp = mock(NicProfile.class);
-        Mockito.when(nicp.getId()).thenReturn(1L);
-
         List<Network.Service> services1 = Collections.emptyList();
 
         Map<Long, List<Network.Service>> supportedServices = new HashMap<>();
@@ -661,80 +658,5 @@ public class ConfigDriveBuilderTest {
 
         Assert.assertEquals(expectedJsonObject, actualJson);
         folder.delete();
-    }
-
-    @Test
-    public void testMergeJsonArraysAndUpdateObjectWithEmptyObjects() {
-        JsonObject finalObject = new JsonObject();
-        JsonObject newObj = new JsonObject();
-        ConfigDriveBuilder.mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
-        Assert.assertEquals("{}", finalObject.toString());
-    }
-
-    @Test
-    public void testMergeJsonArraysAndUpdateObjectWithNewMembersAdded() {
-        JsonObject finalObject = new JsonObject();
-
-        JsonObject newObj = new JsonObject();
-        JsonArray newMembers = new JsonArray();
-        JsonObject newMember = new JsonObject();
-        newMember.addProperty("id", "eth0");
-        newMember.addProperty("type", "phy");
-        newMembers.add(newMember);
-        newObj.add("links", newMembers);
-
-        ConfigDriveBuilder.mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
-        Assert.assertEquals(1, finalObject.getAsJsonArray("links").size());
-        JsonObject expectedObj = new JsonParser().parse("{'links': [{'id': 'eth0', 'type': 'phy'}]}").getAsJsonObject();
-        Assert.assertEquals(expectedObj, finalObject);
-    }
-
-    @Test
-    public void testMergeJsonArraysAndUpdateObjectWithDuplicateMembersIgnored() {
-        JsonObject finalObject = new JsonObject();
-        JsonArray existingMembers = new JsonArray();
-        JsonObject existingMember = new JsonObject();
-        existingMember.addProperty("id", "eth0");
-        existingMember.addProperty("type", "phy");
-        existingMembers.add(existingMember);
-        finalObject.add("links", existingMembers);
-
-        JsonObject newObj = new JsonObject();
-        newObj.add("links", existingMembers); // same as existingMembers for duplication
-
-        ConfigDriveBuilder.mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
-        Assert.assertEquals(1, finalObject.getAsJsonArray("links").size());
-        JsonObject expectedObj = new JsonParser().parse("{'links': [{'id': 'eth0', 'type': 'phy'}]}").getAsJsonObject();
-        Assert.assertEquals(expectedObj, finalObject);
-    }
-
-    @Test
-    public void testMergeJsonArraysAndUpdateObjectWithDifferentMembers() {
-        JsonObject finalObject = new JsonObject();
-
-        JsonArray newMembers = new JsonArray();
-        JsonObject newMember = new JsonObject();
-        newMember.addProperty("id", "eth0");
-        newMember.addProperty("type", "phy");
-        newMembers.add(newMember);
-        finalObject.add("links", newMembers);
-
-        JsonObject newObj = new JsonObject();
-        newMembers = new JsonArray();
-        newMember = new JsonObject();
-        newMember.addProperty("id", "eth1");
-        newMember.addProperty("type", "phy");
-        newMembers.add(newMember);
-        newObj.add("links", newMembers);
-
-        ConfigDriveBuilder.mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
-        Assert.assertEquals(2, finalObject.getAsJsonArray("links").size());
-        JsonObject expectedObj = new JsonParser().parse("{'links': [{'id': 'eth0', 'type': 'phy'}, {'id': 'eth1', 'type': 'phy'}]}").getAsJsonObject();
-        Assert.assertEquals(expectedObj, finalObject);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testMergeJsonArraysAndUpdateObjectWithNullObjects() {
-        ConfigDriveBuilder.mergeJsonArraysAndUpdateObject(null, null, "services", "id", "type");
     }
 }

--- a/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
+++ b/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.cloud.network.Network;
+import com.cloud.vm.NicProfile;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
@@ -51,11 +52,11 @@ import com.google.gson.JsonObject;
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigDriveBuilderTest {
 
-    private static List<Network.Service> supportedServices;
+    private static Map<Long, List<Network.Service>> supportedServices;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        supportedServices = List.of(Network.Service.UserData, Network.Service.Dhcp, Network.Service.Dns);
+        supportedServices = Map.of(1L, List.of(Network.Service.UserData, Network.Service.Dhcp, Network.Service.Dns));
     }
 
     @Test
@@ -145,10 +146,14 @@ public class ConfigDriveBuilderTest {
             configDriveBuilderMocked.when(() -> ConfigDriveBuilder.linkUserData((Mockito.anyString()))).then(invocationOnMock -> null);
 
             configDriveBuilderMocked.when(() -> ConfigDriveBuilder.generateAndRetrieveIsoAsBase64Iso(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenAnswer(invocation -> "mockIsoDataBase64");
-            //force execution of real method
-            Mockito.when(ConfigDriveBuilder.buildConfigDrive(null, new ArrayList<>(), "teste", "C:", null, supportedServices)).thenCallRealMethod();
 
-            String returnedIsoData = ConfigDriveBuilder.buildConfigDrive(null, new ArrayList<>(), "teste", "C:", null, supportedServices);
+            NicProfile mockedNicProfile = Mockito.mock(NicProfile.class);
+            Mockito.when(mockedNicProfile.getId()).thenReturn(1L);
+
+            //force execution of real method
+            Mockito.when(ConfigDriveBuilder.buildConfigDrive(List.of(mockedNicProfile), new ArrayList<>(), "teste", "C:", null, supportedServices)).thenCallRealMethod();
+
+            String returnedIsoData = ConfigDriveBuilder.buildConfigDrive(List.of(mockedNicProfile), new ArrayList<>(), "teste", "C:", null, supportedServices);
 
             Assert.assertEquals("mockIsoDataBase64", returnedIsoData);
 

--- a/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveUtilsTest.java
+++ b/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveUtilsTest.java
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.storage.configdrive;
+
+import static org.apache.cloudstack.storage.configdrive.ConfigDriveUtils.mergeJsonArraysAndUpdateObject;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.gson.JsonObject;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigDriveUtilsTest {
+
+    @Test
+    public void testMergeJsonArraysAndUpdateObjectWithEmptyObjects() {
+        JsonObject finalObject = new JsonObject();
+        JsonObject newObj = new JsonObject();
+        mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
+        Assert.assertEquals("{}", finalObject.toString());
+    }
+
+    @Test
+    public void testMergeJsonArraysAndUpdateObjectWithNewMembersAdded() {
+        JsonObject finalObject = new JsonObject();
+
+        JsonObject newObj = new JsonObject();
+        JsonArray newMembers = new JsonArray();
+        JsonObject newMember = new JsonObject();
+        newMember.addProperty("id", "eth0");
+        newMember.addProperty("type", "phy");
+        newMembers.add(newMember);
+        newObj.add("links", newMembers);
+
+        mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
+        Assert.assertEquals(1, finalObject.getAsJsonArray("links").size());
+        JsonObject expectedObj = new JsonParser().parse("{'links': [{'id': 'eth0', 'type': 'phy'}]}").getAsJsonObject();
+        Assert.assertEquals(expectedObj, finalObject);
+    }
+
+    @Test
+    public void testMergeJsonArraysAndUpdateObjectWithDuplicateMembersIgnored() {
+        JsonObject finalObject = new JsonObject();
+        JsonArray existingMembers = new JsonArray();
+        JsonObject existingMember = new JsonObject();
+        existingMember.addProperty("id", "eth0");
+        existingMember.addProperty("type", "phy");
+        existingMembers.add(existingMember);
+        finalObject.add("links", existingMembers);
+
+        JsonObject newObj = new JsonObject();
+        newObj.add("links", existingMembers); // same as existingMembers for duplication
+
+        mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
+        Assert.assertEquals(1, finalObject.getAsJsonArray("links").size());
+        JsonObject expectedObj = new JsonParser().parse("{'links': [{'id': 'eth0', 'type': 'phy'}]}").getAsJsonObject();
+        Assert.assertEquals(expectedObj, finalObject);
+    }
+
+    @Test
+    public void testMergeJsonArraysAndUpdateObjectWithDifferentMembers() {
+        JsonObject finalObject = new JsonObject();
+
+        JsonArray newMembers = new JsonArray();
+        JsonObject newMember = new JsonObject();
+        newMember.addProperty("id", "eth0");
+        newMember.addProperty("type", "phy");
+        newMembers.add(newMember);
+        finalObject.add("links", newMembers);
+
+        JsonObject newObj = new JsonObject();
+        newMembers = new JsonArray();
+        newMember = new JsonObject();
+        newMember.addProperty("id", "eth1");
+        newMember.addProperty("type", "phy");
+        newMembers.add(newMember);
+        newObj.add("links", newMembers);
+
+        mergeJsonArraysAndUpdateObject(finalObject, newObj, "links", "id", "type");
+        Assert.assertEquals(2, finalObject.getAsJsonArray("links").size());
+        JsonObject expectedObj = new JsonParser().parse("{'links': [{'id': 'eth0', 'type': 'phy'}, {'id': 'eth1', 'type': 'phy'}]}").getAsJsonObject();
+        Assert.assertEquals(expectedObj, finalObject);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testMergeJsonArraysAndUpdateObjectWithNullObjects() {
+        mergeJsonArraysAndUpdateObject(null, null, "services", "id", "type");
+    }
+}

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2174,7 +2174,6 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
         NetworkVO network = _networksDao.findById(networkId);
         Integer networkRate = getNetworkRate(network.getId(), vm.getId());
 
-//        NetworkGuru guru = _networkGurus.get(network.getGuruName());
         NicProfile profile =
             new NicProfile(nic, network, nic.getBroadcastUri(), nic.getIsolationUri(), networkRate, isSecurityGroupSupportedInNetwork(network), getNetworkTag(
                 vm.getHypervisorType(), network));
@@ -2184,7 +2183,17 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
         if (network.getTrafficType() == TrafficType.Guest && network.getPrivateMtu() != null) {
             profile.setMtu(network.getPrivateMtu());
         }
-//        guru.updateNicProfile(profile, network);
+
+        DataCenter dc = _dcDao.findById(network.getDataCenterId());
+
+        Pair<String, String> ip4Dns = getNetworkIp4Dns(network, dc);
+        profile.setIPv4Dns1(ip4Dns.first());
+        profile.setIPv4Dns2(ip4Dns.second());
+
+        Pair<String, String> ip6Dns = getNetworkIp6Dns(network, dc);
+        profile.setIPv6Dns1(ip6Dns.first());
+        profile.setIPv6Dns2(ip6Dns.second());
+
         return profile;
     }
 

--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
@@ -111,6 +112,8 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     ServiceOfferingDao _serviceOfferingDao;
     @Inject
     NetworkModel _networkModel;
+    @Inject
+    NetworkOrchestrationService _networkOrchestrationService;
     @Inject
     GuestOSCategoryDao _guestOSCategoryDao;
     @Inject
@@ -546,8 +549,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
         final String isoFileName = ConfigDrive.configIsoFileName(profile.getInstanceName());
         final String isoPath = ConfigDrive.createConfigDrivePath(profile.getInstanceName());
-        List<? extends Nic> nics = _networkModel.getNics(nic.getVirtualMachineId());
-        List<NicProfile> nicProfiles = getNicProfilesForNic(profile.getVirtualMachine(), nics);
+        List<NicProfile> nicProfiles = _networkOrchestrationService.getNicProfiles(nic.getVirtualMachineId(), profile.getHypervisorType());
         final Map<Long, List<Service>> supportedServices = getSupportedServicesByElementForNetwork(nicProfiles);
         final String isoData = ConfigDriveBuilder.buildConfigDrive(nicProfiles, profile.getVmData(), isoFileName, profile.getConfigDriveLabel(), customUserdataParamMap, supportedServices);
         final HandleConfigDriveIsoCommand configDriveIsoCommand = new HandleConfigDriveIsoCommand(isoPath, isoData, null, false, true, true);
@@ -599,14 +601,6 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         return true;
     }
 
-    private List<NicProfile> getNicProfilesForNic(VirtualMachine vm, List<? extends Nic> nics) {
-        List<NicProfile> nicProfiles = new ArrayList<>();
-        for (Nic nic: nics) {
-            nicProfiles.add(_networkModel.getNicProfile(vm, nic.getNetworkId(), null));
-        }
-        return nicProfiles;
-    }
-
     private Map<Long, List<Network.Service>> getSupportedServicesByElementForNetwork(List<NicProfile> nics) {
 
         Map<Long, List<Network.Service>> supportedServices = new HashMap<>();
@@ -642,8 +636,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
         final String isoFileName = ConfigDrive.configIsoFileName(profile.getInstanceName());
         final String isoPath = ConfigDrive.createConfigDrivePath(profile.getInstanceName());
-        List<? extends Nic> nics = _networkModel.getNics(profile.getId());
-        List<NicProfile> nicProfiles = getNicProfilesForNic(profile.getVirtualMachine(), nics);
+        List<NicProfile> nicProfiles = _networkOrchestrationService.getNicProfiles(nic.getVirtualMachineId(), profile.getHypervisorType());
         final Map<Long, List<Service>> supportedServices = getSupportedServicesByElementForNetwork(nicProfiles);
         final String isoData = ConfigDriveBuilder.buildConfigDrive(
                 nicProfiles, profile.getVmData(), isoFileName, profile.getConfigDriveLabel(), customUserdataParamMap, supportedServices);

--- a/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -170,6 +170,8 @@ public class ConfigDriveNetworkElementTest {
         when(_dcDao.findById(DATACENTERID)).thenReturn(dataCenterVO);
         when(_domainDao.findById(DOMAINID)).thenReturn(domainVO);
         doReturn(nic).when(_networkModel).getDefaultNic(VMID);
+        doReturn(List.of(nic)).when(_networkModel).getNics(VMID);
+        doReturn(nicp).when(_networkModel).getNicProfile(virtualMachine, NETWORK_ID, null);
         when(_serviceOfferingDao.findByIdIncludingRemoved(VMID, SOID)).thenReturn(serviceOfferingVO);
         when(_guestOSDao.findById(Mockito.anyLong())).thenReturn(guestOSVO);
         when(_guestOSCategoryDao.findById(Mockito.anyLong())).thenReturn(guestOSCategoryVo);
@@ -292,7 +294,7 @@ public class ConfigDriveNetworkElementTest {
     public void testCreateConfigDriveIso() throws Exception {
         try (MockedStatic<ConfigDriveBuilder> ignored1 = Mockito.mockStatic(ConfigDriveBuilder.class); MockedStatic<CallContext> ignored2 = Mockito.mockStatic(CallContext.class)) {
             Mockito.when(CallContext.current()).thenReturn(callContextMock);
-            Mockito.when(ConfigDriveBuilder.buildConfigDrive(Mockito.any(NicProfile.class), Mockito.anyList(), Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyList())).thenReturn("content");
+            Mockito.when(ConfigDriveBuilder.buildConfigDrive(Mockito.anyList(), Mockito.anyList(), Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyMap())).thenReturn("content");
 
             final HandleConfigDriveIsoAnswer answer = mock(HandleConfigDriveIsoAnswer.class);
             when(agentManager.easySend(Mockito.anyLong(), Mockito.any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);

--- a/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -61,6 +61,7 @@ import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.google.common.collect.Maps;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
@@ -149,6 +150,7 @@ public class ConfigDriveNetworkElementTest {
     @Mock private AgentManager agentManager;
     @Mock private CallContext callContextMock;
     @Mock private DomainVO domainVO;
+    @Mock private NetworkOrchestrationService _networkOrchestrationService;
 
     @Spy @InjectMocks
     private ConfigDriveNetworkElement _configDrivesNetworkElement = new ConfigDriveNetworkElement();
@@ -170,8 +172,6 @@ public class ConfigDriveNetworkElementTest {
         when(_dcDao.findById(DATACENTERID)).thenReturn(dataCenterVO);
         when(_domainDao.findById(DOMAINID)).thenReturn(domainVO);
         doReturn(nic).when(_networkModel).getDefaultNic(VMID);
-        doReturn(List.of(nic)).when(_networkModel).getNics(VMID);
-        doReturn(nicp).when(_networkModel).getNicProfile(virtualMachine, NETWORK_ID, null);
         when(_serviceOfferingDao.findByIdIncludingRemoved(VMID, SOID)).thenReturn(serviceOfferingVO);
         when(_guestOSDao.findById(Mockito.anyLong())).thenReturn(guestOSVO);
         when(_guestOSCategoryDao.findById(Mockito.anyLong())).thenReturn(guestOSCategoryVo);

--- a/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -264,7 +264,7 @@ public class ConfigDriveNetworkElementTest {
         try (MockedStatic<ConfigDriveBuilder> ignored1 = Mockito.mockStatic(ConfigDriveBuilder.class); MockedStatic<CallContext> ignored2 = Mockito.mockStatic(CallContext.class)) {
             Mockito.when(CallContext.current()).thenReturn(callContextMock);
             Mockito.doReturn(Mockito.mock(Account.class)).when(callContextMock).getCallingAccount();
-            Mockito.when(ConfigDriveBuilder.buildConfigDrive(Mockito.anyList(), Mockito.anyString(), Mockito.anyString(), Mockito.anyMap())).thenReturn("content");
+            Mockito.when(ConfigDriveBuilder.buildConfigDrive(Mockito.any(NicProfile.class), Mockito.anyList(), Mockito.anyString(), Mockito.anyString(), Mockito.anyMap())).thenReturn("content");
 
             final HandleConfigDriveIsoAnswer answer = mock(HandleConfigDriveIsoAnswer.class);
             final UserVmDetailVO userVmDetailVO = mock(UserVmDetailVO.class);

--- a/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.dc.DataCenter;
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.network.PublicIpQuarantine;
 import com.cloud.network.VirtualRouterProvider;
 import com.cloud.utils.fsm.NoTransitionException;
@@ -638,6 +639,11 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     public List<NicProfile> getNicProfiles(VirtualMachine vm) {
         // TODO Auto-generated method stub
         return null;
+    }
+
+    @Override
+    public List<NicProfile> getNicProfiles(Long vmId, Hypervisor.HypervisorType hypervisorType) {
+        return List.of();
     }
 
     @Override

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -2144,7 +2144,7 @@ class TestSharedNetworkWithConfigDrive(cloudstackTestCase):
 
         template = Template.register(
             cls.apiclient,
-            cls.services["test_templates_cloud_init"][cls.hv],
+            cls.services["test_templates_cloud_init"][cls.hv.lower()],
             zoneid=cls.zone.id,
             hypervisor=cls.hv,
         )
@@ -2201,11 +2201,11 @@ class TestSharedNetworkWithConfigDrive(cloudstackTestCase):
         )
 
         cls._cleanup.extend([
-            cls.shared_network,
             cls.service_offering,
             cls.shared_network,
             cls.shared_network_offering,
-            cls.isolated_network
+            cls.isolated_network,
+            cls.isolated_network_offering,
         ])
         cls.tmp_files = []
         cls.keypair = cls.generate_ssh_keys()

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -450,6 +450,21 @@ test_data = {
             "UserData": "VirtualRouter"
         }
     },
+    "shared_network_offering_configdrive": {
+        "name": "MySharedOfferingWithConfigDrive-shared",
+        "displaytext": "MySharedOfferingWithConfigDrive",
+        "guestiptype": "Shared",
+        "supportedservices": "Dhcp,Dns,UserData",
+        "specifyVlan": "False",
+        "specifyIpRanges": "False",
+        "traffictype": "GUEST",
+        "tags": "native",
+        "serviceProviderList": {
+            "Dhcp": "ConfigDrive",
+            "Dns": "ConfigDrive",
+            "UserData": "ConfigDrive"
+        }
+    },
     "shared_network_offering_all_services": {
         "name": "shared network offering with services enabled",
         "displaytext": "Shared network offering",
@@ -1045,6 +1060,41 @@ test_data = {
             "requireshvm": "True",
             "ispublic": "True",
             "isextractable": "True"
+        },
+    },
+    "test_templates_cloud_init": {
+        "kvm": {
+            "name": "ubuntu 22.04 kvm",
+            "displaytext": "ubuntu 22.04 kvm",
+            "format": "raw",
+            "hypervisor": "kvm",
+            "ostype": "Other Linux (64-bit)",
+            "url": "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img",
+            "requireshvm": "True",
+            "ispublic": "True",
+            "isextractable": "False"
+        },
+        "xenserver": {
+            "name": "ubuntu 22.04 xen",
+            "displaytext": "ubuntu 22.04 xen",
+            "format": "vhd",
+            "hypervisor": "xenserver",
+            "ostype": "Other Linux (64-bit)",
+            "url": "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64-azure.vhd.tar.gz",
+            "requireshvm": "True",
+            "ispublic": "True",
+            "isextractable": "True"
+        },
+        "vmware": {
+            "name": "ubuntu 22.04 vmware",
+            "displaytext": "ubuntu 22.04 vmware",
+            "format": "ova",
+            "hypervisor": "vmware",
+            "ostype": "Other Linux (64-bit)",
+            "url": "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.ova",
+            "requireshvm": "True",
+            "ispublic": "True",
+            "deployasis": "True"
         },
     },
     "test_ovf_templates": [


### PR DESCRIPTION
### Description

This PR fixes https://github.com/apache/cloudstack/issues/2872
PR adds support for Dhcp & Dns capabilities for ConfigDrive network element.

Docs PR: https://github.com/apache/cloudstack-documentation/pull/412

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

1. Create a network offering with DHCP, DNS & UserData provider with ConfigDrive
2. Create a network with the above offering
3. Launch an instance using a cloud init configured template.
4. Instance gets the assigned IP, DNS & Userdata.

#### Note
While attaching secondary nics, interface is assigned an IP on boot only if the instance was started for the first time.
Updating of IPs & NICs after first boot doesn't reflect on the instance even after reboot.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
