### PR TITLE
xenserver: destroy halted vm on expunge

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/XenServerGuru.java
@@ -35,6 +35,7 @@ import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
+import com.cloud.agent.api.CleanupVMCommand;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.to.DataObjectType;
 import com.cloud.agent.api.to.DataStoreTO;
@@ -235,5 +236,13 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {MaxNumberOfVCPUSPerVM};
+    }
+
+    @Override
+    public List<Command> finalizeExpunge(VirtualMachine vm) {
+        List<Command> commands = new ArrayList<>();
+        final CleanupVMCommand cleanupVMCommand = new CleanupVMCommand(vm.getInstanceName(), true);
+        commands.add(cleanupVMCommand);
+        return commands;
     }
 }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCleanupVMCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCleanupVMCommandWrapper.java
@@ -48,7 +48,7 @@ public class CitrixCleanupVMCommandWrapper extends CommandWrapper<CleanupVMComma
             final Connection conn = citrixResourceBase.getConnection();
             final Set<VM> vms = VM.getByNameLabel(conn, vmName);
             if (vms.isEmpty()) {
-                return new Answer(command, false, "VM does not exist");
+                return new Answer(command, true, "VM does not exist");
             }
             // destroy vm which is in HALTED state on this host
             final Iterator<VM> iter = vms.iterator();

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCleanupVMCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCleanupVMCommandWrapper.java
@@ -38,7 +38,7 @@ public class CitrixCleanupVMCommandWrapper extends CommandWrapper<CleanupVMComma
 
     @Override
     public Answer execute(final CleanupVMCommand command, final CitrixResourceBase citrixResourceBase) {
-        if (!citrixResourceBase.isDestroyHaltedVms()) {
+        if (citrixResourceBase.isDestroyHaltedVms()) {
             s_logger.debug(String.format("Cleanup VM is not needed for host with version %s",
                     citrixResourceBase.getHost().getProductVersion()));
             return new Answer(command);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCleanupVMCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCleanupVMCommandWrapper.java
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.hypervisor.xenserver.resource.wrapper.xenbase;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CleanupVMCommand;
+import com.cloud.hypervisor.xenserver.resource.CitrixResourceBase;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+import com.xensource.xenapi.Connection;
+import com.xensource.xenapi.Types;
+import com.xensource.xenapi.VM;
+
+@ResourceWrapper(handles =  CleanupVMCommand.class)
+public class CitrixCleanupVMCommandWrapper extends CommandWrapper<CleanupVMCommand, Answer, CitrixResourceBase> {
+
+    private static final Logger s_logger = Logger.getLogger(CitrixCleanupVMCommandWrapper.class);
+
+    @Override
+    public Answer execute(final CleanupVMCommand command, final CitrixResourceBase citrixResourceBase) {
+        if (!citrixResourceBase.isDestroyHaltedVms()) {
+            s_logger.debug(String.format("Cleanup VM is not needed for host with version %s",
+                    citrixResourceBase.getHost().getProductVersion()));
+            return new Answer(command);
+        }
+        final String vmName = command.getVmName();
+        try {
+            final Connection conn = citrixResourceBase.getConnection();
+            final Set<VM> vms = VM.getByNameLabel(conn, vmName);
+            if (vms.isEmpty()) {
+                return new Answer(command, false, "VM does not exist");
+            }
+            // destroy vm which is in HALTED state on this host
+            final Iterator<VM> iter = vms.iterator();
+            while (iter.hasNext()) {
+                final VM vm = iter.next();
+                final VM.Record vmr = vm.getRecord(conn);
+                if (!Types.VmPowerState.HALTED.equals(vmr.powerState)) {
+                    final String msg = String.format("VM %s is not in %s state", vmName, Types.VmPowerState.HALTED);
+                    s_logger.error(msg);
+                    return new Answer(command, false, msg);
+                }
+                if (citrixResourceBase.isRefNull(vmr.residentOn)) {
+                    continue;
+                }
+                if (vmr.residentOn.getUuid(conn).equals(citrixResourceBase.getHost().getUuid())) {
+                    continue;
+                }
+                iter.remove();
+            }
+            for (final VM vm : vms) {
+                citrixResourceBase.destroyVm(vm, conn, true);
+            }
+
+        } catch (final Exception e) {
+            final String msg = String.format("Clean up VM %s fail due to %s", vmName, e);
+            s_logger.error(msg, e);
+            return new Answer(command, false, e.getMessage());
+        }
+        return new Answer(command);
+    }
+}


### PR DESCRIPTION
### Description

Addresses https://github.com/apache/cloudstack/pull/9175#issuecomment-2834546887

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested on XCP-ng 8.2

Deploy a VM
```
(localcloud) 🐱 > list virtualmachines id=3325d71e-d808-451e-abbe-b923226ebc33 filter=id,name,state,instancename,
{
  "count": 1,
  "virtualmachine": [
    {
      "id": "3325d71e-d808-451e-abbe-b923226ebc33",
      "instancename": "i-2-5-VM",
      "name": "VM-3325d71e-d808-451e-abbe-b923226ebc33",
      "state": "Running"
    }
  ]
}
```

Check on XCP-ng host that VM is showing as running

```
[14:54 pr10833-t13246-xcpng82-xs1 ~]# xe vm-list name-label=i-2-5-VM
uuid ( RO)           : 318c6cd0-fae7-c095-706e-ec840b2a0787
     name-label ( RW): i-2-5-VM
    power-state ( RO): running


```

Destroy VM with expunge from ACS

```
(localcloud) 🐱 > destroy virtualmachine expunge=true id=3325d71e-d808-451e-abbe-b923226ebc33 
{
  "null": {
    "affinitygroup": [],
    "nic": [],
    "securitygroup": [],
    "tags": []
  }
}
```

On XCP-ng check VM is not present in HALTED state,

```
[14:57 pr10833-t13246-xcpng82-xs1 ~]# xe vm-list |grep 'power-state ( RO): halted' |wc -l
0
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
