### PR TITLE
Allow config drive deletion of migrated VM, on host maintenance

### DIFF
--- a/api/src/main/java/com/cloud/vm/VmDetailConstants.java
+++ b/api/src/main/java/com/cloud/vm/VmDetailConstants.java
@@ -73,6 +73,7 @@ public interface VmDetailConstants {
     String ENCRYPTED_PASSWORD = "Encrypted.Password";
 
     String CONFIG_DRIVE_LOCATION = "configDriveLocation";
+    String LAST_CONFIG_DRIVE_LOCATION = "lastConfigDriveLocation";
 
     String SKIP_DRS = "skipFromDRS";
 

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentAttache.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentAttache.java
@@ -46,6 +46,7 @@ import com.cloud.agent.api.CleanupNetworkRulesCmd;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.CreateStoragePoolCommand;
 import com.cloud.agent.api.DeleteStoragePoolCommand;
+import com.cloud.agent.api.HandleConfigDriveIsoCommand;
 import com.cloud.agent.api.MaintainCommand;
 import com.cloud.agent.api.MigrateCommand;
 import com.cloud.agent.api.ModifySshKeysCommand;
@@ -119,11 +120,10 @@ public abstract class AgentAttache {
 
     public final static String[] s_commandsAllowedInMaintenanceMode = new String[] { MaintainCommand.class.toString(), MigrateCommand.class.toString(),
         StopCommand.class.toString(), CheckVirtualMachineCommand.class.toString(), PingTestCommand.class.toString(), CheckHealthCommand.class.toString(),
-        ReadyCommand.class.toString(), ShutdownCommand.class.toString(), SetupCommand.class.toString(),
-        CleanupNetworkRulesCmd.class.toString(), CheckNetworkCommand.class.toString(), PvlanSetupCommand.class.toString(), CheckOnHostCommand.class.toString(),
-        ModifyTargetsCommand.class.toString(), ModifySshKeysCommand.class.toString(),
-        CreateStoragePoolCommand.class.toString(), DeleteStoragePoolCommand.class.toString(), ModifyStoragePoolCommand.class.toString(),
-        SetupMSListCommand.class.toString(), RollingMaintenanceCommand.class.toString(), CleanupPersistentNetworkResourceCommand.class.toString()};
+        ReadyCommand.class.toString(), ShutdownCommand.class.toString(), SetupCommand.class.toString(), CleanupNetworkRulesCmd.class.toString(),
+        CheckNetworkCommand.class.toString(), PvlanSetupCommand.class.toString(), CheckOnHostCommand.class.toString(), ModifyTargetsCommand.class.toString(),
+        ModifySshKeysCommand.class.toString(), CreateStoragePoolCommand.class.toString(), DeleteStoragePoolCommand.class.toString(), ModifyStoragePoolCommand.class.toString(),
+        SetupMSListCommand.class.toString(), RollingMaintenanceCommand.class.toString(), CleanupPersistentNetworkResourceCommand.class.toString(), HandleConfigDriveIsoCommand.class.toString()};
     protected final static String[] s_commandsNotAllowedInConnectingMode = new String[] { StartCommand.class.toString(), CreateCommand.class.toString() };
     static {
         Arrays.sort(s_commandsAllowedInMaintenanceMode);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2985,9 +2985,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     public static boolean useBLOCKDiskType(KVMPhysicalDisk physicalDisk) {
         return physicalDisk != null &&
-                physicalDisk.getPool().getType() == StoragePoolType.Linstor &&
+                physicalDisk.getPool() != null &&
+                StoragePoolType.Linstor.equals(physicalDisk.getPool().getType()) &&
                 physicalDisk.getFormat() != null &&
-                physicalDisk.getFormat()== PhysicalDiskFormat.RAW;
+                PhysicalDiskFormat.RAW.equals(physicalDisk.getFormat());
     }
 
     public static DiskDef.DiskType getDiskType(KVMPhysicalDisk physicalDisk) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3424,15 +3424,19 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             InternalErrorException {
         final DiskDef iso = new DiskDef();
         if (isAttach && StringUtils.isNotBlank(isoPath) && isoPath.lastIndexOf("/") > 0) {
-            final int index = isoPath.lastIndexOf("/");
-            final String path = isoPath.substring(0, index);
-            final String name = isoPath.substring(index + 1);
-            final KVMStoragePool secondaryPool = storagePoolManager.getStoragePoolByURI(path);
-            final KVMPhysicalDisk isoVol = secondaryPool.getPhysicalDisk(name);
-            final DiskDef.DiskType diskType = getDiskType(isoVol);
-            isoPath = isoVol.getPath();
+            if (isoPath.startsWith(getConfigPath() + "/" + ConfigDrive.CONFIGDRIVEDIR) && isoPath.contains(vmName)) {
+                iso.defISODisk(isoPath, diskSeq, DiskDef.DiskType.FILE);
+            } else {
+                final int index = isoPath.lastIndexOf("/");
+                final String path = isoPath.substring(0, index);
+                final String name = isoPath.substring(index + 1);
+                final KVMStoragePool storagePool = storagePoolManager.getStoragePoolByURI(path);
+                final KVMPhysicalDisk isoVol = storagePool.getPhysicalDisk(name);
+                final DiskDef.DiskType diskType = getDiskType(isoVol);
+                isoPath = isoVol.getPath();
 
-            iso.defISODisk(isoPath, diskSeq, diskType);
+                iso.defISODisk(isoPath, diskSeq, diskType);
+            }
         } else {
             iso.defISODisk(null, diskSeq, DiskDef.DiskType.FILE);
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3403,13 +3403,15 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
         if (configdrive != null) {
             try {
+                s_logger.debug(String.format("Detaching ConfigDrive ISO of the VM %s, at path %s", vmName, configdrive.getDiskPath()));
                 String result = attachOrDetachISO(conn, vmName, configdrive.getDiskPath(), false, CONFIG_DRIVE_ISO_DEVICE_ID);
                 if (result != null) {
-                    s_logger.warn("Detach ConfigDrive ISO with result: " + result);
+                    s_logger.warn(String.format("Detach ConfigDrive ISO of the VM %s, at path %s with %s: ", vmName, configdrive.getDiskPath(), result));
                 }
+                s_logger.debug(String.format("Attaching ConfigDrive ISO of the VM %s, at path %s", vmName, configdrive.getDiskPath()));
                 result = attachOrDetachISO(conn, vmName, configdrive.getDiskPath(), true, CONFIG_DRIVE_ISO_DEVICE_ID);
                 if (result != null) {
-                    s_logger.warn("Attach ConfigDrive ISO with result: " + result);
+                    s_logger.warn(String.format("Attach ConfigDrive ISO of the VM %s, at path %s with %s: ", vmName, configdrive.getDiskPath(), result));
                 }
             } catch (final LibvirtException | InternalErrorException | URISyntaxException e) {
                 final String msg = "Detach and attach ConfigDrive ISO failed due to " + e.toString();
@@ -3421,7 +3423,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     public synchronized String attachOrDetachISO(final Connect conn, final String vmName, String isoPath, final boolean isAttach, final Integer diskSeq) throws LibvirtException, URISyntaxException,
             InternalErrorException {
         final DiskDef iso = new DiskDef();
-        if (isoPath != null && isAttach) {
+        if (isAttach && StringUtils.isNotBlank(isoPath) && isoPath.lastIndexOf("/") > 0) {
             final int index = isoPath.lastIndexOf("/");
             final String path = isoPath.substring(0, index);
             final String name = isoPath.substring(index + 1);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
@@ -287,6 +287,7 @@ public class KVMStoragePoolManager {
         URI storageUri = null;
 
         try {
+            s_logger.debug("Get storage pool by uri: " + uri);
             storageUri = new URI(uri);
         } catch (URISyntaxException e) {
             throw new CloudRuntimeException(e.toString());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
@@ -296,7 +296,7 @@ public class KVMStoragePoolManager {
         String uuid = null;
         String sourceHost = "";
         StoragePoolType protocol = null;
-        final String scheme = storageUri.getScheme().toLowerCase();
+        final String scheme = (storageUri.getScheme() != null) ? storageUri.getScheme().toLowerCase() : "";
         List<String> acceptedSchemes = List.of("nfs", "networkfilesystem", "filesystem");
         if (acceptedSchemes.contains(scheme)) {
             sourcePath = storageUri.getPath();

--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -341,10 +341,10 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
             try {
                 if (isConfigDriveIsoOnHostCache(vm.getId())) {
                     vm.setConfigDriveLocation(Location.HOST);
-                    configureConfigDriveData(vm, nic, dest);
-
-                    // Create the config drive on dest host cache
-                    createConfigDriveIsoOnHostCache(vm, dest.getHost().getId());
+                    if (configureConfigDriveData(vm, nic, dest)) {
+                        // Create the config drive on dest host cache
+                        createConfigDriveIsoOnHostCache(vm, dest.getHost().getId());
+                    }
                 } else {
                     vm.setConfigDriveLocation(getConfigDriveLocation(vm.getId()));
                     addPasswordAndUserdata(network, nic, vm, dest, context);
@@ -760,7 +760,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
     private boolean configureConfigDriveData(final VirtualMachineProfile profile, final NicProfile nic, final DeployDestination dest) {
         final UserVmVO vm = _userVmDao.findById(profile.getId());
-        if (vm.getType() != VirtualMachine.Type.User) {
+        if (vm == null || vm.getType() != VirtualMachine.Type.User) {
             return false;
         }
         final Nic defaultNic = _networkModel.getDefaultNic(vm.getId());

--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -373,7 +373,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     @Override
     public void commitMigration(NicProfile nic, Network network, VirtualMachineProfile vm, ReservationContext src, ReservationContext dst) {
         try {
-            if (isConfigDriveIsoOnHostCache(vm.getId())) {
+            if (isLastConfigDriveIsoOnHostCache(vm.getId())) {
                 vm.setConfigDriveLocation(Location.HOST);
                 // Delete the config drive on src host cache
                 deleteConfigDriveIsoOnHostCache(vm.getVirtualMachine(), vm.getHostId());
@@ -530,6 +530,17 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         return false;
     }
 
+    private boolean isLastConfigDriveIsoOnHostCache(long vmId) {
+        final UserVmDetailVO vmDetailLastConfigDriveLocation = _userVmDetailsDao.findDetail(vmId, VmDetailConstants.LAST_CONFIG_DRIVE_LOCATION);
+        if (vmDetailLastConfigDriveLocation == null) {
+            return isConfigDriveIsoOnHostCache(vmId);
+        }
+        if (Location.HOST.toString().equalsIgnoreCase(vmDetailLastConfigDriveLocation.getValue())) {
+            return true;
+        }
+        return false;
+    }
+
     private boolean createConfigDriveIsoOnHostCache(VirtualMachineProfile profile, Long hostId) throws ResourceUnavailableException {
         if (hostId == null) {
             throw new ResourceUnavailableException("Config drive iso creation failed, dest host not available",
@@ -556,7 +567,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         }
 
         profile.setConfigDriveLocation(answer.getConfigDriveLocation());
-        _userVmDetailsDao.addDetail(profile.getId(), VmDetailConstants.CONFIG_DRIVE_LOCATION, answer.getConfigDriveLocation().toString(), false);
+        updateConfigDriveLocationInVMDetails(profile.getId(), answer.getConfigDriveLocation());
         addConfigDriveDisk(profile, null);
         return true;
     }
@@ -618,9 +629,21 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
                     answer.getDetails()), ConfigDriveNetworkElement.class, 0L);
         }
         profile.setConfigDriveLocation(answer.getConfigDriveLocation());
-        _userVmDetailsDao.addDetail(profile.getId(), VmDetailConstants.CONFIG_DRIVE_LOCATION, answer.getConfigDriveLocation().toString(), false);
+        updateConfigDriveLocationInVMDetails(profile.getId(), answer.getConfigDriveLocation());
         addConfigDriveDisk(profile, dataStore);
         return true;
+    }
+
+    private void updateConfigDriveLocationInVMDetails(long vmId, NetworkElement.Location configDriveLocation) {
+        final UserVmDetailVO vmDetailConfigDriveLocation = _userVmDetailsDao.findDetail(vmId, VmDetailConstants.CONFIG_DRIVE_LOCATION);
+        if (vmDetailConfigDriveLocation != null) {
+            if (!configDriveLocation.toString().equalsIgnoreCase(vmDetailConfigDriveLocation.getValue())) {
+                _userVmDetailsDao.addDetail(vmId, VmDetailConstants.LAST_CONFIG_DRIVE_LOCATION, vmDetailConfigDriveLocation.getValue(), false);
+            } else {
+                _userVmDetailsDao.removeDetail(vmId, VmDetailConstants.LAST_CONFIG_DRIVE_LOCATION);
+            }
+        }
+        _userVmDetailsDao.addDetail(vmId, VmDetailConstants.CONFIG_DRIVE_LOCATION, configDriveLocation.toString(), false);
     }
 
     private Map<String, String> getVMCustomUserdataParamMap(long vmId) {


### PR DESCRIPTION
### Description

This PR allows config drive deletion of migrated VM, on host maintenance (from it's last source location - host cache/primary/secondary storage).

Fixes below issues identified during host maintenance tests, with VM using config drive on KVM host cache.

1. Old config drive location is overriden in the VM detail, while creating the new one during the migration (config drive location would change here, in case any of the location settings updated after VM is created - vm.configdrive.force.host.cache.use, vm.configdrive.primarypool.enabled, vm.configdrive.use.host.cache.on.unsupported.pool). If so, the rollback or post migration tries to delete the config drive from the new/overriden location in the source host after migration, where the file doesn't exists.

1. Delete config drive command HandleConfigDriveIsoCommand is not allowed when host is in maintenance.

```
2024-12-04 07:36:10,315 DEBUG [c.c.n.e.ConfigDriveNetworkElement] (Work-Job-Executor-10:ctx-fabb0d27 job-58/job-60 ctx-43e67e9c) (logid:332edac0) Deleting config drive ISO for vm: i-2-6-VM on host: 1
2024-12-04 07:36:10,318 WARN  [c.c.a.m.AgentManagerImpl] (Work-Job-Executor-10:ctx-fabb0d27 job-58/job-60 ctx-43e67e9c) (logid:332edac0) Resource [Host:1] is unreachable: Host 1: Unable to send class com.cloud.agent.api.HandleConfigDriveIsoCommand because agent ol8.localdomain is in maintenance mode
2024-12-04 07:36:10,319 ERROR [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-10:ctx-fabb0d27 job-58/job-60 ctx-43e67e9c) (logid:332edac0) Invocation exception, caused by: com.cloud.utils.exception.CloudRuntimeException: Unable to get an answer to handle config drive deletion for vm: i-2-6-VM on host: 1
2024-12-04 07:36:10,319 INFO  [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-10:ctx-fabb0d27 job-58/job-60 ctx-43e67e9c) (logid:332edac0) Rethrow exception com.cloud.utils.exception.CloudRuntimeException: Unable to get an answer to handle config drive deletion for vm: i-2-6-VM on host: 1
2024-12-04 07:36:10,319 DEBUG [c.c.v.VmWorkJobDispatcher] (Work-Job-Executor-10:ctx-fabb0d27 job-58/job-60) (logid:332edac0) Done with run of VM work job: com.cloud.vm.VmWorkMigrateAway for VM 6, job origin: 58
2024-12-04 07:36:10,319 ERROR [c.c.v.VmWorkJobDispatcher] (Work-Job-Executor-10:ctx-fabb0d27 job-58/job-60) (logid:332edac0) Unable to complete AsyncJobVO: {id:60, userId: 1, accountId: 1, instanceType: null, instanceId: null, cmd: com.cloud.vm.VmWorkMigrateAway, cmdInfo: rO0ABXNyAB5jb20uY2xvdWQudm0uVm1Xb3JrTWlncmF0ZUF3YXmt4MX4jtcEmwIAAUoACXNyY0hvc3RJZHhyABNjb20uY2xvdWQudm0uVm1Xb3Jrn5m2VvAlZ2sCAARKAAlhY2NvdW50SWRKAAZ1c2VySWRKAAR2bUlkTAALaGFuZGxlck5hbWV0ABJMamF2YS9sYW5nL1N0cmluZzt4cAAAAAAAAAABAAAAAAAAAAEAAAAAAAAABnQAGVZpcnR1YWxNYWNoaW5lTWFuYWdlckltcGwAAAAAAAAAAQ, cmdVersion: 0, status: IN_PROGRESS, processStatus: 0, resultCode: 0, result: null, initMsid: 32986187695067, completeMsid: null, lastUpdated: null, lastPolled: null, created: Wed Dec 04 07:36:04 UTC 2024, removed: null}, job origin:58
com.cloud.utils.exception.CloudRuntimeException: Unable to get an answer to handle config drive deletion for vm: i-2-6-VM on host: 1
	at com.cloud.network.element.ConfigDriveNetworkElement.deleteConfigDriveIsoOnHostCache(ConfigDriveNetworkElement.java:585)
	at com.cloud.network.element.ConfigDriveNetworkElement.commitMigration(ConfigDriveNetworkElement.java:379)
	at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator.commitNicForMigration(NetworkOrchestrator.java:2264)
	at com.cloud.vm.VirtualMachineManagerImpl.migrate(VirtualMachineManagerImpl.java:2904)
	at com.cloud.vm.VirtualMachineManagerImpl.orchestrateMigrateAway(VirtualMachineManagerImpl.java:3488)
	at com.cloud.vm.VirtualMachineManagerImpl.orchestrateMigrateAway(VirtualMachineManagerImpl.java:5535)
```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Manually tested maintenance on host having some running VMs with config drive on host cache and secondary. Running VMs are migrated to other available hosts and old config drive is removed.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
