### PR TITLE
Add minimum details parameter to Search View's listDomains

### DIFF
--- a/ui/src/components/view/SearchView.vue
+++ b/ui/src/components/view/SearchView.vue
@@ -706,7 +706,7 @@ export default {
     },
     fetchDomains (searchKeyword) {
       return new Promise((resolve, reject) => {
-        api('listDomains', { listAll: true, showicon: true, keyword: searchKeyword }).then(json => {
+        api('listDomains', { listAll: true, details: 'min', showicon: true, keyword: searchKeyword }).then(json => {
           const domain = json.listdomainsresponse.domain
           resolve({
             type: 'domainid',


### PR DESCRIPTION
### Description

This PR adds the `details: min` parameter to `listDomains`  API call. Since they are used only for ids and names, more details are unnecessary and `listDomains` ends up taking a long time to execute when many domains exist.

In a test environment with 5000 domains, running `time cmk listDomains`  yielded `cmk listDomains 0,31s user 0,11s system 1% cpu 31,200 total`, but `time cmk listDomains details=min` yielded `cmk listDomains details=min 0,14s user 0,04s system 7% cpu 2,521 total`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/4a81bba2-112c-41f6-823e-eb4ea81690e8)

After:
![image](https://github.com/user-attachments/assets/fda20882-4909-42a0-97ed-69e8357de89e)


### How Has This Been Tested?

I set up an environment with 5000 domains and unlimited page size. 

I then checked the Network tab on the browser before and after the changes (see Screenshots).

Searching itself worked normally.