### PR TITLE
Fix Stats Collector to not divide by zero

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -718,10 +718,10 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                  getDynamicDataFromDB();
                  long interval = (Long) dbStats.get(uptime) - lastUptime;
                  long activity = (Long) dbStats.get(queries) - lastQueries;
-                 loadHistory.add(0, interval == 0 ? 0 : Double.valueOf(activity / interval));
+                 loadHistory.add(0, interval == 0 ? -1 : Double.valueOf(activity / interval));
                  int maxsize = DATABASE_SERVER_LOAD_HISTORY_RETENTION_NUMBER.value();
                  while (loadHistory.size() > maxsize) {
-                     loadHistory.remove(maxsize - 1);
+                     loadHistory.remove(maxsize);
                  }
              } catch (Throwable e) {
                  // pokemon catch to make sure the thread stays running

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -718,7 +718,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                  getDynamicDataFromDB();
                  long interval = (Long) dbStats.get(uptime) - lastUptime;
                  long activity = (Long) dbStats.get(queries) - lastQueries;
-                 loadHistory.add(0, Double.valueOf(activity / interval));
+                 loadHistory.add(0, interval == 0 ? 0 : Double.valueOf(activity / interval));
                  int maxsize = DATABASE_SERVER_LOAD_HISTORY_RETENTION_NUMBER.value();
                  while (loadHistory.size() > maxsize) {
                      loadHistory.remove(maxsize - 1);


### PR DESCRIPTION
### Description

Currently, the Stats Collector can throw an arithmetic exception when trying to divide by zero if `interval = 0`.

This PR fixes this issue by setting the `loadHistory.add` value to zero when the `interval` variable is equal to zero.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

In debug mode, I tested by setting the `interval` value to zero. Before the changes, an arithmetic exception was thrown. After the changes, I got no exception and could check that the value added to `loadHistory` was equal to `0`.