### PR TITLE
UI: Move templates creation date to the Zones tab

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -629,7 +629,7 @@
             <span v-else>{{ resource.podname || resource.pod || resource.podid }}</span>
           </div>
         </div>
-        <div class="resource-detail-item" v-if="resource.zoneid">
+        <div class="resource-detail-item" v-if="resource.zoneid && !['template'].includes($route.path.split('/')[1])">
           <div class="resource-detail-item__label">{{ $t('label.zone') }}</div>
           <div class="resource-detail-item__details">
             <span v-if="images.zone">
@@ -700,7 +700,7 @@
             <span v-else>{{ resource.managementserver || resource.managementserverid }}</span>
           </div>
         </div>
-        <div class="resource-detail-item" v-if="resource.created">
+        <div class="resource-detail-item" v-if="resource.created && !['template'].includes($route.path.split('/')[1])">
           <div class="resource-detail-item__label">{{ $t('label.created') }}</div>
           <div class="resource-detail-item__details">
             <calendar-outlined />{{ $toLocaleDate(resource.created) }}

--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -629,7 +629,7 @@
             <span v-else>{{ resource.podname || resource.pod || resource.podid }}</span>
           </div>
         </div>
-        <div class="resource-detail-item" v-if="resource.zoneid && !['template'].includes($route.path.split('/')[1])">
+        <div class="resource-detail-item" v-if="resource.zoneid && !['template', 'iso'].includes($route.path.split('/')[1])">
           <div class="resource-detail-item__label">{{ $t('label.zone') }}</div>
           <div class="resource-detail-item__details">
             <span v-if="images.zone">
@@ -700,7 +700,7 @@
             <span v-else>{{ resource.managementserver || resource.managementserverid }}</span>
           </div>
         </div>
-        <div class="resource-detail-item" v-if="resource.created && !['template'].includes($route.path.split('/')[1])">
+        <div class="resource-detail-item" v-if="resource.created && !['template', 'iso'].includes($route.path.split('/')[1])">
           <div class="resource-detail-item__label">{{ $t('label.created') }}</div>
           <div class="resource-detail-item__details">
             <calendar-outlined />{{ $toLocaleDate(resource.created) }}

--- a/ui/src/views/image/IsoZones.vue
+++ b/ui/src/views/image/IsoZones.vue
@@ -48,6 +48,9 @@
           <span v-if="record.isready">{{ $t('label.yes') }}</span>
           <span v-else>{{ $t('label.no') }}</span>
         </template>
+        <template v-else-if="column.key === 'created'">
+          <span v-if="record.created">{{ $toLocaleDate(record.created) }}</span>
+        </template>
         <template v-if="column.key === 'actions'">
           <span style="margin-right: 5px">
             <tooltip-button
@@ -261,6 +264,11 @@ export default {
         key: 'zonename',
         title: this.$t('label.zonename'),
         dataIndex: 'zonename'
+      },
+      {
+        key: 'created',
+        title: this.$t('label.created'),
+        dataIndex: 'created'
       },
       {
         title: this.$t('label.status'),

--- a/ui/src/views/image/TemplateZones.vue
+++ b/ui/src/views/image/TemplateZones.vue
@@ -48,6 +48,9 @@
           <span v-if="record.isready">{{ $t('label.yes') }}</span>
           <span v-else>{{ $t('label.no') }}</span>
         </template>
+        <template v-else-if="column.key === 'created'">
+          <span>{{ $toLocaleDate(record.created) }}</span>
+        </template>
         <template v-if="column.key === 'actions'">
           <tooltip-button
             style="margin-right: 5px"
@@ -307,6 +310,11 @@ export default {
         key: 'zonename',
         title: this.$t('label.zonename'),
         dataIndex: 'zonename'
+      },
+      {
+        key: 'created',
+        title: this.$t('label.created'),
+        dataIndex: 'created'
       },
       {
         title: this.$t('label.status'),

--- a/ui/src/views/image/TemplateZones.vue
+++ b/ui/src/views/image/TemplateZones.vue
@@ -49,7 +49,7 @@
           <span v-else>{{ $t('label.no') }}</span>
         </template>
         <template v-else-if="column.key === 'created'">
-          <span>{{ $toLocaleDate(record.created) }}</span>
+          <span v-if="record.created">{{ $toLocaleDate(record.created) }}</span>
         </template>
         <template v-if="column.key === 'actions'">
           <tooltip-button


### PR DESCRIPTION
### Description

This PR moves the creation date of a template to the Zones tab on the template view and removes the zone field on the left side menu. This behavior is changed to support templates on multiple zones, which should display the different creation dates for each zone. These are correctly displayed on the Template view -> Zones tab.

<img width="1379" alt="Screenshot 2025-04-14 at 11 00 55" src="https://github.com/user-attachments/assets/a66c7e52-5c9e-4b73-8d58-173f37234184" />

Fixes: #10599 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
