### PR TITLE
Update of the schema 41910to42000.sql for compatibility with MariaDB version 10.3.38.

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to42000.sql
@@ -193,8 +193,8 @@ CREATE TABLE `cloud`.`ip4_guest_subnet_network_map` (
    CONSTRAINT `uc_ip4_guest_subnet_network_map__uuid` UNIQUE (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-ALTER TABLE `cloud`.`network_offerings` RENAME COLUMN `nsx_mode` TO `network_mode`;
-ALTER TABLE `cloud`.`vpc_offerings` RENAME COLUMN `nsx_mode` TO `network_mode`;
+CALL `cloud`.`IDEMPOTENT_CHANGE_COLUMN`('network_offerings',  'nsx_mode', 'network_mode', 'varchar(32)  COMMENT "mode in which the network would route traffic"');
+CALL `cloud`.`IDEMPOTENT_CHANGE_COLUMN`('vpc_offerings', 'nsx_mode', 'network_mode', 'varchar(32)  COMMENT "mode in which the network would route traffic"');
 ALTER TABLE `cloud`.`event` MODIFY COLUMN `type` varchar(50) NOT NULL;
 
 -- Add tables for AS Numbers and range


### PR DESCRIPTION
### Description

This PR changes two column renames in `schema-41910to42000.sql`. Using MariaDB version `10.3.38-MariaDB`, some lines are not applying the expected changes to the column names in the tables. This issue results in errors during the version transition process.

The modifications made to the schema-41910to42000.sql ensure that changes to the tables are applied correctly. With these fixes, the transition between versions should proceed successfully, without errors.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

I made the mentioned changes, and the transition between versions went as expected.