### PR TITLE
UI: Hide section divider when all OAuth providers are disabled

### DIFF
--- a/ui/src/views/auth/Login.vue
+++ b/ui/src/views/auth/Login.vue
@@ -289,7 +289,6 @@ export default {
         if (response) {
           const oauthproviders = response.listoauthproviderresponse.oauthprovider || []
           oauthproviders.forEach(item => {
-            this.socialLogin = true
             if (item.provider === 'google') {
               this.googleprovider = item.enabled
               this.googleclientid = item.clientid
@@ -301,6 +300,7 @@ export default {
               this.githubredirecturi = item.redirecturi
             }
           })
+          this.socialLogin = this.googleprovider || this.githubprovider
         }
       })
     },


### PR DESCRIPTION
### Description

Currently, when all OAuth providers are disabled, the authentication page still displays the section divider below the login form.

This PR addresses this issue by ensuring the section divider is only rendered when at least one OAuth provider is enabled.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

#### Before

![image](https://github.com/user-attachments/assets/6baeb066-9c38-46f0-b311-39b598584e4d)

#### After

![image](https://github.com/user-attachments/assets/ce2a36b9-281e-4cbe-b68e-8850da359c9f)

### How Has This Been Tested?

- Verified that when at least one OAuth provider is enabled, both the section divider and the OAuth provider sign-in options are rendered correctly.
- Verified that when all OAuth providers are disabled, the section divider is no longer displayed.