### PR TITLE
core: support chunked transfer for image files

### DIFF
--- a/core/src/main/java/com/cloud/storage/template/HttpTemplateDownloader.java
+++ b/core/src/main/java/com/cloud/storage/template/HttpTemplateDownloader.java
@@ -83,7 +83,7 @@ public class HttpTemplateDownloader extends ManagedContextRunnable implements Te
     private boolean followRedirects = false;
     private boolean isChunkedTransfer;
 
-    protected List<String> CUSTOM_HEADERS_FOR_CHUNKED_TRANSFER_SIZE = Arrays.asList(
+    protected static final List<String> CUSTOM_HEADERS_FOR_CHUNKED_TRANSFER_SIZE = Arrays.asList(
             "x-goog-stored-content-length",
             "x-goog-meta-size",
             "x-amz-meta-size",


### PR DESCRIPTION
### Description

Fixes #10658
Fixes download of with chunked transfer encoding for non-directdownload templates and ISOs

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
Tested download of:
- A non-chunked transfer encoding file
- A chunked transfer encoding file - https://releases.rancher.com/harvester/v1.3.2/harvester-v1.3.2-amd64-net-install.iso
<details>
<summary>SSVM logs - tail -f /var/log/cloud.log | grep -E "HttpTemplateDownloader|DownloadManagerImpl"</summary>

```
2025-05-11T12:53:29,498 INFO  [storage.template.HttpTemplateDownloader] (AgentRequest-Handler-7:[]) No credentials configured for host=10.1.3.130:80
2025-05-11T12:53:29,503 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-2:[]) Remote size for http://10.1.3.130/cks/setup-1.26.0.iso found to be (660.03 MB) 692094976
2025-05-11T12:53:29,505 INFO  [storage.template.HttpTemplateDownloader] (pool-2-thread-2:[]) Starting download from http://10.1.3.130/cks/setup-1.26.0.iso to /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210/dnld16851435041626252415tmp_ remoteSize=(660.03 MB) 692094976 , max size=(50.00 GB) 53687091200
2025-05-11T12:53:29,528 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-2:[]) Verified format of downloading file /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210/dnld16851435041626252415tmp_ is supported
2025-05-11T12:53:31,223 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-2:[]) Reached expected remote size limit: 692094976 bytes
2025-05-11T12:53:31,241 INFO  [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) Download Completion for jobId: 94db7f97-1dd0-4df0-923c-4d86c4c2c208, status=DOWNLOAD_FINISHED
2025-05-11T12:53:31,242 INFO  [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) local: /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210/dnld16851435041626252415tmp_, bytes=(660.03 MB) 692094976, error=Downloaded (660.03 MB) 692094976 bytes (download complete remote=unknown bytes), pct=100
2025-05-11T12:53:31,242 INFO  [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) No checksum available for 'dnld16851435041626252415tmp_'
2025-05-11T12:53:35,477 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) computed checksum: {SHA-512}ad026d55e0fda7dcb65764660258084f9985d8800b684228a367cf7f90a44d05fb3ff83d9d4e6bc0da2b7049c8bdbfa8c432b342faf96386f92666bcbec8a216
2025-05-11T12:53:35,482 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) Executing command [/usr/local/cloud/systemvm/scripts/storage/secondary/createtmplt.sh -s 2 -S 53687091200 -d non-chunked -h -n 210-2-66ee1468-58ee-388e-bf9f-9c8aca93b27d.iso -t /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210 -f /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210/dnld16851435041626252415tmp_ -u ].
2025-05-11T12:53:35,596 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) Successfully executed process [10257] for command [/usr/local/cloud/systemvm/scripts/storage/secondary/createtmplt.sh -s 2 -S 53687091200 -d non-chunked -h -n 210-2-66ee1468-58ee-388e-bf9f-9c8aca93b27d.iso -t /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210 -f /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210/dnld16851435041626252415tmp_ -u ].
2025-05-11T12:53:35,681 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) Cleaning-up temporary download file /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210/dnld16851435041626252415tmp_
2025-05-11T12:53:35,684 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-2:[]) Deleting directory /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/210, if empty, as part of cleanup
2025-05-11T12:54:16,591 INFO  [storage.template.HttpTemplateDownloader] (AgentRequest-Handler-10:[]) No credentials configured for host=releases.rancher.com:443
2025-05-11T12:54:17,039 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-3:[]) https://releases.rancher.com/harvester/v1.3.2/harvester-v1.3.2-amd64-net-install.iso is using chunked transfer encoding, possible remote size: 883715325
2025-05-11T12:54:17,043 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-3:[]) Remote size for https://releases.rancher.com/harvester/v1.3.2/harvester-v1.3.2-amd64-net-install.iso found to be (842.78 MB) 883715325
2025-05-11T12:54:17,051 INFO  [storage.template.HttpTemplateDownloader] (pool-2-thread-3:[]) Starting download from https://releases.rancher.com/harvester/v1.3.2/harvester-v1.3.2-amd64-net-install.iso to /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211/dnld6098655088962065044tmp_ remoteSize=(842.78 MB) 883715325 , max size=(50.00 GB) 53687091200
2025-05-11T12:54:17,533 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-3:[]) Verified format of downloading file /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211/dnld6098655088962065044tmp_ is supported
2025-05-11T12:54:45,608 DEBUG [storage.template.HttpTemplateDownloader] (pool-2-thread-3:[]) Reached expected remote size limit: 883715325 bytes
2025-05-11T12:54:46,113 INFO  [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) Download Completion for jobId: 472028ff-d07e-4b67-abb3-d5065a87d401, status=DOWNLOAD_FINISHED
2025-05-11T12:54:46,114 INFO  [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) local: /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211/dnld6098655088962065044tmp_, bytes=(842.78 MB) 883722310, error=Downloaded (842.78 MB) 883722310 bytes (download complete remote=unknown bytes), pct=100
2025-05-11T12:54:46,115 INFO  [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) No checksum available for 'dnld6098655088962065044tmp_'
2025-05-11T12:54:52,088 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) computed checksum: {SHA-512}44fb1821bbaef863c68da65d84c0363a86efe24592f6b2eff64957b163f1d700041ccde856af418c0a9cc369a1188cb79d44dcaf665fafdebe17e7906742db2d
2025-05-11T12:54:52,092 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) Executing command [/usr/local/cloud/systemvm/scripts/storage/secondary/createtmplt.sh -s 2 -S 53687091200 -d chunked -h -n 211-2-21936ca5-db4d-3030-8f63-ed051b48865a.iso -t /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211 -f /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211/dnld6098655088962065044tmp_ -u ].
2025-05-11T12:54:52,212 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) Successfully executed process [10285] for command [/usr/local/cloud/systemvm/scripts/storage/secondary/createtmplt.sh -s 2 -S 53687091200 -d chunked -h -n 211-2-21936ca5-db4d-3030-8f63-ed051b48865a.iso -t /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211 -f /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211/dnld6098655088962065044tmp_ -u ].
2025-05-11T12:54:52,263 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) Cleaning-up temporary download file /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211/dnld6098655088962065044tmp_
2025-05-11T12:54:52,265 DEBUG [storage.template.DownloadManagerImpl] (pool-2-thread-3:[]) Deleting directory /mnt/SecStorage/037ced3e-bc30-388e-a0c2-d307b6f8ffb1/template/tmpl/2/211, if empty, as part of cleanup

```
</details
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
