### PR TITLE
Grant access to 2FA APIs for default read-only and support roles

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/procedures/cloud.idempotent_update_api_permission.sql
+++ b/engine/schema/src/main/resources/META-INF/db/procedures/cloud.idempotent_update_api_permission.sql
@@ -1,0 +1,52 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+DROP PROCEDURE IF EXISTS `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`;
+
+CREATE PROCEDURE `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION` (
+    IN role VARCHAR(255),
+    IN rule VARCHAR(255),
+    IN permission VARCHAR(255)
+)
+BEGIN
+     DECLARE role_id BIGINT(20) UNSIGNED
+;    DECLARE max_sort_order BIGINT(20) UNSIGNED
+
+;   SELECT `r`.`id` INTO role_id
+    FROM `cloud`.`roles` `r`
+    WHERE `r`.`name` = role
+        AND `r`.`is_default` = 1
+
+;   SELECT MAX(`rp`.`sort_order`) INTO max_sort_order
+    FROM `cloud`.`role_permissions` `rp`
+    WHERE `rp`.`role_id` = role_id
+
+;   IF NOT EXISTS (
+        SELECT * FROM `cloud`.`role_permissions` `rp`
+        WHERE `rp`.`role_id` = role_id
+            AND `rp`.`rule` = rule
+    ) THEN
+        UPDATE `cloud`.`role_permissions` `rp`
+        SET `rp`.`sort_order` = max_sort_order + 1
+        WHERE `rp`.`sort_order` = max_sort_order
+            AND `rp`.`role_id` = role_id
+
+;       INSERT INTO `cloud`.`role_permissions`
+            (uuid, role_id, rule, permission, sort_order)
+        VALUES (uuid(), role_id, rule, permission, max_sort_order)
+;   END IF
+;END;

--- a/engine/schema/src/main/resources/META-INF/db/schema-41910to41920.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41910to41920.sql
@@ -21,3 +21,25 @@
 
 -- Add last_id to the volumes table
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.volumes', 'last_id', 'bigint(20) unsigned DEFAULT NULL');
+
+-- Grant access to 2FA APIs for the "Read-Only User - Default" role
+
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Read-Only User - Default', 'setupUserTwoFactorAuthentication', 'ALLOW');
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Read-Only User - Default', 'validateUserTwoFactorAuthenticationCode', 'ALLOW');
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Read-Only User - Default', 'listUserTwoFactorAuthenticatorProviders', 'ALLOW');
+
+-- Grant access to 2FA APIs for the "Support User - Default" role
+
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Support User - Default', 'setupUserTwoFactorAuthentication', 'ALLOW');
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Support User - Default', 'validateUserTwoFactorAuthenticationCode', 'ALLOW');
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Support User - Default', 'listUserTwoFactorAuthenticatorProviders', 'ALLOW');
+
+-- Grant access to 2FA APIs for the "Read-Only Admin - Default" role
+
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Read-Only Admin - Default', 'setupUserTwoFactorAuthentication', 'ALLOW');
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Read-Only Admin - Default', 'validateUserTwoFactorAuthenticationCode', 'ALLOW');
+
+-- Grant access to 2FA APIs for the "Support Admin - Default" role
+
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Support Admin - Default', 'setupUserTwoFactorAuthentication', 'ALLOW');
+CALL `cloud`.`IDEMPOTENT_UPDATE_API_PERMISSION`('Support Admin - Default', 'validateUserTwoFactorAuthenticationCode', 'ALLOW');


### PR DESCRIPTION
### Description

Accounts created with the `Read-Only User - Default` and `Support User - Default` roles do not have access to `setupUserTwoFactorAuthentication`, `validateUserTwoFactorAuthenticationCode` and `listUserTwoFactorAuthenticatorProviders` APIs. Additionally, accounts created with the `Read-Only Admin - Default` and `Support Admin - Default` roles only have access to the `listUserTwoFactorAuthenticatorProviders` API.

As a consequence, when 2FA is required for authentication, accounts with these roles cannot login into CloudStack. Thus, this PR proposes to grant access to the 2FA-related APIs for the previously mentioned roles.

---

Fixes #10269

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

