### PR TITLE
UI: Allow setting account and domain maximum amount of projects through the UI

### DIFF
--- a/ui/src/components/view/ResourceLimitTab.vue
+++ b/ui/src/components/view/ResourceLimitTab.vue
@@ -27,7 +27,7 @@
     >
       <div v-for="(item, index) in dataResource" :key="index">
         <a-form-item
-          v-if="item.resourcetypename !== 'project'"
+          v-if="item.resourcetypename !== 'project' || !$route.path.startsWith('/project')"
           :v-bind="item.resourcetypename"
           :label="$t('label.max' + (item.resourcetypename ? item.resourcetypename.replace('_', '') : ''))"
           :name="item.resourcetype"


### PR DESCRIPTION
### Description

Currently, it is not possible to change the limit of projects that a domain and account can have through the UI. Therefore, this PR proposes to add this field to the `Configure Limits` form of domains and accounts.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/ae2ad729-bee8-444d-b02d-fd8d1742554b)

### How Has This Been Tested?

- Verified that it was possible to modify the maximum amount of projects that an account can have through the UI
- Verified that it was possible to modify the maximum amount of projects that a domain can have through the UI
- Verified that the `Max. projects` field was not available on the projects `Configure Limits` form:
![image](https://github.com/user-attachments/assets/5e4a0619-b369-49f1-b97a-1c0e1cdde2a7)
