### PR TITLE
Add direct download option to users in register template form

### DIFF
--- a/ui/src/views/image/RegisterOrUploadTemplate.vue
+++ b/ui/src/views/image/RegisterOrUploadTemplate.vue
@@ -214,7 +214,7 @@
             </a-form-item>
           </a-col>
         </a-row>
-        <a-row :gutter="12" v-if="allowed && (hyperKVMShow || hyperCustomShow) && currentForm === 'Create'">
+        <a-row :gutter="12" v-if="(hyperKVMShow || hyperCustomShow) && currentForm === 'Create'">
           <a-col :md="24" :lg="12">
             <a-form-item ref="directdownload" name="directdownload">
               <template #label>


### PR DESCRIPTION
### Description

Normal users are allowed to register a direct download template via API, but the option is disabled in the UI.

This PR fix the issue #9923 by removing this restriction.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

The template registered by a normal user using the direct download option:

![Screenshot from 2025-01-15 17-44-59](https://github.com/user-attachments/assets/410d9eb2-cf54-4d40-8425-a51cad610883)


### How Has This Been Tested?

I tested by registering a template via UI using an account with the User role. Selecting the KVM hypervisor gave me the direct download option.