### PR TITLE
Add search bar on rules of roles

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1947,6 +1947,7 @@
 "label.rolename": "Role",
 "label.roles": "Roles",
 "label.roletype": "Role Type",
+"label.rolepermissiontab.searchbar": "Search Rule",
 "label.root.certificate": "Root certificate",
 "label.root.disk.size": "Root disk size (GB)",
 "label.rootdisk": "ROOT disk",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -1386,6 +1386,7 @@
 "label.rolename": "Fun\u00e7\u00e3o",
 "label.roles": "Fun\u00e7\u00f5es",
 "label.roletype": "Tipo de fun\u00e7\u00e3o",
+"label.rolepermissiontab.searchbar": "Pesquisa de regras",
 "label.root.certificate": "Certificado ra\u00edz",
 "label.root.disk.size": "Tamanho do disco ra\u00edz (GB)",
 "label.rootdisk": "Disco ra\u00edz",

--- a/ui/src/views/iam/RolePermissionTab.vue
+++ b/ui/src/views/iam/RolePermissionTab.vue
@@ -18,12 +18,14 @@
 <template>
   <loading-outlined v-if="loadingTable" class="main-loading-spinner" />
   <div v-else>
-    <div style="width: 100%; display: flex; margin-bottom: 10px">
-      <a-button type="dashed" @click="exportRolePermissions" style="width: 100%">
-        <template #icon><download-outlined /></template>
-        {{ $t('label.export.rules') }}
-      </a-button>
-    </div>
+    <a-input-search
+      v-model:value="searchRule"
+      placeholder="Search Rule"
+      background-color="gray"
+      style="width: 100%; margin-bottom: 10px; display: inline-block"
+      enter-button
+      @search="searchRulePermission"
+    />
     <div v-if="updateTable" class="loading-overlay">
       <loading-outlined />
     </div>
@@ -102,6 +104,12 @@
         </template>
       </draggable>
     </div>
+    <div style="width: 100%; display: flex; margin-top: 20px">
+      <a-button type="dashed" @click="exportRolePermissions" style="width: 100%">
+        <template #icon><download-outlined /></template>
+        {{ $t('label.export.rules') }}
+      </a-button>
+    </div>
   </div>
 </template>
 
@@ -137,7 +145,8 @@ export default {
       newRuleDescription: '',
       newRuleSelectError: false,
       drag: false,
-      apis: []
+      apis: [],
+      searchRule: ''
     }
   },
   created () {
@@ -172,6 +181,7 @@ export default {
       if (!this.resource.id) return
       api('listRolePermissions', { roleid: this.resource.id }).then(response => {
         this.rules = response.listrolepermissionsresponse.rolepermission
+        this.totalRules = this.rules
       }).catch(error => {
         this.$notifyError(error)
       }).finally(() => {
@@ -258,6 +268,19 @@ export default {
       hiddenElement.download = this.resource.name + '_' + this.resource.type + '.csv'
       hiddenElement.click()
       hiddenElement.remove()
+    },
+    searchRulePermission (searchValue) {
+      searchValue = searchValue.toLowerCase()
+      if (!searchValue) {
+        this.rules = this.totalRules
+      } else {
+        this.updateTable = true
+        const searchRules = this.totalRules.filter((rule) => rule.rule.toLowerCase().includes(searchValue))
+        this.rules = searchRules
+        setTimeout(() => {
+          this.updateTable = false
+        })
+      }
     }
   }
 }

--- a/ui/src/views/iam/RolePermissionTab.vue
+++ b/ui/src/views/iam/RolePermissionTab.vue
@@ -18,9 +18,15 @@
 <template>
   <loading-outlined v-if="loadingTable" class="main-loading-spinner" />
   <div v-else>
+    <div style="width: 100%; display: flex; margin-bottom: 20px">
+      <a-button type="dashed" @click="exportRolePermissions" style="width: 100%">
+        <template #icon><download-outlined /></template>
+        {{ $t('label.export.rules') }}
+      </a-button>
+    </div>
     <a-input-search
       v-model:value="searchRule"
-      placeholder="Search Rule"
+      :placeholder="$t('label.rolepermissiontab.searchbar')"
       background-color="gray"
       style="width: 100%; margin-bottom: 10px; display: inline-block"
       enter-button
@@ -29,6 +35,7 @@
     <div v-if="updateTable" class="loading-overlay">
       <loading-outlined />
     </div>
+
     <div
       class="rules-list ant-list ant-list-bordered"
       :class="{'rules-list--overflow-hidden' : updateTable}" >
@@ -103,12 +110,6 @@
           </div>
         </template>
       </draggable>
-    </div>
-    <div style="width: 100%; display: flex; margin-top: 20px">
-      <a-button type="dashed" @click="exportRolePermissions" style="width: 100%">
-        <template #icon><download-outlined /></template>
-        {{ $t('label.export.rules') }}
-      </a-button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Adds search bar on the rules of roles

### Description

When editing a role's rules, you'll need to scroll until the specific rule you're looking for appears. To make this process easier, a search bar has been added to the role's permissions tab.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a0c38fc2-7b88-41f8-a04b-9e3367f97044)



### How Has This Been Tested?

For different roles:

* Tested the search, to verify if the results were consistent with the search values.
* Made alterations on the roles from the searched results.
* Tested if the alterations on the rules of the roles are working.