### `Read-Only User - Default`

<details>

<summary>Role permissions before changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Read-Only User - Default') order by sort_order;
+------+--------------------------------------+---------+---------------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                            | permission | description | sort_order |
+------+--------------------------------------+---------+---------------------------------+------------+-------------+------------+
|  894 | 36edece5-a510-11ef-8a39-9a34acb639ea |       6 | listAccounts                    | ALLOW      | NULL        |          0 |
|  895 | 36edf63d-a510-11ef-8a39-9a34acb639ea |       6 | listAffinityGroupTypes          | ALLOW      | NULL        |          1 |
|  896 | 36edfd6c-a510-11ef-8a39-9a34acb639ea |       6 | listAffinityGroups              | ALLOW      | NULL        |          2 |
|  897 | 36ee0450-a510-11ef-8a39-9a34acb639ea |       6 | listApis                        | ALLOW      | NULL        |          3 |
// (...)
|  971 | 36f02736-a510-11ef-8a39-9a34acb639ea |       6 | cloudianIsEnabled               | ALLOW      | NULL        |         77 |
|  972 | 36f02baf-a510-11ef-8a39-9a34acb639ea |       6 | queryAsyncJobResult             | ALLOW      | NULL        |         78 |
|  973 | 36f02fc1-a510-11ef-8a39-9a34acb639ea |       6 | quotaIsEnabled                  | ALLOW      | NULL        |         79 |
|  974 | 36f0336d-a510-11ef-8a39-9a34acb639ea |       6 | quotaTariffList                 | ALLOW      | NULL        |         80 |
|  975 | 36f0371a-a510-11ef-8a39-9a34acb639ea |       6 | quotaSummary                    | ALLOW      | NULL        |         81 |
| 1117 | 38c4a78b-a510-11ef-8a39-9a34acb639ea |       6 | quotaBalance                    | ALLOW      | NULL        |         82 |
| 1116 | 38c4617d-a510-11ef-8a39-9a34acb639ea |       6 | quotaStatement                  | ALLOW      | NULL        |         83 |
| 1125 | 39fc9915-a510-11ef-8a39-9a34acb639ea |       6 | quotaStatementDetails           | ALLOW      | NULL        |         83 |
| 1132 | 39fd0d57-a510-11ef-8a39-9a34acb639ea |       6 | quotaCreditsList                | ALLOW      | NULL        |         83 |
|  976 | 36f040d1-a510-11ef-8a39-9a34acb639ea |       6 | *                               | DENY       | NULL        |         84 |
+------+--------------------------------------+---------+---------------------------------+------------+-------------+------------+
84 rows in set (0.002 sec)
```

</details>

<details>

<summary>Role permissions after changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Read-Only User - Default') order by sort_order;
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                                    | permission | description | sort_order |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
|  894 | 36edece5-a510-11ef-8a39-9a34acb639ea |       6 | listAccounts                            | ALLOW      | NULL        |          0 |
|  895 | 36edf63d-a510-11ef-8a39-9a34acb639ea |       6 | listAffinityGroupTypes                  | ALLOW      | NULL        |          1 |
|  896 | 36edfd6c-a510-11ef-8a39-9a34acb639ea |       6 | listAffinityGroups                      | ALLOW      | NULL        |          2 |
|  897 | 36ee0450-a510-11ef-8a39-9a34acb639ea |       6 | listApis                                | ALLOW      | NULL        |          3 |
(...)
|  971 | 36f02736-a510-11ef-8a39-9a34acb639ea |       6 | cloudianIsEnabled                       | ALLOW      | NULL        |         77 |
|  972 | 36f02baf-a510-11ef-8a39-9a34acb639ea |       6 | queryAsyncJobResult                     | ALLOW      | NULL        |         78 |
|  973 | 36f02fc1-a510-11ef-8a39-9a34acb639ea |       6 | quotaIsEnabled                          | ALLOW      | NULL        |         79 |
|  974 | 36f0336d-a510-11ef-8a39-9a34acb639ea |       6 | quotaTariffList                         | ALLOW      | NULL        |         80 |
|  975 | 36f0371a-a510-11ef-8a39-9a34acb639ea |       6 | quotaSummary                            | ALLOW      | NULL        |         81 |
| 1117 | 38c4a78b-a510-11ef-8a39-9a34acb639ea |       6 | quotaBalance                            | ALLOW      | NULL        |         82 |
| 1116 | 38c4617d-a510-11ef-8a39-9a34acb639ea |       6 | quotaStatement                          | ALLOW      | NULL        |         83 |
| 1125 | 39fc9915-a510-11ef-8a39-9a34acb639ea |       6 | quotaStatementDetails                   | ALLOW      | NULL        |         83 |
| 1132 | 39fd0d57-a510-11ef-8a39-9a34acb639ea |       6 | quotaCreditsList                        | ALLOW      | NULL        |         83 |
| 1133 | 1da34356-db5a-11ef-878d-9a34acb639ea |       6 | setupUserTwoFactorAuthentication        | ALLOW      | NULL        |         84 |
| 1134 | 1da3b3a9-db5a-11ef-878d-9a34acb639ea |       6 | validateUserTwoFactorAuthenticationCode | ALLOW      | NULL        |         85 |
| 1135 | 1e15b3aa-db5a-11ef-878d-9a34acb639ea |       6 | listUserTwoFactorAuthenticatorProviders | ALLOW      | NULL        |         86 |
|  976 | 36f040d1-a510-11ef-8a39-9a34acb639ea |       6 | *                                       | DENY       | NULL        |         87 |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
87 rows in set (0.001 sec)
```

