### PR TITLE
PowerFlex on demand disable config key

### DIFF
--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -24,6 +24,8 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStore;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.client.ScaleIOGatewayClient;
 import org.apache.cloudstack.storage.datastore.client.ScaleIOGatewayClientConnectionPool;
@@ -51,8 +53,16 @@ import com.cloud.utils.db.GlobalLock;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
-public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
+public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
     private Logger logger = LogManager.getLogger(getClass());
+
+    static ConfigKey<Boolean> ConnectOnDemand = new ConfigKey<>("Storage",
+            Boolean.class,
+            "powerflex.connect.on.demand",
+            Boolean.FALSE.toString(),
+            "Connect PowerFlex client on Host when first Volume created and disconnect when last Volume deleted (or always stay connected otherwise).",
+            Boolean.TRUE,
+            ConfigKey.Scope.Zone);
 
     @Inject
     AgentManager agentManager;
@@ -94,6 +104,11 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
 
     @Override
     public String prepareSDC(Host host, DataStore dataStore) {
+        if (Boolean.FALSE.equals(ConnectOnDemand.valueIn(host.getDataCenterId()))) {
+            logger.debug(String.format("On-demand connect/disconnect config %s disabled in the zone %d, no need to prepare SDC (check for connected SDC)", ConnectOnDemand.key(), host.getDataCenterId()));
+            return getConnectedSdc(host, dataStore);
+        }
+
         String systemId = storagePoolDetailsDao.findDetail(dataStore.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID).getValue();
         if (systemId == null) {
             throw new CloudRuntimeException("Unable to prepare SDC, failed to get the system id for PowerFlex storage pool: " + dataStore.getName());
@@ -116,7 +131,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
 
             long poolId = dataStore.getId();
             long hostId = host.getId();
-            String sdcId = getConnectedSdc(poolId, hostId);
+            String sdcId = getConnectedSdc(host, dataStore);
             if (StringUtils.isNotBlank(sdcId)) {
                 logger.debug(String.format("SDC %s already connected for the pool: %d on host: %d, no need to prepare/start it", sdcId, poolId, hostId));
                 return sdcId;
@@ -227,6 +242,11 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
 
     @Override
     public boolean stopSDC(Host host, DataStore dataStore) {
+        if (Boolean.FALSE.equals(ConnectOnDemand.valueIn(host.getDataCenterId()))) {
+            logger.debug(String.format("On-demand connect/disconnect config %s disabled in the zone %d, no need to unprepare SDC", ConnectOnDemand.key(), host.getDataCenterId()));
+            return true;
+        }
+
         String systemId = storagePoolDetailsDao.findDetail(dataStore.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID).getValue();
         if (systemId == null) {
             throw new CloudRuntimeException("Unable to unprepare SDC, failed to get the system id for PowerFlex storage pool: " + dataStore.getName());
@@ -248,7 +268,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
 
             long poolId = dataStore.getId();
             long hostId = host.getId();
-            String sdcId = getConnectedSdc(poolId, hostId);
+            String sdcId = getConnectedSdc(host, dataStore);
             if (StringUtils.isBlank(sdcId)) {
                 logger.debug("SDC not connected, no need to unprepare it");
                 return true;
@@ -297,7 +317,10 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
         }
     }
 
-    private String getConnectedSdc(long poolId, long hostId) {
+    private String getConnectedSdc(Host host, DataStore dataStore) {
+        long poolId = dataStore.getId();
+        long hostId = host.getId();
+
         try {
             StoragePoolHostVO poolHostVO = storagePoolHostDao.findByPoolHost(poolId, hostId);
             if (poolHostVO == null) {
@@ -343,5 +366,15 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager {
 
     private ScaleIOGatewayClient getScaleIOClient(final Long storagePoolId) throws Exception {
         return ScaleIOGatewayClientConnectionPool.getInstance().getClient(storagePoolId, storagePoolDetailsDao);
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return ScaleIOSDCManager.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey[]{ConnectOnDemand};
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -60,7 +60,8 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
             Boolean.class,
             "powerflex.connect.on.demand",
             Boolean.FALSE.toString(),
-            "Connect PowerFlex client on Host when first Volume created and disconnect when last Volume deleted (or always stay connected otherwise).",
+            "Connect PowerFlex client on Host when first Volume is mapped to SDC and disconnect when last Volume is unmapped from SDC," +
+                    " otherwise no action (that is connection remains in the same state whichever it is, connected or disconnected).",
             Boolean.TRUE,
             ConfigKey.Scope.Zone);
 


### PR DESCRIPTION
### Description

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
Added configuration key `powerflex.connect.on.demand`. When set to `false`, then logic in ScaleIO plugin to disconnect Host from the storage pool when there are no volumes and connect Host to storage pool when new volume created will not be used (https://github.com/apache/cloudstack/pull/9268).

The reason for that - plugin's connect/disconnect logic stops and starts `scini` service. If Host connected to multiple storage pools, then it won't be disconnected from unused pools, there will be all or none. Also we observed `scini` stability issue - after multiple start/stop it is not always starting back properly.
For now we would like to have flag to enable/disable this feature.

In addition, as part of the PR, added SQL to update `resource_reservation` table with two new columns. Right now we are copy-pasting that SQL within RPMs to be executed during deployment, but having migration script would be better issue.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
<img width="1406" alt="Screenshot 2024-08-15 at 6 09 24 PM" src="https://github.com/user-attachments/assets/a0c21841-a709-4610-bcb9-742953cd155f">


### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested manually.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
