### PR TITLE
UI: Fix projects metrics on dashboard

### DIFF
--- a/ui/src/views/dashboard/UsageDashboard.vue
+++ b/ui/src/views/dashboard/UsageDashboard.vue
@@ -460,9 +460,13 @@ export default {
     },
     listProject () {
       this.loading = true
-      api('listProjects', { id: store.getters.project.id }).then(json => {
+      const params = {
+        id: store.getters.project.id,
+        listall: true
+      }
+      api('listProjects', params).then(json => {
         this.loading = false
-        if (json && json.listprojectsresponse && json.listprojectsresponse.project) {
+        if (json?.listprojectsresponse?.project) {
           this.project = json.listprojectsresponse.project[0]
         }
       })


### PR DESCRIPTION
### Description

Currently, the dashboard for projects faces some inconsistencies for the amount of resources consumed by the project. They can be noticed when accessing the project's view, with an account that is not in the same domain as the project is.

Therefore, in scenarios in which a `RootAdmin` accesses the dashboard of a project that belongs to any subdomain of the `ROOT` domain (e.g. `ROOT/d1`), the dashboard will display the project's storage metrics as `NaN` and `undefined`  and the compute metrics will be omitted:

![image](https://github.com/user-attachments/assets/acba9110-6efb-4cd6-a181-cc553cd1edda)

The root cause of the bug is that, when the project's attributes are fetched from the `listProjects` API, the parameter `listall` is not specified:

https://github.com/apache/cloudstack/blob/ee94ae575b7bb28d3350b049454b0026db85c7d1/ui/src/views/dashboard/UsageDashboard.vue#L461-L469

As a consequence of that, the UI is not able to render the projects metrics. This PR fixes this bug.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

- Before:

![image](https://github.com/user-attachments/assets/324405d9-c40e-4f20-bb7e-f0475d1123b3)

- After:

![image](https://github.com/user-attachments/assets/53e67d24-07a2-4cc7-b495-1cd2c957b8f9)

### How Has This Been Tested?

- Created a domain (`d1`), and an account (`d1`) and a project (`project-d1`) within it
- Accessed the `project-d1` view with a `RootAdmin` account
- Before applying the PR's changes, verified that the project's metrics were not correctly fetched and rendered
- After applying the PR's changes, verified that the metrics were correctly fetched and rendered