### PR TITLE
UI: Fix starting VMs through group action by non-root-admin users

### DIFF
--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -120,7 +120,13 @@ export default {
           groupAction: true,
           popup: true,
           groupMap: (selection, values) => { return selection.map(x => { return { id: x, considerlasthost: values.considerlasthost } }) },
-          args: ['considerlasthost'],
+          args: (record, store) => {
+            if (['Admin'].includes(store.userInfo.roletype)) {
+              return ['considerlasthost']
+            }
+
+            return []
+          },
           show: (record) => { return ['Stopped'].includes(record.state) },
           component: shallowRef(defineAsyncComponent(() => import('@/views/compute/StartVirtualMachine.vue')))
         },


### PR DESCRIPTION
### Description

When non-root-admin users try to start multiple virtual machines, the form does not provide options to cancel or confirm the operation.

This PR fixes this bug.

---

Fixes #9651

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/f5d1fded-ad55-44db-a1b5-f6302db51566)

</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/c2e5c61c-f1fa-4eae-92f8-e95184c73f8c)

</details>

### How Has This Been Tested?

- With a non-root-admin user, I selected the option to start multiple virtual machines, and verified that I was able to confirm and cancel the operation.
- With a root admin user, I selected the option to start multiple virtual machines, and verified that the `Consider Last Host` field was rendered correctly.
