### PR TITLE
Remove information about the environment from exception when reverting VM snapshot

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
@@ -419,7 +419,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
                 if (answer != null && answer.getDetails() != null)
                     errMsg = errMsg + " due to " + answer.getDetails();
                 logger.error(errMsg);
-                throw new CloudRuntimeException(errMsg);
+                throw new CloudRuntimeException(String.format("Unable to revert VM %s to snapshot %s.", userVm.getInstanceName(), vmSnapshotVO.getName()));
             }
         } catch (OperationTimedoutException e) {
             logger.debug("Failed to revert vm snapshot", e);


### PR DESCRIPTION
### Description

When attempting to revert a VM to a VM snapshot, the exception displayed to users can expose some information about the environment.

This PR addresses this issue by keeping the current message to be sent to the logs and adding a new one for the exception shown to users.	

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### Screenshots (if appropriate):

![Screenshot from 2024-11-13 15-13-59](https://github.com/user-attachments/assets/d286d170-65fe-4e34-ad48-96f5b292745d)

### How Has This Been Tested?

I forced a `CloudRuntimeException` when reverting a VM to a VM snapshot and the new exception was thrown as expected. Then I checked that the current message was still being added to the logs.