### PR TITLE
NPE fix, addresses test_hostha_kvm_host_fencing failure

### DIFF
--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -718,6 +718,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                 if (vmDetailCpu != null) {
                     //if vmDetail_cpu is not null it means it is running in a overcommited cluster.
                     cpuOvercommitRatio = Float.parseFloat(vmDetailCpu.getValue());
+                }
+                if (vmDetailRam != null) {
                     ramOvercommitRatio = Float.parseFloat(vmDetailRam.getValue());
                 }
                 ServiceOffering so = offeringsMap.get(vm.getServiceOfferingId());


### PR DESCRIPTION
### Description

This PR fixes NPE issue,  addresses test_hostha_kvm_host_fencing failure.

Noticed exception in log with VM details - "details":{"cpuOvercommitRatio":"2.0"} =>

```
2024-07-08 14:46:33,364 DEBUG [c.c.c.ClusterManagerImpl] (AgentConnectTaskPool-143:ctx-6c029670) (logid:a438af23) Forwarding [{"com.cloud.agent.api.ChangeAgentCommand":{"agentId":1,"event":"AgentDisconnected","contextMap":{},"wait":0,"bypassHostMaintenance":false}}] to 32987747976021
2024-07-08 14:46:33,364 DEBUG [c.c.c.ClusterManagerImpl] (Cluster-Worker-1:ctx-f6bca1ba) (logid:017b7b93) Cluster PDU 32986087031685 -> 32987747976021. agent: 1, pdu seq: 28532, pdu ack seq: 0, json: [{"com.cloud.agent.api.ChangeAgentCommand":{"agentId":1,"event":"AgentDisconnected","contextMap":{},"wait":0,"bypassHostMaintenance":false}}]
2024-07-08 14:46:33,366 DEBUG [c.c.a.m.AgentManagerImpl] (AgentConnectTaskPool-143:ctx-6c029670) (logid:a438af23) Failed to handle host connection: 
com.cloud.utils.exception.CloudRuntimeException: Unable to connect 1
	at com.cloud.agent.manager.AgentManagerImpl.notifyMonitorsOfConnection(AgentManagerImpl.java:591)
	at com.cloud.agent.manager.AgentManagerImpl.sendReadyAndGetAttache(AgentManagerImpl.java:1150)
	at com.cloud.agent.manager.AgentManagerImpl.handleConnectedAgent(AgentManagerImpl.java:1168)
	at com.cloud.agent.manager.AgentManagerImpl$HandleAgentConnectTask.runInContext(AgentManagerImpl.java:1252)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:48)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:102)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:45)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NullPointerException
	at com.cloud.capacity.CapacityManagerImpl.updateCapacityForHost(CapacityManagerImpl.java:721)
	at com.cloud.capacity.CapacityManagerImpl.updateCapacityForHost(CapacityManagerImpl.java:643)
	at com.cloud.capacity.ComputeCapacityListener.processConnect(ComputeCapacityListener.java:67)

```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested the marvin test.

**Before fix  =>**

```
==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Jul_08_2024_14_43_35_J24KMY All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
checkForState:: expected=Available, actual={haenable : True, hastate : 'Available', haprovider : 'kvmhaprovider'}
checkForState:: expected=Suspect, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Recovering', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Recovering', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Recovering', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Fencing', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fenced, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
=== TestName: test_hostha_kvm_host_fencing | Status : EXCEPTION ===
```

**After fix =>**
```
==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Jul_08_2024_16_08_03_TO1J1H All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
checkForState:: expected=Available, actual={haenable : True, hastate : 'Available', haprovider : 'kvmhaprovider'}
checkForState:: expected=Suspect, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Checking', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Degraded', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Suspect', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Recovering', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Recovering', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fencing, actual={haenable : True, hastate : 'Fencing', haprovider : 'kvmhaprovider'}
checkForState:: expected=Fenced, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Fenced', haprovider : 'kvmhaprovider'}
checkForState:: expected=Available, actual={haenable : True, hastate : 'Available', haprovider : 'kvmhaprovider'}
=== TestName: test_hostha_kvm_host_fencing | Status : SUCCESS ===
```


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
