### PR TITLE
[UI] Switch between allocated and used capacity on dashboard

### DIFF
--- a/ui/src/views/dashboard/CapacityDashboard.vue
+++ b/ui/src/views/dashboard/CapacityDashboard.vue
@@ -174,8 +174,9 @@
         <template #title>
           <div class="center">
             <h3><cloud-outlined /> {{ $t('label.compute') }}</h3>
-            Display Allocated Capacity
             <a-switch
+              :checked-children="$t('label.allocated') + ' Capacity'"
+              :un-checked-children="$t('label.used') + ' Capacity'"
               v-model:checked="this.displayAllocatedCompute"
               @change="val => { this.displayAllocatedCompute = val }"
             />

--- a/ui/src/views/dashboard/CapacityDashboard.vue
+++ b/ui/src/views/dashboard/CapacityDashboard.vue
@@ -174,6 +174,11 @@
         <template #title>
           <div class="center">
             <h3><cloud-outlined /> {{ $t('label.compute') }}</h3>
+            Display Allocated Capacity
+            <a-switch
+              v-model:checked="this.displayAllocatedCompute"
+              @change="val => { this.displayAllocatedCompute = val }"
+            />
           </div>
         </template>
         <div>
@@ -184,15 +189,19 @@
               </div>
               <a-progress
               status="active"
-              :percent="statsMap[ctype]?.capacitytotal > 0 ? parseFloat(100.0 * statsMap[ctype]?.capacityused / statsMap[ctype]?.capacitytotal) : 0"
-              :format="p => statsMap[ctype]?.capacitytotal > 0 ? parseFloat(100.0 * statsMap[ctype]?.capacityused / statsMap[ctype]?.capacitytotal).toFixed(2) + '%' : '0%'"
+              :percent="statsMap[ctype]?.capacitytotal > 0 ?
+                this.displayAllocatedCompute ? parseFloat(100.0 * statsMap[ctype]?.capacityallocated / statsMap[ctype]?.capacitytotal) : parseFloat(100.0 * statsMap[ctype]?.capacityused / statsMap[ctype]?.capacitytotal)
+                : 0"
+              :format="p => statsMap[ctype]?.capacitytotal > 0 ?
+                this.displayAllocatedCompute ? parseFloat(100.0 * statsMap[ctype]?.capacityallocated / statsMap[ctype]?.capacitytotal).toFixed(2) + '%' : parseFloat(100.0 * statsMap[ctype]?.capacityused / statsMap[ctype]?.capacitytotal).toFixed(2) + '%'
+                : '0%'"
               stroke-color="#52c41a"
               size="small"
               style="width:95%; float: left"
               />
               <br/>
               <div style="text-align: center">
-                {{ displayData(ctype, statsMap[ctype]?.capacityused) }} {{ $t('label.allocated') }} | {{ displayData(ctype, statsMap[ctype]?.capacitytotal) }} {{ $t('label.total') }}
+                {{ this.displayAllocatedCompute ? displayData(ctype, statsMap[ctype]?.capacityallocated) : displayData(ctype, statsMap[ctype]?.capacityused) }} {{ this.displayAllocatedCompute ? $t('label.allocated') : $t('label.used') }} | {{ displayData(ctype, statsMap[ctype]?.capacitytotal) }} {{ $t('label.total') }}
               </div>
             </div>
           </div>
@@ -346,6 +355,7 @@ export default {
       zones: [],
       zoneSelected: {},
       statsMap: {},
+      displayAllocatedCompute: false,
       data: {
         pods: 0,
         clusters: 0,

--- a/ui/src/views/dashboard/CapacityDashboard.vue
+++ b/ui/src/views/dashboard/CapacityDashboard.vue
@@ -175,8 +175,8 @@
           <div class="center">
             <h3><cloud-outlined /> {{ $t('label.compute') }}</h3>
             <a-switch
-              :checked-children="$t('label.allocated') + ' Capacity'"
-              :un-checked-children="$t('label.used') + ' Capacity'"
+              :checked-children="$t('label.allocated') + ' ' + $t('label.capacity')"
+              :un-checked-children="$t('label.used') + ' ' + $t('label.capacity')"
               v-model:checked="this.displayAllocatedCompute"
               @change="val => { this.displayAllocatedCompute = val }"
             />

--- a/ui/src/views/dashboard/CapacityDashboard.vue
+++ b/ui/src/views/dashboard/CapacityDashboard.vue
@@ -191,10 +191,10 @@
               <a-progress
               status="active"
               :percent="statsMap[ctype]?.capacitytotal > 0 ?
-                this.displayAllocatedCompute ? parseFloat(100.0 * statsMap[ctype]?.capacityallocated / statsMap[ctype]?.capacitytotal) : parseFloat(100.0 * statsMap[ctype]?.capacityused / statsMap[ctype]?.capacitytotal)
+                displayPercentUsedOrAllocated(statsMap[ctype]?.capacityused, statsMap[ctype]?.capacityallocated, statsMap[ctype]?.capacitytotal)
                 : 0"
               :format="p => statsMap[ctype]?.capacitytotal > 0 ?
-                this.displayAllocatedCompute ? parseFloat(100.0 * statsMap[ctype]?.capacityallocated / statsMap[ctype]?.capacitytotal).toFixed(2) + '%' : parseFloat(100.0 * statsMap[ctype]?.capacityused / statsMap[ctype]?.capacitytotal).toFixed(2) + '%'
+                displayPercentFormatUsedOrAllocated(statsMap[ctype]?.capacityused, statsMap[ctype]?.capacityallocated, statsMap[ctype]?.capacitytotal)
                 : '0%'"
               stroke-color="#52c41a"
               size="small"
@@ -202,7 +202,7 @@
               />
               <br/>
               <div style="text-align: center">
-                {{ this.displayAllocatedCompute ? displayData(ctype, statsMap[ctype]?.capacityallocated) : displayData(ctype, statsMap[ctype]?.capacityused) }} {{ this.displayAllocatedCompute ? $t('label.allocated') : $t('label.used') }} | {{ displayData(ctype, statsMap[ctype]?.capacitytotal) }} {{ $t('label.total') }}
+                {{ displayDataUsedOrAllocated(ctype, statsMap[ctype]?.capacityused, statsMap[ctype]?.capacityallocated) }} {{ this.displayAllocatedCompute ? $t('label.allocated') : $t('label.used') }} | {{ displayData(ctype, statsMap[ctype]?.capacitytotal) }} {{ $t('label.total') }}
               </div>
             </div>
           </div>
@@ -412,6 +412,18 @@ export default {
         return 'active'
       }
       return 'normal'
+    },
+    displayPercentUsedOrAllocated (used, allocated, total) {
+      var value = this.displayAllocatedCompute ? allocated : used
+      return parseFloat(100.0 * value / total)
+    },
+    displayPercentFormatUsedOrAllocated (used, allocated, total) {
+      var value = this.displayAllocatedCompute ? allocated : used
+      return parseFloat(100.0 * value / total).toFixed(2) + '%'
+    },
+    displayDataUsedOrAllocated (dataType, used, allocated) {
+      var value = this.displayAllocatedCompute ? allocated : used
+      return this.displayData(dataType, value)
     },
     displayData (dataType, value) {
       if (!value) {


### PR DESCRIPTION
### Description

This PR fixes the UI display of used vs allocated resources. It adds a switch to display allocated or used resources

https://github.com/user-attachments/assets/86ce56cb-6cc3-4303-8d63-b336a03b4769



Fixes: #10185 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
