### PR TITLE
Add support to RBD erasure code pools

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/StoragePoolResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/StoragePoolResponse.java
@@ -149,6 +149,10 @@ public class StoragePoolResponse extends BaseResponseWithAnnotations {
     @Param(description = "whether this pool is managed or not")
     private Boolean managed;
 
+    @SerializedName(ApiConstants.DETAILS)
+    @Param(description = "the storage pool details")
+    private Map<String, String> details;
+
     public Map<String, String> getCaps() {
         return caps;
     }
@@ -406,5 +410,13 @@ public class StoragePoolResponse extends BaseResponseWithAnnotations {
 
     public void setManaged(Boolean managed) {
         this.managed = managed;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
     }
 }

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
@@ -59,6 +59,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class DefaultHostListener implements HypervisorHostListener {
     protected Logger logger = LogManager.getLogger(getClass());
@@ -133,8 +134,9 @@ public class DefaultHostListener implements HypervisorHostListener {
     public boolean hostConnect(long hostId, long poolId) throws StorageConflictException {
         StoragePool pool = (StoragePool) this.dataStoreMgr.getDataStore(poolId, DataStoreRole.Primary);
         Map<String, String> detailsMap = storagePoolDetailsDao.listDetailsKeyPairs(poolId);
-        detailsMap.putAll(storageManager.getStoragePoolNFSMountOpts(pool, null).first());
+        Map<String, String> nfsMountOpts = storageManager.getStoragePoolNFSMountOpts(pool, null).first();
 
+        Optional.ofNullable(nfsMountOpts).ifPresent(detailsMap::putAll);
         ModifyStoragePoolCommand cmd = new ModifyStoragePoolCommand(true, pool, detailsMap);
         cmd.setWait(modifyStoragePoolCommandWait);
         HostVO host = hostDao.findById(hostId);

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
@@ -43,7 +43,6 @@ import com.cloud.storage.StoragePool;
 import com.cloud.storage.StoragePoolHostVO;
 import com.cloud.storage.StorageService;
 import com.cloud.storage.dao.StoragePoolHostDao;
-import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -133,9 +132,10 @@ public class DefaultHostListener implements HypervisorHostListener {
     @Override
     public boolean hostConnect(long hostId, long poolId) throws StorageConflictException {
         StoragePool pool = (StoragePool) this.dataStoreMgr.getDataStore(poolId, DataStoreRole.Primary);
-        Pair<Map<String, String>, Boolean> nfsMountOpts = storageManager.getStoragePoolNFSMountOpts(pool, null);
+        Map<String, String> detailsMap = storagePoolDetailsDao.listDetailsKeyPairs(poolId);
+        detailsMap.putAll(storageManager.getStoragePoolNFSMountOpts(pool, null).first());
 
-        ModifyStoragePoolCommand cmd = new ModifyStoragePoolCommand(true, pool, nfsMountOpts.first());
+        ModifyStoragePoolCommand cmd = new ModifyStoragePoolCommand(true, pool, detailsMap);
         cmd.setWait(modifyStoragePoolCommandWait);
         HostVO host = hostDao.findById(hostId);
         logger.debug("Sending modify storage pool command to agent: {} for storage pool: {} with timeout {} seconds", host, pool, cmd.getWait());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCreatePrivateTemplateFromVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCreatePrivateTemplateFromVolumeCommandWrapper.java
@@ -108,9 +108,7 @@ public final class LibvirtCreatePrivateTemplateFromVolumeCommandWrapper extends 
             } else {
                 logger.debug("Converting RBD disk " + disk.getPath() + " into template " + command.getUniqueName());
 
-                final QemuImgFile srcFile =
-                        new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primary.getSourceHost(), primary.getSourcePort(), primary.getAuthUserName(),
-                                primary.getAuthSecret(), disk.getPath()));
+                final QemuImgFile srcFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primary, disk.getPath()));
                 srcFile.setFormat(PhysicalDiskFormat.RAW);
 
                 final QemuImgFile destFile = new QemuImgFile(tmpltPath + "/" + command.getUniqueName() + ".qcow2");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVolumesOnStorageCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVolumesOnStorageCommandWrapper.java
@@ -161,11 +161,7 @@ public final class LibvirtGetVolumesOnStorageCommandWrapper extends CommandWrapp
             QemuImg qemu = new QemuImg(0);
             QemuImgFile qemuFile = new QemuImgFile(disk.getPath(), disk.getFormat());
             if (StoragePoolType.RBD.equals(pool.getType())) {
-                String rbdDestFile = KVMPhysicalDisk.RBDStringBuilder(pool.getSourceHost(),
-                        pool.getSourcePort(),
-                        pool.getAuthUserName(),
-                        pool.getAuthSecret(),
-                        disk.getPath());
+                String rbdDestFile = KVMPhysicalDisk.RBDStringBuilder(pool, disk.getPath());
                 qemuFile = new QemuImgFile(rbdDestFile, disk.getFormat());
             }
             return qemu.info(qemuFile, secure);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
@@ -410,9 +410,7 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
         KVMStoragePool srcPool = srcDisk.getPool();
 
         if (srcPool.getType() == StoragePoolType.RBD) {
-            srcFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(srcPool.getSourceHost(), srcPool.getSourcePort(),
-                                                                       srcPool.getAuthUserName(), srcPool.getAuthSecret(),
-                                                                       srcDisk.getPath()),srcDisk.getFormat());
+            srcFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(srcPool, srcDisk.getPath()), srcDisk.getFormat());
         } else {
             srcFile = new QemuImgFile(srcDisk.getPath(), srcDisk.getFormat());
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class KVMPhysicalDisk {
     private String path;
@@ -32,10 +33,15 @@ public class KVMPhysicalDisk {
     private String vmName;
     private boolean useAsTemplate;
 
-    public static String RBDStringBuilder(String monHost, int monPort, String authUserName, String authSecret, String image) {
-        String rbdOpts;
+    public static String RBDStringBuilder(KVMStoragePool storagePool, String image) {
+        String monHost = storagePool.getSourceHost();
+        int monPort = storagePool.getSourcePort();
+        String authUserName = storagePool.getAuthUserName();
+        String authSecret = storagePool.getAuthSecret();
+        Map<String, String> details = storagePool.getDetails();
+        String dataPool = (details == null) ? null : details.get("rbd_default_data_pool");
 
-        rbdOpts = "rbd:" + image;
+        String rbdOpts = "rbd:" + image;
         rbdOpts += ":mon_host=" + composeOptionForMonHosts(monHost, monPort);
 
         if (authUserName == null) {
@@ -44,6 +50,10 @@ public class KVMPhysicalDisk {
             rbdOpts += ":auth_supported=cephx";
             rbdOpts += ":id=" + authUserName;
             rbdOpts += ":key=" + authSecret;
+        }
+
+        if (dataPool != null) {
+            rbdOpts += String.format(":rbd_default_data_pool=%s", dataPool);
         }
 
         rbdOpts += ":rbd_default_format=2";

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
@@ -33,13 +33,15 @@ public class KVMPhysicalDisk {
     private String vmName;
     private boolean useAsTemplate;
 
+    public static final String RBD_DEFAULT_DATA_POOL = "rbd_default_data_pool";
+
     public static String RBDStringBuilder(KVMStoragePool storagePool, String image) {
         String monHost = storagePool.getSourceHost();
         int monPort = storagePool.getSourcePort();
         String authUserName = storagePool.getAuthUserName();
         String authSecret = storagePool.getAuthSecret();
         Map<String, String> details = storagePool.getDetails();
-        String dataPool = (details == null) ? null : details.get("rbd_default_data_pool");
+        String dataPool = (details == null) ? null : details.get(RBD_DEFAULT_DATA_POOL);
 
         String rbdOpts = "rbd:" + image;
         rbdOpts += ":mon_host=" + composeOptionForMonHosts(monHost, monPort);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -661,9 +661,7 @@ public class KVMStorageProcessor implements StorageProcessor {
             } else {
                 logger.debug("Converting RBD disk " + disk.getPath() + " into template " + templateName);
 
-                final QemuImgFile srcFile =
-                        new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primary.getSourceHost(), primary.getSourcePort(), primary.getAuthUserName(),
-                                primary.getAuthSecret(), disk.getPath()));
+                final QemuImgFile srcFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primary, disk.getPath()));
                 srcFile.setFormat(PhysicalDiskFormat.RAW);
 
                 final QemuImgFile destFile = new QemuImgFile(tmpltPath + "/" + templateName + ".qcow2");
@@ -1010,9 +1008,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                     logger.debug("Attempting to create " + snapDir.getAbsolutePath() + " recursively for snapshot storage");
                     FileUtils.forceMkdir(snapDir);
 
-                    final QemuImgFile srcFile =
-                            new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primaryPool.getSourceHost(), primaryPool.getSourcePort(), primaryPool.getAuthUserName(),
-                                    primaryPool.getAuthSecret(), rbdSnapshot));
+                    final QemuImgFile srcFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primaryPool, rbdSnapshot));
                     srcFile.setFormat(snapshotDisk.getFormat());
 
                     final QemuImgFile destFile = new QemuImgFile(snapshotFile);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -1068,10 +1068,10 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         QemuImgFile destFile;
 
         if (StoragePoolType.RBD.equals(pool.getType())) {
-            volPath = pool.getSourceDir() + "/" + name;
+            volPath = pool.getSourceDir() + File.separator + name;
             destFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(pool, volPath));
         } else {
-            volPath = pool.getLocalPath() + "/" + name;
+            volPath = pool.getLocalPath() + File.separator + name;
             destFile = new QemuImgFile(volPath);
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -1033,7 +1033,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
             volPath = pool.getSourceDir() + "/" + name;
             destFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(pool, volPath));
         } else {
-            volPath = pool.getLocalPath();
+            volPath = pool.getLocalPath() + "/" + name;
             destFile = new QemuImgFile(volPath);
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStoragePool.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStoragePool.java
@@ -56,8 +56,8 @@ public class LibvirtStoragePool implements KVMStoragePool {
     protected String authSecret;
     protected String sourceHost;
     protected int sourcePort;
-
     protected String sourceDir;
+    protected Map<String, String> details;
 
     public LibvirtStoragePool(String uuid, String name, StoragePoolType type, StorageAdaptor adaptor, StoragePool pool) {
         this.uuid = uuid;
@@ -311,7 +311,11 @@ public class LibvirtStoragePool implements KVMStoragePool {
 
     @Override
     public Map<String, String> getDetails() {
-        return null;
+        return this.details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/StoragePoolInformation.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/StoragePoolInformation.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.hypervisor.kvm.storage;
+
+import com.cloud.storage.Storage;
+
+import java.util.Map;
+
+class StoragePoolInformation {
+    private String name;
+    private String host;
+    private int port;
+    private String path;
+    private String userInfo;
+    private boolean type;
+    private Storage.StoragePoolType poolType;
+    private Map<String, String> details;
+
+    public StoragePoolInformation(String name, String host, int port, String path, String userInfo, Storage.StoragePoolType poolType, Map<String, String> details, boolean type) {
+        this.name = name;
+        this.host = host;
+        this.port = port;
+        this.path = path;
+        this.userInfo = userInfo;
+        this.type = type;
+        this.poolType = poolType;
+        this.details = details;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getUserInfo() {
+        return userInfo;
+    }
+
+    public boolean isType() {
+        return type;
+    }
+
+    public Storage.StoragePoolType getPoolType() {
+        return poolType;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+}

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java
@@ -17,43 +17,73 @@
 package com.cloud.hypervisor.kvm.storage;
 
 import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import junit.framework.TestCase;
 import org.mockito.junit.MockitoJUnitRunner;
 
-
 @RunWith(MockitoJUnitRunner.class)
-public class KVMPhysicalDiskTest extends TestCase {
+public class KVMPhysicalDiskTest {
+    @Mock
+    KVMStoragePool kvmStoragePoolMock;
+
+    private final String authUserName = "admin";
+
+    private final String authSecret = "supersecret";
 
     @Test
     public void testRBDStringBuilder() {
-        assertEquals(KVMPhysicalDisk.RBDStringBuilder("ceph-monitor", 8000, "admin", "supersecret", "volume1"),
-                     "rbd:volume1:mon_host=ceph-monitor\\:8000:auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30");
+        String monHosts = "ceph-monitor";
+        int monPort = 8000;
+
+        Mockito.doReturn(monHosts).when(kvmStoragePoolMock).getSourceHost();
+        Mockito.doReturn(monPort).when(kvmStoragePoolMock).getSourcePort();
+        Mockito.doReturn(authUserName).when(kvmStoragePoolMock).getAuthUserName();
+        Mockito.doReturn(authSecret).when(kvmStoragePoolMock).getAuthSecret();
+
+        String expected = "rbd:volume1:mon_host=ceph-monitor\\:8000:auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
+        String result = KVMPhysicalDisk.RBDStringBuilder(kvmStoragePoolMock, "volume1");
+
+        Assert.assertEquals(expected, result);
     }
 
     @Test
     public void testRBDStringBuilder2() {
         String monHosts = "ceph-monitor1,ceph-monitor2,ceph-monitor3";
         int monPort = 3300;
+
+        Mockito.doReturn(monHosts).when(kvmStoragePoolMock).getSourceHost();
+        Mockito.doReturn(monPort).when(kvmStoragePoolMock).getSourcePort();
+        Mockito.doReturn(authUserName).when(kvmStoragePoolMock).getAuthUserName();
+        Mockito.doReturn(authSecret).when(kvmStoragePoolMock).getAuthSecret();
+
         String expected = "rbd:volume1:" +
                 "mon_host=ceph-monitor1\\:3300\\;ceph-monitor2\\:3300\\;ceph-monitor3\\:3300:" +
                 "auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
-        String actualResult = KVMPhysicalDisk.RBDStringBuilder(monHosts, monPort, "admin", "supersecret", "volume1");
-        assertEquals(expected, actualResult);
+        String actualResult = KVMPhysicalDisk.RBDStringBuilder(kvmStoragePoolMock, "volume1");
+
+        Assert.assertEquals(expected, actualResult);
     }
 
     @Test
     public void testRBDStringBuilder3() {
         String monHosts = "[fc00:1234::1],[fc00:1234::2],[fc00:1234::3]";
         int monPort = 3300;
+
+        Mockito.doReturn(monHosts).when(kvmStoragePoolMock).getSourceHost();
+        Mockito.doReturn(monPort).when(kvmStoragePoolMock).getSourcePort();
+        Mockito.doReturn(authUserName).when(kvmStoragePoolMock).getAuthUserName();
+        Mockito.doReturn(authSecret).when(kvmStoragePoolMock).getAuthSecret();
+
         String expected = "rbd:volume1:" +
                 "mon_host=[fc00\\:1234\\:\\:1]\\:3300\\;[fc00\\:1234\\:\\:2]\\:3300\\;[fc00\\:1234\\:\\:3]\\:3300:" +
                 "auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
-        String actualResult = KVMPhysicalDisk.RBDStringBuilder(monHosts, monPort, "admin", "supersecret", "volume1");
-        assertEquals(expected, actualResult);
+        String actualResult = KVMPhysicalDisk.RBDStringBuilder(kvmStoragePoolMock, "volume1");
+
+        Assert.assertEquals(expected, actualResult);
     }
 
     @Test
@@ -64,18 +94,18 @@ public class KVMPhysicalDiskTest extends TestCase {
         LibvirtStoragePool pool = Mockito.mock(LibvirtStoragePool.class);
 
         KVMPhysicalDisk disk = new KVMPhysicalDisk(path, name, pool);
-        assertEquals(disk.getName(), name);
-        assertEquals(disk.getPath(), path);
-        assertEquals(disk.getPool(), pool);
-        assertEquals(disk.getSize(), 0);
-        assertEquals(disk.getVirtualSize(), 0);
+        Assert.assertEquals(disk.getName(), name);
+        Assert.assertEquals(disk.getPath(), path);
+        Assert.assertEquals(disk.getPool(), pool);
+        Assert.assertEquals(disk.getSize(), 0);
+        Assert.assertEquals(disk.getVirtualSize(), 0);
 
         disk.setSize(1024);
         disk.setVirtualSize(2048);
-        assertEquals(disk.getSize(), 1024);
-        assertEquals(disk.getVirtualSize(), 2048);
+        Assert.assertEquals(disk.getSize(), 1024);
+        Assert.assertEquals(disk.getVirtualSize(), 2048);
 
         disk.setFormat(PhysicalDiskFormat.RAW);
-        assertEquals(disk.getFormat(), PhysicalDiskFormat.RAW);
+        Assert.assertEquals(disk.getFormat(), PhysicalDiskFormat.RAW);
     }
 }

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadVolumeCommandWrapper.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadVolumeCommandWrapper.java
@@ -114,11 +114,7 @@ public final class StorPoolDownloadVolumeCommandWrapper extends CommandWrapper<S
             if (isRBDPool) {
                 KVMStoragePool srcPool = srcDisk.getPool();
                 String rbdDestPath = srcPool.getSourceDir() + "/" + srcDisk.getName();
-                srcPath = KVMPhysicalDisk.RBDStringBuilder(srcPool.getSourceHost(),
-                        srcPool.getSourcePort(),
-                        srcPool.getAuthUserName(),
-                        srcPool.getAuthSecret(),
-                        rbdDestPath);
+                srcPath = KVMPhysicalDisk.RBDStringBuilder(srcPool, rbdDestPath);
             } else {
                 srcPath = srcDisk.getPath();
             }

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -164,6 +164,7 @@ import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -3138,27 +3139,40 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         List<StoragePoolResponse> poolResponses = ViewResponseHelper.createStoragePoolResponse(getCustomStats, storagePools.first().toArray(new StoragePoolJoinVO[storagePools.first().size()]));
         Map<String, Long> poolUuidToIdMap = storagePools.first().stream().collect(Collectors.toMap(StoragePoolJoinVO::getUuid, StoragePoolJoinVO::getId, (a, b) -> a));
         for (StoragePoolResponse poolResponse : poolResponses) {
+            Long poolId = poolUuidToIdMap.get(poolResponse.getId());
             DataStore store = dataStoreManager.getPrimaryDataStore(poolResponse.getId());
+
             if (store != null) {
-                DataStoreDriver driver = store.getDriver();
-                if (driver != null && driver.getCapabilities() != null) {
-                    Map<String, String> caps = driver.getCapabilities();
-                    if (Storage.StoragePoolType.NetworkFilesystem.toString().equals(poolResponse.getType()) &&
-                        HypervisorType.VMware.toString().equals(poolResponse.getHypervisor())) {
-                        StoragePoolDetailVO detail = _storagePoolDetailsDao.findDetail(poolUuidToIdMap.get(poolResponse.getId()), Storage.Capability.HARDWARE_ACCELERATION.toString());
-                        if (detail != null) {
-                            caps.put(Storage.Capability.HARDWARE_ACCELERATION.toString(), detail.getValue());
-                        }
-                    }
-                    poolResponse.setCaps(caps);
-                }
+                addPoolDetailsAndCapabilities(poolResponse, store, poolId);
             }
-            setPoolResponseNFSMountOptions(poolResponse, poolUuidToIdMap.get(poolResponse.getId()));
+
+            setPoolResponseNFSMountOptions(poolResponse, poolId);
         }
 
         response.setResponses(poolResponses, storagePools.second());
         return response;
     }
+
+    private void addPoolDetailsAndCapabilities(StoragePoolResponse poolResponse, DataStore store, Long poolId) {
+        Map<String, String> details = _storagePoolDetailsDao.listDetailsKeyPairs(store.getId(), true);
+        poolResponse.setDetails(details);
+
+        DataStoreDriver driver = store.getDriver();
+        if (ObjectUtils.anyNull(driver, driver.getCapabilities())) {
+            return;
+        }
+
+        Map<String, String> caps = driver.getCapabilities();
+        if (Storage.StoragePoolType.NetworkFilesystem.toString().equals(poolResponse.getType()) && HypervisorType.VMware.toString().equals(poolResponse.getHypervisor())) {
+            StoragePoolDetailVO detail = _storagePoolDetailsDao.findDetail(poolId, Storage.Capability.HARDWARE_ACCELERATION.toString());
+            if (detail != null) {
+                caps.put(Storage.Capability.HARDWARE_ACCELERATION.toString(), detail.getValue());
+            }
+        }
+        poolResponse.setCaps(caps);
+    }
+
+
 
     private Pair<List<StoragePoolJoinVO>, Integer> searchForStoragePoolsInternal(ListStoragePoolsCmd cmd) {
         ScopeType scopeType = ScopeType.validateAndGetScopeType(cmd.getScope());

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -651,6 +651,8 @@
 "label.dark.mode": "Dark mode",
 "label.dashboard": "Dashboard",
 "label.data.disk": "Data disk",
+"label.data.pool": "Data pool",
+"label.data.pool.description": "Data pool is required when using a Ceph pool with erasure code",
 "label.data.disk.offering": "Data disk offering",
 "label.date": "Date",
 "label.datetime.filter.period": "From <b>{startDate}</b> to <b>{endDate}</b>",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -463,6 +463,8 @@
 "label.dashboard": "Dashboard",
 "label.data.disk": "Disco de dados",
 "label.data.disk.offering": "Oferta de disco adicional",
+"label.data.pool": "Data pool",
+"label.data.pool.description": "\u00c9 necess\u00e1rio informar um data pool ao utilizar um Ceph pool com erasure code",
 "label.date": "Data",
 "label.day": "Dia",
 "label.day.of.month": "Dia do m\u00eas",

--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -42,14 +42,7 @@
     size="small"
     :dataSource="fetchDetails()">
     <template #renderItem="{item}">
-      <a-list-item v-if="$route.meta.name === 'storagepool' && item === 'details' && dataResource[item].rbd_default_data_pool">
-        <div>
-          <strong>{{ $t('label.data.pool') }}</strong>
-          <br/>
-          <div>{{ dataResource[item].rbd_default_data_pool }}</div>
-        </div>
-      </a-list-item>
-      <a-list-item v-else-if="(item in dataResource && !customDisplayItems.includes(item)) || (offeringDetails.includes(item) && dataResource.serviceofferingdetails)">
+      <a-list-item v-if="(item in dataResource && !customDisplayItems.includes(item)) || (offeringDetails.includes(item) && dataResource.serviceofferingdetails)">
         <div style="width: 100%">
           <strong>{{ item === 'service' ? $t('label.supportedservices') : $t(getDetailTitle(item)) }}</strong>
           <br/>
@@ -158,6 +151,13 @@
           <div>{{ $toLocaleDate(dataResource[item]) }}</div>
         </div>
       </a-list-item>
+      <a-list-item v-else-if="item === 'details' && $route.meta.name === 'storagepool' && dataResource[item].rbd_default_data_pool">
+        <div>
+          <strong>{{ $t('label.data.pool') }}</strong>
+          <br/>
+          <div>{{ dataResource[item].rbd_default_data_pool }}</div>
+        </div>
+      </a-list-item>
     </template>
     <HostInfo :resource="dataResource" v-if="$route.meta.name === 'host' && 'listHosts' in $store.getters.apis" />
     <DedicateData :resource="dataResource" v-if="dedicatedSectionActive" />
@@ -214,7 +214,7 @@ export default {
   },
   computed: {
     customDisplayItems () {
-      var items = ['ip4routes', 'ip6routes', 'privatemtu', 'publicmtu', 'provider']
+      var items = ['ip4routes', 'ip6routes', 'privatemtu', 'publicmtu', 'provider', 'details']
       if (this.$route.meta.name === 'webhookdeliveries') {
         items.push('startdate')
         items.push('enddate')

--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -42,7 +42,14 @@
     size="small"
     :dataSource="fetchDetails()">
     <template #renderItem="{item}">
-      <a-list-item v-if="(item in dataResource && !customDisplayItems.includes(item)) || (offeringDetails.includes(item) && dataResource.serviceofferingdetails)">
+      <a-list-item v-if="$route.meta.name === 'storagepool' && item === 'details' && dataResource[item].rbd_default_data_pool">
+        <div>
+          <strong>{{ $t('label.data.pool') }}</strong>
+          <br/>
+          <div>{{ dataResource[item].rbd_default_data_pool }}</div>
+        </div>
+      </a-list-item>
+      <a-list-item v-else-if="(item in dataResource && !customDisplayItems.includes(item)) || (offeringDetails.includes(item) && dataResource.serviceofferingdetails)">
         <div style="width: 100%">
           <strong>{{ item === 'service' ? $t('label.supportedservices') : $t(getDetailTitle(item)) }}</strong>
           <br/>

--- a/ui/src/config/section/infra/primaryStorages.js
+++ b/ui/src/config/section/infra/primaryStorages.js
@@ -35,7 +35,7 @@ export default {
     fields.push('zonename')
     return fields
   },
-  details: ['name', 'id', 'ipaddress', 'type', 'nfsmountopts', 'scope', 'tags', 'path', 'provider', 'hypervisor', 'overprovisionfactor', 'disksizetotal', 'disksizeallocated', 'disksizeused', 'capacityiops', 'usediops', 'clustername', 'podname', 'zonename', 'created'],
+  details: ['name', 'id', 'ipaddress', 'type', 'details', 'nfsmountopts', 'scope', 'tags', 'path', 'provider', 'hypervisor', 'overprovisionfactor', 'disksizetotal', 'disksizeallocated', 'disksizeused', 'capacityiops', 'usediops', 'clustername', 'podname', 'zonename', 'created'],
   related: [{
     name: 'volume',
     title: 'label.volumes',

--- a/ui/src/views/infra/AddPrimaryStorage.vue
+++ b/ui/src/views/infra/AddPrimaryStorage.vue
@@ -370,6 +370,12 @@
           <a-form-item name="radospool" ref="radospool" :label="$t('label.rados.pool')">
             <a-input v-model:value="form.radospool" :placeholder="$t('label.rados.pool')"/>
           </a-form-item>
+          <a-form-item name="datapool" ref="datapool">
+            <template #label>
+              <tooltip-label :title="$t('label.data.pool')" :tooltip="$t('label.data.pool.description')"/>
+            </template>
+            <a-input v-model:value="form.datapool" :placeholder="$t('label.data.pool')"/>
+          </a-form-item>
           <a-form-item name="radosuser" ref="radosuser" :label="$t('label.rados.user')">
             <a-input v-model:value="form.radosuser" :placeholder="$t('label.rados.user')" />
           </a-form-item>
@@ -499,6 +505,10 @@ export default {
         powerflexGatewayUsername: [{ required: true, message: this.$t('label.required') }],
         powerflexGatewayPassword: [{ required: true, message: this.$t('label.required') }],
         powerflexStoragePool: [{ required: true, message: this.$t('label.required') }],
+        radosmonitor: [{ required: true, message: this.$t('label.required') }],
+        radospool: [{ required: true, message: this.$t('label.required') }],
+        radosuser: [{ required: true, message: this.$t('label.required') }],
+        radossecret: [{ required: true, message: this.$t('label.required') }],
         username: [{ required: true, message: this.$t('label.required') }],
         password: [{ required: true, message: this.$t('label.required') }],
         primeraURL: [{ required: true, message: this.$t('label.url') }],
@@ -845,6 +855,9 @@ export default {
           url = this.clvmURL(vg)
         } else if (values.protocol === 'RBD') {
           url = this.rbdURL(values.radosmonitor, values.radospool, values.radosuser, values.radossecret)
+          if (values.datapool) {
+            params['details[0].rbd_default_data_pool'] = values.datapool
+          }
         } else if (values.protocol === 'vmfs') {
           path = values.vCenterDataCenter
           if (path.substring(0, 1) !== '/') {

--- a/ui/src/views/infra/zone/ZoneWizardAddResources.vue
+++ b/ui/src/views/infra/zone/ZoneWizardAddResources.vue
@@ -469,7 +469,7 @@ export default {
           title: 'label.rados.monitor',
           key: 'primaryStorageRADOSMonitor',
           placeHolder: 'message.error.rados.monitor',
-          required: false,
+          required: true,
           display: {
             primaryStorageProtocol: ['rbd']
           }
@@ -478,6 +478,14 @@ export default {
           title: 'label.rados.pool',
           key: 'primaryStorageRADOSPool',
           placeHolder: 'message.error.rados.pool',
+          required: true,
+          display: {
+            primaryStorageProtocol: ['rbd']
+          }
+        },
+        {
+          title: 'label.data.pool',
+          key: 'primaryStorageDataPool',
           required: false,
           display: {
             primaryStorageProtocol: ['rbd']
@@ -487,7 +495,7 @@ export default {
           title: 'label.rados.user',
           key: 'primaryStorageRADOSUser',
           placeHolder: 'message.error.rados.user',
-          required: false,
+          required: true,
           display: {
             primaryStorageProtocol: ['rbd']
           }
@@ -496,7 +504,7 @@ export default {
           title: 'label.rados.secret',
           key: 'primaryStorageRADOSSecret',
           placeHolder: 'message.error.rados.secret',
-          required: false,
+          required: true,
           display: {
             primaryStorageProtocol: ['rbd']
           }

--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -1486,6 +1486,10 @@ export default {
         const rbdpool = this.prefillContent?.primaryStorageRADOSPool || ''
         const rbdid = this.prefillContent?.primaryStorageRADOSUser || ''
         const rbdsecret = this.prefillContent?.primaryStorageRADOSSecret || ''
+
+        if (this.prefillContent?.primaryStorageDataPool) {
+          params['details[0].rbd_default_data_pool'] = this.prefillContent.primaryStorageDataPool
+        }
         url = this.rbdURL(rbdmonitor, rbdpool, rbdid, rbdsecret)
       } else if (protocol === 'Linstor') {
         url = this.linstorURL(server)


### PR DESCRIPTION
### Description

This PR adds support for Ceph erasure code pools, allowing users to specify the data pool required for using this type of Ceph pool.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):
Details of the data pool in the UI

![image](https://github.com/user-attachments/assets/4e1e5790-972d-403e-b2a3-c69c8a61e3e1)

### How Has This Been Tested?

The following tests were executed to verify this patch; tests were executed on replicated pools as well to check if this patch would interfere in it.

- Deploy of VM in a Ceph replicated pool
- Deploy of VM in a Ceph erasure code pool
- Volume resize in a Ceph replicated pool
- Volume resize in a Ceph erasure code pool
- Live migration of VM with volume allocated in a Ceph replicated pool
- Live migration of VM with volume allocated in a Ceph erasure code pool
- Attach, mount and utilization of volume in a Ceph replicated pool
- Attach, mount and utilization of volume in a Ceph erasure code pool
- Template creation from a volume in a Ceph replicated pool
- Deploy of VM from the template based on volume in a Ceph replicated pool
- Template creation from a volume in a Ceph erasure code pool
- Deploy of VM from the template based on volume in a Ceph erasure code pool
- Volume migration from/to Ceph replicated pool to/from NFS
- Volume migration from/to Ceph replicated pool to/from iSCSI (SharedMountPoint)
- Volume migration from/to Ceph erasure code pool to/from NFS
- Volume migration from/to Ceph erasure code pool to/from iSCSI (SharedMountPoint)
- Volume migration from/to Ceph erasure code pool to/from Ceph replicated pool
- Snapshot of a volume from Ceph replicated pool
- Revert snapshot of a volume from Ceph replicated pool
- Snapshot of a volume from Ceph erasure code pool
- Revert snapshot of a volume from Ceph erasure code pool


#### How did you try to break this feature and the system with this change?

I tried to migrate volumes from different type of pool types (NFS, iSCSI and RBD) to each other, verifying that the migration was successful.