### PR TITLE
Hide CloudStack version from XML response when unauthenticated

### DIFF
--- a/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java
+++ b/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java
@@ -176,7 +176,9 @@ public class ApiResponseSerializer {
 
             sb.append("<").append(result.getResponseName());
             log.append("<").append(result.getResponseName());
-            if (ManagementServerImpl.exposeCloudStackVersionInApiXmlResponse.value()) {
+
+            boolean authenticated = CallContext.current().getCallingAccount().getId() != Account.ACCOUNT_ID_SYSTEM;
+            if (ManagementServerImpl.exposeCloudStackVersionInApiXmlResponse.value() && authenticated) {
                 sb.append(" cloud-stack-version=\"").append(ApiDBUtils.getVersion()).append("\"");
                 log.append(" cloud-stack-version=\"").append(ApiDBUtils.getVersion()).append("\"");
             }

--- a/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java
+++ b/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java
@@ -20,6 +20,7 @@ import com.cloud.api.ApiDBUtils;
 import com.cloud.api.ApiResponseGsonHelper;
 import com.cloud.api.ApiServer;
 import com.cloud.serializer.Param;
+import com.cloud.server.ManagementServerImpl;
 import com.cloud.user.Account;
 import com.cloud.utils.HttpUtils;
 import com.cloud.utils.encoding.URLEncoder;
@@ -171,9 +172,16 @@ public class ApiResponseSerializer {
         if (result != null && log != null) {
             StringBuilder sb = new StringBuilder();
             sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            sb.append("<").append(result.getResponseName()).append(" cloud-stack-version=\"").append(ApiDBUtils.getVersion()).append("\">");
             log.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            log.append("<").append(result.getResponseName()).append(" cloud-stack-version=\"").append(ApiDBUtils.getVersion()).append("\">");
+
+            sb.append("<").append(result.getResponseName());
+            log.append("<").append(result.getResponseName());
+            if (ManagementServerImpl.exposeCloudStackVersionInApiXmlResponse.value()) {
+                sb.append(" cloud-stack-version=\"").append(ApiDBUtils.getVersion()).append("\"");
+                log.append(" cloud-stack-version=\"").append(ApiDBUtils.getVersion()).append("\"");
+            }
+            sb.append(">");
+            log.append(">");
 
             if (result instanceof ListResponse) {
                 Integer count = ((ListResponse)result).getCount();

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -854,6 +854,9 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     static final ConfigKey<Integer> sshKeyLength = new ConfigKey<>("Advanced", Integer.class, "ssh.key.length", "2048", "Specifies custom SSH key length (bit)", true, ConfigKey.Scope.Global);
     static final ConfigKey<Boolean> humanReadableSizes = new ConfigKey<>("Advanced", Boolean.class, "display.human.readable.sizes", "true", "Enables outputting human readable byte sizes to logs and usage records.", false, ConfigKey.Scope.Global);
     public static final ConfigKey<String> customCsIdentifier = new ConfigKey<>("Advanced", String.class, "custom.cs.identifier", UUID.randomUUID().toString().split("-")[0].substring(4), "Custom identifier for the cloudstack installation", true, ConfigKey.Scope.Global);
+    public static final ConfigKey<Boolean> exposeCloudStackVersionInApiXmlResponse = new ConfigKey<Boolean>("Advanced", Boolean.class, "expose.cloudstack.version.api.xml.response", "true", "Indicates whether ACS version should appear in the root element of an API XML response.", true, ConfigKey.Scope.Global);
+    public static final ConfigKey<Boolean> exposeCloudStackVersionInApiListCapabilities = new ConfigKey<Boolean>("Advanced", Boolean.class, "expose.cloudstack.version.api.list.capabilities", "true", "Indicates whether ACS version should show in the listCapabilities API.", true, ConfigKey.Scope.Global);
+
     private static final VirtualMachine.Type []systemVmTypes = { VirtualMachine.Type.SecondaryStorageVm, VirtualMachine.Type.ConsoleProxy};
     private static final List<HypervisorType> LIVE_MIGRATION_SUPPORTING_HYPERVISORS = List.of(HypervisorType.Hyperv, HypervisorType.KVM,
             HypervisorType.LXC, HypervisorType.Ovm, HypervisorType.Ovm3, HypervisorType.Simulator, HypervisorType.VMware, HypervisorType.XenServer);
@@ -4055,7 +4058,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {vmPasswordLength, sshKeyLength, humanReadableSizes, customCsIdentifier};
+        return new ConfigKey<?>[] {exposeCloudStackVersionInApiXmlResponse, exposeCloudStackVersionInApiListCapabilities, vmPasswordLength, sshKeyLength, humanReadableSizes, customCsIdentifier};
     }
 
     protected class EventPurgeTask extends ManagedContextRunnable {
@@ -4481,10 +4484,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         final Integer fsVmMinCpu = Integer.parseInt(_configDao.getValue("sharedfsvm.min.cpu.count"));
         final Integer fsVmMinRam = Integer.parseInt(_configDao.getValue("sharedfsvm.min.ram.size"));
+        if (exposeCloudStackVersionInApiListCapabilities.value()) {
+            capabilities.put("cloudStackVersion", getVersion());
+        }
 
         capabilities.put("securityGroupsEnabled", securityGroupsEnabled);
         capabilities.put("userPublicTemplateEnabled", userPublicTemplateEnabled);
-        capabilities.put("cloudStackVersion", getVersion());
         capabilities.put("supportELB", supportELB);
         capabilities.put("projectInviteRequired", _projectMgr.projectInviteRequired());
         capabilities.put("allowusercreateprojects", _projectMgr.allowUserToCreateProject());


### PR DESCRIPTION
This PR hides the cloudstack version field of XML responses when the caller is unauthenticated (checks if it is SYSTEM account).

It also adds the `expose.cloudstack.version.api.list.capabilities` to allow hiding the field from the `listCapabilities` API call and `expose.cloudstack.version.api.xml.response` to allow hiding the field from XML responses, both are true by default as to not change compatibility. 

It does not change the version information in system VMs and VRs.

Fixes: #10072


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Unauthenticated:
```
<loginresponse>
<errorcode>531</errorcode>
<errortext>
Your authenticated user is not authorized for SAML Single Sign-On, please contact your administrator
</errortext>
</loginresponse>
```

Authenticated and configs:

- `expose.cloudstack.version.api.list.capabilities` = true;  
  `expose.cloudstack.version.api.xml.response` = true;
```
<listcapabilitiesresponse cloud-stack-version="4.21.0.0-SNAPSHOT">
<capability>
<securitygroupsenabled>false</securitygroupsenabled>
<dynamicrolesenabled>true</dynamicrolesenabled>
<cloudstackversion>4.21.0.0-SNAPSHOT</cloudstackversion>
<userpublictemplateenabled>true</userpublictemplateenabled>
<supportELB>false</supportELB>
<projectinviterequired>false</projectinviterequired>
<allowusercreateprojects>true</allowusercreateprojects>
<customdiskofferingminsize>1</customdiskofferingminsize>
<customdiskofferingmaxsize>1024</customdiskofferingmaxsize>
<regionsecondaryenabled>false</regionsecondaryenabled>
<kvmsnapshotenabled>false</kvmsnapshotenabled>
<allowuserviewdestroyedvm>true</allowuserviewdestroyedvm>
<allowuserexpungerecovervm>true</allowuserexpungerecovervm>
<allowuserexpungerecovervolume>true</allowuserexpungerecovervolume>
<allowuserviewalldomainaccounts>false</allowuserviewalldomainaccounts>
<allowuserforcestopvm>true</allowuserforcestopvm>
<kubernetesserviceenabled>true</kubernetesserviceenabled>
<kubernetesclusterexperimentalfeaturesenabled>false</kubernetesclusterexperimentalfeaturesenabled>
<customhypervisordisplayname>Custom</customhypervisordisplayname>
<defaultuipagesize>20</defaultuipagesize>
<instancesstatsretentiontime>720</instancesstatsretentiontime>
<instancesstatsuseronly>false</instancesstatsuseronly>
<instancesdisksstatsretentionenabled>false</instancesdisksstatsretentionenabled>
<instancesdisksstatsretentiontime>720</instancesdisksstatsretentiontime>
<sharedfsvmmincpucount>2</sharedfsvmmincpucount>
<sharedfsvmminramsize>1024</sharedfsvmminramsize>
</capability>
</listcapabilitiesresponse>
```

- `expose.cloudstack.version.api.list.capabilities` = false;  
  `expose.cloudstack.version.api.xml.response` = false;
```
<listcapabilitiesresponse>
<capability>
<securitygroupsenabled>false</securitygroupsenabled>
<dynamicrolesenabled>true</dynamicrolesenabled>
<userpublictemplateenabled>true</userpublictemplateenabled>
<supportELB>false</supportELB>
<projectinviterequired>false</projectinviterequired>
<allowusercreateprojects>true</allowusercreateprojects>
<customdiskofferingminsize>1</customdiskofferingminsize>
<customdiskofferingmaxsize>1024</customdiskofferingmaxsize>
<regionsecondaryenabled>false</regionsecondaryenabled>
<kvmsnapshotenabled>false</kvmsnapshotenabled>
<allowuserviewdestroyedvm>true</allowuserviewdestroyedvm>
<allowuserexpungerecovervm>true</allowuserexpungerecovervm>
<allowuserexpungerecovervolume>true</allowuserexpungerecovervolume>
<allowuserviewalldomainaccounts>false</allowuserviewalldomainaccounts>
<allowuserforcestopvm>true</allowuserforcestopvm>
<kubernetesserviceenabled>true</kubernetesserviceenabled>
<kubernetesclusterexperimentalfeaturesenabled>false</kubernetesclusterexperimentalfeaturesenabled>
<customhypervisordisplayname>Custom</customhypervisordisplayname>
<defaultuipagesize>20</defaultuipagesize>
<instancesstatsretentiontime>720</instancesstatsretentiontime>
<instancesstatsuseronly>false</instancesstatsuseronly>
<instancesdisksstatsretentionenabled>false</instancesdisksstatsretentionenabled>
<instancesdisksstatsretentiontime>720</instancesdisksstatsretentiontime>
<sharedfsvmmincpucount>2</sharedfsvmmincpucount>
<sharedfsvmminramsize>1024</sharedfsvmminramsize>
</capability>
</listcapabilitiesresponse>
```


#### How did you try to break this feature and the system with this change?
