### PR TITLE
UI: Validate inserted values in numeric global settings

### DIFF
--- a/ui/src/views/setting/ConfigurationValue.vue
+++ b/ui/src/views/setting/ConfigurationValue.vue
@@ -39,6 +39,7 @@
             @keydown.esc="editableValueKey = null"
             @pressEnter="updateConfigurationValue(configrecord)"
             @change="value => setConfigurationEditable(configrecord, value)"
+            @keydown="e => handleInputNumberKeyDown(e, false)"
           />
         </a-tooltip>
       </span>
@@ -52,6 +53,7 @@
             @keydown.esc="editableValueKey = null"
             @pressEnter="updateConfigurationValue(configrecord)"
             @change="value => setConfigurationEditable(configrecord, value)"
+            @keydown="e => handleInputNumberKeyDown(e, true)"
           />
         </a-tooltip>
       </span>
@@ -87,6 +89,7 @@
                 @keydown.esc="editableValueKey = null"
                 @pressEnter="updateConfigurationValue(configrecord)"
                 @change="value => setConfigurationEditable(configrecord, value)"
+                @keydown="e => handleInputNumberKeyDown(e, true)"
               />
             </a-tooltip>
           </a-col>
@@ -349,6 +352,26 @@ export default {
         this.editableValueKey = 'edit'
       } else {
         this.editableValueKey = null
+      }
+    },
+    handleInputNumberKeyDown (event, isDecimal) {
+      const allowedCodes = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Minus']
+
+      if (isDecimal) {
+        allowedCodes.push('Period')
+      }
+
+      if (
+        event.getModifierState('Control') ||
+        event.getModifierState('Meta') ||
+        event.getModifierState('Alt')
+      ) {
+        return
+      }
+
+      const isValid = allowedCodes.includes(event.code) || !isNaN(event.key)
+      if (!isValid) {
+        event.preventDefault()
       }
     }
   }


### PR DESCRIPTION
### Description

Currently, when changing the `Decimal`, `Number` and `Range` global settings values through the UI, CloudStack does not validate if the inserted values are numeric. Additionally, when letters are entered in the inputs, a message indicating that the setting value was successfully updated is returned to the operators, which does not effectively happen.

Therefore, this PR proposes to verify the values that are entered in those input fields. If non-numeric values are inserted, they will be ignored. Furthermore, it is still possible to use special keys, such as `Ctrl` and `Alt`, in order to make use of keyboard shortcuts.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

- Verified that in `Decimal` and `Range` global settings it is only possible to enter digits and the period (`.`) character.
- Verified that in `Number` global settings it is only possible to enter digits.
- Verified that in `Decimal`, `Number` and `Range` global settings it is still possible to make use of keyboard shortcuts with special keys.