### PR TITLE
UI: Fix userdata and load balancer selection

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1940,18 +1940,16 @@ export default {
         this.form.userdataid = undefined
         return
       }
+
       this.form.userdataid = id
       this.userDataParams = []
       api('listUserData', { id: id }).then(json => {
         const resp = json?.listuserdataresponse?.userdata || []
         if (resp[0]) {
-          var params = resp[0].params
-          if (params) {
-            var dataParams = params.split(',')
-          }
-          var that = this
-          dataParams.forEach(function (val, index) {
-            that.userDataParams.push({
+          const params = resp[0].params
+          const dataParams = params ? params.split(',') : []
+          dataParams.forEach((val, index) => {
+            this.userDataParams.push({
               id: index,
               key: val
             })

--- a/ui/src/views/compute/wizard/LoadBalancerSelection.vue
+++ b/ui/src/views/compute/wizard/LoadBalancerSelection.vue
@@ -30,6 +30,7 @@
       :rowKey="record => record.id"
       :pagination="false"
       :rowSelection="rowSelection"
+      :customRow="onClickRow"
       size="middle"
       :scroll="{ y: 225 }">
       <template #headerCell="{ column }">
@@ -197,6 +198,14 @@ export default {
       this.options.page = page
       this.options.pageSize = pageSize
       this.$emit('handle-search-filter', this.options)
+    },
+    onClickRow (record) {
+      return {
+        onClick: () => {
+          this.selectedRowKeys = [record.id]
+          this.$emit('select-load-balancer-item', record.id)
+        }
+      }
     }
   }
 }

--- a/ui/src/views/compute/wizard/UserDataSelection.vue
+++ b/ui/src/views/compute/wizard/UserDataSelection.vue
@@ -33,6 +33,7 @@
       :scroll="{ y: 225 }"
     >
       <template #headerCell="{ column }">
+        <template v-if="column.key === 'name'"><solution-outlined /> {{ $t('label.userdata') }}</template>
         <template v-if="column.key === 'account'"><user-outlined /> {{ $t('label.account') }}</template>
         <template v-if="column.key === 'domain'"><block-outlined /> {{ $t('label.domain') }}</template>
       </template>
@@ -78,6 +79,7 @@ export default {
       filter: '',
       columns: [
         {
+          key: 'name',
           dataIndex: 'name',
           title: this.$t('label.userdata'),
           width: '40%'
@@ -181,11 +183,9 @@ export default {
     },
     onClickRow (record) {
       return {
-        on: {
-          click: () => {
-            this.selectedRowKeys = [record.key]
-            this.$emit('select-user-data-item', record.key)
-          }
+        onClick: () => {
+          this.selectedRowKeys = [record.key]
+          this.$emit('select-user-data-item', record.key)
         }
       }
     }


### PR DESCRIPTION
### Description

Currently, in the VM deployment wizard, when the user tries to select a userdata by clicking on its row (outside the radio button), the userdata is not selected. This behavior also occurs for load balancer selection in the autoscale group creation form.

Additionally, whenever the `listUserData` API response doesn't contain the `params` attribute, the following exception is thrown in the browser's console:

```
TypeError: Cannot read properties of undefined (reading 'forEach')
```

This PR addresses these issues by enabling users to select the VM's userdata and the autoscale group's load balancer by clicking on the corresponding resource table rows. Furthermore, the UI exception is now properly handled.

---

Fixes #9990 and fixes #9991

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):


### How Has This Been Tested?

- Verified that VM userdata can now be selected by clicking on the corresponding table row.
- Verified that autoscale group load balancers can now be selected by clicking on the corresponding table row.