### PR TITLE
Restrict the migration of volumes attached to VMs in Starting state

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3201,6 +3201,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         VMInstanceVO vm = null;
         if (instanceId != null) {
             vm = _vmInstanceDao.findById(instanceId);
+            checkIfVmIsStarting(vm, vol);
         }
 
         // Check that Vm to which this volume is attached does not have VM Snapshots
@@ -3396,6 +3397,14 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         return orchestrateMigrateVolume(vol, destPool, liveMigrateVolume, newDiskOffering);
+    }
+
+    private void checkIfVmIsStarting(VMInstanceVO vm, VolumeVO vol) {
+        if (vm.getState().equals(State.Starting)) {
+            s_logger.debug(String.format("Unable to migrate volume: [%s] Id: [%s] because the VM: [%s] Id: [%s] has not started yet.", vol.getName(), vol.getId(), vm.getInstanceName(), vm.getUuid()));
+
+            throw new CloudRuntimeException("Volume migration is not allowed while the VM is starting.");
+        }
     }
 
     private boolean isSourceOrDestNotOnStorPool(StoragePoolVO storagePoolVO, StoragePoolVO destinationStoragePoolVo) {


### PR DESCRIPTION
### Description
 
This PR restricts users from migrating volumes attached to VMs that are in starting state. Migrating volumes while their VMs are starting shouldn't be allowed because sometimes the VM could end up not actually starting, and if ACS starts migrating its volume, this could lead to other issues.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):
<details><summary>Image</summary>

![migrate-volume](https://github.com/user-attachments/assets/eac1c4b3-e8d4-4e91-a7dd-636fc4533e88)

</details>

### How Has This Been Tested?

I tested this PR by deploying an instance and then trying to migrate its volume while the instance was starting. Before the changes, the volume migration process would start. After the migration, an error is thrown, as expected.