### PR TITLE
engine/schema: update url links to match new systemvmtemplate names

### DIFF
--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -101,11 +101,11 @@
                                     def csVersion = project.properties.getProperty('cs.version')
                                     def patch = project.properties.getProperty('patch.version')
                                     def templateList = []
-                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-kvm")
-                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-vmware")
-                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-xen")
-                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-ovm")
-                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-hyperv")
+                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-x86_64-kvm")
+                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-x86_64-vmware")
+                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-x86_64-xen")
+                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-x86_64-ovm")
+                                    templateList.add("systemvmtemplate-${csVersion}.${patch}-x86_64-hyperv")
                                     File file = new File("./engine/schema/dist/systemvm-templates/md5sum.txt")
                                     def lines = file.readLines()
                                     for (template in templateList) {
@@ -194,7 +194,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-kvm.qcow2.bz2</url>
+                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-x86_64-kvm.qcow2.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${kvm.checksum}</md5>
                                 </configuration>
@@ -230,7 +230,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-vmware.ova</url>
+                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-x86_64-vmware.ova</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${vmware.checksum}</md5>
                                 </configuration>
@@ -266,7 +266,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-xen.vhd.bz2</url>
+                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-x86_64-xen.vhd.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${xen.checksum}</md5>
                                 </configuration>
@@ -302,7 +302,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-ovm.raw.bz2</url>
+                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-x86_64-ovm.raw.bz2</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${ovm.checksum}</md5>
                                 </configuration>
@@ -338,7 +338,7 @@
                                 </goals>
                                 <configuration>
                                     <checkSignature>true</checkSignature>
-                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-hyperv.vhd.zip</url>
+                                    <url>${project.systemvm.template.location}/${cs.version}/systemvmtemplate-${cs.version}.${patch.version}-x86_64-hyperv.vhd.zip</url>
                                     <outputDirectory>${basedir}/dist/systemvm-templates/</outputDirectory>
                                     <md5>${hyperv.checksum}</md5>
                                 </configuration>

--- a/engine/schema/templateConfig.sh
+++ b/engine/schema/templateConfig.sh
@@ -60,22 +60,23 @@ function createMetadataFile() {
     section="${template%%:*}"
     hvName=$(getGenericName $section)
 
-    templatename="systemvm-${section}-${VERSION}"
-    checksum=$(getChecksum "$fileData" "$VERSION-$hvName")
     downloadurl="${template#*:}"
+    arch=$(echo ${downloadurl#*"/systemvmtemplate-$VERSION-"} | cut -d'-' -f 1)
+    templatename="systemvm-${section%.*}-${VERSION}-${arch}"
+    checksum=$(getChecksum "$fileData" "$VERSION-${arch}-$hvName")
     filename=$(echo ${downloadurl##*'/'})
-    echo -e "["$section"]\ntemplatename = $templatename\nchecksum = $checksum\ndownloadurl = $downloadurl\nfilename = $filename\n" >> $METADATAFILE
+    echo -e "["$section"]\ntemplatename = $templatename\nchecksum = $checksum\ndownloadurl = $downloadurl\nfilename = $filename\narch = $arch\n" >> $METADATAFILE
   done
 }
 
 declare -a templates
 getTemplateVersion $1
-templates=( "kvm:https://download.cloudstack.org/systemvm/${CS_VERSION}/systemvmtemplate-$VERSION-kvm.qcow2.bz2"
-            "vmware:https://download.cloudstack.org/systemvm/${CS_VERSION}/systemvmtemplate-$VERSION-vmware.ova"
-            "xenserver:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-xen.vhd.bz2"
-            "hyperv:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-hyperv.vhd.zip"
-            "lxc:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-kvm.qcow2.bz2"
-            "ovm3:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-ovm.raw.bz2" )
+templates=( "kvm:https://download.cloudstack.org/systemvm/${CS_VERSION}/systemvmtemplate-$VERSION-x86_64-kvm.qcow2.bz2"
+            "vmware:https://download.cloudstack.org/systemvm/${CS_VERSION}/systemvmtemplate-$VERSION-x86_64-vmware.ova"
+            "xenserver:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-x86_64-xen.vhd.bz2"
+            "hyperv:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-x86_64-hyperv.vhd.zip"
+            "lxc:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-x86_64-kvm.qcow2.bz2"
+            "ovm3:https://download.cloudstack.org/systemvm/$CS_VERSION/systemvmtemplate-$VERSION-x86_64-ovm.raw.bz2" )
 
 PARENTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/dist/systemvm-templates/"
 mkdir -p $PARENTPATH


### PR DESCRIPTION
This handles new systemvmtemplate renames which now includes arch detail in the file name and URL. By default, it continues to use x86_64 for automatic systemvmtemplate seeding and upgrades only.

The systemvmtemplate filenames now have arch flag/substring - https://download.cloudstack.org/systemvm/4.20/ due to which this PR is necessary.