### PR TITLE
Ceph object store: Fix LocationConstraint error 

### DIFF
--- a/plugins/storage/object/ceph/src/main/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImpl.java
+++ b/plugins/storage/object/ceph/src/main/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImpl.java
@@ -95,8 +95,8 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
         AmazonS3 s3client = getS3Client(storeId, accountId);
 
         try {
-            if (s3client.getBucketAcl(bucketName) != null) {
-                throw new CloudRuntimeException("Bucket already exists with name " + bucketName);
+            if (s3client.doesBucketExistV2(bucketName)) {
+                throw new CloudRuntimeException("Bucket already exists with the name: " + bucketName);
             }
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() != 404) {
@@ -221,9 +221,11 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
             if (user.isPresent()) {
                 logger.info("User already exists in Ceph RGW: " + username);
                 return true;
+            } else {
+                logger.debug("User does not exist. Creating user in Ceph RGW: " + username);
             }
         } catch (Exception e) {
-            logger.debug("User does not exist. Creating user in Ceph RGW: " + username);
+            logger.debug("Get user info failed for user {} with exception {}. Proceeding with user creation.",  username, e.getMessage());
         }
 
         try {
@@ -348,7 +350,7 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
                         new AWSStaticCredentialsProvider(
                                 new BasicAWSCredentials(accessKey, secretKey)))
                 .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(url, "auto"))
+                        new AwsClientBuilder.EndpointConfiguration(url, null))
                 .build();
 
         if (client == null) {

--- a/plugins/storage/object/ceph/src/test/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImplTest.java
+++ b/plugins/storage/object/ceph/src/test/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImplTest.java
@@ -96,7 +96,7 @@ public class CephObjectStoreDriverImplTest {
         when(bucketDao.findById(anyLong())).thenReturn(new BucketVO(bucket.getName()));
         Bucket bucketRet = cephObjectStoreDriverImpl.createBucket(bucket, false);
         assertEquals(bucketRet.getName(), bucket.getName());
-        verify(rgwClient, times(1)).getBucketAcl(anyString());
+        verify(rgwClient, times(1)).doesBucketExistV2(anyString());
         verify(rgwClient, times(1)).createBucket(anyString());
     }
 


### PR DESCRIPTION
### Description

This PR fixes https://github.com/apache/cloudstack/issues/10044

```
        AmazonS3 client = AmazonS3ClientBuilder.standard()
                .enablePathStyleAccess()
                .withCredentials(
                        new AWSStaticCredentialsProvider(
                                new BasicAWSCredentials(accessKey, secretKey)))
                .withEndpointConfiguration(
                        new AwsClientBuilder.EndpointConfiguration(url, "auto"))
                .build();
```
Using `auto` as the signingRegion in AwsClientBuilder forces the s3 client to infer region from the url and set it as LocationConstraint while sending the request which is not required for ceph and causes the issue.
`requestRegion = AwsHostNameUtils.parseRegion(requestEndpoint.getHost(), "s3");`
Location constraint was being set if the url starts with "s3." So a possible workaround if using this type of endpoint is to not use such kind of name for the endpoint url. Use some proxy or dns.

Have changed the code to pass null instead of auto which is resulting in LocationConstraint to not be set.

----
One more change is regarding the error msg which is returned while creating a bucket when the same bucket name is already present but created by another user.
Before:
`Failed to create bucket with name: bucket2. AccessDenied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: tx00000610f7487f71ab177-00680a2196-ac4a-default; S3 Extended Request ID: ac4a-default-default; Proxy: null)`
After:
`Failed to create bucket with name: bucket2. Bucket already exists with the name: bucket2`

This was because getBucketAcl doesn't work if the bucket was created by another user as the first user doesn't have Acl level access to the bucket.

----
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
