### PR TITLE
Network rate must be multiplied by 125 not 128

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -207,7 +207,7 @@ public class BridgeVifDriver extends VifDriverBase {
         String trafficLabel = nic.getName();
         Integer networkRateKBps = 0;
         if (libvirtVersion > ((10 * 1000 + 10))) {
-            networkRateKBps = (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) ? nic.getNetworkRateMbps().intValue() * 128 : 0;
+            networkRateKBps = getNetworkRateKbps(nic);
         }
 
         if (nic.getType() == Networks.TrafficType.Guest) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/DirectVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/DirectVifDriver.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 public class DirectVifDriver extends VifDriverBase {
 
-
     /**
      * Experimental driver to configure direct networking in libvirt. This should only
      * be used on an LXC cluster that does not run any system VMs.
@@ -42,13 +41,14 @@ public class DirectVifDriver extends VifDriverBase {
      * @throws InternalErrorException
      * @throws LibvirtException
      */
+
     @Override
     public LibvirtVMDef.InterfaceDef plug(NicTO nic, String guestOsType, String nicAdapter, Map<String, String> extraConfig) throws InternalErrorException, LibvirtException {
         LibvirtVMDef.InterfaceDef intf = new LibvirtVMDef.InterfaceDef();
 
         if (Sets.newHashSet(Networks.TrafficType.Guest,
                             Networks.TrafficType.Public).contains(nic.getType())) {
-            Integer networkRateKBps = (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) ? nic.getNetworkRateMbps().intValue() * 128 : 0;
+            Integer networkRateKBps = getNetworkRateKbps(nic);
             intf.defDirectNet(_libvirtComputingResource.getNetworkDirectDevice(), null, nic.getMac(), getGuestNicModel(guestOsType, nicAdapter),
                 _libvirtComputingResource.getNetworkDirectSourceMode(), networkRateKBps);
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/IvsVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/IvsVifDriver.java
@@ -93,7 +93,7 @@ public class IvsVifDriver extends VifDriverBase {
             vlanId = NetUtils.getPrimaryPvlanFromUri(nic.getBroadcastUri());
         }
         String trafficLabel = nic.getName();
-        Integer networkRateKBps = (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) ? nic.getNetworkRateMbps().intValue() * 128 : 0;
+        Integer networkRateKBps = getNetworkRateKbps(nic);
         if (nic.getType() == Networks.TrafficType.Guest) {
             if ((nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan || nic.getBroadcastType() == Networks.BroadcastDomainType.Pvlan) &&
                     !vlanId.equalsIgnoreCase("untagged")) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/OvsVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/OvsVifDriver.java
@@ -130,7 +130,7 @@ public class OvsVifDriver extends VifDriverBase {
         }
         String trafficLabel = nic.getName();
         if (nic.getType() == Networks.TrafficType.Guest) {
-            Integer networkRateKBps = (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) ? nic.getNetworkRateMbps().intValue() * 128 : 0;
+            Integer networkRateKBps = getNetworkRateKbps(nic);
             if ((nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan || nic.getBroadcastType() == Networks.BroadcastDomainType.Pvlan) &&
                     !vlanId.equalsIgnoreCase("untagged")) {
                 if (trafficLabel != null && !trafficLabel.isEmpty()) {
@@ -162,7 +162,7 @@ public class OvsVifDriver extends VifDriverBase {
             createControlNetwork(_bridges.get("linklocal"));
             intf.defBridgeNet(_bridges.get("linklocal"), null, nic.getMac(), getGuestNicModel(guestOsType, nicAdapter));
         } else if (nic.getType() == Networks.TrafficType.Public) {
-            Integer networkRateKBps = (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) ? nic.getNetworkRateMbps().intValue() * 128 : 0;
+            Integer networkRateKBps = getNetworkRateKbps(nic);
             if (nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan && !vlanId.equalsIgnoreCase("untagged")) {
                 if (trafficLabel != null && !trafficLabel.isEmpty()) {
                     logger.debug("creating a vlan dev and bridge for public traffic per traffic label " + trafficLabel);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
@@ -40,6 +40,8 @@ public abstract class VifDriverBase implements VifDriver {
     protected Map<String, String> _pifs;
     protected Map<String, String> _bridges;
 
+    protected static final int bitsPerMbpsToKbps = 125;
+
     @Override
     public void configure(Map<String, Object> params) throws ConfigurationException {
         _libvirtComputingResource = (LibvirtComputingResource)params.get("libvirt.computing.resource");
@@ -77,5 +79,14 @@ public abstract class VifDriverBase implements VifDriver {
 
     public boolean isExistingBridge(String bridgeName) {
         return false;
+    }
+
+    protected static int getNetworkRateKbps(NicTO nic) {
+        if (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) {
+            return nic.getNetworkRateMbps().intValue() * bitsPerMbpsToKbps;
+        }
+        else {
+          return 0;
+        }
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
@@ -85,8 +85,6 @@ public abstract class VifDriverBase implements VifDriver {
         if (nic.getNetworkRateMbps() != null && nic.getNetworkRateMbps().intValue() != -1) {
             return nic.getNetworkRateMbps().intValue() * bitsPerMbpsToKbps;
         }
-        else {
-          return 0;
-        }
+        return 0;
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a minor bug in the libvirt domain xml concering the interface bandwidth. In a libvirt domain xml when nw_rate=5000 the kilobytes per second configured in the interface is 640000 which is 5.12 Gbit/s. Which is more than the configured network rate of 5Gbit/s. So instead multiply by 125 (1 Megabit = 125 Kilobyte). 5000 * 125 = 625000 KB/s = 5Gbit/s

QoS is defined in Kilobytes per second according to libvirt [docs](https://libvirt.org/formatnetwork.html#quality-of-service)

> **average**
> Specifies the desired average bit rate for the interface being shaped (in kilobytes/second).

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### How Has This Been Tested?

Untested, but the change is trivial.

#### How did you try to break this feature and the system with this change?

N/A
