### PR TITLE
test: fix failure in test_purge_expunged_vms.py

### DIFF
--- a/test/integration/smoke/test_purge_expunged_vms.py
+++ b/test/integration/smoke/test_purge_expunged_vms.py
@@ -358,6 +358,7 @@ class TestPurgeExpungedVms(cloudstackTestCase):
         self.changeConfiguration('expunged.resources.purge.delay', purge_task_delay)
         self.changeConfiguration('expunged.resources.purge.interval', int(purge_task_delay/2))
         self.changeConfiguration('expunged.resources.purge.keep.past.days', 1)
+        self.changeConfiguration('expunged.resources.purge.resources', 'VirtualMachine')
         if len(self.staticConfigurations) > 0:
             self.restartAllManagementServers()
         wait_multiple = 2


### PR DESCRIPTION
### Description

Seen in https://github.com/apache/cloudstack/pull/10006#issuecomment-2691067265 and other test runs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [x] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Ran test after changes,
```
root@pr10006-t12482-kvm-ol8-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr10006-t12482-kvm-ol8-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_purge_expunged_vms.py 
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Mar_03_2025_05_38_49_VUX70X All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_01_purge_expunged_api_vm_start_date | Status : SUCCESS ===

=== TestName: test_02_purge_expunged_api_vm_end_date | Status : SUCCESS ===

=== TestName: test_03_purge_expunged_api_vm_start_end_date | Status : SUCCESS ===

=== TestName: test_04_purge_expunged_api_vm_no_date | Status : SUCCESS ===

=== TestName: test_05_purge_expunged_vm_service_offering | Status : SUCCESS ===

====Trying SSH Connection: Host:10.0.34.25 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.0.34.25 port : 22 SUCCESSFUL===
{Cmd: service cloudstack-management stop via Host: 10.0.34.25} {returns: ['Redirecting to /bin/systemctl stop cloudstack-management.service']}
{Cmd: service cloudstack-management start via Host: 10.0.34.25} {returns: ['Redirecting to /bin/systemctl start cloudstack-management.service']}
====Trying SSH Connection: Host:None User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:None User:root                                   Port:22 RetryCnt:60===
===SSH to Host None port : 22 SUCCESSFUL===
===SSH to Host None port : 22 SUCCESSFUL===
{Cmd: service cloudstack-management stop via Host: None} {returns: ['Redirecting to /bin/systemctl stop cloudstack-management.service', 'Failed to stop cloudstack-management.service: Unit cloudstack-management.service not loaded.']}
{Cmd: service cloudstack-management start via Host: None} {returns: ['Redirecting to /bin/systemctl start cloudstack-management.service', 'Failed to start cloudstack-management.service: Unit not found.']}
====Trying SSH Connection: Host:10.0.34.25 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:10.0.34.25 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 10.0.34.25 port : 22 SUCCESSFUL===
===SSH to Host 10.0.34.25 port : 22 SUCCESSFUL===
{Cmd: service cloudstack-management stop via Host: 10.0.34.25} {returns: ['Redirecting to /bin/systemctl stop cloudstack-management.service']}
{Cmd: service cloudstack-management stop via Host: 10.0.34.25} {returns: ['Redirecting to /bin/systemctl stop cloudstack-management.service']}
{Cmd: service cloudstack-management start via Host: 10.0.34.25} {returns: ['Redirecting to /bin/systemctl start cloudstack-management.service']}
{Cmd: service cloudstack-management start via Host: 10.0.34.25} {returns: ['Redirecting to /bin/systemctl start cloudstack-management.service']}
====Trying SSH Connection: Host:None User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:None User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:None User:root                                   Port:22 RetryCnt:60===
===SSH to Host None port : 22 SUCCESSFUL===
===SSH to Host None port : 22 SUCCESSFUL===
===SSH to Host None port : 22 SUCCESSFUL===
{Cmd: service cloudstack-management stop via Host: None} {returns: ['Redirecting to /bin/systemctl stop cloudstack-management.service', 'Failed to stop cloudstack-management.service: Unit cloudstack-management.service not loaded.']}
{Cmd: service cloudstack-management stop via Host: None} {returns: ['Redirecting to /bin/systemctl stop cloudstack-management.service', 'Failed to stop cloudstack-management.service: Unit cloudstack-management.service not loaded.']}
{Cmd: service cloudstack-management start via Host: None} {returns: ['Redirecting to /bin/systemctl start cloudstack-management.service', 'Failed to start cloudstack-management.service: Unit not found.']}
{Cmd: service cloudstack-management start via Host: None} {returns: ['Redirecting to /bin/systemctl start cloudstack-management.service', 'Failed to start cloudstack-management.service: Unit not found.']}
=== TestName: test_06_purge_expunged_vm_background_task | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_purge_expunged_vms_SIBUW4 ===
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
