### PR TITLE
[VMware] Sync the disk path or datastore changes for IDE disks, and before any volume resize during start vm (for the volumes on datastore cluster)

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2351,51 +2351,8 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
 
                 VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
-                VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
-                DataStoreTO primaryStore = volumeTO.getDataStore();
-                Map<String, String> details = vol.getDetails();
-                boolean managed = false;
-                String iScsiName = null;
-
-                if (details != null) {
-                    managed = Boolean.parseBoolean(details.get(DiskTO.MANAGED));
-                    iScsiName = details.get(DiskTO.IQN);
-                }
-
-                String primaryStoreUuid = primaryStore.getUuid();
-                // if the storage is managed, iScsiName should not be null
-                String datastoreName = managed ? VmwareResource.getDatastoreName(iScsiName) : primaryStoreUuid;
-                Pair<ManagedObjectReference, DatastoreMO> volumeDsDetails = dataStoresDetails.get(datastoreName);
-
-                assert (volumeDsDetails != null);
-                if (volumeDsDetails == null) {
-                    throw new Exception("Primary datastore " + primaryStore.getUuid() + " is not mounted on host.");
-                }
-
-                if (vol.getDetails().get(DiskTO.PROTOCOL_TYPE) != null && vol.getDetails().get(DiskTO.PROTOCOL_TYPE).equalsIgnoreCase("DatastoreCluster")) {
-                    if (diskInfoBuilder != null && matchingExistingDisk != null) {
-                        String[] diskChain = matchingExistingDisk.getDiskChain();
-                        if (diskChain != null && diskChain.length > 0) {
-                            DatastoreFile file = new DatastoreFile(diskChain[0]);
-                            if (!file.getFileBaseName().equalsIgnoreCase(volumeTO.getPath())) {
-                                if (s_logger.isInfoEnabled())
-                                    s_logger.info("Detected disk-chain top file change on volume: " + volumeTO.getId() + " " + volumeTO.getPath() + " -> " + file.getFileBaseName());
-                                volumeTO.setPath(file.getFileBaseName());
-                                vol.setPath(file.getFileBaseName());
-                            }
-                        }
-                        DatastoreMO diskDatastoreMofromVM = getDataStoreWhereDiskExists(hyperHost, context, diskInfoBuilder, vol, diskDatastores);
-                        if (diskDatastoreMofromVM != null) {
-                            String actualPoolUuid = diskDatastoreMofromVM.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
-                            if (actualPoolUuid != null && !actualPoolUuid.equalsIgnoreCase(primaryStore.getUuid())) {
-                                volumeDsDetails = new Pair<>(diskDatastoreMofromVM.getMor(), diskDatastoreMofromVM);
-                                if (s_logger.isInfoEnabled())
-                                    s_logger.info("Detected datastore uuid change on volume: " + volumeTO.getId() + " " + primaryStore.getUuid() + " -> " + actualPoolUuid);
-                                ((PrimaryDataStoreTO)primaryStore).setUuid(actualPoolUuid);
-                            }
-                        }
-                    }
-                }
+                Pair<ManagedObjectReference, DatastoreMO> volumeDsDetails = getVolumeDatastoreDetails(vol, dataStoresDetails);
+                syncVolumeDatastoreAndPathForDatastoreCluster(vol, diskInfoBuilder, matchingExistingDisk, volumeDsDetails, diskDatastores, hyperHost, context);
 
                 if (deployAsIs && vol.getType() == Volume.Type.ROOT) {
                     rootDiskTO = vol;
@@ -2442,6 +2399,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                         scsiUnitNumber++;
                     }
 
+                    VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
                     Long maxIops = volumeTO.getIopsWriteRate() + volumeTO.getIopsReadRate();
                     VirtualDevice device = VmwareHelper.prepareDiskDevice(vmMo, null, controllerKey, diskChain, volumeDsDetails.first(), deviceNumber, i + 1, maxIops);
                     s_logger.debug(LogUtils.logGsonWithoutException("The following definitions will be used to start the VM: virtual device [%s], volume [%s].", device, volumeTO));
