### PR TITLE
packaging: bundle latest cmk x86 build with deb and rpm packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ VERSION := $(shell grep '<version>' pom.xml | head -2 | tail -1 | cut -d'>' -f2 
 PACKAGE = $(shell dh_listpackages|head -n 1|cut -d '-' -f 1)
 SYSCONFDIR = "/etc"
 DESTDIR = "debian/tmp"
-CMK_REL := $(shell wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
+CMK_REL := $(shell wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/releases" 2>/dev/null | jq -r '.[0].tag_name')
 
 %:
 	dh $@ --with systemd

--- a/debian/rules
+++ b/debian/rules
@@ -85,7 +85,8 @@ override_dh_auto_install:
 	rm -rf $(DESTDIR)/usr/share/$(PACKAGE)-management/templates/systemvm/md5sum.txt
 
 	# Bundle cmk in cloudstack-management
-	wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/6.3.0/cmk.linux.x86-64 -O $(DESTDIR)/usr/bin/cmk
+	CMK_REL=$(curl -s  "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" | jq -r '.[0].name')
+	wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$CMK_REL/cmk.linux.x86-64 -O $(DESTDIR)/usr/bin/cmk
 	chmod +x $(DESTDIR)/usr/bin/cmk
 
 	# nast hack for a couple of configuration files

--- a/debian/rules
+++ b/debian/rules
@@ -85,7 +85,7 @@ override_dh_auto_install:
 	rm -rf $(DESTDIR)/usr/share/$(PACKAGE)-management/templates/systemvm/md5sum.txt
 
 	# Bundle cmk in cloudstack-management
-	CMK_REL=$(curl -s  "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" | jq -r '.[0].name')
+	CMK_REL=$(wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
 	wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$CMK_REL/cmk.linux.x86-64 -O $(DESTDIR)/usr/bin/cmk
 	chmod +x $(DESTDIR)/usr/bin/cmk
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@ VERSION := $(shell grep '<version>' pom.xml | head -2 | tail -1 | cut -d'>' -f2 
 PACKAGE = $(shell dh_listpackages|head -n 1|cut -d '-' -f 1)
 SYSCONFDIR = "/etc"
 DESTDIR = "debian/tmp"
+CMK_REL := $(shell wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
 
 %:
 	dh $@ --with systemd
@@ -85,7 +86,6 @@ override_dh_auto_install:
 	rm -rf $(DESTDIR)/usr/share/$(PACKAGE)-management/templates/systemvm/md5sum.txt
 
 	# Bundle cmk in cloudstack-management
-	CMK_REL=$(wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
 	wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$(CMK_REL)/cmk.linux.x86-64 -O $(DESTDIR)/usr/bin/cmk
 	chmod +x $(DESTDIR)/usr/bin/cmk
 

--- a/debian/rules
+++ b/debian/rules
@@ -86,7 +86,7 @@ override_dh_auto_install:
 
 	# Bundle cmk in cloudstack-management
 	CMK_REL=$(wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
-	wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$CMK_REL/cmk.linux.x86-64 -O $(DESTDIR)/usr/bin/cmk
+	wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$(CMK_REL)/cmk.linux.x86-64 -O $(DESTDIR)/usr/bin/cmk
 	chmod +x $(DESTDIR)/usr/bin/cmk
 
 	# nast hack for a couple of configuration files

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -260,7 +260,8 @@ install -D client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{
 install -D client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
 install -D client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
 # Bundle cmk in cloudstack-management
-wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/6.3.0/cmk.linux.x86-64 -O ${RPM_BUILD_ROOT}%{_bindir}/cmk
+CMK_REL=$(curl -s  "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" | jq -r '.[0].name')
+wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$CMK_REL/cmk.linux.x86-64 -O ${RPM_BUILD_ROOT}%{_bindir}/cmk
 chmod +x ${RPM_BUILD_ROOT}%{_bindir}/cmk
 
 cp -r client/target/utilities/scripts/db/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -260,7 +260,7 @@ install -D client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{
 install -D client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
 install -D client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
 # Bundle cmk in cloudstack-management
-CMK_REL=$(curl -s  "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" | jq -r '.[0].name')
+CMK_REL=$(wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
 wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$CMK_REL/cmk.linux.x86-64 -O ${RPM_BUILD_ROOT}%{_bindir}/cmk
 chmod +x ${RPM_BUILD_ROOT}%{_bindir}/cmk
 

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -260,7 +260,7 @@ install -D client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{
 install -D client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
 install -D client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
 # Bundle cmk in cloudstack-management
-CMK_REL=$(wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/tags" 2>/dev/null | jq -r '.[0].name')
+CMK_REL=$(wget -O - "https://api.github.com/repos/apache/cloudstack-cloudmonkey/releases" 2>/dev/null | jq -r '.[0].tag_name')
 wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/$CMK_REL/cmk.linux.x86-64 -O ${RPM_BUILD_ROOT}%{_bindir}/cmk
 chmod +x ${RPM_BUILD_ROOT}%{_bindir}/cmk
 


### PR DESCRIPTION
This uses the latest tag to find and use the latest Github tag from cloudstack-cloudmonkey repo, and use that to bundle the binary CLI in packages.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)
