### PR TITLE
Add access modifier to `VolumeVO`

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
@@ -100,7 +100,7 @@ public class VolumeVO implements Volume {
     private long dataCenterId;
 
     @Column(name = "host_ip")
-    private String hostip;
+    private String hostIp;
 
     @Column(name = "disk_offering_id")
     private long diskOfferingId;
@@ -428,11 +428,11 @@ public class VolumeVO implements Volume {
     }
 
     public String getHostIp() {
-        return hostip;
+        return hostIp;
     }
 
     public void setHostIp(String hostip) {
-        this.hostip = hostip;
+        this.hostIp = hostip;
     }
 
     public void setPodId(Long podId) {

--- a/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
@@ -48,31 +48,31 @@ public class VolumeVO implements Volume {
     @TableGenerator(name = "volume_sq", table = "sequence", pkColumnName = "name", valueColumnName = "value", pkColumnValue = "volume_seq", allocationSize = 1)
     @GeneratedValue(strategy = GenerationType.TABLE)
     @Column(name = "id")
-    long id;
+    private long id;
 
     @Column(name = "name")
-    String name;
+    private String name;
 
     @Column(name = "pool_id")
-    Long poolId;
+    private Long poolId;
 
     @Column(name = "last_pool_id")
-    Long lastPoolId;
+    private Long lastPoolId;
 
     @Column(name = "account_id")
-    long accountId;
+    private long accountId;
 
     @Column(name = "domain_id")
-    long domainId;
+    private long domainId;
 
     @Column(name = "instance_id")
-    Long instanceId = null;
+    private Long instanceId = null;
 
     @Column(name = "device_id")
-    Long deviceId = null;
+    private Long deviceId = null;
 
     @Column(name = "size")
-    Long size;
+    private Long size;
 
     @Column(name = "min_iops")
     private Long minIops;
@@ -81,50 +81,50 @@ public class VolumeVO implements Volume {
     private Long maxIops;
 
     @Column(name = "folder")
-    String folder;
+    private String folder;
 
     @Column(name = "path")
-    String path;
+    private String path;
 
     @Column(name = "pod_id")
-    Long podId;
+    private Long podId;
 
     @Column(name = "created")
-    Date created;
+    private Date created;
 
     @Column(name = "attached")
     @Temporal(value = TemporalType.TIMESTAMP)
-    Date attached;
+    private Date attached;
 
     @Column(name = "data_center_id")
-    long dataCenterId;
+    private long dataCenterId;
 
     @Column(name = "host_ip")
-    String hostip;
+    private String hostip;
 
     @Column(name = "disk_offering_id")
-    long diskOfferingId;
+    private long diskOfferingId;
 
     @Column(name = "template_id")
-    Long templateId;
+    private Long templateId;
 
     @Column(name = "first_snapshot_backup_uuid")
-    String firstSnapshotBackupUuid;
+    private String firstSnapshotBackupUuid;
 
     @Column(name = "volume_type")
     @Enumerated(EnumType.STRING)
-    Type volumeType = Volume.Type.UNKNOWN;
+    private Type volumeType = Volume.Type.UNKNOWN;
 
     @Column(name = "pool_type")
     @Convert(converter = StoragePoolTypeConverter.class)
-    StoragePoolType poolType;
+    private StoragePoolType poolType;
 
     @Column(name = GenericDao.REMOVED_COLUMN)
-    Date removed;
+    private Date removed;
 
     @Column(name = "updated")
     @Temporal(value = TemporalType.TIMESTAMP)
-    Date updated;
+    private Date updated;
 
     @Column(name = "update_count", updatable = true, nullable = false)
     protected long updatedCount; // This field should be updated everytime the
@@ -133,17 +133,17 @@ public class VolumeVO implements Volume {
                                  // dao code.
 
     @Column(name = "recreatable")
-    boolean recreatable;
+    private boolean recreatable;
 
     @Column(name = "state")
     @Enumerated(value = EnumType.STRING)
     private State state;
 
     @Column(name = "chain_info", length = 65535)
-    String chainInfo;
+    private String chainInfo;
 
     @Column(name = "uuid")
-    String uuid;
+    private String uuid;
 
     @Column(name = "format")
     private Storage.ImageFormat format;
@@ -168,7 +168,7 @@ public class VolumeVO implements Volume {
 
     @Transient
     // @Column(name="reservation")
-    String reservationId;
+    private String reservationId;
 
     @Column(name = "hv_ss_reserve")
     private Integer hypervisorSnapshotReserve;

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3336,7 +3336,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
         // In case of VMware, if ROOT volume is being cold-migrated, then ensure destination storage pool is in the same Datacenter as the VM.
         if (vm != null && vm.getHypervisorType().equals(HypervisorType.VMware)) {
-            if (!liveMigrateVolume && vol.volumeType.equals(Volume.Type.ROOT)) {
+            if (!liveMigrateVolume && vol.getVolumeType().equals(Volume.Type.ROOT)) {
                 Long hostId = vm.getHostId() != null ? vm.getHostId() : vm.getLastHostId();
                 HostVO host = _hostDao.findById(hostId);
                 if (host != null) {


### PR DESCRIPTION
### Description

The class `VolumeVO` lacks access modifiers in its fields. This PR aims to improve adherence to object-oriented programming by adding private access modifiers to all fields in the class mentioned above, along with their respective getters and setters. I've also added a getter to an occurrence in `VolumeApiServiceImpl` where a field belonging to `VolumeVO` was being accessed directly.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?
I ran all the tests related to `VolumeVO` and `VolumeApiServiceImpl`, checked all usages of both classes, and made sure nothing was broken.