### PR TITLE
UI: Fix `docHelp` links for Add Hosts, Add Clusters, Disable Clusters and Enable Clusters forms

### DIFF
--- a/ui/src/config/section/infra/clusters.js
+++ b/ui/src/config/section/infra/clusters.js
@@ -73,7 +73,7 @@ export default {
       api: 'addCluster',
       icon: 'plus-outlined',
       label: 'label.add.cluster',
-      docHelp: 'adminguide/installguide/configuration.html#adding-a-cluster',
+      docHelp: 'installguide/configuration.html#adding-a-cluster',
       listView: true,
       popup: true,
       component: shallowRef(defineAsyncComponent(() => import('@/views/infra/ClusterAdd.vue')))

--- a/ui/src/config/section/infra/clusters.js
+++ b/ui/src/config/section/infra/clusters.js
@@ -90,7 +90,7 @@ export default {
       icon: 'play-circle-outlined',
       label: 'label.action.enable.cluster',
       message: 'message.action.enable.cluster',
-      docHelp: 'adminguide/installguide/hosts.html#disabling-and-enabling-zones-pods-and-clusters',
+      docHelp: 'adminguide/hosts.html#disabling-and-enabling-zones-pods-and-clusters',
       dataView: true,
       defaultArgs: { allocationstate: 'Enabled' },
       show: (record) => { return record.allocationstate === 'Disabled' }
@@ -100,7 +100,7 @@ export default {
       icon: 'pause-circle-outlined',
       label: 'label.action.disable.cluster',
       message: 'message.action.disable.cluster',
-      docHelp: 'adminguide/installguide/hosts.html#disabling-and-enabling-zones-pods-and-clusters',
+      docHelp: 'adminguide/hosts.html#disabling-and-enabling-zones-pods-and-clusters',
       dataView: true,
       defaultArgs: { allocationstate: 'Disabled' },
       show: (record) => { return record.allocationstate === 'Enabled' }

--- a/ui/src/config/section/infra/hosts.js
+++ b/ui/src/config/section/infra/hosts.js
@@ -64,7 +64,7 @@ export default {
       api: 'addHost',
       icon: 'plus-outlined',
       label: 'label.add.host',
-      docHelp: 'adminguide/installguide/configuration.html#adding-a-host',
+      docHelp: 'installguide/configuration.html#adding-a-host',
       listView: true,
       popup: true,
       component: shallowRef(defineAsyncComponent(() => import('@/views/infra/HostAdd.vue')))


### PR DESCRIPTION
### Description

The `docHelp` property of the Add Hosts, Add Clusters, Disable Clusters and Enable Clusters UI forms references an incorrect documentation link, resulting in a 404 error when the user clicks the help button. This PR fixes these links.

---

Fixes #10390

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Verified that when the help button of the Add Hosts form is clicked, the Apache CloudStack UI redirects the user to the correct documentation section.
- Verified that when the help button of the Add Clusters form is clicked, the Apache CloudStack UI redirects the user to the correct documentation section.
- Verified that when the help button of the Disable Clusters form is clicked, the Apache CloudStack UI redirects the user to the correct documentation section.
- Verified that when the help button of the Enable Clusters form is clicked, the Apache CloudStack UI redirects the user to the correct documentation section.