### PR TITLE
Fixed Unable to create a domain when networkdomain is mentioned and cleared

### DIFF
--- a/ui/src/views/iam/DomainActionForm.vue
+++ b/ui/src/views/iam/DomainActionForm.vue
@@ -237,6 +237,11 @@ export default {
 
         const resourceName = params.displayname || params.displaytext || params.name || this.resource.name
         let hasJobId = false
+        Object.keys(params).forEach(key => {
+          if (params[key] === '') {
+            delete params[key]
+          }
+        })
         api(this.action.api, params).then(json => {
           for (const obj in json) {
             if (obj.includes('response')) {


### PR DESCRIPTION
### Description

This PR fixes [!9623](https://github.com/apache/cloudstack/issues/9623)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
I tested this PR by typing inside the networkdomain field in the Add domain form and then clearing it, which ended up working as expected after the proposed changes.
