### PR TITLE
UI: Add UI support for `forvpc` and `guestiptype` parameters of the `listNetworkOfferings` API

### DIFF
--- a/ui/src/components/view/SearchView.vue
+++ b/ui/src/components/view/SearchView.vue
@@ -80,7 +80,7 @@
                           </span>
                           <global-outlined v-else style="margin-right: 5px" />
                         </span>
-                        <span v-if="(field.name.startsWith('domain') || field.name === 'account')">
+                        <span v-if="(field.name.startsWith('domain') || field.name === 'account' || field.name.startsWith('associatednetwork'))">
                           <span v-if="opt.icon">
                             <resource-icon :image="opt.icon.base64image" size="1x" style="margin-right: 5px"/>
                           </span>
@@ -90,12 +90,6 @@
                           <status :text="opt.state" />
                         </span>
                         {{ $t((['storageid'].includes(field.name) || !opt.path) ? opt.name : opt.path) }}
-                        <span v-if="(field.name.startsWith('associatednetwork'))">
-                          <span v-if="opt.icon">
-                            <resource-icon :image="opt.icon.base64image" size="1x" style="margin-right: 5px"/>
-                          </span>
-                          <block-outlined v-else style="margin-right: 5px" />
-                        </span>
                       </div>
                     </a-select-option>
                   </a-select>

--- a/ui/src/components/view/SearchView.vue
+++ b/ui/src/components/view/SearchView.vue
@@ -96,7 +96,6 @@
                           </span>
                           <block-outlined v-else style="margin-right: 5px" />
                         </span>
-                        {{ $t(opt.path || opt.name) }}
                       </div>
                     </a-select-option>
                   </a-select>