</details>

### `Support User - Default`

<details>

<summary>Role permissions before changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Support User - Default') order by sort_order;
+------+--------------------------------------+---------+---------------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                            | permission | description | sort_order |
+------+--------------------------------------+---------+---------------------------------+------------+-------------+------------+
| 1006 | 36f134fd-a510-11ef-8a39-9a34acb639ea |       8 | listAccounts                    | ALLOW      | NULL        |          0 |
| 1007 | 36f13e2d-a510-11ef-8a39-9a34acb639ea |       8 | listAffinityGroupTypes          | ALLOW      | NULL        |          1 |
| 1008 | 36f1432c-a510-11ef-8a39-9a34acb639ea |       8 | listAffinityGroups              | ALLOW      | NULL        |          2 |
| 1009 | 36f1478f-a510-11ef-8a39-9a34acb639ea |       8 | listApis                        | ALLOW      | NULL        |          3 |
| 1010 | 36f14ba1-a510-11ef-8a39-9a34acb639ea |       8 | listAsyncJobs                   | ALLOW      | NULL        |          4 |
(...)
| 1093 | 36f3c18c-a510-11ef-8a39-9a34acb639ea |       8 | createVolume                    | ALLOW      | NULL        |         87 |
| 1094 | 36f3c780-a510-11ef-8a39-9a34acb639ea |       8 | attachVolume                    | ALLOW      | NULL        |         88 |
| 1095 | 36f3cb45-a510-11ef-8a39-9a34acb639ea |       8 | detachVolume                    | ALLOW      | NULL        |         89 |
| 1096 | 36f3cee0-a510-11ef-8a39-9a34acb639ea |       8 | uploadVolume                    | ALLOW      | NULL        |         90 |
| 1097 | 36f3d2da-a510-11ef-8a39-9a34acb639ea |       8 | attachIso                       | ALLOW      | NULL        |         91 |
| 1098 | 36f3d6f6-a510-11ef-8a39-9a34acb639ea |       8 | detachIso                       | ALLOW      | NULL        |         92 |
| 1099 | 36f3da8a-a510-11ef-8a39-9a34acb639ea |       8 | registerTemplate                | ALLOW      | NULL        |         93 |
| 1100 | 36f3de07-a510-11ef-8a39-9a34acb639ea |       8 | registerIso                     | ALLOW      | NULL        |         94 |
| 1101 | 36f3e187-a510-11ef-8a39-9a34acb639ea |       8 | getUploadParamsFor*             | ALLOW      | NULL        |         95 |
| 1102 | 36f3e4fe-a510-11ef-8a39-9a34acb639ea |       8 | *                               | DENY       | NULL        |         96 |
+------+--------------------------------------+---------+---------------------------------+------------+-------------+------------+
94 rows in set (0.002 sec)
```

</details>

<details>

<summary>Role permissions after changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Support User - Default') order by sort_order;
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                                    | permission | description | sort_order |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
| 1006 | 36f134fd-a510-11ef-8a39-9a34acb639ea |       8 | listAccounts                            | ALLOW      | NULL        |          0 |
| 1007 | 36f13e2d-a510-11ef-8a39-9a34acb639ea |       8 | listAffinityGroupTypes                  | ALLOW      | NULL        |          1 |
| 1008 | 36f1432c-a510-11ef-8a39-9a34acb639ea |       8 | listAffinityGroups                      | ALLOW      | NULL        |          2 |
| 1009 | 36f1478f-a510-11ef-8a39-9a34acb639ea |       8 | listApis                                | ALLOW      | NULL        |          3 |
| 1010 | 36f14ba1-a510-11ef-8a39-9a34acb639ea |       8 | listAsyncJobs                           | ALLOW      | NULL        |          4 |
(...)
| 1093 | 36f3c18c-a510-11ef-8a39-9a34acb639ea |       8 | createVolume                            | ALLOW      | NULL        |         87 |
| 1094 | 36f3c780-a510-11ef-8a39-9a34acb639ea |       8 | attachVolume                            | ALLOW      | NULL        |         88 |
| 1095 | 36f3cb45-a510-11ef-8a39-9a34acb639ea |       8 | detachVolume                            | ALLOW      | NULL        |         89 |
| 1096 | 36f3cee0-a510-11ef-8a39-9a34acb639ea |       8 | uploadVolume                            | ALLOW      | NULL        |         90 |
| 1097 | 36f3d2da-a510-11ef-8a39-9a34acb639ea |       8 | attachIso                               | ALLOW      | NULL        |         91 |
| 1098 | 36f3d6f6-a510-11ef-8a39-9a34acb639ea |       8 | detachIso                               | ALLOW      | NULL        |         92 |
| 1099 | 36f3da8a-a510-11ef-8a39-9a34acb639ea |       8 | registerTemplate                        | ALLOW      | NULL        |         93 |
| 1100 | 36f3de07-a510-11ef-8a39-9a34acb639ea |       8 | registerIso                             | ALLOW      | NULL        |         94 |
| 1101 | 36f3e187-a510-11ef-8a39-9a34acb639ea |       8 | getUploadParamsFor*                     | ALLOW      | NULL        |         95 |
| 1136 | 5984107f-db5a-11ef-878d-9a34acb639ea |       8 | setupUserTwoFactorAuthentication        | ALLOW      | NULL        |         96 |
| 1137 | 5984d54a-db5a-11ef-878d-9a34acb639ea |       8 | validateUserTwoFactorAuthenticationCode | ALLOW      | NULL        |         97 |
| 1138 | 5a25bb08-db5a-11ef-878d-9a34acb639ea |       8 | listUserTwoFactorAuthenticatorProviders | ALLOW      | NULL        |         98 |
| 1102 | 36f3e4fe-a510-11ef-8a39-9a34acb639ea |       8 | *                                       | DENY       | NULL        |         99 |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
97 rows in set (0.003 sec)
```

