### PR TITLE
test: cleanup test_guest_os.py for multiple execution

### DIFF
--- a/test/integration/smoke/test_guest_os.py
+++ b/test/integration/smoke/test_guest_os.py
@@ -47,19 +47,14 @@ class TestGuestOS(cloudstackTestCase):
 
         cls.hypervisor = cls.get_hypervisor_type()
 
-    @classmethod
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()
 
         #build cleanup list
         self.cleanup = []
 
-    @classmethod
     def tearDown(self):
-        try:
-            cleanup_resources(self.apiclient, self.cleanup)
-        except Exception as e:
-            self.debug("Warning! Exception in tearDown: %s" % e)
+        super(TestGuestOS, self).tearDown()
 
     @classmethod
     def get_hypervisor_type(cls):
@@ -95,6 +90,7 @@ class TestGuestOS(cloudstackTestCase):
             osdisplayname="testCentOS",
             oscategoryid=os_category.id
         )
+        self.cleanup.append(self.guestos1)
         list_guestos = GuestOS.list(self.apiclient, id=self.guestos1.id, listall=True)
         self.assertNotEqual(
             len(list_guestos),
@@ -112,6 +108,7 @@ class TestGuestOS(cloudstackTestCase):
             self.apiclient,
             id=self.guestos1.id
         )
+        self.cleanup.remove(self.guestos1)
 
     @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
     def test_CRUD_operations_guest_OS_mapping(self):
@@ -127,6 +124,7 @@ class TestGuestOS(cloudstackTestCase):
             osdisplayname="testCentOS",
             oscategoryid=os_category.id
         )
+        self.cleanup.append(self.guestos1)
 
         if self.hypervisor.hypervisor.lower() not in ["xenserver", "vmware"]:
             raise unittest.SkipTest("OS name check with hypervisor is supported only on XenServer and VMware")
@@ -138,6 +136,7 @@ class TestGuestOS(cloudstackTestCase):
             hypervisorversion=self.hypervisor.hypervisorversion,
             osnameforhypervisor="testOSMappingName"
         )
+        self.cleanup.append(self.guestosmapping1)
 
         list_guestos_mapping = GuestOsMapping.list(self.apiclient, id=self.guestosmapping1.id, listall=True)
         self.assertNotEqual(
@@ -156,11 +155,13 @@ class TestGuestOS(cloudstackTestCase):
             self.apiclient,
             id=self.guestosmapping1.id
         )
+        self.cleanup.remove(self.guestosmapping1)
 
         GuestOS.remove(
             self.apiclient,
             id=self.guestos1.id
         )
+        self.cleanup.remove(self.guestos1)
 
     @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
     def test_guest_OS_mapping_check_with_hypervisor(self):
@@ -176,6 +177,7 @@ class TestGuestOS(cloudstackTestCase):
             osdisplayname="testOSname1",
             oscategoryid=os_category.id
         )
+        self.cleanup.append(self.guestos1)
 
         if self.hypervisor.hypervisor.lower() not in ["xenserver", "vmware"]:
             raise unittest.SkipTest("OS name check with hypervisor is supported only on XenServer and VMware")
@@ -193,6 +195,7 @@ class TestGuestOS(cloudstackTestCase):
             osnameforhypervisor=testosname,
             osmappingcheckenabled=True
         )
+        self.cleanup.append(self.guestosmapping1)
 
         list_guestos_mapping = GuestOsMapping.list(self.apiclient, id=self.guestosmapping1.id, listall=True)
         self.assertNotEqual(
@@ -211,11 +214,13 @@ class TestGuestOS(cloudstackTestCase):
             self.apiclient,
             id=self.guestosmapping1.id
         )
+        self.cleanup.remove(self.guestosmapping1)
 
         GuestOS.remove(
             self.apiclient,
             id=self.guestos1.id
         )
+        self.cleanup.remove(self.guestos1)
 
     @attr(tags=['advanced', 'simulator', 'basic', 'sg'], required_hardware=False)
     def test_guest_OS_mapping_check_with_hypervisor_failure(self):
@@ -231,6 +236,7 @@ class TestGuestOS(cloudstackTestCase):
             osdisplayname="testOSname2",
             oscategoryid=os_category.id
         )
