### PR TITLE
Add cpu speed detection methods

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
@@ -58,9 +58,8 @@ public class KVMHostInfo {
     private long reservedMemory;
     private long overCommitMemory;
     private List<String> capabilities = new ArrayList<>();
-
-    private static String cpuInfoFreqFileName = "/sys/devices/system/cpu/cpu0/cpufreq/base_frequency";
     private static String cpuArchCommand = "/usr/bin/arch";
+    private static List<String> cpuInfoFreqFileNames = List.of("/sys/devices/system/cpu/cpu0/cpufreq/base_frequency","/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq");
 
     public KVMHostInfo(long reservedMemory, long overCommitMemory, long manualSpeed, int reservedCpus) {
         this.cpuSpeed = manualSpeed;
@@ -134,29 +133,41 @@ public class KVMHostInfo {
     }
 
     private static long getCpuSpeedFromCommandLscpu() {
+        long speed = 0L;
+        LOGGER.info("Fetching CPU speed from command \"lscpu\".");
         try {
-            LOGGER.info("Fetching CPU speed from command \"lscpu\".");
             String command = "lscpu | grep -i 'Model name' | head -n 1 | egrep -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
             String result = Script.runSimpleBashScript(command);
-            long speed = (long) (Float.parseFloat(result) * 1000);
+            speed = (long) (Float.parseFloat(result) * 1000);
             LOGGER.info(String.format("Command [%s] resulted in the value [%s] for CPU speed.", command, speed));
             return speed;
         } catch (NullPointerException | NumberFormatException e) {
             LOGGER.error(String.format("Unable to retrieve the CPU speed from lscpu."), e);
-            return 0L;
         }
+        try {
+            String command = "lscpu | grep -i 'CPU max MHz' | head -n 1 | sed 's/^.*: //' | xargs";
+            String result = Script.runSimpleBashScript(command);
+            speed = (long) (Float.parseFloat(result));
+            LOGGER.info(String.format("Command [%s] resulted in the value [%s] for CPU speed.", command, speed));
+            return speed;
+        } catch (NullPointerException | NumberFormatException e) {
+            LOGGER.error(String.format("Unable to retrieve the CPU speed from lscpu."), e);
+        }
+        return speed;
     }
 
     private static long getCpuSpeedFromFile() {
-        LOGGER.info(String.format("Fetching CPU speed from file [%s].", cpuInfoFreqFileName));
-        try (Reader reader = new FileReader(cpuInfoFreqFileName)) {
-            Long cpuInfoFreq = Long.parseLong(IOUtils.toString(reader).trim());
-            LOGGER.info(String.format("Retrieved value [%s] from file [%s]. This corresponds to a CPU speed of [%s] MHz.", cpuInfoFreq, cpuInfoFreqFileName, cpuInfoFreq / 1000));
-            return cpuInfoFreq / 1000;
-        } catch (IOException | NumberFormatException e) {
-            LOGGER.error(String.format("Unable to retrieve the CPU speed from file [%s]", cpuInfoFreqFileName), e);
-            return 0L;
+        for (final String cpuInfoFreqFileName:  cpuInfoFreqFileNames) {
+            LOGGER.info(String.format("Fetching CPU speed from file [%s].", cpuInfoFreqFileName));
+            try (Reader reader = new FileReader(cpuInfoFreqFileName)) {
+                Long cpuInfoFreq = Long.parseLong(IOUtils.toString(reader).trim());
+                LOGGER.info(String.format("Retrieved value [%s] from file [%s]. This corresponds to a CPU speed of [%s] MHz.", cpuInfoFreq, cpuInfoFreqFileName, cpuInfoFreq / 1000));
+                return cpuInfoFreq / 1000;
+            } catch (IOException | NumberFormatException e) {
+                LOGGER.error(String.format("Unable to retrieve the CPU speed from file [%s]", cpuInfoFreqFileName), e);
+            }
         }
+        return 0L;
     }
 
     protected static long getCpuSpeedFromHostCapabilities(final String capabilities) {


### PR DESCRIPTION
### Description

This PR ads two additional methods to detect cpu speed on kvm hosts. This will improve the speed detection on AMD Epyc cpu's. For cpu's where the Ghz is in the model name no change will occur. For other cpu's the detected cpu speed ca change to the max Mhz of the cpu. 

1. A match on the `CPU max MHz` value from lscpu
2. An additional sysfs file `scaling_max_freq`

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #6914 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
Tested on a kvm host with an AMD EPYC 7601 cpu. 

* With normal agent start the cpu speed is detected as the expected 2200Mhz.
* Removed the cpu max Mhz line from the lscpu output and restarted agent. The detected speed is still the expected 2200Mhz.

On an kvm centos8 vm without the lscpu matches and neither file the agent still falls back on host capabilities.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
