### PR TITLE
linstor: Fix ZFS snapshot backup

### DIFF
--- a/plugins/storage/volume/linstor/CHANGELOG.md
+++ b/plugins/storage/volume/linstor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Linstor CloudStack plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-01-20]
+
+### Fixed
+
+- Volume snapshots on zfs used the wrong dataset path to hide/unhide snapdev
+
 ## [2024-12-13]
 
 ### Fixed

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LinstorBackupSnapshotCommandWrapper.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LinstorBackupSnapshotCommandWrapper.java
@@ -45,11 +45,17 @@ public final class LinstorBackupSnapshotCommandWrapper
 {
     private static final Logger s_logger = Logger.getLogger(LinstorBackupSnapshotCommandWrapper.class);
 
+    private static String zfsDatasetName(String zfsFullSnapshotUrl) {
+        String zfsFullPath = zfsFullSnapshotUrl.substring(6);
+        int atPos = zfsFullPath.indexOf('@');
+        return atPos >= 0 ? zfsFullPath.substring(0, atPos) : zfsFullPath;
+    }
+
     private String zfsSnapdev(boolean hide, String zfsUrl) {
-        Script script = new Script("/usr/bin/zfs", Duration.millis(5000));
+        Script script = new Script("zfs", Duration.millis(5000));
         script.add("set");
         script.add("snapdev=" + (hide ? "hidden" : "visible"));
-        script.add(zfsUrl.substring(6));  // cutting zfs://
+        script.add(zfsDatasetName(zfsUrl));  // cutting zfs:// and @snapshotname
         return script.execute();
     }
 
@@ -133,10 +139,10 @@ public final class LinstorBackupSnapshotCommandWrapper
             s_logger.info("Src: " + srcPath + " | " + src.getName());
             if (srcPath.startsWith("zfs://")) {
                 zfsHidden = true;
-                if (zfsSnapdev(false, srcPath) != null) {
+                if (zfsSnapdev(false, src.getPath()) != null) {
                     return new CopyCmdAnswer("Unable to unhide zfs snapshot device.");
                 }
-                srcPath = "/dev/" + srcPath.substring(6);
+                srcPath = "/dev/zvol/" + srcPath.substring(6);
             }
 
             secondaryPool = storagePoolMgr.getStoragePoolByURI(dstDataStore.getUrl());


### PR DESCRIPTION
### Description

Linstor plugin used the wrong zfs dataset path to hide/unhide the snapshot device.
Also don't use the full path to the zfs binary.

Fixes: #9360

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Linstor cluster with zfs storage backend.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
