### PR TITLE
ui: do not cache config.json and locale files

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -55,7 +55,7 @@
     </div>
   </body>
   <script type="text/javascript">
-    fetch('./config.json')
+    fetch('./config.json?ts=' + Date.now())
       .then(response => response.json())
       .then(data => {
         document.getElementById("favicon").setAttribute("href", data.loginFavicon);

--- a/ui/src/locales/index.js
+++ b/ui/src/locales/index.js
@@ -39,7 +39,7 @@ export function loadLanguageAsync (lang) {
     return Promise.resolve(setLanguage(lang))
   }
 
-  return fetch(`locales/${lang}.json`)
+  return fetch(`locales/${lang}.json?ts=${Date.now()}`)
     .then(response => response.json())
     .then(json => Promise.resolve(setLanguage(lang, json)))
 }

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -54,7 +54,7 @@ vueApp.use(genericUtilPlugin)
 vueApp.use(extensions)
 vueApp.use(directives)
 
-fetch('config.json').then(response => response.json()).then(config => {
+fetch('config.json?ts=' + Date.now()).then(response => response.json()).then(config => {
   vueProps.$config = config
   let basUrl = config.apiBase
   if (config.multipleServer) {


### PR DESCRIPTION
This will add a randomised timestamp when fetching config.json and locale i18n files, to avoid using cached `json` resources. This will address cases when the UI has newer json files (pkgs upgraded/updated).

Fixes #9985

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Testing

Tested by checking UI devtools:

![Screenshot 2025-03-04 at 3 58 30 PM](https://github.com/user-attachments/assets/faa430b8-496f-42db-a8a7-d61a301fb60d)

