### PR TITLE
Disabled Create and Add Volume button for VMs in Error state

### DIFF
--- a/ui/src/views/compute/InstanceTab.vue
+++ b/ui/src/views/compute/InstanceTab.vue
@@ -39,7 +39,7 @@
           style="width: 100%; margin-bottom: 10px"
           @click="showAddVolModal"
           :loading="loading"
-          :disabled="!('createVolume' in $store.getters.apis)">
+          :disabled="!('createVolume' in $store.getters.apis) || this.vm.state === 'Error'">
           <template #icon><plus-outlined /></template> {{ $t('label.action.create.volume.add') }}
         </a-button>
         <volumes-tab :resource="vm" :loading="loading" />


### PR DESCRIPTION
### Description

When a VM fails to deploy, it remains in `Error` state. Currently, there is no functionality to recover a VM in `Error` state, therefore, the only option is to create a new VM. However, the option `Create and Add Volume` is still presented. This PR disables the `Create and Add Volume`  button for VMs in `Error` state

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e316a851-5938-46ab-9e4c-a2d778222ee5)

### How Has This Been Tested?

I made the following tests, in my local lab:

1. Disabled all the hosts in my environment.
2. Tried to deploy a new VM. As expected, the deploy failed and it was set to `Error` state.
3. Validated that when the `Volumes` section was accessed, the Create and Add Volume button was still enabled.
4. Built and installed CloudStack's packages with my fix. 
5. Validated that when the `Volumes` section was accessed again, the button was successfully disabled.
