### PR TITLE
Fix inconsistencies that result in Usage generating usage records when it should not

### DIFF
--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDaoImpl.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.usage.dao;
 
-import com.cloud.network.Network;
 import com.cloud.usage.UsageNetworksVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
@@ -70,11 +69,10 @@ public class UsageNetworksDaoImpl extends GenericDaoBase<UsageNetworksVO, Long> 
             SearchCriteria<UsageNetworksVO> sc = this.createSearchCriteria();
             sc.addAnd("networkId", SearchCriteria.Op.EQ, networkId);
             sc.addAnd("removed", SearchCriteria.Op.NULL);
-            UsageNetworksVO vo = findOneBy(sc);
-            if (vo != null) {
-                vo.setRemoved(removed);
-                vo.setState(Network.State.Destroy.name());
-                update(vo.getId(), vo);
+            List<UsageNetworksVO> usageNetworksVOs = listBy(sc);
+            for (UsageNetworksVO entry : usageNetworksVOs) {
+                entry.setRemoved(removed);
+                update(entry.getId(), entry);
             }
         } catch (final Exception e) {
             txn.rollback();

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.usage.dao;
 
-import com.cloud.network.vpc.Vpc;
 import com.cloud.usage.UsageVpcVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
@@ -64,11 +63,10 @@ public class UsageVpcDaoImpl extends GenericDaoBase<UsageVpcVO, Long> implements
             SearchCriteria<UsageVpcVO> sc = this.createSearchCriteria();
             sc.addAnd("vpcId", SearchCriteria.Op.EQ, vpcId);
             sc.addAnd("removed", SearchCriteria.Op.NULL);
-            UsageVpcVO vo = findOneBy(sc);
-            if (vo != null) {
-                vo.setRemoved(removed);
-                vo.setState(Vpc.State.Inactive.name());
-                update(vo.getId(), vo);
+            List<UsageVpcVO> usageVpcVOs = listBy(sc);
+            for (UsageVpcVO entry : usageVpcVOs) {
+                entry.setRemoved(removed);
+                update(entry.getId(), entry);
             }
         } catch (final Exception e) {
             txn.rollback();


### PR DESCRIPTION
### Description

This PR fixes some inconsistencies which results in Usage generating usage records when it should not, namely:

- Duplicated entries in the networks helper table, resulting in duplicated usage record generation;
- Port forwarding helper entries are never removed, resulting in removed port forwarding rules generating usage records;
- Load balancer helper entries are never removed, resulting in removed load balancer rules generating usage records;
- VM snapshot helper entries are never removed, resulting in removed VM snapshots generating usage records;
- Helper entries for volumes in the secondary storage are never removed after the volume gets attached to a VM, resulting in secondary storage usage records being generated for volumes that are not in the secondary storage anymore.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

#### Duplicated usage record generation for networks

1. I created a network
2. I added a VM to the network
3. I stopped the VM
4. I waited until the network reverted to `Allocated`
5. I started the VM
6. I ran the Usage job

Before the changes, after the Usage job finishes, there would be two non-removed helper entries for the same network, resulting in duplicated usage records being generated for the network. After the changes, the first helper entry was marked as removed.

#### Removed port forwarding rules generating usage records

1. I created a port forwarding rule
2. I ran the Usage job in order to create a helper entry for the PF rule
3. I verified, in `cloud_usage.usage_port_forwarding`, that the helper entry had an ID different from the PF rule's ID
4. I deleted the PF rule
5. I ran the Usage job

Before the changes, the helper entry would not get marked as removed in step 5, resulting in usage records still being generated for the removed PF rule. After the changes, the helper entry got marked as removed.

#### Removed load balancer policies generating usage records

1. I created a load balancer policy
2. I ran the Usage job in order to create a helper entry for the LB policy
3. I verified, in `cloud_usage.usage_load_balancer_policy`, that the helper entry had an ID different from the LB policy's ID
4. I deleted the LB policy
5. I ran the Usage job

Before the changes, the helper entry would not get marked as removed in step 5, resulting in usage records still being generated for the removed LB policy. After the changes, the helper entry got marked as removed.

#### Removed VM snapshots generating usage records

1. I took two VM snapshots of the same VM
2. I ran the Usage job in order to create helper entries for the two VM snapshots
3. I verified, in `cloud_usage.usage_snapshot_on_primary`, that the helper entry had IDs different from the VM's ID
4. I removed the two VM snapshots
5. I ran the Usage job

Before the changes, the helper entries would not get marked as removed in step 5, resulting in usage records still being generated for the removed VM snapshots. After the changes, the helper entries got marked as removed.

#### Volumes in the secondary storage that were attached still generate usage records

1. I uploaded a volume
2. I ran the Usage job in order to create a secondary storage helper entry for the volume 
3. I verified, in `cloud_usage.usage_storage`, that the helper entry had had an ID different from the volume's ID
4. I attached the volume to a VM
5. I ran the Usage job

Before the changes, a helper entry would be created to generate secondary storage usage records for the volume (in `cloud_usage.usage_storage`). After attaching, another entry would be created to generate primary storage volume usage records; however, the secondary storage helper entry did not get removed, resulting in secondary storage usage records being generated for a volume that was not in the secondary storage anymore.

After the changes, the secondary storage helper entry was marked as removed.
