### PR TITLE
Fix the size of a template downloaded from secondary storage

### DIFF
--- a/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/storpool/src/main/java/org/apache/cloudstack/storage/datastore/driver/StorPoolPrimaryDataStoreDriver.java
@@ -776,7 +776,8 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
                         if (answer != null && answer.getResult()) {
                             // successfully downloaded template to primary storage
-                            answer = createVolumeSnapshot(cmd, size, conn, volName, dstTO);
+                            TemplateObjectTO templ = (TemplateObjectTO) ((CopyCmdAnswer) answer).getNewData();
+                            answer = createVolumeSnapshot(cmd, size, conn, volName, templ);
                         } else {
                             err = answer != null ? answer.getDetails() : "Unknown error while downloading template. Null answer returned.";
                         }
@@ -983,7 +984,6 @@ public class StorPoolPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
         } else {
             dstTO.setPath(StorPoolUtil.devPath(
                     StorPoolUtil.getSnapshotNameFromResponse(resp, false, StorPoolUtil.GLOBAL_ID)));
-            dstTO.setSize(size);
             answer = new CopyCmdAnswer(dstTO);
         }
         return answer;


### PR DESCRIPTION


### Description

This PR fixes the size of a template downloaded from secondary storage to StorPool.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
manually