### PR TITLE
[VMware] Make disk controller selection on volume attachment consistent with VM creation and start

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1975,16 +1975,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             return;
         }
 
-        String msg;
-        String rootDiskController = controllerInfo.first();
-        String dataDiskController = controllerInfo.second();
-        String scsiDiskController;
-        String recommendedDiskController = null;
-
-        if (VmwareHelper.isControllerOsRecommended(dataDiskController) || VmwareHelper.isControllerOsRecommended(rootDiskController)) {
-            recommendedDiskController = vmMo.getRecommendedDiskController(null);
-        }
-        scsiDiskController = HypervisorHostHelper.getScsiController(new Pair<String, String>(rootDiskController, dataDiskController), recommendedDiskController);
+        Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(controllerInfo, vmMo, null, null);
+        String scsiDiskController = HypervisorHostHelper.getScsiController(convertedDiskControllers);
         if (scsiDiskController == null) {
             return;
         }
@@ -2337,6 +2329,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             }
 
             int controllerKey;
+            Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(controllerInfo,vmMo, null, null);
 
             //
             // Setup ROOT/DATA disk devices
@@ -2361,10 +2354,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
 
                 VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
-                String diskController = getDiskController(vmMo, matchingExistingDisk, vol, controllerInfo, deployAsIs);
-                if (DiskControllerType.getType(diskController) == DiskControllerType.osdefault) {
-                    diskController = vmMo.getRecommendedDiskController(null);
-                }
+                String diskController = getDiskController(vmMo, matchingExistingDisk, vol, convertedDiskControllers, deployAsIs);
                 if (DiskControllerType.getType(diskController) == DiskControllerType.ide) {
                     controllerKey = vmMo.getIDEControllerKey(ideUnitNumber);
                     if (vol.getType() == Volume.Type.DATADISK) {
@@ -2847,27 +2837,9 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
     }
 
     private Pair<String, String> getControllerInfoFromVmSpec(VirtualMachineTO vmSpec) throws CloudRuntimeException {
-        String dataDiskController = vmSpec.getDetails().get(VmDetailConstants.DATA_DISK_CONTROLLER);
-        String rootDiskController = vmSpec.getDetails().get(VmDetailConstants.ROOT_DISK_CONTROLLER);
-
-        // If root disk controller is scsi, then data disk controller would also be scsi instead of using 'osdefault'
-        // This helps avoid mix of different scsi subtype controllers in instance.
-        if (DiskControllerType.osdefault == DiskControllerType.getType(dataDiskController) && DiskControllerType.lsilogic == DiskControllerType.getType(rootDiskController)) {
-            dataDiskController = DiskControllerType.scsi.toString();
-        }
-
-        // Validate the controller types
-        dataDiskController = DiskControllerType.getType(dataDiskController).toString();
-        rootDiskController = DiskControllerType.getType(rootDiskController).toString();
-
-        if (DiskControllerType.getType(rootDiskController) == DiskControllerType.none) {
-            throw new CloudRuntimeException("Invalid root disk controller detected : " + rootDiskController);
-        }
-        if (DiskControllerType.getType(dataDiskController) == DiskControllerType.none) {
-            throw new CloudRuntimeException("Invalid data disk controller detected : " + dataDiskController);
-        }
-
-        return new Pair<>(rootDiskController, dataDiskController);
+        String rootDiskControllerDetail = vmSpec.getDetails().get(VmDetailConstants.ROOT_DISK_CONTROLLER);
+        String dataDiskControllerDetail = vmSpec.getDetails().get(VmDetailConstants.DATA_DISK_CONTROLLER);
+        return VmwareHelper.getDiskControllersFromVmSettings(rootDiskControllerDetail, dataDiskControllerDetail);
     }
 
     private String getBootModeFromVmSpec(VirtualMachineTO vmSpec, boolean deployAsIs) {
@@ -3615,15 +3587,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             return controllerType.toString();
         }
 
-        if (vol.getType() == Volume.Type.ROOT) {
-            s_logger.info("Chose disk controller for vol " + vol.getType() + " -> " + controllerInfo.first()
-                    + ", based on root disk controller settings at global configuration setting.");
-            return controllerInfo.first();
-        } else {
-            s_logger.info("Chose disk controller for vol " + vol.getType() + " -> " + controllerInfo.second()
-                    + ", based on default data disk controller setting i.e. Operating system recommended."); // Need to bring in global configuration setting & template level setting.
-            return controllerInfo.second();
-        }
+        return VmwareHelper.getControllerBasedOnDiskType(controllerInfo, vol);
     }
 
     private void postDiskConfigBeforeStart(VirtualMachineMO vmMo, VirtualMachineTO vmSpec, DiskTO[] sortedDisks, int ideControllerKey,

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2839,7 +2839,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
     private Pair<String, String> getControllerInfoFromVmSpec(VirtualMachineTO vmSpec) throws CloudRuntimeException {
         String rootDiskControllerDetail = vmSpec.getDetails().get(VmDetailConstants.ROOT_DISK_CONTROLLER);
         String dataDiskControllerDetail = vmSpec.getDetails().get(VmDetailConstants.DATA_DISK_CONTROLLER);
-        return VmwareHelper.getDiskControllersFromVmSettings(rootDiskControllerDetail, dataDiskControllerDetail);
+        VmwareHelper.validateDiskControllerDetails(rootDiskControllerDetail, dataDiskControllerDetail);
+        return new Pair<>(rootDiskControllerDetail, dataDiskControllerDetail);
     }
 
     private String getBootModeFromVmSpec(VirtualMachineTO vmSpec, boolean deployAsIs) {

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1975,8 +1975,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             return;
         }
 
-        Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(controllerInfo, vmMo, null, null);
-        String scsiDiskController = HypervisorHostHelper.getScsiController(convertedDiskControllers);
+        Pair<String, String> chosenDiskControllers = VmwareHelper.chooseRequiredDiskControllers(controllerInfo, vmMo, null, null);
+        String scsiDiskController = HypervisorHostHelper.getScsiController(chosenDiskControllers);
         if (scsiDiskController == null) {
             return;
         }
@@ -2329,7 +2329,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
             }
 
             int controllerKey;
