### PR TITLE
Allow deploy of  VRs on dedicated resources

### DIFF
--- a/api/src/main/java/com/cloud/deploy/DeploymentClusterPlanner.java
+++ b/api/src/main/java/com/cloud/deploy/DeploymentClusterPlanner.java
@@ -68,6 +68,14 @@ public interface DeploymentClusterPlanner extends DeploymentPlanner {
             ConfigKey.Kind.Select,
             "random,firstfit,userdispersing,userconcentratedpod_random,userconcentratedpod_firstfit,firstfitleastconsumed");
 
+    ConfigKey<Boolean> allowRoutersOnDedicatedResources = new ConfigKey<>(
+            "Advanced",
+            Boolean.class,
+            "allow.routers.on.dedicated.resources",
+            "false",
+            "Allow deploying virtual routers on dedicated Hosts, Clusters, Pods, and Zones",
+            true);
+
     /**
      * This is called to determine list of possible clusters where a virtual
      * machine can be deployed.

--- a/api/src/main/java/com/cloud/deploy/DeploymentClusterPlanner.java
+++ b/api/src/main/java/com/cloud/deploy/DeploymentClusterPlanner.java
@@ -68,14 +68,6 @@ public interface DeploymentClusterPlanner extends DeploymentPlanner {
             ConfigKey.Kind.Select,
             "random,firstfit,userdispersing,userconcentratedpod_random,userconcentratedpod_firstfit,firstfitleastconsumed");
 
-    ConfigKey<Boolean> allowRoutersOnDedicatedResources = new ConfigKey<>(
-            "Advanced",
-            Boolean.class,
-            "allow.routers.on.dedicated.resources",
-            "false",
-            "Allow deploying virtual routers on dedicated Hosts, Clusters, Pods, and Zones",
-            true);
-
     /**
      * This is called to determine list of possible clusters where a virtual
      * machine can be deployed.

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -24,8 +24,13 @@ import com.cloud.capacity.dao.CapacityDaoImpl.SummedCapacity;
 import com.cloud.utils.Pair;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.db.GenericDao;
+import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface CapacityDao extends GenericDao<CapacityVO, Long> {
+
+    ConfigKey<Boolean> allowRoutersOnDedicatedResources =  new ConfigKey<>("Advanced", Boolean.class, "allow.routers.on.dedicated.resources", "false",
+            "Allow deploying virtual routers on dedicated Hosts, Clusters, Pods, and Zones", true);
+
     CapacityVO findByHostIdType(Long hostId, short capacityType);
 
     List<CapacityVO> listByHostIdTypes(Long hostId, List<Short> capacityTypes);
@@ -40,7 +45,7 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     List<SummedCapacity> findNonSharedStorageForClusterPodZone(Long zoneId, Long podId, Long clusterId);
 
-    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityType, boolean isZone);
+    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityType,  boolean isVr, boolean isZone);
 
     Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag);
 

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -24,12 +24,8 @@ import com.cloud.capacity.dao.CapacityDaoImpl.SummedCapacity;
 import com.cloud.utils.Pair;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.db.GenericDao;
-import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface CapacityDao extends GenericDao<CapacityVO, Long> {
-
-    ConfigKey<Boolean> allowRoutersOnDedicatedResources =  new ConfigKey<>("Advanced", Boolean.class, "allow.routers.on.dedicated.resources", "false",
-            "Allow deploying virtual routers on dedicated Hosts, Clusters, Pods, and Zones", true);
 
     CapacityVO findByHostIdType(Long hostId, short capacityType);
 
@@ -45,7 +41,7 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     List<SummedCapacity> findNonSharedStorageForClusterPodZone(Long zoneId, Long podId, Long clusterId);
 
-    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityType,  boolean isVr, boolean isZone);
+    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityType,  boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone);
 
     Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag);
 

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -41,7 +41,7 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     List<SummedCapacity> findNonSharedStorageForClusterPodZone(Long zoneId, Long podId, Long clusterId);
 
-    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityType,  boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone);
+    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityType, boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone);
 
     Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag);
 

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -41,7 +41,7 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     List<SummedCapacity> findNonSharedStorageForClusterPodZone(Long zoneId, Long podId, Long clusterId);
 
-    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityType, boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone);
+    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityType, boolean isVr, boolean isZone);
 
     Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag);
 

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -26,7 +26,6 @@ import com.cloud.utils.Ternary;
 import com.cloud.utils.db.GenericDao;
 
 public interface CapacityDao extends GenericDao<CapacityVO, Long> {
-
     CapacityVO findByHostIdType(Long hostId, short capacityType);
 
     List<CapacityVO> listByHostIdTypes(Long hostId, List<Short> capacityTypes);
@@ -41,7 +40,7 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     List<SummedCapacity> findNonSharedStorageForClusterPodZone(Long zoneId, Long podId, Long clusterId);
 
-    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityType, boolean isVr, boolean isZone);
+    Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, Long domainId, short capacityType, boolean isVr, boolean isZone);
 
     Ternary<Long, Long, Long> findCapacityByZoneAndHostTag(Long zoneId, String hostTag);
 

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -26,8 +26,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.collections.CollectionUtils;
@@ -51,7 +49,7 @@ import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
-public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements CapacityDao, Configurable {
+public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements CapacityDao {
 
     private static final String ADD_ALLOCATED_SQL = "UPDATE `cloud`.`op_host_capacity` SET used_capacity = used_capacity + ? WHERE host_id = ? AND capacity_type = ?";
     private static final String SUBTRACT_ALLOCATED_SQL =
@@ -995,7 +993,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityTypeForOrdering, boolean isVr,  boolean isZone) {
+    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityTypeForOrdering, boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone) {
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
@@ -1007,7 +1005,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_OVERCOMMIT_CAPACITY_PART1);
         }
 
-        if (isVr && allowRoutersOnDedicatedResources.value()) {
+        if (isVr && allowRoutersOnDedicatedResources) {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_TO_DOMAIN_JOIN_1);
         } else {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);
@@ -1303,15 +1301,5 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             logger.warn("Error checking cluster threshold", e);
         }
         return 0;
-    }
-
-    @Override
-    public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {allowRoutersOnDedicatedResources};
-    }
-
-    @Override
-    public String getConfigComponentName() {
-        return CapacityDaoImpl.class.getSimpleName();
     }
 }

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.collections.CollectionUtils;
@@ -49,7 +51,7 @@ import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
-public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements CapacityDao {
+public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements CapacityDao, Configurable {
 
     private static final String ADD_ALLOCATED_SQL = "UPDATE `cloud`.`op_host_capacity` SET used_capacity = used_capacity + ? WHERE host_id = ? AND capacity_type = ?";
     private static final String SUBTRACT_ALLOCATED_SQL =
@@ -86,6 +88,13 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
                     "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id " +
                     "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id " +
                     "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id ";
+
+    private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_TO_DOMAIN_JOIN_1 =
+            "JOIN host ON capacity.host_id = host.id " +
+                    "LEFT JOIN (SELECT affinity_group.id, agvm.instance_id FROM affinity_group_vm_map agvm JOIN affinity_group ON agvm.affinity_group_id = affinity_group.id AND affinity_group.type='ExplicitDedication') AS ag ON ag.instance_id = ? " +
+                    "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id AND dr_pod.account_id IS NOT NULL " +
+                    "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id AND dr_cluster.account_id IS NOT NULL " +
+                    "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id AND dr_host.account_id IS NOT NULL ";
 
     private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_2 =
             " AND ((ag.id IS NULL AND dr_pod.pod_id IS NULL AND dr_cluster.cluster_id IS NULL AND dr_host.host_id IS NULL) OR " +
@@ -986,7 +995,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityTypeForOrdering, boolean isZone) {
+    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityTypeForOrdering, boolean isVr,  boolean isZone) {
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
@@ -998,7 +1007,12 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_OVERCOMMIT_CAPACITY_PART1);
         }
 
-        sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);
+        if (isVr && allowRoutersOnDedicatedResources.value()) {
+            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_TO_DOMAIN_JOIN_1);
+        } else {
+            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);
+        }
+
         if (isZone) {
             sql.append("WHERE capacity.capacity_state = 'Enabled' AND capacity.data_center_id = ?");
         } else {
@@ -1291,4 +1305,13 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         return 0;
     }
 
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {allowRoutersOnDedicatedResources};
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return CapacityDaoImpl.class.getSimpleName();
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -87,12 +87,12 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
                     "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id " +
                     "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id ";
 
-    private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_TO_DOMAIN_JOIN_1 =
+    private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_1 =
             "JOIN host ON capacity.host_id = host.id " +
                     "LEFT JOIN (SELECT affinity_group.id, agvm.instance_id FROM affinity_group_vm_map agvm JOIN affinity_group ON agvm.affinity_group_id = affinity_group.id AND affinity_group.type='ExplicitDedication') AS ag ON ag.instance_id = ? " +
-                    "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id AND dr_pod.account_id IS NOT NULL " +
-                    "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id AND dr_cluster.account_id IS NOT NULL " +
-                    "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id AND dr_host.account_id IS NOT NULL ";
+                    "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id AND dr_pod.account_id IS NOT NULL AND dr_pod.account_id != ownerId " +
+                    "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id AND dr_cluster.account_id IS NOT NULL AND dr_cluster.account_id != ownerId " +
+                    "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id AND dr_host.account_id IS NOT NULL AND dr_host.account_id != ownerId ";
 
     private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_2 =
             " AND ((ag.id IS NULL AND dr_pod.pod_id IS NULL AND dr_cluster.cluster_id IS NULL AND dr_host.host_id IS NULL) OR " +
@@ -993,7 +993,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, short capacityTypeForOrdering, boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone) {
+    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityTypeForOrdering, boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone) {
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
@@ -1006,7 +1006,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         }
 
         if (isVr && allowRoutersOnDedicatedResources) {
-            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_TO_DOMAIN_JOIN_1);
+            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_1.replace("ownerId", ownerId.toString()));
         } else {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);
         }

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -993,7 +993,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityTypeForOrdering, boolean isVr, boolean allowRoutersOnDedicatedResources, boolean isZone) {
+    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityTypeForOrdering, boolean isVr, boolean isZone) {
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
@@ -1005,7 +1005,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_OVERCOMMIT_CAPACITY_PART1);
         }
 
-        if (isVr && allowRoutersOnDedicatedResources) {
+        if (isVr) {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_CLAUSE.replace("ownerId", ownerId.toString()));
         } else {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -1006,7 +1006,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         }
 
         if (isVr && allowRoutersOnDedicatedResources) {
-            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_1.replace("ownerId", ownerId.toString()));
+            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_CLAUSE.replace("ownerId", ownerId.toString()));
         } else {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);
         }

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -87,7 +87,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
                     "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id " +
                     "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id ";
 
-    private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_1 =
+    private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_CLAUSE =
             "JOIN host ON capacity.host_id = host.id " +
                     "LEFT JOIN (SELECT affinity_group.id, agvm.instance_id FROM affinity_group_vm_map agvm JOIN affinity_group ON agvm.affinity_group_id = affinity_group.id AND affinity_group.type='ExplicitDedication') AS ag ON ag.instance_id = ? " +
                     "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id AND dr_pod.account_id IS NOT NULL AND dr_pod.account_id != ownerId " +

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -90,9 +90,9 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_CLAUSE =
             "JOIN host ON capacity.host_id = host.id " +
                     "LEFT JOIN (SELECT affinity_group.id, agvm.instance_id FROM affinity_group_vm_map agvm JOIN affinity_group ON agvm.affinity_group_id = affinity_group.id AND affinity_group.type='ExplicitDedication') AS ag ON ag.instance_id = ? " +
-                    "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id AND dr_pod.account_id IS NOT NULL AND dr_pod.account_id != ownerId " +
-                    "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id AND dr_cluster.account_id IS NOT NULL AND dr_cluster.account_id != ownerId " +
-                    "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id AND dr_host.account_id IS NOT NULL AND dr_host.account_id != ownerId ";
+                    "LEFT JOIN dedicated_resources dr_pod ON dr_pod.pod_id IS NOT NULL AND dr_pod.pod_id = host.pod_id AND (dr_pod.domain_id != {{ domainId }} OR dr_pod.account_id IS NOT NULL AND dr_pod.account_id != {{ ownerId }}) " +
+                    "LEFT JOIN dedicated_resources dr_cluster ON dr_cluster.cluster_id IS NOT NULL AND dr_cluster.cluster_id = host.cluster_id AND (dr_cluster.domain_id != {{ domainId }} OR dr_cluster.account_id IS NOT NULL AND dr_cluster.account_id != {{ ownerId }}) " +
+                    "LEFT JOIN dedicated_resources dr_host ON dr_host.host_id IS NOT NULL AND dr_host.host_id = host.id AND (dr_host.domain_id != {{ domainId }} OR dr_host.account_id IS NOT NULL AND dr_host.account_id != {{ ownerId }}) ";
 
     private static final String ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_2 =
             " AND ((ag.id IS NULL AND dr_pod.pod_id IS NULL AND dr_cluster.cluster_id IS NULL AND dr_host.host_id IS NULL) OR " +
@@ -993,7 +993,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, short capacityTypeForOrdering, boolean isVr, boolean isZone) {
+    public Pair<List<Long>, Map<Long, Double>> orderClustersByAggregateCapacity(long id, long vmId, Long ownerId, Long domainId, short capacityTypeForOrdering, boolean isVr, boolean isZone) {
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
@@ -1006,7 +1006,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         }
 
         if (isVr) {
-            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_CLAUSE.replace("ownerId", ownerId.toString()));
+            sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_INCLUDE_DEDICATED_JOIN_CLAUSE.replace("{{ ownerId }}", ownerId.toString()).replace("{{ domainId }}", domainId.toString()));
         } else {
             sql.append(ORDER_CLUSTERS_BY_AGGREGATE_CAPACITY_JOIN_1);
         }
@@ -1302,4 +1302,5 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
         }
         return 0;
     }
+
 }

--- a/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
@@ -250,7 +250,7 @@ public class CapacityDaoImplTest {
         when(pstmt.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
 
-        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, (short) 1, true);
+        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, (short) 1, false,true);
         assertNotNull(result);
         assertTrue(result.first().isEmpty());
         assertTrue(result.second().isEmpty());

--- a/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
@@ -250,7 +250,7 @@ public class CapacityDaoImplTest {
         when(pstmt.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
 
-        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, (short) 1, false,true);
+        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, 1L, (short) 1, false, false, true);
         assertNotNull(result);
         assertTrue(result.first().isEmpty());
         assertTrue(result.second().isEmpty());

--- a/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
@@ -250,7 +250,7 @@ public class CapacityDaoImplTest {
         when(pstmt.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
 
-        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, 1L, (short) 1, false, false, true);
+        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, 1L, (short) 1, false, true);
         assertNotNull(result);
         assertTrue(result.first().isEmpty());
         assertTrue(result.second().isEmpty());

--- a/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/capacity/dao/CapacityDaoImplTest.java
@@ -250,7 +250,7 @@ public class CapacityDaoImplTest {
         when(pstmt.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
 
-        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, 1L, (short) 1, false, true);
+        Pair<List<Long>, Map<Long, Double>> result = capacityDao.orderClustersByAggregateCapacity(1L, 1L, 1L, 1L, (short) 1, false, true);
         assertNotNull(result);
         assertTrue(result.first().isEmpty());
         assertTrue(result.second().isEmpty());

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -366,7 +366,7 @@ public class ImplicitPlannerTest {
         clusterCapacityMap.put(2L, 2048D);
         clusterCapacityMap.put(3L, 2048D);
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -366,7 +366,7 @@ public class ImplicitPlannerTest {
         clusterCapacityMap.put(2L, 2048D);
         clusterCapacityMap.put(3L, 2048D);
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -366,7 +366,7 @@ public class ImplicitPlannerTest {
         clusterCapacityMap.put(2L, 2048D);
         clusterCapacityMap.put(3L, 2048D);
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -366,7 +366,7 @@ public class ImplicitPlannerTest {
         clusterCapacityMap.put(2L, 2048D);
         clusterCapacityMap.put(3L, 2048D);
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/src/test/java/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -366,7 +366,7 @@ public class ImplicitPlannerTest {
         clusterCapacityMap.put(2L, 2048D);
         clusterCapacityMap.put(3L, 2048D);
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, 0L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -398,9 +398,10 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         DataCenter dc = dcDao.findById(vm.getDataCenterId());
         int requiredCpu = offering.getCpu() * offering.getSpeed();
         long requiredRam = offering.getRamSize() * 1024L * 1024L;
+        boolean isVr  = VirtualMachine.Type.DomainRouter.equals(vmProfile.getType());
 
         //list clusters under this zone by cpu and ram capacity
-        Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo = listClustersByCapacity(id, vmProfile.getId(), requiredCpu, requiredRam, avoid, isZone);
+        Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo = listClustersByCapacity(id, vmProfile.getId(), requiredCpu, requiredRam, isVr, isZone);
         List<Long> prioritizedClusterIds = clusterCapacityInfo.first();
         if (!prioritizedClusterIds.isEmpty()) {
             if (avoid.getClustersToAvoid() != null) {
@@ -458,7 +459,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         return podIdsByCapacity;
     }
 
-    protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(long id, long vmId, int requiredCpu, long requiredRam, ExcludeList avoid, boolean isZone) {
+    protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(long id, long vmId, int requiredCpu, long requiredRam, boolean isVr, boolean isZone) {
         //look at the aggregate available cpu and ram per cluster
         //although an aggregate value may be false indicator that a cluster can host a vm, it will at the least eliminate those clusters which definitely cannot
 
@@ -474,7 +475,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         }
 
 
-        Pair<List<Long>, Map<Long, Double>> result = getOrderedClustersByCapacity(id, vmId, isZone);
+        Pair<List<Long>, Map<Long, Double>> result = getOrderedClustersByCapacity(id, vmId, isVr, isZone);
         List<Long> clusterIdsOrderedByAggregateCapacity = result.first();
         //only keep the clusters that have enough capacity to host this VM
         if (logger.isTraceEnabled()) {
@@ -554,14 +555,14 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
     }
 
 
-    private Pair<List<Long>, Map<Long, Double>> getOrderedClustersByCapacity(long id, long vmId, boolean isZone) {
+    private Pair<List<Long>, Map<Long, Double>> getOrderedClustersByCapacity(long id, long vmId, boolean isVr, boolean isZone) {
         double cpuToMemoryWeight = ConfigurationManager.HostCapacityTypeCpuMemoryWeight.value();
         short capacityType = getHostCapacityTypeToOrderCluster(
                 configDao.getValue(Config.HostCapacityTypeToOrderClusters.key()), cpuToMemoryWeight);
 
         logger.debug("CapacityType: {} is used for Cluster ordering", getCapacityTypeName(capacityType));
         if (capacityType >= 0) { // for capacityType other than COMBINED
-            return capacityDao.orderClustersByAggregateCapacity(id, vmId, capacityType, isZone);
+            return capacityDao.orderClustersByAggregateCapacity(id, vmId, capacityType, isVr, isZone);
         }
 
         Long zoneId = isZone ? id : null;

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -562,7 +562,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
 
         logger.debug("CapacityType: {} is used for Cluster ordering", getCapacityTypeName(capacityType));
         if (capacityType >= 0) { // for capacityType other than COMBINED
-            return capacityDao.orderClustersByAggregateCapacity(id, vmId, capacityType, isVr, isZone);
+            return capacityDao.orderClustersByAggregateCapacity(id, vmId, capacityType, isVr, allowRoutersOnDedicatedResources.value(), isZone);
         }
 
         Long zoneId = isZone ? id : null;
@@ -695,6 +695,6 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ClusterCPUCapacityDisableThreshold, ClusterMemoryCapacityDisableThreshold, ClusterThresholdEnabled, VmAllocationAlgorithm};
+        return new ConfigKey<?>[] {ClusterCPUCapacityDisableThreshold, ClusterMemoryCapacityDisableThreshold, ClusterThresholdEnabled, VmAllocationAlgorithm, allowRoutersOnDedicatedResources};
     }
 }

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -399,9 +399,10 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         int requiredCpu = offering.getCpu() * offering.getSpeed();
         long requiredRam = offering.getRamSize() * 1024L * 1024L;
         boolean isVr  = VirtualMachine.Type.DomainRouter.equals(vmProfile.getType());
+        Long ownerId = vm.getAccountId();
 
         //list clusters under this zone by cpu and ram capacity
-        Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo = listClustersByCapacity(id, vmProfile.getId(), requiredCpu, requiredRam, isVr, isZone);
+        Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo = listClustersByCapacity(id, vmProfile.getId(), ownerId, requiredCpu, requiredRam, isVr, isZone);
         List<Long> prioritizedClusterIds = clusterCapacityInfo.first();
         if (!prioritizedClusterIds.isEmpty()) {
             if (avoid.getClustersToAvoid() != null) {
@@ -459,7 +460,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         return podIdsByCapacity;
     }
 
-    protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(long id, long vmId, int requiredCpu, long requiredRam, boolean isVr, boolean isZone) {
+    protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(long id, long vmId, Long ownerId, int requiredCpu, long requiredRam, boolean isVr, boolean isZone) {
         //look at the aggregate available cpu and ram per cluster
         //although an aggregate value may be false indicator that a cluster can host a vm, it will at the least eliminate those clusters which definitely cannot
 
@@ -475,7 +476,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         }
 
 
-        Pair<List<Long>, Map<Long, Double>> result = getOrderedClustersByCapacity(id, vmId, isVr, isZone);
+        Pair<List<Long>, Map<Long, Double>> result = getOrderedClustersByCapacity(id, vmId, ownerId, isVr, isZone);
         List<Long> clusterIdsOrderedByAggregateCapacity = result.first();
         //only keep the clusters that have enough capacity to host this VM
         if (logger.isTraceEnabled()) {
@@ -555,14 +556,14 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
     }
 
 
-    private Pair<List<Long>, Map<Long, Double>> getOrderedClustersByCapacity(long id, long vmId, boolean isVr, boolean isZone) {
+    private Pair<List<Long>, Map<Long, Double>> getOrderedClustersByCapacity(long id, long vmId, Long ownerId, boolean isVr, boolean isZone) {
         double cpuToMemoryWeight = ConfigurationManager.HostCapacityTypeCpuMemoryWeight.value();
         short capacityType = getHostCapacityTypeToOrderCluster(
                 configDao.getValue(Config.HostCapacityTypeToOrderClusters.key()), cpuToMemoryWeight);
 
         logger.debug("CapacityType: {} is used for Cluster ordering", getCapacityTypeName(capacityType));
         if (capacityType >= 0) { // for capacityType other than COMBINED
-            return capacityDao.orderClustersByAggregateCapacity(id, vmId, capacityType, isVr, allowRoutersOnDedicatedResources.value(), isZone);
+            return capacityDao.orderClustersByAggregateCapacity(id, vmId, ownerId, capacityType, isVr, allowRoutersOnDedicatedResources.value(), isZone);
         }
 
         Long zoneId = isZone ? id : null;

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -400,9 +400,10 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         long requiredRam = offering.getRamSize() * 1024L * 1024L;
         boolean isVr  = VirtualMachine.Type.DomainRouter.equals(vmProfile.getType());
         Long ownerId = vm.getAccountId();
+        Long domainId = vm.getDomainId();
 
         //list clusters under this zone by cpu and ram capacity
-        Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo = listClustersByCapacity(id, vmProfile.getId(), ownerId, requiredCpu, requiredRam, isVr, isZone);
+        Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo = listClustersByCapacity(id, vmProfile.getId(), ownerId, domainId, requiredCpu, requiredRam, isVr, isZone);
         List<Long> prioritizedClusterIds = clusterCapacityInfo.first();
         if (!prioritizedClusterIds.isEmpty()) {
             if (avoid.getClustersToAvoid() != null) {
@@ -460,7 +461,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         return podIdsByCapacity;
     }
 
-    protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(long id, long vmId, Long ownerId, int requiredCpu, long requiredRam, boolean isVr, boolean isZone) {
+    protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(long id, long vmId, Long ownerId, Long domainId, int requiredCpu, long requiredRam, boolean isVr, boolean isZone) {
         //look at the aggregate available cpu and ram per cluster
         //although an aggregate value may be false indicator that a cluster can host a vm, it will at the least eliminate those clusters which definitely cannot
 
@@ -476,7 +477,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         }
 
 
-        Pair<List<Long>, Map<Long, Double>> result = getOrderedClustersByCapacity(id, vmId, ownerId, isVr, isZone);
+        Pair<List<Long>, Map<Long, Double>> result = getOrderedClustersByCapacity(id, vmId, ownerId, domainId, isVr, isZone);
         List<Long> clusterIdsOrderedByAggregateCapacity = result.first();
         //only keep the clusters that have enough capacity to host this VM
         if (logger.isTraceEnabled()) {
@@ -556,14 +557,14 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
     }
 
 
-    private Pair<List<Long>, Map<Long, Double>> getOrderedClustersByCapacity(long id, long vmId, Long ownerId, boolean isVr, boolean isZone) {
+    private Pair<List<Long>, Map<Long, Double>> getOrderedClustersByCapacity(long id, long vmId, Long ownerId, Long domainId, boolean isVr, boolean isZone) {
         double cpuToMemoryWeight = ConfigurationManager.HostCapacityTypeCpuMemoryWeight.value();
         short capacityType = getHostCapacityTypeToOrderCluster(
                 configDao.getValue(Config.HostCapacityTypeToOrderClusters.key()), cpuToMemoryWeight);
 
         logger.debug("CapacityType: {} is used for Cluster ordering", getCapacityTypeName(capacityType));
         if (capacityType >= 0) { // for capacityType other than COMBINED
-            return capacityDao.orderClustersByAggregateCapacity(id, vmId, ownerId, capacityType, isVr, isZone);
+            return capacityDao.orderClustersByAggregateCapacity(id, vmId, ownerId, domainId, capacityType, isVr, isZone);
         }
 
         Long zoneId = isZone ? id : null;

--- a/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -563,7 +563,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
 
         logger.debug("CapacityType: {} is used for Cluster ordering", getCapacityTypeName(capacityType));
         if (capacityType >= 0) { // for capacityType other than COMBINED
-            return capacityDao.orderClustersByAggregateCapacity(id, vmId, ownerId, capacityType, isVr, allowRoutersOnDedicatedResources.value(), isZone);
+            return capacityDao.orderClustersByAggregateCapacity(id, vmId, ownerId, capacityType, isVr, isZone);
         }
 
         Long zoneId = isZone ? id : null;
@@ -696,6 +696,6 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ClusterCPUCapacityDisableThreshold, ClusterMemoryCapacityDisableThreshold, ClusterThresholdEnabled, VmAllocationAlgorithm, allowRoutersOnDedicatedResources};
+        return new ConfigKey<?>[] {ClusterCPUCapacityDisableThreshold, ClusterMemoryCapacityDisableThreshold, ClusterThresholdEnabled, VmAllocationAlgorithm};
     }
 }

--- a/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
+++ b/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
@@ -373,7 +373,7 @@ public class FirstFitPlannerTest {
         clusterCapacityMap.put(6L, 2048D);
 
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, false,true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
+++ b/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
@@ -373,7 +373,7 @@ public class FirstFitPlannerTest {
         clusterCapacityMap.put(6L, 2048D);
 
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, false,true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 1L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
+++ b/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
@@ -373,7 +373,7 @@ public class FirstFitPlannerTest {
         clusterCapacityMap.put(6L, 2048D);
 
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
+++ b/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
@@ -373,7 +373,7 @@ public class FirstFitPlannerTest {
         clusterCapacityMap.put(6L, 2048D);
 
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 1L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
+++ b/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
@@ -373,7 +373,7 @@ public class FirstFitPlannerTest {
         clusterCapacityMap.put(6L, 2048D);
 
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, 0L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();

--- a/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
+++ b/server/src/test/java/com/cloud/vm/FirstFitPlannerTest.java
@@ -373,7 +373,7 @@ public class FirstFitPlannerTest {
         clusterCapacityMap.put(6L, 2048D);
 
         Pair<List<Long>, Map<Long, Double>> clustersOrderedByCapacity = new Pair<List<Long>, Map<Long, Double>>(clustersWithEnoughCapacity, clusterCapacityMap);
-        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, false, true)).thenReturn(clustersOrderedByCapacity);
+        when(capacityDao.orderClustersByAggregateCapacity(dataCenterId, 12L, 0L, Capacity.CAPACITY_TYPE_CPU, false, true)).thenReturn(clustersOrderedByCapacity);
 
         List<Long> disabledClusters = new ArrayList<Long>();
         List<Long> clustersWithDisabledPods = new ArrayList<Long>();


### PR DESCRIPTION
### Description

Currently, it is not possible to deploy VRs on dedicated resources, even if they are dedicated to the domain in which the VR will be created.

A new global configuration `allowRoutersOnDedicatedResources` has been created to allow VRs to be deployed on hosts, clusters, pods and zones that are dedicated to their respective domains. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

With the configuration marked as true:

* I dedicated resources to the domain in which the VRs would be deployd and verified that the deploy worked normally.
* I dedicated resources to an account in that domain and verified that I could not deploy VRs on these resources.
* I dedicated resources to a different domain and verified that I could not deploy VRs on these resources.

I marked the configuration as false and verified that I could not deploy VRs on any of the dedicated resources.