### PR TITLE
UI: Improve filtering of VM and template settings

### DIFF
--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -39,7 +39,7 @@
           <a-auto-complete
             class="detail-input"
             ref="keyElm"
-            :filterOption="filterOption"
+            :filterOption="(input, option) => filterOption(input, option, 'key')"
             v-model:value="newKey"
             :options="detailKeys"
             :placeholder="$t('label.name')"
@@ -51,7 +51,7 @@
             disabled />
           <a-auto-complete
             class="detail-input"
-            :filterOption="filterOption"
+            :filterOption="(input, option) => filterOption(input, option, 'value')"
             v-model:value="newValue"
             :options="detailValues"
             :placeholder="$t('label.value')"
@@ -188,7 +188,12 @@ export default {
     this.updateResource(this.resource)
   },
   methods: {
-    filterOption (input, option) {
+    filterOption (input, option, filterType) {
+      if ((filterType === 'key' && !this.newKey) ||
+        (filterType === 'value' && !this.newValue)) {
+        return true
+      }
+
       return (
         option.value.toUpperCase().indexOf(input.toUpperCase()) >= 0
       )

--- a/ui/src/components/view/DetailSettings.vue
+++ b/ui/src/components/view/DetailSettings.vue
@@ -176,7 +176,7 @@ export default {
         if (this.detailOptions[this.newKey]) {
           return { value: this.detailOptions[this.newKey] }
         } else {
-          return ''
+          return []
         }
       }
       return this.detailOptions[this.newKey].map(value => {


### PR DESCRIPTION
### Description

When manipulating VM and template settings, the UI provides a dropdown with the available setting names and values. However, if a user first adds a setting and then tries to add another, the dropdown only shows the previously added setting's name and value.

Furthermore, whenever the user types a character into the setting name input field, a Vue warning is thrown in the console, stating that an incorrect value type has been passed to the `options` prop of the `a-auto-complete` component.

Therefore, this PR improves VM and template settings filtering by always displaying the available setting names and their values, even when a setting has already been added. Besides that, the Vue warning has been properly fixed.

---

Fixes #8074

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/8f8b851a-919e-4f98-b135-7760d68a2185)

![image](https://github.com/user-attachments/assets/415ad6d9-1cf6-4af5-a194-c1116eed967f)

### How Has This Been Tested?

1. When adding the first setting of a VM/template, I verified that all available setting names and their values were displayed correctly in the dropdowns.
2. I then added another setting, and all available setting names and their values were also displayed correctly.
3. When typing the setting name in the input field, I confirmed that no warnings were thrown.
