### PR TITLE
Ownership selection in VPC tiers and VPC public IPs

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -996,6 +996,7 @@ public class ApiConstants {
     public static final String VPC_OFF_NAME = "vpcofferingname";
     public static final String VPC_OFFERING_CONSERVE_MODE = "vpcofferingconservemode";
     public static final String NETWORK = "network";
+    public static final String VPC_ACCESS = "vpcaccess";
     public static final String VPC_ID = "vpcid";
     public static final String VPC_NAME = "vpcname";
     public static final String VPC_GATEWAY_ID = "vpcgatewayid";

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
@@ -240,7 +240,7 @@ public class ListNetworksCmd extends BaseListRetrieveOnlyResourceCountCmd implem
     private void updateNetworkResponse(List<NetworkResponse> response) {
         for (NetworkResponse networkResponse : response) {
             ResourceIcon resourceIcon = resourceIconManager.getByResourceTypeAndUuid(ResourceTag.ResourceObjectType.Network, networkResponse.getId());
-            if (resourceIcon == null && networkResponse.getVpcId() != null) {
+            if (resourceIcon == null && networkResponse.getVpcId() != null && networkResponse.getVpcAccess()) {
                 resourceIcon = resourceIconManager.getByResourceTypeAndUuid(ResourceTag.ResourceObjectType.Vpc, networkResponse.getVpcId());
             }
             if (resourceIcon == null) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/IPAddressResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/IPAddressResponse.java
@@ -144,7 +144,7 @@ public class IPAddressResponse extends BaseResponseWithAnnotations implements Co
     private String purpose;
 
     @SerializedName(ApiConstants.VPC_ACCESS)
-    @Param(description = "Whether the calling account has access to this network's VPC", since = "4.20")
+    @Param(description = "Whether the calling account has access to this network's VPC", since = "4.21.0")
     private boolean vpcAccess;
 
     @SerializedName(ApiConstants.VPC_ID)

--- a/api/src/main/java/org/apache/cloudstack/api/response/IPAddressResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/IPAddressResponse.java
@@ -143,6 +143,10 @@ public class IPAddressResponse extends BaseResponseWithAnnotations implements Co
     @Param(description = "Purpose of the IP address. In Acton this value is not null for IPs with isSystem=true, and can have either StaticNat or LB value")
     private String purpose;
 
+    @SerializedName(ApiConstants.VPC_ACCESS)
+    @Param(description = "Whether the calling account has access to this network's VPC", since = "4.20")
+    private boolean vpcAccess;
+
     @SerializedName(ApiConstants.VPC_ID)
     @Param(description = "VPC ID the IP belongs to")
     private String vpcId;
@@ -299,6 +303,10 @@ public class IPAddressResponse extends BaseResponseWithAnnotations implements Co
 
     public void setPurpose(String purpose) {
         this.purpose = purpose;
+    }
+
+    public void setVpcAccess(boolean vpcAccess) {
+        this.vpcAccess = vpcAccess;
     }
 
     public void setVpcId(String vpcId) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -205,7 +205,7 @@ public class NetworkResponse extends BaseResponseWithAssociatedNetwork implement
 
     @SerializedName(ApiConstants.VPC_ACCESS)
     @Param(description = "Whether the calling account has access to this network's VPC", since = "4.20")
-    private boolean vpcAccess;
+    private Boolean vpcAccess;
 
     @SerializedName(ApiConstants.VPC_ID)
     @Param(description = "VPC the Network belongs to")
@@ -531,7 +531,7 @@ public class NetworkResponse extends BaseResponseWithAssociatedNetwork implement
         this.vpcAccess = vpcAccess;
     }
 
-    public boolean getVpcAccess() {
+    public Boolean getVpcAccess() {
         return vpcAccess;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -203,6 +203,10 @@ public class NetworkResponse extends BaseResponseWithAssociatedNetwork implement
     @Param(description = "True if Network supports specifying IP ranges, false otherwise")
     private Boolean specifyIpRanges;
 
+    @SerializedName(ApiConstants.VPC_ACCESS)
+    @Param(description = "Whether the calling account has access to this network's VPC", since = "4.20")
+    private boolean vpcAccess;
+
     @SerializedName(ApiConstants.VPC_ID)
     @Param(description = "VPC the Network belongs to")
     private String vpcId;
@@ -521,6 +525,14 @@ public class NetworkResponse extends BaseResponseWithAssociatedNetwork implement
 
     public void setSpecifyIpRanges(Boolean specifyIpRanges) {
         this.specifyIpRanges = specifyIpRanges;
+    }
+
+    public void setVpcAccess(boolean vpcAccess) {
+        this.vpcAccess = vpcAccess;
+    }
+
+    public boolean getVpcAccess() {
+        return vpcAccess;
     }
 
     public void setVpcId(String vpcId) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkResponse.java
@@ -204,7 +204,7 @@ public class NetworkResponse extends BaseResponseWithAssociatedNetwork implement
     private Boolean specifyIpRanges;
 
     @SerializedName(ApiConstants.VPC_ACCESS)
-    @Param(description = "Whether the calling account has access to this network's VPC", since = "4.20")
+    @Param(description = "Whether the calling account has access to this network's VPC", since = "4.21.0")
     private Boolean vpcAccess;
 
     @SerializedName(ApiConstants.VPC_ID)

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1262,6 +1262,25 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         vpcUuidSetter.accept(vpc.getUuid());
     }
 
+    private void setAclIdInResponse(Network network, NetworkResponse response) {
+        if (network.getNetworkACLId() == null) {
+            return;
+        }
+
+        NetworkACL acl = ApiDBUtils.findByNetworkACLId(network.getNetworkACLId());
+        if (acl == null) {
+            return;
+        }
+
+        if (!response.getVpcAccess() && acl.getVpcId() != 0) {
+            logger.debug("[{}] not set in response, since caller does not have access to it.", acl);
+            return;
+        }
+
+        response.setAclId(acl.getUuid());
+        response.setAclName(acl.getName());
+    }
+
     private void showVmInfoForSharedNetworks(boolean forVirtualNetworks, IpAddress ipAddr, IPAddressResponse ipResponse) {
         if (!forVirtualNetworks) {
             NicVO nic = ApiDBUtils.findByIp4AddressAndNetworkId(ipAddr.getAddress().toString(), ipAddr.getNetworkId());
@@ -2804,6 +2823,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         response.setSpecifyIpRanges(network.getSpecifyIpRanges());
 
         setVpcIdInResponse(network.getVpcId(), response::setVpcId, response::setVpcName, response::setVpcAccess);
+        setAclIdInResponse(network, response);
 
         setResponseAssociatedNetworkInformation(response, network.getId());
 
@@ -2819,14 +2839,6 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         response.setTags(tagResponses);
         response.setHasAnnotation(annotationDao.hasAnnotations(network.getUuid(), AnnotationService.EntityType.NETWORK.name(),
                 _accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())));
-
-        if (network.getNetworkACLId() != null) {
-            NetworkACL acl = ApiDBUtils.findByNetworkACLId(network.getNetworkACLId());
-            if (acl != null) {
-                response.setAclId(acl.getUuid());
-                response.setAclName(acl.getName());
-            }
-        }
 
         response.setStrechedL2Subnet(network.isStrechedL2Network());
         if (network.isStrechedL2Network()) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1167,7 +1167,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         }
 
 
-        setVpcIdInResponse(ipAddr.getVpcId(), ipResponse::setVpcId, ipResponse::setVpcName);
+        setVpcIdInResponse(ipAddr.getVpcId(), ipResponse::setVpcId, ipResponse::setVpcName, ipResponse::setVpcAccess);
 
 
         // Network id the ip is associated with (if associated networkId is
@@ -1242,20 +1242,24 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         return ipResponse;
     }
 
-
-    private void setVpcIdInResponse(Long vpcId, Consumer<String> vpcUuidSetter, Consumer<String> vpcNameSetter) {
-        if (vpcId != null) {
-            Vpc vpc = ApiDBUtils.findVpcById(vpcId);
-            if (vpc != null) {
-                try {
-                    _accountMgr.checkAccess(CallContext.current().getCallingAccount(), null, false, vpc);
-                    vpcUuidSetter.accept(vpc.getUuid());
-                } catch (PermissionDeniedException e) {
-                    logger.debug("Not setting the vpcId to the response because the caller does not have access to the VPC");
-                }
-                vpcNameSetter.accept(vpc.getName());
-            }
+    private void setVpcIdInResponse(Long vpcId, Consumer<String> vpcUuidSetter, Consumer<String> vpcNameSetter, Consumer<Boolean> vpcAccessSetter) {
+        if (vpcId == null) {
+            return;
         }
+        Vpc vpc = ApiDBUtils.findVpcById(vpcId);
+        if (vpc == null) {
+            return;
+        }
+
+        try {
+            _accountMgr.checkAccess(CallContext.current().getCallingAccount(), null, false, vpc);
+            vpcAccessSetter.accept(true);
+        } catch (PermissionDeniedException e) {
+            vpcAccessSetter.accept(false);
+            logger.debug("Setting [%s] as false because the caller does not have access to the VPC [%s].", ApiConstants.VPC_ACCESS, vpc);
+        }
+        vpcNameSetter.accept(vpc.getName());
+        vpcUuidSetter.accept(vpc.getUuid());
     }
 
     private void showVmInfoForSharedNetworks(boolean forVirtualNetworks, IpAddress ipAddr, IPAddressResponse ipResponse) {
@@ -2799,7 +2803,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
 
         response.setSpecifyIpRanges(network.getSpecifyIpRanges());
 
-        setVpcIdInResponse(network.getVpcId(), response::setVpcId, response::setVpcName);
+        setVpcIdInResponse(network.getVpcId(), response::setVpcId, response::setVpcName, response::setVpcAccess);
 
         setResponseAssociatedNetworkInformation(response, network.getId());
 

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1242,7 +1242,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         return ipResponse;
     }
 
-    private void setVpcIdInResponse(Long vpcId, Consumer<String> vpcUuidSetter, Consumer<String> vpcNameSetter, Consumer<Boolean> vpcAccessSetter) {
+    protected void setVpcIdInResponse(Long vpcId, Consumer<String> vpcUuidSetter, Consumer<String> vpcNameSetter, Consumer<Boolean> vpcAccessSetter) {
         if (vpcId == null) {
             return;
         }
@@ -1262,7 +1262,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
         vpcUuidSetter.accept(vpc.getUuid());
     }
 
-    private void setAclIdInResponse(Network network, NetworkResponse response) {
+    protected void setAclIdInResponse(Network network, NetworkResponse response) {
         if (network.getNetworkACLId() == null) {
             return;
         }
@@ -1272,7 +1272,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
             return;
         }
 
-        if (!response.getVpcAccess() && acl.getVpcId() != 0) {
+        if (Boolean.FALSE.equals(response.getVpcAccess()) && acl.getVpcId() != 0) {
             logger.debug("[{}] not set in response, since caller does not have access to it.", acl);
             return;
         }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1256,7 +1256,7 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
             vpcAccessSetter.accept(true);
         } catch (PermissionDeniedException e) {
             vpcAccessSetter.accept(false);
-            logger.debug("Setting [%s] as false because the caller does not have access to the VPC [%s].", ApiConstants.VPC_ACCESS, vpc);
+            logger.debug("Setting [{}] as false because the caller does not have access to the VPC [{}].", ApiConstants.VPC_ACCESS, vpc);
         }
         vpcNameSetter.accept(vpc.getName());
         vpcUuidSetter.accept(vpc.getUuid());

--- a/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
+++ b/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
@@ -247,7 +247,7 @@ public class ApiResponseHelperTest {
     public void setResponseIpAddressTestIpv4() {
         NicSecondaryIp result = Mockito.mock(NicSecondaryIp.class);
         NicSecondaryIpResponse response = new NicSecondaryIpResponse();
-        setResult(result, "ipv4", "");
+        setResult(result, "ipv4", "ipv6");
 
         ApiResponseHelper.setResponseIpAddress(result, response);
 

--- a/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
+++ b/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
@@ -247,7 +247,7 @@ public class ApiResponseHelperTest {
     public void setResponseIpAddressTestIpv4() {
         NicSecondaryIp result = Mockito.mock(NicSecondaryIp.class);
         NicSecondaryIpResponse response = new NicSecondaryIpResponse();
-        setResult(result, "ipv4", "ipv6");
+        setResult(result, "ipv4", "");
 
         ApiResponseHelper.setResponseIpAddress(result, response);
 

--- a/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
+++ b/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
@@ -83,40 +83,16 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import org.apache.cloudstack.annotation.dao.AnnotationDao;
 import org.apache.cloudstack.api.ResponseObject;
-import org.apache.cloudstack.api.response.AutoScaleVmGroupResponse;
-import org.apache.cloudstack.api.response.AutoScaleVmProfileResponse;
 import org.apache.cloudstack.api.response.ConsoleSessionResponse;
-import org.apache.cloudstack.api.response.DirectDownloadCertificateResponse;
 import org.apache.cloudstack.api.response.GuestOSCategoryResponse;
-import org.apache.cloudstack.api.response.IpQuarantineResponse;
-import org.apache.cloudstack.api.response.NicSecondaryIpResponse;
 import org.apache.cloudstack.api.response.ResourceIconResponse;
 import org.apache.cloudstack.api.response.TemplateResponse;
-import org.apache.cloudstack.api.response.UnmanagedInstanceResponse;
-import org.apache.cloudstack.api.response.UsageRecordResponse;
 import org.apache.cloudstack.api.response.TrafficTypeResponse;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.usage.UsageService;
-import org.apache.cloudstack.vm.UnmanagedInstanceTO;
 
-import com.cloud.capacity.Capacity;
-import com.cloud.configuration.Resource;
-import com.cloud.domain.DomainVO;
 import com.cloud.host.HostVO;
 import com.cloud.network.Networks;
 import com.cloud.network.PhysicalNetworkTrafficType;
-import com.cloud.network.PublicIpQuarantine;
-import com.cloud.network.as.AutoScaleVmGroup;
-import com.cloud.network.as.AutoScaleVmGroupVO;
-import com.cloud.network.as.AutoScaleVmProfileVO;
-import com.cloud.network.as.dao.AutoScaleVmGroupVmMapDao;
-import com.cloud.network.dao.IPAddressDao;
-import com.cloud.network.dao.IPAddressVO;
-import com.cloud.network.dao.LoadBalancerVO;
-import com.cloud.network.dao.NetworkServiceMapDao;
-import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.dao.PhysicalNetworkTrafficTypeVO;
 import com.cloud.resource.icon.ResourceIconVO;
@@ -124,19 +100,7 @@ import com.cloud.server.ResourceIcon;
 import com.cloud.server.ResourceIconManager;
 import com.cloud.server.ResourceTag;
 import com.cloud.storage.GuestOsCategory;
-import com.cloud.storage.VMTemplateVO;
-import com.cloud.usage.UsageVO;
-import com.cloud.user.Account;
-import com.cloud.user.AccountManager;
-import com.cloud.user.AccountVO;
-import com.cloud.user.User;
-import com.cloud.user.UserData;
-import com.cloud.user.UserDataVO;
-import com.cloud.user.UserVO;
-import com.cloud.user.dao.UserDataDao;
-import com.cloud.utils.net.Ip;
 import com.cloud.vm.ConsoleSessionVO;
-import com.cloud.vm.NicSecondaryIp;
 import com.cloud.vm.VMInstanceVO;
 
 import static org.junit.Assert.assertEquals;
@@ -190,11 +154,12 @@ public class ApiResponseHelperTest {
     private HostVO hostVOMock;
     @Mock
     private VMInstanceVO vmInstanceVOMock;
-    VpcVO vpcVOMock;
 
     @Mock
-    NetworkACL networkACLMock;
+    private VpcVO vpcVOMock;
 
+    @Mock
+    private NetworkACL networkACLMock;
 
     @Spy
     @InjectMocks

--- a/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
+++ b/server/src/test/java/com/cloud/api/ApiResponseHelperTest.java
@@ -29,6 +29,47 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import com.cloud.capacity.Capacity;
+import com.cloud.configuration.Resource;
+import com.cloud.domain.DomainVO;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.network.Network;
+import com.cloud.network.PublicIpQuarantine;
+import com.cloud.network.as.AutoScaleVmGroup;
+import com.cloud.network.as.AutoScaleVmGroupVO;
+import com.cloud.network.as.AutoScaleVmProfileVO;
+import com.cloud.network.as.dao.AutoScaleVmGroupVmMapDao;
+import com.cloud.network.dao.IPAddressDao;
+import com.cloud.network.dao.IPAddressVO;
+import com.cloud.network.dao.LoadBalancerVO;
+import com.cloud.network.dao.NetworkServiceMapDao;
+import com.cloud.network.dao.NetworkVO;
+import com.cloud.network.vpc.NetworkACL;
+import com.cloud.network.vpc.VpcVO;
+import com.cloud.storage.VMTemplateVO;
+import com.cloud.usage.UsageVO;
+import com.cloud.user.Account;
+import com.cloud.user.AccountManager;
+import com.cloud.user.AccountVO;
+import com.cloud.user.User;
+import com.cloud.user.UserData;
+import com.cloud.user.UserDataVO;
+import com.cloud.user.UserVO;
+import com.cloud.user.dao.UserDataDao;
+import com.cloud.utils.net.Ip;
+import com.cloud.vm.NicSecondaryIp;
+import org.apache.cloudstack.annotation.dao.AnnotationDao;
+import org.apache.cloudstack.api.response.AutoScaleVmGroupResponse;
+import org.apache.cloudstack.api.response.AutoScaleVmProfileResponse;
+import org.apache.cloudstack.api.response.DirectDownloadCertificateResponse;
+import org.apache.cloudstack.api.response.IpQuarantineResponse;
+import org.apache.cloudstack.api.response.NetworkResponse;
+import org.apache.cloudstack.api.response.NicSecondaryIpResponse;
+import org.apache.cloudstack.api.response.UnmanagedInstanceResponse;
+import org.apache.cloudstack.api.response.UsageRecordResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.usage.UsageService;
+import org.apache.cloudstack.vm.UnmanagedInstanceTO;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -149,6 +190,11 @@ public class ApiResponseHelperTest {
     private HostVO hostVOMock;
     @Mock
     private VMInstanceVO vmInstanceVOMock;
+    VpcVO vpcVOMock;
+
+    @Mock
+    NetworkACL networkACLMock;
+
 
     @Spy
     @InjectMocks
@@ -167,6 +213,9 @@ public class ApiResponseHelperTest {
     static String userdataNew = "userdataNew";
 
     static long autoScaleUserId = 7L;
+
+    static final String A_NAME = "name";
+    static final String A_UUID = "021f94d4-73f9-4a9a-b003-1df9dd968a09";
 
     @Before
     public void injectMocks() throws SecurityException, NoSuchFieldException,
@@ -799,5 +848,136 @@ public class ApiResponseHelperTest {
             Assert.assertEquals(expected.getVmId(), response.getVmId());
             Assert.assertEquals(expected.getVmName(), response.getVmName());
         }
+    }
+
+    @Test
+    public void setVpcIdInResponseTestNullVpcIdReturnNull() {
+        NetworkResponse networkResponse = new NetworkResponse();
+
+        apiResponseHelper.setVpcIdInResponse(null, networkResponse::setVpcId, networkResponse::setVpcName, networkResponse::setVpcAccess);
+        Assert.assertNull(networkResponse.getVpcId());
+        Assert.assertNull(networkResponse.getVpcName());
+        Assert.assertNull(networkResponse.getVpcAccess());
+    }
+
+    @Test
+    public void setVpcIdInResponseTestNullVpcReturnNull() {
+        NetworkResponse networkResponse = new NetworkResponse();
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findVpcById(1L)).thenReturn(null);
+            apiResponseHelper.setVpcIdInResponse(1L, networkResponse::setVpcId, networkResponse::setVpcName, networkResponse::setVpcAccess);
+        }
+        Assert.assertNull(networkResponse.getVpcId());
+        Assert.assertNull(networkResponse.getVpcName());
+        Assert.assertNull(networkResponse.getVpcAccess());
+    }
+
+    @Test
+    public void setVpcIdInResponseCallerHasAccessReturnVpcAccessTrueAndVpcIdAndVpcName() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        Mockito.when(vpcVOMock.getName()).thenReturn(A_NAME);
+        Mockito.when(vpcVOMock.getUuid()).thenReturn(A_UUID);
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findVpcById(1L)).thenReturn(vpcVOMock);
+            apiResponseHelper.setVpcIdInResponse(1L, networkResponse::setVpcId, networkResponse::setVpcName, networkResponse::setVpcAccess);
+        };
+        Assert.assertEquals(A_UUID, networkResponse.getVpcId());
+        Assert.assertEquals(A_NAME, networkResponse.getVpcName());
+        Assert.assertTrue(networkResponse.getVpcAccess());
+    }
+
+    @Test
+    public void setVpcIdInResponseCallerDoesNotHaveAccessReturnVpcAccessFalseAndVpcIdAndVpcName() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        Mockito.when(vpcVOMock.getName()).thenReturn(A_NAME);
+        Mockito.when(vpcVOMock.getUuid()).thenReturn(A_UUID);
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findVpcById(1L)).thenReturn(vpcVOMock);
+            Mockito.doThrow(PermissionDeniedException.class).when(accountManagerMock).checkAccess(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any());
+            apiResponseHelper.setVpcIdInResponse(1L, networkResponse::setVpcId, networkResponse::setVpcName, networkResponse::setVpcAccess);
+        };
+        Assert.assertEquals(A_UUID, networkResponse.getVpcId());
+        Assert.assertEquals(A_NAME, networkResponse.getVpcName());
+        Assert.assertFalse(networkResponse.getVpcAccess());
+    }
+
+    @Test
+    public void setAclIdInResponseTestNullNetworkAclIdReturnNull() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        Network networkMock = Mockito.mock(Network.class);
+        Mockito.when(networkMock.getNetworkACLId()).thenReturn(null);
+
+        apiResponseHelper.setAclIdInResponse(networkMock, networkResponse);
+        Assert.assertNull(networkResponse.getAclId());
+        Assert.assertNull(networkResponse.getAclName());
+    }
+
+    @Test
+    public void setAclIdInResponseTestNullAclReturnNull() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        Network networkMock = Mockito.mock(Network.class);
+        Mockito.when(networkMock.getNetworkACLId()).thenReturn(1L);
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findByNetworkACLId(1L)).thenReturn(null);
+            apiResponseHelper.setAclIdInResponse(networkMock, networkResponse);
+        }
+        Assert.assertNull(networkResponse.getAclId());
+        Assert.assertNull(networkResponse.getAclName());
+    }
+
+    @Test
+    public void setAclIdInResponseTestCallerDoesNotHaveAccessReturnNull() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        networkResponse.setVpcAccess(false);
+        Network networkMock = Mockito.mock(Network.class);
+        Mockito.when(networkMock.getNetworkACLId()).thenReturn(1L);
+        Mockito.when(networkACLMock.getVpcId()).thenReturn(2L);
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findByNetworkACLId(1L)).thenReturn(networkACLMock);
+            apiResponseHelper.setAclIdInResponse(networkMock, networkResponse);
+        }
+        Assert.assertNull(networkResponse.getAclId());
+        Assert.assertNull(networkResponse.getAclName());
+    }
+
+    @Test
+    public void setAclIdInResponseTestCallerDoesNotHaveAccessButAclIsGlobalReturnAclIdAndAclName() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        networkResponse.setVpcAccess(false);
+        Network networkMock = Mockito.mock(Network.class);
+        Mockito.when(networkMock.getNetworkACLId()).thenReturn(1L);
+        Mockito.when(networkACLMock.getVpcId()).thenReturn(0L);
+        Mockito.when(networkACLMock.getName()).thenReturn(A_NAME);
+        Mockito.when(networkACLMock.getUuid()).thenReturn(A_UUID);
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findByNetworkACLId(1L)).thenReturn(networkACLMock);
+            apiResponseHelper.setAclIdInResponse(networkMock, networkResponse);
+        }
+        Assert.assertEquals(A_UUID, networkResponse.getAclId());
+        Assert.assertEquals(A_NAME, networkResponse.getAclName());
+    }
+
+    @Test
+    public void setAclIdInResponseTestCallerHasAccessReturnAclIdAndAclName() {
+        NetworkResponse networkResponse = new NetworkResponse();
+        networkResponse.setVpcAccess(true);
+        Network networkMock = Mockito.mock(Network.class);
+        Mockito.when(networkMock.getNetworkACLId()).thenReturn(1L);
+        Mockito.lenient().when(networkACLMock.getVpcId()).thenReturn(2L);
+        Mockito.when(networkACLMock.getName()).thenReturn(A_NAME);
+        Mockito.when(networkACLMock.getUuid()).thenReturn(A_UUID);
+
+        try (MockedStatic<ApiDBUtils> utils = Mockito.mockStatic(ApiDBUtils.class)) {
+            utils.when(() -> ApiDBUtils.findByNetworkACLId(1L)).thenReturn(networkACLMock);
+            apiResponseHelper.setAclIdInResponse(networkMock, networkResponse);
+        }
+        Assert.assertEquals(A_UUID, networkResponse.getAclId());
+        Assert.assertEquals(A_NAME, networkResponse.getAclName());
     }
 }

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -626,6 +626,7 @@
               <router-link v-if="!isStatic && $router.resolve('/diskoffering/' + resource.rootdiskofferingid).matched[0].redirect !== '/exception/404'" :to="{ path: '/diskoffering/' + resource.rootdiskofferingid }">{{ resource.rootdiskofferingdisplaytext }}</router-link>
               <span v-else>{{ resource.rootdiskofferingdisplaytext }}</span>
             </div>
