### PR TITLE
enhancement: Optimize listZonesMetrics and listClustersMetrics call performance

### DIFF
--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -188,13 +188,6 @@ public class MetricsServiceImpl extends MutualExclusiveIdsManagerBase implements
         super();
     }
 
-    private Double findRatioValue(final String value) {
-        if (value != null) {
-            return Double.valueOf(value);
-        }
-        return 1.0;
-    }
-
     private void updateHostMetrics(final HostMetrics hostMetrics, final HostJoinVO host) {
         hostMetrics.addCpuAllocated(host.getCpuReservedCapacity() + host.getCpuUsedCapacity());
         hostMetrics.addMemoryAllocated(host.getMemReservedCapacity() + host.getMemUsedCapacity());
@@ -764,14 +757,10 @@ public class MetricsServiceImpl extends MutualExclusiveIdsManagerBase implements
             if (AllowListMetricsComputation.value()) {
                 List<Ternary<Long, Long, Long>> cpuList = new ArrayList<>();
                 List<Ternary<Long, Long, Long>> memoryList = new ArrayList<>();
-                for (final Host host : hostDao.findByClusterId(clusterId)) {
-                    if (host == null || host.getType() != Host.Type.Routing) {
-                        continue;
-                    }
-                    updateHostMetrics(hostMetrics, hostJoinDao.findById(host.getId()));
-                    HostJoinVO hostJoin = hostJoinDao.findById(host.getId());
-                    cpuList.add(new Ternary<>(hostJoin.getCpuUsedCapacity(), hostJoin.getCpuReservedCapacity(), hostJoin.getCpus() * hostJoin.getSpeed()));
-                    memoryList.add(new Ternary<>(hostJoin.getMemUsedCapacity(), hostJoin.getMemReservedCapacity(), hostJoin.getTotalMemory()));
+                for (final HostJoinVO host : hostJoinDao.findByClusterId(clusterId, Host.Type.Routing)) {
+                    updateHostMetrics(hostMetrics, host);
+                    cpuList.add(new Ternary<>(host.getCpuUsedCapacity(), host.getCpuReservedCapacity(), host.getCpus() * host.getSpeed()));
+                    memoryList.add(new Ternary<>(host.getMemUsedCapacity(), host.getMemReservedCapacity(), host.getTotalMemory()));
                 }
                 try {
                     Double imbalance = ClusterDrsAlgorithm.getClusterImbalance(clusterId, cpuList, memoryList, null);
@@ -950,11 +939,8 @@ public class MetricsServiceImpl extends MutualExclusiveIdsManagerBase implements
                     if (cluster == null) {
                         continue;
                     }
-                    for (final Host host: hostDao.findByClusterId(cluster.getId())) {
-                        if (host == null || host.getType() != Host.Type.Routing) {
-                            continue;
-                        }
-                        updateHostMetrics(hostMetrics, hostJoinDao.findById(host.getId()));
+                    for (final HostJoinVO host: hostJoinDao.findByClusterId(cluster.getId(), Host.Type.Routing)) {
+                        updateHostMetrics(hostMetrics, host);
                     }
                 }
             } else {


### PR DESCRIPTION
### Description

This PR optimizes the way the hosts are retrieved from the database to speed up `listZonesMetrics` and `listClustersMetrics` calls on large (and slow) databases.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
Instead of retrieving the Host objects by the cluster, and then retrieving HostJoinVO for every host which results to SQL queries `SELECT ... FROM host_view WHERE host.id = <id>`, it retrieves the list of HostJoinVO by cluster and the host type.

Additionally, it removes the method `private Double findRatioValue(final String value)` as it seems to be unused.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Here are the test results for a big loaded platform with 200 hosts:

A mgmt server with vanilla 4.20:
```
# time cmk list zonesmetrics
... output omitted ..
real	1m51.370s
user	0m0.219s
sys	0m0.026s
```

A mgmt server with these changes applied:
```
# time cmk list zonesmetrics
... output omitted ...
real	0m2.024s
user	0m0.220s
sys	0m0.036s
```

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
1. Built the package with these changes
2. Updated one of the mgmt servers of a big platform
3. Waited 10 mins for the StatsCollector to be populated
4. Ran `cmk list zonesmetrcs` and `cmk list clustersmetrics` on both unpatched and patched mgmt servers, measured the time it required to run.
5. Compared the outputs from both mgmt servers. All fields values matched, except the values of the fields `cpumaxdeviation`, `cpuused`, `memorymaxdeviation`, `memoryused`, which _almost_ matched. After closer look I found that these fields are coming from StatsCollector, which is a map that seems to be populated individually on every mgmt server. Therefore, I assume it is normal.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->
This change only affects a very limited scope of the code (a for-loop), therefore it should be good as long as it compiles.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
