### PR TITLE
systemvm-registration: update seeded template_store_ref sizes

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java
@@ -332,7 +332,7 @@ public class SystemVmTemplateRegistration {
         }
     };
 
-    public static boolean validateIfSeeded(String url, String path, String nfsVersion) {
+    public boolean validateIfSeeded(TemplateDataStoreVO templDataStoreVO, String url, String path, String nfsVersion) {
         String filePath = null;
         try {
             filePath = Files.createTempDirectory(TEMPORARY_SECONDARY_STORE).toString();
@@ -345,6 +345,9 @@ public class SystemVmTemplateRegistration {
             String templatePath = filePath + File.separator + partialDirPath;
             File templateProps = new File(templatePath + "/template.properties");
             if (templateProps.exists()) {
+                Pair<Long, Long> templateSizes = readTemplatePropertiesSizes(templatePath + "/template.properties");
+                updateSeededTemplateDetails(templDataStoreVO.getTemplateId(), templDataStoreVO.getDataStoreId(),
+                        templateSizes.first(), templateSizes.second());
                 LOGGER.info("SystemVM template already seeded, skipping registration");
                 return true;
             }
@@ -540,6 +543,21 @@ public class SystemVmTemplateRegistration {
         }
     }
 
+    public void updateSeededTemplateDetails(long templateId, long storeId, long size, long physicalSize) {
+        VMTemplateVO template = vmTemplateDao.findById(templateId);
+        template.setSize(size);
+        vmTemplateDao.update(template.getId(), template);
+
+        TemplateDataStoreVO templateDataStoreVO = templateDataStoreDao.findByStoreTemplate(storeId, template.getId());
+        templateDataStoreVO.setSize(size);
+        templateDataStoreVO.setPhysicalSize(physicalSize);
+        templateDataStoreVO.setLastUpdated(new Date(DateUtil.currentGMTTime().getTime()));
+        boolean updated = templateDataStoreDao.update(templateDataStoreVO.getId(), templateDataStoreVO);
+        if (!updated) {
+            throw new CloudRuntimeException("Failed to update template_store_ref entry for seeded systemVM template");
+        }
+    }
+
     public void updateSystemVMEntries(Long templateId, Hypervisor.HypervisorType hypervisorType) {
         vmInstanceDao.updateSystemVmTemplateId(templateId, hypervisorType);
     }
@@ -553,7 +571,7 @@ public class SystemVmTemplateRegistration {
         }
     }
 
-    private static void readTemplateProperties(String path, SystemVMTemplateDetails details) {
+    private static Pair<Long, Long> readTemplatePropertiesSizes(String path) {
         File tmpFile = new File(path);
         Long size = null;
         Long physicalSize = 0L;
@@ -572,8 +590,13 @@ public class SystemVmTemplateRegistration {
         } catch (IOException ex) {
             LOGGER.warn("Failed to read from template.properties", ex);
         }
-        details.setSize(size);
-        details.setPhysicalSize(physicalSize);
+        return new Pair<>(size, physicalSize);
+    }
+
+    public static void readTemplateProperties(String path, SystemVMTemplateDetails details) {
+        Pair<Long, Long> templateSizes = readTemplatePropertiesSizes(path);
+        details.setSize(templateSizes.first());
+        details.setPhysicalSize(templateSizes.second());
     }
 
     private void updateTemplateTablesOnFailure(long templateId) {
@@ -797,7 +820,7 @@ public class SystemVmTemplateRegistration {
                                         TemplateDataStoreVO templateDataStoreVO = templateDataStoreDao.findByStoreTemplate(storeUrlAndId.second(), templateId);
                                         if (templateDataStoreVO != null) {
                                             String installPath = templateDataStoreVO.getInstallPath();
-                                            if (validateIfSeeded(storeUrlAndId.first(), installPath, nfsVersion)) {
+                                            if (validateIfSeeded(templateDataStoreVO, storeUrlAndId.first(), installPath, nfsVersion)) {
                                                 continue;
                                             }
                                         }

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -3452,8 +3452,8 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                                         templateVO = _templateStoreDao.findByStoreTemplate(store.getId(), templateId);
                                         if (templateVO != null) {
                                             try {
-                                                if (SystemVmTemplateRegistration.validateIfSeeded(
-                                                        url, templateVO.getInstallPath(), nfsVersion)) {
+                                                if (systemVmTemplateRegistration.validateIfSeeded(
+                                                        templateVO, url, templateVO.getInstallPath(), nfsVersion)) {
                                                     continue;
                                                 }
                                             } catch (Exception e) {


### PR DESCRIPTION
### Description

Pre-seeded template storages always had there pre initialized 0 sizes and would never be updated.
This makes later problems, when the primary storage should pre-allocate the volume as it doesn't know the size
and would fail or maybe try to delay the allocation until the agent code knows the size.
This updates the sizes from the template.properties files on the validateIfSeeded check.

The issue was found while reviewing #10132 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Started a fresh KVM cluster with preseeded systemvm template from `cloud-install-sys-tmplt` on Linstor primary storage.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
