### PR TITLE
Fix listing of VMs with removed NICs

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1377,6 +1377,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         if (networkId != null || vpcId != null) {
             SearchBuilder<NicVO> nicSearch = nicDao.createSearchBuilder();
             nicSearch.and("networkId", nicSearch.entity().getNetworkId(), Op.EQ);
+            nicSearch.and("removed", nicSearch.entity().getRemoved(), Op.NULL);
             if (vpcId != null) {
                 SearchBuilder<NetworkVO> networkSearch = networkDao.createSearchBuilder();
                 networkSearch.and("vpcId", networkSearch.entity().getVpcId(), Op.EQ);


### PR DESCRIPTION
### Description

Currently, when listing VMs by network (`networkid`) or VPC (`vpcid`), CloudStack does not check whether the VMs still belong to the specified network or VPC. Therefore, this PR fixes this issue by only filtering the VMs that have non-removed NICs in the specified network or VPC. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

First, I created an isolated network (`nw-01`) and a VPC (`vpc-01`) with two tiers (`tier-01` and `tier-02`). Next, I deployed a VM (`vm-01`) with one NIC in each one of these networks.

![image](https://github.com/user-attachments/assets/857ee962-ebef-408b-9995-9a2eec67ef64)

After that, I checked that the `listVirtualMachines` API had the same behavior as prior to the PR changes:

<details>
<summary>List VMs that belong to the <code>nw-01</code> network</summary>

```bash
(localcloud) 🌍 > listVirtualMachines networkid="f839708e-a21b-4116-a978-c2b6155fa5db" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

<details>
<summary>List VMs that belong to the <code>tier-01</code> network</summary>

```bash
(localcloud) 🐛 > listVirtualMachines networkid="58932108-cb7b-4be8-8663-bde09fc98920" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

<details>
<summary>List VMs that belong to the <code>tier-02</code> network</summary>

```bash
(localcloud) 🐀 > listVirtualMachines networkid="c17a596c-8ac9-483f-84cd-a55dcca0929d" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC</summary>

```bash
(localcloud) 🐃 > listVirtualMachines vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC and <code>tier-01</code> tier</summary>

```bash
(localcloud) 🦈 > listVirtualMachines vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" networkid="58932108-cb7b-4be8-8663-bde09fc98920" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC and <code>tier-02</code> tier</summary>

```bash
(localcloud) 🐦 > listVirtualMachines vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" networkid="c17a596c-8ac9-483f-84cd-a55dcca0929d" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

Next, I removed the NIC associated to the `nw-01` network from the VM. When listing the VMs by that network, I verified that no VMs were returned:

<details>
<summary>List VMs that belong to the <code>nw-01</code> network</summary>

```bash
(localcloud) 🐃 > listVirtualMachines networkid="f839708e-a21b-4116-a978-c2b6155fa5db" filter=displayname
(localcloud) 🐰 >
```
</details>

Then, I removed the NIC associated to the `tier-02` tier. When listing the VMs by that network, I verified that no VMs were returned:

<details>
<summary>List VMs that belong to the <code>tier-02</code> network</summary>

```bash
(localcloud) 🐰 > listVirtualMachines networkid="c17a596c-8ac9-483f-84cd-a55dcca0929d" filter=displayname
(localcloud) 🦂 >
```
</details>

I also verified that when listing the VMs by the `tier-02` tier and the `vpc-01` VPC, no VMs were returned:

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC and <code>tier-02</code> tier</summary>

```bash
(localcloud) 🦂 > listVirtualMachines vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" networkid="c17a596c-8ac9-483f-84cd-a55dcca0929d" filter=displayname
(localcloud) 🐋 >
```
</details>

Furthermore, when only listing by VPC, the VM was returned since it still had a NIC associated to the `tier-01` network:

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC</summary>

```bash
(localcloud) 🐋 > listVirtualMachines vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" filter=displayname
{
  "count": 1,
  "virtualmachine": [
    {
      "displayname": "vm-01"
    }
  ]
}
```
</details>

Next, in order to be able to remove the `tier-01` NIC, I added a NIC corresponding to a Layer 2 network, and set it to be the default VM's NIC. After removing the `tier-01` NIC, I verified that no VMs were returned when listing by the `tier-01` network:

<details>
<summary>List VMs that belong to the <code>tier-01</code> network</summary>

```bash
(localcloud) 🍄 > listVirtualMachines networkid="58932108-cb7b-4be8-8663-bde09fc98920" filter=displayname
(localcloud) 🌴 >
```
</details>

No VMs were returned when listing by the `vpc-01` VPC and `tier-01` network:

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC and <code>tier-01</code> tier</summary>

```bash
(localcloud) 🌴 > listVirtualMachines networkid="58932108-cb7b-4be8-8663-bde09fc98920" vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" filter=displayname
(localcloud) 🐐 >
```
</details>

No VMs were returned when listing by the `vpc-01` VPC:

<details>
<summary>List VMs that belong to the <code>vpc-01</code> VPC</summary>

```bash
(localcloud) 🐐 > listVirtualMachines  vpcid="16938b3c-955a-475f-b72d-f60ad3814c7b" filter=displayname
(localcloud) 🌍 >
```
</details>

---

Fixes #10188 

