### PR TITLE
Fix secondary storage selectors feature

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/GenericPresetVariable.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/GenericPresetVariable.java
@@ -49,8 +49,12 @@ public class GenericPresetVariable {
         fieldNamesToIncludeInToString.add("name");
     }
 
+    /***
+     * Converts the preset variable into a valid JSON object that will be injected into the JS interpreter.
+     * This method should not be overridden or changed.
+     */
     @Override
-    public String toString() {
+    public final String toString() {
         return ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, fieldNamesToIncludeInToString.toArray(new String[0]));
     }
 }

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/Resource.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/activationrule/presetvariables/Resource.java
@@ -40,8 +40,12 @@ public class Resource {
         this.domainId = domainId;
     }
 
+    /***
+     * Converts the preset variable into a valid JSON object that will be injected into the JS interpreter.
+     * This method should not be overridden or changed.
+     */
     @Override
-    public String toString() {
+    public final String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
     }
 

--- a/server/src/main/java/org/apache/cloudstack/storage/heuristics/presetvariables/GenericHeuristicPresetVariable.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/heuristics/presetvariables/GenericHeuristicPresetVariable.java
@@ -38,8 +38,6 @@ public class GenericHeuristicPresetVariable {
 
     @Override
     public String toString() {
-        return String.format("GenericHeuristicPresetVariable %s",
-                ReflectionToStringBuilderUtils.reflectOnlySelectedFields(
-                        this, fieldNamesToIncludeInToString.toArray(new String[0])));
+        return ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, fieldNamesToIncludeInToString.toArray(new String[0]));
     }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/AccountTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/AccountTest.java
