### PR TITLE
Check Qcow2 version before using --bitmaps

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.cloudstack.storage.formatinspector.Qcow2Inspector;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.libvirt.LibvirtException;
@@ -52,6 +53,8 @@ public class QemuImg {
     public static final String TARGET_ZERO_FLAG = "--target-is-zero";
     public static final long QEMU_2_10 = 2010000;
     public static final long QEMU_5_10 = 5010000;
+
+    public static final int MIN_BITMAP_VERSION = 3;
 
     /* The qemu-img binary. We expect this to be in $PATH */
     public String _qemuImgPath = "qemu-img";
@@ -466,7 +469,7 @@ public class QemuImg {
             script.add(srcFile.getFileName());
         }
 
-        if (this.version >= QEMU_5_10 && keepBitmaps) {
+        if (this.version >= QEMU_5_10 && keepBitmaps && Qcow2Inspector.validateQcow2Version(srcFile.getFileName(), MIN_BITMAP_VERSION)) {
             script.add("--bitmaps");
         }
 

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/formatinspector/Qcow2Inspector.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/formatinspector/Qcow2Inspector.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,6 +107,32 @@ public class Qcow2Inspector {
         }
 
         return result;
+    }
+
+
+    /**
+     * Validates if the file has a minimum version.
+     * @param filePath Path of the file to be validated.
+     * @param minVersion the minimum version that it should contain.
+     * @throws RuntimeException If a IOException is thrown.
+     * @return true if file version is >= minVersion, false otherwise.
+     */
+    public static boolean validateQcow2Version(String filePath, int minVersion) {
+        try (InputStream inputStream = new FileInputStream(filePath)) {
+            for (Qcow2HeaderField qcow2Header : Qcow2HeaderField.values()) {
+                if (qcow2Header != Qcow2HeaderField.VERSION) {
+                    skipHeader(inputStream, qcow2Header, filePath);
+                    continue;
+                }
+
+                byte[] headerValue = readHeader(inputStream, qcow2Header, filePath);
+                int version = new BigInteger(headerValue).intValue();
+                return version >= minVersion;
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(String.format("Unable to validate file [%s] due to: ", filePath), ex);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
### Description

This PR adds a validation on the volume copy process. Before adding the --bitmaps flag to the convert command, a check is made in the volume to guarantee that the volume is at least version 3; if it is not, the flag is not added.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Upload image with old compat version, e.g. http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-kvm.qcow2.bz2, attach to VM, stop VM, migrate volume.

Before: 
```
Failed to convert [/mnt/b59eff0f-5b97-37ed-a513-9e1983d1d19b/2784ec51-4776-4b03-9a85-198c465e7d25] to [/mnt/a66f48f5-13c6-3676-b320-a15d32bbf32f/2784ec51-4776-4b03-9a85-198c465e7d25] due to: [qemu-img: Source lacks bitmap support]. org.apache.cloudstack.utils.qemu.QemuImgException: qemu-img: Source lacks bitmap support
```

After:
Image is converted successfully as the --bitmaps option is not informed.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
