### PR TITLE
Clean up network permissions on account deletion

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/network/dao/NetworkPermissionDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/network/dao/NetworkPermissionDao.java
@@ -41,6 +41,13 @@ public interface NetworkPermissionDao extends GenericDao<NetworkPermissionVO, Lo
     void removeAllPermissions(long networkId);
 
     /**
+     * Removes all network permissions associated with a given account.
+     *
+     * @param accountId The ID of the account from which all network permissions will be removed.
+     */
+    void removeAccountPermissions(long accountId);
+
+    /**
      * Find a Network permission by networkId, accountName, and domainId
      *
      * @param networkId

--- a/engine/schema/src/main/java/org/apache/cloudstack/network/dao/NetworkPermissionDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/network/dao/NetworkPermissionDaoImpl.java
@@ -35,6 +35,7 @@ public class NetworkPermissionDaoImpl extends GenericDaoBase<NetworkPermissionVO
 
     private SearchBuilder<NetworkPermissionVO> NetworkAndAccountSearch;
     private SearchBuilder<NetworkPermissionVO> NetworkIdSearch;
+    private SearchBuilder<NetworkPermissionVO> accountSearch;
     private GenericSearchBuilder<NetworkPermissionVO, Long> FindNetworkIdsByAccount;
 
     protected NetworkPermissionDaoImpl() {
@@ -46,6 +47,10 @@ public class NetworkPermissionDaoImpl extends GenericDaoBase<NetworkPermissionVO
         NetworkIdSearch = createSearchBuilder();
         NetworkIdSearch.and("networkId", NetworkIdSearch.entity().getNetworkId(), SearchCriteria.Op.EQ);
         NetworkIdSearch.done();
+
+        accountSearch = createSearchBuilder();
+        accountSearch.and("accountId", accountSearch.entity().getAccountId(), SearchCriteria.Op.EQ);
+        accountSearch.done();
 
         FindNetworkIdsByAccount = createSearchBuilder(Long.class);
         FindNetworkIdsByAccount.select(null, SearchCriteria.Func.DISTINCT, FindNetworkIdsByAccount.entity().getNetworkId());
@@ -69,6 +74,16 @@ public class NetworkPermissionDaoImpl extends GenericDaoBase<NetworkPermissionVO
         SearchCriteria<NetworkPermissionVO> sc = NetworkIdSearch.create();
         sc.setParameters("networkId", networkId);
         expunge(sc);
+    }
+
+    @Override
+    public void removeAccountPermissions(long accountId) {
+        SearchCriteria<NetworkPermissionVO> sc = accountSearch.create();
+        sc.setParameters("accountId", accountId);
+        int networkPermissionRemoved = expunge(sc);
+        if (networkPermissionRemoved > 0) {
+            s_logger.debug(String.format("Removed [%s] network permission(s) for the account with Id [%s]", networkPermissionRemoved, accountId));
+        }
     }
 
     @Override

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -74,6 +74,7 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.framework.messagebus.PublishScope;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.cloudstack.network.dao.NetworkPermissionDao;
 import org.apache.cloudstack.region.gslb.GlobalLoadBalancerRuleDao;
 import org.apache.cloudstack.resourcedetail.UserDetailVO;
 import org.apache.cloudstack.resourcedetail.dao.UserDetailsDao;
@@ -298,6 +299,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     private SSHKeyPairDao _sshKeyPairDao;
     @Inject
     private UserDataDao userDataDao;
+    @Inject
+    private NetworkPermissionDao networkPermissionDao;
 
     private List<QuerySelector> _querySelectors;
 
@@ -1857,24 +1860,36 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         // If the user is a System user, return an error. We do not allow this
         AccountVO account = _accountDao.findById(accountId);
 
-        if (! isDeleteNeeded(account, accountId, caller)) {
+        if (!isDeleteNeeded(account, accountId, caller)) {
             return true;
         }
 
-        // Account that manages project(s) can't be removed
-        List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
-        if (!managedProjectIds.isEmpty()) {
-            StringBuilder projectIds = new StringBuilder();
-            for (Long projectId : managedProjectIds) {
-                projectIds.append(projectId).append(", ");
-            }
-
-            throw new InvalidParameterValueException("The account id=" + accountId + " manages project(s) with ids " + projectIds + "and can't be removed");
-        }
+        checkIfAccountManagesProjects(accountId);
+        checkIfAccountHasNetworkPermissions(accountId);
 
         CallContext.current().putContextParameter(Account.class, account.getUuid());
 
         return deleteAccount(account, callerUserId, caller);
+    }
+
+    protected void checkIfAccountManagesProjects(long accountId) {
+        List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
+        if (!CollectionUtils.isEmpty(managedProjectIds)) {
+            throw new InvalidParameterValueException(String.format(
+                    "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects first.",
+                    accountId, managedProjectIds
+            ));
+        }
+    }
+
+    protected void checkIfAccountHasNetworkPermissions(long accountId) {
+        List<Long> networkIds = networkPermissionDao.listPermittedNetworkIdsByAccounts(List.of(accountId));
+        if (!CollectionUtils.isEmpty(networkIds)) {
+            throw new InvalidParameterValueException(String.format(
+                    "Unable to delete account [%s], because it has network permissions for the following network(s): %s. Please, remove the network permissions first.",
+                    accountId, networkIds
+            ));
+        }
     }
 
     private boolean isDeleteNeeded(AccountVO account, long accountId, Account caller) {

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -873,6 +873,9 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             // delete the account from project accounts
             _projectAccountDao.removeAccountFromProjects(accountId);
 
+            // Delete account's network permissions
+            networkPermissionDao.removeAccountPermissions(accountId);
+
             if (account.getType() != Account.Type.PROJECT) {
                 // delete the account from group
                 _messageBus.publish(_name, MESSAGE_REMOVE_ACCOUNT_EVENT, PublishScope.LOCAL, accountId);
@@ -1865,7 +1868,6 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         }
 
         checkIfAccountManagesProjects(accountId);
-        checkIfAccountHasNetworkPermissions(accountId);
 
         CallContext.current().putContextParameter(Account.class, account.getUuid());
 
@@ -1876,18 +1878,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
         if (!CollectionUtils.isEmpty(managedProjectIds)) {
             throw new InvalidParameterValueException(String.format(
-                    "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects first.",
+                    "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
                     accountId, managedProjectIds
-            ));
-        }
-    }
-
-    protected void checkIfAccountHasNetworkPermissions(long accountId) {
-        List<Long> networkIds = networkPermissionDao.listPermittedNetworkIdsByAccounts(List.of(accountId));
-        if (!CollectionUtils.isEmpty(networkIds)) {
-            throw new InvalidParameterValueException(String.format(
-                    "Unable to delete account [%s], because it has network permissions for the following network(s): %s. Please, remove the network permissions first.",
-                    accountId, networkIds
             ));
         }
     }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -1200,4 +1200,40 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
         Mockito.when(roleService.findRole(2L)).thenReturn(callerRole);
         accountManagerImpl.validateRoleChange(account, newRole, caller);
     }
+
+     @Test
+     public void checkIfAccountManagesProjectsTestNotThrowExceptionWhenTheAccountIsNotAProjectAdministrator() {
+        long accountId = 1L;
+        List<Long> managedProjectIds = new ArrayList<>();
+
+        Mockito.when(_projectAccountDao.listAdministratedProjectIds(accountId)).thenReturn(managedProjectIds);
+        accountManagerImpl.checkIfAccountManagesProjects(accountId);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void checkIfAccountHasNetworkPermissionsTestThrowExceptionWhenTheAccountHasNetworkPermissions() {
+        long accountId = 1L;
+        List<Long> networkIds = List.of(1L);
+
+        Mockito.when(networkPermissionDaoMock.listPermittedNetworkIdsByAccounts(List.of(accountId))).thenReturn(networkIds);
+        accountManagerImpl.checkIfAccountHasNetworkPermissions(accountId);
+    }
+
+    @Test
+    public void checkIfAccountHasNetworkPermissionsTestNotThrowExceptionWhenTheAccountDoesNotHaveNetworkPermissions() {
+        long accountId = 1L;
+        List<Long> networkIds = new ArrayList<>();
+
+        Mockito.when(networkPermissionDaoMock.listPermittedNetworkIdsByAccounts(List.of(accountId))).thenReturn(networkIds);
+        accountManagerImpl.checkIfAccountHasNetworkPermissions(accountId);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void checkIfAccountManagesProjectsTestThrowExceptionWhenTheAccountIsAProjectAdministrator() {
+        long accountId = 1L;
+        List<Long> managedProjectIds = List.of(1L);
+
+        Mockito.when(_projectAccountDao.listAdministratedProjectIds(accountId)).thenReturn(managedProjectIds);
+        accountManagerImpl.checkIfAccountManagesProjects(accountId);
+    }
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -1211,24 +1211,6 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
     }
 
     @Test(expected = InvalidParameterValueException.class)
-    public void checkIfAccountHasNetworkPermissionsTestThrowExceptionWhenTheAccountHasNetworkPermissions() {
-        long accountId = 1L;
-        List<Long> networkIds = List.of(1L);
-
-        Mockito.when(networkPermissionDaoMock.listPermittedNetworkIdsByAccounts(List.of(accountId))).thenReturn(networkIds);
-        accountManagerImpl.checkIfAccountHasNetworkPermissions(accountId);
-    }
-
-    @Test
-    public void checkIfAccountHasNetworkPermissionsTestNotThrowExceptionWhenTheAccountDoesNotHaveNetworkPermissions() {
-        long accountId = 1L;
-        List<Long> networkIds = new ArrayList<>();
-
-        Mockito.when(networkPermissionDaoMock.listPermittedNetworkIdsByAccounts(List.of(accountId))).thenReturn(networkIds);
-        accountManagerImpl.checkIfAccountHasNetworkPermissions(accountId);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
     public void checkIfAccountManagesProjectsTestThrowExceptionWhenTheAccountIsAProjectAdministrator() {
         long accountId = 1L;
         List<Long> managedProjectIds = List.of(1L);

--- a/server/src/test/java/com/cloud/user/AccountManagetImplTestBase.java
+++ b/server/src/test/java/com/cloud/user/AccountManagetImplTestBase.java
@@ -65,6 +65,7 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.engine.service.api.OrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.network.dao.NetworkPermissionDao;
 import org.apache.cloudstack.region.gslb.GlobalLoadBalancerRuleDao;
 import org.apache.cloudstack.resourcedetail.dao.UserDetailsDao;
 import org.junit.After;
@@ -195,6 +196,8 @@ public class AccountManagetImplTestBase {
     SSHKeyPairDao _sshKeyPairDao;
     @Mock
     UserDataDao userDataDao;
+    @Mock
+    NetworkPermissionDao networkPermissionDaoMock;
 
     @Spy
     @InjectMocks


### PR DESCRIPTION
### Description

Currently, if an account with network permissions for guest networks is deleted, CloudStack does not automatically delete these permissions, and operators cannot delete them later through the APIs. The workaround for this scenario is to manually remove the permissions entries from the `cloud.network_permissions` table. Therefore, this PR proposes to clean up the network permissions of an account when it is deleted. 

Additionally, when attempting to delete an account that is a project administrator, an error message is returned. This error message has been enhanced to include instructions on the next steps the operator should perform to properly delete the given account.

---

Fixes #10103

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

First, I created a domain `ROOT/d1`, a domain admin (`d1`) and two regular users within it (`u1` and `u2`). With the `d1` account, I created a project and added the `u1` account as a project administrator. 

When attempting to delete the `u1` account, an error message was returned, indicating that the account was a project administrator.  

![image](https://github.com/user-attachments/assets/125c5a37-c549-4c8d-b29d-aff37a371d8c)

After demoting the account to a regular project role, I created two guest networks and granted permission to both `u1` and `u2` accounts.

```bash
MariaDB [cloud]> select * from network_permissions;
+----+------------+------------+
| id | network_id | account_id |
+----+------------+------------+
|  8 |        209 |         14 |
|  9 |        209 |         16 |
| 10 |        210 |         16 |
| 11 |        210 |         14 |
+----+------------+------------+
4 rows in set (0.001 sec)
```

Then, I deleted the `u1` account, which has a serial ID equal to `16`, and verified that the network permissions were correctly expunged:

```bash
MariaDB [cloud]> select * from network_permissions;
+----+------------+------------+
| id | network_id | account_id |
+----+------------+------------+
|  8 |        209 |         14 |
| 11 |        210 |         14 |
+----+------------+------------+
2 rows in set (0.001 sec)
```

I reproduced these same steps with the `u2` account and verified that the network permissions were also correctly deleted.
