### PR TITLE
Change L2 network offering form to not require a compute offering

### DIFF
--- a/ui/public/locales/el_GR.json
+++ b/ui/public/locales/el_GR.json
@@ -2689,7 +2689,6 @@
 "message.volume.state.uploaderror": "Η αποστολή τόμου αντιμετώπισε κάποιο σφάλμα",
 "message.volume.state.uploadinprogress": "Η αποστολή τόμου βρίσκεται σε εξέλιξη",
 "message.volume.state.uploadop": "Η λειτουργία αποστολής τόμου βρίσκεται σε εξέλιξη ή, εν ολίγοις, ο τόμος βρίσκεται σε δευτερεύουσα αποθήκευση",
-"message.vr.alert.upon.network.offering.creation.l2": "Επειδή εικονικοί δρομολογητές δεν χρησιμοποιούνται για δίκτυα L2 η προσφορά υπολογιστικού νέφους δεν θα χρησιμοποιηθεί",
 "message.vr.alert.upon.network.offering.creation.others": "Εφόσον καμία απο τις υποχρεωτικές υπηρεσίες για την δημιουργία του εικονικού δρομολογητή (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) δεν είναι ενεργή, ο εικονικός δρομολογητές δεν θα δημιουργθεί και η προσφορά υπολογιστικού νέςφους δεν θα χρησιμοποιηθεί.",
 "message.warn.filetype": "jpg, jpeg, png, bmp και svg είναι οι μόνες υποστηριζόμενες μορφές εικόνας.",
 "message.zone.creation.complete": "Η δημιουργία ζώνης ολοκληρώθηκε",

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -3709,7 +3709,6 @@
 "message.volumes.managed": "Volumes controlled by CloudStack.",
 "message.volumes.unmanaged": "Volumes not controlled by CloudStack.",
 "message.vpc.restart.required": "Restart is required for VPC(s). Click here to view VPC(s) which require restart.",
-"message.vr.alert.upon.network.offering.creation.l2": "As virtual routers are not created for L2 Networks, the compute offering will not be used.",
 "message.vr.alert.upon.network.offering.creation.others": "As none of the obligatory services for creating a virtual router (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) are enabled, the virtual router will not be created and the compute offering will not be used.",
 "message.warn.change.primary.storage.scope": "This feature is tested and supported for the following configurations:<br>KVM - NFS/Ceph - DefaultPrimary<br>VMware - NFS - DefaultPrimary<br>*There might be extra steps involved to make it work for other configurations.",
 "message.warn.filetype": "jpg, jpeg, png, bmp and svg are the only supported image formats.",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -2507,7 +2507,6 @@
 "message.volume.state.uploaderror": "O carregamento do volume encontrou um erro",
 "message.volume.state.uploadinprogress": "Carregamento do volume em progresso",
 "message.volume.state.uploadop": "A opera\u00e7\u00e3o de carregamento de volume est\u00e1 em andamento",
-"message.vr.alert.upon.network.offering.creation.l2": "Como VRs n\u00e3o s\u00e3o criados para redes do tipo L2, a oferta de computa\u00e7\u00e3o n\u00e3o ser\u00e1 utilizada.",
 "message.vr.alert.upon.network.offering.creation.others": "Como nenhum dos servi\u00e7os obrigat\u00f3rios para cria\u00e7\u00e3o do VR (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) foram habilitados, o VR n\u00e3o ser\u00e1 criado e a oferta de computa\u00e7\u00e3o n\u00e3o ser\u00e1 usada.",
 "message.warn.filetype": "jpg, jpeg, png, bmp e svg s\u00e3o os \u00fanicos formatos de imagem suportados",
 "message.warn.importing.instance.without.nic": "AVISO: essa inst\u00e2ncia est\u00e1 sendo importada sem NICs e muitos recursos de rede n\u00e3o estar\u00e3o dispon\u00edveis. Considere criar uma NIC antes de importar via VCenter ou assim que a inst\u00e2ncia for importada.",

--- a/ui/public/locales/te.json
+++ b/ui/public/locales/te.json
@@ -3661,7 +3661,6 @@
   "message.volumes.managed": "CloudStack ద్వారా నియంత్రించబడే వాల్యూమ్‌లు.",
   "message.volumes.unmanaged": "CloudStack ద్వారా వాల్యూమ్‌లు నియంత్రించబడవు.",
   "message.vpc.restart.required": "VPC(లు) కోసం పునఃప్రారంభించాల్సిన అవసరం ఉంది. ",
