### PR TITLE
Support user resource name / displaytext with emoji, unicode chars, and some sql exception msg improvements

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiArgValidator.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiArgValidator.java
@@ -32,4 +32,9 @@ public enum ApiArgValidator {
      * Validates if the parameter is an UUID with the method {@link UuidUtils#isUuid(String)}.
      */
     UuidString,
+
+    /**
+     * Validates if the parameter is a valid RFC Compliance domain name.
+     */
+    RFCComplianceDomainName,
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -31,6 +31,7 @@ import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiConstants.IoDriverPolicy;
@@ -97,7 +98,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.TEMPLATE_ID, type = CommandType.UUID, entityType = TemplateResponse.class, required = true, description = "the ID of the template for the virtual machine")
     private Long templateId;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "host name for the virtual machine")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "host name for the virtual machine", validations = {ApiArgValidator.RFCComplianceDomainName})
     private String name;
 
     @Parameter(name = ApiConstants.DISPLAY_NAME, type = CommandType.STRING, description = "an optional user generated name for the virtual machine")

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.cloud.utils.exception.CloudRuntimeException;
+
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.response.UserDataResponse;
 
 import org.apache.cloudstack.acl.RoleType;
@@ -104,7 +106,7 @@ public class UpdateVMCmd extends BaseCustomIdCmd implements SecurityGroupAction,
                description = "true if VM contains XS/VMWare tools inorder to support dynamic scaling of VM cpu/memory. This can be updated only when dynamic scaling is enabled on template, service offering and the corresponding global setting")
     protected Boolean isDynamicallyScalable;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "new host name of the vm. The VM has to be stopped/started for this update to take affect", since = "4.4")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "new host name of the vm. The VM has to be stopped/started for this update to take affect", validations = {ApiArgValidator.RFCComplianceDomainName}, since = "4.4")
     private String name;
 
     @Parameter(name = ApiConstants.INSTANCE_NAME, type = CommandType.STRING, description = "instance name of the user vm", since = "4.4", authorized = {RoleType.Admin})

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41910to42000.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41910to42000.java
@@ -18,12 +18,16 @@ package com.cloud.upgrade.dao;
 
 import java.io.InputStream;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import com.cloud.upgrade.SystemVmTemplateRegistration;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 public class Upgrade41910to42000 extends DbUpgradeAbstractImpl implements DbUpgrade, DbUpgradeSystemVmTemplate {
     private SystemVmTemplateRegistration systemVmTemplateRegistration;
+    private static final int MAX_INDEXED_CHARS_IN_CHAR_SET_UTF8MB4 = 191;
 
     @Override
     public String[] getUpgradableVersionRange() {
@@ -53,6 +57,7 @@ public class Upgrade41910to42000 extends DbUpgradeAbstractImpl implements DbUpgr
 
     @Override
     public void performDataMigration(Connection conn) {
+        checkAndUpdateAffinityGroupNameCharSetToUtf8mb4(conn);
     }
 
     @Override
@@ -78,6 +83,34 @@ public class Upgrade41910to42000 extends DbUpgradeAbstractImpl implements DbUpgr
             systemVmTemplateRegistration.updateSystemVmTemplates(conn);
         } catch (Exception e) {
             throw new CloudRuntimeException("Failed to find / register SystemVM template(s)");
+        }
+    }
+
+    private void checkAndUpdateAffinityGroupNameCharSetToUtf8mb4(Connection conn) {
+        logger.debug("Check and update char set for affinity group name to utf8mb4");
+        try {
+            PreparedStatement pstmt = conn.prepareStatement("SELECT MAX(LENGTH(name)) FROM `cloud`.`affinity_group`");
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                long maxLengthOfName = rs.getLong(1);
+                if (maxLengthOfName <= MAX_INDEXED_CHARS_IN_CHAR_SET_UTF8MB4) {
+                    pstmt = conn.prepareStatement("ALTER TABLE `cloud`.`affinity_group` MODIFY `name` VARCHAR(191) CHARACTER SET utf8mb4 NOT NULL");
+                    pstmt.executeUpdate();
+                    logger.debug("Successfully updated char set for affinity group name to utf8mb4");
+                } else {
+                    logger.warn("Unable to update char set for affinity group name, as there are some names with more than " + MAX_INDEXED_CHARS_IN_CHAR_SET_UTF8MB4 +
+                            " chars (max supported chars for index)");
+                }
+            }
+
+            if (rs != null && !rs.isClosed())  {
+                rs.close();
+            }
+            if (pstmt != null && !pstmt.isClosed())  {
+                pstmt.close();
+            }
+        } catch (final SQLException e) {
+            logger.warn("Exception while updating char set for affinity group name to utf8mb4: " + e.getMessage());
         }
     }
 }

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41910to42000.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade41910to42000.java
@@ -94,7 +94,7 @@ public class Upgrade41910to42000 extends DbUpgradeAbstractImpl implements DbUpgr
             if (rs.next()) {
                 long maxLengthOfName = rs.getLong(1);
                 if (maxLengthOfName <= MAX_INDEXED_CHARS_IN_CHAR_SET_UTF8MB4) {
-                    pstmt = conn.prepareStatement("ALTER TABLE `cloud`.`affinity_group` MODIFY `name` VARCHAR(191) CHARACTER SET utf8mb4 NOT NULL");
+                    pstmt = conn.prepareStatement(String.format("ALTER TABLE `cloud`.`affinity_group` MODIFY `name` VARCHAR(%d) CHARACTER SET utf8mb4 NOT NULL", MAX_INDEXED_CHARS_IN_CHAR_SET_UTF8MB4));
                     pstmt.executeUpdate();
                     logger.debug("Successfully updated char set for affinity group name to utf8mb4");
                 } else {

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -161,9 +161,11 @@ ALTER TABLE `cloud`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER 
 ALTER TABLE `cloud_usage`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
 
 ALTER TABLE `cloud`.`account` MODIFY `account_name` VARCHAR(100) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'an account name set by the creator of the account, defaults to username for single accounts';
+ALTER TABLE `cloud`.`affinity_group` MODIFY `description` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL;
 ALTER TABLE `cloud`.`annotations` MODIFY `annotation` TEXT CHARACTER SET utf8mb4;
 ALTER TABLE `cloud`.`autoscale_vmgroups` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name of the autoscale vm group';
 ALTER TABLE `cloud`.`backup_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'backup offering name';
+ALTER TABLE `cloud`.`backup_offering` MODIFY `description` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'backup offering description';
 ALTER TABLE `cloud`.`disk_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
 ALTER TABLE `cloud`.`disk_offering` MODIFY `unique_name` VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'unique name';
 ALTER TABLE `cloud`.`disk_offering` MODIFY `display_text` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'Optional text set by the admin for display purpose only';
@@ -176,8 +178,10 @@ ALTER TABLE `cloud`.`network_offerings` MODIFY `unique_name` VARCHAR(64) CHARACT
 ALTER TABLE `cloud`.`network_offerings` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'text to display to users';
 ALTER TABLE `cloud`.`networks` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name for this network';
 ALTER TABLE `cloud`.`networks` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'display text for this network';
+ALTER TABLE `cloud`.`project_role` MODIFY `description` TEXT CHARACTER SET utf8mb4 COMMENT 'description of the project role';
 ALTER TABLE `cloud`.`projects` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'project name';
 ALTER TABLE `cloud`.`projects` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'project name';
+ALTER TABLE `cloud`.`roles` MODIFY `description` TEXT CHARACTER SET utf8mb4 COMMENT 'description of the role';
 ALTER TABLE `cloud`.`service_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
 ALTER TABLE `cloud`.`service_offering` MODIFY `unique_name` VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'unique name for offerings';
 ALTER TABLE `cloud`.`service_offering` MODIFY `display_text` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL;
@@ -190,6 +194,7 @@ ALTER TABLE `cloud`.`user` MODIFY `lastname` VARCHAR(255) CHARACTER SET utf8mb4 
 ALTER TABLE `cloud`.`user_data` MODIFY `name` VARCHAR(256) CHARACTER SET utf8mb4 NOT NULL COMMENT 'name of the user data';
 ALTER TABLE `cloud`.`vm_instance` MODIFY `display_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
 ALTER TABLE `cloud`.`vm_snapshots` MODIFY `display_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`vm_snapshots` MODIFY `description` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
 ALTER TABLE `cloud`.`vm_template` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
 ALTER TABLE `cloud`.`vm_template` MODIFY `display_text` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'Description text set by the admin for display purpose only';
 ALTER TABLE `cloud`.`volumes` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'A user specified name for the volume';

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -161,6 +161,7 @@ ALTER TABLE `cloud`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER 
 ALTER TABLE `cloud_usage`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
 
 ALTER TABLE `cloud`.`account` MODIFY `account_name` VARCHAR(100) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'an account name set by the creator of the account, defaults to username for single accounts';
+ALTER TABLE `cloud`.`annotations` MODIFY `annotation` TEXT CHARACTER SET utf8mb4;
 ALTER TABLE `cloud`.`autoscale_vmgroups` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name of the autoscale vm group';
 ALTER TABLE `cloud`.`backup_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'backup offering name';
 ALTER TABLE `cloud`.`disk_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -161,7 +161,6 @@ ALTER TABLE `cloud`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER 
 ALTER TABLE `cloud_usage`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
 
 ALTER TABLE `cloud`.`account` MODIFY `account_name` VARCHAR(100) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'an account name set by the creator of the account, defaults to username for single accounts';
-ALTER TABLE `cloud`.`affinity_group` MODIFY `name` VARCHAR(191) CHARACTER SET utf8mb4 NOT NULL;
 ALTER TABLE `cloud`.`autoscale_vmgroups` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name of the autoscale vm group';
 ALTER TABLE `cloud`.`backup_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'backup offering name';
 ALTER TABLE `cloud`.`disk_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -151,6 +151,50 @@ WHERE
     name IN ("quota.usage.smtp.useStartTLS", "quota.usage.smtp.useAuth", "alert.smtp.useAuth", "project.smtp.useAuth")
     AND value NOT IN ("true", "y", "t", "1", "on", "yes");
 
-
 -- Quota inject tariff result into subsequent ones
 CALL `cloud_usage`.`IDEMPOTENT_ADD_COLUMN`('cloud_usage.quota_tariff', 'position', 'bigint(20) NOT NULL DEFAULT 1 COMMENT "Position in the execution sequence for tariffs of the same type"');
+
+ALTER TABLE `cloud`.`async_job` MODIFY `job_result` TEXT CHARACTER SET utf8mb4 COMMENT 'job result info';
+ALTER TABLE `cloud`.`async_job` MODIFY `job_cmd_info` TEXT CHARACTER SET utf8mb4 COMMENT 'command parameter info';
+ALTER TABLE `cloud`.`event` MODIFY `description` VARCHAR(1024) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud_usage`.`usage_event` MODIFY `resource_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+
+ALTER TABLE `cloud`.`account` MODIFY `account_name` VARCHAR(100) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'an account name set by the creator of the account, defaults to username for single accounts';
+ALTER TABLE `cloud`.`affinity_group` MODIFY `name` VARCHAR(191) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`autoscale_vmgroups` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name of the autoscale vm group';
+ALTER TABLE `cloud`.`backup_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'backup offering name';
+ALTER TABLE `cloud`.`disk_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`disk_offering` MODIFY `unique_name` VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'unique name';
+ALTER TABLE `cloud`.`disk_offering` MODIFY `display_text` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'Optional text set by the admin for display purpose only';
+ALTER TABLE `cloud`.`instance_group` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`kubernetes_cluster` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`kubernetes_cluster` MODIFY `description` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'display text for this Kubernetes cluster';
+ALTER TABLE `cloud`.`kubernetes_supported_version` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'the name of this Kubernetes version';
+ALTER TABLE `cloud`.`network_offerings` MODIFY `name` VARCHAR(64) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name of the network offering';
+ALTER TABLE `cloud`.`network_offerings` MODIFY `unique_name` VARCHAR(64) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'unique name of the network offering';
+ALTER TABLE `cloud`.`network_offerings` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'text to display to users';
+ALTER TABLE `cloud`.`networks` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'name for this network';
+ALTER TABLE `cloud`.`networks` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'display text for this network';
+ALTER TABLE `cloud`.`projects` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'project name';
+ALTER TABLE `cloud`.`projects` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'project name';
+ALTER TABLE `cloud`.`service_offering` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`service_offering` MODIFY `unique_name` VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'unique name for offerings';
+ALTER TABLE `cloud`.`service_offering` MODIFY `display_text` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`snapshots` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COMMENT 'snapshot name';
+ALTER TABLE `cloud`.`ssh_keypairs` MODIFY `keypair_name` VARCHAR(256) CHARACTER SET utf8mb4 NOT NULL COMMENT 'name of the key pair';
+ALTER TABLE `cloud`.`user_vm` MODIFY `display_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`user_vm_details` MODIFY `value` VARCHAR(5120) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`user` MODIFY `firstname` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`user` MODIFY `lastname` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`user_data` MODIFY `name` VARCHAR(256) CHARACTER SET utf8mb4 NOT NULL COMMENT 'name of the user data';
+ALTER TABLE `cloud`.`vm_instance` MODIFY `display_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`vm_snapshots` MODIFY `display_name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `cloud`.`vm_template` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `cloud`.`vm_template` MODIFY `display_text` VARCHAR(4096) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'Description text set by the admin for display purpose only';
+ALTER TABLE `cloud`.`volumes` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'A user specified name for the volume';
+ALTER TABLE `cloud`.`vpc` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'vpc name';
+ALTER TABLE `cloud`.`vpc` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COMMENT 'vpc display text';
+ALTER TABLE `cloud`.`vpc_offerings` MODIFY `name` VARCHAR(255) CHARACTER SET utf8mb4  DEFAULT NULL COMMENT 'vpc offering name';
+ALTER TABLE `cloud`.`vpc_offerings` MODIFY `unique_name` VARCHAR(64) CHARACTER SET utf8mb4  DEFAULT NULL COMMENT 'unique name of the vpc offering';
+ALTER TABLE `cloud`.`vpc_offerings` MODIFY `display_text` VARCHAR(255) CHARACTER SET utf8mb4  DEFAULT NULL COMMENT 'display text';

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -156,10 +156,6 @@ CALL `cloud_usage`.`IDEMPOTENT_ADD_COLUMN`('cloud_usage.quota_tariff', 'position
 
 -- Idempotent IDEMPOTENT_MODIFY_COLUMN_CHAR_SET
 DROP PROCEDURE IF EXISTS `cloud`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET`;
-DROP PROCEDURE IF EXISTS `cloud_usage`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET`;
-
-DELIMITER //
-
 CREATE PROCEDURE `cloud`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET` (
   IN in_table_name VARCHAR(200)
 , IN in_column_name VARCHAR(200)
@@ -167,8 +163,9 @@ CREATE PROCEDURE `cloud`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET` (
 , IN in_column_definition VARCHAR(1000)
 )
 BEGIN
-    DECLARE CONTINUE HANDLER FOR 1060 BEGIN END; SET @ddl = CONCAT('ALTER TABLE ', in_table_name); SET @ddl = CONCAT(@ddl, ' ', ' MODIFY COLUMN') ; SET @ddl = CONCAT(@ddl, ' ', in_column_name); SET @ddl = CONCAT(@ddl, ' ', in_column_type); SET @ddl = CONCAT(@ddl, ' ', ' CHARACTER SET utf8mb4'); SET @ddl = CONCAT(@ddl, ' ', in_column_definition); PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt; END //
+    DECLARE CONTINUE HANDLER FOR 1060 BEGIN END; SET @ddl = CONCAT('ALTER TABLE ', in_table_name); SET @ddl = CONCAT(@ddl, ' ', ' MODIFY COLUMN') ; SET @ddl = CONCAT(@ddl, ' ', in_column_name); SET @ddl = CONCAT(@ddl, ' ', in_column_type); SET @ddl = CONCAT(@ddl, ' ', ' CHARACTER SET utf8mb4'); SET @ddl = CONCAT(@ddl, ' ', in_column_definition); PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt; END;
 
+DROP PROCEDURE IF EXISTS `cloud_usage`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET`;
 CREATE PROCEDURE `cloud_usage`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET` (
   IN in_table_name VARCHAR(200)
 , IN in_column_name VARCHAR(200)
@@ -176,9 +173,7 @@ CREATE PROCEDURE `cloud_usage`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET` (
 , IN in_column_definition VARCHAR(1000)
 )
 BEGIN
-    DECLARE CONTINUE HANDLER FOR 1060 BEGIN END; SET @ddl = CONCAT('ALTER TABLE ', in_table_name); SET @ddl = CONCAT(@ddl, ' ', ' MODIFY COLUMN') ; SET @ddl = CONCAT(@ddl, ' ', in_column_name); SET @ddl = CONCAT(@ddl, ' ', in_column_type); SET @ddl = CONCAT(@ddl, ' ', ' CHARACTER SET utf8mb4'); SET @ddl = CONCAT(@ddl, ' ', in_column_definition); PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt; END //
-
-DELIMITER ;
+    DECLARE CONTINUE HANDLER FOR 1060 BEGIN END; SET @ddl = CONCAT('ALTER TABLE ', in_table_name); SET @ddl = CONCAT(@ddl, ' ', ' MODIFY COLUMN') ; SET @ddl = CONCAT(@ddl, ' ', in_column_name); SET @ddl = CONCAT(@ddl, ' ', in_column_type); SET @ddl = CONCAT(@ddl, ' ', ' CHARACTER SET utf8mb4'); SET @ddl = CONCAT(@ddl, ' ', in_column_definition); PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt; END;
 
 CALL `cloud`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET`('async_job', 'job_result', 'TEXT', 'COMMENT \'job result info\'');
 CALL `cloud`.`IDEMPOTENT_MODIFY_COLUMN_CHAR_SET`('async_job', 'job_cmd_info', 'TEXT', 'COMMENT \'command parameter info\'');

--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -437,9 +437,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return result;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to find on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught: " + pstmt, e);
+            logger.error("Caught: " + pstmt, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
 
@@ -522,9 +524,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
 
             return results;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to find on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught: " + pstmt, e);
+            logger.error("Caught: " + pstmt, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
 
@@ -870,8 +874,9 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             ub.clear();
             return result;
         } catch (final SQLException e) {
+            logger.error("DB Exception on: " + pstmt, e);
             handleEntityExistsException(e);
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to update on DB, due to: " + e.getLocalizedMessage());
         }
     }
 
@@ -1065,7 +1070,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             ResultSet rs = pstmt.executeQuery();
             return rs.next() ? toEntityBean(rs, true) : null;
         } catch (SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to find by id on DB, due to: " + e.getLocalizedMessage());
         }
     }
 
@@ -1180,9 +1186,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return result;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to execute on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught: " + pstmt, e);
+            logger.error("Caught: " + pstmt, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
 
@@ -1231,7 +1239,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return true;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to expunge on DB, due to: " + e.getLocalizedMessage());
         }
     }
 
@@ -1269,9 +1278,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return pstmt.executeUpdate();
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to expunge on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught: " + pstmt, e);
+            logger.error("Caught: " + pstmt, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
     @Override
@@ -1550,7 +1561,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
                 return entity;
             }
 
-            assert false : "Can't call persit if you don't have primary key";
+            assert false : "Can't call persist if you don't have primary key";
         }
 
         ID id = null;
