### PR TITLE
Add API command remove management server

### DIFF
--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -796,6 +796,9 @@ public class EventTypes {
     // Resource Limit
     public static final String EVENT_RESOURCE_LIMIT_UPDATE = "RESOURCE.LIMIT.UPDATE";
 
+    // Management Server
+    public static final String EVENT_MANAGEMENT_SERVER_REMOVE = "MANAGEMENT.SERVER.REMOVE";
+
     public static final String VM_LEASE_EXPIRED = "VM.LEASE.EXPIRED";
     public static final String VM_LEASE_DISABLED = "VM.LEASE.DISABLED";
     public static final String VM_LEASE_CANCELLED = "VM.LEASE.CANCELLED";
@@ -1295,6 +1298,9 @@ public class EventTypes {
         entityEventDetails.put(EVENT_SHAREDFS_DESTROY, SharedFS.class);
         entityEventDetails.put(EVENT_SHAREDFS_EXPUNGE, SharedFS.class);
         entityEventDetails.put(EVENT_SHAREDFS_RECOVER, SharedFS.class);
+
+        // Management Server
+        entityEventDetails.put(EVENT_MANAGEMENT_SERVER_REMOVE, "ManagementServer");
 
         // VM Lease
         entityEventDetails.put(VM_LEASE_EXPIRED, VirtualMachine.class);

--- a/api/src/main/java/com/cloud/server/ManagementService.java
+++ b/api/src/main/java/com/cloud/server/ManagementService.java
@@ -35,6 +35,7 @@ import org.apache.cloudstack.api.command.admin.guest.UpdateGuestOsCmd;
 import org.apache.cloudstack.api.command.admin.guest.UpdateGuestOsMappingCmd;
 import org.apache.cloudstack.api.command.admin.host.ListHostsCmd;
 import org.apache.cloudstack.api.command.admin.host.UpdateHostPasswordCmd;
+import org.apache.cloudstack.api.command.admin.management.RemoveMgmtCmd;
 import org.apache.cloudstack.api.command.admin.pod.ListPodsByCmd;
 import org.apache.cloudstack.api.command.admin.resource.ArchiveAlertsCmd;
 import org.apache.cloudstack.api.command.admin.resource.DeleteAlertsCmd;
@@ -480,5 +481,7 @@ public interface ManagementService {
     void cleanupVMReservations();
 
     Pair<Boolean, String> patchSystemVM(PatchSystemVMCmd cmd);
+
+    boolean removeManagementServer(RemoveMgmtCmd cmd);
 
 }

--- a/api/src/main/java/com/cloud/server/ManagementService.java
+++ b/api/src/main/java/com/cloud/server/ManagementService.java
@@ -35,7 +35,7 @@ import org.apache.cloudstack.api.command.admin.guest.UpdateGuestOsCmd;
 import org.apache.cloudstack.api.command.admin.guest.UpdateGuestOsMappingCmd;
 import org.apache.cloudstack.api.command.admin.host.ListHostsCmd;
 import org.apache.cloudstack.api.command.admin.host.UpdateHostPasswordCmd;
-import org.apache.cloudstack.api.command.admin.management.RemoveMgmtCmd;
+import org.apache.cloudstack.api.command.admin.management.RemoveManagementServerCmd;
 import org.apache.cloudstack.api.command.admin.pod.ListPodsByCmd;
 import org.apache.cloudstack.api.command.admin.resource.ArchiveAlertsCmd;
 import org.apache.cloudstack.api.command.admin.resource.DeleteAlertsCmd;
@@ -482,6 +482,6 @@ public interface ManagementService {
 
     Pair<Boolean, String> patchSystemVM(PatchSystemVMCmd cmd);
 
-    boolean removeManagementServer(RemoveMgmtCmd cmd);
+    boolean removeManagementServer(RemoveManagementServerCmd cmd);
 
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
@@ -36,7 +36,7 @@ import com.cloud.exception.ResourceUnavailableException;
 
 @APICommand(name = "removeManagementServer", description = "Removes a Management Server.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = RoleType.Admin)
-public class RemoveMgmtCmd extends BaseCmd {
+public class RemoveManagementServerCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = ManagementServerResponse.class, required = true, description = "the ID of the Management Server")
     private Long id;

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
@@ -28,12 +28,6 @@ import org.apache.cloudstack.api.response.ManagementServerResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.context.CallContext;
 
-import com.cloud.exception.ConcurrentOperationException;
-import com.cloud.exception.NetworkRuleConflictException;
-import com.cloud.exception.InsufficientCapacityException;
-import com.cloud.exception.ResourceAllocationException;
-import com.cloud.exception.ResourceUnavailableException;
-
 @APICommand(name = "removeManagementServer", description = "Removes a Management Server.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = RoleType.Admin)
 public class RemoveManagementServerCmd extends BaseCmd {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
@@ -52,7 +52,7 @@ public class RemoveManagementServerCmd extends BaseCmd {
             SuccessResponse response = new SuccessResponse(getCommandName());
             this.setResponseObject(response);
         } else {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove Management Server");
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove Management Server.");
         }
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveManagementServerCmd.java
@@ -46,7 +46,7 @@ public class RemoveManagementServerCmd extends BaseCmd {
     }
 
     @Override
-    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+    public void execute() {
         boolean result = _mgr.removeManagementServer(this);
         if (result) {
             SuccessResponse response = new SuccessResponse(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveMgmtCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveMgmtCmd.java
@@ -34,11 +34,11 @@ import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 
-@APICommand(name = "removeManagementServer", description = "Removes a management server.", responseObject = SuccessResponse.class,
+@APICommand(name = "removeManagementServer", description = "Removes a Management Server.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = RoleType.Admin)
 public class RemoveMgmtCmd extends BaseCmd {
 
-    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = ManagementServerResponse.class, required = true, description = "the id of the management server")
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = ManagementServerResponse.class, required = true, description = "the ID of the Management Server")
     private Long id;
 
     public Long getId() {
@@ -52,7 +52,7 @@ public class RemoveMgmtCmd extends BaseCmd {
             SuccessResponse response = new SuccessResponse(getCommandName());
             this.setResponseObject(response);
         } else {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove management server");
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove Management Server");
         }
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveMgmtCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/RemoveMgmtCmd.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.management;
+
+import com.cloud.event.EventTypes;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.response.ManagementServerResponse;
+import org.apache.cloudstack.api.response.SuccessResponse;
+import org.apache.cloudstack.context.CallContext;
+
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+
+@APICommand(name = "removeManagementServer", description = "Removes a management server.", responseObject = SuccessResponse.class,
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = RoleType.Admin)
+public class RemoveMgmtCmd extends BaseCmd {
+
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = ManagementServerResponse.class, required = true, description = "the id of the management server")
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        boolean result = _mgr.removeManagementServer(this);
+        if (result) {
+            SuccessResponse response = new SuccessResponse(getCommandName());
+            this.setResponseObject(response);
+        } else {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove management server");
+        }
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return CallContext.current().getCallingAccountId();
+    }
+
+    public String getEventType() {
+        return EventTypes.EVENT_MANAGEMENT_SERVER_REMOVE;
+    }
+}

--- a/server/src/main/java/com/cloud/api/query/vo/ManagementServerJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/ManagementServerJoinVO.java
@@ -170,4 +170,8 @@ public class ManagementServerJoinVO {
     public String getJavaVersion() {
         return javaVersion;
     }
+
+    public void setRemoved(Date removedDate) {
+        removed = removedDate;
+    }
 }

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -5567,11 +5567,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         ManagementServerJoinVO managementServer = managementServerJoinDao.findById(id);
 
         if (managementServer == null) {
-            throw new InvalidParameterValueException(String.format("Unable to find a Management Server with ID equal to [%s]", managementServer.getUuid()));
+            throw new InvalidParameterValueException(String.format("Unable to find a Management Server with ID equal to [%s].", managementServer.getUuid()));
         }
 
         if (!ManagementServerHost.State.Down.equals(managementServer.getState())) {
-            throw new InvalidParameterValueException(String.format("Unable to remove Management Server with ID [%s]. It can only be removed when it is in the [%s] state, however currently it is in the [%s] state", managementServer.getUuid(), ManagementServerHost.State.Down.name(), managementServer.getState().name()));
+            throw new InvalidParameterValueException(String.format("Unable to remove Management Server with ID [%s]. It can only be removed when it is in the [%s] state, however currently it is in the [%s] state.", managementServer.getUuid(), ManagementServerHost.State.Down.name(), managementServer.getState().name()));
         }
 
         managementServer.setRemoved(new Date());

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -127,7 +127,7 @@ import org.apache.cloudstack.api.command.admin.iso.ListIsosCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.iso.RegisterIsoCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.loadbalancer.ListLoadBalancerRuleInstancesCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.management.ListMgmtsCmd;
-import org.apache.cloudstack.api.command.admin.management.RemoveMgmtCmd;
+import org.apache.cloudstack.api.command.admin.management.RemoveManagementServerCmd;
 import org.apache.cloudstack.api.command.admin.network.AddNetworkDeviceCmd;
 import org.apache.cloudstack.api.command.admin.network.AddNetworkServiceProviderCmd;
 import org.apache.cloudstack.api.command.admin.network.CreateManagementNetworkIpRangeCmd;
@@ -1020,7 +1020,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     @Inject
     StoragePoolTagsDao storagePoolTagsDao;
     @Inject
-    protected ManagementServerJoinDao _managementServerJoinDao;
+    protected ManagementServerJoinDao managementServerJoinDao;
 
     @Inject
     private PublicIpQuarantineDao publicIpQuarantineDao;
@@ -4047,7 +4047,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(ListTemplateDirectDownloadCertificatesCmd.class);
         cmdList.add(ProvisionTemplateDirectDownloadCertificateCmd.class);
         cmdList.add(ListMgmtsCmd.class);
-        cmdList.add(RemoveMgmtCmd.class);
+        cmdList.add(RemoveManagementServerCmd.class);
         cmdList.add(GetUploadParamsForIsoCmd.class);
         cmdList.add(GetRouterHealthCheckResultsCmd.class);
         cmdList.add(StartRollingMaintenanceCmd.class);
@@ -5562,20 +5562,20 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     @Override
     @DB
     @ActionEvent(eventType = EventTypes.EVENT_MANAGEMENT_SERVER_REMOVE, eventDescription = "removing Management Server")
-    public boolean removeManagementServer(RemoveMgmtCmd cmd) {
+    public boolean removeManagementServer(RemoveManagementServerCmd cmd) {
         final Long id = cmd.getId();
-        ManagementServerJoinVO managementServer = _managementServerJoinDao.findById(id);
+        ManagementServerJoinVO managementServer = managementServerJoinDao.findById(id);
 
         if (managementServer == null) {
             throw new InvalidParameterValueException(String.format("Unable to find a Management Server with ID equal to [%s]", managementServer.getUuid()));
         }
 
-        if (ManagementServerHost.State.Up.equals(managementServer.getState())) {
+        if (!ManagementServerHost.State.Down.equals(managementServer.getState())) {
             throw new InvalidParameterValueException(String.format("Unable to remove Management Server with ID [%s]. It can only be removed when it is in the [%s] state, however currently it is in the [%s] state", managementServer.getUuid(), ManagementServerHost.State.Down.name(), ManagementServerHost.State.Up.name()));
         }
 
         managementServer.setRemoved(new Date());
-        return _managementServerJoinDao.update(id, managementServer);
+        return managementServerJoinDao.update(id, managementServer);
 
     }
 

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -5561,17 +5561,17 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     @DB
-    @ActionEvent(eventType = EventTypes.EVENT_MANAGEMENT_SERVER_REMOVE, eventDescription = "removing management server")
+    @ActionEvent(eventType = EventTypes.EVENT_MANAGEMENT_SERVER_REMOVE, eventDescription = "removing Management Server")
     public boolean removeManagementServer(RemoveMgmtCmd cmd) {
         final Long id = cmd.getId();
         ManagementServerJoinVO managementServer = _managementServerJoinDao.findById(id);
 
         if (managementServer == null) {
-            throw new InvalidParameterValueException(String.format("Unable to find the management server for specified id [%s]", managementServer.getUuid()));
+            throw new InvalidParameterValueException(String.format("Unable to find a Management Server with ID equal to [%s]", managementServer.getUuid()));
         }
 
         if (ManagementServerHost.State.Up.equals(managementServer.getState())) {
-            throw new InvalidParameterValueException(String.format("Unable to remove management server [%s], it is not in the right state, it can only be removed when state is [%s]", managementServer.getUuid(), ManagementServerHost.State.Down.name()));
+            throw new InvalidParameterValueException(String.format("Unable to remove Management Server with ID [%s]. It can only be removed when it is in the [%s] state, however currently it is in the [%s] state", managementServer.getUuid(), ManagementServerHost.State.Down.name(), ManagementServerHost.State.Up.name()));
         }
 
         managementServer.setRemoved(new Date());

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -5571,7 +5571,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if (!ManagementServerHost.State.Down.equals(managementServer.getState())) {
-            throw new InvalidParameterValueException(String.format("Unable to remove Management Server with ID [%s]. It can only be removed when it is in the [%s] state, however currently it is in the [%s] state", managementServer.getUuid(), ManagementServerHost.State.Down.name(), ManagementServerHost.State.Up.name()));
+            throw new InvalidParameterValueException(String.format("Unable to remove Management Server with ID [%s]. It can only be removed when it is in the [%s] state, however currently it is in the [%s] state", managementServer.getUuid(), ManagementServerHost.State.Down.name(), managementServer.getState().name()));
         }
 
         managementServer.setRemoved(new Date());


### PR DESCRIPTION
### Description

This PR adds a command to mark a Management Server as removed on the database only if its status is marked as `Down`. To execute the command, it is obligatory to inform the `id` of the targeted MS.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

In a local lab, I added an MS through the database.

- With State="Down" I executed through CMK `remove managementserver id=<uuid>` and verified that the MS wasn't being listed on the UI and was marked as `Removed` on the database.
- With State="Up" I executed the same command and verified an error was returned informing it wasn't possible to remove an MS which state was marked as "Up".
- With State="Down" I executed through a URL `http://<IP>:8080/client/api?command=removeManagementServer&response=json&id=<UUID>` and verified the MS was marked as removed and wasn't being listed on the UI.
- With State="Up" I executed the same URL and received an error informing it wasn't possible to remove an MS which state was marked as "Up".
- Trying to execute the command with a non-existent _id_ returns an error warning the request format may be invalid, the entity may not exist, or the parameter annotation may be wrong.
- Trying to execute the command without an _id_, both in CMK and with a URL, returns an error informing the _id_ parameter is obligatory and it is missing.