### PR TITLE
kvm: fallback to cloud-init aware domain product name

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -135,6 +135,9 @@ public class LibvirtVMDef {
         }
 
         public String getProduct() {
+            if (StringUtils.isEmpty(product)) {
+                return "CloudStack KVM Hypervisor";
+            }
             return product;
         }
 


### PR DESCRIPTION
This uses the previously used KVM domain product name when the provided value is null or empty. This ensure backward compatibilty and allow cloud-init to work on KVM+CloudStack setup.

Fixed #9607

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)
