### PR TITLE
Change `vmsnapshot.max` configuration to be dynamic

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/vm/snapshot/VMSnapshotManager.java
+++ b/engine/components-api/src/main/java/com/cloud/vm/snapshot/VMSnapshotManager.java
@@ -31,7 +31,7 @@ public interface VMSnapshotManager extends VMSnapshotService, Manager {
     static final ConfigKey<Integer> VMSnapshotExpireInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vmsnapshot.expire.interval", "-1",
             "VM Snapshot expire interval in hours", true, ConfigKey.Scope.Account);
 
-    public static final int VMSNAPSHOTMAX = 10;
+    ConfigKey<Integer> VMSnapshotMax = new ConfigKey<Integer>("Advanced", Integer.class, "vmsnapshot.max", "10", "Maximum vm snapshots for a single vm", true, ConfigKey.Scope.Global);
 
     /**
      * Delete all VM snapshots belonging to one VM

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -1740,7 +1740,6 @@ DefaultMaxAccountProjects(
                     null),
 
     // VMSnapshots
-    VMSnapshotMax("Advanced", VMSnapshotManager.class, Integer.class, "vmsnapshot.max", "10", "Maximum vm snapshots for a vm", null),
     VMSnapshotCreateWait("Advanced", VMSnapshotManager.class, Integer.class, "vmsnapshot.create.wait", "1800", "In second, timeout for create vm snapshot", null),
 
     CloudDnsName("Advanced", ManagementServer.class, String.class, "cloud.dns.name", null, "DNS name of the cloud for the GSLB service", null),

--- a/server/src/main/java/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
@@ -174,7 +174,6 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
 
     VmWorkJobHandlerProxy _jobHandlerProxy = new VmWorkJobHandlerProxy(this);
 
-    int _vmSnapshotMax;
     int _wait;
 
     static final ConfigKey<Long> VmJobCheckInterval = new ConfigKey<Long>("Advanced",
@@ -187,8 +186,6 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
         if (_configDao == null) {
             throw new ConfigurationException("Unable to get the configuration dao.");
         }
-
-        _vmSnapshotMax = NumbersUtil.parseInt(_configDao.getValue("vmsnapshot.max"), VMSNAPSHOTMAX);
 
         String value = _configDao.getValue("vmsnapshot.create.wait");
         _wait = NumbersUtil.parseInt(value, 1800);
@@ -398,8 +395,10 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
         _accountMgr.checkAccess(caller, null, true, userVmVo);
 
         // check max snapshot limit for per VM
-        if (_vmSnapshotDao.findByVm(vmId).size() >= _vmSnapshotMax) {
-            throw new CloudRuntimeException("Creating vm snapshot failed due to a VM can just have : " + _vmSnapshotMax + " VM snapshots. Please delete old ones");
+        int vmSnapshotMax = VMSnapshotManager.VMSnapshotMax.value();
+
+        if (_vmSnapshotDao.findByVm(vmId).size() >= vmSnapshotMax) {
+            throw new CloudRuntimeException("Creating vm snapshot failed due to a VM can just have : " + vmSnapshotMax + " VM snapshots. Please delete old ones");
         }
 
         // check if there are active volume snapshots tasks
@@ -1391,6 +1390,6 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {VMSnapshotExpireInterval};
+        return new ConfigKey<?>[] {VMSnapshotExpireInterval, VMSnapshotMax};
     }
 }

--- a/server/src/test/java/com/cloud/vm/snapshot/VMSnapshotManagerTest.java
+++ b/server/src/test/java/com/cloud/vm/snapshot/VMSnapshotManagerTest.java
@@ -136,7 +136,6 @@ public class VMSnapshotManagerTest {
     VMSnapshotDetailsDao _vmSnapshotDetailsDao;
     @Mock
     UserVmManager _userVmManager;
-    int _vmSnapshotMax = 10;
 
     private static final long TEST_VM_ID = 3L;
     private static final long SERVICE_OFFERING_ID = 1L;
@@ -193,8 +192,6 @@ public class VMSnapshotManagerTest {
         _vmSnapshotMgr._serviceOfferingDetailsDao = _serviceOfferingDetailsDao;
 
         doNothing().when(_accountMgr).checkAccess(any(Account.class), any(AccessType.class), any(Boolean.class), any(ControlledEntity.class));
-
-        _vmSnapshotMgr._vmSnapshotMax = _vmSnapshotMax;
 
         _vmSnapshotMgr._serviceOfferingDao = _serviceOfferingDao;
         _vmSnapshotMgr._userVmDetailsDao = _userVmDetailsDao;


### PR DESCRIPTION
### Description

Currently, the configuration `vmsnapshot.max` isn't dynamic, and it is necessary to restart the Management Server after changing the configuration's value.

This PR intends to change the `vmsnapshot.max` config to the new `ConfigKey` standard for dynamic configurations.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

![new-vm-snapshot-max](https://github.com/user-attachments/assets/eb55031d-8062-4c11-9a99-0d0d8da888c9)

### How Has This Been Tested?

To validate the changes, I performed the following steps without restarting the Management Server:

1. Changed the `vmsnapshot.max` value to 2;
2. Tried to take 3 VM snapshots, but as expected, an exception was thrown on the 3rd snapshot;
3. Changed the `vmsnapshot.max` value to 3;
4. Tried to take the 3rd snapshot again, and it was created successfully;
5. Tried to take a 4th snapshot and got the same exception.