### PR TITLE
UI: Fixes and minor enhacements to the Public IP Addresses section

### DIFF
--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -149,6 +149,10 @@
           &nbsp;
           <a-tag>static-nat</a-tag>
         </span>
+        <span v-if="record.issystem">
+          &nbsp;
+          <a-tag>system</a-tag>
+        </span>
       </template>
       <template v-if="column.key === 'ip6address'" href="javascript:;">
         <span>{{ ipV6Address(text, record) }}</span>
@@ -378,8 +382,8 @@
         <status :text="record.enabled ? record.enabled.toString() : 'false'" />
         {{ record.enabled ? 'Enabled' : 'Disabled' }}
       </template>
-      <template v-if="['created', 'sent'].includes(column.key)">
-        {{ $toLocaleDate(text) }}
+      <template v-if="['created', 'sent', 'allocated'].includes(column.key)">
+        {{ text && $toLocaleDate(text) }}
       </template>
       <template v-if="['startdate', 'enddate'].includes(column.key) && ['vm', 'vnfapp'].includes($route.path.split('/')[1])">
         {{ getDateAtTimeZone(text, record.timezone) }}

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -840,10 +840,13 @@ export default {
           message: 'message.action.release.ip',
           docHelp: 'adminguide/networking_and_traffic.html#releasing-an-ip-address-alloted-to-a-vpc',
           dataView: true,
-          show: (record) => { return record.state === 'Allocated' && !record.issourcenat },
+          show: (record) => { return record.state === 'Allocated' && !record.issourcenat && !record.issystem },
           groupAction: true,
           popup: true,
-          groupMap: (selection) => { return selection.map(x => { return { id: x } }) }
+          groupMap: (selection) => { return selection.map(x => { return { id: x } }) },
+          groupShow: (selectedIps) => {
+            return selectedIps.every((ip) => ip.state === 'Allocated' && !ip.issourcenat && !ip.issystem)
+          }
         },
         {
           api: 'reserveIpAddress',
@@ -863,7 +866,10 @@ export default {
           show: (record) => { return record.state === 'Reserved' },
           groupAction: true,
           popup: true,
-          groupMap: (selection) => { return selection.map(x => { return { id: x } }) }
+          groupMap: (selection) => { return selection.map(x => { return { id: x } }) },
+          groupShow: (selectedIps) => {
+            return selectedIps.every((ip) => ip.state === 'Reserved')
+          }
         }
       ]
     },


### PR DESCRIPTION
### Description

In the Public IP Addresses UI section, the options to release reserved IPs (`releaseIpAddress` API) and disassociate IPs (`disassociateIpAddress` API) are always available through group actions, regardless of the public IP's state. Additionally, the option to disassociate IPs is available for IPs in use by system VMs, both through group actions and `dataView`.

This PR fixes these UI bugs. Furthermore, a label, similar to the existing ones for `source-nat` and `static-nat`, was created to indicate that a public IP is in use by a system VM. Lastly, the `allocated` column in the `ListView`, that represents the datetime an IP was allocated, is now parsed and formatted according to the user's timezone.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

- `disassociateIpAddress` through group actions:
    ![image](https://github.com/user-attachments/assets/4c21ae4f-adb6-4a30-a11a-45ab2e4679ab)
- `releaseIpAddress` through group actions:
    ![image](https://github.com/user-attachments/assets/72453b27-2e26-4742-9708-7741a49c6c72)

### How Has This Been Tested?

- Created a VPC (`vpc-01`) and acquired two additional public IPs;
- Accessed the Public IP Addresses UI section and verified that the public IPs in use by the system VMs were marked with the `system` tag;
- Verified that the `allocated` datetime was correctly parsed and formatted according to the timezone in use;
- Verified that:
    - the options to disassociate and release `system` IPs were not available through group actions or `dataView`;
    - the options to disassociate and release `source-nat` IPs were not available through group actions or `dataView`;
    - the option to disassociate an allocated IP was available through group actions;
    - the option to release IP addresses was available for `Reserved` IPs.