### PR TITLE
Shutdown expunged resources cleanup executor properly, and allow other components to configure/start/stop on error

### DIFF
--- a/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
@@ -294,7 +294,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     }
                 }
             } catch (final Throwable e) {
-                logger.error("Unexcpeted exception: ", e);
+                logger.error("Unexpected exception: ", e);
             }
         }
     }
@@ -346,7 +346,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     }
                 });
             } catch (final Throwable e) {
-                logger.error("Unexcpeted exception: ", e);
+                logger.error("Unexpected exception: ", e);
             }
         }
     }
@@ -384,7 +384,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 }
                 executeAsync(peerName, agentId, cmds, true);
             } catch (final Exception e) {
-                logger.warn("Caught exception while talkign to " + peer.getMsid());
+                logger.warn("Caught exception while talking to " + peer.getMsid());
             }
         }
     }

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -70,7 +70,11 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
             @Override
             public void with(ComponentLifecycle lifecycle) {
                 logger.info("starting bean " + lifecycle.getName());
-                lifecycle.start();
+                try {
+                    lifecycle.start();
+                } catch (Exception e) {
+                    logger.error(String.format("Error on starting bean %s - %s", lifecycle.getName(), e.getMessage()), e);
+                }
 
                 if (lifecycle instanceof ManagementBean) {
                     ManagementBean mbean = (ManagementBean)lifecycle;
@@ -100,7 +104,11 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
             @Override
             public void with(ComponentLifecycle lifecycle) {
                 logger.info("stopping bean " + lifecycle.getName());
-                lifecycle.stop();
+                try {
+                    lifecycle.stop();
+                } catch (Exception e) {
+                    logger.error(String.format("Error on stopping bean %s - %s", lifecycle.getName(), e.getMessage()), e);
+                }
             }
         });
 
