### PR TITLE
Update Mockito to 5.16.1

### DIFF
--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/resource/PurgeExpungedResourcesCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/resource/PurgeExpungedResourcesCmdTest.java
@@ -44,7 +44,7 @@ public class PurgeExpungedResourcesCmdTest {
 
     @Spy
     @InjectMocks
-    PurgeExpungedResourcesCmd spyCmd = Mockito.spy(new PurgeExpungedResourcesCmd());
+    PurgeExpungedResourcesCmd spyCmd;
 
     @Test
     public void testGetResourceType() {

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/storage/DownloadImageStoreObjectCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/storage/DownloadImageStoreObjectCmdTest.java
@@ -20,14 +20,11 @@ package org.apache.cloudstack.api.command.admin.storage;
 import com.cloud.utils.Pair;
 import org.apache.cloudstack.api.response.ExtractResponse;
 import org.apache.cloudstack.storage.browser.StorageBrowser;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -47,18 +44,6 @@ public class DownloadImageStoreObjectCmdTest {
     @InjectMocks
     @Spy
     private DownloadImageStoreObjectCmd cmd;
-
-    private AutoCloseable closeable;
-
-    @Before
-    public void setUp() {
-        closeable = MockitoAnnotations.openMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        closeable.close();
-    }
 
     @Test
     public void testExecute() throws Exception {

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/vm/MigrateVirtualMachineWithVolumeCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/vm/MigrateVirtualMachineWithVolumeCmdTest.java
@@ -68,6 +68,12 @@ public class MigrateVirtualMachineWithVolumeCmdTest {
     @Mock
     Host hostMock;
 
+    @Mock
+    private Object job;
+
+    @Mock
+    private Object _responseObject;
+
     @Spy
     @InjectMocks
     MigrateVirtualMachineWithVolumeCmd cmdSpy;

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/vpc/CreateVPCCmdByAdminTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/vpc/CreateVPCCmdByAdminTest.java
@@ -20,7 +20,6 @@ package org.apache.cloudstack.api.command.admin.vpc;
 import com.cloud.network.vpc.VpcService;
 import com.cloud.user.AccountService;
 import com.cloud.utils.db.EntityManager;
-import junit.framework.TestCase;
 import org.apache.cloudstack.api.ResponseGenerator;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,7 +33,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CreateVPCCmdByAdminTest extends TestCase {
+public class CreateVPCCmdByAdminTest {
 
     @Mock
     public VpcService _vpcService;
@@ -43,8 +42,10 @@ public class CreateVPCCmdByAdminTest extends TestCase {
     @Mock
     public AccountService _accountService;
     private ResponseGenerator responseGenerator;
+    @Mock
+    public Object job;
     @InjectMocks
-    CreateVPCCmdByAdmin cmd = new CreateVPCCmdByAdmin();
+    CreateVPCCmdByAdmin cmd;
 
     @Test
     public void testBgpPeerIds() {

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/UpdateNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/UpdateNetworkCmdTest.java
@@ -41,7 +41,10 @@ public class UpdateNetworkCmdTest {
     NetworkService networkService;
     @Mock
     public EntityManager _entityMgr;
-    private ResponseGenerator responseGenerator;
+    @Mock
+    private ResponseGenerator _responseGenerator;
+    @Mock
+    private Object job;
     @InjectMocks
     UpdateNetworkCmd cmd = new UpdateNetworkCmd();
 
@@ -176,15 +179,13 @@ public class UpdateNetworkCmdTest {
         ReflectionTestUtils.setField(cmd, "id", networkId);
         ReflectionTestUtils.setField(cmd, "publicMtu", publicmtu);
         Network network = Mockito.mock(Network.class);
-        responseGenerator = Mockito.mock(ResponseGenerator.class);
         NetworkResponse response = Mockito.mock(NetworkResponse.class);
         response.setPublicMtu(publicmtu);
         Mockito.when(networkService.getNetwork(networkId)).thenReturn(network);
         Mockito.when(networkService.updateGuestNetwork(cmd)).thenReturn(network);
-        cmd._responseGenerator = responseGenerator;
-        Mockito.when(responseGenerator.createNetworkResponse(ResponseObject.ResponseView.Restricted, network)).thenReturn(response);
+        Mockito.when(_responseGenerator.createNetworkResponse(ResponseObject.ResponseView.Restricted, network)).thenReturn(response);
         cmd.execute();
-        Mockito.verify(responseGenerator).createNetworkResponse(Mockito.any(ResponseObject.ResponseView.class), Mockito.any(Network.class));
+        Mockito.verify(_responseGenerator).createNetworkResponse(Mockito.any(ResponseObject.ResponseView.class), Mockito.any(Network.class));
         NetworkResponse actualResponse = (NetworkResponse) cmd.getResponseObject();
 
         Assert.assertEquals(response, actualResponse);

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/vpc/CreateVPCCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/vpc/CreateVPCCmdTest.java
@@ -25,7 +25,6 @@ import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpc.VpcService;
 import com.cloud.user.AccountService;
 import com.cloud.utils.db.EntityManager;
-import junit.framework.TestCase;
 import org.apache.cloudstack.api.ResponseGenerator;
 import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.response.VpcResponse;
@@ -39,7 +38,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CreateVPCCmdTest extends TestCase {
+public class CreateVPCCmdTest {
 
     @Mock
     public VpcService _vpcService;
@@ -47,9 +46,13 @@ public class CreateVPCCmdTest extends TestCase {
     public EntityManager _entityMgr;
     @Mock
     public AccountService _accountService;
-    private ResponseGenerator responseGenerator;
+    @Mock
+    private ResponseGenerator _responseGenerator;
+    @Mock
+    private Object job;
+
     @InjectMocks
-    CreateVPCCmd cmd = new CreateVPCCmd();
+    CreateVPCCmd cmd;
 
     @Test
     public void testGetAccountName() {
@@ -185,11 +188,9 @@ public class CreateVPCCmdTest extends TestCase {
         VpcResponse response = Mockito.mock(VpcResponse.class);
 
         ReflectionTestUtils.setField(cmd, "id", 1L);
-        responseGenerator = Mockito.mock(ResponseGenerator.class);
         Mockito.doNothing().when(_vpcService).startVpc(cmd);
         Mockito.when(_entityMgr.findById(Mockito.eq(Vpc.class), Mockito.any(Long.class))).thenReturn(vpc);
-        cmd._responseGenerator = responseGenerator;
-        Mockito.when(responseGenerator.createVpcResponse(ResponseObject.ResponseView.Restricted, vpc)).thenReturn(response);
+        Mockito.when(_responseGenerator.createVpcResponse(ResponseObject.ResponseView.Restricted, vpc)).thenReturn(response);
         cmd.execute();
         Mockito.verify(_vpcService, Mockito.times(1)).startVpc(cmd);
     }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapperTest.java
@@ -704,7 +704,7 @@ public class LibvirtMigrateCommandWrapperTest {
 
     @Test
     public void deleteOrDisconnectDisksOnSourcePoolTest() {
-        LibvirtMigrateCommandWrapper spyLibvirtMigrateCmdWrapper = Mockito.spy(libvirtMigrateCmdWrapper);
+        LibvirtMigrateCommandWrapper spyLibvirtMigrateCmdWrapper = libvirtMigrateCmdWrapper;
         Mockito.doNothing().when(spyLibvirtMigrateCmdWrapper).deleteLocalVolume("volPath");
 
         List<MigrateDiskInfo> migrateDiskInfoList = new ArrayList<>();

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRevertSnapshotCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRevertSnapshotCommandWrapperTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloud.agent.api.to.DataStoreTO;
@@ -42,7 +43,8 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @RunWith(MockitoJUnitRunner.class)
 public class LibvirtRevertSnapshotCommandWrapperTest {
 
-    LibvirtRevertSnapshotCommandWrapper libvirtRevertSnapshotCommandWrapperSpy = Mockito.spy(LibvirtRevertSnapshotCommandWrapper.class);
+    @Spy
+    LibvirtRevertSnapshotCommandWrapper libvirtRevertSnapshotCommandWrapperSpy;
 
     @Mock
     KVMStoragePool kvmStoragePoolPrimaryMock;
@@ -107,7 +109,7 @@ public class LibvirtRevertSnapshotCommandWrapperTest {
         Mockito.doReturn(snapshotPath).when(snapshotObjectToPrimaryMock).getPath();
 
         try (MockedStatic<Files> ignored = Mockito.mockStatic(Files.class)) {
-            Mockito.when(Files.exists(Mockito.any(Path.class), Mockito.any())).thenReturn(true);
+            Mockito.when(Files.exists(Mockito.any(Path.class))).thenReturn(true);
 
             Pair<String, SnapshotObjectTO> result = libvirtRevertSnapshotCommandWrapperSpy.getSnapshot(
                     snapshotObjectToPrimaryMock, snapshotObjectToSecondaryMock,

--- a/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImplTest.java
+++ b/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImplTest.java
@@ -69,6 +69,8 @@ public class VmwareManagerImplTest {
     private Map<String, String> clusterDetails;
     @Mock
     private Map<String, String> hostDetails;
+    @Mock
+    private Map<String, Object> _configParams;
 
     @Before
     public void beforeTest() {

--- a/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
+++ b/plugins/hypervisors/vmware/src/test/java/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.agent.api.Command;
+import com.cloud.agent.api.ScaleVmAnswer;
 import com.cloud.hypervisor.vmware.mo.DatastoreMO;
 import com.cloud.hypervisor.vmware.mo.HostDatastoreBrowserMO;
 import com.cloud.hypervisor.vmware.mo.HypervisorHostHelper;
@@ -52,7 +54,6 @@ import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.browser.ListDataStoreObjectsAnswer;
 import org.apache.cloudstack.storage.command.browser.ListDataStoreObjectsCommand;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,17 +63,14 @@ import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloud.agent.api.Answer;
-import com.cloud.agent.api.Command;
 import com.cloud.agent.api.CheckGuestOsMappingAnswer;
 import com.cloud.agent.api.CheckGuestOsMappingCommand;
 import com.cloud.agent.api.GetHypervisorGuestOsNamesAnswer;
 import com.cloud.agent.api.GetHypervisorGuestOsNamesCommand;
-import com.cloud.agent.api.ScaleVmAnswer;
 import com.cloud.agent.api.ScaleVmCommand;
 import com.cloud.agent.api.routing.GetAutoScaleMetricsAnswer;
 import com.cloud.agent.api.routing.GetAutoScaleMetricsCommand;
@@ -185,6 +183,8 @@ public class VmwareResourceTest {
     VimPortType vimService;
     @Mock
     HostCapability hostCapability;
+    @Mock
+    ManagedObjectReference _morHyperHost;
 
     CopyCommand storageCmd;
     EnumMap<VmwareStorageProcessorConfigurableFields, Object> params = new EnumMap<VmwareStorageProcessorConfigurableFields,Object>(VmwareStorageProcessorConfigurableFields.class);
@@ -201,11 +201,9 @@ public class VmwareResourceTest {
 
     private Map<String,String> specsArray = new HashMap<String,String>();
 
-    AutoCloseable closeable;
 
     @Before
     public void setup() throws Exception {
-        closeable = MockitoAnnotations.openMocks(this);
         storageCmd = mock(CopyCommand.class);
         doReturn(context).when(_resource).getServiceContext(null);
         when(cmd.getVirtualMachine()).thenReturn(vmSpec);
@@ -232,11 +230,6 @@ public class VmwareResourceTest {
         when(context.getService()).thenReturn(vimService);
         when(vimService.queryTargetCapabilities(envRef, hostRef)).thenReturn(hostCapability);
         when(hostCapability.isNestedHVSupported()).thenReturn(true);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        closeable.close();
     }
 
     //Test successful scaling up the vm

--- a/plugins/maintenance/src/test/java/org/apache/cloudstack/maintenance/ManagementServerMaintenanceManagerImplTest.java
+++ b/plugins/maintenance/src/test/java/org/apache/cloudstack/maintenance/ManagementServerMaintenanceManagerImplTest.java
@@ -154,7 +154,7 @@ public class ManagementServerMaintenanceManagerImplTest {
         ManagementServerHostVO msHost2 = mock(ManagementServerHostVO.class);
         List<ManagementServerHostVO> msHostList = new ArrayList<>();
         msHostList.add(msHost2);
-        Mockito.when(msHostDao.listBy(any())).thenReturn(msHostList);
+        Mockito.lenient().when(msHostDao.listBy(any())).thenReturn(msHostList);
         Mockito.when(msHostDao.findById(1L)).thenReturn(msHost1);
         PrepareForShutdownCmd cmd = mock(PrepareForShutdownCmd.class);
         Mockito.when(cmd.getManagementServerId()).thenReturn(1L);
@@ -169,7 +169,7 @@ public class ManagementServerMaintenanceManagerImplTest {
         ManagementServerHostVO msHost = mock(ManagementServerHostVO.class);
         Mockito.when(msHost.getState()).thenReturn(ManagementServerHost.State.Up);
         List<ManagementServerHostVO> msHostList = new ArrayList<>();
-        Mockito.when(msHostDao.listBy(any())).thenReturn(msHostList);
+        Mockito.lenient().when(msHostDao.listBy(any())).thenReturn(msHostList);
         Mockito.when(msHostDao.findById(1L)).thenReturn(msHost);
         PrepareForShutdownCmd cmd = mock(PrepareForShutdownCmd.class);
         Mockito.when(cmd.getManagementServerId()).thenReturn(1L);
@@ -185,7 +185,7 @@ public class ManagementServerMaintenanceManagerImplTest {
         ManagementServerHostVO msHost = mock(ManagementServerHostVO.class);
         Mockito.when(msHost.getState()).thenReturn(ManagementServerHost.State.Up);
         List<ManagementServerHostVO> msHostList = new ArrayList<>();
-        Mockito.when(msHostDao.listBy(any())).thenReturn(msHostList);
+        Mockito.lenient().when(msHostDao.listBy(any())).thenReturn(msHostList);
         Mockito.when(msHostDao.findById(1L)).thenReturn(msHost);
         PrepareForShutdownCmd cmd = mock(PrepareForShutdownCmd.class);
         Mockito.when(cmd.getManagementServerId()).thenReturn(1L);
@@ -200,7 +200,7 @@ public class ManagementServerMaintenanceManagerImplTest {
     public void prepareForShutdownCmdSuccessResponseFromClusterManager() {
         ManagementServerHostVO msHost = mock(ManagementServerHostVO.class);
         Mockito.when(msHost.getState()).thenReturn(ManagementServerHost.State.Up);
-        Mockito.when(msHostDao.listBy(any())).thenReturn(new ArrayList<>());
+        Mockito.lenient().when(msHostDao.listBy(any())).thenReturn(new ArrayList<>());
         Mockito.when(msHostDao.findById(1L)).thenReturn(msHost);
         Mockito.when(hostDao.listByMs(anyLong())).thenReturn(new ArrayList<>());
         PrepareForShutdownCmd cmd = mock(PrepareForShutdownCmd.class);
@@ -279,7 +279,7 @@ public class ManagementServerMaintenanceManagerImplTest {
         ManagementServerHostVO msHost2 = mock(ManagementServerHostVO.class);
         List<ManagementServerHostVO> msHostList = new ArrayList<>();
         msHostList.add(msHost2);
-        Mockito.when(msHostDao.listBy(any())).thenReturn(msHostList);
+        Mockito.lenient().when(msHostDao.listBy(any())).thenReturn(msHostList);
         Mockito.when(msHostDao.findById(1L)).thenReturn(msHost1);
         TriggerShutdownCmd cmd = mock(TriggerShutdownCmd.class);
         Mockito.when(cmd.getManagementServerId()).thenReturn(1L);

--- a/plugins/storage/volume/storpool/pom.xml
+++ b/plugins/storage/volume/storpool/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${cs.mockito.version}</version>
         </dependency>
         <dependency>

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -134,7 +134,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${cs.mockito.version}</version>
             <scope>compile</scope>
             <exclusions>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.5</version>
+            <version>1.15.11</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -59,6 +59,12 @@
             <artifactId>assertj-core</artifactId>
             <version>${cs.assertj.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/user-authenticators/saml2/src/test/java/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmdTest.java
+++ b/plugins/user-authenticators/saml2/src/test/java/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmdTest.java
@@ -111,6 +111,9 @@ public class SAML2LoginAPIAuthenticatorCmdTest {
     @Mock
     HttpServletRequest req;
 
+    @Mock
+    Object _responseObject;
+
     @Spy
     @InjectMocks
     private SAML2LoginAPIAuthenticatorCmd cmdSpy;

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <cs.junit.dataprovider.version>1.13.1</cs.junit.dataprovider.version>
         <cs.junit.jupiter.version>5.9.1</cs.junit.jupiter.version>
         <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
-        <cs.mockito.version>4.11.0</cs.mockito.version>
+        <cs.mockito.version>5.16.1</cs.mockito.version>
         <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
         <cs.selenium-java-client-driver.version>1.0.1</cs.selenium-java-client-driver.version>
         <cs.testng.version>7.1.0</cs.testng.version>
@@ -750,7 +750,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${cs.mockito.version}</version>
             <scope>test</scope>
             <exclusions>

--- a/server/src/test/java/com/cloud/api/query/QueryManagerImplTest.java
+++ b/server/src/test/java/com/cloud/api/query/QueryManagerImplTest.java
@@ -114,7 +114,7 @@ public class QueryManagerImplTest {
 
     @Spy
     @InjectMocks
-    private QueryManagerImpl queryManagerImplSpy = new QueryManagerImpl();
+    private QueryManagerImpl queryManagerImplSpy;
 
     @Mock
     EntityManager entityManager;
@@ -225,7 +225,7 @@ public class QueryManagerImplTest {
         Mockito.when(entityManager.findByUuidIncludingRemoved(Network.class, uuid)).thenReturn(network);
         Mockito.doNothing().when(accountManager).checkAccess(account, SecurityChecker.AccessType.ListEntry, true, network);
         Mockito.when(eventDao.searchAndCount(Mockito.any(), Mockito.any(Filter.class))).thenReturn(pair);
-        Mockito.when(eventJoinDao.searchByIds(Mockito.any())).thenReturn(eventJoins);
+        Mockito.lenient().when(eventJoinDao.searchByIds(Mockito.any())).thenReturn(eventJoins);
         List<EventResponse> respList = new ArrayList<EventResponse>();
         for (EventJoinVO vt : eventJoins) {
             respList.add(eventJoinDao.newEventResponse(vt));

--- a/server/src/test/java/com/cloud/network/NetworkServiceImplTest.java
+++ b/server/src/test/java/com/cloud/network/NetworkServiceImplTest.java
@@ -119,6 +119,11 @@ import com.cloud.vm.dao.NicDao;
 @RunWith(MockitoJUnitRunner.class)
 public class NetworkServiceImplTest {
     @Mock
+    Object job;
+    @Mock
+    Object _responseObject;
+
+    @Mock
     AccountManager accountManager;
     @Mock
     NetworkOfferingDao networkOfferingDao;
@@ -141,11 +146,11 @@ public class NetworkServiceImplTest {
     @Mock
     VpcManager vpcMgr;
     @Mock
-    NetworkOrchestrationService networkManager;
+    NetworkOrchestrationService _networkMgr;
     @Mock
     AlertManager alertManager;
     @Mock
-    DataCenterDao dcDao;
+    DataCenterDao _dcDao;
     @Mock
     UserDao userDao;
     @Mock
@@ -165,7 +170,7 @@ public class NetworkServiceImplTest {
     @Mock
     DomainRouterDao routerDao;
     @Mock
-    AccountService accountService;
+    AccountService _accountService;
     @Mock
     NetworkHelper networkHelper;
     @Mock
@@ -192,7 +197,7 @@ public class NetworkServiceImplTest {
     @Mock
     private DomainVO domainVOMock;
     @InjectMocks
-    NetworkServiceImpl service = new NetworkServiceImpl();
+    NetworkServiceImpl service;
 
     @Mock
     DomainDao domainDaoMock;
@@ -297,14 +302,11 @@ public class NetworkServiceImplTest {
         vpc = Mockito.mock(VpcVO.class);
         service._networkOfferingDao = networkOfferingDao;
         service._physicalNetworkDao = physicalNetworkDao;
-        service._dcDao = dcDao;
         service._accountMgr = accountManager;
-        service._networkMgr = networkManager;
         service.alertManager = alertManager;
         service._configMgr = configMgr;
         service._vpcDao = vpcDao;
         service._vpcMgr = vpcMgr;
-        service._accountService = accountService;
         service._networksDao = networkDao;
         service._nicDao = nicDao;
         service._ipAddressDao = ipAddressDao;
@@ -323,7 +325,7 @@ public class NetworkServiceImplTest {
         Mockito.when(entityMgr.findById(NetworkOffering.class, 1L)).thenReturn(networkOffering);
         Mockito.when(networkOfferingDao.findById(1L)).thenReturn(offering);
         Mockito.when(physicalNetworkDao.findById(Mockito.anyLong())).thenReturn(phyNet);
-        Mockito.when(dcDao.findById(Mockito.anyLong())).thenReturn(dc);
+        Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dc);
         Mockito.when(accountManager.isRootAdmin(accountMock.getId())).thenReturn(true);
     }
 
@@ -442,12 +444,12 @@ public class NetworkServiceImplTest {
         Mockito.when(dc.getId()).thenReturn(1L);
         Mockito.when(dc.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
         Map<String, String> networkProvidersMap = new HashMap<String, String>();
-        Mockito.when(networkManager.finalizeServicesAndProvidersForNetwork(ArgumentMatchers.any(NetworkOffering.class), anyLong())).thenReturn(networkProvidersMap);
+        Mockito.when(_networkMgr.finalizeServicesAndProvidersForNetwork(ArgumentMatchers.any(NetworkOffering.class), anyLong())).thenReturn(networkProvidersMap);
         Mockito.when(configMgr.isOfferingForVpc(offering)).thenReturn(false);
         Mockito.when(offering.isInternalLb()).thenReturn(false);
 
         service.createGuestNetwork(createNetworkCmd);
-        Mockito.verify(networkManager, times(1)).createGuestNetwork(1L, "testNetwork", "Test Network", null,
+        Mockito.verify(_networkMgr, times(1)).createGuestNetwork(1L, "testNetwork", "Test Network", null,
                 null, null, false, null, accountMock, null, phyNet,
                 1L, null, null, null, null, null,
                 true, null, null, null, null, null,
@@ -769,7 +771,7 @@ public class NetworkServiceImplTest {
 
         DataCenterVO zone = Mockito.mock(DataCenterVO.class);
         when(cmd.getZoneId()).thenReturn(zoneId);
-        when(dcDao.findById(zoneId)).thenReturn(zone);
+        when(_dcDao.findById(zoneId)).thenReturn(zone);
         when(zone.getId()).thenReturn(zoneId);
 
         try {
@@ -795,7 +797,7 @@ public class NetworkServiceImplTest {
         ReflectionTestUtils.setField(createNetworkCmd, "vpcId", vpcId);
 
         dc = Mockito.mock(DataCenterVO.class);
-        Mockito.when(dcDao.findById(zoneId)).thenReturn(dc);
+        Mockito.when(_dcDao.findById(zoneId)).thenReturn(dc);
         Mockito.when(dc.getId()).thenReturn(zoneId);
         vpc = Mockito.mock(VpcVO.class);
         Mockito.when(vpc.getName()).thenReturn("Vpc 1");
@@ -831,7 +833,7 @@ public class NetworkServiceImplTest {
 
         DataCenterVO zone = Mockito.mock(DataCenterVO.class);
         when(cmd.getZoneId()).thenReturn(zoneId);
-        when(dcDao.findById(zoneId)).thenReturn(zone);
+        when(_dcDao.findById(zoneId)).thenReturn(zone);
         when(zone.getId()).thenReturn(zoneId);
 
         try {
@@ -859,7 +861,7 @@ public class NetworkServiceImplTest {
 
         DataCenterVO zone = Mockito.mock(DataCenterVO.class);
         when(cmd.getZoneId()).thenReturn(zoneId);
-        when(dcDao.findById(zoneId)).thenReturn(zone);
+        when(_dcDao.findById(zoneId)).thenReturn(zone);
         when(zone.getId()).thenReturn(zoneId);
 
         try {
@@ -889,7 +891,7 @@ public class NetworkServiceImplTest {
 
         DataCenterVO zone = Mockito.mock(DataCenterVO.class);
         when(cmd.getZoneId()).thenReturn(zoneId);
-        when(dcDao.findById(zoneId)).thenReturn(zone);
+        when(_dcDao.findById(zoneId)).thenReturn(zone);
         when(zone.getId()).thenReturn(zoneId);
 
         try {

--- a/server/src/test/java/com/cloud/network/element/VirtualRouterElementTest.java
+++ b/server/src/test/java/com/cloud/network/element/VirtualRouterElementTest.java
@@ -171,7 +171,9 @@ public class VirtualRouterElementTest {
     @Mock private RemoteAccessVpnDao _vpnDao;
     @Mock private VpnUserDao _vpnUsersDao;
     @Mock private VirtualRouterProviderDao _vrProviderDao;
+    @Mock private LoadBalancerDao loadBalancerDao;
     @Mock private LoadBalancerDao _lbDao;
+    @Mock private NetworkDao networkDao;
     @Mock private NetworkDao _networksDao;
     @Mock private OvsProviderDao _ovsProviderDao;
 
@@ -180,6 +182,7 @@ public class VirtualRouterElementTest {
 
     @Mock private AccountManager _accountMgr;
     @Mock private ConfigurationManager _configMgr;
+    @Mock private NetworkModel networkModel;
     @Mock private NetworkModel _networkMdl;
     @Mock private NetworkOrchestrationService _networkMgr;
     @Mock private ResourceManager _resourceMgr;

--- a/server/src/test/java/com/cloud/resourcelimit/ResourceLimitManagerImplTest.java
+++ b/server/src/test/java/com/cloud/resourcelimit/ResourceLimitManagerImplTest.java
@@ -86,13 +86,11 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vpc.MockResourceLimitManagerImpl;
 
-import junit.framework.TestCase;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ResourceLimitManagerImplTest extends TestCase {
+public class ResourceLimitManagerImplTest {
     private Logger logger = LogManager.getLogger(ResourceLimitManagerImplTest.class);
 
     MockResourceLimitManagerImpl _resourceLimitService = new MockResourceLimitManagerImpl();
@@ -142,14 +140,11 @@ public class ResourceLimitManagerImplTest extends TestCase {
         f.set(configKey, o);
     }
 
+
     @Before
-    public void setUp() {
-        try {
-            overrideDefaultConfigValue(ResourceLimitService.ResourceLimitHostTags, "_defaultValue", StringUtils.join(hostTags, ","));
-            overrideDefaultConfigValue(ResourceLimitService.ResourceLimitStorageTags, "_defaultValue", StringUtils.join(storageTags, ","));
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            logger.error("Failed to update configurations");
-        }
+    public void setUp() throws Exception {
+        overrideDefaultConfigValue(ResourceLimitService.ResourceLimitHostTags, "_defaultValue", StringUtils.join(hostTags, ","));
+        overrideDefaultConfigValue(ResourceLimitService.ResourceLimitStorageTags, "_defaultValue", StringUtils.join(storageTags, ","));
 
         Account account = mock(Account.class);
         User user = mock(User.class);
@@ -288,6 +283,7 @@ public class ResourceLimitManagerImplTest extends TestCase {
         Mockito.when(template.getTemplateTag()).thenReturn(hostTags.get(0));
         Account account = Mockito.mock(Account.class);
         try {
+            Mockito.doNothing().when(resourceLimitManager).checkResourceLimitWithTag(Mockito.any(), Mockito.any(), Mockito.any());
             Mockito.doNothing().when(resourceLimitManager).checkResourceLimitWithTag(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
             resourceLimitManager.checkVmResourceLimit(account, true, serviceOffering, template);
             List<String> tags = new ArrayList<>();
@@ -347,6 +343,7 @@ public class ResourceLimitManagerImplTest extends TestCase {
         Mockito.when(diskOffering.getTagsArray()).thenReturn(new String[]{checkTag});
         Account account = Mockito.mock(Account.class);
         try {
+            Mockito.doNothing().when(resourceLimitManager).checkResourceLimitWithTag(Mockito.any(), Mockito.any(), Mockito.any());
             Mockito.doNothing().when(resourceLimitManager).checkResourceLimitWithTag(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
             resourceLimitManager.checkVolumeResourceLimit(account, true, 100L, diskOffering);
             List<String> tags = new ArrayList<>();

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -113,6 +113,8 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
 
     @Mock
     private AccountVO accountVoMock;
+    @Mock
+    private AccountVO _systemAccount;
 
     @Mock
     private ProjectAccountVO projectAccountVO;

--- a/server/src/test/java/com/cloud/user/AccountManagerImplVolumeDeleteEventTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplVolumeDeleteEventTest.java
@@ -56,8 +56,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -150,7 +150,7 @@ public class AccountManagerImplVolumeDeleteEventTest extends AccountManagetImplT
 
         lenient().when(_domainMgr.getDomain(nullable(Long.class))).thenReturn(domain);
 
-        Mockito.doReturn(true).when(_vmMgr).expunge(any(UserVmVO.class));
+        lenient().doReturn(true).when(_vmMgr).expunge(any(UserVmVO.class));
 
     }
 

--- a/server/src/test/java/org/apache/cloudstack/snapshot/SnapshotHelperTest.java
+++ b/server/src/test/java/org/apache/cloudstack/snapshot/SnapshotHelperTest.java
@@ -286,7 +286,7 @@ public class SnapshotHelperTest {
 
     @Test (expected = CloudRuntimeException.class)
     public void validateThrowCloudRuntimeExceptionOfSnapshotsOnlyInPrimaryStorage() {
-        Mockito.doReturn(new ArrayList<>()).when(snapshotDaoMock).listByIds(Mockito.any());
+        Mockito.lenient().doReturn(new ArrayList<>()).when(snapshotDaoMock).listByIds(Mockito.any());
         snapshotHelperSpy.throwCloudRuntimeExceptionOfSnapshotsOnlyInPrimaryStorage(null, new HashSet<>());
     }
 

--- a/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResourceTest.java
+++ b/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResourceTest.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.Logger;
 import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -104,7 +103,7 @@ public class NfsSecondaryStorageResourceTest {
     @Test
     public void testCleanupStagingNfs() throws Exception{
 
-        NfsSecondaryStorageResource spyResource = spy(resource);
+        NfsSecondaryStorageResource spyResource = resource;
         spyResource.logger = loggerMock;
         RuntimeException exception = new RuntimeException();
         doThrow(exception).when(spyResource).execute(any(DeleteCommand.class));


### PR DESCRIPTION
### Description

This PR updates Mockito to 5.16.1 from 4.
See the release notes for high level changes: https://github.com/mockito/mockito/releases/tag/v5.0.0

Dependency name change `mockito-inline` to `mockito-core`. Inline is now the default and the last version of `mockito-inline` released is `5.2.0`.

* `assertj-core` in user-authenticators/saml2 pulls in an incompatible version of byte-buddy and required an exclusion. Updating the version of assertj is left for a future PR.

The upgrade requires Java 11+, dropping support for Java 8. CloudStack documentation already says to use Java 11 and does not indicate that java 8 is supported.

Test classes using `@RunWith(MockitoJUnitRunner.class)` now get run in strict mode. Changes were made to tests where the stubbing intention was clear. In `ManagementServerMaintenanceManagerImplTest` there are 5 tests where the intention of the test is unclear. Each of the statements now use `Mockito.lenient()` to avoid the exception. Other cases in the tests follow a similar pattern.

```
Unnecessary stubbings detected in test class: ManagementServerMaintenanceManagerImplTest
Clean & maintainable test code requires zero unnecessary code.
Following stubbings are unnecessary (click to navigate to relevant line of code):
  1. -> at org.apache.cloudstack.maintenance.ManagementServerMaintenanceManagerImplTest.prepareForShutdownCmdFailedResponseFromClusterManager(ManagementServerMaintenanceManagerImplTest.java:189)
  2. -> at org.apache.cloudstack.maintenance.ManagementServerMaintenanceManagerImplTest.prepareForShutdownCmdNullResponseFromClusterManager(ManagementServerMaintenanceManagerImplTest.java:173)
  3. -> at org.apache.cloudstack.maintenance.ManagementServerMaintenanceManagerImplTest.prepareForShutdownCmdSuccessResponseFromClusterManager(ManagementServerMaintenanceManagerImplTest.java:204)
  4. -> at org.apache.cloudstack.maintenance.ManagementServerMaintenanceManagerImplTest.prepareForShutdownCmdOtherMsHostsInPreparingState(ManagementServerMaintenanceManagerImplTest.java:158)
  5. -> at org.apache.cloudstack.maintenance.ManagementServerMaintenanceManagerImplTest.triggerShutdownCmdMsInUpStateAndOtherMsHostsInPreparingState(ManagementServerMaintenanceManagerImplTest.java:283)
Please remove unnecessary stubbings or use 'lenient' strictness. More info: javadoc for UnnecessaryStubbingException class.
```

Minor clean up.
* Both `@Spy` and `Mockito.spy(` should not be used. Favored the annotation.
* Both `@RunWith(MockitoJUnitRunner.class)` and `MockitoAnnotations.openMocks(this);` should not be used. Favored the annotation.
* Unnecessary `extends TestCase` removed.
* `@InjectMocks` and `new` in statement unnecessary. Removed new when issue presented.
* Some of the `Cmd` classes like `UpdateNetworkCmd` have a type tree that includes fields of type `Object`. This appears to cause issues with injection, requiring that `@Mock` fields be available. This is where the following fields were added in multiple places:
  * `Object job;`
  * `ResponseGenerator _responseGenerator;`
* Wrong number of parameters for `Mockito.when` in LibvirtRevertSnapshotCommandWrapperTest.java


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [X] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

All tests that run with flags: `-Dnoredist -P developer,systemvm`.

Commands used:
`mvn clean install -Dnoredist -P developer,systemvm`

Do not need to verify running of the server or agent because Mockito is only used in tests.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
