### PR TITLE
Fix: Switch back to CLOUD_DB after purging usage records

### DIFF
--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageDaoImpl.java
@@ -28,6 +28,7 @@ import com.cloud.utils.db.QueryBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
+import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
@@ -469,21 +470,25 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
 
     @Override
     public void removeOldUsageRecords(int days) {
-        String sql = DELETE_ALL_BY_INTERVAL;
-        TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
-        PreparedStatement pstmt = null;
-        try {
-            txn.start();
-            pstmt = txn.prepareAutoCloseStatement(sql);
-            pstmt.setLong(1, days);
-            pstmt.executeUpdate();
-            txn.commit();
-        } catch (Exception ex) {
-            txn.rollback();
-            s_logger.error("error removing old cloud_usage records for interval: " + days);
-        } finally {
-            txn.close();
-        }
+        Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallbackNoReturn() {
+            @Override
+            public void doInTransactionWithoutResult(TransactionStatus status) {
+                TransactionLegacy txn = TransactionLegacy.currentTxn();
+                PreparedStatement pstmt = null;
+                try {
+                    txn.start();
+                    pstmt = txn.prepareAutoCloseStatement(DELETE_ALL_BY_INTERVAL);
+                    pstmt.setLong(1, days);
+                    pstmt.executeUpdate();
+                    txn.commit();
+                } catch (Exception ex) {
+                    txn.rollback();
+                    s_logger.error("error removing old cloud_usage records for interval: " + days);
+                } finally {
+                    txn.close();
+                }
+            }
+        });
     }
 
     public UsageVO persistUsage(final UsageVO usage) {


### PR DESCRIPTION
### Description

Executing `removeRawUsageRecords` command results in Management server becoming unavailable and random failure of subsequent requests. This PR fixes the issue by switching back to CLOUD_DB after the records have been removed from the database.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

#### Steps to reproduce
Execute `cmk removeRawUsageRecords interval=1000`. Requests to the management server will start failing after that.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
