### PR TITLE
UI: Fix slider component in global settings with `Range` type

### DIFF
--- a/ui/src/views/setting/ConfigurationValue.vue
+++ b/ui/src/views/setting/ConfigurationValue.vue
@@ -55,9 +55,9 @@
           />
         </a-tooltip>
       </span>
-      <span v-else-if="configrecord.type ==='Range'">
-        <a-row>
-          <a-col>
+      <span v-else-if="configrecord.type ==='Range'" style="width: 75%;">
+        <a-row type="flex">
+          <a-col flex="auto">
             <a-tooltip :title="editableValue">
               <a-slider
                 style="width: 13vw"
@@ -73,10 +73,10 @@
               />
             </a-tooltip>
           </a-col>
-          <a-col>
+          <a-col flex="30px">
             <a-tooltip :title="editableValue">
               <a-input-number
-                style="width: 5vw; margin-left: 10px; float: right"
+                style="margin-left: 10px;"
                 class="config-slider-text"
                 :defaultValue="configrecord.value * 100"
                 :min="0"


### PR DESCRIPTION
### Description

The slider component for global settings of `Range` type is currently not working correctly. Its width is equal to `0px`, and operators can only set the settings values to 0 or 100%. This PR addresses this issue by fixing the slider's behavior, allowing operators to properly adjust the settings values using the component.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

- Before:
![Image](https://github.com/user-attachments/assets/f946b0ec-bccd-4a14-9cfa-0c40b2c9a446)

- After:
![Image](https://github.com/user-attachments/assets/864de223-facf-473f-b830-1220c7e880b5)

### How Has This Been Tested?

I verified that global settings of `Range` type can be modified using the slider component.