+          </div>
             <div class="resource-detail-item" v-if="resource.keypairs && resource.keypairs.length > 0">
               <div class="resource-detail-item__label">{{ $t('label.keypairs') }}</div>
               <div class="resource-detail-item__details">

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -504,6 +504,127 @@
                 <gold-outlined />
                 <router-link :to="{ path: '/autoscalevmgroup/' + resource.autoscalevmgroupid }">{{ resource.autoscalevmgroupname || resource.autoscalevmgroupid }}</router-link>
               </div>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.resourcetype && resource.resourceid && routeFromResourceType">
+          <div class="resource-detail-item__label">{{ $t('label.resource') }}</div>
+          <div class="resource-detail-item__details">
+            <resource-label :resourceType="resource.resourcetype" :resourceId="resource.resourceid" :resourceName="resource.resourcename" />
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.virtualmachineid">
+          <div class="resource-detail-item__label">{{ $t('label.vmname') }}</div>
+          <div class="resource-detail-item__details">
+            <desktop-outlined />
+            <router-link :to="{ path: createPathBasedOnVmType(resource.vmtype, resource.virtualmachineid) }">{{ resource.vmname || resource.vm || resource.virtualmachinename || resource.virtualmachineid }} </router-link>
+            <status class="status status--end" :text="resource.vmstate" v-if="resource.vmstate"/>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.volumeid">
+          <div class="resource-detail-item__label">{{ $t('label.volume') }}</div>
+          <div class="resource-detail-item__details">
+            <hdd-outlined />
+            <router-link v-if="validLinks.volume" :to="{ path: '/volume/' + resource.volumeid }">{{ resource.volumename || resource.volume || resource.volumeid }} </router-link>
+            <span v-else>{{ resource.volumename || resource.volume || resource.volumeid }}</span>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.associatednetworkid">
+          <div class="resource-detail-item__label">{{ $t('label.associatednetwork') }}</div>
+          <div class="resource-detail-item__details">
+            <wifi-outlined />
+            <router-link :to="{ path: '/guestnetwork/' + resource.associatednetworkid }">{{ resource.associatednetworkname || resource.associatednetwork || resource.associatednetworkid }} </router-link>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.sourceipaddressnetworkid">
+          <div class="resource-detail-item__label">{{ $t('label.network') }}</div>
+          <div class="resource-detail-item__details">
+            <wifi-outlined />
+            <router-link :to="{ path: '/guestnetwork/' + resource.sourceipaddressnetworkid }">{{ resource.sourceipaddressnetworkname || resource.sourceipaddressnetworkid }} </router-link>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.guestnetworkid">
+          <div class="resource-detail-item__label">{{ $t('label.guestnetwork') }}</div>
+          <div class="resource-detail-item__details">
+            <gateway-outlined />
+            <router-link :to="{ path: '/guestnetwork/' + resource.guestnetworkid }">{{ resource.guestnetworkname || resource.guestnetworkid }} </router-link>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.publicip">
+          <div class="resource-detail-item__label">{{ $t('label.public.ip') }}</div>
+          <div class="resource-detail-item__details">
+            <gateway-outlined />
+            <router-link v-if="resource.publicipid" :to="{ path: '/publicip/' + resource.publicipid }">{{ resource.publicip }} </router-link>
+            <copy-label v-if="resource.publicipid" :copyValue="resource.publicip" :showIcon=true />
+            <copy-label v-else :label="resource.publicip" />
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.vpcid">
+          <div class="resource-detail-item__label">{{ $t('label.vpcname') }}</div>
+          <div class="resource-detail-item__details">
+            <span v-if="images.vpc">
+              <resource-icon :image="getImage(images.vpc)" size="1x" style="margin-right: 5px"/>
+            </span>
+            <deployment-unit-outlined v-else />
+            <router-link v-if="resource.vpcaccess" :to="{ path: '/vpc/' + resource.vpcid }">{{ resource.vpcname || resource.vpcid }}</router-link>
+            <span v-else>{{ resource.vpcname || resource.vpcid }}</span>
+          </div>
+        </div>
+
+        <div class="resource-detail-item" v-if="resource.aclid">
+          <div class="resource-detail-item__label">{{ $t('label.aclid') }}</div>
+          <div class="resource-detail-item__details">
+            <span v-if="images.acl">
+              <resource-icon :image="getImage(images.acl)" size="1x" style="margin-right: 5px"/>
+            </span>
+            <deployment-unit-outlined v-else />
+            <router-link :to="{ path: '/acllist/' + resource.aclid }">{{ resource.aclname || resource.aclid }}</router-link>
+          </div>
+        </div>
+
+        <div class="resource-detail-item" v-if="resource.affinitygroup && resource.affinitygroup.length > 0">
+          <div class="resource-detail-item__label">{{ $t('label.affinitygroup') }}</div>
+          <SwapOutlined />
+          <span
+            v-for="(group, index) in resource.affinitygroup"
+            :key="group.id"
+          >
+            <router-link :to="{ path: '/affinitygroup/' + group.id }">{{ group.name }}</router-link>
+            <span v-if="index + 1 < resource.affinitygroup.length">, </span>
+          </span>
+        </div>
+        <div class="resource-detail-item" v-if="resource.templateid">
+          <div class="resource-detail-item__label">{{ resource.templateformat === 'ISO'? $t('label.iso') : $t('label.templatename') }}</div>
+          <div class="resource-detail-item__details">
+            <resource-icon v-if="resource.icon" :image="getImage(resource.icon.base64image)" size="1x" style="margin-right: 5px"/>
+            <SaveOutlined v-else />
+            <router-link :to="{ path: (resource.templateformat === 'ISO' ? '/iso/' : '/template/') + resource.templateid }">{{ resource.templatedisplaytext || resource.templatename || resource.templateid }} </router-link>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.isoid">
+          <div class="resource-detail-item__label">{{ $t('label.isoname') }}</div>
+          <div class="resource-detail-item__details">
+            <resource-icon v-if="resource.icon" :image="getImage(resource.icon.base64image)" size="1x" style="margin-right: 5px"/>
+            <UsbOutlined v-else />
+              <router-link :to="{ path: '/iso/' + resource.isoid }">{{ resource.isodisplaytext || resource.isoname || resource.isoid }} </router-link>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.serviceofferingname && resource.serviceofferingid">
+          <div class="resource-detail-item__label" v-if="$route.meta.name === 'router' || $route.meta.name === 'systemvm'">{{ $t('label.system.offering') }}</div>
+          <div class="resource-detail-item__label" v-else >{{ $t('label.serviceofferingname') }}</div>
+          <div class="resource-detail-item__details">
+            <cloud-outlined />
+            <router-link v-if="!isStatic && ($route.meta.name === 'router' || $route.meta.name === 'systemvm')" :to="{ path: '/systemoffering/' + resource.serviceofferingid}">{{ resource.serviceofferingname || resource.serviceofferingid }} </router-link>
+            <router-link v-else-if="$router.resolve('/computeoffering/' + resource.serviceofferingid).matched[0].redirect !== '/exception/404'" :to="{ path: '/computeoffering/' + resource.serviceofferingid }">{{ resource.serviceofferingname || resource.serviceofferingid }} </router-link>
+            <span v-else>{{ resource.serviceofferingname || resource.serviceofferingid }}</span>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.rootdiskofferingid && resource.rootdiskofferingdisplaytext || resource.datadiskofferingid && resource.datadiskofferingdisplaytext">
+          <div class="resource-detail-item__label">{{ $t('label.diskoffering') }}</div>
+          <div class="resource-detail-item__details">
+            <hdd-outlined />
+            <div v-if="resource.rootdiskofferingid">
+              <router-link v-if="!isStatic && $router.resolve('/diskoffering/' + resource.rootdiskofferingid).matched[0].redirect !== '/exception/404'" :to="{ path: '/diskoffering/' + resource.rootdiskofferingid }">{{ resource.rootdiskofferingdisplaytext }}</router-link>
+              <span v-else>{{ resource.rootdiskofferingdisplaytext }}</span>
             </div>
             <div class="resource-detail-item" v-if="resource.keypairs && resource.keypairs.length > 0">
               <div class="resource-detail-item__label">{{ $t('label.keypairs') }}</div>

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -582,7 +582,7 @@
         <router-link :to="{ path: '/guestnetwork/' + record.associatednetworkid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'vpcname'">
