### PR TITLE
Displaying info of the labels from form CreateSSHKeyPair

### DIFF
--- a/ui/src/views/compute/CreateSSHKeyPair.vue
+++ b/ui/src/views/compute/CreateSSHKeyPair.vue
@@ -27,11 +27,8 @@
         @finish="handleSubmit"
         layout="vertical">
         <a-form-item name="name" ref="name">
-          <template #label :title="apiParams.name.description">
-            {{ $t('label.name') }}
-            <a-tooltip>
-              <info-circle-outlined style="color: rgba(0,0,0,.45)" />
-            </a-tooltip>
+          <template #label>
+            <tooltip-label :title="$t('label.name')" :tooltip="apiParams.name.description"/>
           </template>
           <a-input
             v-model:value="form.name"
@@ -39,22 +36,16 @@
             v-focus="true" />
         </a-form-item>
         <a-form-item name="publickey" ref="publickey">
-          <template #label :title="apiParams.publickey.description">
-            {{ $t('label.publickey') }}
-            <a-tooltip>
-              <info-circle-outlined style="color: rgba(0,0,0,.45)" />
-            </a-tooltip>
+          <template #label>
+            <tooltip-label :title="$t('label.publickey')" :tooltip="apiParams.publickey.description"/>
           </template>
           <a-input
             v-model:value="form.publickey"
             :placeholder="apiParams.publickey.description"/>
         </a-form-item>
         <a-form-item name="domainid" ref="domainid" v-if="isAdminOrDomainAdmin()">
-          <template #label :title="apiParams.domainid.description">
-            {{ $t('label.domainid') }}
-            <a-tooltip>
-              <info-circle-outlined style="color: rgba(0,0,0,.45)" />
-            </a-tooltip>
+          <template #label>
+            <tooltip-label :title="$t('label.domainid')" :tooltip="apiParams.domainid.description"/>
           </template>
           <a-select
             id="domain-selection"
@@ -105,11 +96,15 @@
 import { ref, reactive, toRaw } from 'vue'
 import { api } from '@/api'
 import { mixinForm } from '@/utils/mixin'
+import TooltipLabel from '@/components/widgets/TooltipLabel'
 
 export default {
   name: 'CreateSSHKeyPair',
   mixins: [mixinForm],
   props: {},
+  components: {
+    TooltipLabel
+  },
   data () {
     return {
       domains: [],


### PR DESCRIPTION
### Description

This PR aims to display the label hints in the `CreateSSHKeyPair` form, which are currently not shown, negatively impacting the user experience.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):
<summary>  Before </summary>

![before](https://github.com/user-attachments/assets/6b82103a-c19b-495e-a8bc-04e39672cc3c)

<summary>  After </summary>

![after](https://github.com/user-attachments/assets/35fd83a1-b22e-4866-8f04-cb4cd501d601)

### How Has This Been Tested?
	The label hints were displayed in the form in question.