### PR TITLE
UI: Display system VM count in hosts listing

### DIFF
--- a/ui/src/config/section/infra/hosts.js
+++ b/ui/src/config/section/infra/hosts.js
@@ -32,7 +32,12 @@ export default {
   },
   params: { type: 'routing' },
   columns: () => {
-    const fields = ['name', 'state', 'resourcestate', 'ipaddress', 'arch', 'hypervisor', 'instances', 'powerstate', 'version']
+    const fields = [
+      'name', 'state', 'resourcestate', 'ipaddress',
+      'arch', 'hypervisor', 'instances',
+      { field: 'systeminstances', customTitle: 'system.vms' },
+      'powerstate', 'version'
+    ]
     const metricsFields = ['cpunumber', 'cputotalghz', 'cpuusedghz', 'cpuallocatedghz', 'memorytotalgb', 'memoryusedgb', 'memoryallocatedgb', 'networkread', 'networkwrite']
     if (store.getters.metrics) {
       fields.push(...metricsFields)


### PR DESCRIPTION
### Description

Currently, the hosts listing displays the number of end-user VMs allocated on each host. This PR proposes to also display the number of system VMs allocated on the hosts.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

- Before:

![image](https://github.com/user-attachments/assets/e222e452-fbb6-4e1e-8896-9f973de3752f)

- After:

![image](https://github.com/user-attachments/assets/5cf0ac1c-a94b-4ffe-b4d2-6aa71205b1a6)

### How Has This Been Tested?

- Accessed the hosts listing and verified that the number of system VMs allocated on the hosts was correctly displayed.