### PR TITLE
Added-cpu-core-and-memory-range-fot-type-offers-CustomConstrained

### DIFF
--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -240,6 +240,12 @@
       <template v-if="column.key === 'agentstate'">
         <status :text="text ? text : ''" displayText />
       </template>
+      <template v-if="column.key === 'cpunumber'">
+        <span>{{ record.serviceofferingdetails ? `${record.serviceofferingdetails.mincpunumber} - ${record.serviceofferingdetails.maxcpunumber}` : record.cpunumber }}</span>
+      </template>
+      <template v-if="column.key === 'memory'">
+        <span>{{ record.serviceofferingdetails ? `${record.serviceofferingdetails.minmemory} - ${record.serviceofferingdetails.maxmemory}` : record.memory }}</span>
+      </template>
       <template v-if="column.key === 'quotastate'">
         <status :text="text ? text : ''" displayText />
       </template>

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -244,7 +244,7 @@
         <span>{{ record.serviceofferingdetails?.mincpunumber && record.serviceofferingdetails?.maxcpunumber ? `${record.serviceofferingdetails.mincpunumber} - ${record.serviceofferingdetails.maxcpunumber}` : record.cpunumber }}</span>
       </template>
       <template v-if="column.key === 'memory'">
-        <span>{{ record.serviceofferingdetails ? `${record.serviceofferingdetails.minmemory} - ${record.serviceofferingdetails.maxmemory}` : record.memory }}</span>
+        <span>{{ record.serviceofferingdetails?.minmemory && record.serviceofferingdetails?.maxmemory ? `${record.serviceofferingdetails.minmemory} - ${record.serviceofferingdetails.maxmemory}` : record.memory }}</span>
       </template>
       <template v-if="column.key === 'quotastate'">
         <status :text="text ? text : ''" displayText />

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -241,7 +241,7 @@
         <status :text="text ? text : ''" displayText />
       </template>
       <template v-if="column.key === 'cpunumber'">
-        <span>{{ record.serviceofferingdetails ? `${record.serviceofferingdetails.mincpunumber} - ${record.serviceofferingdetails.maxcpunumber}` : record.cpunumber }}</span>
+        <span>{{ record.serviceofferingdetails?.mincpunumber && record.serviceofferingdetails?.maxcpunumber ? `${record.serviceofferingdetails.mincpunumber} - ${record.serviceofferingdetails.maxcpunumber}` : record.cpunumber }}</span>
       </template>
       <template v-if="column.key === 'memory'">
         <span>{{ record.serviceofferingdetails ? `${record.serviceofferingdetails.minmemory} - ${record.serviceofferingdetails.maxmemory}` : record.memory }}</span>


### PR DESCRIPTION
### Description

This PR intends to enable the visualization of the amount of CPU/memory allocated in custom constrained compute offerings, which is currently not possible, thus improving the user experience.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

<summary>  Before </summary>

![before](https://github.com/user-attachments/assets/a96131f8-0c4d-4204-8898-124562155491)

<summary>  After </summary>

![after](https://github.com/user-attachments/assets/29a68ce0-6b40-4a48-9ed9-b092b20007cd)


### How Has This Been Tested?
The CPU/memory ranges appeared in the offerings table under Compute Offerings.