### PR TITLE
Added project id to kubeadmin user for Kubernetes service

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -1384,7 +1384,15 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         if (owner == null || owner.getType() == Account.Type.PROJECT) {
             owner = CallContext.current().getCallingAccount();
         }
-        String username = owner.getAccountName() + "-" + KUBEADMIN_ACCOUNT_NAME;
+        
+        String projectId = "default";
+        Account account = ApiDBUtils.findAccountById(kubernetesCluster.getAccountId());
+        Project project = ApiDBUtils.findProjectByProjectAccountId(account.getId());
+        if ( project != null ) {
+          projectId = project.getUuid();
+        }
+
+        String username = owner.getAccountName() + "-" + projectId + "-" + KUBEADMIN_ACCOUNT_NAME;
         UserAccount kubeadmin = accountService.getActiveUserAccount(username, owner.getDomainId());
         String[] keys = null;
         if (kubeadmin == null) {


### PR DESCRIPTION
### Description

When Kubernetes cluster is created, a kubeadmin user is created without projectId. The cloudstack-secret created on the Kubernetes cluster can be used by all users with the same account. That could pose security issue with sharing api-key and secret-key. This PR added projectId to the kubeadmin user so that the api-key and secret-key will only be shared within the project.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Created a Kubernetes cluster with the modified code. Made sure the kubeadmin user has the projectId included. Also checked cloudstack-secret on the Kubernetes cluster to make sure project id is part of the cloudstack-secret with api-key and secret-key.

#### How did you try to break this feature and the system with this change?
Without the change, the kubeadmin user can access resources from the account level. With this change, this kubeadmin user can only manage resources for that project.
