### PR TITLE
systemvm: have flags to check x86_64 to install specifics for amd64 arch

### DIFF
--- a/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
+++ b/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
@@ -83,7 +83,7 @@ function install_packages() {
   apt_clean
 
   # 32 bit architecture support for vhd-util
-  if [[ "${arch}" != "i386" && "${arch}" != "arm64" ]]; then
+  if [[ "${arch}" != "i386" && "${arch}" == "amd64" ]]; then
     dpkg --add-architecture i386
     apt-get update
     ${apt_get} install libuuid1:i386 libc6:i386
@@ -96,6 +96,8 @@ function install_packages() {
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
   elif [ "${arch}" == "amd64" ]; then
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+  elif [ "${arch}" == "s390x" ]; then
+    add-apt-repository "deb [arch=s390x] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
   else
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
   fi
@@ -104,7 +106,7 @@ function install_packages() {
 
   apt_clean
 
-  if [ "${arch}" != "arm64" ]; then
+  if [ "${arch}" == "amd64" ]; then
     install_vhd_util
     # Install xenserver guest utilities as debian repos don't have it
     wget --no-check-certificate https://download.cloudstack.org/systemvm/debian/xe-guest-utilities_7.20.2-0ubuntu1_amd64.deb


### PR DESCRIPTION
This flips conditional checks to check specifically for x86_64/amd64 to install dependencies in systemvm.