### PR TITLE
Accept case insensitive values in boolean settings

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -703,7 +703,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Override
     @DB
     public String updateConfiguration(final long userId, final String name, final String category, String value, final String scope, final Long resourceId) {
-        if (getConfigurationTypeWrapperClass(name) == Boolean.class) {
+        if (Boolean.class == getConfigurationTypeWrapperClass(name)) {
             value = value.toLowerCase();
         }
 

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.configuration;
 
+import com.cloud.alert.AlertManager;
 import com.cloud.capacity.dao.CapacityDao;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.VlanVO;
@@ -52,6 +53,7 @@ import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.acl.RoleService;
 import org.apache.cloudstack.annotation.dao.AnnotationDao;
 import org.apache.cloudstack.api.command.admin.network.CreateNetworkOfferingCmd;
 import org.apache.cloudstack.api.command.admin.offering.UpdateDiskOfferingCmd;
@@ -65,6 +67,7 @@ import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.resourcedetail.DiskOfferingDetailVO;
 import org.apache.cloudstack.vm.UnmanagedVMsManager;
+import org.apache.cloudstack.config.Configuration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -896,5 +899,114 @@ public class ConfigurationManagerImplTest {
             String invalidValue = "Admin, SuperUser";
             configurationManagerImplSpy.validateConfigurationAllowedOnlyForDefaultAdmin(AccountManagerImpl.listOfRoleTypesAllowedForOperationsOfSameRoleType.key(), invalidValue);
         }
+    }
+
+
+    @Test
+    public void getConfigurationTypeWrapperClassTestReturnsConfigType() {
+        Config configuration = Config.AlertEmailAddresses;
+
+        Assert.assertEquals(configuration.getType(), configurationManagerImplSpy.getConfigurationTypeWrapperClass(configuration.key()));
+    }
+
+    @Test
+    public void getConfigurationTypeWrapperClassTestReturnsConfigKeyType() {
+        String configurationName = "configuration.name";
+
+        Mockito.when(configDepot.get(configurationName)).thenReturn(configKeyMock);
+        Mockito.when(configKeyMock.type()).thenReturn(Integer.class);
+
+        Assert.assertEquals(Integer.class, configurationManagerImplSpy.getConfigurationTypeWrapperClass(configurationName));
+    }
+
+    @Test
+    public void getConfigurationTypeWrapperClassTestReturnsNullWhenConfigurationDoesNotExist() {
+        String configurationName = "configuration.name";
+
+        Mockito.when(configDepot.get(configurationName)).thenReturn(null);
+        Assert.assertNull(configurationManagerImplSpy.getConfigurationTypeWrapperClass(configurationName));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsStringWhenTypeIsNull() {
+        Assert.assertEquals(Configuration.ValueType.String.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(null, null));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsStringWhenTypeIsStringAndConfigurationKindIsNull() {
+        Mockito.when(configurationVOMock.getKind()).thenReturn(null);
+        Assert.assertEquals(Configuration.ValueType.String.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(String.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsKindWhenTypeIsStringAndKindIsNotNull() {
+        Mockito.when(configurationVOMock.getKind()).thenReturn(ConfigKey.Kind.CSV.name());
+        Assert.assertEquals(ConfigKey.Kind.CSV.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(String.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsKindWhenTypeIsCharacterAndKindIsNotNull() {
+        Mockito.when(configurationVOMock.getKind()).thenReturn(ConfigKey.Kind.CSV.name());
+        Assert.assertEquals(ConfigKey.Kind.CSV.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Character.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsNumberWhenTypeIsInteger() {
+        Assert.assertEquals(Configuration.ValueType.Number.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Integer.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsNumberWhenTypeIsLong() {
+        Assert.assertEquals(Configuration.ValueType.Number.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Long.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsNumberWhenTypeIsShort() {
+        Assert.assertEquals(Configuration.ValueType.Number.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Short.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsDecimalWhenTypeIsFloat() {
+        Assert.assertEquals(Configuration.ValueType.Decimal.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Float.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsDecimalWhenTypeIsDouble() {
+        Assert.assertEquals(Configuration.ValueType.Decimal.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Double.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsBooleanWhenTypeIsBoolean() {
+        Assert.assertEquals(Configuration.ValueType.Boolean.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Boolean.class, configurationVOMock));
+    }
+
+    @Test
+    public void parseConfigurationTypeIntoStringTestReturnsStringWhenTypeDoesNotMatchAnyAvailableType() {
+        Assert.assertEquals(Configuration.ValueType.String.name(), configurationManagerImplSpy.parseConfigurationTypeIntoString(Object.class, configurationVOMock));
+    }
+
+    @Test
+    public void getConfigurationTypeTestReturnsStringWhenConfigurationDoesNotExist() {
+        Mockito.when(configDao.findByName(Mockito.anyString())).thenReturn(null);
+        Assert.assertEquals(Configuration.ValueType.String.name(), configurationManagerImplSpy.getConfigurationType(Mockito.anyString()));
+    }
+
+    @Test
+    public void getConfigurationTypeTestReturnsRangeForConfigurationsThatAcceptIntervals() {
+        String configurationName = AlertManager.CPUCapacityThreshold.key();
+
+        Mockito.when(configDao.findByName(configurationName)).thenReturn(configurationVOMock);
+        Assert.assertEquals(Configuration.ValueType.Range.name(), configurationManagerImplSpy.getConfigurationType(configurationName));
+    }
+
+    @Test
+    public void getConfigurationTypeTestReturnsStringRepresentingConfigurationType() {
+        ConfigKey<Boolean> configuration = RoleService.EnableDynamicApiChecker;
+
+        Mockito.when(configDao.findByName(configuration.key())).thenReturn(configurationVOMock);
+        Mockito.doReturn(configuration.type()).when(configurationManagerImplSpy).getConfigurationTypeWrapperClass(configuration.key());
+
+        configurationManagerImplSpy.getConfigurationType(configuration.key());
+        Mockito.verify(configurationManagerImplSpy).parseConfigurationTypeIntoString(configuration.type(), configurationVOMock);
     }
 }


### PR DESCRIPTION
### Description

Currently, when updating boolean settings, the Management Server performs a case sensitive validation of the inserted values. Thus, only the `true` and `false` values are accepted.

This PR proposes to extend this validation to encompass case insensitive boolean values. Therefore, values such as `True` and `FALSE` will be accepted and will be properly normalized before being persisted in the database.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

- Verified that it was possible to update the `quota.enable.service` global setting to `FaLsE`.

<details>
<summary><code>updateConfiguration</code> API execution</summary>

```bash
(acs-all-in-one) 🦌 > update configuration name="quota.enable.service" value="FaLsE"
{
  "configuration": {
    "category": "Advanced",
    "component": "QUOTA-PLUGIN",
    "defaultvalue": "false",
    "description": "Indicates whether Quota plugin is enabled or not.",
    "displaytext": "Quota enable service",
    "group": "Miscellaneous",
    "isdynamic": true,
    "name": "quota.enable.service",
    "subgroup": "Quota",
    "type": "Boolean",
    "value": "FaLsE"
  }
}
```
</details>

<details>
<summary>Persisted configuration value in the database</summary>

```sql
MariaDB [cloud]> select name,value from configuration where name = "quota.enable.service";
+----------------------+-------+
| name                 | value |
+----------------------+-------+
| quota.enable.service | false |
+----------------------+-------+
1 row in set (0.000 sec)
```
</details>

- Verified that it was possible to update the setting value to `TRUe`:

<details>
<summary><code>updateConfiguration</code> API execution</summary>

```bash
(acs-all-in-one) 🐓 > update configuration name="quota.enable.service" value="TRUe"
{
  "configuration": {
    "category": "Advanced",
    "component": "QUOTA-PLUGIN",
    "defaultvalue": "false",
    "description": "Indicates whether Quota plugin is enabled or not.",
    "displaytext": "Quota enable service",
    "group": "Miscellaneous",
    "isdynamic": true,
    "name": "quota.enable.service",
    "subgroup": "Quota",
    "type": "Boolean",
    "value": "TRUe"
  }
}
```
</details>

<details>
<summary>Persisted configuration value in the database</summary>

```sql
MariaDB [cloud]> select name,value from configuration where name = "quota.enable.service";
+----------------------+-------+
| name                 | value |
+----------------------+-------+
| quota.enable.service | true  |
+----------------------+-------+
1 row in set (0.000 sec)
```
</details>