@@ -313,7 +312,7 @@ export default {
         }
         if (['zoneid', 'domainid', 'imagestoreid', 'storageid', 'state', 'account', 'hypervisor', 'level',
           'clusterid', 'podid', 'groupid', 'entitytype', 'accounttype', 'systemvmtype', 'scope', 'provider',
-          'type', 'scope', 'managementserverid', 'serviceofferingid', 'diskofferingid', 'networkid', 'usagetype', 'restartrequired'].includes(item)
+          'type', 'scope', 'managementserverid', 'serviceofferingid', 'diskofferingid', 'networkid', 'usagetype', 'restartrequired', 'guestiptype'].includes(item)
         ) {
           type = 'list'
         } else if (item === 'tags') {
@@ -335,9 +334,9 @@ export default {
       return arrayField
     },
     fetchStaticFieldData (arrayField) {
-      if (arrayField.includes('type')) {
-        if (this.$route.path === '/guestnetwork' || this.$route.path.includes('/guestnetwork/')) {
-          const typeIndex = this.fields.findIndex(item => item.name === 'type')
+      if (arrayField.includes('type') || arrayField.includes('guestiptype')) {
+        if (this.$route.path.includes('/guestnetwork') || this.$route.path.includes('/networkoffering')) {
+          const typeIndex = this.fields.findIndex(item => ['type', 'guestiptype'].includes(item.name))
           this.fields[typeIndex].loading = true
           this.fields[typeIndex].opts = this.fetchGuestNetworkTypes()
           this.fields[typeIndex].loading = false
@@ -982,7 +981,7 @@ export default {
     },
     fetchGuestNetworkTypes () {
       const types = []
-      if (this.apiName.indexOf('listNetworks') > -1) {
+      if (['listNetworks', 'listNetworkOfferings'].includes(this.apiName)) {
         types.push({
           id: 'Isolated',
           name: 'label.isolated'

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -373,10 +373,22 @@ export default {
       icon: 'wifi-outlined',
       docHelp: 'adminguide/networking.html#network-offerings',
       permission: ['listNetworkOfferings'],
-      searchFilters: ['name', 'zoneid', 'domainid', 'tags'],
+      filters: ['all', 'forvpc', 'guestnetwork'],
+      searchFilters: ['name', 'zoneid', 'domainid', 'guestiptype', 'tags'],
       columns: ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'domain', 'zone', 'order'],
       details: ['name', 'id', 'displaytext', 'guestiptype', 'traffictype', 'internetprotocol', 'networkrate', 'ispersistent', 'egressdefaultpolicy', 'availability', 'conservemode', 'specifyvlan', 'routingmode', 'specifyasnumber', 'specifyipranges', 'supportspublicaccess', 'supportsstrechedl2subnet', 'forvpc', 'fornsx', 'networkmode', 'service', 'tags', 'domain', 'zone'],
       resourceType: 'NetworkOffering',
+      customParamHandler: (params, query) => {
+        const { filter } = query
+        if (!filter) {
+          return params
+        }
+        params.forvpc = filter === 'forvpc'
+        if (filter === 'all') {
+          delete params.forvpc
+        }
+        return params
+      },
       tabs: [
         {
           name: 'details',

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -692,7 +692,7 @@ export default {
         return this.$route.query.filter
       }
       const routeName = this.$route.name
-      if ((this.projectView && routeName === 'vm') || (['Admin', 'DomainAdmin'].includes(this.$store.getters.userInfo.roletype) && ['vm', 'iso', 'template', 'pod', 'cluster', 'host', 'systemvm', 'router', 'storagepool'].includes(routeName)) || ['account', 'guestnetwork', 'guestvlans', 'oauthsetting', 'guestos', 'guestoshypervisormapping', 'kubernetes', 'asnumbers'].includes(routeName)) {
+      if ((this.projectView && routeName === 'vm') || (['Admin', 'DomainAdmin'].includes(this.$store.getters.userInfo.roletype) && ['vm', 'iso', 'template', 'pod', 'cluster', 'host', 'systemvm', 'router', 'storagepool'].includes(routeName)) || ['account', 'guestnetwork', 'guestvlans', 'oauthsetting', 'guestos', 'guestoshypervisormapping', 'kubernetes', 'asnumbers', 'networkoffering'].includes(routeName)) {
         return 'all'
       }
       if (['publicip'].includes(routeName)) {


### PR DESCRIPTION
### Description

Currently, the `listNetworkOfferings` API supports the `forvpc` and `guestiptype` parameters (see [API docs](https://cloudstack.apache.org/api/apidocs-4.19/apis/listNetworkOfferings.html)). The first is used to filter network offerings that can only be used for creating VPC tiers; the second allows filtering by guest network type (available options are: `Isolated`, `Shared` and `L2`).

This PR adds support to these parameters in the UI. The `forvpc` filter has been added as a normal filter (declared in the `filters` property of the network offerings section's object) and the `guestiptype` as a search filter (declared in the `searchFilters` property).

Furthermore, this PR also fixes a bug that caused duplicate options to appear in search filter lists.

---

Fixes #9924

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/9d790963-22c4-4a19-a6c1-80a8a1c88f83)

![image](https://github.com/user-attachments/assets/803e0f68-7c42-4b39-8bc6-f07f7a662263)

### How Has This Been Tested?

### `forvpc` filter tests

- I checked that when selecting `VPC` on the section's filter, a request to `listNetworkOfferings` was sent, with the `forvpc` parameter set to `true`.
- I checked that when selecting `Guest Network` on the section's filter, a request to `listNetworkOfferings` was sent, with the `forvpc` parameter set to `false`.
- I checked that when selecting `All` on the section's filter, a request to `listNetworkOfferings` was sent, without the `forvpc` parameter.

### `guestiptype` filter tests

- I checked that when selecting the `Isolated` option on the `Guest Type` search filter, a request to `listNetworkOfferings` was sent, with the `guestiptype` parameter set to `Isolated`.
- I checked that when selecting the `Shared` option on the `Guest Type` search filter, a request to `listNetworkOfferings` was sent, with the `guestiptype` parameter set to `Shared`.
- I checked that when selecting the `L2` option on the `Guest Type` search filter, a request to `listNetworkOfferings` was sent, with the `guestiptype` parameter set to `L2`.

### Duplicate options in search filter lists

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/c0a4fa4e-ad0c-4506-94a4-22f64db93467)
</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/36d36828-d730-498a-aa51-3d017934ab02)
</details>