+        self.cleanup.append(self.guestos1)
 
         if self.hypervisor.hypervisor.lower() not in ["xenserver", "vmware"]:
             raise unittest.SkipTest("OS name check with hypervisor is supported only on XenServer and VMware")
@@ -246,10 +252,12 @@ class TestGuestOS(cloudstackTestCase):
                 osnameforhypervisor=testosname,
                 osmappingcheckenabled=True
             )
+            self.cleanup.append(self.guestosmapping1)
             GuestOsMapping.remove(
                 self.apiclient,
                 id=self.guestosmapping1.id
             )
+            self.cleanup.remove(self.guestosmapping1)
             self.fail("Since os mapping name is wrong, this API should fail")
         except CloudstackAPIException as e:
             self.debug("Addition guest OS mapping failed as expected %s " % e)
@@ -257,4 +265,5 @@ class TestGuestOS(cloudstackTestCase):
             self.apiclient,
             id=self.guestos1.id
         )
+        self.cleanup.remove(self.guestos1)
         return

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -4576,6 +4576,7 @@ class Project:
     def __init__(self, items):
         self.__dict__.update(items)
 
+
     @classmethod
     def create(cls, apiclient, services, account=None, domainid=None, userid=None, accountid=None):
         """Create project"""
@@ -6720,7 +6721,7 @@ class GuestOSCategory:
 class GuestOS:
     """Manage Guest OS"""
 
-    def __init__(self, items, services):
+    def __init__(self, items):
         self.__dict__.update(items)
 
     @classmethod
@@ -6735,7 +6736,7 @@ class GuestOS:
         if details is not None:
             cmd.details = details
 
-        return (apiclient.addGuestOs(cmd))
+        return GuestOS(apiclient.addGuestOs(cmd).__dict__)
 
     @classmethod
     def remove(cls, apiclient, id):
@@ -6772,10 +6773,13 @@ class GuestOS:
 
         return (apiclient.listOsTypes(cmd))
 
+    def delete(self, apiclient):
+        self.remove(apiclient, self.id)
+
 class GuestOsMapping:
     """Manage Guest OS Mappings"""
 
-    def __init__(self, items, services):
+    def __init__(self, items):
         self.__dict__.update(items)
 
     @classmethod
@@ -6793,7 +6797,7 @@ class GuestOsMapping:
         if forced is not None:
             cmd.forced = forced
 
-        return (apiclient.addGuestOsMapping(cmd))
+        return GuestOsMapping(apiclient.addGuestOsMapping(cmd).__dict__)
 
     @classmethod
     def remove(cls, apiclient, id):
@@ -6836,6 +6840,9 @@ class GuestOsMapping:
             cmd.hypervisorversion = hypervisorversion
 
         return (apiclient.listGuestOsMapping(cmd))
+
+    def delete(self, apiclient):
+        self.remove(apiclient, self.id)
 
 class VMSchedule:
 


### PR DESCRIPTION
### Description

Currently test cases in test_guest_os.py creates new guest os and mapping entries which are not always cleared. This PR makes changes to clear all entries created during tests to allow test cases to run multiple times.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Before:

