### PR TITLE
server: fix npe during start vr edge case

### DIFF
--- a/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -445,7 +445,9 @@ public class NetworkHelperImpl implements NetworkHelper {
         final int retryIndex = 5;
         final ExcludeList[] avoids = new ExcludeList[5];
         avoids[0] = new ExcludeList();
-        avoids[0].addPod(routerToBeAvoid.getPodIdToDeployIn());
+        if (routerToBeAvoid.getPodIdToDeployIn() != null) {
+            avoids[0].addPod(routerToBeAvoid.getPodIdToDeployIn());
+        }
         avoids[1] = new ExcludeList();
         avoids[1].addCluster(_hostDao.findById(routerToBeAvoid.getHostId()).getClusterId());
         avoids[2] = new ExcludeList();


### PR DESCRIPTION
### Description

DeploymentPlanner.addPod takes long value while
VmInstanceVO.getPodIdToDeployIn returns a Long value which can be null when the VM is never started.

Error seen while doing consecutive VPC restarts with cleanup,

```
java.lang.NullPointerException
        at com.cloud.network.router.NetworkHelperImpl.startVirtualRouter(NetworkHelperImpl.java:448)
        at com.cloud.network.router.NetworkHelperImpl.startRouters(NetworkHelperImpl.java:384)
        at org.apache.cloudstack.network.router.deployment.RouterDeploymentDefinition.deployVirtualRouter(RouterDeploymentDefinition.java:209)
        at com.cloud.network.element.VpcVirtualRouterElement.prepare(VpcVirtualRouterElement.java:307)
        at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator.prepareElement(NetworkOrchestrator.java:1756)
        at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator.prepareNic(NetworkOrchestrator.java:2129)
        at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator.prepare(NetworkOrchestrator.java:2056)
        at com.cloud.vm.VirtualMachineManagerImpl.orchestrateStart(VirtualMachineManagerImpl.java:1253)
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
