### PR TITLE
Launch RESIZE event on volume snapshot revert

### DIFF
--- a/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
+++ b/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
@@ -235,7 +235,6 @@ public class SnapshotManagerTest {
 
         doNothing().when(_resourceLimitMgr).checkResourceLimit(any(Account.class), any(ResourceType.class));
         doNothing().when(_resourceLimitMgr).checkResourceLimit(any(Account.class), any(ResourceType.class), anyLong());
-        doNothing().when(_resourceLimitMgr).decrementResourceCount(anyLong(), any(ResourceType.class), anyLong());
         doNothing().when(_resourceLimitMgr).incrementResourceCount(anyLong(), any(ResourceType.class));
         doNothing().when(_resourceLimitMgr).incrementResourceCount(anyLong(), any(ResourceType.class), anyLong());
 
@@ -352,7 +351,6 @@ public class SnapshotManagerTest {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getState()).thenReturn(State.Stopped);
         when (snapshotStrategy.revertSnapshot(any(SnapshotInfo.class))).thenReturn(true);
-        when(_volumeDao.update(anyLong(), any(VolumeVO.class))).thenReturn(true);
         doReturn(DataStoreRole.Image).when(snapshotHelperMock).getDataStoreRole(any());
         Snapshot snapshot = _snapshotMgr.revertSnapshot(TEST_SNAPSHOT_ID);
         Assert.assertNotNull(snapshot);

--- a/utils/src/test/java/com/cloud/utils/UriUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/UriUtilsTest.java
@@ -276,8 +276,8 @@ public class UriUtilsTest {
 
     @Test
     public void validateUrl() {
-        Pair<String, Integer> url1 = UriUtils.validateUrl("https://www.cloudstack.org");
-        Assert.assertEquals(url1.first(), "www.cloudstack.org");
+        Pair<String, Integer> url1 = UriUtils.validateUrl("https://www.cloudstack.apache.org/");
+        Assert.assertEquals(url1.first(), "www.cloudstack.apache.org");
 
         Pair<String, Integer> url2 = UriUtils.validateUrl("https://www.apache.org");
         Assert.assertEquals(url2.first(), "www.apache.org");

--- a/utils/src/test/java/com/cloud/utils/UriUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/UriUtilsTest.java
@@ -276,8 +276,8 @@ public class UriUtilsTest {
 
     @Test
     public void validateUrl() {
-        Pair<String, Integer> url1 = UriUtils.validateUrl("https://www.cloudstack.apache.org/");
-        Assert.assertEquals(url1.first(), "www.cloudstack.apache.org");
+        Pair<String, Integer> url1 = UriUtils.validateUrl("https://cloudstack.apache.org/");
+        Assert.assertEquals(url1.first(), "cloudstack.apache.org");
 
         Pair<String, Integer> url2 = UriUtils.validateUrl("https://www.apache.org");
         Assert.assertEquals(url2.first(), "www.apache.org");


### PR DESCRIPTION
### Description

On volume snapshot revert, if its logical size was changed after the snapshot creation, its size is updated to the previous one, yet, no event is launched on the Usage server pointing to this change.

This behavior was modified, so that a RESIZE event is launched on the Usage server, if the volume's size has been changed after a snapshot revert.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

1. A volume snapshot was created;
2. The resize operation was done;
3. The snapshot was reverted;
4. On the `usage_event` table the `VOLUME.RESIZE` event was launched with the previous size.