### PR TITLE
[linstor] Fix instance snapshot revert and delete on linstor storage

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/snapshot/LinstorVMSnapshotStrategy.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/snapshot/LinstorVMSnapshotStrategy.java
@@ -239,7 +239,8 @@ public class LinstorVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
         final String snapshotName = vmSnapshotVO.getName();
         final List<String> failedToDelete = new ArrayList<>();
         for (VolumeObjectTO volumeObjectTO : volumeTOs) {
-            final String rscName = LinstorUtil.RSC_PREFIX + volumeObjectTO.getUuid();
+            final String volPath = volumeObjectTO.getPath();
+            final String rscName = LinstorUtil.RSC_PREFIX + (volPath != null ? volPath : volumeObjectTO.getUuid());
             String err = linstorDeleteSnapshot(api, rscName, snapshotName);
 
             if (err != null)
@@ -292,7 +293,8 @@ public class LinstorVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
         final String snapshotName = vmSnapshotVO.getName();
 
         for (VolumeObjectTO volumeObjectTO : volumeTOs) {
-            final String rscName = LinstorUtil.RSC_PREFIX + volumeObjectTO.getUuid();
+            final String volPath = volumeObjectTO.getPath();
+            final String rscName = LinstorUtil.RSC_PREFIX + (volPath != null ? volPath : volumeObjectTO.getUuid());
             String err = linstorRevertSnapshot(api, rscName, snapshotName);
             if (err != null) {
                 throw new CloudRuntimeException(String.format(


### PR DESCRIPTION
### Description

This PR is replacing `getUuid` on volume objects by `getPath`. It uses the uuid , when path is not set (which may happen in some cases.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #9522 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

Reproduced the issue using fresh instances on NFS storage. See linked issue for details.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
