### PR TITLE
Consider Quota settings during processing

### DIFF
--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-common-daos-between-management-and-usage-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-common-daos-between-management-and-usage-context.xml
@@ -28,6 +28,9 @@
                       >
 
 	<bean id="accountGuestVlanMapDaoImpl" class="com.cloud.network.dao.AccountGuestVlanMapDaoImpl" />
+	<bean id="accountDetailsDaoImpl" class="com.cloud.user.AccountDetailsDaoImpl" />
+	<bean id="domainDaoImpl" class="com.cloud.domain.dao.DomainDaoImpl" />
+	<bean id="domainDetailsDaoImpl" class="com.cloud.domain.dao.DomainDetailsDaoImpl" />
 	<bean id="clusterDaoImpl" class="com.cloud.dc.dao.ClusterDaoImpl" />
 	<bean id="clusterDetailsDaoImpl" class="com.cloud.dc.ClusterDetailsDaoImpl" />
 	<bean id="dataCenterDaoImpl" class="com.cloud.dc.dao.DataCenterDaoImpl" />

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaAlertManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaAlertManagerImpl.java
@@ -149,7 +149,7 @@ public class QuotaAlertManagerImpl extends ManagerBase implements QuotaAlertMana
      */
     @Override
     public boolean isQuotaEmailTypeEnabledForAccount(AccountVO account, QuotaEmailTemplateTypes quotaEmailTemplateType) {
-        boolean quotaEmailsEnabled = QuotaConfig.QuotaEnableEmails.valueIn(account.getAccountId());
+        boolean quotaEmailsEnabled = _quotaManager.findConfigurationValue(account, QuotaConfig.QuotaEnableEmails);
         if (!quotaEmailsEnabled) {
             logger.debug("Configuration [{}] is disabled for account [{}]. Therefore, the account will not receive Quota email of type [{}].", QuotaConfig.QuotaEnableEmails.key(), account, quotaEmailTemplateType);
             return false;

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManager.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManager.java
@@ -18,11 +18,14 @@ package org.apache.cloudstack.quota;
 
 import com.cloud.user.AccountVO;
 import com.cloud.utils.component.Manager;
+import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface QuotaManager extends Manager {
 
     boolean calculateQuotaUsage();
 
     boolean isLockable(AccountVO account);
+
+    boolean findConfigurationValue(AccountVO accountVO, ConfigKey<Boolean> key);
 
 }

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -360,11 +360,10 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
 
     @Override
     public boolean findConfigurationValue(AccountVO accountVO, ConfigKey<Boolean> key) {
-        boolean result = Boolean.parseBoolean(getConfigValueOrDefaultValue(key));
         logger.trace("Searching configuration [{}] of account [{}] in its settings.", key.key(), accountVO);
         AccountDetailVO accountDetail = accountDetailsDao.findDetail(accountVO.getAccountId(), key.key());
         if (accountDetail != null) {
-            result = Boolean.parseBoolean(accountDetail.getValue());
+            boolean result = Boolean.parseBoolean(accountDetail.getValue());
             logger.trace("Using value [{}] found in account [{}] settings to configuration [{}].", result, accountVO, key.key());
             return result;
         }
@@ -373,11 +372,12 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             logger.trace("Searching for configuration [{}] of account [{}] in its domain [{}] settings.", key.key(), accountVO, accountVO.getDomainId());
             DomainDetailVO domainDetail = domainDetailsDao.findDetail(accountVO.getDomainId(), key.key());
             if (domainDetail != null) {
-                result = Boolean.parseBoolean(domainDetail.getValue());
+                boolean result = Boolean.parseBoolean(domainDetail.getValue());
                 logger.trace("Using value [{}] found in domain [{}] settings to configuration [{}].", result, accountVO.getDomainId(), key.key());
                 return result;
             }
         }
+        boolean result = Boolean.parseBoolean(getConfigValueOrDefaultValue(key));
         logger.trace("Using default value [{}] to configuration [{}].", result, key.key());
         return result;
     }

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -364,7 +364,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         logger.trace("Searching configuration [{}] of account [{}] in its settings.", key.key(), accountVO);
         AccountDetailVO accountDetail = accountDetailsDao.findDetail(accountVO.getAccountId(), key.key());
         if (accountDetail != null) {
-            result = Boolean.TRUE.equals(Boolean.valueOf(accountDetail.getValue()));
+            result = Boolean.parseBoolean(accountDetail.getValue());
             logger.trace("Using value [{}] found in account [{}] settings to configuration [{}].", result, accountVO, key.key());
             return result;
         }
@@ -373,7 +373,7 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             logger.trace("Searching for configuration [{}] of account [{}] in its domain [{}] settings.", key.key(), accountVO, accountVO.getDomainId());
             DomainDetailVO domainDetail = domainDetailsDao.findDetail(accountVO.getDomainId(), key.key());
             if (domainDetail != null) {
-                result = Boolean.TRUE.equals(Boolean.valueOf(domainDetail.getValue()));
+                result = Boolean.parseBoolean(domainDetail.getValue());
                 logger.trace("Using value [{}] found in domain [{}] settings to configuration [{}].", result, accountVO.getDomainId(), key.key());
                 return result;
             }

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaAlertManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaAlertManagerImplTest.java
@@ -33,7 +33,6 @@ import org.apache.cloudstack.quota.dao.QuotaAccountDao;
 import org.apache.cloudstack.quota.dao.QuotaEmailConfigurationDaoImpl;
 import org.apache.cloudstack.quota.dao.QuotaEmailTemplatesDao;
 import org.apache.cloudstack.quota.vo.QuotaAccountVO;
-import org.apache.cloudstack.quota.vo.QuotaEmailConfigurationVO;
 import org.apache.cloudstack.quota.vo.QuotaEmailTemplatesVO;
 import org.junit.Assert;
 import org.junit.Before;

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaAlertManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaAlertManagerImplTest.java
@@ -116,9 +116,6 @@ public class QuotaAlertManagerImplTest extends TestCase {
     @Test
     public void isQuotaEmailTypeEnabledForAccountTestConfigurationIsEnabledAndEmailIsConfiguredReturnConfiguredValue() {
         boolean expectedValue = !QuotaConfig.QuotaEnableEmails.value();
-        QuotaEmailConfigurationVO quotaEmailConfigurationVoMock = Mockito.mock(QuotaEmailConfigurationVO.class);
-        Mockito.when(quotaEmailConfigurationVoMock.isEnabled()).thenReturn(expectedValue);
-        Mockito.doReturn(quotaEmailConfigurationVoMock).when(quotaEmailConfigurationDaoMock).findByAccountIdAndEmailTemplateType(Mockito.anyLong(), Mockito.any(QuotaConfig.QuotaEmailTemplateTypes.class));
 
         boolean result = quotaAlertManager.isQuotaEmailTypeEnabledForAccount(accountMock, QuotaConfig.QuotaEmailTemplateTypes.QUOTA_EMPTY);
 
@@ -128,6 +125,8 @@ public class QuotaAlertManagerImplTest extends TestCase {
     @Test
     public void isQuotaEmailTypeEnabledForAccountTestConfigurationIsEnabledAndEmailIsNotConfiguredReturnDefaultValue() {
         boolean defaultValue = QuotaConfig.QuotaEnableEmails.value();
+
+        Mockito.when(quotaManagerMock.findConfigurationValue(accountMock, QuotaConfig.QuotaEnableEmails)).thenReturn(true);
 
         boolean result = quotaAlertManager.isQuotaEmailTypeEnabledForAccount(accountMock, QuotaConfig.QuotaEmailTemplateTypes.QUOTA_EMPTY);
 


### PR DESCRIPTION
### Description

Currently, when using the Quota plugin, it is possible to enable/disable the plugin specifically in the account settings. However, even if the plugin is disabled for the account, the setting is not considered because the Quota manager is failing to get its value, so that the account's Quota balance is always processed. This PR fixes this behavior.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

1. A account was created and, before the Usage job was run, the Quota plugin was disabled for the account. It was attested via GUI and logs that the account didn't appear in Quota and it wasn't even processed.
2. Another account was created with the Quota plugin enabled. After the Usage job was run once and the Quota was processed for the account, the Quota plugin was disabled and on the second run it was attested that the credit was not decremented. 