```
[root@pr10773-t13212-kvm-ol8-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr10773-t13212-kvm-ol8-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_guest_os.py
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/May_06_2025_05_50_10_X8HXV0 All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_CRUD_operations_guest_OS | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_guest_os_PDFWRM ===
[root@pr10773-t13212-kvm-ol8-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr10773-t13212-kvm-ol8-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_guest_os.py
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/May_06_2025_06_06_52_O0ZF7T All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_CRUD_operations_guest_OS | Status : EXCEPTION ===

=== TestName: test_CRUD_operations_guest_OS_mapping | Status : EXCEPTION ===

=== TestName: test_guest_OS_mapping_check_with_hypervisor | Status : EXCEPTION ===

=== TestName: test_guest_OS_mapping_check_with_hypervisor_failure | Status : EXCEPTION ===

=== Final results are now copied to: /marvin//MarvinLogs/test_guest_os_KIXLY8 ===
[root@pr10773-t13212-kvm-ol8-marvin marvin]# cat /marvin//MarvinLogs/test_guest_os_KIXLY8/failed_plus_exceptions.txt 
2025-05-06 06:06:52,324 - CRITICAL - EXCEPTION: test_CRUD_operations_guest_OS: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_guest_os.py", line 91, in test_CRUD_operations_guest_OS\n    oscategoryid=os_category.id\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 6738, in add\n    return (apiclient.addGuestOs(cmd))\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 4270, in addGuestOs\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 310, in __parseAndGetResponse\n    response_cls)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/jsonHelper.py", line 155, in getResultObj\n    raise cloudstackException.CloudstackAPIException(respname, errMsg)\n', 'marvin.cloudstackException.CloudstackAPIException: Execute cmd: addguestos failed, due to: errorCode: 431, errorText:The specified Guest OS name : testCentOS already exists. Please specify a unique name\n']
2025-05-06 06:06:52,372 - CRITICAL - EXCEPTION: test_CRUD_operations_guest_OS_mapping: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_guest_os.py", line 125, in test_CRUD_operations_guest_OS_mapping\n    oscategoryid=os_category.id\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 6738, in add\n    return (apiclient.addGuestOs(cmd))\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 4270, in addGuestOs\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 310, in __parseAndGetResponse\n    response_cls)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/jsonHelper.py", line 155, in getResultObj\n    raise cloudstackException.CloudstackAPIException(respname, errMsg)\n', 'marvin.cloudstackException.CloudstackAPIException: Execute cmd: addguestos failed, due to: errorCode: 431, errorText:The specified Guest OS name : testCentOS already exists. Please specify a unique name\n']
2025-05-06 06:06:52,414 - CRITICAL - EXCEPTION: test_guest_OS_mapping_check_with_hypervisor: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_guest_os.py", line 178, in test_guest_OS_mapping_check_with_hypervisor\n    oscategoryid=os_category.id\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 6738, in add\n    return (apiclient.addGuestOs(cmd))\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 4270, in addGuestOs\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 310, in __parseAndGetResponse\n    response_cls)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/jsonHelper.py", line 155, in getResultObj\n    raise cloudstackException.CloudstackAPIException(respname, errMsg)\n', 'marvin.cloudstackException.CloudstackAPIException: Execute cmd: addguestos failed, due to: errorCode: 431, errorText:The specified Guest OS name : testOSname1 already exists. Please specify a unique name\n']
2025-05-06 06:06:52,453 - CRITICAL - EXCEPTION: test_guest_OS_mapping_check_with_hypervisor_failure: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 60, in testPartExecutor\n    yield\n', '  File "/usr/lib64/python3.6/unittest/case.py", line 622, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_guest_os.py", line 237, in test_guest_OS_mapping_check_with_hypervisor_failure\n    oscategoryid=os_category.id\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/lib/base.py", line 6738, in add\n    return (apiclient.addGuestOs(cmd))\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 4270, in addGuestOs\n    response = self.connection.marvinRequest(command, response_type=response, method=method)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 381, in marvinRequest\n    raise e\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 376, in marvinRequest\n    raise self.__lastError\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/cloudstackConnection.py", line 310, in __parseAndGetResponse\n    response_cls)\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/jsonHelper.py", line 155, in getResultObj\n    raise cloudstackException.CloudstackAPIException(respname, errMsg)\n', 'marvin.cloudstackException.CloudstackAPIException: Execute cmd: addguestos failed, due to: errorCode: 431, errorText:The specified Guest OS name : testOSname2 already exists. Please specify a unique name\n']
```

After:
```
[root@pr10773-t13212-kvm-ol8-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr10773-t13212-kvm-ol8-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_guest_os.py
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/May_06_2025_06_18_53_RN1VUC All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_CRUD_operations_guest_OS | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_guest_os_EYC44M ===
[root@pr10773-t13212-kvm-ol8-marvin marvin]# nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=./pr10773-t13212-kvm-ol8-advanced-cfg -s -a tags=advanced --hypervisor=KVM tests/smoke/test_guest_os.py
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/May_06_2025_06_19_07_JNHRTP All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_CRUD_operations_guest_OS | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_guest_os_V63BS0 ===

```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
