### PR TITLE
test: improve purge expunged resources b/g task testcase

### DIFF
--- a/test/integration/smoke/test_purge_expunged_vms.py
+++ b/test/integration/smoke/test_purge_expunged_vms.py
@@ -273,7 +273,7 @@ class TestPurgeExpungedVms(cloudstackTestCase):
             return False
         self.debug("Restarting all management server")
         for idx, server_ip in enumerate(server_ips):
-            self.debug("Restarting management server #%d with IP %s" % (idx, server_ip))
+            self.debug(f"Restarting management server #{idx} with IP {server_ip}")
             sshClient = SshClient(
                 server_ip,
                 22,
@@ -362,7 +362,7 @@ class TestPurgeExpungedVms(cloudstackTestCase):
             self.restartAllManagementServers()
         wait_multiple = 2
         wait = wait_multiple * purge_task_delay
-        logging.info("Waiting for %dx%d = %d seconds for background task to execute" % (wait_multiple, purge_task_delay, wait))
+        logging.info(f"Waiting for {wait_multiple}x{purge_task_delay} = {wait} seconds for background task to execute")
         time.sleep(wait)
         logging.debug("Validating expunged VMs")
         self.validatePurgedVmEntriesInDb(


### PR DESCRIPTION
### Description

Failures were seen for during purging of expunged resources via bacground task during different test runs. This PR tries to make sure b/g task execution is not skipped after MS restrat in a multi-MS environment. It also updates expunged.resources.purge.interval to allow running task again in 60s.

https://github.com/apache/cloudstack/pull/9316#issuecomment-2240965788
https://github.com/apache/cloudstack/pull/9316#issuecomment-2241001342

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [x] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
