### PR TITLE
Persist IP addresses related to VM access via CPVM

### DIFF
--- a/agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
+++ b/agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
@@ -397,9 +397,8 @@ public class ConsoleProxyResource extends ServerResourceBase implements ServerRe
     }
 
     public String authenticateConsoleAccess(String host, String port, String vmId, String sid, String ticket,
-                                            Boolean isReauthentication, String sessionToken) {
-
-        ConsoleAccessAuthenticationCommand cmd = new ConsoleAccessAuthenticationCommand(host, port, vmId, sid, ticket, sessionToken);
+                                            Boolean isReauthentication, String sessionToken, String clientAddress) {
+        ConsoleAccessAuthenticationCommand cmd = new ConsoleAccessAuthenticationCommand(host, port, vmId, sid, ticket, sessionToken, clientAddress);
         cmd.setReauthenticating(isReauthentication);
 
         ConsoleProxyAuthenticationResult result = new ConsoleProxyAuthenticationResult();

--- a/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
+++ b/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
@@ -44,7 +44,7 @@ public interface ConsoleAccessManager extends Manager, Configurable {
 
     void removeSessions(String[] sessionUuids);
 
-    void acquireSession(String sessionUuid);
+    void acquireSession(String sessionUuid, String clientAddress);
 
     String genAccessTicket(String host, String port, String sid, String tag, String sessionUuid);
     String genAccessTicket(String host, String port, String sid, String tag, Date normalizedHashTime, String sessionUuid);

--- a/core/src/main/java/com/cloud/agent/api/ConsoleAccessAuthenticationCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/ConsoleAccessAuthenticationCommand.java
@@ -27,6 +27,7 @@ public class ConsoleAccessAuthenticationCommand extends AgentControlCommand {
     private String _sid;
     private String _ticket;
     private String sessionUuid;
+    private String clientAddress;
 
     private boolean _isReauthenticating;
 
@@ -35,13 +36,14 @@ public class ConsoleAccessAuthenticationCommand extends AgentControlCommand {
     }
 
     public ConsoleAccessAuthenticationCommand(String host, String port, String vmId, String sid, String ticket,
-                                              String sessiontkn) {
+                                              String sessiontkn, String clientAddress) {
         _host = host;
         _port = port;
         _vmId = vmId;
         _sid = sid;
         _ticket = ticket;
         sessionUuid = sessiontkn;
+        this.clientAddress = clientAddress;
     }
 
     public String getHost() {
@@ -78,5 +80,13 @@ public class ConsoleAccessAuthenticationCommand extends AgentControlCommand {
 
     public void setSessionUuid(String sessionUuid) {
         this.sessionUuid = sessionUuid;
+    }
+
+    public String getClientAddress() {
+        return clientAddress;
+    }
+
+    public void setClientAddress(String clientAddress) {
+        this.clientAddress = clientAddress;
     }
 }

--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -89,6 +89,7 @@ import com.cloud.upgrade.dao.Upgrade41810to41900;
 import com.cloud.upgrade.dao.Upgrade41900to41910;
 import com.cloud.upgrade.dao.Upgrade41910to42000;
 import com.cloud.upgrade.dao.Upgrade42000to42010;
+import com.cloud.upgrade.dao.Upgrade42010to42100;
 import com.cloud.upgrade.dao.Upgrade420to421;
 import com.cloud.upgrade.dao.Upgrade421to430;
 import com.cloud.upgrade.dao.Upgrade430to440;
@@ -232,6 +233,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.19.0.0", new Upgrade41900to41910())
                 .next("4.19.1.0", new Upgrade41910to42000())
                 .next("4.20.0.0", new Upgrade42000to42010())
+                .next("4.20.1.0", new Upgrade42010to42100())
                 .build();
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42010to42100.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42010to42100.java
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade.dao;
+
+import com.cloud.upgrade.SystemVmTemplateRegistration;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+import java.io.InputStream;
+import java.sql.Connection;
+
+public class Upgrade42010to42100 extends DbUpgradeAbstractImpl implements DbUpgrade, DbUpgradeSystemVmTemplate {
+    private SystemVmTemplateRegistration systemVmTemplateRegistration;
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[] {"4.20.1.0", "4.21.0.0"};
+    }
+
+    @Override
+    public String getUpgradedVersion() {
+        return "4.21.0.0";
+    }
+
+    @Override
+    public boolean supportsRollingUpgrade() {
+        return false;
+    }
+
+    @Override
+    public InputStream[] getPrepareScripts() {
+        final String scriptFile = "META-INF/db/schema-42010to42100.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
+    }
+
+    @Override
+    public void performDataMigration(Connection conn) {
+    }
+
+    @Override
+    public InputStream[] getCleanupScripts() {
+        final String scriptFile = "META-INF/db/schema-42010to42100-cleanup.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
+    }
+
+    private void initSystemVmTemplateRegistration() {
+        systemVmTemplateRegistration = new SystemVmTemplateRegistration("");
+    }
+
+    @Override
+    public void updateSystemVmTemplates(Connection conn) {
+        logger.debug("Updating System Vm template IDs");
+        initSystemVmTemplateRegistration();
+        try {
+            systemVmTemplateRegistration.updateSystemVmTemplates(conn);
+        } catch (Exception e) {
+            throw new CloudRuntimeException("Failed to find / register SystemVM template(s)");
+        }
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/vm/ConsoleSessionVO.java
+++ b/engine/schema/src/main/java/com/cloud/vm/ConsoleSessionVO.java
@@ -64,6 +64,12 @@ public class ConsoleSessionVO {
     @Column(name = "removed")
     private Date removed;
 
+    @Column(name = "console_endpoint_creator_address")
+    private String consoleEndpointCreatorAddress;
+
+    @Column(name = "client_address")
+    private String clientAddress;
+
     public long getId() {
         return id;
     }
@@ -134,5 +140,21 @@ public class ConsoleSessionVO {
 
     public void setAcquired(Date acquired) {
         this.acquired = acquired;
+    }
+
+    public String getConsoleEndpointCreatorAddress() {
+        return consoleEndpointCreatorAddress;
+    }
+
+    public void setConsoleEndpointCreatorAddress(String consoleEndpointCreatorAddress) {
+        this.consoleEndpointCreatorAddress = consoleEndpointCreatorAddress;
+    }
+
+    public String getClientAddress() {
+        return clientAddress;
+    }
+
+    public void setClientAddress(String clientAddress) {
+        this.clientAddress = clientAddress;
     }
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDao.java
@@ -33,7 +33,7 @@ public interface ConsoleSessionDao extends GenericDao<ConsoleSessionVO, Long> {
 
     int expungeSessionsOlderThanDate(Date date);
 
-    void acquireSession(String sessionUuid);
+    void acquireSession(String sessionUuid, String clientAddress);
 
     int expungeByVmList(List<Long> vmIds, Long batchSize);
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/ConsoleSessionDaoImpl.java
@@ -62,9 +62,10 @@ public class ConsoleSessionDaoImpl extends GenericDaoBase<ConsoleSessionVO, Long
     }
 
     @Override
-    public void acquireSession(String sessionUuid) {
+    public void acquireSession(String sessionUuid, String clientAddress) {
         ConsoleSessionVO consoleSessionVO = findByUuid(sessionUuid);
         consoleSessionVO.setAcquired(new Date());
+        consoleSessionVO.setClientAddress(clientAddress);
         update(consoleSessionVO.getId(), consoleSessionVO);
     }
 

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -425,3 +425,9 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervi
 
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.vm_instance', 'delete_protection', 'boolean DEFAULT FALSE COMMENT "delete protection for vm" ');
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.volumes', 'delete_protection', 'boolean DEFAULT FALSE COMMENT "delete protection for volumes" ');
+
+-- Add console_endpoint_creator_address column to cloud.console_session table
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.console_session', 'console_endpoint_creator_address', 'VARCHAR(45)');
+
+-- Add client_address column to cloud.console_session table
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.console_session', 'client_address', 'VARCHAR(45)');

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -425,9 +425,3 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervi
 
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.vm_instance', 'delete_protection', 'boolean DEFAULT FALSE COMMENT "delete protection for vm" ');
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.volumes', 'delete_protection', 'boolean DEFAULT FALSE COMMENT "delete protection for volumes" ');
-
--- Add console_endpoint_creator_address column to cloud.console_session table
-CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.console_session', 'console_endpoint_creator_address', 'VARCHAR(45)');
-
--- Add client_address column to cloud.console_session table
-CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.console_session', 'client_address', 'VARCHAR(45)');

--- a/engine/schema/src/main/resources/META-INF/db/schema-42010to42100-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42010to42100-cleanup.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade cleanup from 4.20.1.0 to 4.21.0.0
+--;

--- a/engine/schema/src/main/resources/META-INF/db/schema-42010to42100.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42010to42100.sql
@@ -1,0 +1,26 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.20.1.0 to 4.21.0.0
+--;
+
+-- Add console_endpoint_creator_address column to cloud.console_session table
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.console_session', 'console_endpoint_creator_address', 'VARCHAR(45)');
+
+-- Add client_address column to cloud.console_session table
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.console_session', 'client_address', 'VARCHAR(45)');

--- a/server/src/main/java/com/cloud/consoleproxy/AgentHookBase.java
+++ b/server/src/main/java/com/cloud/consoleproxy/AgentHookBase.java
@@ -89,6 +89,7 @@ public abstract class AgentHookBase implements AgentHook {
 
         String ticketInUrl = cmd.getTicket();
         String sessionUuid = cmd.getSessionUuid();
+        String clientAddress = cmd.getClientAddress();
 
         if (ticketInUrl == null) {
             logger.error("Access ticket could not be found, you could be running an old version of console proxy. vmId: " + cmd.getVmId());
@@ -111,7 +112,7 @@ public abstract class AgentHookBase implements AgentHook {
             }
 
             logger.debug(String.format("Acquiring session [%s] as it was just used.", sessionUuid));
-            consoleAccessManager.acquireSession(sessionUuid);
+            consoleAccessManager.acquireSession(sessionUuid, clientAddress);
 
             if (!ticket.equals(ticketInUrl)) {
                 Date now = new Date();

--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -389,7 +389,7 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
         String url = generateConsoleAccessUrl(rootUrl, param, token, vncPort, vm, hostVo, details);
 
         logger.debug("Adding allowed session: " + sessionUuid);
-        persistConsoleSession(sessionUuid, vm.getId(), hostVo.getId());
+        persistConsoleSession(sessionUuid, vm.getId(), hostVo.getId(), addr);
         managementServer.setConsoleAccessForVm(vm.getId(), sessionUuid);
 
         ConsoleEndpoint consoleEndpoint = new ConsoleEndpoint(true, url);
@@ -403,13 +403,14 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
         return consoleEndpoint;
     }
 
-    protected void persistConsoleSession(String sessionUuid, long instanceId, long hostId) {
+    protected void persistConsoleSession(String sessionUuid, long instanceId, long hostId, String consoleEndpointCreatorAddress) {
         ConsoleSessionVO consoleSessionVo = new ConsoleSessionVO();
         consoleSessionVo.setUuid(sessionUuid);
         consoleSessionVo.setAccountId(CallContext.current().getCallingAccountId());
         consoleSessionVo.setUserId(CallContext.current().getCallingUserId());
         consoleSessionVo.setInstanceId(instanceId);
         consoleSessionVo.setHostId(hostId);
+        consoleSessionVo.setConsoleEndpointCreatorAddress(consoleEndpointCreatorAddress);
         consoleSessionDao.persist(consoleSessionVo);
     }
 

--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -248,8 +248,8 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
     }
 
     @Override
-    public void acquireSession(String sessionUuid) {
-        consoleSessionDao.acquireSession(sessionUuid);
+    public void acquireSession(String sessionUuid, String clientAddress) {
+        consoleSessionDao.acquireSession(sessionUuid, clientAddress);
     }
 
     protected boolean checkSessionPermission(VirtualMachine vm, Account account) {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -183,7 +183,6 @@ public class ConsoleProxy {
     }
 
     public static ConsoleProxyAuthenticationResult authenticateConsoleAccess(ConsoleProxyClientParam param, boolean reauthentication) {
-
         ConsoleProxyAuthenticationResult authResult = new ConsoleProxyAuthenticationResult();
         authResult.setSuccess(true);
         authResult.setReauthentication(reauthentication);
@@ -227,7 +226,7 @@ public class ConsoleProxy {
             try {
                 result =
                         authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()), param.getClientTag(),
-                                param.getClientHostPassword(), param.getTicket(), reauthentication, param.getSessionUuid());
+                                param.getClientHostPassword(), param.getTicket(), reauthentication, param.getSessionUuid(), param.getClientIp());
             } catch (IllegalAccessException e) {
                 LOGGER.error("Unable to invoke authenticateConsoleAccess due to IllegalAccessException" + " for vm: " + param.getClientTag(), e);
                 authResult.setSuccess(false);
@@ -301,7 +300,7 @@ public class ConsoleProxy {
             final ClassLoader loader = Thread.currentThread().getContextClassLoader();
             Class<?> contextClazz = loader.loadClass("com.cloud.agent.resource.consoleproxy.ConsoleProxyResource");
             authMethod = contextClazz.getDeclaredMethod("authenticateConsoleAccess", String.class, String.class,
-                    String.class, String.class, String.class, Boolean.class, String.class);
+                    String.class, String.class, String.class, Boolean.class, String.class, String.class);
             reportMethod = contextClazz.getDeclaredMethod("reportLoadInfo", String.class);
             ensureRouteMethod = contextClazz.getDeclaredMethod("ensureRoute", String.class);
         } catch (SecurityException e) {


### PR DESCRIPTION
### Description

This PR proposes to persist IP addresses related to VM access via CPVM. Specifically, it stores the IP address of the client accessing a VM and the IP address of the console endpoint creator. To achieve this, the `cloud.console_session` table was extended with two new columns: `client_address`, which stores the client's IP address, and `console_endpoint_creator_address`, which captures the IP address of the console endpoint creator.

These IP addresses were already being captured for logging and validation purposes. The console endpoint creator's IP is captured here, at the start of the `CreateConsoleEndpointCmd` execution:

https://github.com/apache/cloudstack/blob/47a6b7011d7e42be86a748af50b87633147b5a90/api/src/main/java/org/apache/cloudstack/api/command/user/consoleproxy/CreateConsoleEndpointCmd.java#L65-L68

The client address is captured by calling `session.getRemoteAddress().getAddress().getHostAddress()` in this method, that gets executed when the client connects to the console:

https://github.com/apache/cloudstack/blob/47a6b7011d7e42be86a748af50b87633147b5a90/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java#L157-L160

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

1. I manually added the `client_address` and `console_endpoint_creator_address` columns to the `cloud.console_session` table.
2. I generated a VM console endpoint.
3. I executed the following query in order to validate whether the stored IP was correct.


<details>
    <summary>
    <code>SELECT * FROM `cloud`.`console_session` ORDER BY created DESC LIMIT 1;</code>
    </summary>

| id | uuid | created | account_id | user_id | instance_id | host_id | acquired | removed | client_address | console_endpoint_creator_address |
| -- | ---- | ---- |    ---- |       ---- |     ---- |       ---- |      ---- |    ---- |    ---- | ---- |
| 2  | 77f08cea-8068-471f-9464-44810e1ef545 |2024-08-06 17:57:05 |2 | 2 | 14 | 1 | NULL | NULL | NULL | 192.168.122.1 |

</details>

As can be noticed, the `console_endpoint_creator_address` column was populated accordingly, whereas the `client_adress` was still empty since the VM had not been accessed yet.

4. I accessed the VM via CPVM.
5. I executed the following query in order to validate whether the client stored IP was correct.

<details>
    <summary>
    <code>SELECT * FROM `cloud`.`console_session` ORDER BY created DESC LIMIT 1;</code>
    </summary>

| id | uuid | created | account_id | user_id | instance_id | host_id | acquired | removed | client_address | console_endpoint_creator_address |
| -- | ---- | ---- |    ---- |       ---- |     ---- |       ---- |      ---- |    ---- |    ---- | ---- | 
| 2  | 77f08cea-8068-471f-9464-44810e1ef545 |2024-08-06 17:57:05 |2 | 2 | 14 | 1 | NULL | NULL | 192.168.122.1 | 192.168.122.1 |

</details>

As can be noticed, the IP address of the client that accessed the VM through CPVM was persisted correctly.