### PR TITLE
LibvirtOvsFetchInterfaceCommandWrapperTest fix (test fails in mac) - skip it if no interfaces with eth and wl

### DIFF
--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtOvsFetchInterfaceCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtOvsFetchInterfaceCommandWrapperTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
@@ -62,9 +63,13 @@ public class LibvirtOvsFetchInterfaceCommandWrapperTest {
                             break;
                         };
                     }
+                    if (StringUtils.isNotBlank(interfaceName) && StringUtils.isNotBlank(ipAddress)) {
+                        break;
+                    }
                 }
             }
         } catch (SocketException ignored) {}
+        Assume.assumeTrue(StringUtils.isNotBlank(interfaceName));
         Ternary<String, String, String> result = null;
         try {
             result = wrapper.getInterfaceDetails(interfaceName);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtOvsFetchInterfaceCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtOvsFetchInterfaceCommandWrapperTest.java
@@ -52,8 +52,7 @@ public class LibvirtOvsFetchInterfaceCommandWrapperTest {
             while(interfaces.hasMoreElements()) {
                 NetworkInterface networkInterface = interfaces.nextElement();
                 if (networkInterface.getInetAddresses().hasMoreElements() &&
-                        (networkInterface.getName().startsWith("eth") ||
-                                networkInterface.getName().startsWith("wl"))) {
+                        networkInterface.getName().matches("^(eth|wl|en).*")) {
                     interfaceName = networkInterface.getName();
                     Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
                     while(addresses.hasMoreElements()) {


### PR DESCRIPTION
### Description

This PR fixes LibvirtOvsFetchInterfaceCommandWrapperTest (test fails in mac) - skip it if no interfaces with eth and wl.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Ran unit test in local (mac).

**Before change:**

```
[INFO] Running com.cloud.hypervisor.kvm.resource.wrapper.LibvirtOvsFetchInterfaceCommandWrapperTest
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.108 s <<< FAILURE! - in com.cloud.hypervisor.kvm.resource.wrapper.LibvirtOvsFetchInterfaceCommandWrapperTest
[ERROR] testGetInterfaceDetailsValidValid(com.cloud.hypervisor.kvm.resource.wrapper.LibvirtOvsFetchInterfaceCommandWrapperTest)  Time elapsed: 0.096 s  <<< ERROR!
java.lang.NullPointerException

[ERROR] Errors: 
[ERROR]   LibvirtOvsFetchInterfaceCommandWrapperTest.testGetInterfaceDetailsValidValid » NullPointer
[ERROR] Tests run: 455, Failures: 0, Errors: 1, Skipped: 2
```

**After change:**

```
[INFO] Running com.cloud.hypervisor.kvm.resource.wrapper.LibvirtOvsFetchInterfaceCommandWrapperTest
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.109 s - in com.cloud.hypervisor.kvm.resource.wrapper.LibvirtOvsFetchInterfaceCommandWrapperTest
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
