### PR TITLE
UI: Add VM state to Volume list view

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2444,7 +2444,7 @@
 "label.users": "Users",
 "label.usersource": "User type",
 "label.using.cli": "Using CLI",
-"label.utilization": "Utilisation",
+"label.utilization": "Utilization",
 "label.uuid": "ID",
 "label.value": "Value",
 "label.vcenter": "VMware datacenter vCenter",

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -256,6 +256,9 @@
       <template v-if="column.key === 'quotastate'">
         <status :text="text ? text : ''" displayText />
       </template>
+      <template v-if="column.key === 'vmstate'">
+        <status :text="text ? text : ''" displayText vmState/>
+      </template>
       <template v-if="column.key === 'vlan'">
         <a href="javascript:;">
           <router-link v-if="$route.path === '/guestvlans'" :to="{ path: '/guestvlans/' + record.id }">{{ text }}</router-link>

--- a/ui/src/components/widgets/Status.vue
+++ b/ui/src/components/widgets/Status.vue
@@ -44,6 +44,10 @@ export default {
     styles: {
       type: Object,
       default: () => {}
+    },
+    vmState: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {
@@ -182,7 +186,11 @@ export default {
       } else if (this.$route.path === '/vm' || this.$route.path.includes('/vm/')) {
         result = this.$t('message.vm.state.' + state.toLowerCase())
       } else if (this.$route.path === '/volume' || this.$route.path.includes('/volume/')) {
-        result = this.$t('message.volume.state.' + state.toLowerCase())
+        if (this.vmState) {
+          result = this.$t('message.vm.state.' + state.toLowerCase())
+        } else {
+          result = this.$t('message.volume.state.' + state.toLowerCase())
+        }
       } else if (this.$route.path === '/guestnetwork' || this.$route.path.includes('/guestnetwork/')) {
         result = this.$t('message.guestnetwork.state.' + state.toLowerCase())
       } else if (this.$route.path === '/publicip' || this.$route.path.includes('/publicip/')) {

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -38,7 +38,7 @@ export default {
         }
       },
       columns: () => {
-        const fields = ['name', 'state', 'type', 'vmname', 'vmstate', 'sizegb']
+        const fields = ['name', 'state', 'sizegb', 'type', 'vmname', 'vmstate']
         const metricsFields = ['diskkbsread', 'diskkbswrite', 'diskiopstotal']
 
         if (store.getters.userInfo.roletype === 'Admin') {

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -38,7 +38,7 @@ export default {
         }
       },
       columns: () => {
-        const fields = ['name', 'state', 'sizegb', 'type', 'vmname']
+        const fields = ['name', 'state', 'type', 'vmname', 'vmstate', 'sizegb']
         const metricsFields = ['diskkbsread', 'diskkbswrite', 'diskiopstotal']
 
         if (store.getters.userInfo.roletype === 'Admin') {


### PR DESCRIPTION
### Description

This PR adds a new column to the volume list view that shows the state of the VM the volume is attached to.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

![Screenshot from 2025-02-05 17-14-35](https://github.com/user-attachments/assets/a5c121a9-e098-40d4-a4b7-71c894a1ccb1)


### How Has This Been Tested?

In a local environment, I attached a volume to a VM and changed the VM state multiple times. As expected, the current state of the VM was shown in the volume list view.