@@ -2707,6 +2665,64 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
             }
             return startAnswer;
+        }
+    }
+
+    private Pair<ManagedObjectReference, DatastoreMO> getVolumeDatastoreDetails(DiskTO vol, HashMap<String, Pair<ManagedObjectReference, DatastoreMO>> dataStoresDetails) throws Exception {
+        boolean managed = false;
+        String iScsiName = null;
+        Map<String, String> details = vol.getDetails();
+        if (MapUtils.isNotEmpty(details)) {
+            managed = Boolean.parseBoolean(details.get(DiskTO.MANAGED));
+            iScsiName = details.get(DiskTO.IQN);
+        }
+
+        VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
+        DataStoreTO primaryStore = volumeTO.getDataStore();
+        String primaryStoreUuid = primaryStore.getUuid();
+        // if the storage is managed, iScsiName should not be null
+        String datastoreName = managed ? VmwareResource.getDatastoreName(iScsiName) : primaryStoreUuid;
+        Pair<ManagedObjectReference, DatastoreMO> volumeDsDetails = dataStoresDetails.get(datastoreName);
+        if (volumeDsDetails == null) {
+            throw new Exception("Primary datastore " + primaryStore.getUuid() + " is not mounted on host.");
+        }
+
+        return volumeDsDetails;
+    }
+
+    private void syncVolumeDatastoreAndPathForDatastoreCluster(DiskTO vol, VirtualMachineDiskInfoBuilder diskInfoBuilder, VirtualMachineDiskInfo matchingExistingDisk,
+                                                               Pair<ManagedObjectReference, DatastoreMO> volumeDsDetails, List<Pair<Integer, ManagedObjectReference>> diskDatastores,
+                                                               VmwareHypervisorHost hyperHost, VmwareContext context) throws Exception {
+        if (vol.getDetails() == null || vol.getDetails().get(DiskTO.PROTOCOL_TYPE) == null || !vol.getDetails().get(DiskTO.PROTOCOL_TYPE).equalsIgnoreCase("DatastoreCluster")) {
+            return;
+        }
+
+        if (diskInfoBuilder != null && matchingExistingDisk != null) {
+            String[] diskChain = matchingExistingDisk.getDiskChain();
+            if (diskChain != null && diskChain.length > 0) {
+                DatastoreFile file = new DatastoreFile(diskChain[0]);
+                VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
+                if (!file.getFileBaseName().equalsIgnoreCase(volumeTO.getPath())) {
+                    if (s_logger.isInfoEnabled()) {
+                        s_logger.info("Detected disk-chain top file change on volume: " + volumeTO.getId() + " " + volumeTO.getPath() + " -> " + file.getFileBaseName());
+                    }
+                    volumeTO.setPath(file.getFileBaseName());
+                    vol.setPath(file.getFileBaseName());
+                }
+            }
+            DatastoreMO diskDatastoreMofromVM = getDataStoreWhereDiskExists(hyperHost, context, diskInfoBuilder, vol, diskDatastores);
+            if (diskDatastoreMofromVM != null) {
+                String actualPoolUuid = diskDatastoreMofromVM.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
+                VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
+                DataStoreTO primaryStore = volumeTO.getDataStore();
+                if (actualPoolUuid != null && !actualPoolUuid.equalsIgnoreCase(primaryStore.getUuid())) {
+                    volumeDsDetails = new Pair<>(diskDatastoreMofromVM.getMor(), diskDatastoreMofromVM);
+                    if (s_logger.isInfoEnabled()) {
+                        s_logger.info("Detected datastore uuid change on volume: " + volumeTO.getId() + " " + primaryStore.getUuid() + " -> " + actualPoolUuid);
+                    }
+                    ((PrimaryDataStoreTO)primaryStore).setUuid(actualPoolUuid);
+                }
+            }
         }
     }
 

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2381,6 +2381,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                                 if (s_logger.isInfoEnabled())
                                     s_logger.info("Detected disk-chain top file change on volume: " + volumeTO.getId() + " " + volumeTO.getPath() + " -> " + file.getFileBaseName());
                                 volumeTO.setPath(file.getFileBaseName());