@@ -119,6 +127,8 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
                 } catch (ConfigurationException e) {
                     logger.error("Failed to configure " +  lifecycle.getName(), e);
                     throw new CloudRuntimeException(e);
+                } catch (Exception e) {
+                    logger.error(String.format("Error on configuring bean %s - %s", lifecycle.getName(), e.getMessage()), e);
                 }
             }
         });

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -69,6 +69,7 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
         with(new WithComponentLifeCycle() {
             @Override
             public void with(ComponentLifecycle lifecycle) {
+                logger.info("starting bean " + lifecycle.getName());
                 lifecycle.start();
 
                 if (lifecycle instanceof ManagementBean) {
@@ -93,6 +94,8 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
     }
 
     public void stopBeans() {
+        logger.info("Stopping CloudStack Components");
+
         with(new WithComponentLifeCycle() {
             @Override
             public void with(ComponentLifecycle lifecycle) {
@@ -100,6 +103,8 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
                 lifecycle.stop();
             }
         });
+
+        logger.info("Done Stopping CloudStack Components");
     }
 
     private void configure() {
@@ -109,6 +114,7 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
             @Override
             public void with(ComponentLifecycle lifecycle) {
                 try {
+                    logger.info("configuring bean " + lifecycle.getName());
                     lifecycle.configure(lifecycle.getName(), lifecycle.getConfigParams());
                 } catch (ConfigurationException e) {
                     logger.error("Failed to configure " +  lifecycle.getName(), e);

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -69,11 +69,11 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
         with(new WithComponentLifeCycle() {
             @Override
             public void with(ComponentLifecycle lifecycle) {
-                logger.info("starting bean " + lifecycle.getName());
+                logger.info("starting bean {}.", lifecycle.getName());
                 try {
                     lifecycle.start();
                 } catch (Exception e) {
-                    logger.error(String.format("Error on starting bean %s - %s", lifecycle.getName(), e.getMessage()), e);
+                    logger.error("Error on starting bean {} - {}", lifecycle.getName(), e.getMessage(), e);
                 }
 
                 if (lifecycle instanceof ManagementBean) {
@@ -103,11 +103,11 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
         with(new WithComponentLifeCycle() {
             @Override
             public void with(ComponentLifecycle lifecycle) {
-                logger.info("stopping bean " + lifecycle.getName());
+                logger.info("stopping bean {}.", lifecycle.getName());
                 try {
                     lifecycle.stop();
                 } catch (Exception e) {
-                    logger.error(String.format("Error on stopping bean %s - %s", lifecycle.getName(), e.getMessage()), e);
+                    logger.error("Error on stopping bean {} - {}", lifecycle.getName(), e.getMessage(), e);
                 }
             }
         });
@@ -122,13 +122,13 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
             @Override
             public void with(ComponentLifecycle lifecycle) {
                 try {
-                    logger.info("configuring bean " + lifecycle.getName());
+                    logger.info("configuring bean {}.", lifecycle.getName());
                     lifecycle.configure(lifecycle.getName(), lifecycle.getConfigParams());
                 } catch (ConfigurationException e) {
                     logger.error("Failed to configure " +  lifecycle.getName(), e);
                     throw new CloudRuntimeException(e);
                 } catch (Exception e) {
-                    logger.error(String.format("Error on configuring bean %s - %s", lifecycle.getName(), e.getMessage()), e);
+                    logger.error("Error on configuring bean {} - {}", lifecycle.getName(), e.getMessage(), e);
                 }
             }
         });

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycleStart.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycleStart.java
@@ -24,12 +24,7 @@ public class CloudStackExtendedLifeCycleStart extends AbstractSmartLifeCycle imp
 
     @Override
     public void stop() {
-        try {
-            lifeCycle.stopBeans();
-        } catch (Exception e) {
-            logger.error("Error on stopping beans - " + e.getMessage(), e);
-        }
-
+        lifeCycle.stopBeans();
         super.stop();
     }
 
@@ -48,10 +43,6 @@ public class CloudStackExtendedLifeCycleStart extends AbstractSmartLifeCycle imp
 
     @Override
     public void run() {
-        try {
-            lifeCycle.startBeans();
-        } catch (Exception e) {
-            logger.error("Error on starting beans - " + e.getMessage(), e);
-        }
+        lifeCycle.startBeans();
     }
 }

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycleStart.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycleStart.java
@@ -24,7 +24,12 @@ public class CloudStackExtendedLifeCycleStart extends AbstractSmartLifeCycle imp
 
     @Override
     public void stop() {
-        lifeCycle.stopBeans();
+        try {
+            lifeCycle.stopBeans();
+        } catch (Exception e) {
+            logger.error("Error on stopping beans - " + e.getMessage(), e);
+        }
+
         super.stop();
     }
 
@@ -43,7 +48,10 @@ public class CloudStackExtendedLifeCycleStart extends AbstractSmartLifeCycle imp
 
     @Override
     public void run() {
-        lifeCycle.startBeans();
+        try {
+            lifeCycle.startBeans();
+        } catch (Exception e) {
+            logger.error("Error on starting beans - " + e.getMessage(), e);
+        }
     }
-
 }

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
@@ -77,10 +77,10 @@ public class CloudStackSpringContext {
         for (String appName : contextMap.keySet()) {
             ApplicationContext contex = contextMap.get(appName);
             if (contex instanceof ConfigurableApplicationContext) {
-                logger.trace("Registering shutdown hook for bean "+ appName);
+                logger.trace("Registering shutdown hook for bean {}.", appName);
                 ((ConfigurableApplicationContext)contex).registerShutdownHook();
             } else {
-                logger.warn("Shutdown hook not registered for bean " + appName);
+                logger.warn("Shutdown hook not registered for bean {}.", appName);
             }
         }
     }

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
@@ -77,8 +77,10 @@ public class CloudStackSpringContext {
         for (String appName : contextMap.keySet()) {
             ApplicationContext contex = contextMap.get(appName);
             if (contex instanceof ConfigurableApplicationContext) {
-                logger.trace("registering shutdown hook for bean "+ appName);
+                logger.trace("Registering shutdown hook for bean "+ appName);
                 ((ConfigurableApplicationContext)contex).registerShutdownHook();
+            } else {
+                logger.warn("Shutdown hook not registered for bean " + appName);
             }
         }
     }

--- a/server/src/main/java/org/apache/cloudstack/resource/ResourceCleanupServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/resource/ResourceCleanupServiceImpl.java
@@ -579,7 +579,9 @@ public class ResourceCleanupServiceImpl extends ManagerBase implements ResourceC
     @Override
     public boolean stop() {
         purgeExpungedResourcesJobExecutor.shutdown();
-        expungedResourcesCleanupExecutor.shutdownNow();
+        if (expungedResourcesCleanupExecutor != null) {
+            expungedResourcesCleanupExecutor.shutdownNow();
+        }
         return true;
     }
 


### PR DESCRIPTION
### Description

This PR shutdowns expunged resources cleanup executor when obj is available (when config expunged.resources.purge.enabled is true), allows other components to configure/start/stop on error, and adds some logs in component lifecycle classes.

Noticed this exception with custom logs, the remaining components fails to stop after this exception.
```
WARN  [o.a.c.s.l.CloudStackExtendedLifeCycleStart] (SpringContextShutdownHook:null) (logid:) Error on stopping beans - null
java.lang.NullPointerException
        at org.apache.cloudstack.resource.ResourceCleanupServiceImpl.stop(ResourceCleanupServiceImpl.java:584)
        at org.apache.cloudstack.spring.lifecycle.CloudStackExtendedLifeCycle$2.with(CloudStackExtendedLifeCycle.java:105)
        at org.apache.cloudstack.spring.lifecycle.CloudStackExtendedLifeCycle.with(CloudStackExtendedLifeCycle.java:159)
        at org.apache.cloudstack.spring.lifecycle.CloudStackExtendedLifeCycle.stopBeans(CloudStackExtendedLifeCycle.java:101)
        at org.apache.cloudstack.spring.lifecycle.CloudStackExtendedLifeCycleStart.stop(CloudStackExtendedLifeCycleStart.java:32)
        at org.apache.cloudstack.spring.lifecycle.AbstractSmartLifeCycle.stop(AbstractSmartLifeCycle.java:49)
        at org.springframework.context.support.DefaultLifecycleProcessor.doStop(DefaultLifecycleProcessor.java:234)
        at org.springframework.context.support.DefaultLifecycleProcessor.access$300(DefaultLifecycleProcessor.java:54)
        at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.stop(DefaultLifecycleProcessor.java:373)
        at org.springframework.context.support.DefaultLifecycleProcessor.stopBeans(DefaultLifecycleProcessor.java:206)
        at org.springframework.context.support.DefaultLifecycleProcessor.onClose(DefaultLifecycleProcessor.java:129)
        at org.springframework.context.support.AbstractApplicationContext.doClose(AbstractApplicationContext.java:1069)
        at org.springframework.context.support.AbstractApplicationContext$1.run(AbstractApplicationContext.java:993)
```

Fixes #9722 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

Mgmt2 service stopped =>

<img width="1263" alt="MgmtServers_4 20 0 0-SNAPSHOT_Fixed" src="https://github.com/user-attachments/assets/410ef580-7fd9-4c4d-98a1-89f1a81ed626">


### How Has This Been Tested?

Manually tested management server start & stop.

```
2024-09-23 18:20:51,111 INFO  [o.a.c.s.l.CloudStackExtendedLifeCycle] (SpringContextShutdownHook:[]) (logid:) stopping bean ClusterServiceServletAdapter
2024-09-23 18:20:51,111 INFO  [o.a.c.s.l.CloudStackExtendedLifeCycle] (SpringContextShutdownHook:[]) (logid:) stopping bean ClusterManagerImpl

[root@ol8 ~]# cat stopping-beans-check.txt | wc -l
665
```

[stopping-beans-check.txt](https://github.com/user-attachments/files/17102657/stopping-beans-check.txt)


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
