### PR TITLE
Show icon to changeOfferingForVolume for the other users

### DIFF
--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -223,7 +223,7 @@ export default {
           label: 'label.change.offering.for.volume',
           args: ['id', 'diskofferingid', 'size', 'miniops', 'maxiops', 'automigrate'],
           dataView: true,
-          show: (record, store) => { return ['Allocated', 'Ready'].includes(record.state) && ['Admin'].includes(store.userInfo.roletype) },
+          show: (record, store) => { return ['Allocated', 'Ready'].includes(record.state) && (['Admin'].includes(store.userInfo.roletype) || !!store.apis.changeOfferingForVolume) },
           popup: true,
           component: shallowRef(defineAsyncComponent(() => import('@/views/storage/ChangeOfferingForVolume.vue')))
         },


### PR DESCRIPTION
### Description

This PR corrects an incorrect behavior in the UI where users who have access to the `changeOfferingForVolume` API, but are not _admins_, cannot use it.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):
<summary>  Before </summary>

![2024-12-22_23-01](https://github.com/user-attachments/assets/dd9904a4-9e2a-43f7-81c6-64da4275bd04)


<summary>  After </summary>

![2024-12-22_23-02](https://github.com/user-attachments/assets/42019514-4d98-4dfe-89cd-22dc382c42e7)


### How Has This Been Tested?
1. A role was created (based on the default user role) with permission to access the `changeOfferingForVolume` API.

2. An account and a user were created using this role.

3. The `changeOfferingForVolume` API icon appeared correctly in the UI (`npm run server`).

4. The change in the volume offer was made correctly