### PR TITLE
Add logs to keystore-setup and fix password regex

### DIFF
--- a/scripts/util/keystore-setup
+++ b/scripts/util/keystore-setup
@@ -22,48 +22,71 @@ KS_PASS="$3"
 KS_VALIDITY="$4"
 CSR_FILE="$5"
 
+LOG_FILE="/var/log/cloudstack/agent/keystore-setup.log"
+
 ALIAS="cloud"
 LIBVIRTD_FILE="/etc/libvirt/libvirtd.conf"
 
+log() {
+    __log_line="${1}"
+    __log_level="${2:-INFO}"
+
+    __log_line="${__log_level}: ${__log_line}"
+    echo "${__log_line}" >> "${LOG_FILE}"
+    echo "${__log_line}"
+}
+
+log "$(date) - starting keystore-setup" >> "${LOG_FILE}"
+
 # Re-use existing password or use the one provided
 if [ -f "$PROPS_FILE" ]; then
-    OLD_PASS=$(sed -n '/keystore.passphrase/p' "$PROPS_FILE" 2>/dev/null  | sed 's/keystore.passphrase=//g' 2>/dev/null)
+    log "Previous props file exists, trying to extract password"
+    OLD_PASS=$(sed -n '/^keystore.passphrase/p' "$PROPS_FILE" 2>> "${LOG_FILE}"  | sed 's/^keystore.passphrase=//g' 2>> "${LOG_FILE}")
     if [ ! -z "${OLD_PASS// }" ]; then
         KS_PASS="$OLD_PASS"
+        log "Password extraction successful"
     else
-        sed -i "/keystore.passphrase.*/d" $PROPS_FILE 2> /dev/null || true
+        sed -i "/^keystore.passphrase.*/d" $PROPS_FILE 2>> "${LOG_FILE}" || true
         echo "keystore.passphrase=$KS_PASS" >> $PROPS_FILE
+        if [ $? != 0 ]; then
+                log "Could not add new password to agent.properties" "ERROR"
+        else
+                log "New keystore password set"
+        fi
     fi
 fi
 
 if [ -f "$KS_FILE" ]; then
-    keytool -delete -noprompt -alias "$ALIAS" -keystore "$KS_FILE" -storepass "$KS_PASS" > /dev/null 2>&1 || true
+    log "keystore file exists. Deleting current entries"
+    keytool -delete -noprompt -alias "$ALIAS" -keystore "$KS_FILE" -storepass "$KS_PASS" >> "${LOG_FILE}" || log "Failed to delete current entries" "ERROR"
 fi
 
+log "Generating new key"
 CN=$(hostname --fqdn)
-keytool -genkey -storepass "$KS_PASS" -keypass "$KS_PASS" -alias "$ALIAS" -keyalg RSA -validity "$KS_VALIDITY" -dname cn="$CN",ou="cloudstack",o="cloudstack",c="cloudstack" -keystore "$KS_FILE" > /dev/null 2>&1
+keytool -genkey -storepass "$KS_PASS" -keypass "$KS_PASS" -alias "$ALIAS" -keyalg RSA -validity "$KS_VALIDITY" -dname cn="$CN",ou="cloudstack",o="cloudstack",c="cloudstack" -keystore "$KS_FILE" >> "${LOG_FILE}" 2>&1
 
 # Generate CSR
-rm -f "$CSR_FILE"
+log "Generating CSR"
+[ -f "$CSR_FILE" ] && rm -f "$CSR_FILE"
 addresses=$(ip address | grep inet | awk '{print $2}' | sed 's/\/.*//g' | grep -v '^169.254.' | grep -v '^127.0.0.1' | egrep -v '^::1|^fe80' | grep -v '^::1' | sed 's/^/ip:/g' | tr '\r\n' ',')
-keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" > /dev/null 2>&1
-
+log "Found following SAN addresses to add to CSR: ${addresses}"
+keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" >> "${LOG_FILE}" 2>&1
 if [ $? -ne 0 ];then
-    echo "Failed to generate CSR file, retrying after removing existing settings"
+    log "Failed to generate CSR file, retrying after removing existing settings" "ERROR"
 
     if [ -f "$LIBVIRTD_FILE" ]; then
-        echo "Reverting libvirtd to not listen on TLS"
+        log "Reverting libvirtd to not listen on TLS"
         sed -i "s,^listen_tls=1,listen_tls=0,g" $LIBVIRTD_FILE
         systemctl restart libvirtd
     fi
 
-    echo "Removing cloud.* files in /etc/cloudstack/agent"
-    rm -f /etc/cloudstack/agent/cloud.*
+    log "Removing cloud.* files in /etc/cloudstack/agent"
+    rm -f /etc/cloudstack/agent/cloud.* || log "Could not remove /etc/cloudstack/agent/cloud.*" "ERROR"
 
