### PR TITLE
fix: prometheus: don't poll the same tag multiple times

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.metrics;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -302,7 +303,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
                 .flatMap( h -> _hostTagsDao.getHostTags(h).stream())
                 .distinct()
                 .collect(Collectors.toList());
-        List<String> allHostTags = new ArrayList<>();
+        HashSet<String> allHostTags = new HashSet<>();
         allHostTagVOS.forEach(hostTagVO -> allHostTags.add(hostTagVO.getTag()));
 
         for (final State state : State.values()) {


### PR DESCRIPTION
### Description

This PR speeds up Prometheus exporter reply generation by ensuring the same host tag is not polled multiple times.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
It utilizes `HashSet` instead of `ArrayList` to store the host tags, therefore deduplicates the tags when they are present on multiple hosts.
It fixes two bugs:
1. Prevents duplication of the `cloudstack_vms_total_by_tag{filter="<vm state>", zone="<zonename>", tags="<tagname>"}` in the reply.
2. Speeds up forming Prometheus exporter reply on large Cloudstack installations when multiple hosts with repeating tags are used, for example 200 hosts but only 5 unique host tags. The time to get the Prometheus exporter reply has reduced from 4.5 mins to 26 seconds in my setup.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
## Steps to reproduce
1. Take a large Cloudstack installation with > 100 hosts
2. Populate these hosts with the several unique tags (e.g. 5 tags). So the host1 gets some of those tags, host2 gets the same tags, host3 gets the same tags etc.
4. `time curl http://<cs.server.ip>:<prometheus.port>/metrics` from the prometheus exporter port. Inspect the reply, and note the time it took to finish.
5. Apply this patch.
6. Run the same command from the Step 3, and check the difference in time taken to process the request.

Expected behavior:
- The metrics with the same name + labels, such as `cloudstack_vms_total_by_tag{filter="<vm state>", zone="<zonename>", tags="<tagname>"}` shall not be duplicated in the reply.
- The processing time shall not be taking more than a minute or so.

Actual behavior:
- the `cloudstack_vms_total_by_tag` metrics with the same labels are not unique
- it takes a longer time to process, than it is necessary

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
