### PR TITLE
Fix userdata append header restrictions

### DIFF
--- a/engine/userdata/cloud-init/src/main/java/org/apache/cloudstack/userdata/CloudInitUserDataProvider.java
+++ b/engine/userdata/cloud-init/src/main/java/org/apache/cloudstack/userdata/CloudInitUserDataProvider.java
@@ -88,14 +88,20 @@ public class CloudInitUserDataProvider extends AdapterBase implements UserDataPr
                 .filter(x -> (x.startsWith("#") && !x.startsWith("##")) || (x.startsWith("Content-Type:")))
                 .collect(Collectors.toList());
         if (CollectionUtils.isEmpty(lines)) {
-            throw new CloudRuntimeException("Failed to detect the user data format type as it " +
-                    "does not contain a header");
+            LOGGER.debug("Failed to detect the user data format type as it does not contain a header");
+            return null;
         }
         return lines.get(0);
     }
 
-    protected FormatType mapUserDataHeaderToFormatType(String header) {
-        if (header.equalsIgnoreCase("#cloud-config")) {
+    protected FormatType mapUserDataHeaderToFormatType(String header, FormatType defaultFormatType) {
+        if (StringUtils.isBlank(header)) {
+            if (defaultFormatType == null) {
+                throw new CloudRuntimeException("Failed to detect the user data format type as it does not contain a header");
+            }
+            LOGGER.debug(String.format("Empty header for userdata, using the default format type: %s", defaultFormatType.name()));
+            return defaultFormatType;
+        } else if (header.equalsIgnoreCase("#cloud-config")) {
             return FormatType.CLOUD_CONFIG;
         } else if (header.startsWith("#!")) {
             return FormatType.BASH_SCRIPT;
@@ -115,9 +121,11 @@ public class CloudInitUserDataProvider extends AdapterBase implements UserDataPr
 
     /**
      * Detect the user data type
+     * @param userdata the userdata string to detect the type
+     * @param defaultFormatType if not null, then use it in case the header does not exist in the userdata, otherwise fail
      * Reference: <a href="https://canonical-cloud-init.readthedocs-hosted.com/en/latest/explanation/format.html#user-data-formats" />
      */
-    protected FormatType getUserDataFormatType(String userdata) {
+    protected FormatType getUserDataFormatType(String userdata, FormatType defaultFormatType) {
         if (StringUtils.isBlank(userdata)) {
             String msg = "User data expected but provided empty user data";
             LOGGER.error(msg);
@@ -125,7 +133,7 @@ public class CloudInitUserDataProvider extends AdapterBase implements UserDataPr
         }
 
         String header = extractUserDataHeader(userdata);
-        return mapUserDataHeaderToFormatType(header);
+        return mapUserDataHeaderToFormatType(header, defaultFormatType);
     }
 
     private String getContentType(String userData, FormatType formatType) throws MessagingException {
@@ -249,8 +257,8 @@ public class CloudInitUserDataProvider extends AdapterBase implements UserDataPr
             checkGzipAppend(encodedUserData1, encodedUserData2);
             String userData1 = new String(Base64.decodeBase64(encodedUserData1));
             String userData2 = new String(Base64.decodeBase64(encodedUserData2));
-            FormatType formatType1 = getUserDataFormatType(userData1);
-            FormatType formatType2 = getUserDataFormatType(userData2);
+            FormatType formatType1 = getUserDataFormatType(userData1, null);
+            FormatType formatType2 = getUserDataFormatType(userData2, formatType1);
             if (formatType1.equals(formatType2) && List.of(FormatType.CLOUD_CONFIG, FormatType.BASH_SCRIPT).contains(formatType1)) {
                 return simpleAppendSameFormatTypeUserData(userData1, userData2);
             }

--- a/engine/userdata/cloud-init/src/main/java/org/apache/cloudstack/userdata/CloudInitUserDataProvider.java
+++ b/engine/userdata/cloud-init/src/main/java/org/apache/cloudstack/userdata/CloudInitUserDataProvider.java
@@ -242,7 +242,9 @@ public class CloudInitUserDataProvider extends AdapterBase implements UserDataPr
     }
 
     private String simpleAppendSameFormatTypeUserData(String userData1, String userData2) {
-        return String.format("%s\n\n%s", userData1, userData2.substring(userData2.indexOf('\n')+1));
+        String userdata2Header = extractUserDataHeader(userData2);
+        int beginIndex = StringUtils.isNotBlank(userdata2Header) ? userData2.indexOf('\n')+1 : 0;
+        return String.format("%s\n\n%s", userData1, userData2.substring(beginIndex));
     }
 
     private void checkGzipAppend(String encodedUserData1, String encodedUserData2) {

--- a/engine/userdata/cloud-init/src/test/java/org/apache/cloudstack/userdata/CloudInitUserDataProviderTest.java
+++ b/engine/userdata/cloud-init/src/test/java/org/apache/cloudstack/userdata/CloudInitUserDataProviderTest.java
@@ -147,6 +147,22 @@ public class CloudInitUserDataProviderTest {
     }
 
     @Test
+    public void testAppendCloudConfig() {
+        String userdata1 = "#cloud-config\n" +
+                "chpasswd:\n" +
+                "  list: |\n" +
+                "    root:password\n" +
+                "  expire: False";
+        String userdata2 = "write_files:\n" +
+                "- path: /root/CLOUD_INIT_WAS_HERE";
+        String userdataWithHeader = Base64.encodeBase64String(userdata1.getBytes());
+        String userdataWithoutHeader = Base64.encodeBase64String(userdata2.getBytes());
+        String appended = provider.appendUserData(userdataWithHeader, userdataWithoutHeader);
+        String expected = String.format("%s\n\n%s", userdata1, userdata2);
+        Assert.assertEquals(expected, appended);
+    }
+
+    @Test
     public void testAppendUserDataMIMETemplateData() {
         String multipartUserData = provider.appendUserData(
                 Base64.encodeBase64String(SINGLE_BODYPART_CLOUDCONFIG_MULTIPART_USERDATA.getBytes()),

--- a/ui/src/utils/plugins.js
+++ b/ui/src/utils/plugins.js
@@ -506,7 +506,7 @@ export const genericUtilPlugin = {
       if (isBase64(text)) {
         return text
       }
-      return encodeURIComponent(btoa(unescape(encodeURIComponent(text))))
+      return encodeURI(btoa(unescape(encodeURIComponent(text))))
     }
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the userdata header restrictions on the APPEND operation:
- Allow the second userdata not having a header
- In case the second userdata does not have a header, it uses the first userdata header as its format type

Fixes: #7918 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
