### PR TITLE
plugin/shutdown: use mgmt server uuid in the shutdown response

### DIFF
--- a/plugins/shutdown/src/main/java/org/apache/cloudstack/api/response/ReadyForShutdownResponse.java
+++ b/plugins/shutdown/src/main/java/org/apache/cloudstack/api/response/ReadyForShutdownResponse.java
@@ -38,10 +38,10 @@ public class ReadyForShutdownResponse extends BaseResponse {
 
     @SerializedName(ApiConstants.MANAGEMENT_SERVER_ID)
     @Param(description = "The id of the management server")
-    private Long msId;
+    private String msUuid;
 
-    public ReadyForShutdownResponse(Long msId, Boolean shutdownTriggered, Boolean readyForShutdown, long pendingJobsCount) {
-        this.msId = msId;
+    public ReadyForShutdownResponse(String msUuid, Boolean shutdownTriggered, Boolean readyForShutdown, long pendingJobsCount) {
+        this.msUuid = msUuid;
         this.shutdownTriggered = shutdownTriggered;
         this.readyForShutdown = readyForShutdown;
         this.pendingJobsCount = pendingJobsCount;
@@ -69,13 +69,5 @@ public class ReadyForShutdownResponse extends BaseResponse {
 
     public void setPendingJobsCount(Long pendingJobsCount) {
         this.pendingJobsCount = pendingJobsCount;
-    }
-
-    public Long getMsId() {
-        return msId;
-    }
-
-    public void setMsId(Long msId) {
-        this.msId = msId;
     }
 }

--- a/plugins/shutdown/src/main/java/org/apache/cloudstack/shutdown/ShutdownManagerImpl.java
+++ b/plugins/shutdown/src/main/java/org/apache/cloudstack/shutdown/ShutdownManagerImpl.java
@@ -137,6 +137,7 @@ public class ShutdownManagerImpl extends ManagerBase implements ShutdownManager,
     public ReadyForShutdownResponse readyForShutdown(Long managementserverid) {
         Long[] msIds = null;
         boolean shutdownTriggeredAnywhere = false;
+        String msUuid = null;
         State[] shutdownTriggeredStates = {State.ShuttingDown, State.PreparingToShutDown, State.ReadyToShutDown};
         if (managementserverid == null) {
             List<ManagementServerHostVO> msHosts = msHostDao.listBy(shutdownTriggeredStates);
@@ -149,11 +150,12 @@ public class ShutdownManagerImpl extends ManagerBase implements ShutdownManager,
             }
         } else {
             ManagementServerHostVO msHost = msHostDao.findById(managementserverid);
+            msUuid = msHost.getUuid();
             msIds = new Long[]{msHost.getMsid()};
             shutdownTriggeredAnywhere = Arrays.asList(shutdownTriggeredStates).contains(msHost.getState());
         }
         long pendingJobCount = countPendingJobs(msIds);
-        return new ReadyForShutdownResponse(managementserverid, shutdownTriggeredAnywhere, pendingJobCount == 0, pendingJobCount);
+        return new ReadyForShutdownResponse(msUuid, shutdownTriggeredAnywhere, pendingJobCount == 0, pendingJobCount);
     }
 
     @Override


### PR DESCRIPTION
Fixes #10669

Creates shutdown response to use management server UUID than internal DB ID.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial