### PR TITLE
ui: vm metrics note about behaviour across hypervisors

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2949,6 +2949,7 @@
 "message.failed.to.remove": "Failed to remove",
 "message.generate.keys": "Please confirm that you would like to generate new API/Secret keys for this User.",
 "message.chart.statistic.info": "The shown charts are self-adjustable, that means, if the value gets close to the limit or overpass it, it will grow to adjust the shown value",
+"message.chart.statistic.info.hypervisor.additionals": "The metrics data depend on the hypervisor plugin used for each hypervisor. The behavior can vary across different hypervisors. For instance, with KVM, metrics are real-time statistics provided by libvirt. In contrast, with VMware, the metrics are averaged data for a given time interval controlled by configuration.",
 "message.guest.traffic.in.advanced.zone": "Guest Network traffic is communication between end-user Instances. Specify a range of VLAN IDs or VXLAN Network identifiers (VNIs) to carry guest traffic for each physical Network.",
 "message.guest.traffic.in.basic.zone": "Guest Network traffic is communication between end-user Instances. Specify a range of IP addresses that CloudStack can assign to guest Instances. Make sure this range does not overlap the reserved system IP range.",
 "message.host.controlstate": "The Control Plane Status of this Instance is ",

--- a/ui/src/components/view/stats/ResourceStatsInfo.vue
+++ b/ui/src/components/view/stats/ResourceStatsInfo.vue
@@ -45,7 +45,8 @@ export default {
         {
           resourceType: 'CHART',
           messageList: [
-            this.$t('message.chart.statistic.info')
+            this.$t('message.chart.statistic.info'),
+            this.$t('message.chart.statistic.info.hypervisor.additionals')
           ]
         },
         {


### PR DESCRIPTION
### Description

The metrics for VMs and VM disks in CloudStack depend on the hypervisor plugin used for each hypervisor. The behavior can vary across different hypervisors. For VMware, metrics are retrieved as average value for the time interval defined in the global configuration - vmware.stats.time.window.

Related documentation PR: https://github.com/apache/cloudstack-documentation/pull/413

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4cf6a817-0e0d-4ff8-a217-f75576f506fd)


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
