### PR TITLE
Fix local storage deletion cases

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -431,7 +431,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     protected static final String LOCAL_STORAGE_PATH = "local.storage.path";
     protected static final String LOCAL_STORAGE_UUID = "local.storage.uuid";
-    protected static final String DEFAULT_LOCAL_STORAGE_PATH = "/var/lib/libvirt/images/";
+    public static final String DEFAULT_LOCAL_STORAGE_PATH = "/var/lib/libvirt/images";
 
     protected List<String> localStoragePaths = new ArrayList<>();
     protected List<String> localStorageUUIDs = new ArrayList<>();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteStoragePoolCommandWrapper.java
@@ -41,6 +41,7 @@ public final class LibvirtDeleteStoragePoolCommandWrapper extends CommandWrapper
     @Override
     public Answer execute(final DeleteStoragePoolCommand command, final LibvirtComputingResource libvirtComputingResource) {
         try {
+            // if getRemoveDatastore() is true, then we are dealing with managed storage and can skip the delete logic here
             if (!command.getRemoveDatastore()) {
                 handleStoragePoolDeletion(command, libvirtComputingResource);
             }

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -803,7 +803,9 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         if (!(dc.isLocalStorageEnabled() || useLocalStorageForSystemVM)) {
             return null;
         }
-        DataStore store;
+        DataStore store = null;
+        DataStoreProvider provider = _dataStoreProviderMgr.getDefaultPrimaryDataStoreProvider();
+        DataStoreLifeCycle lifeCycle = provider.getDataStoreLifeCycle();
         try {
             String hostAddress = pInfo.getHost();
             if (host.getHypervisorType() == Hypervisor.HypervisorType.VMware) {
@@ -829,8 +831,6 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 }
             }
 
-            DataStoreProvider provider = _dataStoreProviderMgr.getDefaultPrimaryDataStoreProvider();
-            DataStoreLifeCycle lifeCycle = provider.getDataStoreLifeCycle();
             if (pool == null) {
                 Map<String, Object> params = new HashMap<String, Object>();
                 String name = pInfo.getName() != null ? pInfo.getName() : createLocalStoragePoolName(host, pInfo);
@@ -860,6 +860,14 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
 
         } catch (Exception e) {
             s_logger.warn("Unable to setup the local storage pool for " + host, e);
+            try {
+                if (store != null) {
+                    s_logger.debug(String.format("Trying to delete storage pool entry if exists %s", store));
+                    lifeCycle.deleteDataStore(store);
+                }
+            } catch (Exception ex) {
+                s_logger.debug(String.format("Failed to clean up local storage pool: %s", ex.getMessage()));
+            }
             throw new ConnectionException(true, "Unable to setup the local storage pool for " + host, e);
         }
 


### PR DESCRIPTION
### Description

This PR addresses the issues raised in https://github.com/apache/cloudstack/issues/9820

Case 0: Documentation admin should not remove the local.storage.uuid. Addressed here https://github.com/apache/cloudstack-documentation/pull/473
Case 1: Delete local storage pool entry even if local storage addition fails.
Case 2: Delete local.storage.uuid and path entries in agent.properties when local storage is deleted from management server. If not deleted then on every agent restart it will be added again in the management server.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

Case 0: Doc PR https://github.com/apache/cloudstack-documentation/pull/473

Case 1: 
1. Create local storage with invalid path.
2. Local storage addition fails.
3. Previously there is an active local storage entry even it failed to add, now there won't be any entry.

Case 2:
1. Add multiple local storages as in steps mentioned here https://docs.cloudstack.apache.org/en/4.19.0.0/adminguide/storage.html#manually-adding-local-storage-pool
2. Delete one local storage from management server
3. Previously that local storage entry existed in agent.properties and on restart of the agent the same local storage gets added again. Now the entry is deleted in agent.properties and on restart of agent did not added the local storage again.

