### PR TITLE
Fix Usage job not executing

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-42000to42010.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42000to42010.sql
@@ -22,6 +22,7 @@
 -- Add column api_key_access to user and account tables
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.user', 'api_key_access', 'boolean DEFAULT NULL COMMENT "is api key access allowed for the user" AFTER `secret_key`');
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.account', 'api_key_access', 'boolean DEFAULT NULL COMMENT "is api key access allowed for the account" ');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud_usage.account', 'api_key_access', 'boolean DEFAULT NULL COMMENT "is api key access allowed for the account" ');
 
 -- Modify index for mshost_peer
 DELETE FROM `cloud`.`mshost_peer`;


### PR DESCRIPTION
### Description

The Usage job does not execute successfully in 4.20 because `cloud_usage.account` is missing a column. This PR fixes the issue.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

1. Before the changes, I tried to execute the Usage job. However, I got an exception and no usage records were generated

```
2025-01-26 00:13:58,470 INFO  [cloud.usage.UsageManagerImpl_EnhancerByCloudStack_bc7085c8] (Usage-Job-1:[]) (logid:) Parsing usage records between [2024-11-27T11:50:00+0000] and [2025-01-26T00:12:59+0000].
2025-01-26 00:13:58,838 ERROR [user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f] (Usage-Job-1:[]) (logid:) DB Exception on: HikariProxyPreparedStatement@1912723807 wrapping com.mysql.cj.jdbc.ClientPreparedStatement: SELECT account.id, account.account_name, account.type, account.role_id, account.domain_id, account.state, account.created, account.removed, account.cleanup_needed, account.network_domain, account.uuid, account.default_zone_id, account.default, account.api_key_access FROM account WHERE account.id = 1 java.sql.SQLSyntaxErrorException: Unknown column 'account.api_key_access' in 'field list'
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:121)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:916)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:972)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
	at com.cloud.utils.db.GenericDaoBase.findById(GenericDaoBase.java:1074)
	at com.cloud.user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f.CGLIB$findById$48(<generated>)
	at com.cloud.user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f_FastClassByCloudStack_ef992de4.invoke(<generated>)
	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
	at com.cloud.utils.component.ComponentInstantiationPostProcessor$InterceptorDispatcher.intercept(ComponentInstantiationPostProcessor.java:123)
	at com.cloud.user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f.findById(<generated>)
	at com.cloud.utils.db.GenericDaoBase.findByIdIncludingRemoved(GenericDaoBase.java:1029)
	at com.cloud.user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f.CGLIB$findByIdIncludingRemoved$99(<generated>)
	at com.cloud.user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f_FastClassByCloudStack_ef992de4.invoke(<generated>)
	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
	at com.cloud.utils.component.ComponentInstantiationPostProcessor$InterceptorDispatcher.intercept(ComponentInstantiationPostProcessor.java:123)
	at com.cloud.user.dao.AccountDaoImpl_EnhancerByCloudStack_90169b7f.findByIdIncludingRemoved(<generated>)
	at com.cloud.usage.UsageManagerImpl.handleNetworkEvent(UsageManagerImpl.java:2152)
	at com.cloud.usage.UsageManagerImpl.createHelperRecord(UsageManagerImpl.java:1100)
	at com.cloud.usage.UsageManagerImpl.parse(UsageManagerImpl.java:726)
	at com.cloud.usage.UsageManagerImpl.runInContextInternal(UsageManagerImpl.java:442)
	at com.cloud.usage.UsageManagerImpl$1.runInContext(UsageManagerImpl.java:379)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:56)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:103)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:53)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46)
	at com.cloud.usage.UsageManagerImpl.run(UsageManagerImpl.java:381)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

2. I executed the query manually and tried and tried to execute the Usage job. This time, it finished successfully

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->