### PR TITLE
Added domain path to all entities

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/affinity/AffinityGroupResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/affinity/AffinityGroupResponse.java
@@ -56,6 +56,10 @@ public class AffinityGroupResponse extends BaseResponse implements ControlledVie
     @Param(description = "the domain name of the affinity group")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the affinity group belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.PROJECT_ID)
     @Param(description = "the project ID of the affinity group")
     private String projectId;
@@ -113,6 +117,11 @@ public class AffinityGroupResponse extends BaseResponse implements ControlledVie
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
@@ -133,6 +133,7 @@ public class AddVpnUserCmd extends BaseAsyncCreateCmd {
         if (domain != null) {
             vpnResponse.setDomainId(domain.getUuid());
             vpnResponse.setDomainName(domain.getName());
+            vpnResponse.setDomainPath(domain.getPath());
         }
 
         vpnResponse.setResponseName(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/response/AcquireIPAddressResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AcquireIPAddressResponse.java
@@ -75,6 +75,10 @@ public class AcquireIPAddressResponse  extends BaseResponse implements Controlle
  @Param(description = "the domain the public IP address is associated with")
  private String domainName;
 
+ @SerializedName(ApiConstants.DOMAIN_PATH)
+ @Param(description = "path of the domain to which the public IP address belongs", since = "4.19.2.0")
+ private String domainPath;
+
  @SerializedName(ApiConstants.FOR_VIRTUAL_NETWORK)
  @Param(description = "the virtual network for the IP address")
  private Boolean forVirtualNetwork;
@@ -188,6 +192,11 @@ public class AcquireIPAddressResponse  extends BaseResponse implements Controlle
  @Override
  public void setDomainName(String domainName) {
      this.domainName = domainName;
+ }
+
+ @Override
+ public void setDomainPath(String domainPath) {
+  this.domainPath = domainPath;
  }
 
  public void setForVirtualNetwork(Boolean forVirtualNetwork) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/ApplicationLoadBalancerResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ApplicationLoadBalancerResponse.java
@@ -76,6 +76,10 @@ public class ApplicationLoadBalancerResponse extends BaseResponse implements Con
     @Param(description = "the domain of the Load Balancer")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the Load Balancer belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName("loadbalancerrule")
     @Param(description = "the list of rules associated with the Load Balancer", responseObject = ApplicationLoadBalancerRuleResponse.class)
     private List<ApplicationLoadBalancerRuleResponse> lbRules;
@@ -105,6 +109,11 @@ public class ApplicationLoadBalancerResponse extends BaseResponse implements Con
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/AutoScalePolicyResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AutoScalePolicyResponse.java
@@ -74,6 +74,10 @@ public class AutoScalePolicyResponse extends BaseResponse implements ControlledE
     @Param(description = "the domain name of the autoscale policy")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the autoscale policy belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @Override
     public String getObjectId() {
         return this.id;
@@ -116,6 +120,11 @@ public class AutoScalePolicyResponse extends BaseResponse implements ControlledE
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/AutoScaleVmGroupResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AutoScaleVmGroupResponse.java
@@ -123,6 +123,10 @@ public class AutoScaleVmGroupResponse extends BaseResponseWithAnnotations implem
     @Param(description = "the domain name of the vm group")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the vm group belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.FOR_DISPLAY)
     @Param(description = "is group for display to the regular user", since = "4.4", authorized = {RoleType.Admin})
     private Boolean forDisplay;
@@ -225,6 +229,11 @@ public class AutoScaleVmGroupResponse extends BaseResponseWithAnnotations implem
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/AutoScaleVmProfileResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AutoScaleVmProfileResponse.java
@@ -114,6 +114,10 @@ public class AutoScaleVmProfileResponse extends BaseResponse implements Controll
     @Param(description = "the domain name of the vm profile")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the vm profile belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.FOR_DISPLAY)
     @Param(description = "is profile for display to the regular user", since = "4.4", authorized = {RoleType.Admin})
     private Boolean forDisplay;
@@ -196,6 +200,10 @@ public class AutoScaleVmProfileResponse extends BaseResponse implements Controll
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     @Override
     public void setProjectId(String projectId) {
         this.projectId = projectId;

--- a/api/src/main/java/org/apache/cloudstack/api/response/BucketResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/BucketResponse.java
@@ -54,6 +54,10 @@ public class BucketResponse extends BaseResponseWithTagInformation implements Co
     @SerializedName(ApiConstants.DOMAIN)
     @Param(description = "the domain associated with the bucket")
     private String domainName;
+
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the bucket belongs", since = "4.19.2.0")
+    private String domainPath;
     @SerializedName(ApiConstants.OBJECT_STORAGE_ID)
     @Param(description = "id of the object storage hosting the Bucket; returned to admin user only")
     private String objectStoragePoolId;
@@ -144,6 +148,11 @@ public class BucketResponse extends BaseResponseWithTagInformation implements Co
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/ConditionResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ConditionResponse.java
@@ -61,6 +61,10 @@ public class ConditionResponse extends BaseResponse implements ControlledEntityR
     @Param(description = "the domain name of the owner.")
     private String domain;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the Condition owner belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.ZONE_ID)
     @Param(description = "zone id of counter")
     private String zoneId;
@@ -137,5 +141,10 @@ public class ConditionResponse extends BaseResponse implements ControlledEntityR
     @Override
     public void setDomainName(String domainName) {
         this.domain = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/ControlledEntityResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ControlledEntityResponse.java
@@ -27,4 +27,6 @@ public interface ControlledEntityResponse {
     public void setDomainId(String domainId);
 
     public void setDomainName(String domainName);
+
+    public void setDomainPath(String domainPath);
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/ControlledViewEntityResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ControlledViewEntityResponse.java
@@ -27,4 +27,6 @@ public interface ControlledViewEntityResponse {
     public void setDomainId(String domainId);
 
     public void setDomainName(String domainName);
+
+    public void setDomainPath(String domainPath);
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/DomainRouterResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DomainRouterResponse.java
@@ -185,6 +185,10 @@ public class DomainRouterResponse extends BaseResponseWithAnnotations implements
     @Param(description = "the domain associated with the router")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the router belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.SERVICE_OFFERING_ID)
     @Param(description = "the ID of the service offering of the virtual machine")
     private String serviceOfferingId;
@@ -381,6 +385,10 @@ public class DomainRouterResponse extends BaseResponseWithAnnotations implements
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setPublicNetworkId(String publicNetworkId) {
         this.publicNetworkId = publicNetworkId;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/EventResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/EventResponse.java
@@ -69,6 +69,10 @@ public class EventResponse extends BaseResponse implements ControlledViewEntityR
     @Param(description = "the name of the account's domain")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the account's domain belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.RESOURCE_ID)
     @Param(description = "the id of the resource", since = "4.17.0")
     private String resourceId;
@@ -130,6 +134,11 @@ public class EventResponse extends BaseResponse implements ControlledViewEntityR
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setResourceId(String resourceId) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/GlobalLoadBalancerResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/GlobalLoadBalancerResponse.java
@@ -82,6 +82,10 @@ public class GlobalLoadBalancerResponse extends BaseResponse implements Controll
     @Param(description = "the domain of the load balancer rule")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the load balancer rule belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.LOAD_BALANCER_RULE)
     @Param(description = "List of load balancer rules that are part of GSLB rule", responseObject = LoadBalancerResponse.class)
     private List<LoadBalancerResponse> siteLoadBalancers;
@@ -141,6 +145,11 @@ public class GlobalLoadBalancerResponse extends BaseResponse implements Controll
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setSiteLoadBalancers(List<LoadBalancerResponse> siteLoadBalancers) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/GuestVlanRangeResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/GuestVlanRangeResponse.java
@@ -44,6 +44,10 @@ public class GuestVlanRangeResponse extends BaseResponse implements ControlledEn
     @Param(description = "the domain name of the guest VLAN range")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the guest VLAN range belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.GUEST_VLAN_RANGE)
     @Param(description = "the guest VLAN range")
     private String guestVlanRange;
@@ -83,6 +87,10 @@ public class GuestVlanRangeResponse extends BaseResponse implements ControlledEn
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setGuestVlanRange(String guestVlanRange) {
         this.guestVlanRange = guestVlanRange;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/GuestVlanResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/GuestVlanResponse.java
@@ -49,6 +49,10 @@ public class GuestVlanResponse extends BaseResponse implements ControlledEntityR
     @Param(description = "the domain name of the guest VLAN range")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the guest VLAN range belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.PROJECT_ID)
     @Param(description = "the project id of the guest VLAN range")
     private String projectId;
@@ -108,6 +112,10 @@ public class GuestVlanResponse extends BaseResponse implements ControlledEntityR
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     @Override
     public void setProjectId(String projectId) {
         this.projectId = projectId;

--- a/api/src/main/java/org/apache/cloudstack/api/response/IPAddressResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/IPAddressResponse.java
@@ -75,6 +75,10 @@ public class IPAddressResponse extends BaseResponseWithAnnotations implements Co
     @Param(description = "the domain the public IP address is associated with")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the public IP address belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.FOR_VIRTUAL_NETWORK)
     @Param(description = "the virtual network for the IP address")
     private Boolean forVirtualNetwork;
@@ -207,6 +211,10 @@ public class IPAddressResponse extends BaseResponseWithAnnotations implements Co
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setForVirtualNetwork(Boolean forVirtualNetwork) {
         this.forVirtualNetwork = forVirtualNetwork;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/InstanceGroupResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/InstanceGroupResponse.java
@@ -63,6 +63,10 @@ public class InstanceGroupResponse extends BaseResponseWithAnnotations implement
     @Param(description = "the domain name of the instance group")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the instance group belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     public void setId(String id) {
         this.id = id;
     }
@@ -88,6 +92,11 @@ public class InstanceGroupResponse extends BaseResponseWithAnnotations implement
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/LoadBalancerResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/LoadBalancerResponse.java
@@ -87,6 +87,10 @@ public class LoadBalancerResponse extends BaseResponse implements ControlledEnti
     @Param(description = "the domain of the load balancer rule")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the load balancer rule belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.STATE)
     @Param(description = "the state of the rule")
     private String state;
@@ -156,6 +160,11 @@ public class LoadBalancerResponse extends BaseResponse implements ControlledEnti
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setState(String state) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -424,6 +424,7 @@ public class NetworkResponse extends BaseResponseWithAssociatedNetwork implement
         this.domain = domain;
     }
 
+    @Override
     public void setDomainPath(String domainPath) {
         this.domainPath = domainPath;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/OvsProviderResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/OvsProviderResponse.java
@@ -54,6 +54,10 @@ public class OvsProviderResponse extends BaseResponse implements
     @Param(description = "the domain associated with the provider")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the provider belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @Override
     public void setAccountName(String accountName) {
         this.accountName = accountName;
@@ -73,6 +77,10 @@ public class OvsProviderResponse extends BaseResponse implements
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     @Override
     public void setProjectId(String projectId) {
         this.projectId = projectId;

--- a/api/src/main/java/org/apache/cloudstack/api/response/PrivateGatewayResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/PrivateGatewayResponse.java
@@ -89,6 +89,10 @@ public class PrivateGatewayResponse extends BaseResponseWithAssociatedNetwork im
     @Param(description = "the domain associated with the private gateway")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the private gateway belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.STATE)
     @Param(description = "State of the gateway, can be Creating, Ready, Deleting")
     private String state;
@@ -165,6 +169,10 @@ public class PrivateGatewayResponse extends BaseResponseWithAssociatedNetwork im
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     @Override
     public void setProjectId(String projectId) {
         this.projectId = projectId;

--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectAccountResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectAccountResponse.java
@@ -73,6 +73,10 @@ public class ProjectAccountResponse extends BaseResponse implements ControlledVi
     @Param(description = "name of the Domain the account belongs too")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the account belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.USER)
     @Param(description = "the list of users associated with account", responseObject = UserResponse.class)
     private List<UserResponse> users;
@@ -108,6 +112,11 @@ public class ProjectAccountResponse extends BaseResponse implements ControlledVi
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setUserId(String userId) { this.userId = userId; }

--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectInvitationResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectInvitationResponse.java
@@ -51,6 +51,10 @@ public class ProjectInvitationResponse extends BaseResponse implements Controlle
     @Param(description = "the domain name where the project belongs to")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the project belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.ACCOUNT)
     @Param(description = "the account name of the project's owner")
     private String accountName;
@@ -85,6 +89,11 @@ public class ProjectInvitationResponse extends BaseResponse implements Controlle
     @Override
     public void setDomainName(String domain) {
         this.domainName = domain;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/RemoteAccessVpnResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/RemoteAccessVpnResponse.java
@@ -65,6 +65,10 @@ public class RemoteAccessVpnResponse extends BaseResponse implements ControlledE
     @Param(description = "the domain name of the account of the remote access vpn")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the remote access vpn belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.STATE)
     @Param(description = "the state of the rule")
     private String state;
@@ -104,6 +108,10 @@ public class RemoteAccessVpnResponse extends BaseResponse implements ControlledE
         this.domainName = name;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setState(String state) {
         this.state = state;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/ResourceCountResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ResourceCountResponse.java
@@ -46,6 +46,10 @@ public class ResourceCountResponse extends BaseResponse implements ControlledEnt
     @Param(description = "the domain name for which resource count's are updated")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the resource counts are updated", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.RESOURCE_TYPE)
     @Param(description = "resource type. Values include 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11. See the resourceType parameter for more information on these values.")
     private String resourceType;
@@ -71,6 +75,11 @@ public class ResourceCountResponse extends BaseResponse implements ControlledEnt
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setResourceType(Resource.ResourceType resourceType) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/ResourceLimitResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ResourceLimitResponse.java
@@ -41,6 +41,10 @@ public class ResourceLimitResponse extends BaseResponse implements ControlledEnt
     @Param(description = "the domain name of the resource limit")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the resource limit belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.RESOURCE_TYPE)
     @Param(description = "resource type. Values include 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11. See the resourceType parameter for more information on these values.")
     private String resourceType;
@@ -81,6 +85,10 @@ public class ResourceLimitResponse extends BaseResponse implements ControlledEnt
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setResourceType(Resource.ResourceType resourceType) {
         this.resourceType = Integer.valueOf(resourceType.getOrdinal()).toString();
         this.resourceTypeName = resourceType.getName();

--- a/api/src/main/java/org/apache/cloudstack/api/response/ResourceTagResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ResourceTagResponse.java
@@ -61,6 +61,10 @@ public class ResourceTagResponse extends BaseResponse implements ControlledViewE
     @Param(description = "the domain associated with the tag")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain associated with the tag", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.CUSTOMER)
     @Param(description = "customer associated with the tag")
     private String customer;
@@ -94,6 +98,11 @@ public class ResourceTagResponse extends BaseResponse implements ControlledViewE
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/SecurityGroupResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SecurityGroupResponse.java
@@ -63,6 +63,10 @@ public class SecurityGroupResponse extends BaseResponse implements ControlledVie
     @Param(description = "the domain name of the security group")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the security group belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName("ingressrule")
     @Param(description = "the list of ingress rules associated with the security group", responseObject = SecurityGroupRuleResponse.class)
     private Set<SecurityGroupRuleResponse> ingressRules;
@@ -124,6 +128,11 @@ public class SecurityGroupResponse extends BaseResponse implements ControlledVie
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setSecurityGroupIngressRules(Set<SecurityGroupRuleResponse> securityGroupRules) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/Site2SiteCustomerGatewayResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/Site2SiteCustomerGatewayResponse.java
@@ -98,6 +98,10 @@ public class Site2SiteCustomerGatewayResponse extends BaseResponseWithAnnotation
     @Param(description = "the domain name of the owner")
     private String domain;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "the domain path of the owner", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.REMOVED)
     @Param(description = "the date and time the host was removed")
     private Date removed;
@@ -191,6 +195,11 @@ public class Site2SiteCustomerGatewayResponse extends BaseResponseWithAnnotation
     @Override
     public void setDomainName(String domainName) {
         this.domain = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/Site2SiteVpnConnectionResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/Site2SiteVpnConnectionResponse.java
@@ -120,6 +120,10 @@ public class Site2SiteVpnConnectionResponse extends BaseResponse implements Cont
     @Param(description = "the domain name of the owner")
     private String domain;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "the domain path of the owner", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.CREATED)
     @Param(description = "the date and time the host was created")
     private Date created;
@@ -239,6 +243,11 @@ public class Site2SiteVpnConnectionResponse extends BaseResponse implements Cont
     @Override
     public void setDomainName(String domainName) {
         this.domain = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setForDisplay(Boolean forDisplay) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/Site2SiteVpnGatewayResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/Site2SiteVpnGatewayResponse.java
@@ -66,6 +66,10 @@ public class Site2SiteVpnGatewayResponse extends BaseResponse implements Control
     @Param(description = "the domain name of the owner")
     private String domain;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "the domain path of the owner", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.REMOVED)
     @Param(description = "the date and time the host was removed")
     private Date removed;
@@ -119,6 +123,10 @@ public class Site2SiteVpnGatewayResponse extends BaseResponse implements Control
         this.domain = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setForDisplay(Boolean forDisplay) {
         this.forDisplay = forDisplay;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/SnapshotResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SnapshotResponse.java
@@ -47,6 +47,10 @@ public class SnapshotResponse extends BaseResponseWithTagInformation implements 
     @Param(description = "the domain name of the snapshot's account")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the snapshot's account belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.PROJECT_ID)
     @Param(description = "the project id of the snapshot")
     private String projectId;
@@ -185,6 +189,11 @@ public class SnapshotResponse extends BaseResponseWithTagInformation implements 
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setSnapshotType(String snapshotType) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
@@ -70,6 +70,10 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
     @Param(description = "the domain associated with the static route")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "the domain path associated with the static route", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.TAGS)
     @Param(description = "the list of resource tags associated with static route", responseObject = ResourceTagResponse.class)
     private List<ResourceTagResponse> tags;
@@ -114,6 +118,10 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     @Override
     public void setProjectId(String projectId) {
         this.projectId = projectId;

--- a/api/src/main/java/org/apache/cloudstack/api/response/TemplateResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/TemplateResponse.java
@@ -135,6 +135,10 @@ public class TemplateResponse extends BaseResponseWithTagInformation implements 
     @Param(description = "the name of the domain to which the template belongs")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the template belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.DOMAIN_ID)
     @Param(description = "the ID of the domain to which the template belongs")
     private String domainId;
@@ -352,6 +356,11 @@ public class TemplateResponse extends BaseResponseWithTagInformation implements 
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
@@ -51,6 +51,10 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
     @Param(description = "the domain the resource is associated with")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the usage reocrd belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.ZONE_ID)
     @Param(description = "the zone ID")
     private String zoneId;
@@ -276,6 +280,10 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setNetworkId(String networkId) {
         this.networkId = networkId;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/UserDataResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserDataResponse.java
@@ -54,6 +54,10 @@ public class UserDataResponse extends BaseResponseWithAnnotations implements Con
     @SerializedName(ApiConstants.DOMAIN) @Param(description="the domain name of the userdata owner")
     private String domain;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the userdata owner belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.USER_DATA) @Param(description="base64 encoded userdata content")
     private String userData;
 
@@ -142,5 +146,10 @@ public class UserDataResponse extends BaseResponseWithAnnotations implements Con
 
     public void setDomainName(String domain) {
         this.domain = domain;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -82,6 +82,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     @Param(description = "the name of the domain in which the virtual machine exists")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain in which the virtual machine exists", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.CREATED)
     @Param(description = "the date when this virtual machine was created")
     private Date created;
@@ -703,6 +707,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public void setCreated(Date created) {
         this.created = created;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/response/VMSnapshotResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VMSnapshotResponse.java
@@ -108,6 +108,10 @@ public class VMSnapshotResponse extends BaseResponseWithTagInformation implement
     @Param(description = "the domain associated with the disk volume")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the disk volume belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.HYPERVISOR)
     @Param(description = "the type of hypervisor on which snapshot is stored")
     private String hypervisor;
@@ -259,6 +263,11 @@ public class VMSnapshotResponse extends BaseResponseWithTagInformation implement
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setTags(Set<ResourceTagResponse> tags) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/VirtualRouterProviderResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VirtualRouterProviderResponse.java
@@ -60,6 +60,10 @@ public class VirtualRouterProviderResponse extends BaseResponse implements Contr
     @Param(description = "the domain associated with the provider")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the provider belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @Override
     public void setAccountName(String accountName) {
         this.accountName = accountName;
@@ -79,6 +83,10 @@ public class VirtualRouterProviderResponse extends BaseResponse implements Contr
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     @Override
     public void setProjectId(String projectId) {
         this.projectId = projectId;

--- a/api/src/main/java/org/apache/cloudstack/api/response/VlanIpRangeResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VlanIpRangeResponse.java
@@ -55,6 +55,10 @@ public class VlanIpRangeResponse extends BaseResponse implements ControlledEntit
     @Param(description = "the domain name of the VLAN IP range")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the VLAN IP range belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.POD_ID)
     @Param(description = "the Pod ID for the VLAN IP range")
     private String podId;
@@ -160,6 +164,11 @@ public class VlanIpRangeResponse extends BaseResponse implements ControlledEntit
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setPodId(String podId) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/VolumeResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VolumeResponse.java
@@ -145,6 +145,10 @@ public class VolumeResponse extends BaseResponseWithTagInformation implements Co
     @Param(description = "the domain associated with the disk volume")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain the disk volume belongs to", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName("storagetype")
     @Param(description = "shared or local storage")
     private String storageType;
@@ -407,6 +411,11 @@ public class VolumeResponse extends BaseResponseWithTagInformation implements Co
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setStorageType(String storageType) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/VpcResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VpcResponse.java
@@ -96,6 +96,10 @@ public class VpcResponse extends BaseResponseWithAnnotations implements Controll
     @Param(description = "the domain name of the owner")
     private String domain;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "the domain path of the owner", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.NETWORK)
     @Param(description = "the list of networks belongign to the VPC", responseObject = NetworkResponse.class)
     private List<NetworkResponse> networks;
@@ -207,6 +211,11 @@ public class VpcResponse extends BaseResponseWithAnnotations implements Controll
     @Override
     public void setDomainName(final String domainName) {
         domain = domainName;
+    }
+
+    @Override
+    public void setDomainPath(String path) {
+        this.domainPath = path;
     }
 
     public void setZoneId(final String zoneId) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/VpnUsersResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VpnUsersResponse.java
@@ -48,6 +48,10 @@ public class VpnUsersResponse extends BaseResponse implements ControlledEntityRe
     @Param(description = "the domain name of the account of the remote access vpn")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the remote access vpn belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.PROJECT_ID)
     @Param(description = "the project id of the vpn")
     private String projectId;
@@ -81,6 +85,11 @@ public class VpnUsersResponse extends BaseResponse implements ControlledEntityRe
     @Override
     public void setDomainName(String name) {
         this.domainName = name;
+    }
+
+    @Override
+    public void setDomainPath(String path) {
+        this.domainPath = path;
     }
 
     @Override

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -581,6 +581,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         Domain domain = ApiDBUtils.findDomainById(kubernetesCluster.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
+        response.setDomainPath(domain.getPath());
         response.setKeypair(kubernetesCluster.getKeyPair());
         response.setState(kubernetesCluster.getState().toString());
         response.setCores(String.valueOf(kubernetesCluster.getCores()));

--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/response/KubernetesClusterResponse.java
@@ -98,6 +98,10 @@ public class KubernetesClusterResponse extends BaseResponseWithAnnotations imple
     @Param(description = "the name of the domain in which the Kubernetes cluster exists")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the domain to which the Kubernetes cluster belongs", since = "4.19.2.0")
+    private String domainPath;
+
     @SerializedName(ApiConstants.SSH_KEYPAIR)
     @Param(description = "keypair details")
     private String keypair;
@@ -279,6 +283,10 @@ public class KubernetesClusterResponse extends BaseResponseWithAnnotations imple
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
     public String getKeypair() {
         return keypair;
     }

--- a/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/api/response/ServiceInstanceResponse.java
+++ b/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/api/response/ServiceInstanceResponse.java
@@ -59,6 +59,10 @@ public class ServiceInstanceResponse extends BaseResponse implements ControlledE
     @Param(description = "the name of the domain in which the virtual machine exists")
     private String domainName;
 
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "path of the Domain in which the virtual machine exists", since = "4.19.2.0")
+    private String domainPath;
+
     public void setId(String id) {
         this.id = id;
     }
@@ -88,4 +92,8 @@ public class ServiceInstanceResponse extends BaseResponse implements ControlledE
         this.domainName = domainName;
     }
 