</details>

### `Read-Only Admin - Default`

<details>

<summary>Role permissions before changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Read-Only Admin - Default') order by sort_order;
+------+--------------------------------------+---------+-----------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                  | permission | description | sort_order |
+------+--------------------------------------+---------+-----------------------+------------+-------------+------------+
|  885 | 36ed8afa-a510-11ef-8a39-9a34acb639ea |       5 | list*                 | ALLOW      | NULL        |          0 |
|  886 | 36ed9278-a510-11ef-8a39-9a34acb639ea |       5 | getUploadParamsFor*   | DENY       | NULL        |          1 |
|  887 | 36ed97b5-a510-11ef-8a39-9a34acb639ea |       5 | get*                  | ALLOW      | NULL        |          2 |
|  888 | 36ed9bb8-a510-11ef-8a39-9a34acb639ea |       5 | cloudianIsEnabled     | ALLOW      | NULL        |          3 |
|  889 | 36ed9f83-a510-11ef-8a39-9a34acb639ea |       5 | queryAsyncJobResult   | ALLOW      | NULL        |          4 |
|  890 | 36eda459-a510-11ef-8a39-9a34acb639ea |       5 | quotaIsEnabled        | ALLOW      | NULL        |          5 |
|  891 | 36eda8be-a510-11ef-8a39-9a34acb639ea |       5 | quotaTariffList       | ALLOW      | NULL        |          6 |
|  892 | 36edada1-a510-11ef-8a39-9a34acb639ea |       5 | quotaSummary          | ALLOW      | NULL        |          7 |
| 1115 | 38c3b20d-a510-11ef-8a39-9a34acb639ea |       5 | quotaBalance          | ALLOW      | NULL        |          8 |
| 1114 | 38c35a0f-a510-11ef-8a39-9a34acb639ea |       5 | quotaStatement        | ALLOW      | NULL        |          9 |
| 1124 | 39fc98e9-a510-11ef-8a39-9a34acb639ea |       5 | quotaStatementDetails | ALLOW      | NULL        |          9 |
| 1131 | 39fd0d35-a510-11ef-8a39-9a34acb639ea |       5 | quotaCreditsList      | ALLOW      | NULL        |          9 |
|  893 | 36edb1f6-a510-11ef-8a39-9a34acb639ea |       5 | *                     | DENY       | NULL        |         10 |
+------+--------------------------------------+---------+-----------------------+------------+-------------+------------+
13 rows in set (0.001 sec)
```

</details>

<details>

<summary>Role permissions after changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Read-Only Admin - Default') order by sort_order;
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                                    | permission | description | sort_order |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
|  885 | 36ed8afa-a510-11ef-8a39-9a34acb639ea |       5 | list*                                   | ALLOW      | NULL        |          0 |
|  886 | 36ed9278-a510-11ef-8a39-9a34acb639ea |       5 | getUploadParamsFor*                     | DENY       | NULL        |          1 |
|  887 | 36ed97b5-a510-11ef-8a39-9a34acb639ea |       5 | get*                                    | ALLOW      | NULL        |          2 |
|  888 | 36ed9bb8-a510-11ef-8a39-9a34acb639ea |       5 | cloudianIsEnabled                       | ALLOW      | NULL        |          3 |
|  889 | 36ed9f83-a510-11ef-8a39-9a34acb639ea |       5 | queryAsyncJobResult                     | ALLOW      | NULL        |          4 |
|  890 | 36eda459-a510-11ef-8a39-9a34acb639ea |       5 | quotaIsEnabled                          | ALLOW      | NULL        |          5 |
|  891 | 36eda8be-a510-11ef-8a39-9a34acb639ea |       5 | quotaTariffList                         | ALLOW      | NULL        |          6 |
|  892 | 36edada1-a510-11ef-8a39-9a34acb639ea |       5 | quotaSummary                            | ALLOW      | NULL        |          7 |
| 1115 | 38c3b20d-a510-11ef-8a39-9a34acb639ea |       5 | quotaBalance                            | ALLOW      | NULL        |          8 |
| 1114 | 38c35a0f-a510-11ef-8a39-9a34acb639ea |       5 | quotaStatement                          | ALLOW      | NULL        |          9 |
| 1124 | 39fc98e9-a510-11ef-8a39-9a34acb639ea |       5 | quotaStatementDetails                   | ALLOW      | NULL        |          9 |
| 1131 | 39fd0d35-a510-11ef-8a39-9a34acb639ea |       5 | quotaCreditsList                        | ALLOW      | NULL        |          9 |
| 1139 | 98c7cfdf-db5a-11ef-878d-9a34acb639ea |       5 | setupUserTwoFactorAuthentication        | ALLOW      | NULL        |         10 |
| 1140 | 9a27c65c-db5a-11ef-878d-9a34acb639ea |       5 | validateUserTwoFactorAuthenticationCode | ALLOW      | NULL        |         11 |
|  893 | 36edb1f6-a510-11ef-8a39-9a34acb639ea |       5 | *                                       | DENY       | NULL        |         12 |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
15 rows in set (0.000 sec)
```

