### PR TITLE
VR: fix password server exception when no password is found

### DIFF
--- a/systemvm/debian/opt/cloud/bin/passwd_server_ip.py
+++ b/systemvm/debian/opt/cloud/bin/passwd_server_ip.py
@@ -114,7 +114,7 @@ class PasswordRequestHandler(BaseHTTPRequestHandler):
         if requestType == 'send_my_password':
             password = getPassword(clientAddress)
             if not password:
-                self.wfile.write('saved_password')
+                self.wfile.write('saved_password'.encode())
                 syslog.syslog('serve_password: requested password not found for %s' % clientAddress)
             else:
                 self.wfile.write(password.encode())
@@ -122,11 +122,11 @@ class PasswordRequestHandler(BaseHTTPRequestHandler):
         elif requestType == 'saved_password':
             removePassword(clientAddress)
             savePasswordFile()
-            self.wfile.write('saved_password')
+            self.wfile.write('saved_password'.encode())
             syslog.syslog('serve_password: saved_password ack received from %s' % clientAddress)
         else:
             self.send_response(400)
-            self.wfile.write('bad_request')
+            self.wfile.write('bad_request'.encode())
             syslog.syslog('serve_password: bad_request from IP %s' % clientAddress)
         return
 


### PR DESCRIPTION
### Description

This PR fixes errors appeared in /var/log/daemon.log below
```
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]: ----------------------------------------
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]: Exception occurred during processing of request from ('192.168.20.8', 51108)
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]: Traceback (most recent call last):
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/usr/lib/python3.11/socketserver.py", line 691, in process_request_thread
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     self.finish_request(request, client_address)
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/usr/lib/python3.11/socketserver.py", line 361, in finish_request
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     self.RequestHandlerClass(request, client_address, self)
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/usr/lib/python3.11/socketserver.py", line 755, in __init__
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     self.handle()
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/usr/lib/python3.11/http/server.py", line 432, in handle
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     self.handle_one_request()
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/usr/lib/python3.11/http/server.py", line 420, in handle_one_request
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     method()
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/opt/cloud/bin/passwd_server_ip.py", line 117, in do_GET
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     self.wfile.write('saved_password')
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:   File "/usr/lib/python3.11/socketserver.py", line 834, in write
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]:     self._sock.sendall(b)
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]: TypeError: a bytes-like object is required, not 'str'
Sep 13 12:36:58 systemvm passwd_server_ip.py[2154]: ----------------------------------------
```

steps to reproduce the issue
- register a template with password-enabled
- create a vm from the template
- when vm is started and running, reboot it
- check `/var/log/daemon.log` in cloudstack VR

This is a minor issue caused by python3 upgrade #8497 . There is no real issue with the user vms.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