@@ -14,17 +14,33 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
-public class Domain extends GenericHeuristicPresetVariable {
-    private String id;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-    public String getId() {
-        return id;
+@RunWith(MockitoJUnitRunner.class)
+public class AccountTest {
+
+    @Test
+    public void toStringTestReturnsValidJson() {
+        Account variable = new Account();
+        variable.setName("test name");
+        variable.setId("test id");
+
+        Domain domainVariable = new Domain();
+        domainVariable.setId("domain id");
+        domainVariable.setName("domain name");
+        variable.setDomain(domainVariable);
+
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name", "id", "domain");
+        String result = variable.toString();
+
+        Assert.assertEquals(expected, result);
     }
 
-    public void setId(String id) {
-        this.id = id;
-        fieldNamesToIncludeInToString.add("id");
-    }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/DomainTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/DomainTest.java
@@ -14,17 +14,28 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
-public class Domain extends GenericHeuristicPresetVariable {
-    private String id;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-    public String getId() {
-        return id;
+@RunWith(MockitoJUnitRunner.class)
+public class DomainTest {
+
+    @Test
+    public void toStringTestReturnsValidJson() {
+        Domain variable = new Domain();
+        variable.setName("test name");
+        variable.setId("test id");
+
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name", "id");
+        String result = variable.toString();
+
+        Assert.assertEquals(expected, result);
     }
 
-    public void setId(String id) {
-        this.id = id;
-        fieldNamesToIncludeInToString.add("id");
-    }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/GenericHeuristicPresetVariableTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/GenericHeuristicPresetVariableTest.java
@@ -14,17 +14,27 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
-public class Domain extends GenericHeuristicPresetVariable {
-    private String id;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-    public String getId() {
-        return id;
+@RunWith(MockitoJUnitRunner.class)
+public class GenericHeuristicPresetVariableTest {
+
+    @Test
+    public void toStringTestReturnsValidJson() {
+        GenericHeuristicPresetVariable variable = new GenericHeuristicPresetVariable();
+        variable.setName("test name");
+
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name");
+        String result = variable.toString();
+
+        Assert.assertEquals(expected, result);
     }
 
-    public void setId(String id) {
-        this.id = id;
-        fieldNamesToIncludeInToString.add("id");
-    }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/SecondaryStorageTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/SecondaryStorageTest.java
@@ -14,17 +14,32 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
-public class Domain extends GenericHeuristicPresetVariable {
-    private String id;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-    public String getId() {
-        return id;
+@RunWith(MockitoJUnitRunner.class)
+public class SecondaryStorageTest {
+
+    @Test
+    public void toStringTestReturnsValidJson() {
+        SecondaryStorage variable = new SecondaryStorage();
+        variable.setName("test name");
+        variable.setId("test id");
+        variable.setProtocol("test protocol");
+        variable.setUsedDiskSize(1L);
+        variable.setTotalDiskSize(2L);
+
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name", "id",
+                "protocol", "usedDiskSize", "totalDiskSize");
+        String result = variable.toString();
+
+        Assert.assertEquals(expected, result);
     }
 
-    public void setId(String id) {
-        this.id = id;
-        fieldNamesToIncludeInToString.add("id");
-    }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/SnapshotTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/SnapshotTest.java
@@ -14,17 +14,31 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
-public class Domain extends GenericHeuristicPresetVariable {
-    private String id;
+import com.cloud.hypervisor.Hypervisor;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-    public String getId() {
-        return id;
+@RunWith(MockitoJUnitRunner.class)
+public class SnapshotTest {
+
+    @Test
+    public void toStringTestReturnsValidJson() {
+        Snapshot variable = new Snapshot();
+        variable.setName("test name");
+        variable.setSize(1L);
+        variable.setHypervisorType(Hypervisor.HypervisorType.KVM);
+
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name", "size",
+                "hypervisorType");
+        String result = variable.toString();
+
+        Assert.assertEquals(expected, result);
     }
 
-    public void setId(String id) {
-        this.id = id;
-        fieldNamesToIncludeInToString.add("id");
-    }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/TemplateTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/TemplateTest.java
@@ -14,34 +14,33 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.Storage;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.HashSet;
-import java.util.Set;
+@RunWith(MockitoJUnitRunner.class)
+public class TemplateTest {
 
-public class GenericHeuristicPresetVariable {
+    @Test
+    public void toStringTestReturnsValidJson() {
+        Template variable = new Template();
+        variable.setName("test name");
+        variable.setTemplateType(Storage.TemplateType.USER);
+        variable.setHypervisorType(Hypervisor.HypervisorType.KVM);
+        variable.setFormat(Storage.ImageFormat.QCOW2);
 
-    protected transient Set<String> fieldNamesToIncludeInToString = new HashSet<>();
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name", "templateType",
+                "hypervisorType", "format");
+        String result = variable.toString();
 
-    private String name;
-
-    public String getName() {
-        return name;
+        Assert.assertEquals(expected, result);
     }
 
-    public void setName(String name) {
-        this.name = name;
-        fieldNamesToIncludeInToString.add("name");
-    }
-
-    /***
-     * Converts the preset variable into a valid JSON object that will be injected into the JS interpreter.
-     * This method should not be overridden or changed.
-     */
-    @Override
-    public final String toString() {
-        return ReflectionToStringBuilderUtils.reflectOnlySelectedFields(this, fieldNamesToIncludeInToString.toArray(new String[0]));
-    }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/VolumeTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/heuristics/presetvariables/VolumeTest.java
@@ -14,17 +14,31 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.storage.heuristics.presetvariables;
 
-public class Domain extends GenericHeuristicPresetVariable {
-    private String id;
+import com.cloud.storage.Storage;
+import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-    public String getId() {
-        return id;
+@RunWith(MockitoJUnitRunner.class)
+public class VolumeTest {
+
+    @Test
+    public void toStringTestReturnsValidJson() {
+        Volume variable = new Volume();
+        variable.setName("test name");
+        variable.setFormat(Storage.ImageFormat.QCOW2);
+        variable.setSize(1L);
+
+        String expected = ReflectionToStringBuilderUtils.reflectOnlySelectedFields(variable, "name", "format",
+                "size");
+        String result = variable.toString();
+
+        Assert.assertEquals(expected, result);
     }
 
-    public void setId(String id) {
-        this.id = id;
-        fieldNamesToIncludeInToString.add("id");
-    }
 }


### PR DESCRIPTION
### Description

The secondary storage selectors feature is not working in the 4.20 and main branches.

PR #9873 changed the return of `org.apache.cloudstack.storage.heuristics.presetvariables.GenericHeuristicPresetVariable#toString`; however, as this method is used to build the secondary storage selection script, the changes made it stop working.

Here's how the script looked like before #9873:

```js
secondaryStorages = [{"id":"f7e21c42-f621-4412-8994-36e077f0faec","protocol":"nfs","totalDiskSize":104028176384,"usedDiskSize":47059042304,"name":"sec"}, {"id":"0d88afc2-93eb-4070-8fbf-d8909f62364d","protocol":"nfs","totalDiskSize":104028176384,"usedDiskSize":47059042304,"name":"sec-2"}]; snapshot = {"hypervisorType":"KVM","size":52428800,"name":"e"}; account = {"domain":{"id":"40815ad7-28b2-11ef-a04e-6ac09c2b3d6b","name":"ROOT"},"id":"60b92e66-28b2-11ef-a04e-6ac09c2b3d6b","name":"admin"}; '0d88afc2-93eb-4070-8fbf-d8909f62364d';
```

And how it looks like now:

```js
secondaryStorages = [GenericHeuristicPresetVariable {"id":"865197af-0bcc-4041-b031-8e6590cf41c4","protocol":"nfs","totalDiskSize":51460964352,"usedDiskSize":37255905280,"name":"sec-a-zn-1"}, GenericHeuristicPresetVariable {"id":"16babc8c-a6e8-4bb3-b581-c37afad4b442","protocol":"nfs","totalDiskSize":51460964352,"usedDiskSize":37255905280,"name":"sec-b-zn-1"}]; snapshot = GenericHeuristicPresetVariable {"hypervisorType":"KVM","size":52428800,"name":"a"}; account = GenericHeuristicPresetVariable {"domain":"GenericHeuristicPresetVariable {\"id\":\"40815ad7-28b2-11ef-a04e-6ac09c2b3d6b\",\"name\":\"ROOT\"}","id":"60b92e66-28b2-11ef-a04e-6ac09c2b3d6b","name":"admin"}; '16babc8c-a6e8-4bb3-b581-c37afad4b442';
```

This PR reverts the method to its previous state.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [X] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

1. I created a heuristic rule to direct snapshots to a specific secondary storage

```
(admin) 🐢 > create secondarystorageselector description=a name=a zoneid=065b0fd8-f562-480a-b278-ea3d9306a326  heuristicrule="'0d88afc2-93eb-4070-8fbf-d8909f62364d';" type=SNAPSHOT
```

2. I tried to take a snapshot

Before the changes, the snapshot process would fail due to an exception thrown by the JS interpreter. Applying the patch made it work again and correctly directed the snapshot to the secondary storage that I specified.