### PR TITLE
Disabled the setting `reboot.host.and.alert.management.on.heartbeat.timeout` by default

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -306,7 +306,7 @@ iscsi.session.cleanup.enabled=false
 #vm.migrate.domain.retrieve.timeout=10
 
 # This parameter specifies if the host must be rebooted when something goes wrong with the heartbeat.
-#reboot.host.and.alert.management.on.heartbeat.timeout=true
+#reboot.host.and.alert.management.on.heartbeat.timeout=false
 
 # Enables manually setting CPU's topology on KVM's VM.
 #enable.manually.setting.cpu.topology.on.kvm.vm=true

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -556,10 +556,10 @@ public class AgentProperties{
     /**
      * This parameter specifies if the host must be rebooted when something goes wrong with the heartbeat.<br>
      * Data type: Boolean.<br>
-     * Default value: <code>true</code>
+     * Default value: <code>false</code>
      */
     public static final Property<Boolean> REBOOT_HOST_AND_ALERT_MANAGEMENT_ON_HEARTBEAT_TIMEOUT
-        = new Property<>("reboot.host.and.alert.management.on.heartbeat.timeout", true);
+        = new Property<>("reboot.host.and.alert.management.on.heartbeat.timeout", false);
 
     /**
      * Enables manually setting CPU's topology on KVM's VM. <br>


### PR DESCRIPTION
### Description

This PR disables the setting `reboot.host.and.alert.management.on.heartbeat.timeout`. When there is a storage issue, even if the high availability isn't enabled, CloudStack will reboot the host.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