-  "message.vr.alert.upon.network.offering.creation.l2": "L2 నెట్‌వర్క్‌ల కోసం వర్చువల్ రూటర్‌లు సృష్టించబడనందున, కంప్యూట్ ఆఫర్ ఉపయోగించబడదు.",
   "message.vr.alert.upon.network.offering.creation.others": "వర్చువల్ రూటర్‌ను (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) సృష్టించడం కోసం తప్పనిసరి సేవలు ఏవీ ప్రారంభించబడనందున, వర్చువల్ రూటర్ సృష్టించబడదు మరియు గణన సమర్పణ ఉపయోగించబడదు.",
   "message.warn.change.primary.storage.scope": "ఈ ఫీచర్ క్రింది కాన్ఫిగరేషన్‌ల కోసం పరీక్షించబడింది మరియు మద్దతు ఇస్తుంది:<br>KVM - NFS/Ceph - డిఫాల్ట్ ప్రైమరీ<br>VMware - NFS - డిఫాల్ట్ ప్రైమరీ<br>*ఇతర కాన్ఫిగరేషన్‌ల కోసం ఇది పని చేయడానికి అదనపు దశలు ఉండవచ్చు.",
   "message.warn.filetype": "jpg, jpeg, png, bmp మరియు svg మాత్రమే మద్దతు ఉన్న ఇమేజ్ ఫార్మాట్‌లు.",

--- a/ui/src/views/offering/AddNetworkOffering.vue
+++ b/ui/src/views/offering/AddNetworkOffering.vue
@@ -312,11 +312,10 @@
             </a-radio-button>
           </a-radio-group>
         </a-form-item>
-        <a-form-item name="serviceofferingid" ref="serviceofferingid">
+        <a-form-item name="serviceofferingid" ref="serviceofferingid" v-if="guestType !== 'l2'">
           <a-alert v-if="!isVirtualRouterForAtLeastOneService" type="warning" style="margin-bottom: 10px">
             <template #message>
-              <span v-if="guestType === 'l2'" v-html="$t('message.vr.alert.upon.network.offering.creation.l2')" />
-              <span v-else v-html="$t('message.vr.alert.upon.network.offering.creation.others')" />
+              <span v-html="$t('message.vr.alert.upon.network.offering.creation.others')" />
             </template>
           </a-alert>
           <template #label>
@@ -331,8 +330,11 @@
             }"
             :loading="serviceOfferingLoading"
             :placeholder="apiParams.serviceofferingid.description">
-            <a-select-option v-for="(opt) in serviceOfferings" :key="opt.id" :label="opt.name || opt.description">
-              {{ opt.name || opt.description }}
+            <a-select-option
+              v-for="(offering, index) in serviceOfferings"
+              :value="offering.id"
+              :key="index">
+              {{ offering.displaytext || offering.name }}
             </a-select-option>
           </a-select>
         </a-form-item>
@@ -765,7 +767,6 @@ export default {
         this.form.lbtype = 'publicLb'
         this.isVirtualRouterForAtLeastOneService = false
         this.isVpcVirtualRouterForAtLeastOneService = false
-        this.serviceOfferings = []
         this.serviceOfferingLoading = false
         this.sourceNatServiceChecked = false
         this.lbServiceChecked = false
@@ -853,9 +854,7 @@ export default {
       params.systemvmtype = 'domainrouter'
       this.serviceOfferingLoading = true
       api('listServiceOfferings', params).then(json => {
-        const listServiceOfferings = json.listserviceofferingsresponse.serviceoffering
-        this.serviceOfferings = this.serviceOfferings.concat(listServiceOfferings)
-        this.form.serviceofferingid = this.serviceOfferings.length > 0 ? this.serviceOfferings[0].id : ''
+        this.serviceOfferings = json.listserviceofferingsresponse.serviceoffering || []
       }).finally(() => {
         this.serviceOfferingLoading = false
       })


### PR DESCRIPTION
### Description

When creating a L2 network offering via UI, the compute offering parameter is required despite L2 networks not using a virtual router and the compute offering itself.

This PR removes the compute offering parameter from `Add Network Offering` form when L2 guest type is selected.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

![L2-network-offering-PR](https://github.com/user-attachments/assets/91269841-f300-46db-98c9-5d494e54d844)

### How Has This Been Tested?

As shown in the screenshot above, the compute offering option is no longer present when selecting L2 guest type. By selecting the Isolated and Shared types, I checked that the parameter still available.

I also created some network offerings of each type and everything is working as intended.