### PR TITLE
Icon changed for control-outlined

### DIFF
--- a/ui/src/config/section/infra/hosts.js
+++ b/ui/src/config/section/infra/hosts.js
@@ -283,7 +283,7 @@ export default {
     },
     {
       api: 'startRollingMaintenance',
-      icon: 'setting-outlined',
+      icon: 'control-outlined',
       label: 'label.start.rolling.maintenance',
       message: 'label.start.rolling.maintenance',
       docHelp: 'adminguide/hosts.html#kvm-rolling-maintenance',


### PR DESCRIPTION
### Description
On the hosts details page, icons with distinct functionalities currently share the same image. This PR aims to enhance the user experience by proposing a change to differentiate the icons Start rolling maintenance and Configure out-of-band management on the hosts details page.
### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)
### Feature/Enhancement Scale or Bug Severity
#### Feature/Enhancement Scale
- [ ] Major
- [x] Minor
#### Bug Severity
- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial
### Screenshots (if appropriate):
Hosts page before changes
![image](https://github.com/user-attachments/assets/a25c6331-2134-4b0c-a994-8d60310c4375)

Hosts page after changes
![image](https://github.com/user-attachments/assets/2ef54f91-a89e-4e9d-8431-e636447232b5)

### How Has This Been Tested?
After the UI change, the icon for Start rolling maintenance has been updated and is now reflected in the UI as well