### PR TITLE
check tags while fetching storage pool for importing vm

### DIFF
--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -277,6 +277,7 @@ public class UnmanagedVMsManagerImplTest {
         List<UnmanagedInstanceTO.Disk> instanceDisks = new ArrayList<>();
         UnmanagedInstanceTO.Disk instanceDisk = new UnmanagedInstanceTO.Disk();
         instanceDisk.setDiskId("1000-1");
+        instanceDisk.setPosition(0);
         instanceDisk.setLabel("DiskLabel");
         instanceDisk.setController("scsi");
         instanceDisk.setImagePath("[b6ccf44a1fa13e29b3667b4954fa10ee] TestInstance/ROOT-1.vmdk");

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -423,6 +423,7 @@ public class UnmanagedVMsManagerImplTest {
         ImportUnmanagedInstanceCmd importUnmanageInstanceCmd = Mockito.mock(ImportUnmanagedInstanceCmd.class);
         when(importUnmanageInstanceCmd.getName()).thenReturn("TestInstance");
         when(importUnmanageInstanceCmd.getDomainId()).thenReturn(null);
+        when(volumeApiService.doesTargetStorageSupportDiskOffering(any(StoragePool.class), any())).thenReturn(true);
         try (MockedStatic<UsageEventUtils> ignored = Mockito.mockStatic(UsageEventUtils.class)) {
             unmanagedVMsManager.importUnmanagedInstance(importUnmanageInstanceCmd);
         }
@@ -780,11 +781,13 @@ public class UnmanagedVMsManagerImplTest {
 
     @Test
     public void testImportVmFromVmwareToKvmExistingVcenterSetConvertHost() throws OperationTimedoutException, AgentUnavailableException {
+        when(volumeApiService.doesTargetStorageSupportDiskOffering(any(StoragePool.class), any())).thenReturn(true);
         baseTestImportVmFromVmwareToKvm(VcenterParameter.EXISTING, true, false);
     }
 
     @Test
     public void testImportVmFromVmwareToKvmExistingVcenterSetConvertHostAndTemporaryStorage() throws OperationTimedoutException, AgentUnavailableException {
+        when(volumeApiService.doesTargetStorageSupportDiskOffering(any(StoragePool.class), any())).thenReturn(true);
         baseTestImportVmFromVmwareToKvm(VcenterParameter.EXISTING, true, true);
     }
 

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -703,6 +703,8 @@ public class UnmanagedVMsManagerImplTest {
             when(agentManager.send(Mockito.eq(convertHostId), Mockito.any(CheckConvertInstanceCommand.class))).thenReturn(checkConvertInstanceAnswer);
         }
 
+        when(volumeApiService.doesTargetStorageSupportDiskOffering(any(StoragePool.class), any())).thenReturn(true);
+
         ConvertInstanceAnswer convertInstanceAnswer = mock(ConvertInstanceAnswer.class);
         ImportConvertedInstanceAnswer convertImportedInstanceAnswer = mock(ImportConvertedInstanceAnswer.class);
         when(convertInstanceAnswer.getResult()).thenReturn(vcenterParameter != VcenterParameter.CONVERT_FAILURE);
@@ -781,13 +783,11 @@ public class UnmanagedVMsManagerImplTest {
 
     @Test
     public void testImportVmFromVmwareToKvmExistingVcenterSetConvertHost() throws OperationTimedoutException, AgentUnavailableException {
-        when(volumeApiService.doesTargetStorageSupportDiskOffering(any(StoragePool.class), any())).thenReturn(true);
         baseTestImportVmFromVmwareToKvm(VcenterParameter.EXISTING, true, false);
     }
 
     @Test
     public void testImportVmFromVmwareToKvmExistingVcenterSetConvertHostAndTemporaryStorage() throws OperationTimedoutException, AgentUnavailableException {
-        when(volumeApiService.doesTargetStorageSupportDiskOffering(any(StoragePool.class), any())).thenReturn(true);
         baseTestImportVmFromVmwareToKvm(VcenterParameter.EXISTING, true, true);
     }
 


### PR DESCRIPTION
### Description

This PR fixes https://github.com/apache/cloudstack/issues/9670

<details><summary>Details</summary>
<p>

This pull request includes several changes to the `UnmanagedVMsManagerImpl` class to enhance the handling of disk offerings during the import and conversion of unmanaged instances. The most important changes include modifications to the `getStoragePool` method, updates to the conversion and import logic, and adjustments to the test cases.

Enhancements to disk offering handling:

* [`server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java`](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L539-R539): Modified the `getStoragePool` method to accept an additional `diskOfferingTags` parameter and updated the logic to ensure the storage pool supports the disk offering. [[1]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L539-R539) [[2]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L549-R550) [[3]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L561-R563)

Updates to conversion and import logic:

* [`server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java`](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L624-R627): Updated various methods to include disk offering tags and ensure compatibility with storage pools, such as `checkUnmanagedDiskAndOfferingForImport`, `importDisk`, `importUnmanagedInstanceFromVmwareToKvm`, `sanitizeConvertedInstance`, `checkConversionSupportOnHost`, `convertVmwareInstanceToKVMWithOVFOnConvertLocation`, and `convertVmwareInstanceToKVMAfterExportingOVFToConvertLocation`. [[1]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L624-R627) [[2]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L861-R864) [[3]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L1615-R1618) [[4]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L1631-R1645) [[5]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L1729-R1737) [[6]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L1915-R1930) [[7]](diffhunk://#diff-b1de8eb3cd6ebc9cdb187e0e4a3ff9674b6c5cf169fe338c059c5e42f70598f0L1935-R1951)

Adjustments to test cases:

* [`server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java`](diffhunk://#diff-dd50c77f36c757c8f23e541fe742b29587ebe88b27704d18fb181e994a3805b8R426): Updated the test methods `importUnmanagedInstanceTest` and `baseTestImportVmFromVmwareToKvm` to mock the `doesTargetStorageSupportDiskOffering` method and ensure the tests reflect the new disk offering logic. [[1]](diffhunk://#diff-dd50c77f36c757c8f23e541fe742b29587ebe88b27704d18fb181e994a3805b8R426) [[2]](diffhunk://#diff-dd50c77f36c757c8f23e541fe742b29587ebe88b27704d18fb181e994a3805b8R706-R707)

</p>
</details> 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
