### PR TITLE
Fix Ctrl+Enter command on `Start Instance` dialog

### DIFF
--- a/ui/src/views/compute/StartVirtualMachine.vue
+++ b/ui/src/views/compute/StartVirtualMachine.vue
@@ -16,7 +16,7 @@
 // under the License.
 
 <template>
-  <div class="form-layout" v-ctrl-enter="handleSubmit">
+  <div class="form-layout">
     <a-spin :spinning="loading">
       <a-alert type="warning">
         <template #message>{{ $t('message.action.start.instance') }}</template>
@@ -93,7 +93,7 @@
             <template #label>
               <tooltip-label :title="$t('label.considerlasthost')" :tooltip="apiParams.considerlasthost.description"/>
             </template>
-            <a-switch v-model:checked="form.considerlasthost" />
+            <a-switch v-model:checked="form.considerlasthost" v-focus="true"/>
           </a-form-item>
         </div>
 
@@ -150,6 +150,12 @@ export default {
       this.fetchClusters()
       this.fetchHosts()
     }
+  },
+  mounted () {
+    document.addEventListener('keydown', this.handleKeyPress)
+  },
+  beforeUnmount () {
+    document.removeEventListener('keydown', this.handleKeyPress)
   },
   methods: {
     initForm () {
@@ -264,6 +270,12 @@ export default {
     },
     closeAction () {
       this.$emit('close-action')
+    },
+    handleKeyPress (event) {
+      event.preventDefault()
+      if ((event.code === 'Enter' || event.code === 'NumpadEnter') && event.ctrlKey === true) {
+        this.handleSubmit(event)
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the bug presented in the issue #9668, where the `Start instance` dialog  in the UI does not respond to the `Ctrl+Enter` command.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I tested by using the `Ctrl+Enter` command when starting a VM in the instance list view and the VM details view. Worked as intended in both cases.
