### PR TITLE
smoke tests / CI : Fix test_vm_stric_host_tags

### DIFF
--- a/test/integration/smoke/test_vm_strict_host_tags.py
+++ b/test/integration/smoke/test_vm_strict_host_tags.py
@@ -190,7 +190,7 @@ class TestVMDeploymentPlannerStrictTags(cloudstackTestCase):
             self.cleanup.append(vm)
             self.fail("VM should not be deployed")
         except Exception as e:
-            self.assertTrue("No suitable host found for vm " in str(e))
+            self.assertTrue("No destination found for a deployment for VM instance" in str(e))
 
 
 class TestScaleVMStrictTags(cloudstackTestCase):
@@ -310,7 +310,7 @@ class TestScaleVMStrictTags(cloudstackTestCase):
             vm.start(self.apiclient)
             self.fail("VM should not be be able scale and start")
         except Exception as e:
-            self.assertTrue("No suitable host found for vm " in str(e))
+            self.assertTrue("Unable to orchestrate the start of VM instance" in str(e))
 
 
 class TestRestoreVMStrictTags(cloudstackTestCase):
@@ -423,7 +423,7 @@ class TestRestoreVMStrictTags(cloudstackTestCase):
             vm.restore(self.apiclient, templateid=self.template_t2.id, expunge=True)
             self.fail("VM should not be restored")
         except Exception as e:
-            self.assertTrue("No suitable host found for vm " in str(e))
+            self.assertTrue("Unable to start VM with specified id" in str(e))
 
 
 class TestMigrateVMStrictTags(cloudstackTestCase):


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/10802
This PR fixes the test failure observed with test_vm_strict_host_tags.py both in smoke test runs and CI
https://github.com/apache/cloudstack/pull/10668#issuecomment-2837179220

https://github.com/apache/cloudstack/actions/runs/14738890400/job/41371735755?pr=10668
![image](https://github.com/user-attachments/assets/9bd01d41-816d-462a-a272-fcfc72f01afa)


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
```
$ nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=setup/dev/advanced.cfg -s -a tags=advanced --hypervisor=simulator test/integration/smoke/test_vm_strict_host_tags.py

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp/MarvinLogs/May_02_2025_15_57_28_F9LIM7 All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_01_migrate_vm_strict_tags_success | Status : SUCCESS ===

=== TestName: test_02_migrate_vm_strict_tags_failure | Status : SUCCESS ===

=== TestName: test_01_restore_vm_strict_tags_success | Status : SUCCESS ===

=== TestName: test_02_restore_vm_strict_tags_failure | Status : SUCCESS ===

=== TestName: test_01_scale_vm_strict_tags_success | Status : SUCCESS ===

=== TestName: test_02_scale_vm_strict_tags_failure | Status : SUCCESS ===

=== TestName: test_01_deploy_vm_on_specific_host_without_strict_tags | Status : SUCCESS ===

=== TestName: test_02_deploy_vm_on_any_host_without_strict_tags | Status : SUCCESS ===

=== TestName: test_03_deploy_vm_on_specific_host_with_strict_tags_success | Status : SUCCESS ===

=== TestName: test_04_deploy_vm_on_any_host_with_strict_tags_success | Status : SUCCESS ===

=== TestName: test_05_deploy_vm_on_specific_host_with_strict_tags_failure | Status : SUCCESS ===

=== TestName: test_06_deploy_vm_on_any_host_with_strict_tags_failure | Status : SUCCESS ===

=== Final results are now copied to: /tmp/MarvinLogs/test_vm_strict_host_tags_00WIUK ===

```
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
