### PR TITLE
VMware Import - Support external VMware VMs in any folders/subfolders other than the root folder of datacenter

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/to/RemoteInstanceTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/RemoteInstanceTO.java
@@ -27,6 +27,7 @@ public class RemoteInstanceTO implements Serializable {
 
     private Hypervisor.HypervisorType hypervisorType;
     private String instanceName;
+    private String instancePath;
 
     // VMware Remote Instances parameters (required for exporting OVA through ovftool)
     // TODO: cloud.agent.transport.Request#getCommands() cannot handle gsoc decode for polymorphic classes
@@ -44,9 +45,10 @@ public class RemoteInstanceTO implements Serializable {
         this.instanceName = instanceName;
     }
 
-    public RemoteInstanceTO(String instanceName, String vcenterHost, String vcenterUsername, String vcenterPassword, String datacenterName) {
+    public RemoteInstanceTO(String instanceName, String instancePath, String vcenterHost, String vcenterUsername, String vcenterPassword, String datacenterName) {
         this.hypervisorType = Hypervisor.HypervisorType.VMware;
         this.instanceName = instanceName;
+        this.instancePath = instancePath;
         this.vcenterHost = vcenterHost;
         this.vcenterUsername = vcenterUsername;
         this.vcenterPassword = vcenterPassword;
@@ -59,6 +61,10 @@ public class RemoteInstanceTO implements Serializable {
 
     public String getInstanceName() {
         return this.instanceName;
+    }
+
+    public String getInstancePath() {
+        return this.instancePath;
     }
 
     public String getVcenterUsername() {

--- a/api/src/main/java/org/apache/cloudstack/vm/UnmanagedInstanceTO.java
+++ b/api/src/main/java/org/apache/cloudstack/vm/UnmanagedInstanceTO.java
@@ -33,6 +33,8 @@ public class UnmanagedInstanceTO {
 
     private String internalCSName;
 
+    private String path;
+
     private PowerState powerState;
 
     private PowerState cloneSourcePowerState;
@@ -73,6 +75,14 @@ public class UnmanagedInstanceTO {
 
     public void setInternalCSName(String internalCSName) {
         this.internalCSName = internalCSName;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 
     public PowerState getPowerState() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapper.java
@@ -57,6 +57,7 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
         RemoteInstanceTO sourceInstance = cmd.getSourceInstance();
         Hypervisor.HypervisorType sourceHypervisorType = sourceInstance.getHypervisorType();
         String sourceInstanceName = sourceInstance.getInstanceName();
+        String sourceInstancePath = sourceInstance.getInstancePath();
         Hypervisor.HypervisorType destinationHypervisorType = cmd.getDestinationHypervisorType();
         DataStoreTO conversionTemporaryLocation = cmd.getConversionTemporaryLocation();
         long timeout = (long) cmd.getWait() * 1000;
@@ -177,9 +178,15 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
         String password = vmwareInstance.getVcenterPassword();
         String datacenter = vmwareInstance.getDatacenterName();
         String vm = vmwareInstance.getInstanceName();
+        String path = vmwareInstance.getInstancePath();
 
         String encodedUsername = encodeUsername(username);
         String encodedPassword = encodeUsername(password);
+        if (StringUtils.isNotBlank(path)) {
+            s_logger.info("VM path: " + path);
+            return String.format("vi://%s:%s@%s/%s/%s/%s",
+                    encodedUsername, encodedPassword, vcenter, datacenter, path, vm);
+        }
         return String.format("vi://%s:%s@%s/%s/vm/%s",
                 encodedUsername, encodedPassword, vcenter, datacenter, vm);
     }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1947,7 +1947,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         LOGGER.debug(String.format("Delegating the conversion of instance %s from VMware to KVM to the host %s (%s) after OVF export through ovftool",
                 sourceVM, convertHost.getId(), convertHost.getName()));
 
-        RemoteInstanceTO remoteInstanceTO = new RemoteInstanceTO(sourceVMwareInstance.getName(), vcenterHost, vcenterUsername, vcenterPassword, datacenterName);
+        RemoteInstanceTO remoteInstanceTO = new RemoteInstanceTO(sourceVMwareInstance.getName(), sourceVMwareInstance.getPath(), vcenterHost, vcenterUsername, vcenterPassword, datacenterName);
         List<String> destinationStoragePools = selectInstanceConversionStoragePools(convertStoragePools, sourceVMwareInstance.getDisks(), serviceOffering, dataDiskOfferingMap);
         ConvertInstanceCommand cmd = new ConvertInstanceCommand(remoteInstanceTO,
                 Hypervisor.HypervisorType.KVM, temporaryConvertLocation, null, false, true);

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -891,6 +891,27 @@ public class VirtualMachineMO extends BaseMO {
         return fileLayout;
     }
 
+    public String getPath() throws Exception {
+        List<String> subPaths = new ArrayList<>();
+        ManagedObjectReference mor = _context.getVimClient().getDynamicProperty(_mor, "parent");
+        while (mor != null && mor.getType().equalsIgnoreCase("Folder")) {
+            String subPath = _context.getVimClient().getDynamicProperty(mor, "name");
+            if (StringUtils.isBlank(subPath)) {
+                return null;
+            }
+            subPaths.add(subPath);
+            mor = _context.getVimClient().getDynamicProperty(mor, "parent");
+        }
+
+        if (!subPaths.isEmpty()) {
+            Collections.reverse(subPaths);
+            String path = StringUtils.join(subPaths, "/");
+            return path;
+        }
+
+        return null;
+    }
+
     @Override
     public ManagedObjectReference getParentMor() throws Exception {
         return _context.getVimClient().getDynamicProperty(_mor, "parent");

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -801,6 +801,7 @@ public class VmwareHelper {
             instance = new UnmanagedInstanceTO();
             instance.setName(vmMo.getVmName());
             instance.setInternalCSName(vmMo.getInternalCSName());
+            instance.setPath((vmMo.getPath()));
             instance.setCpuCoresPerSocket(vmMo.getCoresPerSocket());
             instance.setOperatingSystemId(vmMo.getVmGuestInfo().getGuestId());
             VirtualMachineConfigSummary configSummary = vmMo.getConfigSummary();


### PR DESCRIPTION
### Description

This PR adds import/migration support for external VMware VMs in any folders/subfolders other than the root folder ('vm') of datacenter.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Manually tested the VMware VMs import for the VMs created in root folder ('vm'), folder & subfolder.

```
[root@kvm1 ~]# ps -ef|grep ovftool
root       38585   37625 54 16:54 ?        00:00:05 /root/ovftool/ovftool.bin --noSSLVerify vi://administrator%40vsphere.local:P%40ssword123@10.1.33.168/Trillian/vm/fd8dda05-07f1-4160-84fa-37ec42aeff0e /mnt/22fe2ce5-1e80-3af4-b1e5-05ffa3ad4e05/911923cb-e570-4ae9-b266-fc40030ad1e0/
root       38643   31339  0 16:54 pts/2    00:00:00 grep --color=auto ovftool

[root@kvm1 ~]# grep "VM path" /var/log/cloudstack/agent/agent.log
2025-02-17 16:54:28,826 INFO  [resource.wrapper.LibvirtConvertInstanceCommandWrapper] (agentRequest-Handler-2:null) (logid:6c03048c) VM path: vm

[root@kvm2 ~]# ps -ef|grep ovftool
root       42230   41346 53 16:50 ?        00:00:15 /root/ovftool/ovftool.bin --noSSLVerify vi://administrator%40vsphere.local:P%40ssword123@10.1.33.168/Trillian/vm/MyTestFolder/Test/newvm /mnt/22fe2ce5-1e80-3af4-b1e5-05ffa3ad4e05/c28b36f7-9c55-4c67-8c5a-d139cf6fe218/

[root@kvm2 ~]# ps -ef|grep ovftool
root       42725   41346 54 16:55 ?        00:00:01 /root/ovftool/ovftool.bin --noSSLVerify vi://administrator%40vsphere.local:P%40ssword123@10.1.33.168/Trillian/vm/MyTestFolder/testvm /mnt/22fe2ce5-1e80-3af4-b1e5-05ffa3ad4e05/3b907bd3-2534-44ab-8ab7-3c2b7ac88688/

[root@kvm2 ~]# grep "VM path" /var/log/cloudstack/agent/agent.log
2025-02-17 16:50:26,513 INFO  [resource.wrapper.LibvirtConvertInstanceCommandWrapper] (agentRequest-Handler-4:null) (logid:1f799005) VM path: vm/MyTestFolder/Test
2025-02-17 16:55:33,977 INFO  [resource.wrapper.LibvirtConvertInstanceCommandWrapper] (agentRequest-Handler-4:null) (logid:ce3ee4ab) VM path: vm/MyTestFolder
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
