### PR TITLE
Reset modifier button's state when connection is completed

### DIFF
--- a/systemvm/agent/noVNC/app/ui.js
+++ b/systemvm/agent/noVNC/app/ui.js
@@ -1147,6 +1147,7 @@ const UI = {
             msg = _("Connected (unencrypted) to ") + UI.desktopName;
         }
         UI.showStatus(msg);
+        UI.resetModifierKeysState();
         UI.updateVisualState('connected');
 
         // Do this last because it can only be used on rendered elements
@@ -1781,6 +1782,35 @@ const UI = {
         optn.text = text;
         optn.value = value;
         selectbox.options.add(optn);
+    },
+
+    // Function to reset all modifier key states when reconnecting
+    resetModifierKeysState() {
+        // Reset the UI buttons for special keys
+        const modifierButtons = [
+            'noVNC_toggle_ctrl_button',
+            'noVNC_toggle_shift_button',
+            'noVNC_toggle_alt_button',
+            'noVNC_toggle_windows_button'
+        ];
+
+        for (let id of modifierButtons) {
+            const btn = document.getElementById(id);
+            if (btn && btn.classList.contains("noVNC_selected")) {
+                btn.classList.remove("noVNC_selected");
+
+                // Also send the key-up event if needed
+                if (id === 'noVNC_toggle_ctrl_button') {
+                    UI.sendKey(KeyTable.XK_Control_L, "ControlLeft", false);
+                } else if (id === 'noVNC_toggle_shift_button') {
+                    UI.sendKey(KeyTable.XK_Shift_L, "ShiftLeft", false);
+                } else if (id === 'noVNC_toggle_alt_button') {
+                    UI.sendKey(KeyTable.XK_Alt_L, "AltLeft", false);
+                } else if (id === 'noVNC_toggle_windows_button') {
+                    UI.sendKey(KeyTable.XK_Super_L, "MetaLeft", false);
+                }
+            }
+        }
     },
 
 /* ------^-------


### PR DESCRIPTION
### Description

This PR fixes #9940

<details><summary>Copilot Generated summary</summary>
<p>

This pull request introduces functionality to reset the state of modifier keys in the noVNC UI when reconnecting. This ensures that the visual state of the UI and the actual key states are synchronized, improving the user experience.

### Enhancements to UI state management:

* [`systemvm/agent/noVNC/app/ui.js`](diffhunk://#diff-3df0143f0eb09699c3773a85f3a9ef7ef064262abc761dab25666299e878cb8aR1787-R1815): Added a new method `resetModifierKeysState` to reset the states of modifier keys (`Ctrl`, `Shift`, `Alt`, `Windows`) in the UI. This includes updating button styles and sending key-up events if necessary.
* [`systemvm/agent/noVNC/app/ui.js`](diffhunk://#diff-3df0143f0eb09699c3773a85f3a9ef7ef064262abc761dab25666299e878cb8aR1150): Integrated the `resetModifierKeysState` method into the connection flow by calling it when the connection state changes to "connected."

</p>
</details> 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
This needs a rebuild of systemvm template or patch the scripts in CPVM to test this patch.

1. Open Console for a VM in Chromium
2. Hold the shift key and then close the tab or the window
3. Open the console session again. Try typing some text and check if the behaviour is as if the shift key is pressed or not.

Before the patch, when you enter any text it will appear as if the shift key is pressed even when it's not. Once the CPVM session goes into this buggy state, it's not possible to recover without restarting the VM.

After the patch, the keys works as expected.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
