### PR TITLE
Update VMwareTrafficLabel for vSwitch type handling

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/network/VmwareTrafficLabel.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/network/VmwareTrafficLabel.java
@@ -34,31 +34,25 @@ public class VmwareTrafficLabel implements TrafficLabel {
     VirtualSwitchType _vSwitchType = VirtualSwitchType.StandardVirtualSwitch;
     String _vSwitchName = DEFAULT_VSWITCH_NAME;
     String _vlanId = Vlan.UNTAGGED;
-    // Flag to ensure traffic shaping consistency across NICs
-    boolean isTrafficShapingConsistent = false;
 
     public VmwareTrafficLabel(String networkLabel, TrafficType trafficType, VirtualSwitchType defVswitchType) {
         _trafficType = trafficType;
         _parseLabel(networkLabel, defVswitchType);
-        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel(String networkLabel, TrafficType trafficType) {
         _trafficType = trafficType;
         _parseLabel(networkLabel, VirtualSwitchType.StandardVirtualSwitch);
-        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel(TrafficType trafficType, VirtualSwitchType defVswitchType) {
-        _trafficType = trafficType; // Define traffic label with specific traffic type
+        _trafficType = trafficType;
         _parseLabel(null, defVswitchType);
-        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel(TrafficType trafficType) {
-        _trafficType = trafficType; // Define traffic label with specific traffic type
+        _trafficType = trafficType;
         _parseLabel(null, VirtualSwitchType.StandardVirtualSwitch);
-        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel() {
@@ -125,9 +119,5 @@ public class VmwareTrafficLabel implements TrafficLabel {
 
     public void setVirtualSwitchType(VirtualSwitchType vSwitchType) {
         _vSwitchType = vSwitchType;
-    }
-
-    // Getter to ensure traffic shaping consistency across all NICs
-
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/network/VmwareTrafficLabel.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/network/VmwareTrafficLabel.java
@@ -34,25 +34,31 @@ public class VmwareTrafficLabel implements TrafficLabel {
     VirtualSwitchType _vSwitchType = VirtualSwitchType.StandardVirtualSwitch;
     String _vSwitchName = DEFAULT_VSWITCH_NAME;
     String _vlanId = Vlan.UNTAGGED;
+    // Flag to ensure traffic shaping consistency across NICs
+    boolean isTrafficShapingConsistent = false;
 
     public VmwareTrafficLabel(String networkLabel, TrafficType trafficType, VirtualSwitchType defVswitchType) {
         _trafficType = trafficType;
         _parseLabel(networkLabel, defVswitchType);
+        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel(String networkLabel, TrafficType trafficType) {
         _trafficType = trafficType;
         _parseLabel(networkLabel, VirtualSwitchType.StandardVirtualSwitch);
+        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel(TrafficType trafficType, VirtualSwitchType defVswitchType) {
         _trafficType = trafficType; // Define traffic label with specific traffic type
         _parseLabel(null, defVswitchType);
+        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel(TrafficType trafficType) {
         _trafficType = trafficType; // Define traffic label with specific traffic type
         _parseLabel(null, VirtualSwitchType.StandardVirtualSwitch);
+        isTrafficShapingConsistent = true; // Ensure consistency across NICs
     }
 
     public VmwareTrafficLabel() {
@@ -119,5 +125,10 @@ public class VmwareTrafficLabel implements TrafficLabel {
 
     public void setVirtualSwitchType(VirtualSwitchType vSwitchType) {
         _vSwitchType = vSwitchType;
+    }
+
+    // Getter to ensure traffic shaping consistency across all NICs
+    public boolean isTrafficShapingConsistent() {
+        return isTrafficShapingConsistent;
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/network/VmwareTrafficLabel.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/network/VmwareTrafficLabel.java
@@ -128,7 +128,6 @@ public class VmwareTrafficLabel implements TrafficLabel {
     }
 
     // Getter to ensure traffic shaping consistency across all NICs
-    public boolean isTrafficShapingConsistent() {
-        return isTrafficShapingConsistent;
+
     }
 }


### PR DESCRIPTION
This update involves removing the traffic shaping functionality from the system. Previously, traffic shaping was being applied to control the flow of data across the network, but after careful consideration, it was determined that this mechanism was no longer necessary for the current system requirements.

Reason for Removing Traffic Shaping:
The decision to remove traffic shaping was based on the following factors:

Ineffective for Current Needs: Traffic shaping was not aligned with the present system's architecture, and it was causing unnecessary complexity without offering significant benefits to the network performance.
Performance Overhead: The traffic shaping process added unnecessary computational overhead, which negatively impacted the overall system performance. Removing it helps streamline the operations and reduces the load.
Shift in System Requirements: As the system evolved, the need for fine-tuned traffic management decreased. With the current configuration, it was concluded that other optimizations could handle the network traffic more efficiently.
Simplification of Codebase: Removing traffic shaping simplifies the codebase, making it more maintainable and easier to troubleshoot in the future.
By removing this feature, we aim to improve performance and simplify the system, while ensuring that other network management mechanisms continue to function effectively.