### PR TITLE
SSL_Handshake: close nio channel when NioClient fail to handshake wit…

### DIFF
--- a/utils/src/main/java/com/cloud/utils/nio/NioClient.java
+++ b/utils/src/main/java/com/cloud/utils/nio/NioClient.java
@@ -79,6 +79,7 @@ public class NioClient extends NioConnection {
             _selector.close();
             throw new IOException("Failed to initialise security", e);
         } catch (final IOException e) {
+            _clientConnection.close();
             _selector.close();
             throw e;
         }


### PR DESCRIPTION
### Description

This PR solved an issue when cs-agent throws an exception during ssl handshake; the TCP connection is not closed between cs-server and cs-agent, which further causes the server thread to hang forever. 

When the ssl handshake is at the **client key exchange** phrase, the server will be waiting for the agent to provide cipher suit, but at the agent side the exception could happen when the agent can’t conform to the cipher suite that the server provides, so the agent couldn’t communicate client key to the server. Thus at the server side the handshake thread is **forever pending** on a function that expects to read packets from SocketChannel.


Steps to reproduce this issue
1.server uses a 1024 bit rsa public key which you can verify by typing “keytool -list -storepass $keystore_password -keystore $keystore_file -v”. 
2.find “Subject Public Key Algorithm” in the step 1 output.
2.at the agent, edit “JAVA_HOME/jre/lib/security/java.security” and append “RSA keySize < 2048” to **jdk.tls.disabledAlgorithms**.
3.restart cloudstack-agent.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
Before I applied this change, in that situation and at the agent side, the state of the tcp connection was CLOSE_WAIT and remained there forever.  When I applied this change, the agent actively closed the channel which in turn actively closed the tcp connection and the state of the tcp connection will move to TIME_WAIT which is a normal state indicating the connection is closing.
