### PR TITLE
smoke tests: Fix cluster DRS & non-strict host affinity smoke test failures on XenServer / XCP-ng

### DIFF
--- a/test/integration/smoke/test_cluster_drs.py
+++ b/test/integration/smoke/test_cluster_drs.py
@@ -23,11 +23,12 @@ import logging
 import time
 from collections.abc import Iterable
 
+from marvin.codes import FAILED
 from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.cloudstackAPI import (migrateSystemVm, listRouters, listSystemVms)
 from marvin.lib.base import (Cluster, Configurations, Host, Network, NetworkOffering, ServiceOffering, VirtualMachine,
                              Zone)
-from marvin.lib.common import (get_domain, get_zone, get_template)
+from marvin.lib.common import (get_domain, get_zone, get_test_template)
 from marvin.lib.utils import wait_until
 from marvin import jsonHelper
 from nose.plugins.attrib import attr
@@ -43,7 +44,15 @@ class TestClusterDRS(cloudstackTestCase):
 
         zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
         cls.zone = Zone(zone.__dict__)
-        cls.template = get_template(cls.apiclient, cls.zone.id)
+        cls.hypervisor = cls.testClient.getHypervisorInfo()
+        cls.template = cls.template = get_test_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.hypervisor
+        )
+        if cls.template == FAILED:
+            assert False, "get_test_template() failed to return template\
+                        with hypervisor %s" % cls.hypervisor
         cls._cleanup = []
 
         cls.logger = logging.getLogger("TestClusterDRS")

--- a/test/integration/smoke/test_cluster_drs.py
+++ b/test/integration/smoke/test_cluster_drs.py
@@ -45,7 +45,7 @@ class TestClusterDRS(cloudstackTestCase):
         zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
         cls.zone = Zone(zone.__dict__)
         cls.hypervisor = cls.testClient.getHypervisorInfo()
-        cls.template = cls.template = get_test_template(
+        cls.template = get_test_template(
             cls.apiclient,
             cls.zone.id,
             cls.hypervisor

--- a/test/integration/smoke/test_nonstrict_affinity_group.py
+++ b/test/integration/smoke/test_nonstrict_affinity_group.py
@@ -21,6 +21,7 @@ Tests of Non-Strict (host anti-affinity and host affinity) affinity groups
 
 import logging
 
+from marvin.codes import FAILED
 from nose.plugins.attrib import attr
 from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.cloudstackAPI import startVirtualMachine, stopVirtualMachine, destroyVirtualMachine
@@ -56,10 +57,10 @@ class TestNonStrictAffinityGroups(cloudstackTestCase):
         zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
         cls.zone = Zone(zone.__dict__)
         cls.hypervisor = cls.testClient.getHypervisorInfo()
-        if cls.hypervisor.lower() not in ["xenserver"]:
-            cls.template = get_template(cls.apiclient, cls.zone.id)
-        else:
-            cls.template = get_test_template(cls.apiclient, cls.zone.id, cls.hypervisor)
+        cls.template = get_test_template(cls.apiclient, cls.zone.id, cls.hypervisor)
+        if cls.template == FAILED:
+            assert False, "get_test_template() failed to return template\
+                        with hypervisor %s" % cls.hypervisor
         cls._cleanup = []
 
         cls.logger = logging.getLogger("TestNonStrictAffinityGroups")

--- a/test/integration/smoke/test_nonstrict_affinity_group.py
+++ b/test/integration/smoke/test_nonstrict_affinity_group.py
@@ -37,7 +37,8 @@ from marvin.lib.base import (Account,
 
 from marvin.lib.common import (get_domain,
                                get_zone,
-                               get_template)
+                               get_template,
+                               get_test_template)
 
 
 class TestNonStrictAffinityGroups(cloudstackTestCase):
@@ -54,7 +55,11 @@ class TestNonStrictAffinityGroups(cloudstackTestCase):
 
         zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
         cls.zone = Zone(zone.__dict__)
-        cls.template = get_template(cls.apiclient, cls.zone.id)
+        cls.hypervisor = cls.testClient.getHypervisorInfo()
+        if cls.hypervisor.lower() not in ["xenserver"]:
+            cls.template = get_template(cls.apiclient, cls.zone.id)
+        else:
+            cls.template = get_test_template(cls.apiclient, cls.zone.id, cls.hypervisor)
         cls._cleanup = []
 
         cls.logger = logging.getLogger("TestNonStrictAffinityGroups")


### PR DESCRIPTION
### Description

This PR fixes the consistent test failure noticed on the cluster drs test suite on the 4.19 and 4.20 health check PRs for XenServer/XCP-ng versions 8.0+.
https://github.com/apache/cloudstack/pull/10668#issuecomment-2816554283
This is because the template used - namely the built-in centos 5.6 template does not have PV drivers installed i.e., xenserver tools, thus migration of the VM fails with the following exception:

```
2025-04-22 05:13:01,446 DEBUG [c.c.a.m.D.Task] (DirectAgent-428:[ctx-8a11e226]) (logid:b6b3bd33) Seq 2-3585709728317048979: Executing request
2025-04-22 05:13:01,481 WARN  [c.c.h.x.r.XenServer650Resource] (DirectAgent-428:[ctx-8a11e226]) (logid:0348b8ac) Task failed! Task record:                 uuid: 15d12e85-9a6d-0a91-2662-ee82cd6215c2
           nameLabel: Async.VM.pool_migrate
     nameDescription:
   allowedOperations: []
   currentOperations: {}
             created: Tue Apr 22 05:13:01 UTC 2025
            finished: Tue Apr 22 05:13:01 UTC 2025
              status: failure
          residentOn: com.xensource.xenapi.Host@a4064fa5
            progress: 1.0
                type: <none/>
              result:
           errorInfo: [VM_LACKS_FEATURE, OpaqueRef:457e3157-4d65-4041-b6f1-0fe971f57b44]
         otherConfig: {}
           subtaskOf: com.xensource.xenapi.Task@aaf13f6f
            subtasks: []

```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [X] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

```
[root@ref-trl-8376-x-mol8-pearl-dsilva-marvin ~]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=/marvin/ref-trl-8376-x-Mol8-pearl-dsilva-advanced-cfg -s -a tags=advanced --hypervisor=Xenserver test_cluster_drs.py 
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Apr_22_2025_05_19_55_ZM6BYI All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
system vms and routers to migrate -- 0
=== Running test_01_condensed_drs_algorithm ===
=== TestName: test_01_condensed_drs_algorithm | Status : SUCCESS ===

system vms and routers to migrate -- 0
=== Running test_02_balanced_drs_algorithm ===
=== TestName: test_02_balanced_drs_algorithm | Status : SUCCESS ===

```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
