### PR TITLE
[VMware] Disconnect/Detach config drive ISO (if exists) on stop VM

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -55,6 +55,7 @@ import com.vmware.vim25.FileQueryFlags;
 import com.vmware.vim25.FolderFileInfo;
 import com.vmware.vim25.HostDatastoreBrowserSearchResults;
 import com.vmware.vim25.HostDatastoreBrowserSearchSpec;
+import com.vmware.vim25.VirtualCdromIsoBackingInfo;
 import com.vmware.vim25.VirtualMachineConfigSummary;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.backup.PrepareForBackupRestorationCommand;
@@ -2738,8 +2739,9 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
 
     private DiskTO[] getDisks(DiskTO[] sortedDisks) {
        return Arrays.stream(sortedDisks).filter(vol -> ((vol.getPath() != null &&
-                vol.getPath().contains("configdrive"))) || (vol.getType() != Volume.Type.ISO)).toArray(DiskTO[]::new);
+                vol.getPath().contains(ConfigDrive.CONFIGDRIVEDIR))) || (vol.getType() != Volume.Type.ISO)).toArray(DiskTO[]::new);
     }
+
     private void configureIso(VmwareHypervisorHost hyperHost, VirtualMachineMO vmMo, DiskTO vol,
                               VirtualDeviceConfigSpec[] deviceConfigSpecArray, int ideUnitNumber, int i) throws Exception {
         TemplateObjectTO iso = (TemplateObjectTO) vol.getData();
@@ -4448,6 +4450,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                             msg = "Have problem in powering off VM " + cmd.getVmName() + ", let the process continue";
                             s_logger.warn(msg);
                         }
+
+                        disconnectConfigDriveIsoIfExists(vmMo);
                         return new StopAnswer(cmd, msg, true);
                     }
 
