### PR TITLE
Allow modification of user vm details if user.vm.readonly.details is empty

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/query/QueryService.java
+++ b/api/src/main/java/org/apache/cloudstack/query/QueryService.java
@@ -118,7 +118,7 @@ public interface QueryService {
 
     ConfigKey<String> UserVMReadOnlyDetails = new ConfigKey<>(String.class,
     "user.vm.readonly.details", "Advanced", "dataDiskController, rootDiskController",
-            "List of read-only VM settings/details as comma separated string", true, ConfigKey.Scope.Global, null, null, null, null, null, ConfigKey.Kind.CSV, null);
+            "List of read-only VM settings/details as comma separated string", true, ConfigKey.Scope.Global, null, null, null, null, null, ConfigKey.Kind.CSV, null, "");
 
     ConfigKey<Boolean> SortKeyAscending = new ConfigKey<>("Advanced", Boolean.class, "sortkey.algorithm", "true",
             "Sort algorithm - ascending or descending - to use. For entities that use sort key(template, disk offering, service offering, " +

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -120,8 +120,16 @@ public class ConfigKey<T> {
 
     static ConfigDepotImpl s_depot = null;
 
-    static public void init(ConfigDepotImpl depot) {
+    private String _defaultValueIfEmpty = null;
+
+    public static void init(ConfigDepotImpl depot) {
         s_depot = depot;
+    }
+
+    public ConfigKey(Class<T> type, String name, String category, String defaultValue, String description, boolean isDynamic, Scope scope, T multiplier,
+                     String displayText, String parent, Ternary<String, String, Long> group, Pair<String, Long> subGroup, Kind kind, String options, String defaultValueIfEmpty) {
+        this(type, name, category, defaultValue, description, isDynamic, scope, multiplier, displayText, parent, group, subGroup, kind, options);
+        this._defaultValueIfEmpty = defaultValueIfEmpty;
     }
 
     public ConfigKey(String category, Class<T> type, String name, String defaultValue, String description, boolean isDynamic, Scope scope) {
@@ -216,7 +224,19 @@ public class ConfigKey<T> {
     public T value() {
         if (_value == null || isDynamic()) {
             String value = s_depot != null ? s_depot.getConfigStringValue(_name, Scope.Global, null) : null;
-            _value = valueOf((value == null) ? defaultValue() : value);
+
+            String effective;
+            if (value != null) {
+                if (value.isEmpty() && _defaultValueIfEmpty != null) {
+                    effective = _defaultValueIfEmpty;
+                } else {
+                    effective = value;
+                }
+            } else {
+                effective = _defaultValueIfEmpty != null ? _defaultValueIfEmpty : defaultValue();
+            }
+
+            _value = valueOf(effective);
         }
 
         return _value;
@@ -230,6 +250,10 @@ public class ConfigKey<T> {
         String value = s_depot != null ? s_depot.getConfigStringValue(_name, scope, id) : null;
         if (value == null) {
             return value();
+        }
+
+        if (value.isEmpty() && _defaultValueIfEmpty != null) {
+            return valueOf(_defaultValueIfEmpty);
         }
         return valueOf(value);
     }


### PR DESCRIPTION
### Description

This PR fixes: https://github.com/apache/cloudstack/issues/10305
Currently when the global setting 'user.vm.readonly.details' is cleared, it sets the global setting value to NULL. Querying a global setting whose value is null returns the default value. Hence, updating this specific global setting value to "" as opposed to NULL.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
