### PR TITLE
Add download link of volumes, templates and ISOs to the download event details

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/iso/ExtractIsoCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/iso/ExtractIsoCmd.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.api.command.user.iso;
 
 
+import com.cloud.dc.DataCenter;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.api.ApiConstants;
@@ -101,7 +102,15 @@ public class ExtractIsoCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "extracting ISO: " + getId() + " from zone: " + getZoneId();
+        String isoId = this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId());
+        String baseDescription = String.format("Extracting ISO: %s", isoId);
+
+        Long zoneId = getZoneId();
+        if (zoneId == null) {
+            return baseDescription;
+        }
+
+        return String.format("%s from zone: %s", baseDescription, this._uuidMgr.getUuid(DataCenter.class, zoneId));
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/ExtractTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/ExtractTemplateCmd.java
@@ -101,7 +101,15 @@ public class ExtractTemplateCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-     return "extracting template: " + this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId()) + ((getZoneId() != null) ? " from zone: " + this._uuidMgr.getUuid(DataCenter.class, getZoneId()) : "");
+        String templateId = this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId());
+        String baseDescription = String.format("Extracting template: %s", templateId);
+
+        Long zoneId = getZoneId();
+        if (zoneId == null) {
+            return baseDescription;
+        }
+
+        return String.format("%s from zone: %s", baseDescription, this._uuidMgr.getUuid(DataCenter.class, zoneId));
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ExtractVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ExtractVolumeCmd.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.api.command.user.volume;
 
 
+import com.cloud.dc.DataCenter;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.APICommand;
@@ -114,12 +115,15 @@ public class ExtractVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "Extraction job";
+        String volumeId = this._uuidMgr.getUuid(Volume.class, getId());
+        String zoneId = this._uuidMgr.getUuid(DataCenter.class, getZoneId());
+
+        return String.format("Extracting volume: %s from zone: %s", volumeId, zoneId);
     }
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getId()));
+        CallContext.current().setEventDetails(getEventDescription());
         String uploadUrl = _volumeService.extractVolume(this);
         if (uploadUrl != null) {
             ExtractResponse response = _responseGenerator.createVolumeExtractResponse(id, zoneId, getEntityOwnerId(), mode, uploadUrl);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -4115,7 +4115,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         Optional<String> extractUrl = setExtractVolumeSearchCriteria(sc, volume);
         if (extractUrl.isPresent()) {
-            return extractUrl.get();
+            String url = extractUrl.get();
+            CallContext.current().setEventDetails(String.format("Download URL: %s, volume ID: %s", url, volume.getUuid()));
+            return url;
         }
 
         VMInstanceVO vm = null;
@@ -4132,7 +4134,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 VmWorkJobVO placeHolder = null;
                 placeHolder = createPlaceHolderWork(vm.getId());
                 try {
-                    return orchestrateExtractVolume(volume.getId(), zoneId);
+                    String url = orchestrateExtractVolume(volume.getId(), zoneId);
+                    CallContext.current().setEventDetails(String.format("Download URL: %s, volume ID: %s", url, volume.getUuid()));
+                    return url;
                 } finally {
                     _workJobDao.expunge(placeHolder.getId());
                 }
@@ -4161,13 +4165,17 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
                 // retrieve the entity url from job result
                 if (jobResult != null && jobResult instanceof String) {
-                    return (String)jobResult;
+                    String url = (String) jobResult;
+                    CallContext.current().setEventDetails(String.format("Download URL: %s, volume ID: %s", url, volume.getUuid()));
+                    return url;
                 }
                 return null;
             }
         }
 
-        return orchestrateExtractVolume(volume.getId(), zoneId);
+        String url = orchestrateExtractVolume(volume.getId(), zoneId);
+        CallContext.current().setEventDetails(String.format("Download URL: %s, volume ID: %s", url, volume.getUuid()));
+        return url;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -488,7 +488,9 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         String mode = cmd.getMode();
         Long eventId = cmd.getStartEventId();
 
-        return extract(account, templateId, url, zoneId, mode, eventId, true);
+        String extractUrl = extract(account, templateId, url, zoneId, mode, eventId, true);
+        CallContext.current().setEventDetails(String.format("Download URL: %s, ISO ID: %s", extractUrl, _tmpltDao.findById(templateId).getUuid()));
+        return extractUrl;
     }
 
     @Override
@@ -506,7 +508,9 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             throw new InvalidParameterValueException("unable to find template with id " + templateId);
         }
 
-        return extract(caller, templateId, url, zoneId, mode, eventId, false);
+        String extractUrl = extract(caller, templateId, url, zoneId, mode, eventId, false);
+        CallContext.current().setEventDetails(String.format("Download URL: %s, template ID: %s", extractUrl, template.getUuid()));
+        return extractUrl;
     }
 
     @Override


### PR DESCRIPTION
### Description

When the download of templates, ISOs and volumes is finished, a download link is generated and displayed to end users in a notification. However, in situations in which the download process takes a large amount of time, the user's authentication session may be expired by inactivity and, thus, the reference to the link gets lost.

Therefore, this PR proposes to add the templates, ISOs and volumes download links to the details of the `TEMPLATE.EXTRACT`, `ISO.EXTRACT` and `VOLUME.EXTRACT` events, respectively. As a consequence of that, in scenarios that users sessions are expired when downloading such resources, the event details can be accessed by users to retrieve the download link.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

- `TEMPLATE.EXTRACT` event details:

![image](https://github.com/user-attachments/assets/dbaf772c-1ae5-4577-abf6-1f47a6d7b053)

- `ISO.EXTRACT` event details:

![image](https://github.com/user-attachments/assets/8f844951-4df7-4e33-91c7-08b813c424fa)

- `VOLUME.EXTRACT` event details:

![image](https://github.com/user-attachments/assets/0fd84292-8954-480e-877f-c818da96fed7)

### How Has This Been Tested?

- Verified that when the templates extraction process is completed, the `TEMPLATE.EXTRACT` event description is generated with the template download URL.
- Verified that when the ISOs extraction process is completed, the `ISO.EXTRACT` event description is generated with the ISO download URL.
- Verified that when the volume extraction process is completed for root disks, the `VOLUME.EXTRACT` event description is generated with the volume download URL.
- Verified that when the volume extraction process is completed for attached data disks, the `VOLUME.EXTRACT` event description is generated with the volume download URL.
- Verified that when the volume extraction process is completed for detached data disks, the `VOLUME.EXTRACT` event description is generated with the volume download URL.