### PR TITLE
Fix smoke test for restore vm strict tags failure

### DIFF
--- a/test/integration/smoke/test_vm_strict_host_tags.py
+++ b/test/integration/smoke/test_vm_strict_host_tags.py
@@ -420,7 +420,11 @@ class TestRestoreVMStrictTags(cloudstackTestCase):
 
         self.assertEqual(self.host_h1.id, vm.hostid, "VM instance was not deployed on target host ID")
         try:
+            # remove vm from cleanup list since it should not be restored and the vm gets expunged
+            self.cleanup.remove(vm)
             vm.restore(self.apiclient, templateid=self.template_t2.id, expunge=True)
+            # If restore is successful, it will be added to the cleanup list. Ideally, this code should not be reached.
+            self.cleanup.append(vm)
             self.fail("VM should not be restored")
         except Exception as e:
             self.assertTrue("No suitable host found for vm " in str(e))


### PR DESCRIPTION
### Description

This PR fixes the smoke test failure for test_02_restore_vm_strict_tags_failure.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [x] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
