### PR TITLE
Preview-Experimental Support EL10 as Management Server and KVM host

### DIFF
--- a/agent/bindir/cloud-setup-agent.in
+++ b/agent/bindir/cloud-setup-agent.in
@@ -20,6 +20,19 @@ import os
 import logging
 import sys
 import socket
+
+# ---- This snippet of code adds the sources path and the waf configured PYTHONDIR to the Python path ----
+# ---- We do this so cloud_utils can be looked up in the following order:
+# ---- 1) Sources directory
+# ---- 2) waf configured PYTHONDIR
+# ---- 3) System Python path
+for pythonpath in (
+        "@PYTHONDIR@",
+        os.path.join(os.path.dirname(__file__),os.path.pardir,os.path.pardir,"python","lib"),
+    ):
+        if os.path.isdir(pythonpath): sys.path.insert(0,pythonpath)
+# ---- End snippet of code ----
+
 from cloudutils.cloudException import CloudRuntimeException, CloudInternalException
 from cloudutils.utilities import initLoging, bash
 from cloudutils.configFileOps import  configFileOps

--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -20,6 +20,19 @@ import sys
 import os
 import subprocess
 from threading import Timer
+
+# ---- This snippet of code adds the sources path and the waf configured PYTHONDIR to the Python path ----
+# ---- We do this so cloud_utils can be looked up in the following order:
+# ---- 1) Sources directory
+# ---- 2) waf configured PYTHONDIR
+# ---- 3) System Python path
+for pythonpath in (
+        "@PYTHONDIR@",
+        os.path.join(os.path.dirname(__file__),os.path.pardir,os.path.pardir,"python","lib"),
+    ):
+        if os.path.isdir(pythonpath): sys.path.insert(0,pythonpath)
+# ---- End snippet of code ----
+
 from xml.dom.minidom import parse
 from cloudutils.configFileOps import configFileOps
 from cloudutils.networkConfig import networkConfig

--- a/client/bindir/cloud-setup-management.in
+++ b/client/bindir/cloud-setup-management.in
@@ -16,13 +16,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 import sys
+# ---- This snippet of code adds the sources path and the waf configured PYTHONDIR to the Python path ----
+# ---- We do this so cloud_utils can be looked up in the following order:
+# ---- 1) Sources directory
+# ---- 2) waf configured PYTHONDIR
+# ---- 3) System Python path
+for pythonpath in (
+        "@PYTHONDIR@",
+        os.path.join(os.path.dirname(__file__),os.path.pardir,os.path.pardir,"python","lib"),
+    ):
+        if os.path.isdir(pythonpath): sys.path.insert(0,pythonpath)
+# ---- End snippet of code ----
+
 from cloudutils.syscfg import sysConfigFactory
 from cloudutils.utilities import initLoging, UnknownSystemException
 from cloudutils.cloudException import CloudRuntimeException, CloudInternalException
 from cloudutils.globalEnv import globalEnv
 from cloudutils.serviceConfigServer import cloudManagementConfig
 from optparse import OptionParser
+
 if __name__ == '__main__':
     initLoging("@MSLOGDIR@/setupManagement.log")
     glbEnv = globalEnv()

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -437,6 +437,8 @@ class cgroupConfig(serviceCfgBase):
 
     def config(self):
         try:
+            # TODO: /etc/cgconfig.conf & /etc/cgrules.conf not available on F40/EL10
+            # had to install: dnf install libcgroup libcgroup-tools
             cfo = configFileOps("/etc/cgconfig.conf", self)
             addConfig = "group virt {\n \
                             cpu {\n \
@@ -452,6 +454,7 @@ class cgroupConfig(serviceCfgBase):
             cfgline = "root:/usr/sbin/libvirtd  cpu virt/\n"
             cfo.add_lines(cfgline)
 
+            # TODO: This doesn't work on EL10/Fedora 40
             self.syscfg.svo.stopService("cgred", True)
             if not self.syscfg.svo.enableService("cgred"):
                 return False

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -437,8 +437,6 @@ class cgroupConfig(serviceCfgBase):
 
     def config(self):
         try:
-            # TODO: /etc/cgconfig.conf & /etc/cgrules.conf not available on F40/EL10
-            # had to install: dnf install libcgroup libcgroup-tools
             cfo = configFileOps("/etc/cgconfig.conf", self)
             addConfig = "group virt {\n \
                             cpu {\n \
@@ -454,7 +452,6 @@ class cgroupConfig(serviceCfgBase):
             cfgline = "root:/usr/sbin/libvirtd  cpu virt/\n"
             cfo.add_lines(cfgline)
 
-            # TODO: This doesn't work on EL10/Fedora 40
             self.syscfg.svo.stopService("cgred", True)
             if not self.syscfg.svo.enableService("cgred"):
                 return False

--- a/python/lib/cloudutils/syscfg.py
+++ b/python/lib/cloudutils/syscfg.py
@@ -39,11 +39,11 @@ class sysConfigAgentFactory:
             return sysConfigAgentUbuntu(glbEnv)
         elif distribution == "CentOS" or distribution == "RHEL5":
             return sysConfigEL5(glbEnv)
-        elif distribution == "Fedora" or distribution == "RHEL6":
+        elif distribution == "RHEL6":
             return sysConfigEL6(glbEnv)
         elif distribution == "RHEL7":
             return sysConfigEL7(glbEnv)
-        elif distribution in ["RHEL8", "RHEL9"]:
+        elif distribution in ["Fedora", "RHEL8", "RHEL9", "RHEL10"]:
             return sysConfigEL(glbEnv)
         elif distribution == "SUSE":
             return sysConfigSUSE(glbEnv)
@@ -183,9 +183,10 @@ class sysConfigEL5(sysConfigAgentRedhatBase):
                          networkConfigRedhat(self),
                          libvirtConfigRedhat(self),
                          firewallConfigAgent(self),
+                         nfsConfig(self),
                          cloudAgentConfig(self)]
 
-#it covers RHEL6/Fedora13/Fedora14
+#it covers RHEL6
 class sysConfigEL6(sysConfigAgentRedhatBase):
     def __init__(self, glbEnv):
         super(sysConfigEL6, self).__init__(glbEnv)

--- a/python/lib/cloudutils/utilities.py
+++ b/python/lib/cloudutils/utilities.py
@@ -124,6 +124,10 @@ class Distribution:
                 version.find("Red Hat Enterprise Linux release 9") != -1 or version.find("Linux release 9.") != -1 or
                 version.find("Linux release 9") != -1):
                 self.distro = "RHEL9"
+            elif (version.find("Red Hat Enterprise Linux Server release 10") != -1 or version.find("Scientific Linux release 10") != -1 or
+                version.find("Red Hat Enterprise Linux release 10") != -1 or version.find("Linux release 10.") != -1 or
+                version.find("Linux release 10") != -1):
+                self.distro = "RHEL10"
             elif version.find("CentOS") != -1:
                 self.distro = "CentOS"
             else:


### PR DESCRIPTION
This adds support for Fedora 40 and (upcoming) EL10 distro to be used as mgmt/usage server, mysql/nfs & KVM host. Python3 version has changed to 3.12.9 which isn't automatically determining the python-path.

This is experimental tech-preview support to ensure packages & installation works. Actual support & testing is due after EL10's release around mid 2025.

Fixes #10494

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

### How Has This Been Tested?

See https://github.com/apache/cloudstack/issues/10494#issuecomment-2696680066