@@ -4463,6 +4467,28 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             }
         } catch (Exception e) {
             return new StopAnswer(cmd, createLogMessageException(e, cmd), false);
+        }
+    }
+
+    private void disconnectConfigDriveIsoIfExists(VirtualMachineMO vmMo) {
+        try {
+            List<VirtualDevice> isoDevices = vmMo.getIsoDevices();
+            if (CollectionUtils.isEmpty(isoDevices)) {
+                return;
+            }
+
+            for (VirtualDevice isoDevice : isoDevices) {
+                if(isoDevice.getBacking() instanceof VirtualCdromIsoBackingInfo) {
+                    String isoFilePath = ((VirtualCdromIsoBackingInfo)isoDevice.getBacking()).getFileName();
+                    if (isoFilePath.contains(ConfigDrive.CONFIGDRIVEDIR)) {
+                        s_logger.info(String.format("Disconnecting config drive at location: %s", isoFilePath));
+                        vmMo.detachIso(isoFilePath, true);
+                        return;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            s_logger.warn(String.format("Couldn't check/disconnect config drive, error: %s", e.getMessage()), e);
         }
     }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -4478,14 +4478,16 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             }
 
             for (VirtualDevice isoDevice : isoDevices) {
-                if(isoDevice.getBacking() instanceof VirtualCdromIsoBackingInfo) {
-                    String isoFilePath = ((VirtualCdromIsoBackingInfo)isoDevice.getBacking()).getFileName();
-                    if (isoFilePath.contains(ConfigDrive.CONFIGDRIVEDIR)) {
-                        s_logger.info(String.format("Disconnecting config drive at location: %s", isoFilePath));
-                        vmMo.detachIso(isoFilePath, true);
-                        return;
-                    }
+                if (!(isoDevice.getBacking() instanceof VirtualCdromIsoBackingInfo)) {
+                    continue;
                 }
+                String isoFilePath = ((VirtualCdromIsoBackingInfo)isoDevice.getBacking()).getFileName();
+                if (!isoFilePath.contains(ConfigDrive.CONFIGDRIVEDIR)) {
+                    continue;
+                }
+                s_logger.info(String.format("Disconnecting config drive at location: %s", isoFilePath));
+                vmMo.detachIso(isoFilePath, true);
+                return;
             }
         } catch (Exception e) {
             s_logger.warn(String.format("Couldn't check/disconnect config drive, error: %s", e.getMessage()), e);

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -3203,6 +3203,19 @@ public class VirtualMachineMO extends BaseMO {
         return null;
     }
 
+    public List<VirtualDevice> getIsoDevices() throws Exception {
+        List<VirtualDevice> isoDevices = new ArrayList<>();
+        List<VirtualDevice> devices = _context.getVimClient().getDynamicProperty(_mor, "config.hardware.device");
+        if (devices != null && devices.size() > 0) {
+            for (VirtualDevice device : devices) {
+                if (device instanceof VirtualCdrom) {
+                    isoDevices.add(device);
+                }
+            }
+        }
+        return isoDevices;
+    }
+
     public VirtualDevice getIsoDevice(int key) throws Exception {
         List<VirtualDevice> devices = _context.getVimClient().getDynamicProperty(_mor, "config.hardware.device");
         if (devices != null && devices.size() > 0) {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -3204,16 +3204,11 @@ public class VirtualMachineMO extends BaseMO {
     }
 
     public List<VirtualDevice> getIsoDevices() throws Exception {
-        List<VirtualDevice> isoDevices = new ArrayList<>();
         List<VirtualDevice> devices = _context.getVimClient().getDynamicProperty(_mor, "config.hardware.device");
-        if (devices != null && devices.size() > 0) {
-            for (VirtualDevice device : devices) {
-                if (device instanceof VirtualCdrom) {
-                    isoDevices.add(device);
-                }
-            }
+        if (CollectionUtils.isEmpty(devices)) {
+            return new ArrayList<>();
         }
-        return isoDevices;
+        return devices.stream().filter(device -> device instanceof VirtualCdrom).collect(Collectors.toList());
     }
 
     public VirtualDevice getIsoDevice(int key) throws Exception {


### PR DESCRIPTION
### Description

This PR disconnects/detachs config drive ISO (if exists) on stop VM in VMware. This is required for support some VM operations involving export OVF, on stopped VMs.

Root cause: Export OVF fails as there is no config drive file, it is removed when VM is stopped.

Fixes #9453

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Manually tested the start,stop,start VM operations and VM instance volume snapshots with config drive on VMware.

**Before =>**

![Before_ConfigDrive_NotDetached_VMware](https://github.com/user-attachments/assets/9d2e5e45-daee-431f-868e-ad12c28ef62b)

<img width="1000" alt="Before_ConfigDrive_NotDetached_And_Snapshot_CS" src="https://github.com/user-attachments/assets/c0033c7f-8d38-4aed-a9cc-4a432ace9253">

**After =>**

![After_ConfigDrive_Detached_VMware](https://github.com/user-attachments/assets/7b6ccb29-13c1-4bdd-9f7e-536c58c8a697)

<img width="1014" alt="After_ConfigDrive_Detached_And_Snapshot_CS" src="https://github.com/user-attachments/assets/346a270b-4b0c-42a1-b590-63556d4272a2">

```
2024-07-29T15:56:17,721 DEBUG [c.c.a.t.Request] (Work-Job-Executor-2:[ctx-bd90a732, job-217/job-218, ctx-bd64bbee]) (logid:fd80b170) Seq 1-234468655599976463: Executing:  { Cmd , MgmtId: 32989425697365, via: 1(10.0.34.85), Ver: v1, Flags: 100011, [{"com.cloud.agent.api.StopCommand":{"isProxy":"false","checkBeforeCleanup":"false","forceStop":"false","vlanToPersistenceMap":{"1727":"true"},"volumesToDisconnect":[],"vmName":"i-2-25-VM","executeInSequence":"false","wait":"0","bypassHostMaintenance":"false"}}] }
...
2024-07-29T15:56:21,045 INFO  [c.c.h.v.r.VmwareResource] (DirectAgent-14:[ctx-7ac38317, 10.0.34.85, job-217/job-218, cmd: StopCommand]) (logid:fd80b170) Disconnecting config drive at location: [c25a36f2689731989d17a452538ae70d] configdrive/i-2-25-VM.iso

2024-07-29T15:56:21,253 DEBUG [c.c.n.e.ConfigDriveNetworkElement] (Work-Job-Executor-2:[ctx-bd90a732, job-217/job-218, ctx-bd64bbee]) (logid:fd80b170) Deleting config drive ISO for vm: i-2-25-VM
2024-07-29T15:56:21,256 DEBUG [c.c.a.m.ClusteredAgentAttache] (Work-Job-Executor-2:[ctx-bd90a732, job-217/job-218, ctx-bd64bbee]) (logid:fd80b170) Seq 2-4190599453268246540: Routed from 32989425697365
2024-07-29T15:56:21,257 DEBUG [c.c.a.t.Request] (Work-Job-Executor-2:[ctx-bd90a732, job-217/job-218, ctx-bd64bbee]) (logid:fd80b170) Seq 3-4190599453268246540: Sending  { Cmd , MgmtId: 32989425697365, via: 3(s-2-VM), Ver: v1, Flags: 100011, [{"com.cloud.agent.api.HandleConfigDriveIsoCommand":{"isoFile":"configdrive/i-2-25-VM.iso","create":"false","destStore":{"com.cloud.agent.api.to.NfsTO":{"_url":"NFS://10.0.32.4/acs/secondary/pr9346-t10845-vmware-80/pr9346-t10845-vmware-80-sec1","_role":"Image"}},"useHostCacheOnUnsupportedPool":"false","preferHostCache":"false","wait":"0","bypassHostMaintenance":"false"}}] }
2024-07-29T15:56:21,321 DEBUG [c.c.a.t.Request] (AgentManager-Handler-8:[]) (logid:) Seq 3-4190599453268246540: Processing:  { Ans: , MgmtId: 32989425697365, via: 3, Ver: v1, Flags: 10, [{"com.cloud.agent.api.HandleConfigDriveIsoAnswer":{"result":"true","wait":"0","bypassHostMaintenance":"false"}}] }
2024-07-29T15:56:21,321 DEBUG [c.c.a.t.Request] (Work-Job-Executor-2:[ctx-bd90a732, job-217/job-218, ctx-bd64bbee]) (logid:fd80b170) Seq 3-4190599453268246540: Received:  { Ans: , MgmtId: 32989425697365, via: 3(s-2-VM), Ver: v1, Flags: 10, { HandleConfigDriveIsoAnswer } }
...
2024-07-29T15:56:21,213 DEBUG [c.c.a.t.Request] (DirectAgent-14:[ctx-7ac38317]) (logid:fd80b170) Seq 1-234468655599976463: Processing:  { Ans: , MgmtId: 32989425697365, via: 1(10.0.34.85), Ver: v1, Flags: 10, [{"com.cloud.agent.api.StopAnswer":{"result":"true","details":"Stop VM i-2-25-VM Succeed","wait":"0","bypassHostMaintenance":"false"}}] }
2024-07-29T15:56:21,213 DEBUG [c.c.a.t.Request] (Work-Job-Executor-2:[ctx-bd90a732, job-217/job-218, ctx-bd64bbee]) (logid:fd80b170) Seq 1-234468655599976463: Received:  { Ans: , MgmtId: 32989425697365, via: 1(10.0.34.85), Ver: v1, Flags: 10, { StopAnswer } }
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
