### PR TITLE
Backport #9888 to 4.19: Fix Usage inconsistencies

### DIFF
--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDao.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDao.java
@@ -28,4 +28,6 @@ public interface UsageNetworksDao extends GenericDao<UsageNetworksVO, Long> {
     void remove(long networkId, Date removed);
 
     List<UsageNetworksVO> getUsageRecords(Long accountId, Date startDate, Date endDate);
+
+    List<UsageNetworksVO> listAll(long networkId);
 }

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDaoImpl.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.usage.dao;
 
-import com.cloud.network.Network;
 import com.cloud.usage.UsageNetworksVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
@@ -68,11 +67,10 @@ public class UsageNetworksDaoImpl extends GenericDaoBase<UsageNetworksVO, Long> 
             SearchCriteria<UsageNetworksVO> sc = this.createSearchCriteria();
             sc.addAnd("networkId", SearchCriteria.Op.EQ, networkId);
             sc.addAnd("removed", SearchCriteria.Op.NULL);
-            UsageNetworksVO vo = findOneBy(sc);
-            if (vo != null) {
-                vo.setRemoved(removed);
-                vo.setState(Network.State.Destroy.name());
-                update(vo.getId(), vo);
+            List<UsageNetworksVO> usageNetworksVOs = listBy(sc);
+            for (UsageNetworksVO entry : usageNetworksVOs) {
+                entry.setRemoved(removed);
+                update(entry.getId(), entry);
             }
         } catch (final Exception e) {
             txn.rollback();

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageNetworksDaoImpl.java
@@ -19,11 +19,13 @@ package com.cloud.usage.dao;
 import com.cloud.usage.UsageNetworksVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.TransactionLegacy;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -38,6 +40,14 @@ public class UsageNetworksDaoImpl extends GenericDaoBase<UsageNetworksVO, Long> 
             " account_id = ? AND ((removed IS NULL AND created <= ?) OR (created BETWEEN ? AND ?) OR (removed BETWEEN ? AND ?) " +
             " OR ((created <= ?) AND (removed >= ?)))";
 
+    private SearchBuilder<UsageNetworksVO> usageNetworksSearch;
+
+    @PostConstruct
+    public void init() {
+        usageNetworksSearch = createSearchBuilder();
+        usageNetworksSearch.and("networkId", usageNetworksSearch.entity().getNetworkId(), SearchCriteria.Op.EQ);
+        usageNetworksSearch.done();
+    }
 
     @Override
     public void update(long networkId, long newNetworkOffering, String state) {
@@ -128,5 +138,12 @@ public class UsageNetworksDaoImpl extends GenericDaoBase<UsageNetworksVO, Long> 
         }
 
         return usageRecords;
+    }
+
+    @Override
+    public List<UsageNetworksVO> listAll(long networkId) {
+        SearchCriteria<UsageNetworksVO> sc = usageNetworksSearch.create();
+        sc.setParameters("networkId", networkId);
+        return listBy(sc);
     }
 }

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDao.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDao.java
@@ -24,6 +24,10 @@ import java.util.List;
 
 public interface UsageVpcDao extends GenericDao<UsageVpcVO, Long> {
     void update(UsageVpcVO usage);
+
     void remove(long vpcId, Date removed);
+
     List<UsageVpcVO> getUsageRecords(Long accountId, Date startDate, Date endDate);
+
+    List<UsageVpcVO> listAll(long vpcId);
 }

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.usage.dao;
 
-import com.cloud.network.vpc.Vpc;
 import com.cloud.usage.UsageVpcVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
@@ -66,11 +65,10 @@ public class UsageVpcDaoImpl extends GenericDaoBase<UsageVpcVO, Long> implements
             SearchCriteria<UsageVpcVO> sc = this.createSearchCriteria();
             sc.addAnd("vpcId", SearchCriteria.Op.EQ, vpcId);
             sc.addAnd("removed", SearchCriteria.Op.NULL);
