### PR TITLE
linstor: try to delete -rst resource before snapshot backup

### DIFF
--- a/plugins/storage/volume/linstor/CHANGELOG.md
+++ b/plugins/storage/volume/linstor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Linstor CloudStack plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-21]
+
+### Fixed
+
+- Always try to delete cs-...-rst resource before doing a snapshot backup
+
 ## [2025-01-27]
 
 ### Fixed

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -1117,6 +1117,8 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             String snapshotName,
             String restoredName) throws ApiException {
         final String rscGrp = getRscGrp(storagePoolVO);
+        // try to delete -rst resource, could happen if the copy failed and noone deleted it.
+        deleteResourceDefinition(storagePoolVO, restoredName);
         ResourceDefinitionCreate rdc = createResourceDefinitionCreate(restoredName, rscGrp);
         api.resourceDefinitionCreate(rdc);
 
@@ -1259,19 +1261,22 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             throws ApiException {
         Answer answer;
         String restoreName = rscName + "-rst";
-        String devName = restoreResourceFromSnapshot(api, pool, rscName, snapshotName, restoreName);
+        try {
+            String devName = restoreResourceFromSnapshot(api, pool, rscName, snapshotName, restoreName);
 
-        Optional<RemoteHostEndPoint> optEPAny = getLinstorEP(api, restoreName);
-        if (optEPAny.isPresent()) {
-            // patch the src device path to the temporary linstor resource
-            snapshotObject.setPath(devName);
-            origCmd.setSrcTO(snapshotObject.getTO());
-            answer = optEPAny.get().sendMessage(origCmd);
-        } else{
-            answer = new Answer(origCmd, false, "Unable to get matching Linstor endpoint.");
+            Optional<RemoteHostEndPoint> optEPAny = getLinstorEP(api, restoreName);
+            if (optEPAny.isPresent()) {
+                // patch the src device path to the temporary linstor resource
+                snapshotObject.setPath(devName);
+                origCmd.setSrcTO(snapshotObject.getTO());
+                answer = optEPAny.get().sendMessage(origCmd);
+            } else{
+                answer = new Answer(origCmd, false, "Unable to get matching Linstor endpoint.");
+            }
+        } finally {
+            // delete the temporary resource, noop if already gone
+            api.resourceDefinitionDelete(restoreName);
         }
-        // delete the temporary resource, noop if already gone
-        api.resourceDefinitionDelete(restoreName);
         return answer;
     }
 


### PR DESCRIPTION
### Description

This PR deletes temporary Linstor -rst resources before trying to do the snapshot backup on non-hyperconverged setups.
If a -rst resource wasn't deleted because of a failed copy, a reoccurring snapshot attempt couldn't be done, because there was still the "old" -rst resource. To prevent this always try to remove the -rst resource before, if it doesn't exist it is a noop.
<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Linstor cluster  hyperconverged and non hyperconverged, doing snapshots.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
