### PR TITLE
Fix Kubernetes cluster view when user is unable to scale

### DIFF
--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -537,7 +537,7 @@ export default {
         if (store.listAllProjects) {
           fields.push('project')
         }
-        if (store.apis.scaleKubernetesCluster.params.filter(x => x.name === 'autoscalingenabled').length > 0) {
+        if (store.apis.scaleKubernetesCluster?.params?.filter(x => x.name === 'autoscalingenabled').length > 0) {
           fields.splice(2, 0, 'autoscalingenabled')
         }
         fields.push('zonename')

--- a/ui/src/views/compute/KubernetesServiceTab.vue
+++ b/ui/src/views/compute/KubernetesServiceTab.vue
@@ -278,7 +278,7 @@ export default {
     }
   },
   mounted () {
-    if (this.$store.getters.apis.scaleKubernetesCluster.params.filter(x => x.name === 'nodeids').length > 0 && this.resource.clustertype === 'CloudManaged') {
+    if (this.$store.getters.apis.scaleKubernetesCluster?.params?.filter(x => x.name === 'nodeids').length > 0 && this.resource.clustertype === 'CloudManaged') {
       this.vmColumns.push({
         key: 'actions',
         title: this.$t('label.actions'),


### PR DESCRIPTION
### Description

If a user does not have access to the `scaleKubernetesCluster` API and tries to list Kubernetes clusters through the UI, an error is thrown. Therefore, it is not possible to list and create Kubernetes clusters due to this error, even if the user has permission for such actions.

![Screenshot from 2024-10-28 13-42-38](https://github.com/user-attachments/assets/1bd4b524-f744-4a2e-92ba-8ed77d39f5ec)

Since then, changes have been made so that this error no longer occurs and the user can list and manage Kubernetes clusters even if he doesn't have access to the `scaleKubernetesCluster` API.

![Screenshot from 2024-10-28 18-08-21](https://github.com/user-attachments/assets/2432b9bd-bace-4fd8-93b3-325ccd8e3743)


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I created an account from a custom admin role that has the `scaleKubernetesCluster` API as `DENY` and all other APIs as `ALLOW`. Then, I logged into this account and was able to perform some basic operations like creating, listing and deleting a Kubernetes cluster.