-            UsageVpcVO vo = findOneBy(sc);
-            if (vo != null) {
-                vo.setRemoved(removed);
-                vo.setState(Vpc.State.Inactive.name());
-                update(vo.getId(), vo);
+            List<UsageVpcVO> usageVpcVOs = listBy(sc);
+            for (UsageVpcVO entry : usageVpcVOs) {
+                entry.setRemoved(removed);
+                update(entry.getId(), entry);
             }
         } catch (final Exception e) {
             txn.rollback();

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.usage.dao;
 
-import com.cloud.usage.UsageNetworksVO;
 import com.cloud.usage.UsageVpcVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageVpcDaoImpl.java
@@ -16,14 +16,17 @@
 // under the License.
 package com.cloud.usage.dao;
 
+import com.cloud.usage.UsageNetworksVO;
 import com.cloud.usage.UsageVpcVO;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.TransactionLegacy;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -37,6 +40,15 @@ public class UsageVpcDaoImpl extends GenericDaoBase<UsageVpcVO, Long> implements
     protected static final String GET_USAGE_RECORDS_BY_ACCOUNT = "SELECT id, vpc_id, zone_id, account_id, domain_id, state, created, removed FROM usage_vpc WHERE " +
             " account_id = ? AND ((removed IS NULL AND created <= ?) OR (created BETWEEN ? AND ?) OR (removed BETWEEN ? AND ?) " +
             " OR ((created <= ?) AND (removed >= ?)))";
+
+    private SearchBuilder<UsageVpcVO> usageVpcSearch;
+
+    @PostConstruct
+    public void init() {
+        usageVpcSearch = createSearchBuilder();
+        usageVpcSearch.and("vpcId", usageVpcSearch.entity().getVpcId(), SearchCriteria.Op.EQ);
+        usageVpcSearch.done();
+    }
 
     @Override
     public void update(UsageVpcVO usage) {
@@ -125,5 +137,12 @@ public class UsageVpcDaoImpl extends GenericDaoBase<UsageVpcVO, Long> implements
         }
 
         return usageRecords;
+    }
+
+    @Override
+    public List<UsageVpcVO> listAll(long vpcId) {
+        SearchCriteria<UsageVpcVO> sc = usageVpcSearch.create();
+        sc.setParameters("vpcId", vpcId);
+        return listBy(sc);
     }
 }

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -2148,10 +2148,15 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (EventTypes.EVENT_NETWORK_DELETE.equals(event.getType())) {
             usageNetworksDao.remove(event.getResourceId(), event.getCreateDate());
         } else if (EventTypes.EVENT_NETWORK_CREATE.equals(event.getType())) {
-            s_logger.debug(String.format("Marking existing helper entries for network [%s] as removed.", event.getResourceId()));
-            usageNetworksDao.remove(event.getResourceId(), event.getCreateDate());
+            List<UsageNetworksVO> entries = usageNetworksDao.listAll(event.getResourceId());
+            if (!entries.isEmpty()) {
+                s_logger.warn(String.format("Active helper entries already exist for network [%s]; we will not create a new one.",
+                        event.getResourceId()));
+                return;
+            }
             s_logger.debug(String.format("Creating a helper entry for network [%s].", event.getResourceId()));
-            UsageNetworksVO usageNetworksVO = new UsageNetworksVO(event.getResourceId(), event.getOfferingId(), event.getZoneId(), event.getAccountId(), domainId, Network.State.Allocated.name(), event.getCreateDate(), null);
+            UsageNetworksVO usageNetworksVO = new UsageNetworksVO(event.getResourceId(), event.getOfferingId(), event.getZoneId(),
+                    event.getAccountId(), domainId, Network.State.Allocated.name(), event.getCreateDate(), null);
             usageNetworksDao.persist(usageNetworksVO);
         } else if (EventTypes.EVENT_NETWORK_UPDATE.equals(event.getType())) {
             usageNetworksDao.update(event.getResourceId(), event.getOfferingId(), event.getResourceType());
@@ -2166,8 +2171,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (EventTypes.EVENT_VPC_DELETE.equals(event.getType())) {
             usageVpcDao.remove(event.getResourceId(), event.getCreateDate());
         } else if (EventTypes.EVENT_VPC_CREATE.equals(event.getType())) {
-            s_logger.debug(String.format("Marking existing helper entries for VPC [%s] as removed.", event.getResourceId()));
-            usageVpcDao.remove(event.getResourceId(), event.getCreateDate());
+            List<UsageVpcVO> entries = usageVpcDao.listAll(event.getResourceId());
+            if (!entries.isEmpty()) {
+                s_logger.warn(String.format("Active helper entries already exist for VPC [%s]; we will not create a new one.",
+                        event.getResourceId()));
+                return;
+            }
             s_logger.debug(String.format("Creating a helper entry for VPC [%s].", event.getResourceId()));
             UsageVpcVO usageVPCVO = new UsageVpcVO(event.getResourceId(), event.getZoneId(), event.getAccountId(), domainId, Vpc.State.Enabled.name(), event.getCreateDate(), null);
             usageVpcDao.persist(usageVPCVO);

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -1540,7 +1540,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             //For volumes which are 'attached' successfully, set the 'deleted' column in the usage_storage table,
             //so that the secondary storage should stop accounting and only primary will be accounted.
             SearchCriteria<UsageStorageVO> sc = _usageStorageDao.createSearchCriteria();
-            sc.addAnd("id", SearchCriteria.Op.EQ, volId);
+            sc.addAnd("entityId", SearchCriteria.Op.EQ, volId);
             sc.addAnd("storageType", SearchCriteria.Op.EQ, StorageTypes.VOLUME);
             List<UsageStorageVO> volumesVOs = _usageStorageDao.search(sc, null);
             if (volumesVOs != null) {
@@ -1595,7 +1595,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             //For Upload event add an entry to the usage_storage table.
             SearchCriteria<UsageStorageVO> sc = _usageStorageDao.createSearchCriteria();
             sc.addAnd("accountId", SearchCriteria.Op.EQ, event.getAccountId());
-            sc.addAnd("id", SearchCriteria.Op.EQ, volId);
+            sc.addAnd("entityId", SearchCriteria.Op.EQ, volId);
+            sc.addAnd("storageType", SearchCriteria.Op.EQ, StorageTypes.VOLUME);
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageStorageVO> volumesVOs = _usageStorageDao.search(sc, null);
 
@@ -1772,7 +1773,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         } else if (EventTypes.EVENT_LOAD_BALANCER_DELETE.equals(event.getType())) {
             SearchCriteria<UsageLoadBalancerPolicyVO> sc = _usageLoadBalancerPolicyDao.createSearchCriteria();
             sc.addAnd("accountId", SearchCriteria.Op.EQ, event.getAccountId());
-            sc.addAnd("id", SearchCriteria.Op.EQ, id);
+            sc.addAnd("lbId", SearchCriteria.Op.EQ, id);
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageLoadBalancerPolicyVO> lbVOs = _usageLoadBalancerPolicyDao.search(sc, null);
             if (lbVOs.size() > 1) {
@@ -1806,7 +1807,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         } else if (EventTypes.EVENT_NET_RULE_DELETE.equals(event.getType())) {
             SearchCriteria<UsagePortForwardingRuleVO> sc = _usagePortForwardingRuleDao.createSearchCriteria();
             sc.addAnd("accountId", SearchCriteria.Op.EQ, event.getAccountId());
-            sc.addAnd("id", SearchCriteria.Op.EQ, id);
+            sc.addAnd("pfId", SearchCriteria.Op.EQ, id);
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsagePortForwardingRuleVO> pfVOs = _usagePortForwardingRuleDao.search(sc, null);
             if (pfVOs.size() > 1) {
@@ -2104,7 +2105,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         } else if (EventTypes.EVENT_VM_SNAPSHOT_OFF_PRIMARY.equals(event.getType())) {
             QueryBuilder<UsageSnapshotOnPrimaryVO> sc = QueryBuilder.create(UsageSnapshotOnPrimaryVO.class);
             sc.and(sc.entity().getAccountId(), SearchCriteria.Op.EQ, event.getAccountId());
-            sc.and(sc.entity().getId(), SearchCriteria.Op.EQ, vmId);
+            sc.and(sc.entity().getVmId(), SearchCriteria.Op.EQ, vmId);
             sc.and(sc.entity().getName(), SearchCriteria.Op.EQ, name);
             sc.and(sc.entity().getDeleted(), SearchCriteria.Op.NULL);
             List<UsageSnapshotOnPrimaryVO> vmsnaps = sc.list();
@@ -2147,6 +2148,9 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (EventTypes.EVENT_NETWORK_DELETE.equals(event.getType())) {
             usageNetworksDao.remove(event.getResourceId(), event.getCreateDate());
         } else if (EventTypes.EVENT_NETWORK_CREATE.equals(event.getType())) {
+            s_logger.debug(String.format("Marking existing helper entries for network [%s] as removed.", event.getResourceId()));
+            usageNetworksDao.remove(event.getResourceId(), event.getCreateDate());
+            s_logger.debug(String.format("Creating a helper entry for network [%s].", event.getResourceId()));
             UsageNetworksVO usageNetworksVO = new UsageNetworksVO(event.getResourceId(), event.getOfferingId(), event.getZoneId(), event.getAccountId(), domainId, Network.State.Allocated.name(), event.getCreateDate(), null);
             usageNetworksDao.persist(usageNetworksVO);
         } else if (EventTypes.EVENT_NETWORK_UPDATE.equals(event.getType())) {
@@ -2162,6 +2166,9 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (EventTypes.EVENT_VPC_DELETE.equals(event.getType())) {
             usageVpcDao.remove(event.getResourceId(), event.getCreateDate());
         } else if (EventTypes.EVENT_VPC_CREATE.equals(event.getType())) {
+            s_logger.debug(String.format("Marking existing helper entries for VPC [%s] as removed.", event.getResourceId()));
+            usageVpcDao.remove(event.getResourceId(), event.getCreateDate());
+            s_logger.debug(String.format("Creating a helper entry for VPC [%s].", event.getResourceId()));
             UsageVpcVO usageVPCVO = new UsageVpcVO(event.getResourceId(), event.getZoneId(), event.getAccountId(), domainId, Vpc.State.Enabled.name(), event.getCreateDate(), null);
             usageVpcDao.persist(usageVPCVO);
         } else {

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -2143,52 +2143,88 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     }
 
     private void handleNetworkEvent(UsageEventVO event) {
-        long networkId = event.getResourceId();
-        Account account = _accountDao.findByIdIncludingRemoved(event.getAccountId());
-        long domainId = account.getDomainId();
-        if (EventTypes.EVENT_NETWORK_DELETE.equals(event.getType())) {
-            usageNetworksDao.remove(networkId, event.getCreateDate());
-        } else if (EventTypes.EVENT_NETWORK_CREATE.equals(event.getType())) {
-            List<UsageNetworksVO> entries = usageNetworksDao.listAll(networkId);
-            if (!entries.isEmpty()) {
-                s_logger.warn(String.format("Received a NETWORK.CREATE event for a network [%s] that already has helper entries; " +
-                                "therefore, we will not create a new one.", networkId));
-                return;
-            }
-            s_logger.debug(String.format("Creating a helper entry for network [%s].", networkId));
-            UsageNetworksVO usageNetworksVO = new UsageNetworksVO(networkId, event.getOfferingId(), event.getZoneId(),
-                    event.getAccountId(), domainId, Network.State.Allocated.name(), event.getCreateDate(), null);
-            usageNetworksDao.persist(usageNetworksVO);
-        } else if (EventTypes.EVENT_NETWORK_UPDATE.equals(event.getType())) {
-            s_logger.debug(String.format("Marking previous helper entries of network [%s] as removed.", networkId));
-            usageNetworksDao.remove(networkId, event.getCreateDate());
-            s_logger.debug(String.format("Creating an updated helper entry for network [%s].", networkId));
-            UsageNetworksVO usageNetworksVO = new UsageNetworksVO(networkId, event.getOfferingId(), event.getZoneId(),
-                    event.getAccountId(), domainId, event.getResourceType(), event.getCreateDate(), null);
-            usageNetworksDao.persist(usageNetworksVO);
+        String eventType = event.getType();
+        if (EventTypes.EVENT_NETWORK_DELETE.equals(eventType)) {
+            removeNetworkHelperEntry(event);
+        } else if (EventTypes.EVENT_NETWORK_CREATE.equals(eventType)) {
+            createNetworkHelperEntry(event);
+        } else if (EventTypes.EVENT_NETWORK_UPDATE.equals(eventType)) {
+            updateNetworkHelperEntry(event);
         } else {
-            s_logger.error(String.format("Unknown event type [%s] in Networks event parser. Skipping it.", event.getType()));
+            s_logger.error(String.format("Unknown event type [%s] in Networks event parser. Skipping it.", eventType));
         }
     }
 
-    private void handleVpcEvent(UsageEventVO event) {
+    private void removeNetworkHelperEntry(UsageEventVO event) {
+        long networkId = event.getResourceId();
+        s_logger.debug(String.format("Removing helper entries of network [%s].", networkId));
+        usageNetworksDao.remove(networkId, event.getCreateDate());
+    }
+
+    private void createNetworkHelperEntry(UsageEventVO event) {
+        long networkId = event.getResourceId();
         Account account = _accountDao.findByIdIncludingRemoved(event.getAccountId());
         long domainId = account.getDomainId();
-        if (EventTypes.EVENT_VPC_DELETE.equals(event.getType())) {
-            usageVpcDao.remove(event.getResourceId(), event.getCreateDate());
-        } else if (EventTypes.EVENT_VPC_CREATE.equals(event.getType())) {
-            List<UsageVpcVO> entries = usageVpcDao.listAll(event.getResourceId());
-            if (!entries.isEmpty()) {
-                s_logger.warn(String.format("Active helper entries already exist for VPC [%s]; therefore, we will not create a new one.",
-                        event.getResourceId()));
-                return;
-            }
-            s_logger.debug(String.format("Creating a helper entry for VPC [%s].", event.getResourceId()));
-            UsageVpcVO usageVPCVO = new UsageVpcVO(event.getResourceId(), event.getZoneId(), event.getAccountId(), domainId, Vpc.State.Enabled.name(), event.getCreateDate(), null);
-            usageVpcDao.persist(usageVPCVO);
-        } else {
-            s_logger.error(String.format("Unknown event type [%s] in VPC event parser. Skipping it.", event.getType()));
+
+        List<UsageNetworksVO> entries = usageNetworksDao.listAll(networkId);
+        if (!entries.isEmpty()) {
+            s_logger.warn(String.format("Received a NETWORK.CREATE event for a network [%s] that already has helper entries; " +
+                    "therefore, we will not create a new one.", networkId));
+            return;
         }
+
+        s_logger.debug(String.format("Creating a helper entry for network [%s].", networkId));
+        UsageNetworksVO usageNetworksVO = new UsageNetworksVO(networkId, event.getOfferingId(), event.getZoneId(),
+                event.getAccountId(), domainId, Network.State.Allocated.name(), event.getCreateDate(), null);
+        usageNetworksDao.persist(usageNetworksVO);
+    }
+
+    private void updateNetworkHelperEntry(UsageEventVO event) {
+        long networkId = event.getResourceId();
+        Account account = _accountDao.findByIdIncludingRemoved(event.getAccountId());
+        long domainId = account.getDomainId();
+
+        s_logger.debug(String.format("Marking previous helper entries of network [%s] as removed.", networkId));
+        usageNetworksDao.remove(networkId, event.getCreateDate());
+
+        s_logger.debug(String.format("Creating an updated helper entry for network [%s].", networkId));
+        UsageNetworksVO usageNetworksVO = new UsageNetworksVO(networkId, event.getOfferingId(), event.getZoneId(),
+                event.getAccountId(), domainId, event.getResourceType(), event.getCreateDate(), null);
+        usageNetworksDao.persist(usageNetworksVO);
+    }
+
+    private void handleVpcEvent(UsageEventVO event) {
+        String eventType = event.getType();
+        if (EventTypes.EVENT_VPC_DELETE.equals(eventType)) {
+            removeVpcHelperEntry(event);
+        } else if (EventTypes.EVENT_VPC_CREATE.equals(eventType)) {
+            createVpcHelperEntry(event);
+        } else {
+            s_logger.error(String.format("Unknown event type [%s] in VPC event parser. Skipping it.", eventType));
+        }
+    }
+
+    private void removeVpcHelperEntry(UsageEventVO event) {
+        long vpcId = event.getResourceId();
+        s_logger.debug(String.format("Removing helper entries of VPC [%s].", vpcId));
+        usageVpcDao.remove(vpcId, event.getCreateDate());
+    }
+
+    private void createVpcHelperEntry(UsageEventVO event) {
+        long vpcId = event.getResourceId();
+        Account account = _accountDao.findByIdIncludingRemoved(event.getAccountId());
+        long domainId = account.getDomainId();
+
+        List<UsageVpcVO> entries = usageVpcDao.listAll(vpcId);
+        if (!entries.isEmpty()) {
+            s_logger.warn(String.format("Active helper entries already exist for VPC [%s]; therefore, we will not create a new one.",
+                    vpcId));
+            return;
+        }
+
+        s_logger.debug(String.format("Creating a helper entry for VPC [%s].", vpcId));
+        UsageVpcVO usageVPCVO = new UsageVpcVO(vpcId, event.getZoneId(), event.getAccountId(), domainId, Vpc.State.Enabled.name(), event.getCreateDate(), null);
+        usageVpcDao.persist(usageVPCVO);
     }
 
     private class Heartbeat extends ManagedContextRunnable {


### PR DESCRIPTION
### Description

This PR backports #9888 to 4.19, fixing the issue described in #10687 and some other ones.

- Duplicated entries in the networks helper table, resulting in duplicated usage record generation;
- Port forwarding helper entries are never removed, resulting in removed port forwarding rules generating usage records;
- Load balancer helper entries are never removed, resulting in removed load balancer rules generating usage records;
- VM snapshot helper entries are never removed, resulting in removed VM snapshots generating usage records;
- Helper entries for volumes in the secondary storage are never removed after the volume gets attached to a VM, resulting in secondary storage usage records being generated for volumes that are not in the secondary storage anymore.

I still intend to work on a normalization script before closing #10687, but it can be merged separately from this PR.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

I reproduced the tests described in #9888.