### PR TITLE
Xenserver smoke-test: Allow emojis to be accepted in volume name during volume creation

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -838,9 +838,17 @@ public class XenServerStorageProcessor implements StorageProcessor {
         String decoded = new String(utf8Bytes, "UTF-8");
         // Print each code unit as a Unicode escape
         StringBuilder unicodeEscaped = new StringBuilder();
-        for (char ch : decoded.toCharArray()) {
-            unicodeEscaped.append(String.format("\\u%04X", (int) ch));
+        for (int i = 0; i < decoded.length(); i++) {
+            char ch = decoded.charAt(i);
+            if (ch <= 127 && Character.isLetterOrDigit(ch)) {
+                // Keep ASCII alphanumerics as-is
+                unicodeEscaped.append(ch);
+            } else {
+                // Escape non-ASCII characters
+                unicodeEscaped.append(String.format("\\u%04X", (int) ch));
+            }
         }
+
         return unicodeEscaped.toString();
     }
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -23,6 +23,7 @@ import static com.cloud.utils.ReflectUtil.flattenProperties;
 import static com.google.common.collect.Lists.newArrayList;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -810,7 +811,7 @@ public class XenServerStorageProcessor implements StorageProcessor {
             final SR poolSr = hypervisorResource.getStorageRepository(conn,
                     CitrixHelper.getSRNameLabel(primaryStore.getUuid(), primaryStore.getPoolType(), primaryStore.getPath()));
             VDI.Record vdir = new VDI.Record();
-            vdir.nameLabel = volume.getName();
+            vdir.nameLabel = getEncodedVolumeName(volume.getName());
             vdir.SR = poolSr;
             vdir.type = Types.VdiType.USER;
 
@@ -829,6 +830,18 @@ public class XenServerStorageProcessor implements StorageProcessor {
             logger.debug("create volume failed: " + e.toString());
             return new CreateObjectAnswer(e.toString());
         }
+    }
+
+    private String getEncodedVolumeName(String volumeName) throws UnsupportedEncodingException {
+        byte[] utf8Bytes = volumeName.getBytes("UTF-8");
+        // Decode UTF-8 into a Java String (UTF-16)
+        String decoded = new String(utf8Bytes, "UTF-8");
+        // Print each code unit as a Unicode escape
+        StringBuilder unicodeEscaped = new StringBuilder();
+        for (char ch : decoded.toCharArray()) {
+            unicodeEscaped.append(String.format("\\u%04X", (int) ch));
+        }
+        return unicodeEscaped.toString();
     }
 
     @Override


### PR DESCRIPTION
### Description

This PR fixes: #10756 
Fixes consistent test failure observed on Xenserver / XCP-ng
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
```
[root@ref-trl-8376-x-mol8-pearl-dsilva-marvin ~]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=/marvin/ref-trl-8376-x-Mol8-pearl-dsilva-advanced-cfg -s -a tags=fix --hypervisor=Xenserver resource_names.py 
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/Apr_24_2025_12_30_11_0V0CT0 All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_02_create_volume | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs//N1C2O3 ===

```
#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
