### PR TITLE
UI: Tooltip on the host information card to display the CPU speed in MHz and the memory value in MB (to 3 decimal places)

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -180,7 +180,14 @@
           <div class="resource-detail-item__label">{{ $t('label.cpu') }}</div>
           <div class="resource-detail-item__details">
             <appstore-outlined />
-            <span v-if="'cpunumber' in resource && 'cpuspeed' in resource">{{ resource.cpunumber }} CPU x {{ parseFloat(resource.cpuspeed / 1000.0).toFixed(2) }} Ghz</span>
+            <span v-if="'cpunumber' in resource && 'cpuspeed' in resource">{{ resource.cpunumber }} CPU x {{ (resource.cpuspeed / 1000.0).toFixed(2) }} GHz
+              <a-tooltip placement="top">
+                <template #title>
+                  {{ resource.cpuspeed }} MHz
+                </template>
+                <QuestionCircleOutlined />
+              </a-tooltip>
+            </span>
             <span v-else>{{ resource.cputotal }}</span>
           </div>
           <div>

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -231,7 +231,16 @@
         <div class="resource-detail-item" v-else-if="resource.memorytotalgb">
           <div class="resource-detail-item__label">{{ $t('label.memory') }}</div>
           <div class="resource-detail-item__details">
-            <bulb-outlined />{{ resource.memorytotalgb + ' ' + $t('label.memory') }}
+            <bulb-outlined />
+            <span>
+              {{ resource.memorytotalgb + ' ' + $t('label.memory') }}
+              <a-tooltip placement="top">
+                <template #title>
+                  {{ (resource.memorytotal/(1024**2)).toFixed(3) }} MB
+                </template>
+                <QuestionCircleOutlined />
+              </a-tooltip>
+            </span>
           </div>
           <div>
             <span v-if="resource.memoryusedgb">


### PR DESCRIPTION
### Description

This PR proposes adding a `tooltip` that displays the exact frequency (without rounding and described in MHz) of the `cpuspeed` and the `memory` value in MB to three decimal places on Hosts pages. Currently, the InfoCard component treats the CPU frequency to be displayed in GHz to two decimal places. The current way in which computing resources are displayed can mislead the end user.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
<summary>  Before </summary>

![before](https://github.com/user-attachments/assets/212a59f9-13fd-4a14-87a2-9ff1e45fc037)

<summary>  After </summary>

![after](https://github.com/user-attachments/assets/78a40bc8-98c7-48f4-988c-cf6c45fc989d)

### How Has This Been Tested?
	The tooltip with the exact frequency was displayed on the Hosts page.