### PR TITLE
UI: Add `View ISOs` button to the account details pages

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -1211,6 +1211,9 @@ export default {
         if (item.name === 'template') {
           query.templatefilter = 'self'
           query.filter = 'self'
+        } else if (item.name === 'iso') {
+          query.isofilter = 'self'
+          query.filter = 'self'
         }
 
         if (item.param === 'account') {

--- a/ui/src/config/section/account.js
+++ b/ui/src/config/section/account.js
@@ -61,6 +61,10 @@ export default {
     name: 'template',
     title: 'label.templates',
     param: 'account'
+  }, {
+    name: 'iso',
+    title: 'label.isos',
+    param: 'account'
   }],
   filters: () => {
     const filters = ['enabled', 'disabled', 'locked']


### PR DESCRIPTION
### Description

The `InfoCard` component on the account details pages provides several buttons to view the resources associated to an account. However, currently, there isn't a button to view an account's ISOs.

Therefore, this PR, similarly to what has been done on #10425, adds the `View ISOs` button in the accounts `InfoCard` component. Additionally, as mentioned on https://github.com/apache/cloudstack/issues/10393#issuecomment-2666531345, support for filtering templates and ISOs by domain will be handled on separate PRs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/a43f5b66-b9bd-4b3c-81e0-455410dacc47)

### How Has This Been Tested?

Verified that when selecting the `View ISOs` button in an account's `InfoCard`, the UI redirects the user to the following URL: `/iso?isofilter=self&filter=self&account=<account>&domainid=<domain-uuid>`.
