### PR TITLE
UI: Change resource settings to be type based

### DIFF
--- a/ui/src/views/setting/ConfigurationTable.vue
+++ b/ui/src/views/setting/ConfigurationTable.vue
@@ -37,6 +37,7 @@
       </template>
     </a-table>
     <a-pagination
+      v-if="this.$route.meta.name === 'globalsetting'"
       class="config-row-element"
       style="margin-top: 10px"
       size="small"

--- a/ui/src/views/setting/ConfigurationValue.vue
+++ b/ui/src/views/setting/ConfigurationValue.vue
@@ -222,12 +222,35 @@ export default {
   data () {
     return {
       valueLoading: this.loading,
+      scopeKey: '',
       actualValue: null,
       editableValue: null,
       editableValueKey: null
     }
   },
   created () {
+    switch (this.$route.meta.name) {
+      case 'account':
+        this.scopeKey = 'accountid'
+        break
+      case 'domain':
+        this.scopeKey = 'domainid'
+        break
+      case 'zone':
+        this.scopeKey = 'zoneid'
+        break
+      case 'cluster':
+        this.scopeKey = 'clusterid'
+        break
+      case 'storagepool':
+        this.scopeKey = 'storageid'
+        break
+      case 'imagestore':
+        this.scopeKey = 'imagestoreuuid'
+        break
+      default:
+        this.scopeKey = ''
+    }
     this.setConfigData()
   },
   watch: {
@@ -253,6 +276,7 @@ export default {
         newValue = newValue.join(' ')
       }
       const params = {
+        [this.scopeKey]: this.$route.params?.id,
         name: configrecord.name,
         value: newValue
       }
@@ -287,9 +311,11 @@ export default {
     resetConfigurationValue (configrecord) {
       this.valueLoading = true
       this.editableValueKey = null
-      api('resetConfiguration', {
+      const params = {
+        [this.scopeKey]: this.$route.params?.id,
         name: configrecord.name
-      }).then(json => {
+      }
+      api('resetConfiguration', params).then(json => {
         this.editableValue = this.getEditableValue(json.resetconfigurationresponse.configuration)
         this.actualValue = this.editableValue
         var newValue = this.editableValue


### PR DESCRIPTION
### Description

Currently, the only way to update a value in the resource settings tabs is by typing the new value as a text, regardless of its type (boolean, range, percentage, etc).

This PR change this behavior to work like the global settings, where the edition is based on the value type.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

![Screenshot from 2025-03-18 17-50-25](https://github.com/user-attachments/assets/88183133-ca8f-4c6d-b94e-c17d06655e85)


### How Has This Been Tested?

I tested it by accessing each affected settings tab to confirm that the changes were applied.

I also changed some configurations values to see if everything still works as intended.