</details>

### `Support Admin - Default`

<details>

<summary>Role permissions before changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Support Admin - Default') order by sort_order;
+------+--------------------------------------+---------+---------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                      | permission | description | sort_order |
+------+--------------------------------------+---------+---------------------------+------------+-------------+------------+
|  977 | 36f07380-a510-11ef-8a39-9a34acb639ea |       7 | list*                     | ALLOW      | NULL        |          0 |
|  978 | 36f07a1d-a510-11ef-8a39-9a34acb639ea |       7 | get*                      | ALLOW      | NULL        |          1 |
|  979 | 36f07f3b-a510-11ef-8a39-9a34acb639ea |       7 | cloudianIsEnabled         | ALLOW      | NULL        |          2 |
|  980 | 36f084f5-a510-11ef-8a39-9a34acb639ea |       7 | queryAsyncJobResult       | ALLOW      | NULL        |          3 |
|  981 | 36f0893b-a510-11ef-8a39-9a34acb639ea |       7 | quotaIsEnabled            | ALLOW      | NULL        |          4 |
(...)
| 1002 | 36f0e049-a510-11ef-8a39-9a34acb639ea |       7 | detachIso                 | ALLOW      | NULL        |         25 |
| 1003 | 36f0e45b-a510-11ef-8a39-9a34acb639ea |       7 | registerTemplate          | ALLOW      | NULL        |         26 |
| 1004 | 36f0eabb-a510-11ef-8a39-9a34acb639ea |       7 | registerIso               | ALLOW      | NULL        |         27 |
| 1005 | 36f0f3c4-a510-11ef-8a39-9a34acb639ea |       7 | *                         | DENY       | NULL        |         28 |
+------+--------------------------------------+---------+---------------------------+------------+-------------+------------+
29 rows in set (0.001 sec)

