### PR TITLE
Fix to allow actions on the network if it belongs to a project

### DIFF
--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -140,7 +140,9 @@ export default {
           icon: 'edit-outlined',
           label: 'label.update.network',
           dataView: true,
-          disabled: (record, user) => { return (record.account !== user.userInfo.account && !['Admin', 'DomainAdmin'].includes(user.userInfo.roletype)) },
+          disabled: (record, user) => {
+            return !record.projectid && (record.account !== user.userInfo.account && !['Admin', 'DomainAdmin'].includes(user.userInfo.roletype))
+          },
           popup: true,
           component: shallowRef(defineAsyncComponent(() => import('@/views/network/UpdateNetwork.vue')))
         },
@@ -150,7 +152,9 @@ export default {
           label: 'label.restart.network',
           message: 'message.restart.network',
           dataView: true,
-          disabled: (record, user) => { return (record.account !== user.userInfo.account && !['Admin', 'DomainAdmin'].includes(user.userInfo.roletype)) },
+          disabled: (record, user) => {
+            return !record.projectid && (record.account !== user.userInfo.account && !['Admin', 'DomainAdmin'].includes(user.userInfo.roletype))
+          },
           args: (record, store, isGroupAction) => {
             var fields = []
             if (isGroupAction || record.vpcid == null) {
@@ -189,7 +193,9 @@ export default {
           label: 'label.action.delete.network',
           message: 'message.action.delete.network',
           dataView: true,
-          disabled: (record, user) => { return (record.account !== user.userInfo.account && !['Admin', 'DomainAdmin'].includes(user.userInfo.roletype)) },
+          disabled: (record, user) => {
+            return !record.projectid && (record.account !== user.userInfo.account && !['Admin', 'DomainAdmin'].includes(user.userInfo.roletype))
+          },
           groupAction: true,
           popup: true,
           groupMap: (selection) => { return selection.map(x => { return { id: x } }) }


### PR DESCRIPTION
### Description

This PR fixes the issue #9413 

The original fix was to allow user to do actions (update, restart, delete) on the network only if the user owns the network and if user role is of Admin or domain admin.

If the network belongs to a project then the actions can be allowed as it belongs to only to that project.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
Before fix with a network in project
![Screenshot 2024-08-20 at 12 11 16 PM](https://github.com/user-attachments/assets/235c0577-0e13-4724-bdbe-5fdb06943328)

After fix with a network in project
![Screenshot 2024-08-20 at 12 11 50 PM](https://github.com/user-attachments/assets/1491eb6c-721d-4771-b440-0f808ed7c1f4)


### How Has This Been Tested?
1. Create an account of type user
2. Login with that user
3. Create a project and switch to that project
4. Create a new network in that project
5. Before fix user won't be able to do any actions on that network, after fix it is allowed.