### PR TITLE
engine/orchestration: fix missing vm powerstate update vm state

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
@@ -83,13 +83,13 @@ public class VirtualMachinePowerStateSyncImpl implements VirtualMachinePowerStat
             return;
         }
         Set<Long> vmIds = instancePowerStates.keySet();
-        Map<Long, VirtualMachine.PowerState> notUpdated = _instanceDao.updatePowerState(instancePowerStates, hostId,
-                updateTime);
+        Map<Long, VirtualMachine.PowerState> notUpdated =
+                _instanceDao.updatePowerState(instancePowerStates, hostId, updateTime);
         if (notUpdated.size() > vmIds.size()) {
             return;
         }
         for (Long vmId : vmIds) {
-            if (!notUpdated.isEmpty() && !notUpdated.containsKey(vmId)) {
+            if (!notUpdated.containsKey(vmId)) {
                 logger.debug("VM state report is updated. {}, {}, power state: {}",
                         () -> hostCache.get(hostId), () -> vmCache.get(vmId), () -> instancePowerStates.get(vmId));
                 _messageBus.publish(null, VirtualMachineManager.Topics.VM_POWER_STATE,

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
@@ -77,8 +77,8 @@ public class VirtualMachinePowerStateSyncImpl implements VirtualMachinePowerStat
         processReport(hostId, translatedInfo, force);
     }
 
-    private void updateAndPublishVmPowerStates(long hostId, Map<Long, VirtualMachine.PowerState> instancePowerStates,
-           Date updateTime) {
+    protected void updateAndPublishVmPowerStates(long hostId, Map<Long, VirtualMachine.PowerState> instancePowerStates,
+               Date updateTime) {
         if (instancePowerStates.isEmpty()) {
             return;
         }

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachinePowerStateSyncImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachinePowerStateSyncImplTest.java
@@ -1,0 +1,91 @@
+package com.cloud.vm;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.framework.messagebus.PublishScope;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.vm.dao.VMInstanceDao;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VirtualMachinePowerStateSyncImplTest {
+    @Mock
+    MessageBus messageBus;
+    @Mock
+    VMInstanceDao instanceDao;
+    @Mock
+    HostDao hostDao;
+
+    @InjectMocks
+    VirtualMachinePowerStateSyncImpl virtualMachinePowerStateSync = new VirtualMachinePowerStateSyncImpl();
+
+    @Before
+    public void setup() {
+        Mockito.when(instanceDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(VMInstanceVO.class));
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+    }
+
+    @Test
+    public void test_updateAndPublishVmPowerStates_emptyStates() {
+        virtualMachinePowerStateSync.updateAndPublishVmPowerStates(1L, new HashMap<>(), new Date());
+        Mockito.verify(instanceDao, Mockito.never()).updatePowerState(Mockito.anyMap(), Mockito.anyLong(),
+                Mockito.any(Date.class));
+    }
+
+    @Test
+    public void test_updateAndPublishVmPowerStates_moreNotUpdated() {
+        Map<Long, VirtualMachine.PowerState> powerStates = new HashMap<>();
+        powerStates.put(1L, VirtualMachine.PowerState.PowerOff);
+        Map<Long, VirtualMachine.PowerState> notUpdated = new HashMap<>(powerStates);
+        notUpdated.put(2L, VirtualMachine.PowerState.PowerOn);
+        Mockito.when(instanceDao.updatePowerState(Mockito.anyMap(), Mockito.anyLong(),
+                Mockito.any(Date.class))).thenReturn(notUpdated);
+        virtualMachinePowerStateSync.updateAndPublishVmPowerStates(1L, powerStates, new Date());
+        Mockito.verify(messageBus, Mockito.never()).publish(Mockito.nullable(String.class), Mockito.anyString(),
+                Mockito.any(PublishScope.class), Mockito.anyLong());
+    }
+
+    @Test
+    public void test_updateAndPublishVmPowerStates_allUpdated() {
+        Map<Long, VirtualMachine.PowerState> powerStates = new HashMap<>();
+        powerStates.put(1L, VirtualMachine.PowerState.PowerOff);
+        Mockito.when(instanceDao.updatePowerState(Mockito.anyMap(), Mockito.anyLong(),
+                Mockito.any(Date.class))).thenReturn(new HashMap<>());
+        virtualMachinePowerStateSync.updateAndPublishVmPowerStates(1L, powerStates, new Date());
+        Mockito.verify(messageBus, Mockito.times(1)).publish(null,
+                VirtualMachineManager.Topics.VM_POWER_STATE,
+                PublishScope.GLOBAL,
+                1L);
+    }
+
+    @Test
+    public void test_updateAndPublishVmPowerStates_partialUpdated() {
+        Map<Long, VirtualMachine.PowerState> powerStates = new HashMap<>();
+        powerStates.put(1L, VirtualMachine.PowerState.PowerOn);
+        powerStates.put(2L, VirtualMachine.PowerState.PowerOff);
+        Map<Long, VirtualMachine.PowerState> notUpdated = new HashMap<>();
+        notUpdated.put(2L, VirtualMachine.PowerState.PowerOff);
+        Mockito.when(instanceDao.updatePowerState(Mockito.anyMap(), Mockito.anyLong(),
+                Mockito.any(Date.class))).thenReturn(notUpdated);
+        virtualMachinePowerStateSync.updateAndPublishVmPowerStates(1L, powerStates, new Date());
+        Mockito.verify(messageBus, Mockito.times(1)).publish(null,
+                VirtualMachineManager.Topics.VM_POWER_STATE,
+                PublishScope.GLOBAL,
+                1L);
+        Mockito.verify(messageBus, Mockito.never()).publish(null,
+                VirtualMachineManager.Topics.VM_POWER_STATE,
+                PublishScope.GLOBAL,
+                2L);
+    }
+}

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachinePowerStateSyncImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachinePowerStateSyncImplTest.java
@@ -48,8 +48,8 @@ public class VirtualMachinePowerStateSyncImplTest {
 
     @Before
     public void setup() {
-        Mockito.when(instanceDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(VMInstanceVO.class));
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+        Mockito.lenient().when(instanceDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(VMInstanceVO.class));
+        Mockito.lenient().when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
     }
 
     @Test

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachinePowerStateSyncImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachinePowerStateSyncImplTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.vm;
 
 import java.util.Date;


### PR DESCRIPTION
### Description

Fixes #10406
VMs were not moving to Stopped state when PowerReportMissing is processed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
