### PR TITLE
framework-config: improve configkey caching

### DIFF
--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
@@ -85,7 +85,7 @@ public class ConfigDepotImpl implements ConfigDepot, ConfigDepotAdmin {
     List<ScopedConfigStorage> _scopedStorages;
     Set<Configurable> _configured = Collections.synchronizedSet(new HashSet<Configurable>());
     Set<String> newConfigs = Collections.synchronizedSet(new HashSet<>());
-    LazyCache<String, String> configCache;
+    LazyCache<Ternary<String, ConfigKey.Scope, Long>, String> configCache;
 
     private HashMap<String, Pair<String, ConfigKey<?>>> _allKeys = new HashMap<String, Pair<String, ConfigKey<?>>>(1007);
 
@@ -273,15 +273,10 @@ public class ConfigDepotImpl implements ConfigDepot, ConfigDepotAdmin {
         return _configDao;
     }
 
-    protected String getConfigStringValueInternal(String cacheKey) {
-        String[] parts = cacheKey.split("-");
-        String key = parts[0];
-        ConfigKey.Scope scope = ConfigKey.Scope.Global;
-        Long scopeId = null;
-        try {
-            scope = ConfigKey.Scope.valueOf(parts[1]);
-            scopeId = Long.valueOf(parts[2]);
-        } catch (IllegalArgumentException ignored) {}
+    protected String getConfigStringValueInternal(Ternary<String, ConfigKey.Scope, Long> cacheKey) {
+        String key = cacheKey.first();
+        ConfigKey.Scope scope = cacheKey.second();
+        Long scopeId = cacheKey.third();
         if (!ConfigKey.Scope.Global.equals(scope) && scopeId != null) {
             ScopedConfigStorage scopedConfigStorage = null;
             for (ScopedConfigStorage storage : _scopedStorages) {
@@ -301,8 +296,8 @@ public class ConfigDepotImpl implements ConfigDepot, ConfigDepotAdmin {
         return null;
     }
 
-    private String getConfigCacheKey(String key, ConfigKey.Scope scope, Long scopeId) {
-        return String.format("%s-%s-%d", key, scope, (scopeId == null ? 0 : scopeId));
+    protected Ternary<String, ConfigKey.Scope, Long> getConfigCacheKey(String key, ConfigKey.Scope scope, Long scopeId) {
+        return new Ternary<>(key, scope, scopeId);
     }
 
     @Override

--- a/framework/config/src/test/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImplTest.java
+++ b/framework/config/src/test/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImplTest.java
@@ -81,6 +81,12 @@ public class ConfigDepotImplTest {
         runTestGetConfigStringValue("test", "value");
     }
 
+    @Test
+    public void testGetConfigStringValue_nameWithCharacters() {
+        runTestGetConfigStringValue("test.1-1", "value");
+        runTestGetConfigStringValue("test_1#2", "value");
+    }
+
     private void runTestGetConfigStringValueExpiry(long wait, int configDBRetrieval) {
         String key = "test1";
         String value = "expiry";


### PR DESCRIPTION
### Description

Using a simple hyphen as a delimiter for config cache key can lead to ambiguity if the “name” field itself contains hyphens. To address this, a Ternary object of configkey name, scope and scope ID is used as the config cache keys.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
