### PR TITLE
server: reset 2fa user configuration on incomplete setup

### DIFF
--- a/engine/schema/src/main/java/com/cloud/user/UserAccountVO.java
+++ b/engine/schema/src/main/java/com/cloud/user/UserAccountVO.java
@@ -35,6 +35,8 @@ import org.apache.cloudstack.api.InternalIdentity;
 
 import com.cloud.utils.db.Encrypt;
 import com.cloud.utils.db.GenericDao;
+
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.commons.lang3.StringUtils;
 
 @Entity
@@ -367,5 +369,10 @@ public class UserAccountVO implements UserAccount, InternalIdentity {
     @Override
     public void setDetails(Map<String, String> details) {
         this.details = details;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("User %s", ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, "id", "name", "uuid"));
     }
 }

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
@@ -516,4 +516,9 @@ public class MockAccountManager extends ManagerBase implements AccountManager {
     public ConfigKey<?>[] getConfigKeys() {
         return null;
     }
+
+    @Override
+    public UserAccount clearUserTwoFactorAuthenticationInSetupStateOnLogin(UserAccount user) {
+        return null;
+    }
 }

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -1159,7 +1159,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             domainId = userDomain.getId();
         }
 
-        final UserAccount userAcct = accountMgr.authenticateUser(username, password, domainId, loginIpAddress, requestParameters);
+        UserAccount userAcct = accountMgr.authenticateUser(username, password, domainId, loginIpAddress, requestParameters);
         if (userAcct != null) {
             final String timezone = userAcct.getTimezone();
             float offsetInHrs = 0f;
@@ -1204,6 +1204,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 session.setAttribute("timezoneoffset", Float.valueOf(offsetInHrs).toString());
             }
 
+            userAcct = accountMgr.clearUserTwoFactorAuthenticationInSetupStateOnLogin(userAcct);
             boolean is2faEnabled = false;
             if (userAcct.isUser2faEnabled() || (Boolean.TRUE.equals(AccountManagerImpl.enableUserTwoFactorAuthentication.valueIn(userAcct.getDomainId())) && Boolean.TRUE.equals(AccountManagerImpl.mandateUserTwoFactorAuthentication.valueIn(userAcct.getDomainId())))) {
                 is2faEnabled = true;

--- a/server/src/main/java/com/cloud/user/AccountManager.java
+++ b/server/src/main/java/com/cloud/user/AccountManager.java
@@ -195,6 +195,9 @@ public interface AccountManager extends AccountService, Configurable {
     UserTwoFactorAuthenticator getUserTwoFactorAuthenticator(final Long domainId, final Long userAccountId);
 
     void verifyUsingTwoFactorAuthenticationCode(String code, Long domainId, Long userAccountId);
+
     UserTwoFactorAuthenticationSetupResponse setupUserTwoFactorAuthentication(SetupUserTwoFactorAuthenticationCmd cmd);
+
+    UserAccount clearUserTwoFactorAuthenticationInSetupStateOnLogin(UserAccount user);
 
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -39,10 +39,12 @@ import org.apache.cloudstack.auth.UserAuthenticator.ActionOnFailedAuthentication
 import org.apache.cloudstack.auth.UserTwoFactorAuthenticator;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.resourcedetail.UserDetailVO;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -1217,5 +1219,55 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
 
         Mockito.when(_projectAccountDao.listAdministratedProjectIds(accountId)).thenReturn(managedProjectIds);
         accountManagerImpl.checkIfAccountManagesProjects(accountId);
+    }
+
+    @Test
+    public void testClearUser2FA_When2FADisabled_NoChanges() {
+        UserAccount user = Mockito.mock(UserAccount.class);
+        Mockito.when(user.isUser2faEnabled()).thenReturn(false);
+        Mockito.when(user.getUser2faProvider()).thenReturn(null);
+        UserAccount result = accountManagerImpl.clearUserTwoFactorAuthenticationInSetupStateOnLogin(user);
+        Assert.assertSame(user, result);
+        Mockito.verifyNoInteractions(userDetailsDaoMock, userAccountDaoMock);
+    }
+
+    @Test
+    public void testClearUser2FA_When2FAInVerifiedState_NoChanges() {
+        UserAccount user = Mockito.mock(UserAccount.class);
+        Mockito.when(user.getId()).thenReturn(1L);
+        Mockito.when(user.isUser2faEnabled()).thenReturn(true);
+        UserDetailVO userDetail = new UserDetailVO();
+        userDetail.setValue(UserAccountVO.Setup2FAstatus.VERIFIED.name());
+        Mockito.when(userDetailsDaoMock.findDetail(1L, UserDetailVO.Setup2FADetail)).thenReturn(userDetail);
+        UserAccount result = accountManagerImpl.clearUserTwoFactorAuthenticationInSetupStateOnLogin(user);
+        Assert.assertSame(user, result);
+        Mockito.verify(userDetailsDaoMock).findDetail(1L, UserDetailVO.Setup2FADetail);
+        Mockito.verifyNoMoreInteractions(userDetailsDaoMock, userAccountDaoMock);
+    }
+
+    @Test
+    public void testClearUser2FA_When2FAInSetupState_Disable2FA() {
+        UserAccount user = Mockito.mock(UserAccount.class);
+        Mockito.when(user.getId()).thenReturn(1L);
+        Mockito.when(user.isUser2faEnabled()).thenReturn(true);
+        UserDetailVO userDetail = new UserDetailVO();
+        userDetail.setValue(UserAccountVO.Setup2FAstatus.ENABLED.name());
+        UserAccountVO userAccountVO = new UserAccountVO();
+        userAccountVO.setId(1L);
+        Mockito.when(userDetailsDaoMock.findDetail(1L, UserDetailVO.Setup2FADetail)).thenReturn(userDetail);
+        Mockito.when(userAccountDaoMock.findById(1L)).thenReturn(userAccountVO);
+        UserAccount result = accountManagerImpl.clearUserTwoFactorAuthenticationInSetupStateOnLogin(user);
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isUser2faEnabled());
+        Assert.assertNull(result.getUser2faProvider());
+        Mockito.verify(userDetailsDaoMock).findDetail(1L, UserDetailVO.Setup2FADetail);
+        Mockito.verify(userDetailsDaoMock).remove(Mockito.anyLong());
+        Mockito.verify(userAccountDaoMock).findById(1L);
+        ArgumentCaptor<UserAccountVO> captor = ArgumentCaptor.forClass(UserAccountVO.class);
+        Mockito.verify(userAccountDaoMock).update(Mockito.eq(1L), captor.capture());
+        UserAccountVO updatedUser = captor.getValue();
+        Assert.assertFalse(updatedUser.isUser2faEnabled());
+        Assert.assertNull(updatedUser.getUser2faProvider());
+        Assert.assertNull(updatedUser.getKeyFor2fa());
     }
 }

--- a/server/src/test/java/com/cloud/user/MockAccountManagerImpl.java
+++ b/server/src/test/java/com/cloud/user/MockAccountManagerImpl.java
@@ -484,4 +484,8 @@ public class MockAccountManagerImpl extends ManagerBase implements Manager, Acco
         return null;
     }
 
+    @Override
+    public UserAccount clearUserTwoFactorAuthenticationInSetupStateOnLogin(UserAccount user) {
+        return null;
+    }
 }


### PR DESCRIPTION
### Description

Fixes #9308

When 2FA isn't validated and completed during setup and a login request is made, this PR clears 2FA configuration to allow setting it up again.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