+                                vol.setPath(file.getFileBaseName());
                             }
                         }
                         DatastoreMO diskDatastoreMofromVM = getDataStoreWhereDiskExists(hyperHost, context, diskInfoBuilder, vol, diskDatastores);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2350,13 +2350,58 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                     continue;
                 }
 
+                VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
+                VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
+                DataStoreTO primaryStore = volumeTO.getDataStore();
+                Map<String, String> details = vol.getDetails();
+                boolean managed = false;
+                String iScsiName = null;
+
+                if (details != null) {
+                    managed = Boolean.parseBoolean(details.get(DiskTO.MANAGED));
+                    iScsiName = details.get(DiskTO.IQN);
+                }
+
+                String primaryStoreUuid = primaryStore.getUuid();
+                // if the storage is managed, iScsiName should not be null
+                String datastoreName = managed ? VmwareResource.getDatastoreName(iScsiName) : primaryStoreUuid;
+                Pair<ManagedObjectReference, DatastoreMO> volumeDsDetails = dataStoresDetails.get(datastoreName);
+
+                assert (volumeDsDetails != null);
+                if (volumeDsDetails == null) {
+                    throw new Exception("Primary datastore " + primaryStore.getUuid() + " is not mounted on host.");
+                }
+
+                if (vol.getDetails().get(DiskTO.PROTOCOL_TYPE) != null && vol.getDetails().get(DiskTO.PROTOCOL_TYPE).equalsIgnoreCase("DatastoreCluster")) {
+                    if (diskInfoBuilder != null && matchingExistingDisk != null) {
+                        String[] diskChain = matchingExistingDisk.getDiskChain();
+                        if (diskChain != null && diskChain.length > 0) {
+                            DatastoreFile file = new DatastoreFile(diskChain[0]);
+                            if (!file.getFileBaseName().equalsIgnoreCase(volumeTO.getPath())) {
+                                if (s_logger.isInfoEnabled())
+                                    s_logger.info("Detected disk-chain top file change on volume: " + volumeTO.getId() + " " + volumeTO.getPath() + " -> " + file.getFileBaseName());
+                                volumeTO.setPath(file.getFileBaseName());
+                            }
+                        }
+                        DatastoreMO diskDatastoreMofromVM = getDataStoreWhereDiskExists(hyperHost, context, diskInfoBuilder, vol, diskDatastores);
+                        if (diskDatastoreMofromVM != null) {
+                            String actualPoolUuid = diskDatastoreMofromVM.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
+                            if (actualPoolUuid != null && !actualPoolUuid.equalsIgnoreCase(primaryStore.getUuid())) {
+                                volumeDsDetails = new Pair<>(diskDatastoreMofromVM.getMor(), diskDatastoreMofromVM);
+                                if (s_logger.isInfoEnabled())
+                                    s_logger.info("Detected datastore uuid change on volume: " + volumeTO.getId() + " " + primaryStore.getUuid() + " -> " + actualPoolUuid);
+                                ((PrimaryDataStoreTO)primaryStore).setUuid(actualPoolUuid);
+                            }
+                        }
+                    }
+                }
+
                 if (deployAsIs && vol.getType() == Volume.Type.ROOT) {
                     rootDiskTO = vol;
                     resizeRootDiskOnVMStart(vmMo, rootDiskTO, hyperHost, context);
                     continue;
                 }
 
