### PR TITLE
UI: Fix filtering of templates by account

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -1159,6 +1159,10 @@ export default {
       if (item.value) {
         query[item.param] = this.resource[item.value]
       } else {
+        if (item.name === 'template') {
+          query.templatefilter = 'self'
+        }
+
         if (item.param === 'account') {
           query[item.param] = this.resource.name
           query.domainid = this.resource.domainid

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -1161,6 +1161,7 @@ export default {
       } else {
         if (item.name === 'template') {
           query.templatefilter = 'self'
+          query.filter = 'self'
         }
 
         if (item.param === 'account') {


### PR DESCRIPTION
### Description

Currently, an account's `InfoCard` contains buttons that enable the users to view the resources of a given account. However, the `View Templates` button is not working. When selected, all templates are listed.

This PR proposes to fix this issue by only listing the templates associated to an account when the `View Templates` button on its `InfoCard` is selected.

---

Fixes #10391

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/df000350-890f-4c53-b20f-27e0f3b8d75f)


### How Has This Been Tested?

Verified that when selecting the `View Templates` button present on an account's `InfoCard`, the UI redirects the user to the following path `/template?templatefilter=self&account=<account-name>&domainid=<domain-id>`. Therefore, only the templates associated with the account are listed. 