```

</details>

<details>

<summary>Role permissions after changes</summary>

```sql
MariaDB [(none)]> select * from cloud.role_permissions where role_id = (select id from cloud.roles where name = 'Support Admin - Default') order by sort_order;
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
| id   | uuid                                 | role_id | rule                                    | permission | description | sort_order |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
|  977 | 36f07380-a510-11ef-8a39-9a34acb639ea |       7 | list*                                   | ALLOW      | NULL        |          0 |
|  978 | 36f07a1d-a510-11ef-8a39-9a34acb639ea |       7 | get*                                    | ALLOW      | NULL        |          1 |
|  979 | 36f07f3b-a510-11ef-8a39-9a34acb639ea |       7 | cloudianIsEnabled                       | ALLOW      | NULL        |          2 |
|  980 | 36f084f5-a510-11ef-8a39-9a34acb639ea |       7 | queryAsyncJobResult                     | ALLOW      | NULL        |          3 |
|  981 | 36f0893b-a510-11ef-8a39-9a34acb639ea |       7 | quotaIsEnabled                          | ALLOW      | NULL        |          4 |
(...)
| 1002 | 36f0e049-a510-11ef-8a39-9a34acb639ea |       7 | detachIso                               | ALLOW      | NULL        |         25 |
| 1003 | 36f0e45b-a510-11ef-8a39-9a34acb639ea |       7 | registerTemplate                        | ALLOW      | NULL        |         26 |
| 1004 | 36f0eabb-a510-11ef-8a39-9a34acb639ea |       7 | registerIso                             | ALLOW      | NULL        |         27 |
| 1141 | a1159975-db5a-11ef-878d-9a34acb639ea |       7 | setupUserTwoFactorAuthentication        | ALLOW      | NULL        |         28 |
| 1142 | a11714c1-db5a-11ef-878d-9a34acb639ea |       7 | validateUserTwoFactorAuthenticationCode | ALLOW      | NULL        |         29 |
| 1005 | 36f0f3c4-a510-11ef-8a39-9a34acb639ea |       7 | *                                       | DENY       | NULL        |         30 |
+------+--------------------------------------+---------+-----------------------------------------+------------+-------------+------------+
31 rows in set (0.001 sec)
```

</details>