-                VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
                 String diskController = getDiskController(vmMo, matchingExistingDisk, vol, chosenDiskControllers, deployAsIs);
                 if (DiskControllerType.getType(diskController) == DiskControllerType.ide) {
                     controllerKey = vmMo.getIDEControllerKey(ideUnitNumber);
@@ -2365,7 +2410,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                         // Ensure maximum of 2 data volumes over IDE controller, 3 includeing root volume
                         if (vmMo.getNumberOfVirtualDisks() > 3) {
                             throw new CloudRuntimeException("Found more than 3 virtual disks attached to this VM [" + vmMo.getVmName() + "]. Unable to implement the disks over "
-                                    + diskController + " controller, as maximum number of devices supported over IDE controller is 4 includeing CDROM device.");
+                                    + diskController + " controller, as maximum number of devices supported over IDE controller is 4 including CDROM device.");
                         }
                     }
                 } else {
@@ -2384,51 +2429,6 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
                 }
                 if (!hasSnapshot) {
                     deviceConfigSpecArray[i] = new VirtualDeviceConfigSpec();
-
-                    VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
-                    DataStoreTO primaryStore = volumeTO.getDataStore();
-                    Map<String, String> details = vol.getDetails();
-                    boolean managed = false;
-                    String iScsiName = null;
-
-                    if (details != null) {
-                        managed = Boolean.parseBoolean(details.get(DiskTO.MANAGED));
-                        iScsiName = details.get(DiskTO.IQN);
-                    }
-
-                    String primaryStoreUuid = primaryStore.getUuid();
-                    // if the storage is managed, iScsiName should not be null
-                    String datastoreName = managed ? VmwareResource.getDatastoreName(iScsiName) : primaryStoreUuid;
-                    Pair<ManagedObjectReference, DatastoreMO> volumeDsDetails = dataStoresDetails.get(datastoreName);
-
-                    assert (volumeDsDetails != null);
-                    if (volumeDsDetails == null) {
-                        throw new Exception("Primary datastore " + primaryStore.getUuid() + " is not mounted on host.");
-                    }
-
-                    if (vol.getDetails().get(DiskTO.PROTOCOL_TYPE) != null && vol.getDetails().get(DiskTO.PROTOCOL_TYPE).equalsIgnoreCase("DatastoreCluster")) {
-                        if (diskInfoBuilder != null && matchingExistingDisk != null) {
-                            String[] diskChain = matchingExistingDisk.getDiskChain();
-                            if (diskChain != null && diskChain.length > 0) {
-                                DatastoreFile file = new DatastoreFile(diskChain[0]);
-                                if (!file.getFileBaseName().equalsIgnoreCase(volumeTO.getPath())) {
-                                    if (s_logger.isInfoEnabled())
-                                        s_logger.info("Detected disk-chain top file change on volume: " + volumeTO.getId() + " " + volumeTO.getPath() + " -> " + file.getFileBaseName());
-                                    volumeTO.setPath(file.getFileBaseName());
-                                }
-                            }
-                            DatastoreMO diskDatastoreMofromVM = getDataStoreWhereDiskExists(hyperHost, context, diskInfoBuilder, vol, diskDatastores);
-                            if (diskDatastoreMofromVM != null) {
-                                String actualPoolUuid = diskDatastoreMofromVM.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
-                                if (actualPoolUuid != null && !actualPoolUuid.equalsIgnoreCase(primaryStore.getUuid())) {
-                                    volumeDsDetails = new Pair<>(diskDatastoreMofromVM.getMor(), diskDatastoreMofromVM);
-                                    if (s_logger.isInfoEnabled())
-                                        s_logger.info("Detected datastore uuid change on volume: " + volumeTO.getId() + " " + primaryStore.getUuid() + " -> " + actualPoolUuid);
-                                    ((PrimaryDataStoreTO)primaryStore).setUuid(actualPoolUuid);
-                                }
-                            }
-                        }
-                    }
 
                     String[] diskChain = syncDiskChain(dcMo, vmMo, vol, matchingExistingDisk, volumeDsDetails.second());
 


### PR DESCRIPTION
### Description

This PR syncs the disk path or datastore changes for IDE disks as well, and before any volume resize during start vm (for the volumes on datastore cluster pool) in VMware.

Fixes #10626 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested VM (with ISO) start after storage drs triggered in datastore cluster for the ROOT volume.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
