### PR TITLE
framework/cluster: fix NPE for ms-host status when mgr stops

### DIFF
--- a/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
@@ -1112,6 +1112,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     mshostStatus.setLastJvmStop(new Date());
                     mshostStatusDao.update(mshostStatus.getId(), mshostStatus);
                 } else {
+                    logger.warn("an MS host, [{}] without a status? this should never happen!", mshost);
                     mshostStatus = new ManagementServerStatusVO();
                     mshostStatus.setMsId(mshost.getUuid());
                     mshostStatus.setLastSystemBoot(new Date());

--- a/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
@@ -1107,9 +1107,18 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         if (_mshostId != null) {
             final ManagementServerHostVO mshost = _mshostDao.findByMsid(_msId);
             if (mshost != null) {
-                final ManagementServerStatusVO mshostStatus = mshostStatusDao.findByMsId(mshost.getUuid());
-                mshostStatus.setLastJvmStop(new Date());
-                mshostStatusDao.update(mshostStatus.getId(), mshostStatus);
+                ManagementServerStatusVO mshostStatus = mshostStatusDao.findByMsId(mshost.getUuid());
+                if (mshostStatus != null) {
+                    mshostStatus.setLastJvmStop(new Date());
+                    mshostStatusDao.update(mshostStatus.getId(), mshostStatus);
+                } else {
+                    mshostStatus = new ManagementServerStatusVO();
+                    mshostStatus.setMsId(mshost.getUuid());
+                    mshostStatus.setLastSystemBoot(new Date());
+                    mshostStatus.setLastJvmStart(new Date());
+                    mshostStatus.setUpdated(new Date());
+                    mshostStatusDao.persist(mshostStatus);
+                }
 
                 ManagementServerHost.State msHostState = ManagementServerHost.State.Down;
                 if (ManagementServerHost.State.Maintenance.equals(mshost.getState()) || ManagementServerHost.State.PreparingForMaintenance.equals(mshost.getState())) {

--- a/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
@@ -1112,7 +1112,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     mshostStatus.setLastJvmStop(new Date());
                     mshostStatusDao.update(mshostStatus.getId(), mshostStatus);
                 } else {
-                    logger.warn("an MS host, [{}] without a status? this should never happen!", mshost);
+                    logger.warn("Found a management server host [{}] without a status. This should never happen!", mshost);
                     mshostStatus = new ManagementServerStatusVO();
                     mshostStatus.setMsId(mshost.getUuid());
                     mshostStatus.setLastSystemBoot(new Date());


### PR DESCRIPTION
This handles an NPE case for when management server host status is not found in the DB, when stopping the cluster manager.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

On Mac OS, the stat collector doesn't run well as the code assumes to be running on Linux. On non-Linux env, this is easily reproducible.