### PR TITLE
In Install.md->CloudStack UI Commands(npm)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,9 +87,7 @@ Start the management server:
 
 If this works, you've successfully setup a single server Apache CloudStack installation.
 
-Open the following URL on your browser to access the Management Server UI:
-
-    http://localhost:8080/client/
+To access the Management Server UI, follow the following procedure:
 
 The default credentials are; user: admin, password: password and the domain
 field should be left blank which is defaulted to the ROOT domain.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,8 @@ Setup up NodeJS (LTS):
 Start the MySQL service:
 
     $ service mysqld start
+    $ mysql_secure_installation
+    
 
 ### Using jenv and/or pyenv for Version Management
 
@@ -92,6 +94,16 @@ Open the following URL on your browser to access the Management Server UI:
 
 The default credentials are; user: admin, password: password and the domain
 field should be left blank which is defaulted to the ROOT domain.
+
+## To bring up CloudStack UI
+ $ cd /path/to/cloudstack/ui
+ $ npm install
+ $ npm run build
+ $ npm start
+
+Make sure to set CS_URL=http://localhost:8080/client on .env.local file on ui.
+
+You should be able to run the management server on http://localhost:5050
 
 ## Building with non-redistributable plugins
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,8 +97,11 @@ field should be left blank which is defaulted to the ROOT domain.
 
 ## To bring up CloudStack UI
  $ cd /path/to/cloudstack/ui
+
  $ npm install
+
  $ npm run build
+ 
  $ npm start
 
 Make sure to set CS_URL=http://localhost:8080/client on .env.local file on ui.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,11 +98,11 @@ field should be left blank which is defaulted to the ROOT domain.
 ## To bring up CloudStack UI
  $ cd /path/to/cloudstack/ui
 
- $ npm install
+Use $ npm install to install dependencies.
 
- $ npm run build
- 
- $ npm start
+Use $ npm build to build the project.
+
+Use $ npm start for development mode.
 
 Make sure to set CS_URL=http://localhost:8080/client on .env.local file on ui.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,11 +98,17 @@ field should be left blank which is defaulted to the ROOT domain.
 ## To bring up CloudStack UI
  $ cd /path/to/cloudstack/ui
 
-    Use $ npm install to install dependencies.
+To install dependencies.
 
-    Use $ npm build to build the project.
+    $ npm install 
 
-    Use $ npm start for development mode.
+To build the project.
+
+    $ npm build
+
+For Development Mode.
+
+    $ npm start 
 
 Make sure to set CS_URL=http://localhost:8080/client on .env.local file on ui.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,6 @@ Start the MySQL service:
 
     $ service mysqld start
     $ mysql_secure_installation
-    
 
 ### Using jenv and/or pyenv for Version Management
 
@@ -103,7 +102,7 @@ Move to UI Directory
 
 To install dependencies.
 
-    $ npm install 
+    $ npm install
 
 To build the project.
 
@@ -111,7 +110,7 @@ To build the project.
 
 For Development Mode.
 
-    $ npm start 
+    $ npm start
 
 Make sure to set CS_URL=http://localhost:8080/client on .env.local file on ui.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,11 +98,11 @@ field should be left blank which is defaulted to the ROOT domain.
 ## To bring up CloudStack UI
  $ cd /path/to/cloudstack/ui
 
-Use $ npm install to install dependencies.
+    Use $ npm install to install dependencies.
 
-Use $ npm build to build the project.
+    Use $ npm build to build the project.
 
-Use $ npm start for development mode.
+    Use $ npm start for development mode.
 
 Make sure to set CS_URL=http://localhost:8080/client on .env.local file on ui.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,10 @@ The default credentials are; user: admin, password: password and the domain
 field should be left blank which is defaulted to the ROOT domain.
 
 ## To bring up CloudStack UI
- $ cd /path/to/cloudstack/ui
+
+Move to UI Directory
+
+    $ cd /path/to/cloudstack/ui
 
 To install dependencies.
 


### PR DESCRIPTION
Description

This PR updates INSTALL.md to include essential setup commands for first-time contributors, ensuring a smoother installation process and reducing setup errors.
Changes:

    Added mysql_secure_installation to improve MySQL security.
    Included steps for setting up the CloudStack UI (npm install, npm build, npm start).
    Clarified the requirement to set CS_URL=http://localhost:8080/client in .env.local for API communication.
    Explicitly mentioned that the management server runs at http://localhost:5050/.

These improvements will make onboarding easier and reduce setup issues.
#10590 
Types of changes

Breaking change (fix or feature that would cause existing functionality to change)
New feature (non-breaking change which adds functionality)
Bug fix (non-breaking change which fixes an issue)
Enhancement (improves an existing feature and functionality)
Cleanup (Code refactoring and cleanup, that may add test cases)
build/CI

    test (unit or integration test code)

Feature/Enhancement Scale or Bug Severity
Feature/Enhancement Scale

Minor

    Major

Bug Severity

BLOCKER
Critical
Major
Minor

    Trivial

Screenshots :

![Screenshot from 2025-03-20 18-22-45](https://github.com/user-attachments/assets/8c7b6056-9b3b-4375-b6b7-aa0048599fd8)



How Has This Been Tested?

    Followed the updated steps on a fresh Ubuntu 22.04.5 environment.
    Ensured the UI builds successfully and connects to the management server.
    Verified mysql_secure_installation improves security settings.
    Confirmed the management server is accessible at http://localhost:5050/.

How did you try to break this feature and the system with this change?

    Tested installation without mysql_secure_installation to confirm the security risk.
    Omitted CS_URL in .env.local and verified API connection failure.
    Attempted to start the UI without installing dependencies to confirm issues.