### PR TITLE
Always separate decimals by a dot in metrics response

### DIFF
--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -21,10 +21,12 @@ import static com.cloud.utils.NumbersUtil.toReadableSize;
 
 import java.lang.reflect.InvocationTargetException;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -461,8 +463,8 @@ public class MetricsServiceImpl extends MutualExclusiveIdsManagerBase implements
      * @return the set of responses that was created.
      */
     protected List<StatsResponse> createStatsResponse(List<VmStatsVO> vmStatsList) {
-        List<StatsResponse> statsResponseList = new ArrayList<StatsResponse>();
-        DecimalFormat decimalFormat = new DecimalFormat("#.##");
+        List<StatsResponse> statsResponseList = new ArrayList<>();
+        DecimalFormat decimalFormat = new DecimalFormat("#.##", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
         for (VmStatsVO vmStats : vmStatsList) {
             StatsResponse response = new StatsResponse();
             response.setTimestamp(vmStats.getTimestamp());


### PR DESCRIPTION
### Description

Depending on the Management Server's Locale, `listVirtualMachinesUsageHistory` may return decimal values separated by a comma in the `cpuused` field; however, the UI expects that this decimal is separated by a dot. In this situation, the metrics page will not show the CPU utilization graph properly (see #10672).

This PR fixes this issue by always formatting the decimal value separated by a dot.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

0. Initially, my Locale was set to English
1. I left a VM running for some time, and left the MS collecting utilization metrics 
2. I accessed the VM's metrics page, and verified that the graphs were shown properly
3. I changed my MS's Locale to Italian
4. I accessed the VM's metrics page

Before the patch, the CPU utilization graph would not be shown properly in step 4 because the decimal value in `cpuused` was being separated with a comma. After the patch, the graphs are shown properly because the value always gets separated with a dot.
