### PR TITLE
Fix primary storage update form not showing existing values

### DIFF
--- a/ui/src/views/infra/UpdatePrimaryStorage.vue
+++ b/ui/src/views/infra/UpdatePrimaryStorage.vue
@@ -121,7 +121,6 @@ export default {
   },
   created () {
     this.initForm()
-    this.form.name = this.resource.name
   },
   computed: {
     canUpdateNFSMountOpts () {
@@ -136,7 +135,14 @@ export default {
   methods: {
     initForm () {
       this.formRef = ref()
-      this.form = reactive({ })
+      this.form = reactive({
+        name: this.resource.name,
+        tags: this.resource.tags,
+        isTagARule: this.resource.istagarule,
+        capacityBytes: this.resource.disksizetotal,
+        capacityIOPS: this.resource.capacityiops,
+        nfsMountOpts: this.resource.nfsmountopts
+      })
       this.rules = reactive({ })
     },
     isAdmin () {


### PR DESCRIPTION
### Description

Fixes the bug described in #9806. The primary storage update form is not showing the existing values of the following fields: tags, is tag a rule, capacity bytes, IOPS total and NFS mount options.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/6da6401c-0e12-451d-8964-7128165338ab)

### How Has This Been Tested?

I accessed a NFS primary storage's details page, enabled maintenance mode and edited its name, tags, tag as JS rule, capacity bytes, IOPS total and NFS mount options fields. Then, I opened the edit form again and verified that the updated values were shown.