### PR TITLE
Refactor Quota Summary API

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api;
 public class ApiConstants {
     public static final String ACCOUNT = "account";
     public static final String ACCOUNTS = "accounts";
+    public static final String ACCOUNT_STATE_TO_SHOW = "accountstatetoshow";
     public static final String ACCOUNT_TYPE = "accounttype";
     public static final String ACCOUNT_ID = "accountid";
     public static final String ACCOUNT_IDS = "accountids";

--- a/engine/schema/src/main/java/com/cloud/domain/dao/DomainDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/domain/dao/DomainDaoImpl.java
@@ -262,7 +262,7 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
         SearchCriteria<DomainVO> sc = DomainPairSearch.create();
         sc.setParameters("id", parentId, childId);
 
-        List<DomainVO> domainPair = listBy(sc);
+        List<DomainVO> domainPair = listIncludingRemovedBy(sc);
 
         if ((domainPair != null) && (domainPair.size() == 2)) {
             DomainVO d1 = domainPair.get(0);

--- a/engine/schema/src/main/resources/META-INF/db/views/cloud_usage.quota_summary_view.sql
+++ b/engine/schema/src/main/resources/META-INF/db/views/cloud_usage.quota_summary_view.sql
@@ -1,0 +1,48 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- cloud_usage.quota_summary_view source
+
+-- Create view for quota summary
+DROP VIEW IF EXISTS `cloud_usage`.`quota_summary_view`;
+CREATE VIEW `cloud_usage`.`quota_summary_view` AS
+SELECT
+    cloud_usage.quota_account.account_id AS account_id,
+    cloud_usage.quota_account.quota_balance AS quota_balance,
+    cloud_usage.quota_account.quota_balance_date AS quota_balance_date,
+    cloud_usage.quota_account.quota_enforce AS quota_enforce,
+    cloud_usage.quota_account.quota_min_balance AS quota_min_balance,
+    cloud_usage.quota_account.quota_alert_date AS quota_alert_date,
+    cloud_usage.quota_account.quota_alert_type AS quota_alert_type,
+    cloud_usage.quota_account.last_statement_date AS last_statement_date,
+    cloud.account.uuid AS account_uuid,
+    cloud.account.account_name AS account_name,
+    cloud.account.state AS account_state,
+    cloud.account.removed AS account_removed,
+    cloud.domain.id AS domain_id,
+    cloud.domain.uuid AS domain_uuid,
+    cloud.domain.name AS domain_name,
+    cloud.domain.path AS domain_path,
+    cloud.domain.removed AS domain_removed,
+    cloud.projects.uuid AS project_uuid,
+    cloud.projects.name AS project_name,
+    cloud.projects.removed AS project_removed
+FROM
+    cloud_usage.quota_account
+        INNER JOIN cloud.account ON (cloud.account.id = cloud_usage.quota_account.account_id)
+        INNER JOIN cloud.domain ON (cloud.domain.id = cloud.account.domain_id)
+        LEFT JOIN cloud.projects ON (cloud.account.type = 5 AND cloud.account.id = cloud.projects.project_account_id);

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaAccountStateFilter.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaAccountStateFilter.java
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.quota;
+
+public enum QuotaAccountStateFilter {
+    ALL, ACTIVE, REMOVED;
+
+    public static QuotaAccountStateFilter getValue(String value) {
+        for (QuotaAccountStateFilter state : values()) {
+            if (state.name().equalsIgnoreCase(value)) {
+                return state;
+            }
+        }
+
+        return null;
+    }
+}

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/dao/QuotaSummaryDao.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/dao/QuotaSummaryDao.java
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.quota.dao;
+
+import java.util.List;
+
+import org.apache.cloudstack.quota.QuotaAccountStateFilter;
+import org.apache.cloudstack.quota.vo.QuotaSummaryVO;
+
+import com.cloud.utils.Pair;
+import com.cloud.utils.db.GenericDao;
+
+public interface QuotaSummaryDao extends GenericDao<QuotaSummaryVO, Long> {
+
+    Pair<List<QuotaSummaryVO>, Integer> listQuotaSummariesForAccountAndOrDomain(Long accountId, String accountName, Long domainId, String domainPath,
+                                                                                QuotaAccountStateFilter accountStateFilter, Long startIndex, Long pageSize);
+}

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/dao/QuotaSummaryDaoImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/dao/QuotaSummaryDaoImpl.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.quota.dao;
+
+import java.util.List;
+
+import org.apache.cloudstack.quota.QuotaAccountStateFilter;
+import org.apache.cloudstack.quota.vo.QuotaSummaryVO;
+
+import com.cloud.utils.Pair;
+import com.cloud.utils.db.Filter;
+import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.db.Transaction;
+import com.cloud.utils.db.TransactionCallback;
+import com.cloud.utils.db.TransactionLegacy;
+
+public class QuotaSummaryDaoImpl extends GenericDaoBase<QuotaSummaryVO, Long> implements QuotaSummaryDao {
+
+    @Override
+    public Pair<List<QuotaSummaryVO>, Integer> listQuotaSummariesForAccountAndOrDomain(Long accountId, String accountName, Long domainId, String domainPath,
+                                                                                       QuotaAccountStateFilter accountStateFilter, Long startIndex, Long pageSize) {
+        SearchCriteria<QuotaSummaryVO> searchCriteria = createListQuotaSummariesSearchCriteria(accountId, accountName, domainId, domainPath, accountStateFilter);
+        Filter filter = new Filter(QuotaSummaryVO.class, "accountName", true, startIndex, pageSize);
+
+        return Transaction.execute(TransactionLegacy.USAGE_DB, (TransactionCallback<Pair<List<QuotaSummaryVO>, Integer>>) status -> searchAndCount(searchCriteria, filter));
+    }
+
+    protected SearchCriteria<QuotaSummaryVO> createListQuotaSummariesSearchCriteria(Long accountId, String accountName, Long domainId, String domainPath,
+                                                                                    QuotaAccountStateFilter accountStateFilter) {
+        SearchCriteria<QuotaSummaryVO> searchCriteria = createListQuotaSummariesSearchBuilder(accountStateFilter).create();
+
+        searchCriteria.setParametersIfNotNull("accountId", accountId);
+        searchCriteria.setParametersIfNotNull("domainId", domainId);
+
+        if (accountName != null) {
+            searchCriteria.setParameters("accountName", "%" + accountName + "%");
+        }
+
+        if (domainPath != null) {
+            searchCriteria.setParameters("domainPath", domainPath + "%");
+        }
+
+        return searchCriteria;
+    }
+
+    protected SearchBuilder<QuotaSummaryVO> createListQuotaSummariesSearchBuilder(QuotaAccountStateFilter accountStateFilter) {
+        SearchBuilder<QuotaSummaryVO> searchBuilder = createSearchBuilder();
+
+        searchBuilder.and("accountId", searchBuilder.entity().getAccountId(), SearchCriteria.Op.EQ);
+        searchBuilder.and("accountName", searchBuilder.entity().getAccountName(), SearchCriteria.Op.LIKE);
+        searchBuilder.and("domainId", searchBuilder.entity().getDomainId(), SearchCriteria.Op.EQ);
+        searchBuilder.and("domainPath", searchBuilder.entity().getDomainPath(), SearchCriteria.Op.LIKE);
+
+        if (QuotaAccountStateFilter.REMOVED.equals(accountStateFilter)) {
+            searchBuilder.and("accountRemoved", searchBuilder.entity().getAccountRemoved(), SearchCriteria.Op.NNULL);
+        } else if (QuotaAccountStateFilter.ACTIVE.equals(accountStateFilter)) {
+            searchBuilder.and("accountRemoved", searchBuilder.entity().getAccountRemoved(), SearchCriteria.Op.NULL);
+        }
+
+        return searchBuilder;
+    }
+
+}

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/vo/QuotaSummaryVO.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/vo/QuotaSummaryVO.java
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.quota.vo;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import com.cloud.user.Account;
+
+@Entity
+@Table(name = "quota_summary_view")
+public class QuotaSummaryVO {
+
+    @Id
+    @Column(name = "account_id")
+    private Long accountId = null;
+
+    @Column(name = "quota_enforce")
+    private Integer quotaEnforce = 0;
+
+    @Column(name = "quota_balance")
+    private BigDecimal quotaBalance;
+
+    @Column(name = "quota_balance_date")
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date quotaBalanceDate = null;
+
+    @Column(name = "quota_min_balance")
+    private BigDecimal quotaMinBalance;
+
+    @Column(name = "quota_alert_type")
+    private Integer quotaAlertType = null;
+
+    @Column(name = "quota_alert_date")
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date quotaAlertDate = null;
+
+    @Column(name = "last_statement_date")
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date lastStatementDate = null;
+
+    @Column(name = "account_uuid")
+    private String accountUuid;
+
+    @Column(name = "account_name")
+    private String accountName;
+
+    @Column(name = "account_state")
+    @Enumerated(EnumType.STRING)
+    private Account.State accountState;
+
+    @Column(name = "account_removed")
+    private Date accountRemoved;
+
+    @Column(name = "domain_id")
+    private Long domainId;
+
+    @Column(name = "domain_uuid")
+    private String domainUuid;
+
+    @Column(name = "domain_name")
+    private String domainName;
+
+    @Column(name = "domain_path")
+    private String domainPath;
+
+    @Column(name = "domain_removed")
+    private Date domainRemoved;
+
+    @Column(name = "project_uuid")
+    private String projectUuid;
+
+    @Column(name = "project_name")
+    private String projectName;
+
+    @Column(name = "project_removed")
+    private Date projectRemoved;
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public BigDecimal getQuotaBalance() {
+        return quotaBalance;
+    }
+
+    public String getAccountUuid() {
+        return accountUuid;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public Date getAccountRemoved() {
+        return accountRemoved;
+    }
+
+    public Account.State getAccountState() {
+        return accountState;
+    }
+
+    public Long getDomainId() {
+        return domainId;
+    }
+
+    public String getDomainUuid() {
+        return domainUuid;
+    }
+
+    public String getDomainPath() {
+        return domainPath;
+    }
+
+    public Date getDomainRemoved() {
+        return domainRemoved;
+    }
+
+    public String getProjectUuid() {
+        return projectUuid;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public Date getProjectRemoved() {
+        return projectRemoved;
+    }
+}

--- a/framework/quota/src/main/resources/META-INF/cloudstack/quota/spring-framework-quota-context.xml
+++ b/framework/quota/src/main/resources/META-INF/cloudstack/quota/spring-framework-quota-context.xml
@@ -19,7 +19,8 @@
 
 	<bean id="presetVariableHelper" class="org.apache.cloudstack.quota.activationrule.presetvariables.PresetVariableHelper" />
 	<bean id="QuotaTariffDao" class="org.apache.cloudstack.quota.dao.QuotaTariffDaoImpl" />
-    <bean id="QuotaAccountDao" class="org.apache.cloudstack.quota.dao.QuotaAccountDaoImpl" />
+	<bean id="QuotaSummaryDao" class="org.apache.cloudstack.quota.dao.QuotaSummaryDaoImpl" />
+	<bean id="QuotaAccountDao" class="org.apache.cloudstack.quota.dao.QuotaAccountDaoImpl" />
 	<bean id="QuotaBalanceDao" class="org.apache.cloudstack.quota.dao.QuotaBalanceDaoImpl" />
 	<bean id="QuotaCreditsDao" class="org.apache.cloudstack.quota.dao.QuotaCreditsDaoImpl" />
 	<bean id="QuotaEmailTemplatesDao"

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
@@ -28,12 +28,18 @@ import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.QuotaResponseBuilder;
 import org.apache.cloudstack.api.response.QuotaSummaryResponse;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.quota.QuotaAccountStateFilter;
+import org.apache.cloudstack.quota.QuotaService;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+
 
 import java.util.List;
 
 import javax.inject.Inject;
 
-@APICommand(name = "quotaSummary", responseObject = QuotaSummaryResponse.class, description = "Lists balance and quota usage for all accounts", since = "4.7.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = "quotaSummary", responseObject = QuotaSummaryResponse.class, description = "Lists accounts' balance summary.", since = "4.7.0",
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class QuotaSummaryCmd extends BaseListCmd {
 
     @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, required = false, description = "Optional, Account Id for which statement needs to be generated")
@@ -42,27 +48,31 @@ public class QuotaSummaryCmd extends BaseListCmd {
     @Parameter(name = ApiConstants.DOMAIN_ID, type = CommandType.UUID, required = false, entityType = DomainResponse.class, description = "Optional, If domain Id is given and the caller is domain admin then the statement is generated for domain.")
     private Long domainId;
 
-    @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, required = false, description = "Optional, to list all accounts irrespective of the quota activity")
+    @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, description = "False (default) lists balance summary for account. True lists balance summary for " +
+            "accounts which the caller has access.")
     private Boolean listAll;
 
-    @Inject
-    QuotaResponseBuilder _responseBuilder;
+    @Parameter(name = ApiConstants.ACCOUNT_STATE_TO_SHOW, type = CommandType.STRING, description =  "Possible values are [ALL, ACTIVE, REMOVED]. ALL will list summaries for " +
+            "active and removed accounts; ACTIVE will list summaries only for active accounts; REMOVED will list summaries only for removed accounts. The default value is ACTIVE.")
+    private String accountStateToShow;
 
-    public QuotaSummaryCmd() {
-        super();
-    }
+    @Inject
+    QuotaResponseBuilder quotaResponseBuilder;
+
+    @Inject
+    QuotaService quotaService;
 
     @Override
     public void execute() {
         Account caller = CallContext.current().getCallingAccount();
-        Pair<List<QuotaSummaryResponse>, Integer> responses;
+        Pair<List<QuotaSummaryResponse>, Integer> responses = quotaResponseBuilder.createQuotaSummaryResponse(this);
         if (caller.getType() == Account.Type.ADMIN) {
             if (getAccountName() != null && getDomainId() != null)
-                responses = _responseBuilder.createQuotaSummaryResponse(getAccountName(), getDomainId());
+                responses = quotaResponseBuilder.createQuotaSummaryResponse(getAccountName(), getDomainId());
             else
-                responses = _responseBuilder.createQuotaSummaryResponse(isListAll(), getKeyword(), getStartIndex(), getPageSizeVal());
+                responses = quotaResponseBuilder.createQuotaSummaryResponse(isListAll(), getKeyword(), getStartIndex(), getPageSizeVal());
         } else {
-            responses = _responseBuilder.createQuotaSummaryResponse(caller.getAccountName(), caller.getDomainId());
+            responses = quotaResponseBuilder.createQuotaSummaryResponse(caller.getAccountName(), caller.getDomainId());
         }
         final ListResponse<QuotaSummaryResponse> response = new ListResponse<QuotaSummaryResponse>();
         response.setResponses(responses.first(), responses.second());
@@ -87,11 +97,22 @@ public class QuotaSummaryCmd extends BaseListCmd {
     }
 
     public Boolean isListAll() {
-        return listAll == null ? false: listAll;
+        return BooleanUtils.toBoolean(listAll);
     }
 
     public void setListAll(Boolean listAll) {
         this.listAll = listAll;
+    }
+
+    public QuotaAccountStateFilter getAccountStateToShow() {
+        if (StringUtils.isNotBlank(accountStateToShow)) {
+            QuotaAccountStateFilter state = QuotaAccountStateFilter.getValue(accountStateToShow);
+            if (state != null) {
+                return state;
+            }
+        }
+
+        return QuotaAccountStateFilter.ACTIVE;
     }
 
     @Override

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaResponseBuilder.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaResponseBuilder.java
@@ -24,6 +24,7 @@ import org.apache.cloudstack.api.command.QuotaEmailTemplateListCmd;
 import org.apache.cloudstack.api.command.QuotaEmailTemplateUpdateCmd;
 import org.apache.cloudstack.api.command.QuotaPresetVariablesListCmd;
 import org.apache.cloudstack.api.command.QuotaStatementCmd;
+import org.apache.cloudstack.api.command.QuotaSummaryCmd;
 import org.apache.cloudstack.api.command.QuotaTariffCreateCmd;
 import org.apache.cloudstack.api.command.QuotaTariffListCmd;
 import org.apache.cloudstack.api.command.QuotaTariffUpdateCmd;
@@ -51,6 +52,8 @@ public interface QuotaResponseBuilder {
     QuotaStatementResponse createQuotaStatementResponse(List<QuotaUsageVO> quotaUsage);
 
     QuotaBalanceResponse createQuotaBalanceResponse(List<QuotaBalanceVO> quotaUsage, Date startDate, Date endDate);
+
+    Pair<List<QuotaSummaryResponse>, Integer> createQuotaSummaryResponse(QuotaSummaryCmd cmd);
 
     Pair<List<QuotaSummaryResponse>, Integer> createQuotaSummaryResponse(Boolean listAll);
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaSummaryResponse.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/response/QuotaSummaryResponse.java
@@ -17,7 +17,6 @@
 package org.apache.cloudstack.api.response;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Date;
 
 import com.google.gson.annotations.SerializedName;
@@ -30,52 +29,68 @@ import com.cloud.user.Account.State;
 public class QuotaSummaryResponse extends BaseResponse {
 
     @SerializedName("accountid")
-    @Param(description = "account id")
+    @Param(description = "Account's ID")
     private String accountId;
 
     @SerializedName("account")
-    @Param(description = "account name")
+    @Param(description = "Account's name")
     private String accountName;
 
     @SerializedName("domainid")
-    @Param(description = "domain id")
+    @Param(description = "Domain's ID")
     private String domainId;
 
     @SerializedName("domain")
-    @Param(description = "domain name")
-    private String domainName;
+    @Param(description = "Domain's path")
+    private String domainPath;
 
     @SerializedName("balance")
-    @Param(description = "account balance")
+    @Param(description = "Account's balance")
     private BigDecimal balance;
 
     @SerializedName("state")
-    @Param(description = "account state")
+    @Param(description = "Account's state")
     private State state;
 
+    @SerializedName("domainremoved")
+    @Param(description = "If the domain is removed or not")
+    private boolean domainRemoved;
+
+    @SerializedName("accountremoved")
+    @Param(description = "If the account is removed or not")
+    private boolean accountRemoved;
+
     @SerializedName("quota")
-    @Param(description = "quota usage of this period")
+    @Param(description = "Quota consumed between the startdate and enddate")
     private BigDecimal quotaUsage;
 
     @SerializedName("startdate")
-    @Param(description = "start date")
-    private Date startDate = null;
+    @Param(description = "Start date of the quota consumption")
+    private Date startDate;
 
     @SerializedName("enddate")
-    @Param(description = "end date")
-    private Date endDate = null;
+    @Param(description = "End date of the quota consumption")
+    private Date endDate;
 
     @SerializedName("currency")
-    @Param(description = "currency")
+    @Param(description = "Currency")
     private String currency;
 
     @SerializedName("quotaenabled")
     @Param(description = "if the account has the quota config enabled")
     private boolean quotaEnabled;
 
-    public QuotaSummaryResponse() {
-        super();
-    }
+    @SerializedName("projectname")
+    @Param(description = "Name of the project")
+    private String projectName;
+
+    @SerializedName("projectid")
+    @Param(description = "Project's id")
+    private String projectId;
+
+    @SerializedName("projectremoved")
+    @Param(description = "Whether the project is removed or not")
+    private Boolean projectRemoved;
 
     public String getAccountId() {
         return accountId;
@@ -101,28 +116,16 @@ public class QuotaSummaryResponse extends BaseResponse {
         this.domainId = domainId;
     }
 
-    public String getDomainName() {
-        return domainName;
-    }
-
-    public void setDomainName(String domainName) {
-        this.domainName = domainName;
-    }
-
-    public BigDecimal getQuotaUsage() {
-        return quotaUsage;
-    }
-
-    public State getState() {
-        return state;
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setState(State state) {
         this.state = state;
     }
 
-    public void setQuotaUsage(BigDecimal startQuota) {
-        this.quotaUsage = startQuota.setScale(2, RoundingMode.HALF_EVEN);
+    public void setQuotaUsage(BigDecimal quotaUsage) {
+        this.quotaUsage = quotaUsage;
     }
 
     public BigDecimal getBalance() {
@@ -130,38 +133,42 @@ public class QuotaSummaryResponse extends BaseResponse {
     }
 
     public void setBalance(BigDecimal balance) {
-        this.balance = balance.setScale(2, RoundingMode.HALF_EVEN);
-    }
-
-    public Date getStartDate() {
-        return startDate == null ?  null : new Date(startDate.getTime());
+        this.balance = balance;
     }
 
     public void setStartDate(Date startDate) {
-        this.startDate =  startDate == null ?  null : new Date(startDate.getTime());
-    }
-
-    public Date getEndDate() {
-        return  endDate == null ?  null : new Date(endDate.getTime());
+        this.startDate = startDate;
     }
 
     public void setEndDate(Date endDate) {
-        this.endDate = endDate == null ?  null : new Date(endDate.getTime());
-    }
-
-    public String getCurrency() {
-        return currency;
+        this.endDate = endDate;
     }
 
     public void setCurrency(String currency) {
         this.currency = currency;
     }
 
-    public boolean getQuotaEnabled() {
-        return quotaEnabled;
-    }
-
     public void setQuotaEnabled(boolean quotaEnabled) {
         this.quotaEnabled = quotaEnabled;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public void setProjectRemoved(Boolean projectRemoved) {
+        this.projectRemoved = projectRemoved;
+    }
+
+    public void setDomainRemoved(boolean domainRemoved) {
+        this.domainRemoved = domainRemoved;
+    }
+
+    public void setAccountRemoved(boolean accountRemoved) {
+        this.accountRemoved = accountRemoved;
     }
 }

--- a/plugins/database/quota/src/test/java/org/apache/cloudstack/api/command/QuotaSummaryCmdTest.java
+++ b/plugins/database/quota/src/test/java/org/apache/cloudstack/api/command/QuotaSummaryCmdTest.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QuotaSummaryCmdTest {
+
+    QuotaSummaryCmd quotaSummaryCmdSpy = Mockito.spy(QuotaSummaryCmd.class);
+
+    @Test
+    public void isListAllTestNullReturnsFalse() {
+        quotaSummaryCmdSpy.setListAll(null);
+        Assert.assertFalse(quotaSummaryCmdSpy.isListAll());
+    }
+
+    @Test
+    public void isListAllTestFalseReturnsFalse() {
+        quotaSummaryCmdSpy.setListAll(false);
+        Assert.assertFalse(quotaSummaryCmdSpy.isListAll());
+    }
+
+    @Test
+    public void isListAllTestTrueReturnsTrue() {
+        quotaSummaryCmdSpy.setListAll(true);
+        Assert.assertTrue(quotaSummaryCmdSpy.isListAll());
+    }
+
+}


### PR DESCRIPTION
### Description

The `quotaSummary` API has abstract behaviors and codes, as well as return values not aligned with its purposes. Furthermore, when the account is a project, no information is returned.

Also, in the UI, when opening the Quota Summary details for accounts who owned removed domains, the CloudStack launches an error to the user.

Therefore, this PR:
- improves the API's behavior and return values;
- adds information for project accounts (through parameter `listall=true`);
- adds information for accounts/domains which have been already removed and a filter for accounts in the UI;
- fixes the resource access validation in the API.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

### How Has This Been Tested?

On CloudMonkey I called `quotaSummary` API and checked the return value:
- only relevant information about the summaries is being displayed;
- accounts and domains which have been removed are especified in the summary;
- project accounts are also being considered by the API.

On the UI, the filter for removed accounts is working properly.