### PR TITLE
Fix VMWare leftovers when deleting VM without root disk

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/CleanupVMCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/CleanupVMCommand.java
@@ -1,0 +1,46 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.agent.api;
+
+/**
+ * This command will destroy a leftover VM during the expunge process if it wasn't destroyed before.
+ *
+ */
+public class CleanupVMCommand extends Command {
+    String vmName;
+    boolean executeInSequence;
+
+    public CleanupVMCommand(String vmName) {
+        this(vmName, false);
+    }
+    public CleanupVMCommand(String vmName, boolean executeInSequence) {
+        this.vmName = vmName;
+        this.executeInSequence = executeInSequence;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return executeInSequence;
+    }
+
+    public String getVmName() {
+        return vmName;
+    }
+}

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.cloud.agent.api.CleanupVMCommand;
+import com.cloud.storage.VolumeApiService;
+import com.cloud.utils.LogUtils;
 import javax.inject.Inject;
 
 import com.cloud.agent.api.to.NfsTO;
@@ -369,6 +372,13 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
             return guid;
 
         return tokens[0] + "@" + vCenterIp;
+    }
+
+    @Override public List<Command> finalizeExpunge(VirtualMachine vm) {
+        List<Command> commands = new ArrayList<Command>();
+        final CleanupVMCommand cleanupVMCommand = new CleanupVMCommand(vm.getInstanceName(), true);
+        commands.add(cleanupVMCommand);
+        return commands;
     }
 
     @Override public List<Command> finalizeExpungeNics(VirtualMachine vm, List<NicProfile> nics) {

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.cloud.agent.api.CleanupVMCommand;
-import com.cloud.storage.VolumeApiService;
-import com.cloud.utils.LogUtils;
 import javax.inject.Inject;
 
 import com.cloud.agent.api.to.NfsTO;

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -45,6 +45,8 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.cloud.agent.api.CleanupVMCommand;
+import com.vmware.vim25.StorageIOAllocationInfo;
 import javax.naming.ConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -585,6 +587,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 return execute((ResizeVolumeCommand) cmd);
             } else if (clz == UnregisterVMCommand.class) {
                 return execute((UnregisterVMCommand) cmd);
+            } else if (clz == CleanupVMCommand.class) {
+                return execute((CleanupVMCommand) cmd);
             } else if (cmd instanceof StorageSubSystemCommand) {
                 checkStorageProcessorAndHandlerNfsVersionAttribute((StorageSubSystemCommand) cmd);
                 return storageHandler.handleStorageCommands((StorageSubSystemCommand) cmd);
@@ -5829,6 +5833,26 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
         // that issue this command. Note that pvlan operations are supported only
         // in Distributed Virtual Switch environments for vmware deployments.
         return new Answer(cmd, true, "success");
+    }
+
+    protected Answer execute(CleanupVMCommand cmd) {
+        VmwareContext context = getServiceContext();
+        VmwareHypervisorHost hyperHost = getHyperHost(context);
+
+        try {
+            VirtualMachineMO vmMo = hyperHost.findVmOnHyperHost(cmd.getVmName());
+            if (vmMo == null) {
+                String msg = String.format("VM [%s] not found on vCenter, cleanup not needed.", cmd.getVmName());
+                s_logger.debug(msg);
+                return new Answer(cmd, true, msg);
+            }
+            vmMo.destroy();
+            String msg = String.format("VM [%s] remnants on vCenter cleaned up.", cmd.getVmName());
+            s_logger.debug(msg);
+            return new Answer(cmd, true, msg);
+        } catch (Exception e) {
+            return new Answer(cmd, false, createLogMessageException(e, cmd));
+        }
     }
 
     protected Answer execute(UnregisterVMCommand cmd) {

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -46,7 +46,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.cloud.agent.api.CleanupVMCommand;
-import com.vmware.vim25.StorageIOAllocationInfo;
 import javax.naming.ConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 


### PR DESCRIPTION
### Description

The MS sends the destroy/delete command of a VM to vCenter when cleaning up its volumes.  If the VM does not have a root volume, the VM with its folder and metadata files remain in vCenter.

To reproduce, deploy a VM, detach its volume, and delete the VM. Then, check vCenter and the VM will still be there.

This PR fixes it by implementing finalizeExpunge for VMWareGuru, which queues a Cleanup Command that, if the VM still exists, sends a destroy command to vCenter to cleanup whatever remained.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

| Deploy VM | Destroy VM | Before PR | After PR |
| ------ | ------ | ------ |  ------ | 
| Without data disks, detach root disk. | With expunge | VM remains on vCenter :x: | VM gone from vCenter :white_check_mark: |
| Without data disks, detach root disk. | Without expunge | VM remains on vCenter :white_check_mark: | VM remains on vCenter :white_check_mark: |
| Without data disks, detach nothing | With expunge | VM gone from vCenter :white_check_mark: | VM gone from vCenter :white_check_mark: |
| With a data disk, detach root disk | With expunge, without selecting data disk | VM remains on vCenter :x: | VM gone from vCenter :white_check_mark: |
| With a data disk, detach root disk | With expunge, selecting the data disk | VM remains on vCenter :x: | VM gone from vCenter :white_check_mark: |
| With a data disk, detach nothing | With expunge, without selecting the data disk | VM gone from vCenter :white_check_mark: | VM gone from vCenter :white_check_mark: |