### PR TITLE
[VMware] Consider CD/DVD drive when calculating next free unit number for volume attachment over IDE controller

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -3171,7 +3171,10 @@ public class VirtualMachineMO extends BaseMO {
         int ideDeviceUnitNumber = -1;
         if (devices != null && devices.size() > 0) {
             for (VirtualDevice device : devices) {
-                if (device instanceof VirtualDisk && (controllerKey == device.getControllerKey())) {
+                if (device.getControllerKey() == null || device.getControllerKey() != controllerKey) {
+                    continue;
+                }
+                if (device instanceof VirtualDisk || device instanceof VirtualCdrom) {
                     deviceCount++;
                     ideDeviceUnitNumber = device.getUnitNumber();
                 }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -3169,7 +3169,7 @@ public class VirtualMachineMO extends BaseMO {
 
         int deviceCount = 0;
         int ideDeviceUnitNumber = -1;
-        if (devices != null && devices.size() > 0) {
+        if (devices != null) {
             for (VirtualDevice device : devices) {
                 if (device.getControllerKey() == null || device.getControllerKey() != controllerKey) {
                     continue;


### PR DESCRIPTION
### Description

When attaching a volume to an instance, CloudStack calculates the next free unit number of the disk controller that should be associated with the volume. However, for IDE disk controllers, CD/DVD drives associated with the controller are not taken into consideration when calculating the next available unit number. Due to this, an error happens in some situations when trying to attach a volume to an instance over IDE controllers because CloudStack tries to associate the volume to an unit number that is already being used.

The generic method of reproducing this problem is:
1. Deploy a VM
2. Set `dataDiskController` to `ide`
3. If there are any volumes using IDE controllers, detach them
4. Try to attach a volume

This PR fixes the issue by making the code also consider CD/DVD drives. Tests will be added in another PR alongside an extension for the disk controllers that I'm currently working on, as it will require me to modify this code again.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

1. I deployed a VM from a template with both `rootDiskController` and `dataDiskController` set to `ide`, with only a root disk
2. I detached the root disk
3. I reattached the root disk. Before, an exception would be thrown in this step. After the changes, I verified that the volume was associated successfully to IDE(0:1)
5. I attached a data disk. I verified that the volume was associated successfully to IDE(1:0)
6. I attached another data disk. I verified that the volume was associated successfully to IDE(1:1)
7. I tried to attach another data disk. I verified that an exception was thrown because the maximum number of devices over IDE controllers was reached