### PR TITLE
Hide UserData field from the EditVM view for VMs that do not offer it

### DIFF
--- a/ui/src/views/compute/EditVM.vue
+++ b/ui/src/views/compute/EditVM.vue
@@ -300,7 +300,8 @@ export default {
         return
       }
       const listNetworkParams = {
-        id: networkId
+        id: networkId,
+        listall: true
       }
       api(`listNetworks`, listNetworkParams).then(json => {
         json.listnetworksresponse.network[0].service.forEach(service => {
@@ -309,7 +310,8 @@ export default {
 
             const listVmParams = {
               id: this.resource.id,
-              userdata: true
+              userdata: true,
+              listall: true
             }
             api('listVirtualMachines', listVmParams).then(json => {
               this.form.userdata = atob(json.listvirtualmachinesresponse.virtualmachine[0].userdata || '')

--- a/ui/src/views/compute/EditVM.vue
+++ b/ui/src/views/compute/EditVM.vue
@@ -84,7 +84,7 @@
           }"
           :options="groups.opts" />
       </a-form-item>
-      <a-form-item>
+      <a-form-item v-if="userDataEnabled">
         <template #label>
           <tooltip-label :title="$t('label.userdata')" :tooltip="apiParams.userdata.description"/>
         </template>
@@ -143,6 +143,7 @@ export default {
     return {
       serviceOffering: {},
       template: {},
+      userDataEnabled: false,
       securityGroupsEnabled: false,
       dynamicScalingVmConfig: false,
       loading: false,
@@ -289,15 +290,35 @@ export default {
       return decodedData.toString('utf-8')
     },
     fetchUserData () {
-      const params = {
-        id: this.resource.id,
-        userdata: true
+      let networkId
+      this.resource.nic.forEach(nic => {
+        if (nic.isdefault) {
+          networkId = nic.networkid
+        }
+      })
+      if (!networkId) {
+        return
       }
+      const listNetworkParams = {
+        id: networkId
+      }
+      api(`listNetworks`, listNetworkParams).then(json => {
+        json.listnetworksresponse.network[0].service.forEach(service => {
+          if (service.name === 'UserData') {
+            this.userDataEnabled = true
 
-      api('listVirtualMachines', params).then(json => {
-        this.form.userdata = this.decodeUserData(json.listvirtualmachinesresponse.virtualmachine[0].userdata || '')
+            const listVmParams = {
+              id: this.resource.id,
+              userdata: true
+            }
+            api('listVirtualMachines', listVmParams).then(json => {
+              this.form.userdata = atob(json.listvirtualmachinesresponse.virtualmachine[0].userdata || '')
+            })
+          }
+        })
       })
     },
+
     handleSubmit () {
       this.formRef.value.validate().then(() => {
         const values = toRaw(this.form)


### PR DESCRIPTION
### Description
 
Currently in ACS, when editing a VM, the field userdata will be present even if the VM's network does not support the feature. This PR fixes this issue by not showing the field if the VM does not offer userdata.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I tested this by verifying if the userdata field would still show up in the Edit VM View when editing VMs whose networks did not offer userdata, and it worked as expected. I've also tested cases in which a VM could have more than one network, and for these cases it will consider the default network and disregard the other networks. 
