### PR TITLE
Remove isMirrored parameter when creating a disk offering through UI

### DIFF
--- a/ui/src/views/offering/AddDiskOffering.vue
+++ b/ui/src/views/offering/AddDiskOffering.vue
@@ -491,7 +491,6 @@ export default {
         const formRaw = toRaw(this.form)
         const values = this.handleRemoveFields(formRaw)
         var params = {
-          isMirrored: false,
           name: values.name,
           displaytext: values.displaytext,
           storageType: values.storagetype,


### PR DESCRIPTION
### Description

When a Disk Offering is created through UI, CloudStack passes the `isMirrored` value as a parameter. However, the `createDiskOffering` API does not have this parameter.

Therefore, the UI was changed in order to not send the `isMirrored` parameter to the `createDiskOffering` API.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

After the changes, a Disk Offering was created through UI and the `isMirrored` parameter was no longer being send in the request.