### PR TITLE
changed the kubernetestool url

### DIFF
--- a/scripts/util/create-kubernetes-binaries-iso.sh
+++ b/scripts/util/create-kubernetes-binaries-iso.sh
@@ -53,7 +53,7 @@ echo "Downloading Kubernetes tools ${RELEASE}..."
 k8s_dir="${working_dir}/k8s"
 mkdir -p "${k8s_dir}"
 cd "${k8s_dir}"
-curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
 kubeadm_file_permissions=`stat --format '%a' kubeadm`
 chmod +x kubeadm
 


### PR DESCRIPTION
### Description

Currently, if we execute the script (create-kubernetes-binaries-iso.sh) to create the latest CKS iso its fails with the following error

```
+ mkdir -p /tmp/iso//docker
++ /tmp/iso//k8s/kubeadm config images list --kubernetes-version=v1.31.1
/tmp/iso//k8s/kubeadm: line 1: syntax error near unexpected token `<'
/tmp/iso//k8s/kubeadm: line 1: `<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.31.1/bin/linux/amd64/kubeadm</Details></Error>'

```

On investigating found that kubernetes community recommended to use "dl.k8s.io" instead of "storage.googleapis.com/kubernetes-release"

Blog post

https://kubernetes.io/blog/2023/06/09/dl-adopt-cdn/


https://github.com/CircleCI-Public/kubernetes-orb/issues/74

https://github.com/kubernetes/kubernetes/issues/127796


### Types of changes


### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

After making the change the cks iso got created successfully 

```
+ curl -L --remote-name-all https://dl.k8s.io//release/v1.31.1/bin/linux/amd64/kubeadm https://dl.k8s.io//release/v1.31.1/bin/linux/amd64/kubelet https://dl.k8s.io//release/v1.31.1/bin/linux/amd64/kubectl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0    383      0 --:--:-- --:--:-- --:--:--   383
100 55.5M  100 55.5M    0     0  18.2M      0  0:00:03  0:00:03 --:--:-- 22.3M
100   138  100   138    0     0    985      0 --:--:-- --:--:-- --:--:--   985
100 73.3M  100 73.3M    0     0  21.7M      0  0:00:03  0:00:03 --:--:-- 23.1M
100   138  100   138    0     0    985      0 --:--:-- --:--:-- --:--:--   985
100 53.7M  100 53.7M    0     0  5296k      0  0:00:10  0:00:10 --:--:-- 5070k
++ stat --format %a kubeadm

```