### PR TITLE
Add new column `last_id` to the table volumes

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
@@ -48,8 +48,8 @@ public class VolumeVO implements Volume {
     @Column(name = "id")
     long id;
 
-    @Column(name = "previous_id")
-    private long previousId;
+    @Column(name = "last_id")
+    private long lastId;
 
     @Column(name = "name")
     String name;
@@ -681,11 +681,11 @@ public class VolumeVO implements Volume {
 
     public void setEncryptFormat(String encryptFormat) { this.encryptFormat = encryptFormat; }
 
-    public long getPreviousId() {
-        return previousId;
+    public long getLastId() {
+        return lastId;
     }
 
-    public void setPreviousId(long previousId) {
-        this.previousId = previousId;
+    public void setLastId(long lastId) {
+        this.lastId = lastId;
     }
 }

--- a/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/VolumeVO.java
@@ -48,6 +48,9 @@ public class VolumeVO implements Volume {
     @Column(name = "id")
     long id;
 
+    @Column(name = "previous_id")
+    private long previousId;
+
     @Column(name = "name")
     String name;
 
@@ -677,4 +680,12 @@ public class VolumeVO implements Volume {
     public String getEncryptFormat() { return encryptFormat; }
 
     public void setEncryptFormat(String encryptFormat) { this.encryptFormat = encryptFormat; }
+
+    public long getPreviousId() {
+        return previousId;
+    }
+
+    public void setPreviousId(long previousId) {
+        this.previousId = previousId;
+    }
 }

--- a/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
@@ -71,4 +71,4 @@ UPDATE `cloud`.`configuration` SET
     `options` = 'FirstFitRouting,RandomAllocator,TestingAllocator,FirstFitAllocator,RecreateHostAllocator'
 WHERE `name` = 'host.allocators.order';
 
-CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('volumes','previous_id', 'bigint(20) unsigned DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('volumes','last_id', 'bigint(20) unsigned DEFAULT NULL');

--- a/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
@@ -70,3 +70,5 @@ CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.user_data', 'removed', 'datetime COM
 UPDATE `cloud`.`configuration` SET
     `options` = 'FirstFitRouting,RandomAllocator,TestingAllocator,FirstFitAllocator,RecreateHostAllocator'
 WHERE `name` = 'host.allocators.order';
+
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('volumes','previous_id', 'bigint(20) unsigned DEFAULT NULL');

--- a/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41900to41910.sql
@@ -71,4 +71,5 @@ UPDATE `cloud`.`configuration` SET
     `options` = 'FirstFitRouting,RandomAllocator,TestingAllocator,FirstFitAllocator,RecreateHostAllocator'
 WHERE `name` = 'host.allocators.order';
 
+-- Add last_id to the volumes table
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('volumes','last_id', 'bigint(20) unsigned DEFAULT NULL');

--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -2283,6 +2283,8 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             if (success) {
                 VolumeVO volumeVO = _volumeDao.findById(destVolumeInfo.getId());
                 volumeVO.setFormat(ImageFormat.QCOW2);
+                volumeVO.setPreviousId(srcVolumeInfo.getId());
+
                 _volumeDao.update(volumeVO.getId(), volumeVO);
 
                 _volumeService.copyPoliciesBetweenVolumesAndDestroySourceVolumeAfterMigration(Event.OperationSuccessed, null, srcVolumeInfo, destVolumeInfo, false);

--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -2283,7 +2283,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             if (success) {
                 VolumeVO volumeVO = _volumeDao.findById(destVolumeInfo.getId());
                 volumeVO.setFormat(ImageFormat.QCOW2);
-                volumeVO.setPreviousId(srcVolumeInfo.getId());
+                volumeVO.setLastId(srcVolumeInfo.getId());
 
                 _volumeDao.update(volumeVO.getId(), volumeVO);
 

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -1720,7 +1720,7 @@ public class VolumeServiceImpl implements VolumeService {
             newVol.setPassphraseId(volume.getPassphraseId());
             newVol.setEncryptFormat(volume.getEncryptFormat());
         }
-        newVol.setPreviousId(volume.getId());
+        newVol.setLastId(volume.getId());
         return volDao.persist(newVol);
     }
 

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -1720,6 +1720,7 @@ public class VolumeServiceImpl implements VolumeService {
             newVol.setPassphraseId(volume.getPassphraseId());
             newVol.setEncryptFormat(volume.getEncryptFormat());
         }
+        newVol.setPreviousId(volume.getId());
         return volDao.persist(newVol);
     }
 


### PR DESCRIPTION
### Description
 
In ACS Once a volume is migrated, it duplicates its row in the database and labels the previous one as removed; however, there is no reference to the deleted row, making it so the operator is unable to track the previous volume effectively. This PR aims to change this by adding a new column to the table volumes called `last_id`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

This PR was tested by live migrating VM with storage and also by migrating a volume with the VM turned off; in both cases, the new column was populated accordingly.