-        <a v-if="record.vpcid">
+        <a v-if="record.vpcid && record.vpcaccess">
           <router-link :to="{ path: '/vpc/' + record.vpcid }">{{ text || record.vpcid }}</router-link>
         </a>
         <span v-else>{{ text }}</span>

--- a/ui/src/views/network/IpAddressesTab.vue
+++ b/ui/src/views/network/IpAddressesTab.vue
@@ -145,7 +145,9 @@
       centered
       width="450px">
       <a-spin :spinning="acquireLoading" v-ctrl-enter="acquireIpAddress">
-        <a-alert :message="$t('message.action.acquire.ip')" type="warning" />
+        <div v-if="$route.path.startsWith('/vpc') && !isNormalUserOrProject()">
+          <ownership-selection :override="possibleOwnership" @fetch-owner="fetchOwnerOptions"/>
+        </div>
         <a-form layout="vertical" style="margin-top: 10px">
           <a-form-item :label="$t('label.ipaddress')">
             <infinite-scroll-select
@@ -160,6 +162,7 @@
               :autoSelectFirstOption="true"
               @change-option-value="(ip) => acquireIp = ip" />
           </a-form-item>
+          <a-alert :message="$t('message.action.acquire.ip')" type="warning" />
           <div :span="24" class="action-button">
             <a-button @click="onCloseModal">{{ $t('label.cancel') }}</a-button>
             <a-button ref="submit" type="primary" @click="acquireIpAddress">{{ $t('label.ok') }}</a-button>
