### PR TITLE
ui: fix minor issue with webhook forms

### DIFF
--- a/ui/src/views/tools/CreateWebhook.vue
+++ b/ui/src/views/tools/CreateWebhook.vue
@@ -325,8 +325,10 @@ export default {
     closeAction () {
       this.$emit('close-action')
     },
-    handleParamUpdate (e) {
-      this.$refs.dispatchview.timedTestWebhookDelivery()
+    handleParamUpdate () {
+      setTimeout(() => {
+        this.$refs.dispatchview.timedTestWebhookDelivery()
+      }, 1)
     },
     handleScopeChange (e) {
       if (['Domain', 'Local'].includes(this.form.scope)) {

--- a/ui/src/views/tools/TestWebhookDelivery.vue
+++ b/ui/src/views/tools/TestWebhookDelivery.vue
@@ -120,7 +120,7 @@ export default {
     width: 80vw;
 
     @media (min-width: 600px) {
-      max-width: 95%;
+      max-width: 550px;
     }
   }
 


### PR DESCRIPTION
### Description

- Fix width of Test webhook delivery form
- Fix auto execution of test delivery in create webhook form

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before:
Form width is too much
![Screenshot from 2024-07-04 14-10-38](https://github.com/apache/cloudstack/assets/153340/339fb4fc-5305-4f52-b146-cae246b38a48)

Form is not executing test webhook delivery automatically when one of the earlier used value is selected
https://github.com/apache/cloudstack/assets/153340/a9fc0a83-1fad-434c-97a3-8034a3768519

**After**

Form width fixed
![Screenshot from 2024-07-04 14-14-27](https://github.com/apache/cloudstack/assets/153340/c8eb4c3b-f63b-44df-af53-f85b30ca1dcc)


Form is now executing test webhook delivery automatically when one of the earlier used value is selected
https://github.com/apache/cloudstack/assets/153340/1904a5cf-54de-463b-8763-562a435ce784


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
