### PR TITLE
UI: Fix VPC network offerings listing on VPC tier creation

### DIFF
--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -555,7 +555,7 @@ export default {
           } else if (!this.publicLBExists && vpcLbServiceIndex > -1) {
             const vpcLbServiceProvider = vpcLbServiceIndex === -1 ? undefined : this.resource.service[vpcLbServiceIndex].provider[0].name
             const offeringLbServiceProvider = idx === -1 ? undefined : offering.service[idx].provider[0].name
-            if (vpcLbServiceProvider && offeringLbServiceProvider && vpcLbServiceProvider === offeringLbServiceProvider) {
+            if (vpcLbServiceProvider && (!offeringLbServiceProvider || (offeringLbServiceProvider && vpcLbServiceProvider === offeringLbServiceProvider))) {
               filteredOfferings.push(offering)
             }
           } else {

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -538,12 +538,16 @@ export default {
     fetchNetworkOfferings () {
       this.fetchLoading = true
       this.modalLoading = true
-      api('listNetworkOfferings', {
+      const params = {
         forvpc: true,
         guestiptype: 'Isolated',
-        supportedServices: 'SourceNat',
         state: 'Enabled'
-      }).then(json => {
+      }
+      params.supportedServices = 'SourceNat'
+      if (this.resource.service.map(svc => { return svc.name }).indexOf('Lb') > -1) {
+        params.supportedServices += ',Lb'
+      }
+      api('listNetworkOfferings', params).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering || []
         var filteredOfferings = []
         if (this.publicLBExists) {

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -544,8 +544,11 @@ export default {
         state: 'Enabled'
       }
       params.supportedServices = 'SourceNat'
-      if (this.resource.service.map(svc => { return svc.name }).indexOf('Lb') > -1) {
+      const vpcServiceLbIndex = this.resource.service.map(svc => { return svc.name }).indexOf('Lb')
+      var vpcLbProvider = null
+      if (vpcServiceLbIndex > -1) {
         params.supportedServices += ',Lb'
+        vpcLbProvider = this.resource.service[vpcServiceLbIndex].provider[0].name
       }
       api('listNetworkOfferings', params).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering || []
@@ -555,6 +558,15 @@ export default {
             const offering = this.networkOfferings[index]
             const idx = offering.service.map(svc => { return svc.name }).indexOf('Lb')
             if (idx === -1 || this.lbProviderMap.publicLb.vpc.indexOf(offering.service.map(svc => { return svc.provider[0].name })[idx]) === -1) {
+              filteredOfferings.push(offering)
+            }
+          }
+          this.networkOfferings = filteredOfferings
+        } else if (vpcServiceLbIndex > -1) {
+          for (var i in this.networkOfferings) {
+            const offering = this.networkOfferings[i]
+            const lbIndex = offering.service.map(svc => { return svc.name }).indexOf('Lb')
+            if (lbIndex > -1 && offering.service[lbIndex].provider[0].name === vpcLbProvider) {
               filteredOfferings.push(offering)
             }
           }

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -522,7 +522,7 @@ export default {
       }).then(async json => {
         var lbNetworks = json.listnetworksresponse.network || []
         if (lbNetworks.length > 0) {
-          this.publicLBExists = true
+          this.publicLBExists = false
           for (var idx = 0; idx < lbNetworks.length; idx++) {
             const lbNetworkOffering = await this.getNetworkOffering(lbNetworks[idx].networkofferingid)
             const index = lbNetworkOffering.service.map(svc => { return svc.name }).indexOf('Lb')
@@ -538,40 +538,31 @@ export default {
     fetchNetworkOfferings () {
       this.fetchLoading = true
       this.modalLoading = true
-      const params = {
+      api('listNetworkOfferings', {
         forvpc: true,
         guestiptype: 'Isolated',
+        supportedServices: 'SourceNat',
         state: 'Enabled'
-      }
-      params.supportedServices = 'SourceNat'
-      const vpcServiceLbIndex = this.resource.service.map(svc => { return svc.name }).indexOf('Lb')
-      var vpcLbProvider = null
-      if (vpcServiceLbIndex > -1) {
-        params.supportedServices += ',Lb'
-        vpcLbProvider = this.resource.service[vpcServiceLbIndex].provider[0].name
-      }
-      api('listNetworkOfferings', params).then(json => {
+      }).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering || []
         var filteredOfferings = []
-        if (this.publicLBExists) {
-          for (var index in this.networkOfferings) {
-            const offering = this.networkOfferings[index]
-            const idx = offering.service.map(svc => { return svc.name }).indexOf('Lb')
-            if (idx === -1 || this.lbProviderMap.publicLb.vpc.indexOf(offering.service.map(svc => { return svc.provider[0].name })[idx]) === -1) {
+        const vpcLbServiceIndex = this.resource.service.map(svc => { return svc.name }).indexOf('Lb')
+        for (var index in this.networkOfferings) {
+          const offering = this.networkOfferings[index]
+          const idx = offering.service.map(svc => { return svc.name }).indexOf('Lb')
+          if (this.publicLBExists && (idx === -1 || this.lbProviderMap.publicLb.vpc.indexOf(offering.service.map(svc => { return svc.provider[0].name })[idx]) === -1)) {
+            filteredOfferings.push(offering)
+          } else if (!this.publicLBExists && vpcLbServiceIndex > -1) {
+            const vpcLbServiceProvider = vpcLbServiceIndex === -1 ? undefined : this.resource.service[vpcLbServiceIndex].provider[0].name
+            const offeringLbServiceProvider = idx === -1 ? undefined : offering.service[idx].provider[0].name
+            if (vpcLbServiceProvider && offeringLbServiceProvider && vpcLbServiceProvider === offeringLbServiceProvider) {
               filteredOfferings.push(offering)
             }
+          } else {
+            filteredOfferings.push(offering)
           }
-          this.networkOfferings = filteredOfferings
-        } else if (vpcServiceLbIndex > -1) {
-          for (var i in this.networkOfferings) {
-            const offering = this.networkOfferings[i]
-            const lbIndex = offering.service.map(svc => { return svc.name }).indexOf('Lb')
-            if (lbIndex > -1 && offering.service[lbIndex].provider[0].name === vpcLbProvider) {
-              filteredOfferings.push(offering)
-            }
-          }
-          this.networkOfferings = filteredOfferings
         }
+        this.networkOfferings = filteredOfferings
         this.form.networkOffering = this.networkOfferings[0].id
       }).catch(error => {
         this.$notifyError(error)


### PR DESCRIPTION
### Description

This PR fixes the VPC network offerings listing on VPC tiers creation
Fixes: #8023 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
Create VPC offering with Lb as supported service and VpcVirtualRouter as provider
Create VPC with the selected VPC offering
VPC -> Add new network tier -> verify available network offerings

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
