### PR TITLE
server: fix pod retrieval during volume attach

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2429,7 +2429,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     protected StoragePool getPoolForAllocatedOrUploadedVolumeForAttach(final VolumeInfo volumeToAttach, final UserVmVO vm) {
         DataCenter zone = _dcDao.findById(vm.getDataCenterId());
         Pair<Long, Long> clusterHostId = virtualMachineManager.findClusterAndHostIdForVm(vm, false);
-        long podId = vm.getPodIdToDeployIn();
+        Long podId = vm.getPodIdToDeployIn();
         if (clusterHostId.first() != null) {
             Cluster cluster = clusterDao.findById(clusterHostId.first());
             podId = cluster.getPodId();

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2426,7 +2426,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         return existingVolumeOfVm;
     }
 
-    protected StoragePool getPoolForAllocatedOrUploadedVolumeForAttach(final VolumeInfo volumeToAttach, final UserVmVO vm) {
+    protected StoragePool getSuitablePoolForAllocatedOrUploadedVolumeForAttach(final VolumeInfo volumeToAttach, final UserVmVO vm) {
         DataCenter zone = _dcDao.findById(vm.getDataCenterId());
         Pair<Long, Long> clusterHostId = virtualMachineManager.findClusterAndHostIdForVm(vm, false);
         Long podId = vm.getPodIdToDeployIn();
@@ -2441,12 +2441,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 offering.isUseLocalStorage(), offering.isRecreatable(),
                 volumeToAttach.getTemplateId());
         diskProfile.setHyperType(vm.getHypervisorType());
-        StoragePool pool = _volumeMgr.findStoragePool(diskProfile, zone, pod, clusterHostId.first(),
+        return _volumeMgr.findStoragePool(diskProfile, zone, pod, clusterHostId.first(),
                 clusterHostId.second(), vm, Collections.emptySet());
-        if (pool == null) {
-            throw new CloudRuntimeException(String.format("Failed to find a primary storage for volume in state: %s", volumeToAttach.getState()));
-        }
-        return pool;
     }
 
     protected VolumeInfo createVolumeOnPrimaryForAttachIfNeeded(final VolumeInfo volumeToAttach, final UserVmVO vm, VolumeVO existingVolumeOfVm) {
@@ -2464,7 +2460,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
         }
         if (destPrimaryStorage == null) {
-            destPrimaryStorage = getPoolForAllocatedOrUploadedVolumeForAttach(volumeToAttach, vm);
+            destPrimaryStorage = getSuitablePoolForAllocatedOrUploadedVolumeForAttach(volumeToAttach, vm);
+            if (destPrimaryStorage == null) {
+                if (Volume.State.Allocated.equals(volumeToAttach.getState()) && State.Stopped.equals(vm.getState())) {
+                    return newVolumeOnPrimaryStorage;
+                }
+                throw new CloudRuntimeException(String.format("Failed to find a primary storage for volume in state: %s", volumeToAttach.getState()));
+            }
         }
         try {
             if (volumeOnSecondary && Storage.StoragePoolType.PowerFlex.equals(destPrimaryStorage.getPoolType())) {


### PR DESCRIPTION
### Description
Includes changes from #10267 as they've been reverted by #10323 

Fixes issue highlighted in https://github.com/apache/cloudstack/pull/9315#issuecomment-2633353671

A volume in Allocated state can be attached to a stopped VM even when the actual volume is not created in the primary store.
`test_12_start_vm_multiple_volumes_allocated` in test/integration/smoke/test_vm_life_cycle.py does the same.
After changes in #10267, a scenario was failing as a suitable pool was not found for an allocated volume when attached to a VM which has never been started

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

Verified test_vm_life_cycle.py with changes,

```
[root@pr9315-t7075-kvm-rocky8-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr9315-t7075-kvm-rocky8-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_vm_life_cycle.py 
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Feb_05_2025_08_29_31_XD4RCY All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_advZoneVirtualRouter | Status : SUCCESS ===

=== TestName: test_deploy_vm | Status : SUCCESS ===

=== TestName: test_deploy_vm_multiple | Status : SUCCESS ===

=== TestName: test_01_migrate_VM_and_root_volume | Status : SUCCESS ===

=== TestName: test_02_migrate_VM_with_two_data_disks | Status : SUCCESS ===

Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
====Trying SSH Connection: Host:10.1.35.116 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.35.116 port : 22 SUCCESSFUL===
{Cmd: grep -a listen_tls=1 /etc/libvirt/libvirtd.conf | tail -1 via Host: 10.1.35.116} {returns: ['listen_tls=1']}
Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
=== TestName: test_01_secure_vm_migration | Status : SUCCESS ===

Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
====Trying SSH Connection: Host:10.1.35.116 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.35.116 port : 22 SUCCESSFUL===
{Cmd: rm -f /etc/cloudstack/agent/cloud* &&                       service cloudstack-agent stop ;                       service libvirtd stop ;                       service libvirt-bin stop ;                       sed -i 's/listen_tls.*/listen_tls=0/g' /etc/libvirt/libvirtd.conf &&                       sed -i 's/listen_tcp.*/listen_tcp=1/g' /etc/libvirt/libvirtd.conf &&                       sed -i '/.*_file=.*/d' /etc/libvirt/libvirtd.conf &&                       sed -i 's/vnc_tls.*/vnc_tls=0/g' /etc/libvirt/qemu.conf &&                       service libvirtd start ;                       service libvirt-bin start ;                       sleep 30 ;                       service cloudstack-agent start via Host: 10.1.35.116} {returns: ['Redirecting to /bin/systemctl stop cloudstack-agent.service', 'Redirecting to /bin/systemctl stop libvirtd.service', 'Redirecting to /bin/systemctl stop libvirt-bin.service', 'Failed to stop libvirt-bin.service: Unit libvirt-bin.service not loaded.', 'Redirecting to /bin/systemctl start libvirtd.service', 'Redirecting to /bin/systemctl start libvirt-bin.service', 'Failed to start libvirt-bin.service: Unit libvirt-bin.service not found.', 'Redirecting to /bin/systemctl start cloudstack-agent.service']}
Unsecuring Host: pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
====Trying SSH Connection: Host:10.1.34.196 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.34.196 port : 22 SUCCESSFUL===
{Cmd: rm -f /etc/cloudstack/agent/cloud* &&                       service cloudstack-agent stop ;                       service libvirtd stop ;                       service libvirt-bin stop ;                       sed -i 's/listen_tls.*/listen_tls=0/g' /etc/libvirt/libvirtd.conf &&                       sed -i 's/listen_tcp.*/listen_tcp=1/g' /etc/libvirt/libvirtd.conf &&                       sed -i '/.*_file=.*/d' /etc/libvirt/libvirtd.conf &&                       sed -i 's/vnc_tls.*/vnc_tls=0/g' /etc/libvirt/qemu.conf &&                       service libvirtd start ;                       service libvirt-bin start ;                       sleep 30 ;                       service cloudstack-agent start via Host: 10.1.34.196} {returns: ['Redirecting to /bin/systemctl stop cloudstack-agent.service', 'Redirecting to /bin/systemctl stop libvirtd.service', 'Redirecting to /bin/systemctl stop libvirt-bin.service', 'Failed to stop libvirt-bin.service: Unit libvirt-bin.service not loaded.', 'Redirecting to /bin/systemctl start libvirtd.service', 'Redirecting to /bin/systemctl start libvirt-bin.service', 'Failed to start libvirt-bin.service: Unit libvirt-bin.service not found.', 'Redirecting to /bin/systemctl start cloudstack-agent.service']}
Unsecuring Host: pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
====Trying SSH Connection: Host:10.1.35.116 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.35.116 port : 22 SUCCESSFUL===
{Cmd: grep -a listen_tcp=1 /etc/libvirt/libvirtd.conf | tail -1 via Host: 10.1.35.116} {returns: ['listen_tcp=1']}
Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
=== TestName: test_02_unsecure_vm_migration | Status : SUCCESS ===

Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
====Trying SSH Connection: Host:10.1.35.116 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.35.116 port : 22 SUCCESSFUL===
{Cmd: rm -f /etc/cloudstack/agent/cloud* &&                       service cloudstack-agent stop ;                       service libvirtd stop ;                       service libvirt-bin stop ;                       sed -i 's/listen_tls.*/listen_tls=0/g' /etc/libvirt/libvirtd.conf &&                       sed -i 's/listen_tcp.*/listen_tcp=1/g' /etc/libvirt/libvirtd.conf &&                       sed -i '/.*_file=.*/d' /etc/libvirt/libvirtd.conf &&                       sed -i 's/vnc_tls.*/vnc_tls=0/g' /etc/libvirt/qemu.conf &&                       service libvirtd start ;                       service libvirt-bin start ;                       sleep 30 ;                       service cloudstack-agent start via Host: 10.1.35.116} {returns: ['Redirecting to /bin/systemctl stop cloudstack-agent.service', 'Redirecting to /bin/systemctl stop libvirtd.service', 'Redirecting to /bin/systemctl stop libvirt-bin.service', 'Failed to stop libvirt-bin.service: Unit libvirt-bin.service not loaded.', 'Redirecting to /bin/systemctl start libvirtd.service', 'Redirecting to /bin/systemctl start libvirt-bin.service', 'Failed to start libvirt-bin.service: Unit libvirt-bin.service not found.', 'Redirecting to /bin/systemctl start cloudstack-agent.service']}
Unsecuring Host: pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
====Trying SSH Connection: Host:10.1.34.196 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.34.196 port : 22 SUCCESSFUL===
{Cmd: grep -a listen_tls=1 /etc/libvirt/libvirtd.conf | tail -1 via Host: 10.1.34.196} {returns: ['listen_tls=1']}
Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
=== TestName: test_03_secured_to_nonsecured_vm_migration | Status : SUCCESS ===

Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
====Trying SSH Connection: Host:10.1.35.116 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.35.116 port : 22 SUCCESSFUL===
{Cmd: rm -f /etc/cloudstack/agent/cloud* &&                       service cloudstack-agent stop ;                       service libvirtd stop ;                       service libvirt-bin stop ;                       sed -i 's/listen_tls.*/listen_tls=0/g' /etc/libvirt/libvirtd.conf &&                       sed -i 's/listen_tcp.*/listen_tcp=1/g' /etc/libvirt/libvirtd.conf &&                       sed -i '/.*_file=.*/d' /etc/libvirt/libvirtd.conf &&                       sed -i 's/vnc_tls.*/vnc_tls=0/g' /etc/libvirt/qemu.conf &&                       service libvirtd start ;                       service libvirt-bin start ;                       sleep 30 ;                       service cloudstack-agent start via Host: 10.1.35.116} {returns: ['Redirecting to /bin/systemctl stop cloudstack-agent.service', 'Redirecting to /bin/systemctl stop libvirtd.service', 'Redirecting to /bin/systemctl stop libvirt-bin.service', 'Failed to stop libvirt-bin.service: Unit libvirt-bin.service not loaded.', 'Redirecting to /bin/systemctl start libvirtd.service', 'Redirecting to /bin/systemctl start libvirt-bin.service', 'Failed to start libvirt-bin.service: Unit libvirt-bin.service not found.', 'Redirecting to /bin/systemctl start cloudstack-agent.service']}
Unsecuring Host: pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
====Trying SSH Connection: Host:10.1.35.116 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.1.35.116 port : 22 SUCCESSFUL===
{Cmd: grep -a listen_tcp=1 /etc/libvirt/libvirtd.conf | tail -1 via Host: 10.1.35.116} {returns: ['listen_tcp=1']}
Securing Host pr9315-t7075-kvm-rocky8-kvm1
Host 9ba61cf4-a8a2-4ad7-afe7-f421a58ce2dd now showing as Up
Securing Host pr9315-t7075-kvm-rocky8-kvm2
Host 82c7aff5-ead2-4576-ba98-bfc4cdd81f8b now showing as Up
=== TestName: test_04_nonsecured_to_secured_vm_migration | Status : SUCCESS ===

=== TestName: test_01_stop_vm | Status : SUCCESS ===

=== TestName: test_01_stop_vm_forced | Status : SUCCESS ===

=== TestName: test_02_start_vm | Status : SUCCESS ===

=== TestName: test_03_reboot_vm | Status : SUCCESS ===

=== TestName: test_04_reboot_vm_forced | Status : SUCCESS ===

=== TestName: test_06_destroy_vm | Status : SUCCESS ===

=== TestName: test_07_restore_vm | Status : SUCCESS ===

=== TestName: test_08_migrate_vm | Status : SUCCESS ===

=== TestName: test_09_expunge_vm | Status : SUCCESS ===

====Trying SSH Connection: Host:10.1.53.86 User:root                                   Port:22 RetryCnt:20===
===SSH to Host 10.1.53.86 port : 22 SUCCESSFUL===
{Cmd: mkdir -p /mnt/tmp via Host: 10.1.53.86} {returns: []}
{Cmd: mount -rt iso9660 /dev/vdc /mnt/tmp via Host: 10.1.53.86} {returns: ['mount: special device /dev/vdc does not exist']}
{Cmd: mount -rt iso9660 /dev/vdb /mnt/tmp via Host: 10.1.53.86} {returns: ['mount: special device /dev/vdb does not exist']}
{Cmd: mount -rt iso9660 /dev/hdb /mnt/tmp via Host: 10.1.53.86} {returns: ['mount: special device /dev/hdb does not exist']}
{Cmd: mount -rt iso9660 /dev/hdc /mnt/tmp via Host: 10.1.53.86} {returns: []}
{Cmd: mount |grep /dev/hdc|head -1 via Host: 10.1.53.86} {returns: ['/dev/hdc on /mnt/tmp type iso9660 (ro)']}
{Cmd: du /dev/hdc | tail -1 via Host: 10.1.53.86} {returns: ['0\t/dev/hdc']}
{Cmd: umount /mnt/tmp via Host: 10.1.53.86} {returns: []}
{Cmd: mount |grep /dev/hdc|head -1 via Host: 10.1.53.86} {returns: []}
=== TestName: test_10_attachAndDetach_iso | Status : SUCCESS ===

=== TestName: test_11_destroy_vm_and_volumes | Status : SUCCESS ===

=== TestName: test_12_start_vm_multiple_volumes_allocated | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_vm_life_cycle_HAM8FF ===
[root@pr9315-t7075-kvm-rocky8-marvin marvin]# cat /marvin//MarvinLogs/test_vm_life_cycle_HAM8FF/results.txt 
Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test VM will be migrated with it's root volume ... === TestName: test_01_migrate_VM_and_root_volume | Status : SUCCESS ===
ok
Test VM will be migrated with it's root volume ... === TestName: test_02_migrate_VM_with_two_data_disks | Status : SUCCESS ===
ok
Test VM will be migrated with it's root volume ... SKIP: VM Migration with Volumes is not supported on other than VMware
Test VM will be migrated with it's root volume ... SKIP: VM Migration with Volumes is not supported on other than VMware
Test VM will be migrated with it's root volume ... SKIP: VM Migration with Volumes is not supported on other than VMware
Test VM will be migrated with it's root volume ... SKIP: VM Migration with Volumes is not supported on other than VMware
Test secure VM migration ... === TestName: test_01_secure_vm_migration | Status : SUCCESS ===
ok
Test Non-secured VM Migration ... === TestName: test_02_unsecure_vm_migration | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_03_secured_to_nonsecured_vm_migration | Status : SUCCESS ===
ok
Test Non-secured VM Migration ... === TestName: test_04_nonsecured_to_secured_vm_migration | Status : SUCCESS ===
ok
Test the following for all found ovf templates: ... SKIP: Skipping test: Reason -  hypervisorNotSupported
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Force Stop Virtual Machine ... === TestName: test_01_stop_vm_forced | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test Force Reboot Virtual Machine ... === TestName: test_04_reboot_vm_forced | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... === TestName: test_08_migrate_vm | Status : SUCCESS ===
ok
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok
Test for attach and detach ISO to virtual machine ... === TestName: test_10_attachAndDetach_iso | Status : SUCCESS ===
ok
Test destroy Virtual Machine and it's volumes ... === TestName: test_11_destroy_vm_and_volumes | Status : SUCCESS ===
ok
Test attaching multiple datadisks and start VM ... === TestName: test_12_start_vm_multiple_volumes_allocated | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 26 tests in 1770.170s

OK (SKIP=5)
```

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
