### PR TITLE
UI: Add cluster arch type to the zone creation wizard

### DIFF
--- a/ui/src/views/infra/zone/ZoneWizardAddResources.vue
+++ b/ui/src/views/infra/zone/ZoneWizardAddResources.vue
@@ -862,7 +862,7 @@ export default {
       }],
       storageProviders: [],
       currentStep: null,
-      options: ['primaryStorageScope', 'primaryStorageProtocol', 'provider', 'primaryStorageProvider', 'archType']
+      options: ['primaryStorageScope', 'primaryStorageProtocol', 'provider', 'primaryStorageProvider']
     }
   },
   created () {

--- a/ui/src/views/infra/zone/ZoneWizardAddResources.vue
+++ b/ui/src/views/infra/zone/ZoneWizardAddResources.vue
@@ -197,7 +197,7 @@ export default {
           key: 'arch',
           required: false,
           select: true,
-          options: this.archTypes
+          options: this.architectureTypes
         },
         {
           title: 'label.vcenter.host',
@@ -853,7 +853,7 @@ export default {
       primaryStorageScopes: [],
       primaryStorageProtocols: [],
       primaryStorageProviders: [],
-      archTypes: [{
+      architectureTypes: [{
         id: 'x86_64',
         description: 'AMD 64 bits (x86_64)'
       }, {

--- a/ui/src/views/infra/zone/ZoneWizardAddResources.vue
+++ b/ui/src/views/infra/zone/ZoneWizardAddResources.vue
@@ -193,6 +193,14 @@ export default {
           required: true
         },
         {
+          title: 'label.arch',
+          key: 'arch',
+          placeHolder: 'message.error.cluster.name',
+          required: false,
+          select: true,
+          options: this.archTypes
+        },
+        {
           title: 'label.vcenter.host',
           key: 'vCenterHost',
           placeHolder: 'message.error.vcenter.host',
@@ -846,9 +854,16 @@ export default {
       primaryStorageScopes: [],
       primaryStorageProtocols: [],
       primaryStorageProviders: [],
+      archTypes: [{
+        id: 'x86_64',
+        description: 'AMD 64 bits (x86_64)'
+      }, {
+        id: 'aarch64',
+        description: 'ARM 64 bits (aarch64)'
+      }],
       storageProviders: [],
       currentStep: null,
-      options: ['primaryStorageScope', 'primaryStorageProtocol', 'provider', 'primaryStorageProvider']
+      options: ['primaryStorageScope', 'primaryStorageProtocol', 'provider', 'primaryStorageProvider', 'archType']
     }
   },
   created () {

--- a/ui/src/views/infra/zone/ZoneWizardAddResources.vue
+++ b/ui/src/views/infra/zone/ZoneWizardAddResources.vue
@@ -195,7 +195,6 @@ export default {
         {
           title: 'label.arch',
           key: 'arch',
-          placeHolder: 'message.error.cluster.name',
           required: false,
           select: true,
           options: this.archTypes

--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -1283,6 +1283,7 @@ export default {
       if (this.isEdgeZone) {
         clusterName = 'Cluster-' + this.stepData.zoneReturned.name
       }
+      params.arch = this.prefillContent?.arch || null
 
       if (hypervisor === 'VMware') {
         params.username = this.prefillContent?.vCenterUsername || null


### PR DESCRIPTION
### Description

This PR adds the arch type on the cluster creation step on the zone creation wizard.

<img width="1047" alt="Screenshot 2024-12-10 at 23 01 03" src="https://github.com/user-attachments/assets/ff2d8354-79a2-4026-9015-eb7e7acbaaaf">

Fixes: #10014 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Tested locally KVM on ARM nested virtualization on UTM 4.6.3 on macOs:
- On the cluster step: selected ARM 64
- On the host step: entered the ARM host information
- Result: Zone successfully created

#### How did you try to break this feature and the system with this change?