-            Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(controllerInfo,vmMo, null, null);
+            Pair<String, String> chosenDiskControllers = VmwareHelper.chooseRequiredDiskControllers(controllerInfo,vmMo, null, null);
 
             //
             // Setup ROOT/DATA disk devices
@@ -2354,7 +2354,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
 
                 VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
-                String diskController = getDiskController(vmMo, matchingExistingDisk, vol, convertedDiskControllers, deployAsIs);
+                String diskController = getDiskController(vmMo, matchingExistingDisk, vol, chosenDiskControllers, deployAsIs);
                 if (DiskControllerType.getType(diskController) == DiskControllerType.ide) {
                     controllerKey = vmMo.getIDEControllerKey(ideUnitNumber);
                     if (vol.getType() == Volume.Type.DATADISK) {

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -2109,8 +2109,8 @@ public class VmwareStorageProcessor implements StorageProcessor {
                     dataDiskControllerDetail = controllerInfo.get(VmDetailConstants.DATA_DISK_CONTROLLER);
                 }
 
-                Pair<String, String> updatedDiskControllers = VmwareHelper.getDiskControllersFromVmSettings(rootDiskControllerDetail, dataDiskControllerDetail);
-                Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(updatedDiskControllers, vmMo, null, null);
+                VmwareHelper.validateDiskControllerDetails(rootDiskControllerDetail, dataDiskControllerDetail);
+                Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(new Pair<>(rootDiskControllerDetail, dataDiskControllerDetail), vmMo, null, null);
                 String diskController = VmwareHelper.getControllerBasedOnDiskType(convertedDiskControllers, disk);
 
                 vmMo.attachDisk(new String[] { datastoreVolumePath }, morDs, diskController, storagePolicyId, volumeTO.getIopsReadRate() + volumeTO.getIopsWriteRate());

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -2100,15 +2100,18 @@ public class VmwareStorageProcessor implements StorageProcessor {
             AttachAnswer answer = new AttachAnswer(disk);
 
             if (isAttach) {
-                String diskController = getLegacyVmDataDiskController();
-
+                String rootDiskControllerDetail = DiskControllerType.ide.toString();
+                if (controllerInfo != null && StringUtils.isNotEmpty(controllerInfo.get(VmDetailConstants.ROOT_DISK_CONTROLLER))) {
+                    rootDiskControllerDetail = controllerInfo.get(VmDetailConstants.ROOT_DISK_CONTROLLER);
+                }
+                String dataDiskControllerDetail = getLegacyVmDataDiskController();
                 if (controllerInfo != null && StringUtils.isNotEmpty(controllerInfo.get(VmDetailConstants.DATA_DISK_CONTROLLER))) {
-                    diskController = controllerInfo.get(VmDetailConstants.DATA_DISK_CONTROLLER);
+                    dataDiskControllerDetail = controllerInfo.get(VmDetailConstants.DATA_DISK_CONTROLLER);
                 }
 
-                if (DiskControllerType.getType(diskController) == DiskControllerType.osdefault) {
-                    diskController = vmMo.getRecommendedDiskController(null);
-                }
+                Pair<String, String> updatedDiskControllers = VmwareHelper.getDiskControllersFromVmSettings(rootDiskControllerDetail, dataDiskControllerDetail);
+                Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(updatedDiskControllers, vmMo, null, null);
+                String diskController = VmwareHelper.getControllerBasedOnDiskType(convertedDiskControllers, disk);
 
                 vmMo.attachDisk(new String[] { datastoreVolumePath }, morDs, diskController, storagePolicyId, volumeTO.getIopsReadRate() + volumeTO.getIopsWriteRate());
                 VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -2110,8 +2110,8 @@ public class VmwareStorageProcessor implements StorageProcessor {
                 }
 
                 VmwareHelper.validateDiskControllerDetails(rootDiskControllerDetail, dataDiskControllerDetail);
-                Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(new Pair<>(rootDiskControllerDetail, dataDiskControllerDetail), vmMo, null, null);
-                String diskController = VmwareHelper.getControllerBasedOnDiskType(convertedDiskControllers, disk);
+                Pair<String, String> chosenDiskControllers = VmwareHelper.chooseRequiredDiskControllers(new Pair<>(rootDiskControllerDetail, dataDiskControllerDetail), vmMo, null, null);
+                String diskController = VmwareHelper.getControllerBasedOnDiskType(chosenDiskControllers, disk);
 
                 vmMo.attachDisk(new String[] { datastoreVolumePath }, morDs, diskController, storagePolicyId, volumeTO.getIopsReadRate() + volumeTO.getIopsWriteRate());
                 VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
@@ -1567,8 +1567,8 @@ public class HypervisorHostHelper {
 
         VmwareHelper.setBasicVmConfig(vmConfig, cpuCount, cpuSpeedMHz, cpuReservedMHz, memoryMB, memoryReserveMB, guestOsIdentifier, limitCpuUse, false);
 
-        Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(controllerInfo, null, host, guestOsIdentifier);
-        String scsiDiskController = HypervisorHostHelper.getScsiController(convertedDiskControllers);
+        Pair<String, String> chosenDiskControllers = VmwareHelper.chooseRequiredDiskControllers(controllerInfo, null, host, guestOsIdentifier);
+        String scsiDiskController = HypervisorHostHelper.getScsiController(chosenDiskControllers);
         // If there is requirement for a SCSI controller, ensure to create those.
         if (scsiDiskController != null) {
         int busNum = 0;

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
@@ -1567,15 +1567,8 @@ public class HypervisorHostHelper {
 
         VmwareHelper.setBasicVmConfig(vmConfig, cpuCount, cpuSpeedMHz, cpuReservedMHz, memoryMB, memoryReserveMB, guestOsIdentifier, limitCpuUse, false);
 
-        String newRootDiskController = controllerInfo.first();
-        String newDataDiskController = controllerInfo.second();
-        String recommendedController = null;
-        if (VmwareHelper.isControllerOsRecommended(newRootDiskController) || VmwareHelper.isControllerOsRecommended(newDataDiskController)) {
-            recommendedController = host.getRecommendedDiskController(guestOsIdentifier);
-        }
-
-        Pair<String, String> updatedControllerInfo = new Pair<String, String>(newRootDiskController, newDataDiskController);
-        String scsiDiskController = HypervisorHostHelper.getScsiController(updatedControllerInfo, recommendedController);
+        Pair<String, String> convertedDiskControllers = VmwareHelper.convertRecommendedDiskControllers(controllerInfo, null, host, guestOsIdentifier);
+        String scsiDiskController = HypervisorHostHelper.getScsiController(convertedDiskControllers);
         // If there is requirement for a SCSI controller, ensure to create those.
         if (scsiDiskController != null) {
         int busNum = 0;
@@ -2249,19 +2242,11 @@ public class HypervisorHostHelper {
         return morHyperHost;
     }
 
-    public static String getScsiController(Pair<String, String> controllerInfo, String recommendedController) {
+    public static String getScsiController(Pair<String, String> controllerInfo) {
         String rootDiskController = controllerInfo.first();
         String dataDiskController = controllerInfo.second();
 
-        // If "osdefault" is specified as controller type, then translate to actual recommended controller.
-        if (VmwareHelper.isControllerOsRecommended(rootDiskController)) {
-            rootDiskController = recommendedController;
-        }
-        if (VmwareHelper.isControllerOsRecommended(dataDiskController)) {
-            dataDiskController = recommendedController;
-        }
-
-        String scsiDiskController = null; //If any of the controller provided is SCSI then return it's sub-type.
+        String scsiDiskController; //If any of the controller provided is SCSI then return it's sub-type.
         if (isIdeController(rootDiskController) && isIdeController(dataDiskController)) {
             //Default controllers would exist
             return null;

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -1073,7 +1073,6 @@ public class VmwareHelper {
      */
     public static Pair<String, String> getDiskControllersFromVmSettings(String rootDiskControllerDetail,
                                                                         String dataDiskControllerDetail) {
-        // Validate the controller types
         rootDiskControllerDetail = DiskControllerType.getType(rootDiskControllerDetail).toString();
         if (DiskControllerType.getType(rootDiskControllerDetail) == DiskControllerType.none) {
             throw new CloudRuntimeException("Invalid root disk controller detected : " + rootDiskControllerDetail);

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -1091,8 +1091,8 @@ public class VmwareHelper {
      * @param host              host to derive the recommended disk controllers from. Must be provided with <code>guestOsIdentifier</code>.
      * @param guestOsIdentifier used to derive the recommended disk controllers from the host.
      */
-    public static Pair<String, String> convertRecommendedDiskControllers(Pair<String, String> controllerInfo, VirtualMachineMO vmMo,
-                                                                         VmwareHypervisorHost host, String guestOsIdentifier) throws Exception {
+    public static Pair<String, String> chooseRequiredDiskControllers(Pair<String, String> controllerInfo, VirtualMachineMO vmMo,
+                                                                     VmwareHypervisorHost host, String guestOsIdentifier) throws Exception {
         String recommendedDiskControllerClassName = vmMo != null ? vmMo.getRecommendedDiskController(null) : host.getRecommendedDiskController(guestOsIdentifier);
         String recommendedDiskController = DiskControllerType.getType(recommendedDiskControllerClassName).toString();
 


### PR DESCRIPTION
### Description

When both `rootDiskController` and `dataDiskController` details are set to SCSI controllers, the VM creation and start processes prioritize creating and using the controllers specified by `rootDiskController` for all volumes. However, the volume attachment process does not consider this and always tries to attach volumes using the controllers specified for the data disks (even if a root disk is being attached). 

This way, in a scenario where `rootDiskController` is set to `pvscsi` and `dataDiskController` is set to `lsilogic` (one example, as this problem also happens for other combinations) we ignore the `dataDiskController` setting defined by the operator and choose to use only PVSCSI controllers for both the root and data disks on VM creation/start. Then, when a user tries to attach a new data disk, we only consider `dataDiskController` and try to attach with LSI Logic instead. However, the process fails, as there are no LSI Logic controllers because we ignored the data disk controller chosen by the operator and opted to create PVSCSI controllers for both root and data disks when creating/starting the VM. Also, if we detach the root disk and try to attach it again, the process also fails because CloudStack tries to attach it using the controller specified for the data disks.

To solve this issue, this PR makes the volume attachment disk controller selection logic consistent with VM creation/start. Tests will be added in another PR alongside an extension for the disk controllers that I'm currently working on, as it will require me to modify this code again.

Fixes #9400

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

For each of the following `rootDiskController`/`dataDiskController` combinations: 
1. I deployed a VM that had 1 root disk and 1 data disk, and verified which disk controllers were being used for them;
2. I attached a data disk, and verified which disk controller was used;
3. I detached the root disk and attached it again, and verified which disk controller was used.

Below are my results.

| Configuration       | Initial root disk | Initial data disk | (re)Attached root disk | Attached data disk |
|---------------------|-------------------|-------------------|--------------------|--------------------|
| pvscsi/osdefault    | PVSCSI            | PVSCSI            | PVSCSI             | PVSCSI             |
| osdefault/pvscsi    | LSI Logic            | LSI Logic            | LSI Logic             | LSI Logic             |
| osdefault/osdefault | LSI Logic         | LSI Logic         | LSI Logic          | LSI Logic          |
| lsilogic/pvscsi     | LSI Logic         | LSI Logic         | LSI Logic          | LSI Logic          |
| pvscsi/lsilogic     | PVSCSI            | PVSCSI            | PVSCSI             | PVSCSI             |
| ide/ide             | IDE               | IDE               | IDE                | IDE                |
| ide/pvscsi          | IDE               | PVSCSI            | IDE, but see [1]   | PVSCSI             |
| lsilogic/lsilogic   | LSI Logic         | LSI Logic         | LSI Logic          | LSI Logic          |
| ide/osdefault       | IDE         | LSI Logic         | IDE, but see [1]          | LSI Logic          |
| osdefault/ide       | LSI Logic         | IDE         | LSI Logic          | IDE, but see [1]          |

[1] CloudStack tried to attach using an IDE controller. However, an exception happened because it ignored the CDRom when calculating the next available unit number, and tried to attach the disk on an unit number that was already being used. I will fix this issue separately in another PR.