### PR TITLE
linstor: fix host connect recursion regression

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/provider/LinstorHostListener.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/provider/LinstorHostListener.java
@@ -18,7 +18,6 @@ package org.apache.cloudstack.storage.datastore.provider;
 
 import com.cloud.exception.StorageConflictException;
 import com.cloud.host.HostVO;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 
 public class LinstorHostListener extends DefaultHostListener {
     @Override
@@ -28,7 +27,6 @@ public class LinstorHostListener extends DefaultHostListener {
             host.setParent(host.getName());
             hostDao.update(host.getId(), host);
         }
-        StoragePoolVO pool = primaryStoreDao.findById(poolId);
-        return super.hostConnect(host, pool);
+        return super.hostConnect(hostId, poolId);
     }
 }


### PR DESCRIPTION
### Description

PR #9873 changed the default implementation of hostConnect on the DefaultHostListener, and Linstor tried to call the none existent default implementation. With the change in the PR a recursion was triggered that triggered a StackOverflow and stopped adding Linstor primary storage.

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Creating a new cluster with Linstor primary storage

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
