### PR TITLE
Change the `value` parameter of the `updateConfiguration` API to be required

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1031,7 +1031,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         if (value == null) {
-            throw new InvalidParameterValueException(String.format(“The new value for the [%s] configuration must be given.", name));
+            throw new InvalidParameterValueException(String.format("The new value for the [%s] configuration must be given.", name));
         }
 
         validateIpAddressRelatedConfigValues(name, value);


### PR DESCRIPTION
### Description

Currently, the `value` parameter of the `updateConfiguration` API is not required. Thus, when the API is executed and the `value` parameter is not specified, the attributes of the configuration set by the `name` parameter are returned.

<details>
<summary><code>updateConfiguration</code> API call without specifying the <code>value</code> parameter</summary>

```bash
> update configuration name="quota.enable.service"
{
  "configuration": {
    "category": "Advanced",
    "component": "QUOTA-PLUGIN",
    "defaultvalue": "false",
    "description": "Indicates whether Quota plugin is enabled or not.",
    "displaytext": "Quota enable service",
    "group": "Miscellaneous",
    "isdynamic": true,
    "name": "quota.enable.service",
    "subgroup": "Quota",
    "type": "Boolean"
  }
}
```
</details>

As a consequence of that, when managing global configuration through the UI, for instance, when a configuration value is cleared and updated with a blank value, the UI sends the API call without the `value` parameter. Since the UI receives a successful response from the backend, it notifies the user that the setting was successfully updated, which does not actually happens.

Additionally, since that the `updateConfiguration` API is an API to update a resource, it should not be used to list resource details. Currently, however, it is possible to achieve such action through the API.

Therefore, aiming to improve UX, avoid possible inconsistent behaviors and maintain a semantic consistency between the API name and its actual behavior, this PR proposes to change the `value` parameter of the `updateConfiguration` API to be required.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

- Executed the `updateConfiguration` API through Cloudmonkey, without specifying the `value` parameter, and the following API response was returned:

```bash
> update configuration name="quota.enable.service"
Missing required parameters:  value
```
- Accessed the global settings page, updated the `account.cleanup.interval` configuration to a blank value and verified that a semantic error message was returned:

![image](https://github.com/user-attachments/assets/1a645ebe-dc14-4410-97e8-167d11a59535)