@@ -1606,8 +1617,9 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             txn.commit();
         } catch (final SQLException e) {
+            logger.error("DB Exception on: " + pstmt, e);
             handleEntityExistsException(e);
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to persist on DB, due to: " + e.getLocalizedMessage());
         } catch (IllegalArgumentException e) {
             throw new CloudRuntimeException("Problem with getting the ec attribute ", e);
         } catch (IllegalAccessException e) {
@@ -1956,7 +1968,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             pstmt.executeUpdate();
             txn.commit();
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to expunge on DB, due to: " + e.getLocalizedMessage());
         }
     }
 
@@ -1984,7 +1997,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return result > 0;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to unremove on DB, due to: " + e.getLocalizedMessage());
         }
     }
 
@@ -2027,7 +2041,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return result > 0;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to remove on DB, due to: " + e.getLocalizedMessage());
         }
     }
 
@@ -2175,9 +2190,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return 0;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to get count on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught: " + pstmt, e);
+            logger.error("Caught: " + pstmt, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
 
@@ -2234,9 +2251,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return 0;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception in executing: " + sql, e);
+            logger.error("DB Exception in executing: " + sql, e);
+            throw new CloudRuntimeException("Unable to get count on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught exception in : " + sql, e);
+            logger.error("Caught exception in : " + sql, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
 
@@ -2309,9 +2328,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
             return 0;
         } catch (final SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + pstmt, e);
+            logger.error("DB Exception on: " + pstmt, e);
+            throw new CloudRuntimeException("Unable to get count on DB, due to: " + e.getLocalizedMessage());
         } catch (final Exception e) {
-            throw new CloudRuntimeException("Caught: " + pstmt, e);
+            logger.error("Caught: " + pstmt, e);
+            throw new CloudRuntimeException("Caught error: " + e.getLocalizedMessage());
         }
     }
 

