### PR TITLE
Change log level of AgentHandler#processRequest()

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -1454,7 +1454,7 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                         }
                     }
                 } catch (final Throwable th) {
-                    s_logger.warn("Caught: ", th);
+                    s_logger.error("Caught: ", th);
                     answer = new Answer(cmd, false, th.getMessage());
                 }
                 answers[i] = answer;
@@ -1471,7 +1471,7 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
             try {
                 link.send(response.toBytes());
             } catch (final ClosedChannelException e) {
-                s_logger.warn("Unable to send response because connection is closed: " + response);
+                s_logger.error("Unable to send response because connection is closed: " + response);
             }
         }
 


### PR DESCRIPTION
Change log level

### Description
In the method `AgentHandler#processRequest()`, the timeout exception of database requests are logged with level warning, this PR corrects the log level to error.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial


### Screenshots (if appropriate):



### How Has This Been Tested?

Running the project, and then stopping the database service, to trigger the exception shown below:

``` 
2025-04-25 16:20:39,356 ERROR [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-1:null) (logid:) Caught: 
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: null
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:864)
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:819)
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:1490)
	at com.cloud.vm.dao.ConsoleProxyDaoImpl.update(ConsoleProxyDaoImpl.java:138)
	at jdk.internal.reflect.GeneratedMethodAccessor91.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at com.cloud.utils.db.TransactionContextInterceptor.invoke(TransactionContextInterceptor.java:34)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy191.update(Unknown Source)
	at com.cloud.consoleproxy.ConsoleProxyManagerImpl.updateConsoleProxyStatus(ConsoleProxyManagerImpl.java:1655)
	at com.cloud.consoleproxy.ConsoleProxyManagerImpl$VmBasedAgentHook.onLoadReport(ConsoleProxyManagerImpl.java:282)
	at com.cloud.consoleproxy.ConsoleProxyListener.processControlCommand(ConsoleProxyListener.java:56)
```

This other exception was triggered during remote debug, setting the `_key` variable to null  on the file `utils/src/main/java/com/cloud/utils/nio/Link.java` line 316.

``` 
2025-04-25 16:39:08,580 ERROR [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-8:null) (logid:) Unable to send response because connection is closed: Seq 2-395:  { Ans: , MgmtId: 51351695036381, via: 2, Ver: v1, Flags: 100010, [{"com.cloud.agent.api.Answer":{"result":"false","details":"DB Exception on: null","wait":"0","bypassHostMaintenance":"false"}}] }
2025-04-25 16:38:47,782 ERROR [c.c.a.m.AgentManagerImpl] (AgentManager-Handler-5:null) (logid:) Caught: 
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: null
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:864)
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:819)
	at com.cloud.utils.db.GenericDaoBase.update(GenericDaoBase.java:1490)
	at com.cloud.vm.dao.ConsoleProxyDaoImpl.update(ConsoleProxyDaoImpl.java:138)
	at jdk.internal.reflect.GeneratedMethodAccessor91.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at com.cloud.utils.db.TransactionContextInterceptor.invoke(TransactionContextInterceptor.java:34)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at com.sun.proxy.$Proxy191.update(Unknown Source)
	at com.cloud.consoleproxy.ConsoleProxyManagerImpl.updateConsoleProxyStatus(ConsoleProxyManagerImpl.java:1655)

```



<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