@@ -210,6 +213,7 @@ import TooltipButton from '@/components/widgets/TooltipButton'
 import BulkActionView from '@/components/view/BulkActionView'
 import eventBus from '@/config/eventBus'
 import InfiniteScrollSelect from '@/components/widgets/InfiniteScrollSelect'
+import OwnershipSelection from '@/views/compute/wizard/OwnershipSelection.vue'
 
 export default {
   name: 'IpAddressesTab',
@@ -217,7 +221,8 @@ export default {
     Status,
     TooltipButton,
     BulkActionView,
-    InfiniteScrollSelect
+    InfiniteScrollSelect,
+    OwnershipSelection
   },
   props: {
     resource: {
@@ -281,7 +286,12 @@ export default {
       acquireLoading: false,
       acquireIp: null,
       changeSourceNat: false,
-      zoneExtNetProvider: ''
+      zoneExtNetProvider: '',
+      possibleOwnership: {
+        domains: null,
+        projects: null,
+        accounts: null
+      }
     }
   },
   async created () {
@@ -321,6 +331,9 @@ export default {
     }
   },
   methods: {
+    isNormalUserOrProject () {
+      return ['User'].includes(this.$store.getters.userInfo.roletype) || this.$store.getters.project?.id
+    },
     fetchData () {
       const params = {
         listall: true,
@@ -334,6 +347,7 @@ export default {
         if (this.vpcTier) {
           params.associatednetworkid = this.vpcTier
         }
+        this.getAvailableOwnersForIP()
       } else if (this.resource.type === 'Shared') {
         params.networkid = this.resource.id
         params.allocatedonly = false
@@ -362,13 +376,20 @@ export default {
         }).catch(reject)
       })
     },
-    fetchListPublicIpAddress (state) {
-      return new Promise((resolve, reject) => {
-        getAPI('listPublicIpAddresses', this.listApiParams).then(json => {
-          const listPublicIps = json.listpublicipaddressesresponse.publicipaddress || []
-          resolve(listPublicIps)
-        }).catch(reject)
-      })
+    fetchOwnerOptions (OwnerOptions) {
+      this.owner = {}
+      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+        if (!OwnerOptions.selectedAccount) {
+          return
+        }
+        this.owner.account = OwnerOptions.selectedAccount
+        this.owner.domainid = OwnerOptions.selectedDomain
+      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+        if (!OwnerOptions.selectedProject) {
+          return
+        }
+        this.owner.projectid = OwnerOptions.selectedProject
+      }
     },
     handleTierSelect (tier) {
       this.vpcTier = tier
@@ -453,6 +474,11 @@ export default {
       const params = {}
       if (this.$route.path.startsWith('/vpc')) {
         params.vpcid = this.resource.id
+        if (this.owner) {
+          params.domainid = this.owner.domainid
+          params.account = this.owner.projectid ? null : this.owner.account
+          params.projectid = this.owner.projectid ? this.owner.projectid : null
+        }
         if (this.vpcTier) {
           params.networkid = this.vpcTier
         }
@@ -559,6 +585,20 @@ export default {
         case 'SecondaryStorageVm': return '/systemvm/'
         default: return '/vm/'
       }
+    },
+    getAvailableOwnersForIP () {
+      this.possibleOwnership.domains = new Set([this.resource.domainid])
+      this.possibleOwnership.projects = this.resource.projectid ? new Set([this.resource.projectid]) : new Set([])
+      this.possibleOwnership.accounts = this.resource.projectid ? new Set([]) : new Set([this.resource.account])
+
+      this.resource.network.forEach(network => {
+        this.possibleOwnership.domains.add(network.domainid)
+        if (network.projectid) {
+          this.possibleOwnership.projects.add(network.projectid)
+        } else {
+          this.possibleOwnership.accounts.add(network.account)
+        }
+      })
     },
     async onShowAcquireIp () {
       this.showAcquireIp = true

--- a/ui/src/views/network/IpAddressesTab.vue
+++ b/ui/src/views/network/IpAddressesTab.vue
@@ -47,12 +47,12 @@
           showSearch
           optionFilterProp="label"
           :filterOption="(input, option) => {
-            return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
           }" >
           <a-select-option key="all" value="">
             {{ $t('label.view.all') }}
           </a-select-option>
-          <a-select-option v-for="network in networksList" :key="network.id" :value="network.id">
+          <a-select-option v-for="network in networksList" :key="network.id" :value="network.id" :label="network.name">
             {{ network.name }}
           </a-select-option>
         </a-select>
@@ -65,35 +65,57 @@
         :rowKey="item => item.id"
         :rowSelection="{selectedRowKeys: selectedRowKeys, onChange: onSelectChange}"
         :pagination="false" >
-        <template #ipaddress="{ text, record }">
-          <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/publicip/' + record.id }" >{{ text }} </router-link>
-          <div v-else>{{ text }}</div>
-          <a-tag v-if="record.issourcenat === true">source-nat</a-tag>
-        </template>
+        <template #bodyCell="{ column, text, record }">
+          <template v-if="column.key === 'ipaddress'">
+            <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/publicip/' + record.id }" >{{ text }}&nbsp;</router-link>
+            <div v-else>{{ text }}</div>
+            <template v-if="record.issourcenat === true">
+              <a-tag>{{ $t('label.sourcenat') }}</a-tag>
+            </template>
+            <template v-else-if="record.isstaticnat === true">
+              <a-tag>{{ $t('label.staticnat') }}</a-tag>
+            </template>
+            <template v-else-if="record.hasrules === false">
+              <tooltip-button
+                v-if="record.forvirtualnetwork === true"
+                :tooltip="$t('label.action.set.as.source.nat.ip')"
+                type="primary"
+                :danger="false"
+                icon="aim-outlined"
+                :disabled="!('updateNetwork' in $store.getters.apis)"
+                @onClick="showChangeSourceNat(record)"></tooltip-button>
+            </template>
+            <template v-else><!-- -if="record.hasrules === true" -->
+              <Tooltip placement="topLeft" :title="$t('message.sourcenatip.change.inhibited')" >
+                <a-tag>{{ $t('label.hasrules') }}</a-tag>
+              </Tooltip>
+            </template>
+          </template>
 
-        <template #state="{ record }">
-          <status :text="record.state" displayText />
-        </template>
+          <template v-if="column.key === 'state'">
+            <status :text="record.state" displayText />
+          </template>
 
-        <template #virtualmachineid="{ record }">
-          <desktop-outlined v-if="record.virtualmachineid" />
-          <router-link :to="{ path: '/vm/' + record.virtualmachineid }" > {{ record.virtualmachinename || record.virtualmachineid }} </router-link>
-        </template>
+          <template v-if="column.key === 'virtualmachineid'">
+            <desktop-outlined v-if="record.virtualmachineid" />
+            <router-link :to="{ path: getVmRouteUsingType(record) + record.virtualmachineid }" > {{ record.virtualmachinename || record.virtualmachineid }} </router-link>
+          </template>
 
-        <template #associatednetworkname="{ record }">
-          <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/guestnetwork/' + record.associatednetworkid }" > {{ record.associatednetworkname || record.associatednetworkid }} </router-link>
-          <div v-else>{{ record.networkname }}</div>
-        </template>
+          <template v-if="column.key === 'associatednetworkname'">
+            <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/guestnetwork/' + record.associatednetworkid }" > {{ record.associatednetworkname || record.associatednetworkid }} </router-link>
+            <div v-else>{{ record.networkname }}</div>
+          </template>
 
-        <template #action="{ record }">
-          <tooltip-button
-            v-if="record.issourcenat !== true && record.forvirtualnetwork === true"
-            :tooltip="$t('label.action.release.ip')"
-            type="primary"
-            :danger="true"
-            icon="delete-outlined"
-            :disabled="!('disassociateIpAddress' in $store.getters.apis)"
-            @onClick="releaseIpAddress(record)" />
+          <template v-if="column.key === 'actions'">
+            <tooltip-button
+              v-if="record.issourcenat !== true && record.forvirtualnetwork === true"
+              :tooltip="$t('label.action.release.ip')"
+              type="primary"
+              :danger="true"
+              icon="delete-outlined"
+              :disabled="!('disassociateIpAddress' in $store.getters.apis)"
+              @onClick="releaseIpAddress(record)" />
+          </template>
         </template>
       </a-table>
       <a-divider/>
@@ -126,19 +148,17 @@
         <a-alert :message="$t('message.action.acquire.ip')" type="warning" />
         <a-form layout="vertical" style="margin-top: 10px">
           <a-form-item :label="$t('label.ipaddress')">
-            <a-select
+            <infinite-scroll-select
               v-focus="true"
-              style="width: 100%;"
               v-model:value="acquireIp"
-              showSearch
-              optionFilterProp="label"
-              :filterOption="(input, option) => {
-                return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
-              }" >
-              <a-select-option
-                v-for="ip in listPublicIpAddress"
-                :key="ip.ipaddress">{{ ip.ipaddress }} ({{ ip.state }})</a-select-option>
-            </a-select>
+              api="listPublicIpAddresses"
+              :apiParams="listApiParamsForAssociate"
+              resourceType="publicipaddress"
+              optionValueKey="ipaddress"
+              :optionLabelFn="ip => ip.ipaddress + ' (' + ip.state + ')'"
+              defaultIcon="environment-outlined"
+              :autoSelectFirstOption="true"
+              @change-option-value="(ip) => acquireIp = ip" />
           </a-form-item>
           <div :span="24" class="action-button">
             <a-button @click="onCloseModal">{{ $t('label.cancel') }}</a-button>
@@ -146,6 +166,24 @@
           </div>
         </a-form>
       </a-spin>
+    </a-modal>
+    <a-modal
+      v-if="changeSourceNat"
+      :title="$t('message.sourcenatip.change.warning')"
+      :visible="changeSourceNat"
+      :closable="true"
+      :footer="null"
+      @cancel="cancelChangeSourceNat"
+      centered
+      :disabled="!('updateNetwork' in $store.getters.apis)"
+      width="450px">
+      <template>
+        <a-alert :message="$t('message.sourcenatip.change.warning')" type="warning" />
+      </template>
+      <div :span="24" class="action-button">
+        <a-button @click="cancelChangeSourceNat">{{ $t('label.cancel') }}</a-button>
+        <a-button ref="submit" type="primary" @click="setSourceNatIp(record)">{{ $t('label.ok') }}</a-button>
+      </div>
     </a-modal>
     <bulk-action-view
       v-if="showConfirmationAction || showGroupActionModal"
@@ -164,19 +202,22 @@
       @close-modal="closeModal" />
   </div>
 </template>
+
 <script>
-import { api } from '@/api'
+import { getAPI, postAPI } from '@/api'
 import Status from '@/components/widgets/Status'
 import TooltipButton from '@/components/widgets/TooltipButton'
 import BulkActionView from '@/components/view/BulkActionView'
 import eventBus from '@/config/eventBus'
+import InfiniteScrollSelect from '@/components/widgets/InfiniteScrollSelect'
 
 export default {
   name: 'IpAddressesTab',
   components: {
     Status,
     TooltipButton,
-    BulkActionView
+    BulkActionView,
+    InfiniteScrollSelect
   },
   props: {
     resource: {
@@ -204,7 +245,7 @@ export default {
       showGroupActionModal: false,
       selectedItems: [],
       selectedColumns: [],
-      filterColumns: ['Action'],
+      filterColumns: ['Actions'],
       showConfirmationAction: false,
       message: {
         title: this.$t('label.action.bulk.release.public.ip.address'),
@@ -212,37 +253,39 @@ export default {
       },
       columns: [
         {
+          key: 'ipaddress',
           title: this.$t('label.ipaddress'),
-          dataIndex: 'ipaddress',
-          slots: { customRender: 'ipaddress' }
+          dataIndex: 'ipaddress'
         },
         {
+          key: 'state',
           title: this.$t('label.state'),
-          dataIndex: 'state',
-          slots: { customRender: 'state' }
+          dataIndex: 'state'
         },
         {
+          key: 'virtualmachineid',
           title: this.$t('label.vm'),
-          dataIndex: 'virtualmachineid',
-          slots: { customRender: 'virtualmachineid' }
+          dataIndex: 'virtualmachineid'
         },
         {
+          key: 'associatednetworkname',
           title: this.$t('label.network'),
-          dataIndex: 'associatednetworkname',
-          slots: { customRender: 'associatednetworkname' }
+          dataIndex: 'associatednetworkname'
         },
         {
-          title: '',
-          slots: { customRender: 'action' }
+          key: 'actions',
+          title: ''
         }
       ],
       showAcquireIp: false,
       acquireLoading: false,
       acquireIp: null,
-      listPublicIpAddress: []
+      changeSourceNat: false,
+      zoneExtNetProvider: ''
     }
   },
-  created () {
+  async created () {
+    await this.fetchZones()
     this.fetchData()
   },
   watch: {
@@ -257,6 +300,26 @@ export default {
     }
   },
   inject: ['parentFetchData'],
+  computed: {
+    listApiParams () {
+      const params = {
+        zoneid: this.resource.zoneid,
+        domainid: this.resource.domainid,
+        account: this.resource.account,
+        forvirtualnetwork: true,
+        allocatedonly: false
+      }
+      if (['nsx', 'netris'].includes(this.zoneExtNetProvider?.toLowerCase())) {
+        params.forprovider = true
+      }
+      return params
+    },
+    listApiParamsForAssociate () {
+      const params = this.listApiParams
+      params.state = 'Free,Reserved'
+      return params
+    }
+  },
   methods: {
     fetchData () {
       const params = {
@@ -278,24 +341,30 @@ export default {
       } else {
         params.associatednetworkid = this.resource.id
       }
+      if (['nsx', 'netris'].includes(this.zoneExtNetProvider?.toLowerCase())) {
+        params.forprovider = true
+      }
       this.fetchLoading = true
-      api('listPublicIpAddresses', params).then(json => {
+      getAPI('listPublicIpAddresses', params).then(json => {
         this.totalIps = json.listpublicipaddressesresponse.count || 0
         this.ips = json.listpublicipaddressesresponse.publicipaddress || []
       }).finally(() => {
         this.fetchLoading = false
       })
     },
-    fetchListPublicIpAddress () {
+    fetchZones () {
       return new Promise((resolve, reject) => {
-        const params = {
-          zoneid: this.resource.zoneid,
-          domainid: this.resource.domainid,
-          account: this.resource.account,
-          forvirtualnetwork: true,
-          allocatedonly: false
-        }
-        api('listPublicIpAddresses', params).then(json => {
+        getAPI('listZones', {
+          id: this.resource.zoneid
+        }).then(json => {
+          this.zoneExtNetProvider = json?.listzonesresponse?.zone?.[0]?.provider || null
+          resolve(this.zoneExtNetProvider)
+        }).catch(reject)
+      })
+    },
+    fetchListPublicIpAddress (state) {
+      return new Promise((resolve, reject) => {
+        getAPI('listPublicIpAddresses', this.listApiParams).then(json => {
           const listPublicIps = json.listpublicipaddressesresponse.publicipaddress || []
           resolve(listPublicIps)
         }).catch(reject)
@@ -311,6 +380,50 @@ export default {
       this.selectedItems = (this.ips.filter(function (item) {
         return selection.indexOf(item.id) !== -1
       }))
+    },
+    setSourceNatIp (ipaddress) {
+      if (this.settingsourcenat) return
+      if (this.$route.path.startsWith('/vpc')) {
+        this.updateVpc(ipaddress)
+      } else {
+        this.updateNetwork(ipaddress)
+      }
+    },
+    updateNetwork (ipaddress) {
+      const params = {}
+      params.sourcenatipaddress = this.sourceNatIp.ipaddress
+      params.id = this.resource.id
+      this.settingsourcenat = true
+      postAPI('updateNetwork', params).then(response => {
+        this.fetchData()
+      }).catch(error => {
+        this.$notification.error({
+          message: `${this.$t('label.error')} ${error.response.status}`,
+          description: error.response.data.updatenetworkresponse.errortext || error.response.data.errorresponse.errortext,
+          duration: 0
+        })
+      }).finally(() => {
+        this.settingsourcenat = false
+        this.cancelChangeSourceNat()
+      })
+    },
+    updateVpc (ipaddress) {
+      const params = {}
+      params.sourcenatipaddress = this.sourceNatIp.ipaddress
+      params.id = this.resource.id
+      this.settingsourcenat = true
+      postAPI('updateVPC', params).then(response => {
+        this.fetchData()
+      }).catch(error => {
+        this.$notification.error({
+          message: `${this.$t('label.error')} ${error.response.status}`,
+          description: error.response.data.updatevpcresponse.errortext || error.response.data.errorresponse.errortext,
+          duration: 0
+        })
+      }).finally(() => {
+        this.settingsourcenat = false
+        this.cancelChangeSourceNat()
+      })
     },
     resetSelection () {
       this.setSelection([])
@@ -349,7 +462,7 @@ export default {
       params.ipaddress = this.acquireIp
       this.acquireLoading = true
 
-      api('associateIpAddress', params).then(response => {
+      postAPI('associateIpAddress', params).then(response => {
         this.$pollJob({
           jobId: response.associateipaddressresponse.jobid,
           successMessage: `${this.$t('message.success.acquire.ip')} ${this.$t('label.for')} ${this.resource.name}`,
@@ -366,8 +479,8 @@ export default {
         this.onCloseModal()
       }).catch(error => {
         this.$notification.error({
-          message: `${this.$t('label.error')} ${error.response.status}`,
-          description: error.response.data.associateipaddressresponse.errortext || error.response.data.errorresponse.errortext,
+          message: this.$t('message.request.failed'),
+          description: (error.response && error.response.headers && error.response.headers['x-description']) || error.message,
           duration: 0
         })
       }).finally(() => {
@@ -385,9 +498,9 @@ export default {
     releaseIpAddresses (e) {
       this.showConfirmationAction = false
       this.selectedColumns.splice(0, 0, {
+        key: 'status',
         dataIndex: 'status',
         title: this.$t('label.operation.status'),
-        slots: { customRender: 'status' },
         filters: [
           { text: 'In Progress', value: 'InProgress' },
           { text: 'Success', value: 'success' },
@@ -403,7 +516,7 @@ export default {
     },
     releaseIpAddress (ip) {
       this.fetchLoading = true
-      api('disassociateIpAddress', {
+      postAPI('disassociateIpAddress', {
         id: ip.id
       }).then(response => {
         const jobId = response.disassociateipaddressresponse.jobid
@@ -439,38 +552,29 @@ export default {
         })
       })
     },
+    getVmRouteUsingType (record) {
+      switch (record.virtualmachinetype) {
+        case 'DomainRouter' : return '/router/'
+        case 'ConsoleProxy' :
+        case 'SecondaryStorageVm': return '/systemvm/'
+        default: return '/vm/'
+      }
+    },
     async onShowAcquireIp () {
       this.showAcquireIp = true
-      this.acquireLoading = true
-      this.listPublicIpAddress = []
-
-      try {
-        const listPublicIpAddress = await this.fetchListPublicIpAddress()
-        listPublicIpAddress.forEach(item => {
-          if (item.state === 'Free' || item.state === 'Reserved') {
-            this.listPublicIpAddress.push({
-              ipaddress: item.ipaddress,
-              state: item.state
-            })
-          }
-        })
-        this.listPublicIpAddress.sort(function (a, b) {
-          if (a.ipaddress < b.ipaddress) { return -1 }
-          if (a.ipaddress > b.ipaddress) { return 1 }
-          return 0
-        })
-        this.acquireIp = this.listPublicIpAddress && this.listPublicIpAddress.length > 0 ? this.listPublicIpAddress[0].ipaddress : null
-        this.acquireLoading = false
-      } catch (e) {
-        this.acquireLoading = false
-        this.$notifyError(e)
-      }
     },
     onCloseModal () {
       this.showAcquireIp = false
     },
     closeModal () {
       this.showConfirmationAction = false
+    },
+    showChangeSourceNat (ipaddress) {
+      this.changeSourceNat = true
+      this.sourceNatIp = ipaddress
+    },
+    cancelChangeSourceNat () {
+      this.changeSourceNat = false
     }
   }
 }

--- a/ui/src/views/network/IpAddressesTab.vue
+++ b/ui/src/views/network/IpAddressesTab.vue
@@ -47,12 +47,12 @@
           showSearch
           optionFilterProp="label"
           :filterOption="(input, option) => {
-            return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
           }" >
           <a-select-option key="all" value="">
             {{ $t('label.view.all') }}
           </a-select-option>
-          <a-select-option v-for="network in networksList" :key="network.id" :value="network.id" :label="network.name">
+          <a-select-option v-for="network in networksList" :key="network.id" :value="network.id">
             {{ network.name }}
           </a-select-option>
         </a-select>
@@ -65,57 +65,35 @@
         :rowKey="item => item.id"
         :rowSelection="{selectedRowKeys: selectedRowKeys, onChange: onSelectChange}"
         :pagination="false" >
-        <template #bodyCell="{ column, text, record }">
-          <template v-if="column.key === 'ipaddress'">
-            <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/publicip/' + record.id }" >{{ text }}&nbsp;</router-link>
-            <div v-else>{{ text }}</div>
-            <template v-if="record.issourcenat === true">
-              <a-tag>{{ $t('label.sourcenat') }}</a-tag>
-            </template>
-            <template v-else-if="record.isstaticnat === true">
-              <a-tag>{{ $t('label.staticnat') }}</a-tag>
-            </template>
-            <template v-else-if="record.hasrules === false">
-              <tooltip-button
-                v-if="record.forvirtualnetwork === true"
-                :tooltip="$t('label.action.set.as.source.nat.ip')"
-                type="primary"
-                :danger="false"
-                icon="aim-outlined"
-                :disabled="!('updateNetwork' in $store.getters.apis)"
-                @onClick="showChangeSourceNat(record)"></tooltip-button>
-            </template>
-            <template v-else><!-- -if="record.hasrules === true" -->
-              <Tooltip placement="topLeft" :title="$t('message.sourcenatip.change.inhibited')" >
-                <a-tag>{{ $t('label.hasrules') }}</a-tag>
-              </Tooltip>
-            </template>
-          </template>
+        <template #ipaddress="{ text, record }">
+          <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/publicip/' + record.id }" >{{ text }} </router-link>
+          <div v-else>{{ text }}</div>
+          <a-tag v-if="record.issourcenat === true">source-nat</a-tag>
+        </template>
 
-          <template v-if="column.key === 'state'">
-            <status :text="record.state" displayText />
-          </template>
+        <template #state="{ record }">
+          <status :text="record.state" displayText />
+        </template>
 
-          <template v-if="column.key === 'virtualmachineid'">
-            <desktop-outlined v-if="record.virtualmachineid" />
-            <router-link :to="{ path: getVmRouteUsingType(record) + record.virtualmachineid }" > {{ record.virtualmachinename || record.virtualmachineid }} </router-link>
-          </template>
+        <template #virtualmachineid="{ record }">
+          <desktop-outlined v-if="record.virtualmachineid" />
+          <router-link :to="{ path: '/vm/' + record.virtualmachineid }" > {{ record.virtualmachinename || record.virtualmachineid }} </router-link>
+        </template>
 
-          <template v-if="column.key === 'associatednetworkname'">
-            <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/guestnetwork/' + record.associatednetworkid }" > {{ record.associatednetworkname || record.associatednetworkid }} </router-link>
-            <div v-else>{{ record.networkname }}</div>
-          </template>
+        <template #associatednetworkname="{ record }">
+          <router-link v-if="record.forvirtualnetwork === true" :to="{ path: '/guestnetwork/' + record.associatednetworkid }" > {{ record.associatednetworkname || record.associatednetworkid }} </router-link>
+          <div v-else>{{ record.networkname }}</div>
+        </template>
 
-          <template v-if="column.key === 'actions'">
-            <tooltip-button
-              v-if="record.issourcenat !== true && record.forvirtualnetwork === true"
-              :tooltip="$t('label.action.release.ip')"
-              type="primary"
-              :danger="true"
-              icon="delete-outlined"
-              :disabled="!('disassociateIpAddress' in $store.getters.apis)"
-              @onClick="releaseIpAddress(record)" />
-          </template>
+        <template #action="{ record }">
+          <tooltip-button
+            v-if="record.issourcenat !== true && record.forvirtualnetwork === true"
+            :tooltip="$t('label.action.release.ip')"
+            type="primary"
+            :danger="true"
+            icon="delete-outlined"
+            :disabled="!('disassociateIpAddress' in $store.getters.apis)"
+            @onClick="releaseIpAddress(record)" />
         </template>
       </a-table>
       <a-divider/>
@@ -148,17 +126,19 @@
         <a-alert :message="$t('message.action.acquire.ip')" type="warning" />
         <a-form layout="vertical" style="margin-top: 10px">
           <a-form-item :label="$t('label.ipaddress')">
-            <infinite-scroll-select
+            <a-select
               v-focus="true"
+              style="width: 100%;"
               v-model:value="acquireIp"
-              api="listPublicIpAddresses"
-              :apiParams="listApiParamsForAssociate"
-              resourceType="publicipaddress"
-              optionValueKey="ipaddress"
-              :optionLabelFn="ip => ip.ipaddress + ' (' + ip.state + ')'"
-              defaultIcon="environment-outlined"
-              :autoSelectFirstOption="true"
-              @change-option-value="(ip) => acquireIp = ip" />
+              showSearch
+              optionFilterProp="label"
+              :filterOption="(input, option) => {
+                return option.children[0].children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+              }" >
+              <a-select-option
+                v-for="ip in listPublicIpAddress"
+                :key="ip.ipaddress">{{ ip.ipaddress }} ({{ ip.state }})</a-select-option>
+            </a-select>
           </a-form-item>
           <div :span="24" class="action-button">
             <a-button @click="onCloseModal">{{ $t('label.cancel') }}</a-button>
@@ -166,24 +146,6 @@
           </div>
         </a-form>
       </a-spin>
-    </a-modal>
-    <a-modal
-      v-if="changeSourceNat"
-      :title="$t('message.sourcenatip.change.warning')"
-      :visible="changeSourceNat"
-      :closable="true"
-      :footer="null"
-      @cancel="cancelChangeSourceNat"
-      centered
-      :disabled="!('updateNetwork' in $store.getters.apis)"
-      width="450px">
-      <template>
-        <a-alert :message="$t('message.sourcenatip.change.warning')" type="warning" />
-      </template>
-      <div :span="24" class="action-button">
-        <a-button @click="cancelChangeSourceNat">{{ $t('label.cancel') }}</a-button>
-        <a-button ref="submit" type="primary" @click="setSourceNatIp(record)">{{ $t('label.ok') }}</a-button>
-      </div>
     </a-modal>
     <bulk-action-view
       v-if="showConfirmationAction || showGroupActionModal"
@@ -202,22 +164,19 @@
       @close-modal="closeModal" />
   </div>
 </template>
-
 <script>
-import { getAPI, postAPI } from '@/api'
+import { api } from '@/api'
 import Status from '@/components/widgets/Status'
 import TooltipButton from '@/components/widgets/TooltipButton'
 import BulkActionView from '@/components/view/BulkActionView'
 import eventBus from '@/config/eventBus'
-import InfiniteScrollSelect from '@/components/widgets/InfiniteScrollSelect'
 
 export default {
   name: 'IpAddressesTab',
   components: {
     Status,
     TooltipButton,
-    BulkActionView,
-    InfiniteScrollSelect
+    BulkActionView
   },
   props: {
     resource: {
@@ -245,7 +204,7 @@ export default {
       showGroupActionModal: false,
       selectedItems: [],
       selectedColumns: [],
-      filterColumns: ['Actions'],
+      filterColumns: ['Action'],
       showConfirmationAction: false,
       message: {
         title: this.$t('label.action.bulk.release.public.ip.address'),
@@ -253,39 +212,37 @@ export default {
       },
       columns: [
         {
-          key: 'ipaddress',
           title: this.$t('label.ipaddress'),
-          dataIndex: 'ipaddress'
+          dataIndex: 'ipaddress',
+          slots: { customRender: 'ipaddress' }
         },
         {
-          key: 'state',
           title: this.$t('label.state'),
-          dataIndex: 'state'
+          dataIndex: 'state',
+          slots: { customRender: 'state' }
         },
         {
-          key: 'virtualmachineid',
           title: this.$t('label.vm'),
-          dataIndex: 'virtualmachineid'
+          dataIndex: 'virtualmachineid',
+          slots: { customRender: 'virtualmachineid' }
         },
         {
-          key: 'associatednetworkname',
           title: this.$t('label.network'),
-          dataIndex: 'associatednetworkname'
+          dataIndex: 'associatednetworkname',
+          slots: { customRender: 'associatednetworkname' }
         },
         {
-          key: 'actions',
-          title: ''
+          title: '',
+          slots: { customRender: 'action' }
         }
       ],
       showAcquireIp: false,
       acquireLoading: false,
       acquireIp: null,
-      changeSourceNat: false,
-      zoneExtNetProvider: ''
+      listPublicIpAddress: []
     }
   },
-  async created () {
-    await this.fetchZones()
+  created () {
     this.fetchData()
   },
   watch: {
@@ -300,26 +257,6 @@ export default {
     }
   },
   inject: ['parentFetchData'],
-  computed: {
-    listApiParams () {
-      const params = {
-        zoneid: this.resource.zoneid,
-        domainid: this.resource.domainid,
-        account: this.resource.account,
-        forvirtualnetwork: true,
-        allocatedonly: false
-      }
-      if (['nsx', 'netris'].includes(this.zoneExtNetProvider?.toLowerCase())) {
-        params.forprovider = true
-      }
-      return params
-    },
-    listApiParamsForAssociate () {
-      const params = this.listApiParams
-      params.state = 'Free,Reserved'
-      return params
-    }
-  },
   methods: {
     fetchData () {
       const params = {
@@ -341,30 +278,24 @@ export default {
       } else {
         params.associatednetworkid = this.resource.id
       }
-      if (['nsx', 'netris'].includes(this.zoneExtNetProvider?.toLowerCase())) {
-        params.forprovider = true
-      }
       this.fetchLoading = true
-      getAPI('listPublicIpAddresses', params).then(json => {
+      api('listPublicIpAddresses', params).then(json => {
         this.totalIps = json.listpublicipaddressesresponse.count || 0
         this.ips = json.listpublicipaddressesresponse.publicipaddress || []
       }).finally(() => {
         this.fetchLoading = false
       })
     },
-    fetchZones () {
+    fetchListPublicIpAddress () {
       return new Promise((resolve, reject) => {
-        getAPI('listZones', {
-          id: this.resource.zoneid
-        }).then(json => {
-          this.zoneExtNetProvider = json?.listzonesresponse?.zone?.[0]?.provider || null
-          resolve(this.zoneExtNetProvider)
-        }).catch(reject)
-      })
-    },
-    fetchListPublicIpAddress (state) {
-      return new Promise((resolve, reject) => {
-        getAPI('listPublicIpAddresses', this.listApiParams).then(json => {
+        const params = {
+          zoneid: this.resource.zoneid,
+          domainid: this.resource.domainid,
+          account: this.resource.account,
+          forvirtualnetwork: true,
+          allocatedonly: false
+        }
+        api('listPublicIpAddresses', params).then(json => {
           const listPublicIps = json.listpublicipaddressesresponse.publicipaddress || []
           resolve(listPublicIps)
         }).catch(reject)
@@ -380,50 +311,6 @@ export default {
       this.selectedItems = (this.ips.filter(function (item) {
         return selection.indexOf(item.id) !== -1
       }))
-    },
-    setSourceNatIp (ipaddress) {
-      if (this.settingsourcenat) return
-      if (this.$route.path.startsWith('/vpc')) {
-        this.updateVpc(ipaddress)
-      } else {
-        this.updateNetwork(ipaddress)
-      }
-    },
-    updateNetwork (ipaddress) {
-      const params = {}
-      params.sourcenatipaddress = this.sourceNatIp.ipaddress
-      params.id = this.resource.id
-      this.settingsourcenat = true
-      postAPI('updateNetwork', params).then(response => {
-        this.fetchData()
-      }).catch(error => {
-        this.$notification.error({
-          message: `${this.$t('label.error')} ${error.response.status}`,
-          description: error.response.data.updatenetworkresponse.errortext || error.response.data.errorresponse.errortext,
-          duration: 0
-        })
-      }).finally(() => {
-        this.settingsourcenat = false
-        this.cancelChangeSourceNat()
-      })
-    },
-    updateVpc (ipaddress) {
-      const params = {}
-      params.sourcenatipaddress = this.sourceNatIp.ipaddress
-      params.id = this.resource.id
-      this.settingsourcenat = true
-      postAPI('updateVPC', params).then(response => {
-        this.fetchData()
-      }).catch(error => {
-        this.$notification.error({
-          message: `${this.$t('label.error')} ${error.response.status}`,
-          description: error.response.data.updatevpcresponse.errortext || error.response.data.errorresponse.errortext,
-          duration: 0
-        })
-      }).finally(() => {
-        this.settingsourcenat = false
-        this.cancelChangeSourceNat()
-      })
     },
     resetSelection () {
       this.setSelection([])
@@ -462,7 +349,7 @@ export default {
       params.ipaddress = this.acquireIp
       this.acquireLoading = true
 
-      postAPI('associateIpAddress', params).then(response => {
+      api('associateIpAddress', params).then(response => {
         this.$pollJob({
           jobId: response.associateipaddressresponse.jobid,
           successMessage: `${this.$t('message.success.acquire.ip')} ${this.$t('label.for')} ${this.resource.name}`,
@@ -479,8 +366,8 @@ export default {
         this.onCloseModal()
       }).catch(error => {
         this.$notification.error({
-          message: this.$t('message.request.failed'),
-          description: (error.response && error.response.headers && error.response.headers['x-description']) || error.message,
+          message: `${this.$t('label.error')} ${error.response.status}`,
+          description: error.response.data.associateipaddressresponse.errortext || error.response.data.errorresponse.errortext,
           duration: 0
         })
       }).finally(() => {
@@ -498,9 +385,9 @@ export default {
     releaseIpAddresses (e) {
       this.showConfirmationAction = false
       this.selectedColumns.splice(0, 0, {
-        key: 'status',
         dataIndex: 'status',
         title: this.$t('label.operation.status'),
+        slots: { customRender: 'status' },
         filters: [
           { text: 'In Progress', value: 'InProgress' },
           { text: 'Success', value: 'success' },
@@ -516,7 +403,7 @@ export default {
     },
     releaseIpAddress (ip) {
       this.fetchLoading = true
-      postAPI('disassociateIpAddress', {
+      api('disassociateIpAddress', {
         id: ip.id
       }).then(response => {
         const jobId = response.disassociateipaddressresponse.jobid
@@ -552,29 +439,38 @@ export default {
         })
       })
     },
-    getVmRouteUsingType (record) {
-      switch (record.virtualmachinetype) {
-        case 'DomainRouter' : return '/router/'
-        case 'ConsoleProxy' :
-        case 'SecondaryStorageVm': return '/systemvm/'
-        default: return '/vm/'
-      }
-    },
     async onShowAcquireIp () {
       this.showAcquireIp = true
+      this.acquireLoading = true
+      this.listPublicIpAddress = []
+
+      try {
+        const listPublicIpAddress = await this.fetchListPublicIpAddress()
+        listPublicIpAddress.forEach(item => {
+          if (item.state === 'Free' || item.state === 'Reserved') {
+            this.listPublicIpAddress.push({
+              ipaddress: item.ipaddress,
+              state: item.state
+            })
+          }
+        })
+        this.listPublicIpAddress.sort(function (a, b) {
+          if (a.ipaddress < b.ipaddress) { return -1 }
+          if (a.ipaddress > b.ipaddress) { return 1 }
+          return 0
+        })
+        this.acquireIp = this.listPublicIpAddress && this.listPublicIpAddress.length > 0 ? this.listPublicIpAddress[0].ipaddress : null
+        this.acquireLoading = false
+      } catch (e) {
+        this.acquireLoading = false
+        this.$notifyError(e)
+      }
     },
     onCloseModal () {
       this.showAcquireIp = false
     },
     closeModal () {
       this.showConfirmationAction = false
-    },
-    showChangeSourceNat (ipaddress) {
-      this.changeSourceNat = true
-      this.sourceNatIp = ipaddress
-    },
-    cancelChangeSourceNat () {
-      this.changeSourceNat = false
     }
   }
 }

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -58,6 +58,16 @@
                 </router-link>
               </div>
             </div>
+            <div class="list__col" v-if="!(resource.domainid === network.domainid && resource.account === network.account)">
+              <div class="list__label">
+                {{ $t('label.account') }}
+              </div>
+              <div>
+                <router-link :to="{ path: '/account', query: { name: network.account, domainid: network.domainid, dataView: true } }">
+                  {{ network.account }}
+                </router-link>
+              </div>
+            </div>
           </div>
           <a-collapse :bordered="false" style="margin-left: -18px">
             <template #expandIcon="props">

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -34,7 +34,14 @@
                 {{ $t('label.name') }}
               </div>
               <div>
-                <router-link :to="{ path: '/guestnetwork/' + network.id }">{{ network.name }} </router-link>
+                <router-link
+                  v-if="network.projectid"
+                  :to="{ path: '/guestnetwork/' + network.id, query: {projectid: -1 }}">
+                  {{ network.name }}
+                </router-link>
+                <router-link v-else :to="{ path: '/guestnetwork/' + network.id }">
+                  {{ network.name }}
+                </router-link>
                 <a-tag v-if="network.broadcasturi">{{ network.broadcasturi }}</a-tag>
               </div>
             </div>
@@ -58,7 +65,23 @@
                 </router-link>
               </div>
             </div>
-            <div class="list__col" v-if="!(resource.domainid === network.domainid && resource.account === network.account)">
+            <div
+              class="list__col"
+              v-if="(network.projectid && resource.account) || (network.projectid !== resource.projectid)"
+            >
+              <div class="list__label">
+                {{ $t('label.project') }}
+              </div>
+              <div>
+                <router-link :to="{ path: '/project/' + network.projectid }">
+                  {{ network.project }}
+                </router-link>
+              </div>
+            </div>
+            <div
+              class="list__col"
+              v-else-if="(network.account && resource.projectid) || network.account !== resource.account || network.domainid !== resource.domainid"
+            >
               <div class="list__label">
                 {{ $t('label.account') }}
               </div>
@@ -549,7 +572,7 @@ export default {
       }
       for (const network of this.networks) {
         this.fetchLoadBalancers(network.id)
-        this.fetchVMs(network.id)
+        this.fetchVMs(network)
         this.updateDisplayCollapsible(network.networkofferingid, network)
       }
       this.publicLBNetworkExists()
@@ -710,17 +733,21 @@ export default {
         this.fetchLoading = false
       })
     },
-    fetchVMs (id) {
+    fetchVMs (network) {
       this.fetchLoading = true
-      getAPI('listVirtualMachines', {
+      var params = {
         listAll: true,
         vpcid: this.resource.id,
-        networkid: id,
+        networkid: network.id,
         page: this.page,
         pagesize: this.pageSize
-      }).then(json => {
-        this.vms[id] = json.listvirtualmachinesresponse.virtualmachine || []
-        this.itemCounts.vms[id] = json.listvirtualmachinesresponse.count || 0
+      }
+      if (network.projectid) {
+        params.projectid = -1
+      }
+      getAPI('listVirtualMachines', params).then(json => {
+        this.vms[network.id] = json.listvirtualmachinesresponse.virtualmachine || []
+        this.itemCounts.vms[network.id] = json.listvirtualmachinesresponse.count || 0
       }).finally(() => {
         this.fetchLoading = false
       })
@@ -784,7 +811,7 @@ export default {
         var params = {
           vpcid: this.resource.id,
           domainid: this.owner?.domainid || this.resource.domainid,
-          account: this.owner?.projectid ? null : (this.owner?.account ? this.owner.account : this.resource.account),
+          account: this.owner?.projectid ? null : (this.owner?.account || this.resource.account),
           projectid: this.owner?.projectid || null,
           networkOfferingId: values.networkOffering,
           name: values.name,

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -166,6 +166,9 @@
       :footer="null"
       @cancel="showCreateNetworkModal = false">
       <a-spin :spinning="modalLoading" v-ctrl-enter="handleAddNetworkSubmit">
+        <div v-if="!isNormalUserOrProject()">
+          <ownership-selection @fetch-owner="fetchOwnerOptions"/>
+        </div>
         <a-form
           layout="vertical"
           :ref="formRef"
@@ -370,11 +373,13 @@ import { mixinForm } from '@/utils/mixin'
 import Status from '@/components/widgets/Status'
 import TooltipLabel from '@/components/widgets/TooltipLabel'
 import { getNetmaskFromCidr } from '@/utils/network'
+import OwnershipSelection from '@/views/compute/wizard/OwnershipSelection.vue'
 
 export default {
   name: 'VpcTiersTab',
   mixins: [mixinForm],
   components: {
+    OwnershipSelection,
     Status,
     TooltipLabel
   },
@@ -506,6 +511,9 @@ export default {
     isObjectEmpty (obj) {
       return !(obj !== null && obj !== undefined && Object.keys(obj).length > 0 && obj.constructor === Object)
     },
+    isNormalUserOrProject () {
+      return ['User'].includes(this.$store.getters.userInfo.roletype) || this.$store.getters.project?.id
+    },
     initForm () {
       this.formRef = ref()
       this.form = reactive({})
@@ -535,6 +543,23 @@ export default {
         this.updateDisplayCollapsible(network.networkofferingid, network)
       }
       this.publicLBNetworkExists()
+    },
+    fetchOwnerOptions (OwnerOptions) {
+      this.owner = {}
+      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+        if (!OwnerOptions.selectedAccount) {
+          this.owner = undefined
+          return
+        }
+        this.owner.account = OwnerOptions.selectedAccount
+        this.owner.domainid = OwnerOptions.selectedDomain
+      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+        if (!OwnerOptions.selectedProject) {
+          this.owner = undefined
+          return
+        }
+        this.owner.projectid = OwnerOptions.selectedProject
+      }
     },
     fetchMtuForZone () {
       getAPI('listZones', {
@@ -748,8 +773,9 @@ export default {
         this.showCreateNetworkModal = false
         var params = {
           vpcid: this.resource.id,
-          domainid: this.resource.domainid,
-          account: this.resource.account,
+          domainid: this.owner?.domainid ? this.owner.domainid : this.resource.domainid,
+          account: this.owner?.projectid ? null : (this.owner?.account ? this.owner.account : this.resource.account),
+          projectid: this.owner?.projectid ? this.owner.projectid : null,
           networkOfferingId: values.networkOffering,
           name: values.name,
           displayText: values.name,

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -783,9 +783,9 @@ export default {
         this.showCreateNetworkModal = false
         var params = {
           vpcid: this.resource.id,
-          domainid: this.owner?.domainid ? this.owner.domainid : this.resource.domainid,
+          domainid: this.owner?.domainid || this.resource.domainid,
           account: this.owner?.projectid ? null : (this.owner?.account ? this.owner.account : this.resource.account),
-          projectid: this.owner?.projectid ? this.owner.projectid : null,
+          projectid: this.owner?.projectid || null,
           networkOfferingId: values.networkOffering,
           name: values.name,
           displayText: values.name,


### PR DESCRIPTION
### Description

This PR adds the "ownership selection" UI fields to VPC tiers and VPC public IPs. 

The "vpcAccess" response attribute was added so the UI can know if the caller has access to the VPC without needing to make a whole new request. This is needed to avoid 404 links (since router.resolve is assembled through API permissions) and so the UI can present the correct public IPs to their possible network tiers (e.g. if the User has tiers of two different VPCs, they can't use one's public IP in the other).

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<details>
<summary>New tier possible owners' listing </summary>

![image](https://github.com/user-attachments/assets/5aab77e1-2105-423b-b976-f937c5cd732e)
</details>

<details>
<summary>Tier listing</summary>

![image](https://github.com/user-attachments/assets/d952e39d-76e1-403d-b143-762488896a73)
</details>

<details>
<summary>User accessing their tier of the Admin's VPC</summary>

![image](https://github.com/user-attachments/assets/d952e39d-76e1-403d-b143-762488896a73)
</details>

<details>
<summary>Possible owners for new IP</summary>

![image](https://github.com/user-attachments/assets/daae5363-358e-4ff9-a3a0-02e23f69cce3)
</details>

### How Has This Been Tested?
Environment with domains Root (with accounts Root Admin and User), Root/1 (with a Domain Admin), Root/A (with a Domain Admin) and Root/A/B (with a Domain Admin and a User). There is a Project in each domain, owned by the respective admins.

| Situation  | Test |
| ------------- | ------------- |
| As Root Admin with VPC owned by self. | Every account and project listed as possible owners in Tier creation |
| As Root Admin with VPC owned by self and one tier for each account and project. | Every account and project listed as possible owners in acquiring public IP. |
| Same as previous, but remove some of the tiers. | The deleted tiers' owners also disappeared from IP possible owners' list, except Root Admin itself. |
| As Root Admin with VPC owned by self, create one tier with a private ACL for the User. | User's access to network page did not present the 'ACL' attribute. |
| As Root Admin with VPC owned by self, create one tier with a global ACL for the User. | User's access to network page showed  'ACL' attribute. |

#### How did you try to break this feature and the system with this change?