### PR TITLE
Fix the Cloudian Integration SSO Redirect link

### DIFF
--- a/plugins/integrations/cloudian/src/main/java/org/apache/cloudstack/cloudian/client/CloudianUtils.java
+++ b/plugins/integrations/cloudian/src/main/java/org/apache/cloudstack/cloudian/client/CloudianUtils.java
@@ -81,12 +81,8 @@ public class CloudianUtils {
             return null;
         }
 
-        stringBuilder.append("&redirect=");
-        if (group.equals("0")) {
-            stringBuilder.append("admin.htm");
-        } else {
-            stringBuilder.append("explorer.htm");
-        }
+        // Redirects to dashboard for admin users or the bucket browser for regular users
+        stringBuilder.append("&redirect=/");
 
         return cmcUrlPath + "ssosecurelogin.htm?" + stringBuilder.toString();
     }


### PR DESCRIPTION
### Description

The Single Sign On (SSO) URL that the CloudStack Cloudian Integration plugin generates includes a `redirect` portion. This used to be required on the older 6.x Cloudian Management Console (CMC) in order for the admin user to see an appropriate page on login. As of 7.x+, it is better to `redirect` both types of users to `/` and let CMC display the appropriate page.

Unfortunately as this is an integration it may be difficult to confirm this fix without running Cloudian HyperStore on your network and configuring the Cloudian plugin as per CloudStack documentation. Please see the screenshots below for the before and after.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

Before applying this fix, when the "Cloudian Storage" integration button on the left is clicked and SSO does its magic to open up CMC in a new tab, the user is logged in but is redirected to `explorer.htm` which no longer exists in 7.x versions of Cloudian HyperStore.
<img width="1142" alt="CMC_broken_redirect" src="https://github.com/user-attachments/assets/668b4a93-b9bd-4715-a836-a1d34ce55f7a">

Post Fix `admin` user is correctly redirected to `dashboard.htm`:
<img width="1214" alt="CMC_admin_redirect_fixed" src="https://github.com/user-attachments/assets/123d3b9d-fddc-4ec6-bca3-133177db6817">

Post Fix a regular user is correctly redirected to `bucket.htm`:
<img width="1235" alt="CMC_user_redirect_fixed" src="https://github.com/user-attachments/assets/81e519b5-e520-48c0-a3cf-ce9511cd3234">

### How Has This Been Tested?

This fix only modifies a single function `generateSSOUrl()` which is part of the Cloudian Integration plugin code. To test this fix, I configured CloudStack to enable the Cloudian plugin and pointed it at a Cloudian HyperStore system that I have on my network. I tried the plugin without the fix first to confirm existing broken behaviour and then I applied the fix, recompiled and retested to confirm the changes worked as expected. I took screenshots (above) showing each of the cases.

#### How did you try to break this feature and the system with this change?

N/A