### PR TITLE
Make isAccountAllowedToCreateOfferingsWithTags API id parameter required

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/IsAccountAllowedToCreateOfferingsWithTagsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/IsAccountAllowedToCreateOfferingsWithTagsCmd.java
@@ -29,7 +29,7 @@ import org.apache.cloudstack.api.response.IsAccountAllowedToCreateOfferingsWithT
         responseObject = IsAccountAllowedToCreateOfferingsWithTagsResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class IsAccountAllowedToCreateOfferingsWithTagsCmd extends BaseCmd {
 
-    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = AccountResponse.class, description = "Account UUID")
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = AccountResponse.class, description = "Account UUID", required = true)
     private Long id;
 
     @Override


### PR DESCRIPTION
### Description

This PR makes the `id` parameter from `isAccountAllowedToCreateOfferingsWithTags` api required to prevent a NullPointerException when trying to execute the command without an `id`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### How Has This Been Tested?

I've created a test environment with a CloudStack setup. When I tried to execute the command without the `id` parameter, the following exception was thrown:

```
2025-02-03 15:00:11,909 ERROR [c.c.a.ApiServer] (qtp1507118393-20:[ctx-de956cc8, ctx-37d7a594]) (logid:5e002cf6) unhandled exception executing api command: [Ljava.lang.String;@588ef940 java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.cloudstack.api.command.admin.offering.IsAccountAllowedToCreateOfferingsWithTagsCmd.getId()" is null
	at com.cloud.configuration.ConfigurationManagerImpl.isAccountAllowedToCreateOfferingsWithTags(ConfigurationManagerImpl.java:8076)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at jdk.proxy3/jdk.proxy3.$Proxy149.isAccountAllowedToCreateOfferingsWithTags(Unknown Source)
	at org.apache.cloudstack.api.command.admin.offering.IsAccountAllowedToCreateOfferingsWithTagsCmd.execute(IsAccountAllowedToCreateOfferingsWithTagsCmd.java:37)
```

Then I built and applied the updated packages to my environment. After that, I tried to force the same error to ensure my fix was working. The response shown was now the message: `Missing required parameters:  id`