### PR TITLE
Add account.created preset variable to Quota tariffs

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/Account.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/Account.java
@@ -17,10 +17,18 @@
 
 package org.apache.cloudstack.quota.activationrule.presetvariables;
 
+import com.cloud.utils.DateUtil;
+
+import java.util.Date;
+import java.util.TimeZone;
+
 public class Account extends GenericPresetVariable {
     @PresetVariableDefinition(description = "Role of the account. This field will not exist if the account is a project.")
 
     private Role role;
+
+    @PresetVariableDefinition(description = "The date the account was created in GMT. This field will not exist for the first root admin account.")
+    private String created;
 
     public Role getRole() {
         return role;
@@ -31,4 +39,12 @@ public class Account extends GenericPresetVariable {
         fieldNamesToIncludeInToString.add("role");
     }
 
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = DateUtil.displayDateInTimezone(TimeZone.getTimeZone("GMT"), created);
+        fieldNamesToIncludeInToString.add("created");
+    }
 }

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelper.java
@@ -224,6 +224,7 @@ public class PresetVariableHelper {
         Account account = new Account();
         account.setId(accountVo.getUuid());
         account.setName(accountVo.getName());
+        account.setCreated(accountVo.getCreated());
 
         setPresetVariableRoleInAccountIfAccountIsNotAProject(accountVo.getType(), accountVo.getRoleId(), account);
 

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelperTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/activationrule/presetvariables/PresetVariableHelperTest.java
@@ -375,11 +375,12 @@ public class PresetVariableHelperTest {
         Account account = getAccountForTests();
         Mockito.doReturn(account.getId()).when(accountVoMock).getUuid();
         Mockito.doReturn(account.getName()).when(accountVoMock).getName();
+        Mockito.doReturn(account.getCreated()).when(accountVoMock).getCreated();
 
         Account result = presetVariableHelperSpy.getPresetVariableAccount(1l);
 
         assertPresetVariableIdAndName(account, result);
-        validateFieldNamesToIncludeInToString(Arrays.asList("id", "name"), result);
+        validateFieldNamesToIncludeInToString(Arrays.asList("created", "id", "name"), result);
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR adds the `account.created` preset variable to Quota tariffs, allowing users to consider an account's creation date when defining values to, for instance, grant a discount on the first month.

This variable is injected as a String. Therefore, users need to parse it first: `Date.parse(account.created)`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

In a local lab, the billing of two accounts was compared in relation to the amount of VM snapshots each one has.

- User Account: created on 17 Oct 2024 17:36:46, with 3 VM snapshots
- Root Account: created on 24 Oct 2024 13:51:35, with 1 VM snapshot

The base script for the activation rule used was:

```js
today = new Date(); // current date was 24 Oct 2024
daysDiff = (today-Date.parse(account.created))/(1000*60*60*24);

if (daysDiff <= 5 && daysDiff >= 0) {
  20
} else {
  0
}
```

When `daysDiff` is less than or equal to 15 both accounts were charged. When `daysDiff` is less than or equal to 5 only the Root Account was charged.

It was noted that the first Root Account created by ACS doesn't have a creation date so the script was changed to: 

```js
today = new Date();
daysDiff = (today-Date.parse(account.created))/(1000*60*60*24);

if (daysDiff <= 30 && daysDiff >= 0) {
  0
} else {
  20
}
```

In this condition, it was observed that the first Root Account was charged while the others weren't.