### PR TITLE
UI: Standardize OwnershipSelection to use logic independent of language

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -2312,14 +2312,14 @@ export default {
         domainid: store.getters.userInfo.domainid,
         account: store.getters.userInfo.account
       }
-      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+      if (OwnerOptions.selectedAccountType === 'Account') {
         if (!OwnerOptions.selectedAccount) {
           return
         }
         this.owner.account = OwnerOptions.selectedAccount
         this.owner.domainid = OwnerOptions.selectedDomain
         this.owner.projectid = null
-      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+      } else if (OwnerOptions.selectedAccountType === 'Project') {
         if (!OwnerOptions.selectedProject) {
           return
         }

--- a/ui/src/views/compute/wizard/OwnershipSelection.vue
+++ b/ui/src/views/compute/wizard/OwnershipSelection.vue
@@ -31,8 +31,8 @@
           }
         "
       >
-        <a-select-option :value="$t('label.account')">{{ $t('label.account') }}</a-select-option>
-        <a-select-option :value="$t('label.project')">{{ $t('label.project') }}</a-select-option>
+        <a-select-option :value="'Account'">{{ $t('label.account') }}</a-select-option>
+        <a-select-option :value="'Project'">{{ $t('label.project') }}</a-select-option>
       </a-select>
     </a-form-item>
     <a-form-item :label="$t('label.domain')" required>
@@ -67,7 +67,7 @@
       </a-select>
     </a-form-item>
 
-    <template v-if="selectedAccountType === $t('label.account')">
+    <template v-if="selectedAccountType === 'Account'">
       <a-form-item :label="$t('label.account')" required>
         <a-select
           @change="emitChangeEvent"
@@ -139,7 +139,7 @@ export default {
       domains: [],
       accounts: [],
       projects: [],
-      selectedAccountType: this.$store.getters.project?.id ? this.$t('label.project') : this.$t('label.account'),
+      selectedAccountType: this.$store.getters.project?.id ? 'Project' : 'Account',
       selectedDomain: null,
       selectedAccount: null,
       selectedProject: null,
@@ -243,7 +243,7 @@ export default {
         })
     },
     changeDomain () {
-      if (this.selectedAccountType === this.$t('label.account')) {
+      if (this.selectedAccountType === 'Account') {
         this.fetchAccounts()
       } else {
         this.fetchProjects()

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -492,14 +492,14 @@ export default {
         domainid: this.$store.getters.userInfo.domainid,
         account: this.$store.getters.userInfo.account
       }
-      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+      if (OwnerOptions.selectedAccountType === 'Account') {
         if (!OwnerOptions.selectedAccount) {
           return
         }
         this.owner.account = OwnerOptions.selectedAccount
         this.owner.domainid = OwnerOptions.selectedDomain
         this.owner.projectid = null
-      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+      } else if (OwnerOptions.selectedAccountType === 'Project') {
         if (!OwnerOptions.selectedProject) {
           return
         }

--- a/ui/src/views/network/CreateL2NetworkForm.vue
+++ b/ui/src/views/network/CreateL2NetworkForm.vue
@@ -294,14 +294,14 @@ export default {
         domainid: this.$store.getters.userInfo.domainid,
         account: this.$store.getters.userInfo.account
       }
-      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+      if (OwnerOptions.selectedAccountType === 'Account') {
         if (!OwnerOptions.selectedAccount) {
           return
         }
         this.owner.account = OwnerOptions.selectedAccount
         this.owner.domainid = OwnerOptions.selectedDomain
         this.owner.projectid = null
-      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+      } else if (OwnerOptions.selectedAccountType === 'Project') {
         if (!OwnerOptions.selectedProject) {
           return
         }

--- a/ui/src/views/storage/CreateSharedFS.vue
+++ b/ui/src/views/storage/CreateSharedFS.vue
@@ -273,14 +273,14 @@ export default {
     fetchOwnerOptions (OwnerOptions) {
       this.owner = {}
       console.log('fetching owner')
-      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+      if (OwnerOptions.selectedAccountType === 'Account') {
         if (!OwnerOptions.selectedAccount) {
           return
         }
         console.log('fetched account')
         this.owner.account = OwnerOptions.selectedAccount
         this.owner.domainid = OwnerOptions.selectedDomain
-      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+      } else if (OwnerOptions.selectedAccountType === 'Project') {
         if (!OwnerOptions.selectedProject) {
           return
         }

--- a/ui/src/views/storage/CreateVolume.vue
+++ b/ui/src/views/storage/CreateVolume.vue
@@ -211,13 +211,13 @@ export default {
     },
     fetchOwnerOptions (OwnerOptions) {
       this.owner = {}
-      if (OwnerOptions.selectedAccountType === this.$t('label.account')) {
+      if (OwnerOptions.selectedAccountType === 'Account') {
         if (!OwnerOptions.selectedAccount) {
           return
         }
         this.owner.account = OwnerOptions.selectedAccount
         this.owner.domainid = OwnerOptions.selectedDomain
-      } else if (OwnerOptions.selectedAccountType === this.$t('label.project')) {
+      } else if (OwnerOptions.selectedAccountType === 'Project') {
         if (!OwnerOptions.selectedProject) {
           return
         }


### PR DESCRIPTION
### Description

This PR addresses an issue when trying to assign an instance to another account/project when using ACS in another language besides English. To accomplish this fix, the `OwnershipSelection` component was standardized to use logic independent of the language used by the user.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### How Has This Been Tested?

Before this patch, the message `The new account is the same as the old account.` was shown when trying to assign the VM to another account/project.

With this patch, assigning an instance works as intended in different languages, as expected.

I also test the creation of VMs, Isolated networks, L2 networks, shared FS and volumes; all resources were created accordingly to the owner specified.