### PR TITLE
Simplify validation while creating volume templates via UI

### DIFF
--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -251,9 +251,7 @@ export default {
           label: 'label.action.create.template.from.volume',
           dataView: true,
           show: (record) => {
-            return !['Destroy', 'Destroyed', 'Expunging', 'Expunged', 'Migrating', 'Uploading', 'UploadError', 'Creating'].includes(record.state) &&
-                ((record.type === 'ROOT' && record.vmstate === 'Stopped') ||
-                    (record.type !== 'ROOT' && !record.virtualmachineid && !['Allocated', 'Uploaded'].includes(record.state)))
+            return record.state === 'Ready' && (record.vmstate === 'Stopped' || !record.virtualmachineid)
           },
           args: (record, store) => {
             var fields = ['volumeid', 'name', 'displaytext', 'ostypeid', 'isdynamicallyscalable', 'requireshvm', 'passwordenabled']


### PR DESCRIPTION
### Description

Currently, creating templates for `DATADISK` volumes is only possible if they have already been part of a VM and are detached. This behavior has been extended so that the volume does not need to be detached and the template can be created as long as the VM is stopped.

Furthermore, the UI allows templates to be created for `ROOT` volumes in the `Allocated` state, however, the creation always results in an error as the volume needs to exist in the primary storage for the template creation to be possible. With the changes, this option is no longer available.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

In the UI, I tried creating a template from a volume in different scenarios:

| N° | VM State | Volume Type | Volume State | Could create the template? |
| ------ | ------ | ------ | ------ | ------ |
| 1 | Stopped | `ROOT` | `Allocated` | No | OK
| 2 | Stopped | `ROOT` | `Ready` | Yes |
| 3 | Stopped | `DATADISK` | `Ready` | Yes |
| 4 | Detached volume | `DATADISK` | `Ready` | Yes | OK
| 5 | Running | `ROOT` | `Ready` | No | OK
| 6 | Running | `DATADISK` | `Ready` | No | OK