--- a/test/integration/smoke/test_resource_names.py
+++ b/test/integration/smoke/test_resource_names.py
@@ -1,0 +1,299 @@
+# -- coding: utf-8 --
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" BVT tests for resource names with emojis / unicode
+"""
+from marvin.cloudstackTestCase import cloudstackTestCase
+
+from marvin.lib.base import (Account,
+                             ServiceOffering,
+                             VirtualMachine,
+                             Template,
+                             Iso,
+                             Volume,
+                             DiskOffering)
+from marvin.lib.common import (get_domain,
+                               get_zone,
+                               get_suitable_test_template,
+                               get_builtin_template_info)
+from marvin.codes import FAILED
+from nose.plugins.attrib import attr
+# Import System modules
+import time
+
+_multiprocess_shared_ = True
+
+class TestResourceNames(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        testClient = super(TestResourceNames, cls).getClsTestClient()
+        cls.apiclient = testClient.getApiClient()
+        cls.services = testClient.getParsedTestDataConfig()
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.apiclient)
+        cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
+        cls.hypervisor = testClient.getHypervisorInfo()
+        cls.services['mode'] = cls.zone.networktype
+        cls._cleanup = []
+
+        template = get_suitable_test_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"],
+            cls.hypervisor
+        )
+        if template == FAILED:
+            assert False, "get_suitable_test_template() failed to return template with description %s" % cls.services[
+                "ostype"]
+
+        # Set Zones and disk offerings
+        cls.services["domainid"] = cls.domain.id
+        cls.services["zoneid"] = cls.zone.id
+        cls.services["template"] = template.id
+        cls.services["iso1"]["zoneid"] = cls.zone.id
+        cls.services["small"]["zoneid"] = cls.zone.id
+        cls.services["small"]["template"] = template.id
+
+        cls.services["account"]["firstname"] = "test🎉"
+        cls.services["account"]["lastname"] = "account🙂"
+        cls.account = Account.create(
+            cls.apiclient,
+            cls.services["account"],
+            domainid=cls.domain.id
+        )
+        cls._cleanup.append(cls.account)
+
+        cls.services["service_offerings"]["tiny"]["name"] = "test🎉svcoffering🙂"
+        cls.service_offering = ServiceOffering.create(
+            cls.apiclient,
+            cls.services["service_offerings"]["tiny"]
+        )
+        cls._cleanup.append(cls.service_offering)
+
+        cls.services["disk_offering"]["name"] = "test🎉diskoffering🙂"
+        cls.disk_offering = DiskOffering.create(
+            cls.apiclient,
+            cls.services["disk_offering"]
+        )
+        cls._cleanup.append(cls.disk_offering)
+
+        cls.services["small"]["displayname"] = "test🎉vm🙂"
+        cls.virtual_machine = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["small"],
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id,
+            mode=cls.services['mode']
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestResourceNames, cls).tearDownClass()
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.dbclient = self.testClient.getDbConnection()
+        self.cleanup = []
+
+    def tearDown(self):
+        super(TestResourceNames, self).tearDown()
+
+    @attr(tags=["advanced", "smoke", "basic"], required_hardware="false")
+    def test_01_deploy_vm(self):
+        """Test for deploy virtual machine
+        """
+        # Validate the following:
+        # 1. listVirtualMachines returns accurate information, and check name
+        list_vm_response = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine.id
+        )
+
+        self.debug(
+            "Verify listVirtualMachines response for virtual machine: %s" \
+            % self.virtual_machine.id
+        )
+        self.assertEqual(
+            isinstance(list_vm_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        self.assertNotEqual(
+            len(list_vm_response),
+            0,
+            "Check VM available in List Virtual Machines"
+        )
+
+        vm_response = list_vm_response[0]
+        self.assertEqual(
+            vm_response.id,
+            self.virtual_machine.id,
+            "Check virtual machine id in listVirtualMachines"
+        )
+        self.assertEqual(
+            vm_response.name,
+            self.virtual_machine.name,
+            "Check virtual machine name in listVirtualMachines"
+        )
+        self.assertEqual(
+            vm_response.displayname,
+            self.virtual_machine.displayname,
+            "Check virtual machine display name in listVirtualMachines"
+        )
+        self.assertEqual(
+            vm_response.state,
+            'Running',
+            msg="VM is not in Running state"
+        )
+        return
+
+    @attr(tags=["advanced", "smoke", "basic"], required_hardware="true")
+    def test_02_create_volume(self):
+        """Test for create volume
+        """
+        # Validate the following:
+        # 1. Create volume and check name
+
+        self.services["diskname"] = "test🎉data🙂volume"
+        self.volume = Volume.create(
+            self.apiclient,
+            self.services,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            diskofferingid=self.disk_offering.id
+        )
+        # self.cleanup.append(self.volume)
+        self.virtual_machine.attach_volume(self.apiclient, self.volume)
+        list_volume_response = Volume.list(
+            self.apiclient,
+            id=self.volume.id
+        )
+        self.assertEqual(
+            isinstance(list_volume_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        self.assertNotEqual(
+            list_volume_response,
+            None,
+            "Check if volume exists in ListVolumes"
+        )
+
+        volume_response = list_volume_response[0]
+        self.assertNotEqual(
+            volume_response.virtualmachineid,
+            None,
+            "Check if volume state (attached) is reflected"
+        )
+        self.assertEqual(
+            volume_response.name,
+            self.volume.name,
+            "Check virtual machine display name in listVirtualMachines"
+        )
+
+    @attr(tags=["advanced", "smoke", "basic"], required_hardware="true")
+    def test_03_register_template(self):
+        """Test for register template
+        """
+        # Validate the following:
+        # 1. Register template and check name
+
+        if self.hypervisor.lower() in ["lxc"]:
+            self.skipTest("Skipping test, unsupported hypervisor %s" % self.hypervisor)
+
+        builtin_info = get_builtin_template_info(self.apiclient, self.zone.id)
+        self.services["template_2"]["url"] = builtin_info[0]
+        self.services["template_2"]["hypervisor"] = builtin_info[1]
+        self.services["template_2"]["format"] = builtin_info[2]
+        self.services["template_2"]["name"] = "test🎉tmpl🙂"
+        self.services["template_2"]["displaytext"] = "test🎉tmpl🙂"
+
+        template = Template.register(self.apiclient,
+                                     self.services["template_2"],
+                                     zoneid=self.zone.id,
+                                     account=self.account.name,
+                                     domainid=self.account.domainid
+                                     )
+        self.debug("Successfully registered template with ID: %s" % template.id)
+        self.cleanup.append(template)
+
+        # Get template response
+        timeout = 600
+        list_template_response = None
+        while timeout >= 0:
+            list_template_response = Template.list(self.apiclient,
+                                                   templatefilter=self.services["template_2"]["templatefilter"],
+                                                   id=template.id)
+
+            if list_template_response is not None and list_template_response[0].isready:
+                break
+
+            time.sleep(30)
+            timeout -= 30
+
+        template_response = list_template_response[0]
+        self.assertEqual(
+            template_response.displaytext,
+            template.displaytext,
+            "Check template displaytext in response"
+        )
+
+    @attr(tags=["advanced", "smoke", "basic"], required_hardware="true")
+    def test_04_register_iso(self):
+        """Test for register ISO
+        """
+        # Validate the following:
+        # 1. Register ISO and check name
+
+        if self.hypervisor.lower() in ["lxc"]:
+            self.skipTest("Skipping test, unsupported hypervisor %s" % self.hypervisor)
+
+        self.services["iso1"]["displaytext"] = "test🎉iso🙂"
+        self.services["iso1"]["name"] = "test🎉iso🙂"
+        iso = Iso.create(
+            self.apiclient,
+            self.services["iso1"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Successfully registered ISO with ID: %s" % iso.id)
+        self.cleanup.append(iso)
+
+        # Get ISO response
+        timeout = 600
+        list_iso_response = None
+        while timeout >= 0:
+            list_iso_response = Iso.list(
+                self.apiclient,
+                isofilter="self",
+                id=iso.id
+            )
+
+            if list_iso_response is not None and list_iso_response[0].isready:
+                break
+
+            time.sleep(30)
+            timeout -= 30
+
+        iso_response = list_iso_response[0]
+        self.assertEqual(
+            iso_response.displaytext,
+            iso.displaytext,
+            "Check ISO displaytext in response"
+        )


### PR DESCRIPTION
### Description

This PR allows the below resource name / display text with unicode / emoji chars, and improves SQL exception msgs (doesn't include any sql stmts). Also, adds a validator for VM host/domain name.

- User VM
- Volume
- Volume Snapshot
- VM Snapshot
- Template
- ISO
- Disk Offering
- Compute Offering
- Network Offering
- VPC Offering
- Backup Offering
- Instance Group
- Affinity Group
- SSH Key
- Userdata
- Guest Network
- VPC
- Kubernetes Cluster
- Autoscale VM Group
- Account
- User
- Project
- Annotation

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Manually, tested the name / display names for these resources.

test_resource_names.py
[Checks support for emoji in the resource name for vm, volume, service & disk offering, template, iso, account(first/lastname)]

```
Test for deploy virtual machine ... === TestName: test_01_deploy_vm | Status : SUCCESS ===
ok
Test for create volume ... === TestName: test_02_create_volume | Status : SUCCESS ===
ok
Test for register template ... === TestName: test_03_register_template | Status : SUCCESS ===
ok
Test for register ISO ... === TestName: test_04_register_iso | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 201.090s

OK
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
