### PR TITLE
UI: make a newly added Network the default one

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1365,6 +1365,7 @@
 "label.maintenance": "Maintenance",
 "label.majorsequence": "Major Sequence",
 "label.make": "Make",
+"label.make.default": "Make default",
 "label.make.project.owner": "Make Account project owner",
 "label.make.user.project.owner": "Make User project owner",
 "label.makeredundant": "Make redundant",

--- a/ui/src/views/network/NicsTab.vue
+++ b/ui/src/views/network/NicsTab.vue
@@ -106,6 +106,11 @@
           </a-select>
           <p class="modal-form__label">{{ $t('label.publicip') }}:</p>
           <a-input v-model:value="addNetworkData.ip"></a-input>
+          <br>
+          <a-checkbox v-model:checked="addNetworkData.makedefault">
+            {{ $t('label.make.default') }}
+          </a-checkbox>
+          <br>
         </div>
 
         <div :span="24" class="action-button">
@@ -248,13 +253,15 @@ export default {
   data () {
     return {
       vm: {},
+      nic: {},
       showAddNetworkModal: false,
       showUpdateIpModal: false,
       showSecondaryIpModal: false,
       addNetworkData: {
         allNetworks: [],
         network: '',
-        ip: ''
+        ip: '',
+        makedefault: false
       },
       loadingNic: false,
       editIpAddressNic: '',
@@ -332,6 +339,7 @@ export default {
       this.showSecondaryIpModal = false
       this.addNetworkData.network = ''
       this.addNetworkData.ip = ''
+      this.addNetworkData.makedefault = false
       this.editIpAddressValue = ''
       this.newSecondaryIp = ''
     },
@@ -368,9 +376,26 @@ export default {
         this.$pollJob({
           jobId: response.addnictovirtualmachineresponse.jobid,
           successMessage: this.$t('message.success.add.network'),
-          successMethod: () => {
-            this.loadingNic = false
-            this.closeModals()
+          successMethod: async () => {
+            if (this.addNetworkData.makedefault) {
+              try {
+                this.nic = await this.getNic(params.networkid, params.virtualmachineid)
+                if (this.nic) {
+                  this.setAsDefault(this.nic)
+                } else {
+                  this.$notifyError('NIC data not found.')
+                  this.loadingNic = false
+                  this.closeModals()
+                }
+              } catch (error) {
+                this.$notifyError('Failed to fetch NIC data.')
+                this.loadingNic = false
+                this.closeModals()
+              }
+            } else {
+              this.loadingNic = false
+              this.closeModals()
+            }
           },
           errorMessage: this.$t('message.add.network.failed'),
           errorMethod: () => {
@@ -388,6 +413,14 @@ export default {
       }).catch(error => {
         this.$notifyError(error)
         this.loadingNic = false
+      })
+    },
+    getNic (networkid, virtualmachineid) {
+      const params = {}
+      params.virtualmachineid = virtualmachineid
+      params.networkid = networkid
+      return api('listNics', params).then(response => {
+        return response.listnicsresponse.nic[0]
       })
     },
     setAsDefault (item) {

--- a/ui/src/views/network/NicsTab.vue
+++ b/ui/src/views/network/NicsTab.vue
@@ -384,18 +384,13 @@ export default {
                   this.setAsDefault(this.nic)
                 } else {
                   this.$notifyError('NIC data not found.')
-                  this.loadingNic = false
-                  this.closeModals()
                 }
               } catch (error) {
                 this.$notifyError('Failed to fetch NIC data.')
-                this.loadingNic = false
-                this.closeModals()
               }
-            } else {
-              this.loadingNic = false
-              this.closeModals()
             }
+            this.loadingNic = false
+            this.closeModals()
           },
           errorMessage: this.$t('message.add.network.failed'),
           errorMethod: () => {


### PR DESCRIPTION
Checkbox to make a newly added Network the default one in the Instance's Network tab

### Description

This PR adds a checkbox into the Add Network dialogue to make the newly added network the default one in Instance's Network Tab. This will save users from performing an extra step to make the network the default one. 
 
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
![Screenshot from 2024-09-19 11-13-08](https://github.com/user-attachments/assets/d0752bc7-fd0c-48c6-83f5-00620b8724e4)
![Screenshot from 2024-09-19 11-13-19](https://github.com/user-attachments/assets/4070b974-6b06-4ef2-a395-064107937396)
![Screenshot from 2024-09-19 11-13-22](https://github.com/user-attachments/assets/724afc02-19dd-400b-9428-1bbd863d0d96)


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
