### PR TITLE
UI: Fixes in the Usage UI

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1523,6 +1523,7 @@
 "label.networkspeed": "Network speed",
 "label.networktype": "Network type",
 "label.networkwrite": "Network write",
+"label.never": "Never",
 "label.new": "New",
 "label.new.autoscale.vmgroup": "New AutoScaling Group",
 "label.new.instance.group": "New Instance group",

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -26,7 +26,7 @@
     :rowSelection="explicitlyAllowRowSelection || enableGroupAction() || $route.name === 'event' ? {selectedRowKeys: selectedRowKeys, onChange: onSelectChange, columnWidth: 30} : null"
     :rowClassName="getRowClassName"
     @resizeColumn="handleResizeColumn"
-    style="overflow-y: auto"
+    :style="{ 'overflow-y': this.$route.name === 'usage' ? 'hidden' : 'auto' }"
   >
     <template #customFilterDropdown>
       <div style="padding: 8px" class="filter-dropdown">

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -50,7 +50,7 @@
           <a-row justify="end">
             <a-col>
               <tooltip-button
-                v-if="'generateUsageRecords' in this.$store.getters.apis"
+                v-if="'generateUsageRecords' in $store.getters.apis"
                 type="primary"
                 icon="hdd-outlined"
                 :tooltip="$t('label.usage.records.generate')"

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -88,7 +88,7 @@
         <a-card-grid style="width: 35%; text-align: center; font-size: small;">
           <a-statistic
             :title="$t('label.lastheartbeat')"
-            :value="$toLocaleDate(serverStats.lastheartbeat)"
+            :value="serverStats.lastheartbeat ? $toLocaleDate(serverStats.lastheartbeat) : $t('label.never')"
             valueStyle="font-size: medium"
           />
           <a-card-meta :description="getTimeSince(serverStats.collectiontime)" />

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -503,6 +503,11 @@ export default {
       }
     },
     listUsageServerMetrics () {
+      if (!('listUsageServerMetrics' in this.$store.getters.apis)) {
+        this.serverMetricsLoading = false
+        return
+      }
+
       this.serverMetricsLoading = true
       api('listUsageServerMetrics').then(json => {
         this.stats = []
@@ -639,6 +644,10 @@ export default {
       })
     },
     getUsageTypes () {
+      if (!('listUsageTypes' in this.$store.getters.apis)) {
+        return
+      }
+
       api('listUsageTypes').then(json => {
         if (json && json.listusagetypesresponse && json.listusagetypesresponse.usagetype) {
           this.usageTypes = [{ id: null, value: '' }, ...json.listusagetypesresponse.usagetype.map(x => {

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -59,7 +59,7 @@
             </a-col>&nbsp;&nbsp;
             <a-col>
               <tooltip-button
-                v-if="'removeRawUsageRecords' in this.$store.getters.apis"
+                v-if="'removeRawUsageRecords' in $store.getters.apis"
                 type="danger"
                 icon="delete-outlined"
                 :tooltip="$t('label.usage.records.purge')"

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -72,7 +72,7 @@
     </a-card>
   </a-affix>
   <a-col>
-    <a-card size="small" :loading="serverMetricsLoading" v-if="'listUsageServerMetrics' in this.$store.getters.apis">
+    <a-card size="small" :loading="serverMetricsLoading" v-if="'listUsageServerMetrics' in $store.getters.apis">
       <a-row justify="space-around">
         <a-card-grid style="width: 30%; text-align: center; font-size: small;">
           <a-statistic

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -91,7 +91,7 @@
             :value="serverStats.lastheartbeat ? $toLocaleDate(serverStats.lastheartbeat) : $t('label.never')"
             valueStyle="font-size: medium"
           />
-          <a-card-meta :description="getTimeSince(serverStats.collectiontime)" />
+          <a-card-meta v-if="!!serverStats.lastheartbeat" :description="getTimeSince(serverStats.collectiontime)" />
         </a-card-grid>
         <a-card-grid style="width: 35%; text-align: center; font-size: small;">
           <a-statistic

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -50,6 +50,7 @@
           <a-row justify="end">
             <a-col>
               <tooltip-button
+                v-if="'generateUsageRecords' in this.$store.getters.apis"
                 type="primary"
                 icon="hdd-outlined"
                 :tooltip="$t('label.usage.records.generate')"
@@ -58,6 +59,7 @@
             </a-col>&nbsp;&nbsp;
             <a-col>
               <tooltip-button
+                v-if="'removeRawUsageRecords' in this.$store.getters.apis"
                 type="danger"
                 icon="delete-outlined"
                 :tooltip="$t('label.usage.records.purge')"
@@ -70,7 +72,7 @@
     </a-card>
   </a-affix>
   <a-col>
-    <a-card size="small" :loading="serverMetricsLoading">
+    <a-card size="small" :loading="serverMetricsLoading" v-if="'listUsageServerMetrics' in this.$store.getters.apis">
       <a-row justify="space-around">
         <a-card-grid style="width: 30%; text-align: center; font-size: small;">
           <a-statistic
@@ -159,7 +161,7 @@
               />
             </a-form-item>
           </a-col>
-          <a-col :span="3">
+          <a-col :span="3" v-if="'listUsageTypes' in this.$store.getters.apis">
             <a-form-item
               ref="type"
               name="type"
@@ -173,7 +175,7 @@
               />
             </a-form-item>
           </a-col>
-          <a-col :span="3">
+          <a-col :span="3" v-if="'listUsageTypes' in this.$store.getters.apis">
             <a-form-item
               ref="id"
               name="id"

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -175,7 +175,7 @@
               />
             </a-form-item>
           </a-col>
-          <a-col :span="3" v-if="'listUsageTypes' in this.$store.getters.apis">
+          <a-col :span="3" v-if="'listUsageTypes' in $store.getters.apis">
             <a-form-item
               ref="id"
               name="id"

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -161,7 +161,7 @@
               />
             </a-form-item>
           </a-col>
-          <a-col :span="3" v-if="'listUsageTypes' in this.$store.getters.apis">
+          <a-col :span="3" v-if="'listUsageTypes' in $store.getters.apis">
             <a-form-item
               ref="type"
               name="type"


### PR DESCRIPTION
### Description

This PR addresses the following issues related to the Usage UI:
- Usage metrics section is displayed with `null` values to users without access to the `listUsageServerMetrics` API (Fixes #9992);
- Purge usage records action is displayed to users without access to the `removeRawUsageRecords` API (Fixes #9995);
- Generate usage records action is displayed to users without access to the `generateUsageRecords` API (Fixes #9994);
- Vertical scroll overflow in the usage records table (Fixes #9996);
- Usage types input field is displayed to users without access to the `listUsageTypes` API. Since the `usageid` parameter of the `listUsageRecords` API can only be used alongside the `type` parameter, both form fields are now hidden when the caller does not have access to the `listUsageTypes` API.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):

- Usage UI view when the user does not have access to the `listUsageServerMetrics`,  `removeRawUsageRecords`, `generateUsageRecords` and `listUsageTypes` APIs

![image](https://github.com/user-attachments/assets/b8387809-ca9d-45f5-b9ae-2f9bdc2c55cc)


### How Has This Been Tested?

- Verified that users without access to the `listUsageServerMetrics`,  `removeRawUsageRecords`, `generateUsageRecords` and `listUsageTypes` APIs were not able to interact with them through the UI.
- Verified that the vertical overflow issue was resolved. 
