### PR TITLE
Remove unfinished usage job entries of the host on start

### DIFF
--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageJobDao.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageJobDao.java
@@ -37,4 +37,6 @@ public interface UsageJobDao extends GenericDao<UsageJobVO, Long> {
     UsageJobVO isOwner(String hostname, int pid);
 
     void updateJobSuccess(Long jobId, long startMillis, long endMillis, long execTime, boolean success);
+
+    void removeLastOpenJobsOwned(String hostname, int pid);
 }

--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageJobDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageJobDaoImpl.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -116,7 +117,7 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
     public UsageJobVO isOwner(String hostname, int pid) {
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
         try {
-            if ((hostname == null) || (pid <= 0)) {
+            if (hostname == null || pid <= 0) {
                 return null;
             }
 
@@ -176,7 +177,7 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
         SearchCriteria<UsageJobVO> sc = createSearchCriteria();
         sc.addAnd("endMillis", SearchCriteria.Op.EQ, Long.valueOf(0));
         sc.addAnd("jobType", SearchCriteria.Op.EQ, Integer.valueOf(UsageJobVO.JOB_TYPE_SINGLE));
-        sc.addAnd("scheduled", SearchCriteria.Op.EQ, Integer.valueOf(0));
+        sc.addAnd("scheduled", SearchCriteria.Op.EQ, Integer.valueOf(UsageJobVO.JOB_NOT_SCHEDULED));
         List<UsageJobVO> jobs = search(sc, filter);
 
         if ((jobs == null) || jobs.isEmpty()) {
@@ -195,5 +196,37 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
             return null;
         }
         return jobs.get(0).getHeartbeat();
+    }
+
+    private List<UsageJobVO> getLastOpenJobsOwned(String hostname, int pid) {
+        SearchCriteria<UsageJobVO> sc = createSearchCriteria();
+        sc.addAnd("endMillis", SearchCriteria.Op.EQ, Long.valueOf(0));
+        sc.addAnd("host", SearchCriteria.Op.EQ, hostname);
+        if (pid > 0) {
+            sc.addAnd("pid", SearchCriteria.Op.EQ, Integer.valueOf(pid));
+        }
+        return listBy(sc);
+    }
+
+    @Override
+    public void removeLastOpenJobsOwned(String hostname, int pid) {
+        if (hostname == null) {
+            return;
+        }
+
+        TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
+        try {
+            List<UsageJobVO> jobs = getLastOpenJobsOwned(hostname, pid);
+            if (CollectionUtils.isNotEmpty(jobs)) {
+                s_logger.info(String.format("Found %s opens job, to remove", jobs.size()));
+                for (UsageJobVO job : jobs) {
+                    s_logger.debug(String.format("Removing job - id: %d, pid: %d, job type: %d, scheduled: %d, heartbeat: %s",
+                            job.getId(), job.getPid(), job.getJobType(), job.getScheduled(), job.getHeartbeat()));
+                    remove(job.getId());
+                }
+            }
+        } finally {
+            txn.close();
+        }
     }
 }

--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -319,6 +319,9 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             s_logger.info("Starting Usage Manager");
         }
 
+        _usageJobDao.removeLastOpenJobsOwned(_hostname, 0);
+        Runtime.getRuntime().addShutdownHook(new AbandonJob());
+
         // use the configured exec time and aggregation duration for scheduling the job
         _scheduledFuture =
                 _executor.scheduleAtFixedRate(this, _jobExecTime.getTimeInMillis() - System.currentTimeMillis(), _aggregationDuration * 60 * 1000, TimeUnit.MILLISECONDS);
@@ -331,7 +334,6 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             _sanity = _sanityExecutor.scheduleAtFixedRate(new SanityCheck(), 1, _sanityCheckInterval, TimeUnit.DAYS);
         }
 
