### PR TITLE
Maintenance mode: Add host to deployment planner avoid list to fix local storage migration

### DIFF
--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -1469,8 +1469,10 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         final VirtualMachineProfile profile = new VirtualMachineProfileImpl(vm, null, offeringVO, null, null);
         plan.setMigrationPlan(true);
         DeployDestination dest = null;
+        DeploymentPlanner.ExcludeList avoids = new DeploymentPlanner.ExcludeList();
+        avoids.addHost(host.getId());
         try {
-            dest = deploymentManager.planDeployment(profile, plan, new DeploymentPlanner.ExcludeList(), null);
+            dest = deploymentManager.planDeployment(profile, plan, avoids, null);
         } catch (InsufficientServerCapacityException e) {
             throw new CloudRuntimeException(String.format("Maintenance failed, could not find deployment destination for VM [id=%s, name=%s].", vm.getId(), vm.getInstanceName()),
                     e);


### PR DESCRIPTION
### Description

This PR adds the host preparing for maintenance to the avoid list for the deployment planner.

Without adding the host to the avoid list the deployment planner will return the host preparing for maintenance when a vm has a local storage root disk and has the host preparing for maintenance as the last host.

#### Steps to reproduce

- Create vm with local storage
- Set host with the vm in maintenance

#### Actual behaviour
```
(qa6-4.19-upstream-54bd5b60-kvm-host1) Failed to prepare host for maintenance due to: Migration of the vm VM instance {"id":13,"instanceName":"i-2-13-VM","type":"User","uuid":"209d346b-b2e7-485f-a889-8462dd0078cc"}from host Host {"id":1,"name":"qa6-4.19-upstream-54bd5b60-kvm-host1","type":"Routing","uuid":"224ca458-90e6-4efb-8532-e5efc83df9f4"} to destination host Host {"id":1,"name":"qa6-4.19-upstream-54bd5b60-kvm-host1","type":"Routing","uuid":"224ca458-90e6-4efb-8532-e5efc83df9f4"} doesn't involve migrating the volumes.
```

#### Expected
Local storage vm live migrated to another host.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
Centos8 mbx env with `host.maintenance.local.storage.strategy` set to Migration.

Tested maintenance mode on a host with 

1. Local storage vm
2. HA vm
3. Local storage vm with ha data disk
4. ha vm with ha datadisk
5. Local storage vm with local data disk
6. ha vm with local datadisk

5 and 6 result in an ErrorInMaintenance due to dest being null. Similar as described in https://github.com/apache/cloudstack/issues/9887. Without this patch these would still fail with the same error as described in actual behavior.

After creation of a ha vm with ha data disk maintenance was not possible. After manual migration to another host and back, migration did complete. Migration without selecting host also gave a no destination found error and also occurred without this patch so is unrelated.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
