### PR TITLE
Add parameter to not create additional users on `cloudstack-setup-databases`

### DIFF
--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -221,18 +221,16 @@ for full help
             )
 
         queriesToSkip = (
-            "CREATE USER cloud@`localhost` identified by 'cloud';",
-            "CREATE USER cloud@`%` identified by 'cloud';",
-            "GRANT ALL ON cloud.* to cloud@`localhost`;",
-            "GRANT ALL ON cloud.* to cloud@`%`;",
-            "GRANT ALL ON cloud_usage.* to cloud@`localhost`;",
-            "GRANT ALL ON cloud_usage.* to cloud@`%`;",
-            "GRANT process ON *.* TO cloud@`localhost`;",
-            "GRANT process ON *.* TO cloud@`%`;",
-            "IF foo > 0 THEN",
-            "DROP USER 'cloud'@'localhost' ;",
-            "END IF;",
-            "DROP USER 'cloud'@'%' ;"
+            ("CREATE USER cloud@`localhost` identified by 'cloud';", ""),
+            ("CREATE USER cloud@`%` identified by 'cloud';", ""),
+            ("GRANT ALL ON cloud.* to cloud@`localhost`;", ""),
+            ("GRANT ALL ON cloud.* to cloud@`%`;", ""),
+            ("GRANT ALL ON cloud_usage.* to cloud@`localhost`;", ""),
+            ("GRANT ALL ON cloud_usage.* to cloud@`%`;", ""),
+            ("GRANT process ON *.* TO cloud@`localhost`;", ""),
+            ("GRANT process ON *.* TO cloud@`%`;", ""),
+            ("DROP USER 'cloud'@'localhost' ;", "DO NULL;"),
+            ("DROP USER 'cloud'@'%' ;", "DO NULL;")
         )
 
         scriptsToRun = ["create-database","create-schema", "create-database-premium","create-schema-premium"]
@@ -244,7 +242,7 @@ for full help
             if not os.path.exists(p): continue
             text = open(p).read()
             if self.options.skipUsersAutoCreation:
-                for t in queriesToSkip: text = text.replace(t,"")
+                for t, r in queriesToSkip: text = text.replace(t,r)
             for t, r in replacements: text = text.replace(t,r)
             self.info("Applying %s"%p)
             self.runMysql(text, p, self.rootuser != None)


### PR DESCRIPTION
### Description

When using the `cloudstack-setup-databases` command during the database setup process, some additional users are created. Since the standard procedure involves creating and configuring database users prior to the ACS setup, these extra users are not used. Moreover, the additional users created by `cloudstack-setup-databases` are granted excessive permissions, requiring operators to manually delete them.

This PR introduces a new optional parameter, `--skip-users-auto-creation`. By using this parameter, ACS will skip the automatic creation of these additional users.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### Screenshots (if appropriate):


### How Has This Been Tested?

After executing the `cloudstack-setup-databases` with the new flag, I checked the database users and, as expected, no new users were created. I then repeated the procedure without the new flag, and the extra users were created as usual.