### PR TITLE
UI workaround for the inconsistent formatting of listVirtualMachinesUsageHistory

### DIFF
--- a/ui/src/components/view/StatsTab.vue
+++ b/ui/src/components/view/StatsTab.vue
@@ -521,7 +521,7 @@ export default {
         this.chartLabels.push(currentLabel)
 
         if (this.resourceIsVirtualMachine) {
-          cpuLine.data.push({ timestamp: currentLabel, stat: element.cpuused.split('%')[0] })
+          cpuLine.data.push({ timestamp: currentLabel, stat: element.cpuused.replace(',', '.').split('%')[0] })
 
           element.memoryusedkbs = element.memorykbs - element.memoryintfreekbs
           memFreeLinePercent.data.push({ timestamp: currentLabel, stat: this.calculateMemoryPercentage(false, element.memorykbs, element.memoryintfreekbs) })


### PR DESCRIPTION
### Description

Depending on the Management Server's Locale, `listVirtualMachinesUsageHistory` may return decimal values separated by a comma in the `cpuused` field; however, the UI currently expects that this decimal is separated by a dot. In this situation, the metrics page will not show the CPU utilization graph properly (see #10672).

This PR makes the UI work around the issue by replacing commas with a dot in order to properly display the metrics page. The response formatting issue will be addressed by #10699 for the next major.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

<details>

<summary>
Without the patch:
</summary>

![Screenshot from 2025-05-06 20-23-26](https://github.com/user-attachments/assets/cf49fc24-e574-4ef8-b724-af0fd3f12fd8)

</details>

<details>

<summary>
With the patch:
</summary>

![Screenshot from 2025-05-06 20-26-58](https://github.com/user-attachments/assets/18a70c5a-5025-4aa0-82c7-9770794f03d9)

</details>

### How Has This Been Tested?

0. Initially, my Locale was set to English
1. I left a VM running for some time, and left the MS collecting utilization metrics 
2. I accessed the VM's metrics page, and verified that the graphs were shown properly
3. I changed my MS's Locale to Italian
4. I accessed the VM's metrics page

Before the patch, the CPU utilization graph would not be displayed properly in step 4. After the patch, the graph is displayed properly.
