### PR TITLE
Implemented the lateral expansion of the area-box in the forms (creat…

### DIFF
--- a/ui/src/style/objects/form.scss
+++ b/ui/src/style/objects/form.scss
@@ -18,11 +18,20 @@
 .form {
   width: 80vw;
 
-  .full-width-input {
-    width: 100%;
-  }
-
   @media (min-width: 500px) {
-    width: 400px;
+    width: fit-content;
+    min-width: 20vw;
   }
 }
+
+.form textarea {
+  resize: both;
+  min-width: 20vw;
+  max-width: 80vw;
+}
+
+.ant-input-number,
+.ant-calendar-picker {
+  width: 100%;
+}
+


### PR DESCRIPTION
### Description
Currently, the expansion of the textarea field in the _quota tariff_ creation and update forms is limited to vertical growth. This can make the experience unsatisfactory for entering larger texts, as the field does not expand horizontally, which can hinder the visualization and editing of the content.

Changes have been made to the UI to allow the textarea to expand in both directions (vertical and horizontal).

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

1- Accessed the create form and update form for quota tariff.
2- Verified that the textarea fields now expand horizontally as well as vertically.
3- Ensured that the enhanced textarea functionality works as expected in different scenarios.