### PR TITLE
linstor: improve heartbeat check with also asking linstor

### DIFF
--- a/plugins/storage/volume/linstor/CHANGELOG.md
+++ b/plugins/storage/volume/linstor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Linstor CloudStack plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2024-12-13]
+
+### Fixed
+
+- Linstor heartbeat check now also ask linstor-controller if there is no connection between nodes
+
 ## [2024-10-28]
 
 ### Fixed

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -45,6 +45,7 @@ import com.linbit.linstor.api.Configuration;
 import com.linbit.linstor.api.DevelopersApi;
 import com.linbit.linstor.api.model.ApiCallRc;
 import com.linbit.linstor.api.model.ApiCallRcList;
+import com.linbit.linstor.api.model.Node;
 import com.linbit.linstor.api.model.Properties;
 import com.linbit.linstor.api.model.ProviderKind;
 import com.linbit.linstor.api.model.Resource;
@@ -707,6 +708,21 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
                     .sum() * 1024; // linstor uses Kib
             s_logger.debug("Linstor: getUsed() -> " + used);
             return used;
+        } catch (ApiException apiEx) {
+            s_logger.error(apiEx.getMessage());
+            throw new CloudRuntimeException(apiEx.getBestMessage(), apiEx);
+        }
+    }
+
+    public boolean isNodeOnline(LinstorStoragePool pool, String nodeName) {
+        DevelopersApi linstorApi = getLinstorAPI(pool);
+        try {
+            List<Node> node = linstorApi.nodeList(Collections.singletonList(nodeName), Collections.emptyList(), null, null);
+            if (node == null || node.isEmpty()) {
+                return false;
+            }
+
+            return Node.ConnectionStatusEnum.ONLINE.equals(node.get(0).getConnectionStatus());
         } catch (ApiException apiEx) {
             s_logger.error(apiEx.getMessage());
             throw new CloudRuntimeException(apiEx.getBestMessage(), apiEx);

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStoragePool.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStoragePool.java
@@ -279,22 +279,52 @@ public class LinstorStoragePool implements KVMStoragePool {
         return sc.execute(parser);
     }
 
+    private boolean checkLinstorNodeOnline(String nodeName) {
+        return ((LinstorStorageAdaptor)_storageAdaptor).isNodeOnline(this, nodeName);
+    }
+
+    /**
+     * Checks output of drbdsetup status output if this node has any valid connection to the specified
+     * otherNodeName.
+     * If there is no connection, ask the Linstor controller if the node is seen online and return false if not.
+     * If there is a connection but not connected(valid) return false.
+     * @param output Output of the drbdsetup status --json command
+     * @param otherNodeName Name of the node to check against
+     * @return true if we could say that this node thinks the node in question is reachable, otherwise false.
+     */
     private boolean checkDrbdSetupStatusOutput(String output, String otherNodeName) {
         JsonParser jsonParser = new JsonParser();
         JsonArray jResources = (JsonArray) jsonParser.parse(output);
+        boolean connectionFound = false;
         for (JsonElement jElem : jResources) {
             JsonObject jRes = (JsonObject) jElem;
             JsonArray jConnections = jRes.getAsJsonArray("connections");
             for (JsonElement jConElem : jConnections) {
                 JsonObject jConn = (JsonObject) jConElem;
-                if (jConn.getAsJsonPrimitive("name").getAsString().equals(otherNodeName)
-                        && jConn.getAsJsonPrimitive("connection-state").getAsString().equalsIgnoreCase("Connected")) {
-                    return true;
+                if (jConn.getAsJsonPrimitive("name").getAsString().equals(otherNodeName))
+                {
+                    connectionFound = true;
+                    if (jConn.getAsJsonPrimitive("connection-state").getAsString()
+                            .equalsIgnoreCase("Connected")) {
+                        return true;
+                    }
                 }
             }
         }
-        s_logger.warn(String.format("checkDrbdSetupStatusOutput: no resource connected to %s.", otherNodeName));
-        return false;
+        boolean otherNodeOnline = false;
+        if (connectionFound) {
+            s_logger.warn(String.format(
+                    "checkingHeartBeat: connection found, but not in state 'Connected' to %s", otherNodeName));
+        } else {
+            s_logger.warn(String.format(
+                    "checkingHeartBeat: no resource connected to %s, checking LINSTOR", otherNodeName));
+            otherNodeOnline = checkLinstorNodeOnline(otherNodeName);
+        }
+        s_logger.info(String.format(
+                "checkingHeartBeat: other node %s is %s.",
+                otherNodeName,
+                otherNodeOnline ? "online on controller" : "down"));
+        return otherNodeOnline;
     }
 
     private String executeDrbdEventsNow(OutputInterpreter.AllLinesParser parser) {


### PR DESCRIPTION
### Description

This improves the heartbeat check done from Linstor primary storage.
If a node doesn't have a DRBD connection to another node, additionally ask Linstor-Controller if the node is alive. Otherwise we would have simply said no and the node might still be alive. This is always the case in a non hyperconverged setup.

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

Test VM-HA in a Linstor cluster

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