-        Runtime.getRuntime().addShutdownHook(new AbandonJob());
         TransactionLegacy usageTxn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
         try {
             if (_heartbeatLock.lock(3)) { // 3 second timeout
@@ -2197,17 +2199,17 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                         // the aggregation range away from executing the next job
                         long now = System.currentTimeMillis();
                         long timeToJob = _jobExecTime.getTimeInMillis() - now;
-                        long timeSinceJob = 0;
+                        long timeSinceLastSuccessJob = 0;
                         long aggregationDurationMillis = _aggregationDuration * 60L * 1000L;
                         long lastSuccess = _usageJobDao.getLastJobSuccessDateMillis();
                         if (lastSuccess > 0) {
-                            timeSinceJob = now - lastSuccess;
+                            timeSinceLastSuccessJob = now - lastSuccess;
                         }
 
-                        if ((timeSinceJob > 0) && (timeSinceJob > (aggregationDurationMillis - 100))) {
+                        if ((timeSinceLastSuccessJob > 0) && (timeSinceLastSuccessJob > (aggregationDurationMillis - 100))) {
                             if (timeToJob > (aggregationDurationMillis / 2)) {
                                 if (s_logger.isDebugEnabled()) {
-                                    s_logger.debug("it's been " + timeSinceJob + " ms since last usage job and " + timeToJob +
+                                    s_logger.debug("it's been " + timeSinceLastSuccessJob + " ms since last usage job and " + timeToJob +
                                             " ms until next job, scheduling an immediate job to catch up (aggregation duration is " + _aggregationDuration + " minutes)");
                                 }
                                 scheduleParse();
@@ -2294,17 +2296,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             }
         }
     }
+
     private class AbandonJob extends Thread {
         @Override
         public void run() {
-            s_logger.info("exitting Usage Manager");
-            deleteOpenjob();
-        }
-        private void deleteOpenjob() {
-            UsageJobVO job = _usageJobDao.isOwner(_hostname, _pid);
-            if (job != null) {
-                _usageJobDao.remove(job.getId());
-            }
+            s_logger.info("exiting Usage Manager");
+            _usageJobDao.removeLastOpenJobsOwned(_hostname, _pid);
         }
     }
 }


### PR DESCRIPTION
### Description

This PR removes unfinished usage job entries of the host.

The stale / unfinished usage job entries are not allowing to pick the latest job for processing, and prevents usage from running, to fix this, cleanup the unfinished usage jobs during start.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested with some unfinished job entires in the cloud_usage.usage_job table.

```
2025-05-12 09:10:25,875 INFO  [cloud.usage.UsageManagerImpl] (main:null) (logid:) Starting Usage Manager
2025-05-12 09:10:25,985 INFO  [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Found 13 opens job, to remove
2025-05-12 09:10:25,986 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17099, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 10:20:58 UTC 2020
2025-05-12 09:10:25,998 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17100, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 10:25:58 UTC 2020
2025-05-12 09:10:26,005 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17101, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 10:30:58 UTC 2020
2025-05-12 09:10:26,014 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17102, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 10:34:58 UTC 2020
2025-05-12 09:10:26,022 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17103, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 10:39:58 UTC 2020
2025-05-12 09:10:26,028 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17104, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 10:44:58 UTC 2020
2025-05-12 09:10:26,034 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 17105, pid: 683, job type: 0, scheduled: 0, heartbeat: Fri Nov 27 23:19:58 UTC 2020
2025-05-12 09:10:26,040 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 19990, pid: 814, job type: 0, scheduled: 0, heartbeat: Thu Oct 21 22:17:16 UTC 2021
2025-05-12 09:10:26,045 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 19991, pid: 814, job type: 0, scheduled: 0, heartbeat: Thu Oct 21 22:17:19 UTC 2021
2025-05-12 09:10:26,051 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 19992, pid: 814, job type: 0, scheduled: 0, heartbeat: Thu Oct 21 22:17:19 UTC 2021
2025-05-12 09:10:26,057 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 19993, pid: 814, job type: 0, scheduled: 0, heartbeat: Thu Oct 21 22:17:19 UTC 2021
2025-05-12 09:10:26,064 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 19994, pid: 814, job type: 0, scheduled: 0, heartbeat: Fri Oct 22 22:16:16 UTC 2021
2025-05-12 09:10:26,070 DEBUG [usage.dao.UsageJobDaoImpl] (main:null) (logid:) Removing job - id: 26119, pid: 1855871, job type: 0, scheduled: 0, heartbeat: Mon May 12 09:00:08 UTC 2025
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
