### PR TITLE
Fix volume allocation on local VMFS storage

### DIFF
--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -126,17 +126,23 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
     protected List<StoragePool> reorderPoolsByCapacity(DeploymentPlan plan, List<StoragePool> pools) {
         Long zoneId = plan.getDataCenterId();
         Long clusterId = plan.getClusterId();
-        short capacityType;
 
         if (CollectionUtils.isEmpty(pools)) {
             return null;
         }
 
-        if (pools.get(0).getPoolType().isShared()) {
+        short capacityType = Capacity.CAPACITY_TYPE_LOCAL_STORAGE;
+        String storageType = "local";
+        StoragePool storagePool = pools.get(0);
+        if (storagePool.isShared()) {
             capacityType = Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED;
-        } else {
-            capacityType = Capacity.CAPACITY_TYPE_LOCAL_STORAGE;
+            storageType = "shared";
         }
+
+        s_logger.debug(String.format(
+                "Filtering storage pools by capacity type [%s] as the first storage pool of the list, with name [%s] and ID [%s], is a [%s] storage.",
+                capacityType, storagePool.getName(), storagePool.getUuid(), storageType
+        ));
 
         List<Long> poolIdsByCapacity = capacityDao.orderHostsByFreeCapacity(zoneId, clusterId, capacityType);
 
@@ -223,6 +229,8 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
     }
 
     List<StoragePool> reorderStoragePoolsBasedOnAlgorithm(List<StoragePool> pools, DeploymentPlan plan, Account account) {
+        s_logger.debug(String.format("Using allocation algorithm [%s] to reorder pools.", allocationAlgorithm));
+
         if (allocationAlgorithm.equals("random") || allocationAlgorithm.equals("userconcentratedpod_random") || (account == null)) {
             reorderRandomPools(pools);
         } else if (StringUtils.equalsAny(allocationAlgorithm, "userdispersing", "firstfitleastconsumed")) {


### PR DESCRIPTION
### Description

On the allocation process of VM volumes, the reordering of storage pools by capacity is wrongly identifying whether a pool is shared or not. A pool is considered to be shared when its type (represented by the `Storage.StoragePoolType` enum) is shared; however, as can be observed from the enum options, the `VMFS` storage type is considered to be shared.

https://github.com/apache/cloudstack/blob/35fe19f096dd38987bd1f892c78e9cce42c05c49/api/src/main/java/com/cloud/storage/Storage.java#L138-L159

As a consequence of that, when trying to deploy VMs in `VMFS` local storages, the allocation of the volumes will fail. Based on the current reordering flow, CloudStack will check that the `VMFS` pool type is shared and set the capacity type to be equal to `Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED`. Then, when the DAO method is executed, the `VMFS` pools will not be present in the returned list of pools, as they require the capacity type `Capacity.CAPACITY_TYPE_LOCAL_STORAGE` to be retrieved.

https://github.com/apache/cloudstack/blob/35fe19f096dd38987bd1f892c78e9cce42c05c49/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java#L135-L141

Therefore, this PR proposes to fix this issue by changing the validation of whether a given storage pool is shared. For this check, the `com.cloud.storage.StoragePool#isShared` method is now invoked, which considers a storage pool to be local if it has a scope equal to `HOST`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

To validate the allocation process of VM volumes before the PR changes, I first changed the `vm.allocation.algorithm` value to `firstfitleastconsumed`. Then, when deploying a VM with a local storage compute offering, I checked through the logs that no `VMFS` pool was being retrieved. When reproducing the same steps after applying the PR changes, I verified that the `VMFS` pools were correctly retrieved.