+    @Override
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -786,6 +786,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         if (domain != null) {
             vmSnapshotResponse.setDomainId(domain.getUuid());
             vmSnapshotResponse.setDomainName(domain.getName());
+            vmSnapshotResponse.setDomainPath(domain.getPath());
         }
 
         List<? extends ResourceTag> tags = _resourceTagDao.listBy(vmSnapshot.getId(), ResourceObjectType.VMSnapshot);
@@ -2622,6 +2623,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             if (domain != null) {
                 response.setDomainId(domain.getUuid());
                 response.setDomainName(domain.getName());
+                response.setDomainPath(domain.getPath());
             }
 
         }
@@ -2870,6 +2872,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(object.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
+        response.setDomainPath(domain.getPath());
     }
 
     private void populateOwner(ControlledViewEntityResponse response, ControlledEntity object) {
@@ -2926,6 +2929,7 @@ public class ApiResponseHelper implements ResponseGenerator {
 
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
+        response.setDomainPath(domain.getPath());
     }
 
     @Override
@@ -3864,6 +3868,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         if (domain != null) {
             usageRecResponse.setDomainId(domain.getUuid());
             usageRecResponse.setDomainName(domain.getName());
+            usageRecResponse.setDomainPath(domain.getPath());
         }
 
         if (usageRecord.getZoneId() != null) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2221,6 +2221,7 @@ public class ApiResponseHelper implements ResponseGenerator {
 
             response.setDomainId(securityGroup.getDomainUuid());
             response.setDomainName(securityGroup.getDomainName());
+            response.setDomainPath(securityGroup.getDomainPath());
 
             for (SecurityRule securityRule : securityRules) {
                 SecurityGroupRuleResponse securityGroupData = new SecurityGroupRuleResponse();
@@ -2890,6 +2891,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(object.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
+        response.setDomainPath(domain.getPath());
     }
 
     public static void populateOwner(ControlledViewEntityResponse response, ControlledViewEntity object) {
@@ -2903,6 +2905,7 @@ public class ApiResponseHelper implements ResponseGenerator {
 
         response.setDomainId(object.getDomainUuid());
         response.setDomainName(object.getDomainName());
+        response.setDomainPath(object.getDomainPath());
     }
 
     private void populateAccount(ControlledEntityResponse response, long accountId) {
@@ -4666,6 +4669,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         if (domain != null) {
             response.setDomainId(domain.getUuid());
             response.setDomainName(domain.getName());
+            response.setDomainPath(domain.getPath());
         }
 
         response.setObjectName("affinitygroup");

--- a/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
@@ -210,6 +210,7 @@ public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, 
 
         routerResponse.setDomainId(router.getDomainUuid());
         routerResponse.setDomainName(router.getDomainName());
+        routerResponse.setDomainPath(router.getDomainPath());
 
         routerResponse.setZoneName(router.getDataCenterName());
         routerResponse.setDns1(router.getDns1());

--- a/server/src/main/java/com/cloud/api/query/dao/ProjectAccountJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ProjectAccountJoinDaoImpl.java
@@ -61,6 +61,7 @@ public class ProjectAccountJoinDaoImpl extends GenericDaoBase<ProjectAccountJoin
         projectAccountResponse.setRole(proj.getAccountRole().toString());
         projectAccountResponse.setDomainId(proj.getDomainUuid());
         projectAccountResponse.setDomainName(proj.getDomainName());
+        projectAccountResponse.setDomainPath(proj.getDomainPath());
 
         projectAccountResponse.setObjectName("projectaccount");
 

--- a/server/src/main/java/com/cloud/api/query/dao/ProjectInvitationJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ProjectInvitationJoinDaoImpl.java
@@ -67,6 +67,7 @@ public class ProjectInvitationJoinDaoImpl extends GenericDaoBase<ProjectInvitati
 
         response.setDomainId(invite.getDomainUuid());
         response.setDomainName(invite.getDomainName());
+        response.setDomainPath(invite.getDomainPath());
 
         response.setObjectName("projectinvitation");
         return response;

--- a/server/src/main/java/com/cloud/api/query/dao/ResourceTagJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ResourceTagJoinDaoImpl.java
@@ -82,6 +82,7 @@ public class ResourceTagJoinDaoImpl extends GenericDaoBase<ResourceTagJoinVO, Lo
 
             response.setDomainId(resourceTag.getDomainUuid());
             response.setDomainName(resourceTag.getDomainName());
+            response.setDomainPath(resourceTag.getDomainPath());
 
             response.setCustomer(resourceTag.getCustomer());
         }

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -276,6 +276,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         // populate domain
         templateResponse.setDomainId(template.getDomainUuid());
         templateResponse.setDomainName(template.getDomainName());
+        templateResponse.setDomainPath(template.getDomainPath());
 
         // If the user is an 'Admin' or 'the owner of template' or template belongs to a project, add the template download status
         if (view == ResponseView.Full ||
@@ -415,6 +416,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         // populate domain
         response.setDomainId(result.getDomainUuid());
         response.setDomainName(result.getDomainName());
+        response.setDomainPath(result.getDomainPath());
 
         // set details map
         if (result.getDetailName() != null) {
@@ -501,6 +503,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         // populate domain
         isoResponse.setDomainId(iso.getDomainUuid());
         isoResponse.setDomainName(iso.getDomainName());
+        isoResponse.setDomainPath(iso.getDomainPath());
 
         Account caller = CallContext.current().getCallingAccount();
         boolean isAdmin = false;

--- a/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -168,6 +168,7 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
         }
         userVmResponse.setDomainId(userVm.getDomainUuid());
         userVmResponse.setDomainName(userVm.getDomainName());
+        userVmResponse.setDomainPath(userVm.getDomainPath());
 
         userVmResponse.setCreated(userVm.getCreated());
         userVmResponse.setLastUpdated(userVm.getLastUpdated());


### PR DESCRIPTION
### Description

This PR fixes the ticket #8086. Added domain path to all the responses whereever domain and domain names are already used.

Added domain path to all the responses which implements the interfaces ControlledViewEntityResponse and ControlledEntityResponse

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

(localcloud) 🐱 > list virtualmachines filter=name,domainpath,domain
{
  "count": 6,
  "virtualmachine": [
    {
      "domain": "ROOT",
      "domainpath": "/",
      "name": "Vm1N1"
    },
    {

List of responses where we have added the domain paths are

From ControlledEntityResponse:

```
ServiceInstanceResponse
KubernetesClusterResponse
ConditionResponse
VpnUsersResponse
StaticRouteResponse
VlanIpRangeResponse
ResourceLimitResponse
AutoScaleVmProfileResponse
RemoteAccessVpnResponse
GuestVlanRangeResponse
ApplicationLoadBalancerResponse
UserDataResponse
AutoScalePolicyResponse
UserVmResponse
GlobalLoadBalancerResponse
VirtualRouterProviderResponse
NetworkResponse
Site2SiteVpnGatewayResponse
LoadBalancerResponse
VpcResponse
UsageRecordResponse
Site2SiteCustomerGatewayResponse
PrivateGatewayResponse
IPAddressResponse
GuestVlanResponse
Site2SiteVpnConnectionResponse
ResourceCountResponse
AcquireIPAddressResponse
AutoScaleVmGroupResponse
VMSnapshotResponse
```

From ControlledViewEntityResponse

```
AffinityGroupResponse
TemplateResponse
BucketResponse
EventResponse
SecurityGroupResponse
DomainRouterResponse
VolumeResponse
ResourceTagResponse
InstanceGroupResponse
SnapshotResponse
ProjectInvitationResponse
ProjectAccountResponse
```




<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
