### PR TITLE
server: fix stopped vm volume migration check on local volume attach

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -4312,7 +4312,11 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 }
             } else if (storeForNewStoreScope.getScopeType() == ScopeType.HOST
                     && (storeForExistingStoreScope.getScopeType() == ScopeType.CLUSTER || storeForExistingStoreScope.getScopeType() == ScopeType.ZONE)) {
-                Long hostId = _vmInstanceDao.findById(existingVolume.getInstanceId()).getHostId();
+                VMInstanceVO vm = _vmInstanceDao.findById(existingVolume.getInstanceId());
+                Long hostId = vm.getHostId();
+                if (hostId == null) {
+                    hostId = vm.getLastHostId();
+                }
                 if (storeForNewStoreScope.getScopeId().equals(hostId)) {
                     return false;
                 }


### PR DESCRIPTION
### Description

Fixes #8645

When a local storage volume is being attached to a stopped VM, volume migration is only needed when it is not present on the last host as the current host ID will be null in the database.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested attaching a volume with a localstorage offering to a stopped VM,

```
(localcloud) 🐱 > list serviceofferings id=45770553-e18f-4dfd-ba16-b0106af20dd2 
{
  "count": 1,
  "serviceoffering": [
    {
      "cacheMode": "none",
      "cpunumber": 1,
      "cpuspeed": 1000,
      "created": "2024-08-23T07:24:45+0000",
      "defaultuse": false,
      "diskofferingstrictness": false,
      "displaytext": "SharedStorage Instance",
      "dynamicscalingenabled": true,
      "encryptroot": false,
      "hasannotations": false,
      "id": "45770553-e18f-4dfd-ba16-b0106af20dd2",
      "iscustomized": false,
      "issystem": false,
      "isvolatile": false,
      "limitcpuuse": false,
      "memory": 1024,
      "name": "SharedStorage Instance",
      "offerha": false,
      "provisioningtype": "thin",
      "rootdisksize": 0,
      "state": "Active",
      "storagetype": "shared"
    }
  ]
}
(localcloud) 🐱 > list diskofferings id=a3f4a836-2b28-4baa-9912-3ad886b8d75b 
{
  "count": 1,
  "diskoffering": [
    {
      "cacheMode": "none",
      "created": "2024-08-23T07:24:03+0000",
      "disksize": 5,
      "disksizestrictness": false,
      "displayoffering": true,
      "displaytext": "Local",
      "encrypt": false,
      "hasannotations": false,
      "id": "a3f4a836-2b28-4baa-9912-3ad886b8d75b",
      "iscustomized": false,
      "name": "Local",
      "provisioningtype": "fat",
      "state": "Active",
      "storagetype": "local"
    }
  ]
}
(localcloud) 🐱 > list virtualmachines id=3b4b5df4-de5c-4045-9162-403fdd500920 
{
  "count": 1,
  "virtualmachine": [
    {
      "account": "admin",
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 1000,
      "created": "2024-08-23T07:30:29+0000",
      "details": {
        "Message.ReservedCapacityFreed.Flag": "false",
        "cpuOvercommitRatio": "2.0"
      },
      "displayname": "VM-3b4b5df4-de5c-4045-9162-403fdd500920",
      "displayvm": true,
      "domain": "ROOT",
      "domainid": "bbde89eb-611d-11ef-932b-1e008e000940",
      "guestosid": "bbf6f513-611d-11ef-932b-1e008e000940",
      "haenable": false,
      "hasannotations": false,
      "hypervisor": "KVM",
      "id": "3b4b5df4-de5c-4045-9162-403fdd500920",
      "instancename": "i-2-6-VM",
      "isdynamicallyscalable": false,
      "lastupdated": "2024-08-23T07:33:24+0000",
      "memory": 1024,
      "name": "VM-3b4b5df4-de5c-4045-9162-403fdd500920",
      "nic": [
        {
          "deviceid": "0",
          "extradhcpoption": [],
          "id": "01ded4c8-1c5a-4922-a4d6-1892d1f940d9",
          "isdefault": true,
          "macaddress": "02:01:00:cc:00:01",
          "networkid": "ffc6752d-78f9-46de-aa05-5d4fa618465f",
          "networkname": "l2-test",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "L2"
        }
      ],
      "osdisplayname": "CentOS 5.5 (64-bit)",
      "ostypeid": "bbf6f513-611d-11ef-932b-1e008e000940",
      "passwordenabled": false,
      "pooltype": "NetworkFilesystem",
      "receivedbytes": 0,
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "sentbytes": 0,
      "serviceofferingid": "45770553-e18f-4dfd-ba16-b0106af20dd2",
      "serviceofferingname": "SharedStorage Instance",
      "state": "Stopped",
      "tags": [],
      "templatedisplaytext": "CentOS 5.5(64-bit) no GUI (KVM)",
      "templateformat": "QCOW2",
      "templateid": "bbe4722c-611d-11ef-932b-1e008e000940",
      "templatename": "CentOS 5.5(64-bit) no GUI (KVM)",
      "templatetype": "BUILTIN",
      "userid": "f0dab248-611d-11ef-932b-1e008e000940",
      "username": "admin",
      "zoneid": "9cc01d3d-ed2e-4f8b-8fb6-178fbd73c93e",
      "zonename": "ref-trl-5591-k-Mol8-abhishek-kumar"
    }
  ]
}
(localcloud) 🐱 > create volume zoneid=9cc01d3d-ed2e-4f8b-8fb6-178fbd73c93e diskofferingid=a3f4a836-2b28-4baa-9912-3ad886b8d75b name=test123
{
  "volume": {
    "account": "admin",
    "created": "2024-08-23T08:21:26+0000",
    "destroyed": false,
    "diskofferingdisplaytext": "Local",
    "diskofferingid": "a3f4a836-2b28-4baa-9912-3ad886b8d75b",
    "diskofferingname": "Local",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "bbde89eb-611d-11ef-932b-1e008e000940",
    "hasannotations": false,
    "hypervisor": "None",
    "id": "28f0cba0-4260-413b-92d4-75c8cc7e4c3f",
    "isextractable": true,
    "jobid": "6b31ff14-063f-49fa-b7ec-c2e3b8ce4e48",
    "jobstatus": 0,
    "name": "test123",
    "provisioningtype": "fat",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Allocated",
    "storagetype": "local",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "zoneid": "9cc01d3d-ed2e-4f8b-8fb6-178fbd73c93e",
    "zonename": "ref-trl-5591-k-Mol8-abhishek-kumar"
  }
}
(localcloud) 🐱 > attach volume virtualmachineid=3b4b5df4-de5c-4045-9162-403fdd500920 id=28f0cba0-4260-413b-92d4-75c8cc7e4c3f 
{
  "volume": {
    "account": "admin",
    "attached": "2024-08-23T08:22:31+0000",
    "clusterid": "b49fd024-1a67-4ac3-a26e-4def97a3ecbd",
    "clustername": "p1-c1",
    "created": "2024-08-23T08:21:26+0000",
    "destroyed": false,
    "deviceid": 1,
    "diskioread": 0,
    "diskiowrite": 0,
    "diskkbsread": 0,
    "diskkbswrite": 0,
    "diskofferingdisplaytext": "Local",
    "diskofferingid": "a3f4a836-2b28-4baa-9912-3ad886b8d75b",
    "diskofferingname": "Local",
    "displayvolume": true,
    "domain": "ROOT",
    "domainid": "bbde89eb-611d-11ef-932b-1e008e000940",
    "hasannotations": false,
    "hypervisor": "KVM",
    "id": "28f0cba0-4260-413b-92d4-75c8cc7e4c3f",
    "isextractable": true,
    "jobid": "8c869e8b-cfe2-4f21-91fd-c281f09f4923",
    "jobstatus": 0,
    "name": "test123",
    "path": "28f0cba0-4260-413b-92d4-75c8cc7e4c3f",
    "podid": "951975d0-f672-43a0-bbe5-40e0d1d0730b",
    "podname": "Pod1",
    "provisioningtype": "fat",
    "quiescevm": false,
    "size": 5368709120,
    "state": "Ready",
    "storage": "ol8.localdomain-local-aa9ebe37",
    "storageid": "aa9ebe37-e542-4750-9659-757358c079e6",
    "storagetype": "local",
    "supportsstoragesnapshot": false,
    "tags": [],
    "type": "DATADISK",
    "virtualmachineid": "3b4b5df4-de5c-4045-9162-403fdd500920",
    "vmdisplayname": "VM-3b4b5df4-de5c-4045-9162-403fdd500920",
    "vmname": "VM-3b4b5df4-de5c-4045-9162-403fdd500920",
    "vmstate": "Stopped",
    "vmtype": "User",
    "zoneid": "9cc01d3d-ed2e-4f8b-8fb6-178fbd73c93e",
    "zonename": "ref-trl-5591-k-Mol8-abhishek-kumar"
  }
}
```
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