-    echo "Retrying to generate CSR file"
-    keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" >/dev/null 2>&1
+    log "Retrying to generate CSR file"
+    keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" >> "${LOG_FILE}" 2>&1
     if [ $? -ne 0 ];then
-        echo "Failed to generate CSR file while retrying"
+        log "Failed to generate CSR file while retrying" "ERROR"
         exit 1
     fi
 fi
@@ -71,6 +94,6 @@ fi
 cat "$CSR_FILE"
 
 # Fix file permissions
-chmod 600 $KS_FILE
-chmod 600 $PROPS_FILE
-chmod 600 $CSR_FILE
+chmod 600 $KS_FILE || log "Cannot chmod $KS_FILE" "ERROR"
+chmod 600 $PROPS_FILE || log "Cannot chmod $PROPS_FILE" "ERROR"
+chmod 600 $CSR_FILE || log "Cannot chmod $CSR_FILE" "ERROR"

--- a/scripts/util/keystore-setup
+++ b/scripts/util/keystore-setup
@@ -22,71 +22,78 @@ KS_PASS="$3"
 KS_VALIDITY="$4"
 CSR_FILE="$5"
 
-LOG_FILE="/var/log/cloudstack/agent/keystore-setup.log"
-
 ALIAS="cloud"
 LIBVIRTD_FILE="/etc/libvirt/libvirtd.conf"
 
-log() {
-    __log_line="${1}"
-    __log_level="${2:-INFO}"
+if type -p logger > /dev/null; then
+    LOGGER_CMD="$(type -p logger) -t cloudstack-keystore-setup"
+else
+    LOG_FILE="/var/log/cloudstack/agent/cloudstack-keystore-setup.log"
+    log() {
+        if [ "${1}" != "" ]; then
+            __log_line="${1}"
+        else
+            read -r __log_line
+        fi
 
-    __log_line="${__log_level}: ${__log_line}"
-    echo "${__log_line}" >> "${LOG_FILE}"
-    echo "${__log_line}"
-}
+        echo "${__log_line}" >> "${LOG_FILE}"
+        echo "${__log_line}"
+    }
+    LOGGER_CMD=log
+fi
 
-log "$(date) - starting keystore-setup" >> "${LOG_FILE}"
+$LOGGER_CMD "$(date) - starting keystore-setup"
 
 # Re-use existing password or use the one provided
 if [ -f "$PROPS_FILE" ]; then
-    log "Previous props file exists, trying to extract password"
-    OLD_PASS=$(sed -n '/^keystore.passphrase/p' "$PROPS_FILE" 2>> "${LOG_FILE}"  | sed 's/^keystore.passphrase=//g' 2>> "${LOG_FILE}")
-    if [ ! -z "${OLD_PASS// }" ]; then
+    $LOGGER_CMD "Previous props file exists, trying to extract password"
+    OLD_PASS=$(sed -n '/^keystore.passphrase/p' "$PROPS_FILE" | sed 's/^keystore.passphrase=//g')
+    if [ -n "${OLD_PASS// }" ]; then
         KS_PASS="$OLD_PASS"
-        log "Password extraction successful"
+        $LOGGER_CMD "Password extraction successful"
     else
-        sed -i "/^keystore.passphrase.*/d" $PROPS_FILE 2>> "${LOG_FILE}" || true
-        echo "keystore.passphrase=$KS_PASS" >> $PROPS_FILE
+        sed -i "/^keystore.passphrase.*/d" "$PROPS_FILE" 2>&1 | $LOGGER_CMD || true
+        echo "keystore.passphrase=$KS_PASS" >> "$PROPS_FILE"
         if [ $? != 0 ]; then
-                log "Could not add new password to agent.properties" "ERROR"
+                $LOGGER_CMD "Could not add new password to agent.properties"
         else
-                log "New keystore password set"
+                $LOGGER_CMD "New keystore password set"
         fi
     fi
 fi
 
 if [ -f "$KS_FILE" ]; then
-    log "keystore file exists. Deleting current entries"
-    keytool -delete -noprompt -alias "$ALIAS" -keystore "$KS_FILE" -storepass "$KS_PASS" >> "${LOG_FILE}" || log "Failed to delete current entries" "ERROR"
+    $LOGGER_CMD "keystore file exists. Deleting current entries"
+    keytool -delete -noprompt -alias "$ALIAS" -keystore "$KS_FILE" -storepass "$KS_PASS" 2>&1 | $LOGGER_CMD
+    [ $? -ne 0 ] && $LOGGER_CMD "Failed to delete current entries"
 fi
 
-log "Generating new key"
+$LOGGER_CMD "Generating new key"
 CN=$(hostname --fqdn)
