### PR TITLE
Support to enable/disable VM High Availability manager

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public interface HighAvailabilityManager extends Manager {
 
-    public ConfigKey<Boolean> ForceHA = new ConfigKey<>("Advanced", Boolean.class, "force.ha", "false",
+    ConfigKey<Boolean> ForceHA = new ConfigKey<>("Advanced", Boolean.class, "force.ha", "false",
         "Force High-Availability to happen even if the VM says no.", true, Cluster);
 
     ConfigKey<Integer> HAWorkers = new ConfigKey<>("Advanced", Integer.class, "ha.workers", "5",
@@ -112,7 +112,7 @@ public interface HighAvailabilityManager extends Manager {
 
     void cancelDestroy(VMInstanceVO vm, Long hostId);
 
-    void scheduleDestroy(VMInstanceVO vm, long hostId);
+    boolean scheduleDestroy(VMInstanceVO vm, long hostId);
 
     /**
      * Schedule restarts for all vms running on the host.
@@ -143,7 +143,7 @@ public interface HighAvailabilityManager extends Manager {
      * @param host host the virtual machine is on.
      * @param type which type of stop is requested.
      */
-    void scheduleStop(VMInstanceVO vm, long hostId, WorkType type);
+    boolean scheduleStop(VMInstanceVO vm, long hostId, WorkType type);
 
     void cancelScheduledMigrations(HostVO host);
 

--- a/server/src/test/java/com/cloud/ha/HighAvailabilityManagerImplTest.java
+++ b/server/src/test/java/com/cloud/ha/HighAvailabilityManagerImplTest.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.ha;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -32,6 +33,7 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProviderManager;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.managed.context.ManagedContext;
 import org.apache.logging.log4j.LogManager;
@@ -174,9 +176,14 @@ public class HighAvailabilityManagerImplTest {
     public void scheduleRestartForVmsOnHost() {
         Mockito.when(hostVO.getType()).thenReturn(Host.Type.Routing);
         Mockito.when(hostVO.getHypervisorType()).thenReturn(HypervisorType.KVM);
+        Mockito.when(hostVO.getDataCenterId()).thenReturn(1L);
         Mockito.lenient().when(_instanceDao.listByHostId(42l)).thenReturn(Arrays.asList(Mockito.mock(VMInstanceVO.class)));
         Mockito.when(_podDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostPodVO.class));
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(DataCenterVO.class));
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(true);
 
         highAvailabilityManager.scheduleRestartForVmsOnHost(hostVO, true);
     }
@@ -190,10 +197,24 @@ public class HighAvailabilityManagerImplTest {
     }
 
     @Test
+    public void scheduleRestartForVmsOnHostHADisabled() {
+        Mockito.when(hostVO.getType()).thenReturn(Host.Type.Routing);
+        Mockito.when(hostVO.getHypervisorType()).thenReturn(HypervisorType.KVM);
+        Mockito.when(hostVO.getDataCenterId()).thenReturn(1L);
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(false);
+
+        highAvailabilityManager.scheduleRestartForVmsOnHost(hostVO, true);
+    }
+
+    @Test
     public void scheduleRestartForVmsOnHostNonEmptyVMList() {
         Mockito.when(hostVO.getId()).thenReturn(1l);
         Mockito.when(hostVO.getType()).thenReturn(Host.Type.Routing);
         Mockito.when(hostVO.getHypervisorType()).thenReturn(HypervisorType.XenServer);
+        Mockito.when(hostVO.getDataCenterId()).thenReturn(1L);
         List<VMInstanceVO> vms = new ArrayList<VMInstanceVO>();
         VMInstanceVO vm1 = Mockito.mock(VMInstanceVO.class);
         Mockito.lenient().when(vm1.getHostId()).thenReturn(1l);
@@ -206,6 +227,7 @@ public class HighAvailabilityManagerImplTest {
         //Mockito.when(vm2.getInstanceName()).thenReturn("r-2-VM");
         Mockito.when(vm2.getType()).thenReturn(VirtualMachine.Type.DomainRouter);
         Mockito.when(vm2.isHaEnabled()).thenReturn(true);
+        Mockito.when(vm2.getDataCenterId()).thenReturn(1L);
         vms.add(vm2);
         Mockito.when(_instanceDao.listByHostId(Mockito.anyLong())).thenReturn(vms);
         Mockito.when(_instanceDao.findByUuid(vm1.getUuid())).thenReturn(vm1);
@@ -216,12 +238,125 @@ public class HighAvailabilityManagerImplTest {
         Mockito.when(_haDao.persist((HaWorkVO)Mockito.any())).thenReturn(Mockito.mock(HaWorkVO.class));
         Mockito.when(_serviceOfferingDao.findById(vm1.getServiceOfferingId())).thenReturn(Mockito.mock(ServiceOfferingVO.class));
 
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(true);
+
         highAvailabilityManager.scheduleRestartForVmsOnHost(hostVO, true);
+    }
+
+    @Test
+    public void scheduleRestartHADisabled() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(false);
+
+        highAvailabilityManager.scheduleRestart(vm, true);
+    }
+
+    @Test
+    public void scheduleRestartHostNotSupported() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+        Mockito.when(vm.getHostId()).thenReturn(1L);
+        Mockito.when(vm.getHypervisorType()).thenReturn(HypervisorType.VMware);
+
+        highAvailabilityManager.scheduleRestart(vm, true);
+    }
+
+    @Test
+    public void scheduleStop() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+        Mockito.when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(vm.getState()).thenReturn(VirtualMachine.State.Running);
+        Mockito.when(_haDao.hasBeenScheduled(vm.getId(), WorkType.Stop)).thenReturn(false);
+        Mockito.when(_haDao.persist((HaWorkVO)Mockito.any())).thenReturn(Mockito.mock(HaWorkVO.class));
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(true);
+
+        assertTrue(highAvailabilityManager.scheduleStop(vm, 1L, WorkType.Stop));
+    }
+
+    @Test
+    public void scheduleStopHADisabled() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+        Mockito.when(_haDao.hasBeenScheduled(vm.getId(), WorkType.Stop)).thenReturn(false);
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(false);
+
+        assertFalse(highAvailabilityManager.scheduleStop(vm, 1L, WorkType.Stop));
+    }
+
+    @Test
+    public void scheduleMigration() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+        Mockito.when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(vm.getState()).thenReturn(VirtualMachine.State.Running);
+        Mockito.when(vm.getHostId()).thenReturn(1L);
+        Mockito.when(_haDao.persist((HaWorkVO)Mockito.any())).thenReturn(Mockito.mock(HaWorkVO.class));
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(true);
+
+        assertTrue(highAvailabilityManager.scheduleMigration(vm));
+    }
+
+    @Test
+    public void scheduleMigrationHADisabled() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getHostId()).thenReturn(1L);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(false);
+
+        assertFalse(highAvailabilityManager.scheduleMigration(vm));
+    }
+
+    @Test
+    public void scheduleDestroy() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+        Mockito.when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(vm.getState()).thenReturn(VirtualMachine.State.Running);
+        Mockito.when(_haDao.persist((HaWorkVO)Mockito.any())).thenReturn(Mockito.mock(HaWorkVO.class));
+
+        assertTrue(highAvailabilityManager.scheduleDestroy(vm, 1L));
+    }
+
+    @Test
+    public void scheduleDestroyHADisabled() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getDataCenterId()).thenReturn(1L);
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(false);
+
+        assertFalse(highAvailabilityManager.scheduleDestroy(vm, 1L));
     }
 
     @Test
     public void investigateHostStatusSuccess() {
         Mockito.when(_hostDao.findById(Mockito.anyLong())).thenReturn(hostVO);
+        Mockito.when(hostVO.getDataCenterId()).thenReturn(1L);
         // Set the list of investigators, CheckOnAgentInvestigator suffices for now
         Investigator investigator = Mockito.mock(CheckOnAgentInvestigator.class);
         List<Investigator> investigators = new ArrayList<Investigator>();
@@ -230,12 +365,17 @@ public class HighAvailabilityManagerImplTest {
         // Mock isAgentAlive to return host status as Down
         Mockito.when(investigator.isAgentAlive(hostVO)).thenReturn(Status.Down);
 
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(true);
+
         assertTrue(highAvailabilityManager.investigate(1l) == Status.Down);
     }
 
     @Test
     public void investigateHostStatusFailure() {
         Mockito.when(_hostDao.findById(Mockito.anyLong())).thenReturn(hostVO);
+        Mockito.when(hostVO.getDataCenterId()).thenReturn(1L);
         // Set the list of investigators, CheckOnAgentInvestigator suffices for now
         // Also no need to mock isAgentAlive() as actual implementation returns null
         Investigator investigator = Mockito.mock(CheckOnAgentInvestigator.class);
@@ -243,7 +383,23 @@ public class HighAvailabilityManagerImplTest {
         investigators.add(investigator);
         highAvailabilityManager.setInvestigators(investigators);
 
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(true);
+
         assertNull(highAvailabilityManager.investigate(1l));
+    }
+
+    @Test
+    public void investigateHostStatusHADisabled() {
+        Mockito.when(_hostDao.findById(Mockito.anyLong())).thenReturn(hostVO);
+        Mockito.when(hostVO.getDataCenterId()).thenReturn(1L);
+
+        ConfigKey<Boolean> haEnabled = Mockito.mock(ConfigKey.class);
+        highAvailabilityManager.VmHaEnabled = haEnabled;
+        Mockito.when(highAvailabilityManager.VmHaEnabled.valueIn(1L)).thenReturn(false);
+
+        assertTrue(highAvailabilityManager.investigate(1L) == Status.Alert);
     }
 
     private void processWorkWithRetryCount(int count, Step expectedStep) {


### PR DESCRIPTION
### Description

This PR  adds support to enable/disable VM High Availability manager. 

- New config 'vm.ha.enabled'  with Zone scope is added, to enable/disable VM High Availability manager. This is enable by default (for backward compatibilty). When enabled, the VM HA WorkItems (for VM Stop, Restart, Migration, Destroy) can be created and the scheduled items are executed. When disabled, new VM HA WorkItems are not allowed and the scheduled items are retried until max retries configured at 'vm.ha.migration.max.retries' (executed in case HA is re-enabled during retry attempts), and then purged after 'time.between.failures' by the cleanup thread that runs regularly at 'time.between.cleanup'.
- New config 'vm.ha.alerts.enabled' with Zone scope is added, to enable/disable alerts for the VM HA operations. This is enabled by default.

Both these config settings can defined at zone/global level.

Doc PR: https://github.com/apache/cloudstack-documentation/pull/464


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):

**New Settings =>**

<img width="1248" alt="VmHaGlobalSettings" src="https://github.com/user-attachments/assets/2028851c-904f-44fe-8384-4b84a4679c85" />

**Sample Alert when 'vm.ha.enabled' is false =>**

<img width="1269" alt="VmHaAlert" src="https://github.com/user-attachments/assets/7ae49f19-faf6-4436-9579-7fc6d4fd978e" />

### How Has This Been Tested?

Manually tested the VM HA related operations on host maintenance and during host down/alert, enabling & disabling  new config  'vm.ha.enabled'.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

