### PR TITLE
Display associated resource name on storage pools objects

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/storage/browser/DataStoreObjectResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/storage/browser/DataStoreObjectResponse.java
@@ -41,6 +41,10 @@ public class DataStoreObjectResponse extends BaseResponse {
     @Param(description = "Template ID associated with the data store object.")
     private String templateId;
 
+    @SerializedName(ApiConstants.TEMPLATE_NAME)
+    @Param(description = "Template Name associated with the data store object.")
+    private String templateName;
+
     @SerializedName(ApiConstants.FORMAT)
     @Param(description = "Format of template associated with the data store object.")
     private String format;
@@ -49,9 +53,17 @@ public class DataStoreObjectResponse extends BaseResponse {
     @Param(description = "Snapshot ID associated with the data store object.")
     private String snapshotId;
 
+    @SerializedName("snapshotname")
+    @Param(description = "Snapshot Name associated with the data store object.")
+    private String snapshotName;
+
     @SerializedName(ApiConstants.VOLUME_ID)
     @Param(description = "Volume ID associated with the data store object.")
     private String volumeId;
+
+    @SerializedName(ApiConstants.VOLUME_NAME)
+    @Param(description = "Volume Name associated with the data store object.")
+    private String volumeName;
 
     @SerializedName(ApiConstants.LAST_UPDATED)
     @Param(description = "Last modified date of the file/directory.")
@@ -86,6 +98,18 @@ public class DataStoreObjectResponse extends BaseResponse {
         this.volumeId = volumeId;
     }
 
+    public void setTemplateName(String templateName) {
+        this.templateName = templateName;
+    }
+
+    public void setSnapshotName(String snapshotName) {
+        this.snapshotName = snapshotName;
+    }
+
+    public void setVolumeName(String volumeName) {
+        this.volumeName = volumeName;
+    }
+
     public String getName() {
         return name;
     }
@@ -116,5 +140,17 @@ public class DataStoreObjectResponse extends BaseResponse {
 
     public Date getLastUpdated() {
         return lastUpdated;
+    }
+
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public String getSnapshotName() {
+        return snapshotName;
+    }
+
+    public String getVolumeName() {
+        return volumeName;
     }
 }

--- a/server/src/main/java/org/apache/cloudstack/storage/browser/StorageBrowserImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/browser/StorageBrowserImpl.java
@@ -233,14 +233,20 @@ public class StorageBrowserImpl extends MutualExclusiveIdsManagerBase implements
                     new Date(answer.getLastModified().get(i)));
             String filePath = paths.get(i);
             if (pathTemplateMap.get(filePath) != null) {
-                response.setTemplateId(pathTemplateMap.get(filePath).getUuid());
-                response.setFormat(pathTemplateMap.get(filePath).getFormat().toString());
+                VMTemplateVO vmTemplateVO = pathTemplateMap.get(filePath);
+                response.setTemplateId(vmTemplateVO.getUuid());
+                response.setFormat(vmTemplateVO.getFormat().toString());
+                response.setTemplateName(vmTemplateVO.getName());
             }
             if (pathSnapshotMap.get(filePath) != null) {
-                response.setSnapshotId(pathSnapshotMap.get(filePath).getUuid());
+                SnapshotVO snapshotVO = pathSnapshotMap.get(filePath);
+                response.setSnapshotId(snapshotVO.getUuid());
+                response.setSnapshotName(snapshotVO.getName());
             }
             if (pathVolumeMap.get(filePath) != null) {
-                response.setVolumeId(pathVolumeMap.get(filePath).getUuid());
+                VolumeVO volumeVO = pathVolumeMap.get(filePath);
+                response.setVolumeId(volumeVO.getUuid());
+                response.setVolumeName(volumeVO.getName());
             }
             responses.add(response);
         }

--- a/ui/src/views/infra/StorageBrowser.vue
+++ b/ui/src/views/infra/StorageBrowser.vue
@@ -127,20 +127,20 @@
           <template v-if="column.key == 'associatedResource'">
             <template v-if="record.snapshotid">
               <router-link :to="{ path: '/snapshot/' + record.snapshotid }" target='_blank' >
-                {{ $t('label.snapshot') }}
+                {{ record.snapshotname }}
               </router-link>
             </template>
             <template v-else-if="record.volumeid">
               <router-link :to="{ path: '/volume/' + record.volumeid }" target='_blank' >
-                {{ $t('label.volume') }}
+                {{ record.volumename }}
               </router-link>
             </template>
             <template v-else-if="record.templateid">
               <router-link v-if="record.format === 'ISO'" :to="{ path: '/iso/' + record.templateid }" target='_blank' >
-                {{ $t('label.iso') }}
+                {{ record.templatename }}
               </router-link>
               <router-link v-else :to="{ path: '/template/' + record.templateid }" target='_blank'>
-                {{ $t('label.templatename') }}
+                {{ record.templatename }}
               </router-link>
             </template>
             <template v-else>


### PR DESCRIPTION
### Description

This PR adds the resource name for templates, volumes and snapshots on the `listStoragePoolObjects` API response and displays them UI under the Associated Resource column on the Storage Pool Browser section

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before the fix:
<img width="998" alt="Screenshot 2024-07-25 at 18 37 34" src="https://github.com/user-attachments/assets/773653f5-eda2-492e-8045-69ad9b1d95cd">

After the fix:
<img width="998" alt="Screenshot 2024-07-25 at 18 50 37" src="https://github.com/user-attachments/assets/afafa803-dfd7-4d1e-9cb5-e14f5c7692b3">


### How Has This Been Tested?
Tested for Primary and Secondary Storage pools

#### How did you try to break this feature and the system with this change?