-keytool -genkey -storepass "$KS_PASS" -keypass "$KS_PASS" -alias "$ALIAS" -keyalg RSA -validity "$KS_VALIDITY" -dname cn="$CN",ou="cloudstack",o="cloudstack",c="cloudstack" -keystore "$KS_FILE" >> "${LOG_FILE}" 2>&1
+keytool -genkey -storepass "$KS_PASS" -keypass "$KS_PASS" -alias "$ALIAS" -keyalg RSA -validity "$KS_VALIDITY" -dname cn="$CN",ou="cloudstack",o="cloudstack",c="cloudstack" -keystore "$KS_FILE" 2>&1 | $LOGGER_CMD
 
 # Generate CSR
-log "Generating CSR"
+$LOGGER_CMD "Generating CSR"
 [ -f "$CSR_FILE" ] && rm -f "$CSR_FILE"
 addresses=$(ip address | grep inet | awk '{print $2}' | sed 's/\/.*//g' | grep -v '^169.254.' | grep -v '^127.0.0.1' | egrep -v '^::1|^fe80' | grep -v '^::1' | sed 's/^/ip:/g' | tr '\r\n' ',')
-log "Found following SAN addresses to add to CSR: ${addresses}"
-keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" >> "${LOG_FILE}" 2>&1
+$LOGGER_CMD "Found following SAN addresses to add to CSR: ${addresses}"
+keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file "$CSR_FILE" -keystore "$KS_FILE" -ext san="$addresses" 2>&1 | $LOGGER_CMD
 if [ $? -ne 0 ];then
-    log "Failed to generate CSR file, retrying after removing existing settings" "ERROR"
+    $LOGGER_CMD "Failed to generate CSR file, retrying after removing existing settings"
 
     if [ -f "$LIBVIRTD_FILE" ]; then
-        log "Reverting libvirtd to not listen on TLS"
+        $LOGGER_CMD "Reverting libvirtd to not listen on TLS"
         sed -i "s,^listen_tls=1,listen_tls=0,g" $LIBVIRTD_FILE
         systemctl restart libvirtd
     fi
 
-    log "Removing cloud.* files in /etc/cloudstack/agent"
-    rm -f /etc/cloudstack/agent/cloud.* || log "Could not remove /etc/cloudstack/agent/cloud.*" "ERROR"
+    $LOGGER_CMD "Removing cloud.* files in /etc/cloudstack/agent"
+    rm -f /etc/cloudstack/agent/cloud.* || $LOGGER_CMD "Could not remove /etc/cloudstack/agent/cloud.*"
 
-    log "Retrying to generate CSR file"
-    keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file $CSR_FILE -keystore "$KS_FILE" -ext san="$addresses" >> "${LOG_FILE}" 2>&1
+    $LOGGER_CMD "Retrying to generate CSR file"
+    keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file "$CSR_FILE" -keystore "$KS_FILE" -ext san="$addresses" 2>&1 | $LOGGER_CMD
     if [ $? -ne 0 ];then
-        log "Failed to generate CSR file while retrying" "ERROR"
+        $LOGGER_CMD "Failed to generate CSR file while retrying"
         exit 1
     fi
 fi
@@ -94,6 +101,6 @@ fi
 cat "$CSR_FILE"
 
 # Fix file permissions
-chmod 600 $KS_FILE || log "Cannot chmod $KS_FILE" "ERROR"
-chmod 600 $PROPS_FILE || log "Cannot chmod $PROPS_FILE" "ERROR"
-chmod 600 $CSR_FILE || log "Cannot chmod $CSR_FILE" "ERROR"
+chmod 600 "$KS_FILE" || $LOGGER_CMD "Cannot chmod $KS_FILE"
+chmod 600 "$PROPS_FILE" || $LOGGER_CMD "Cannot chmod $PROPS_FILE"
+chmod 600 "$CSR_FILE" || $LOGGER_CMD "Cannot chmod $CSR_FILE"


### PR DESCRIPTION
### Description

This PR adds logging to the `keystore-setup` script, and fixes the regex to check old cloudstack-agent password.

When adding KVM hosts, the `keystore-setup` script may fail with `530: Failed to setup keystore on the KVM host).
On the KVM host` for various reasons (absence of keystore, malformatted agent.properties file, missing permissions...).

This adds logs to almost all actions, and also fixes the regex that gets the password from `agent.properties` in order to not fetch commented-out passwords.

Fixes #10703 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Script has been tested on two AlmaLinux 9.5 KVM hosts with a Cloudstack 4.20 management server.
Script has also been submitted to Shellcheck.

#### How did you try to break this feature and the system with this change?
Re-ran the tests on multiple hosts to validate that the script works ;)
Log function from the script has been tested on both RHEL and Debian systems.
