### PR TITLE
[WIP] Allow CIDR update for the shared network when the network IPs are not in use

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/dao/NicDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/NicDao.java
@@ -34,6 +34,8 @@ public interface NicDao extends GenericDao<NicVO, Long> {
 
     List<NicVO> listByNetworkId(long networkId);
 
+    List<NicVO> listNonDeallocatedByNetworkId(long networkId);
+
     NicVO findByNtwkIdAndInstanceId(long networkId, long instanceId);
 
     NicVO findByInstanceIdAndNetworkIdIncludingRemoved(long networkId, long instanceId);

--- a/engine/schema/src/main/java/com/cloud/vm/dao/NicDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/NicDaoImpl.java
@@ -84,6 +84,7 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         NonReleasedSearch.and("instance", NonReleasedSearch.entity().getInstanceId(), Op.EQ);
         NonReleasedSearch.and("network", NonReleasedSearch.entity().getNetworkId(), Op.EQ);
         NonReleasedSearch.and("state", NonReleasedSearch.entity().getState(), Op.NOTIN);
+        NonReleasedSearch.and("strategy", NonReleasedSearch.entity().getReservationStrategy(), Op.NEQ);
         NonReleasedSearch.done();
 
         deviceIdSearch = createSearchBuilder(Integer.class);
@@ -148,6 +149,15 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
     public List<NicVO> listByNetworkId(long networkId) {
         SearchCriteria<NicVO> sc = AllFieldsSearch.create();
         sc.setParameters("network", networkId);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<NicVO> listNonDeallocatedByNetworkId(long networkId) {
+        SearchCriteria<NicVO> sc = NonReleasedSearch.create();
+        sc.setParameters("network", networkId);
+        sc.setParameters("state", Nic.State.Deallocating);
+        sc.setParameters("strategy", Nic.ReservationStrategy.PlaceHolder.toString());
         return listBy(sc);
     }
 

--- a/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -444,7 +444,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                         nic.setIpv4AllocationRaceCheck(true);
                     }
                     if (guestIp == null && network.getGuestType() != GuestType.L2 && !_networkModel.listNetworkOfferingServices(network.getNetworkOfferingId()).isEmpty()) {
-                        throw new InsufficientVirtualNetworkCapacityException("Unable to acquire Guest IP" + " address for network " + network, DataCenter.class,
+                        throw new InsufficientVirtualNetworkCapacityException("Unable to acquire Guest IP address for network " + network, DataCenter.class,
                                 dc.getId());
                     }
                 }


### PR DESCRIPTION
### Description

This PR allows allows CIDR update for the shared network when the network IPs are not in use (i.e. IPs not allocated)

Addresses #10459 / #10692.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Created shared network, deployed instances on it, Successfully updated CIDR after destroying the instances & destroying router (to ensure there are no allocated IPs). Deployed the instances after CIDR updated. Other tests:

Updated CIDR 10.0.0.0/22 (not subset of cidr) =>

<img width="1201" alt="SharedNetworkCIDR_SubnetCIDR" src="https://github.com/user-attachments/assets/f00e5905-8a9a-4ab4-bbbf-24d659c8322c" />

Updated CIDR when instance is deployed, and IP reserved =>

<img width="1201" alt="SharedNetworkCIDR_IPsInUse" src="https://github.com/user-attachments/assets/c08cbe40-20c3-4607-bdce-192dc01ae436" />

Updated CIDR 10.0.0.0/25 (outside of existing IP range) =>

<img width="1197" alt="SharedNetworkCIDR_IPsRange" src="https://github.com/user-attachments/assets/eba18602-be40-4bde-83c0-42cf50533dca" />

<img width="1190" alt="SharedNetworkCIDR_OutsideIPRange" src="https://github.com/user-attachments/assets/a94fe2ce-5981-408e-8aad-6489efbdcc26" />


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
