### PR TITLE
Smoke test: Update user for XenServer template

### DIFF
--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -2153,7 +2153,10 @@ class TestSharedNetworkWithConfigDrive(cloudstackTestCase):
 
         cls.services["virtual_machine"]["zoneid"] = cls.zone.id
         cls.services["virtual_machine"]["template"] = template.id
-        cls.services["virtual_machine"]["username"] = "ubuntu"
+        if cls.hv.lower() == 'xenserver':
+            cls.services["virtual_machine"]["username"] = "root"
+        else:
+            cls.services["virtual_machine"]["username"] = "ubuntu"
         # Create Network Offering
         cls.services["shared_network_offering_configdrive"]["specifyVlan"] = "True"
         cls.services["shared_network_offering_configdrive"]["specifyIpRanges"] = "True"


### PR DESCRIPTION
### Description

This PR fixes the constant test failure observed on the [4.20 health check branch](https://github.com/apache/cloudstack/pull/10668#issuecomment-2899738057). This depends on change of the template being used as well as fixing Configdrive functionality on XenServer / XCP-ng addressed with: #10912 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [X] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

```
nosetests --with-xunit --xunit-file=results.xml --with-marvin --marvin-config=/marvin/pr10912-t13399-xcpng82-advanced-cfg -s -a tags=failure --hypervisor=xenserver /marvin/tests/smoke/test_network.py
/usr/local/lib/python3.6/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend

==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /marvin/MarvinLogs/May_26_2025_08_08_00_6GSRX6 All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
Executing command '{'name': 'MySharedNetwork - Test', 'displaytext': 'MySharedNetwork', 'vlan': 124, 'gateway': '172.16.129.1', 'netmask': '255.255.255.0', 'startip': '172.16.129.2', 'endip': '172.16.129.21', 'acltype': 'domain', 'scope': 'all', 'networkofferingid': 'd58f4a2b-6639-40d0-badd-f18496c83a8d', 'physicalnetworkid': 'b845d0aa-0287-4085-92df-5a078ebfdc25'}'
====Trying SSH Connection: Host:10.0.56.94 User:root                                   Port:22 RetryCnt:5===
SshClient: Exception under createConnection: ['Traceback (most recent call last):\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/sshClient.py", line 130, in createConnection\n    look_for_keys=False\n', '  File "/usr/local/lib/python3.6/site-packages/paramiko/client.py", line 409, in connect\n    raise NoValidConnectionsError(errors)\n', 'paramiko.ssh_exception.NoValidConnectionsError: [Errno None] Unable to connect to port 22 on 10.0.56.94\n']
NoneType: None
====Trying SSH Connection: Host:10.0.56.94 User:root                                   Port:22 RetryCnt:4===
SshClient: Exception under createConnection: ['Traceback (most recent call last):\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/sshClient.py", line 130, in createConnection\n    look_for_keys=False\n', '  File "/usr/local/lib/python3.6/site-packages/paramiko/client.py", line 409, in connect\n    raise NoValidConnectionsError(errors)\n', 'paramiko.ssh_exception.NoValidConnectionsError: [Errno None] Unable to connect to port 22 on 10.0.56.94\n']
NoneType: None
====Trying SSH Connection: Host:10.0.56.94 User:root                                   Port:22 RetryCnt:3===
SshClient: Exception under createConnection: ['Traceback (most recent call last):\n', '  File "/usr/local/lib/python3.6/site-packages/marvin/sshClient.py", line 130, in createConnection\n    look_for_keys=False\n', '  File "/usr/local/lib/python3.6/site-packages/paramiko/client.py", line 457, in connect\n    server_key = t.get_remote_server_key()\n', '  File "/usr/local/lib/python3.6/site-packages/paramiko/transport.py", line 953, in get_remote_server_key\n    raise SSHException("No existing session")\n', 'paramiko.ssh_exception.SSHException: No existing session\n']
NoneType: None
====Trying SSH Connection: Host:10.0.56.94 User:root                                   Port:22 RetryCnt:2===
===SSH to Host 10.0.56.94 port : 22 SUCCESSFUL===
{Cmd: sudo bash -c "if [ ! -d /root/iso ]; then mkdir /root/iso; fi" via Host: 10.0.56.94} {returns: []}
{Cmd: sudo umount /root/iso via Host: 10.0.56.94} {returns: ['umount: /root/iso: not mounted.']}
{Cmd: sudo blkid -t LABEL='config-2' /dev/sr? /dev/hd? /dev/sd? /dev/xvd? -o device via Host: 10.0.56.94} {returns: ['/dev/sr0']}
{Cmd: sudo mount /dev/sr0 /root/iso via Host: 10.0.56.94} {returns: ['mount: /root/iso: WARNING: source write-protected, mounted read-only.']}
{Cmd: sudo cat /root/iso/openstack/latest/network_data.json via Host: 10.0.56.94} {returns: ['{"links":[{"ethernet_mac_address":"1e:00:78:00:00:35","id":"eth0","mtu":1500,"type":"phy"},{"ethernet_mac_address":"02:01:00:cd:00:01","id":"eth1","mtu":1500,"type":"phy"}],"networks":[{"id":"eth0","ip_address":"172.16.129.14","link":"eth0","netmask":"255.255.255.0","network_id":"02647b90-edb5-4a1a-a4c6-d9cc468c1e13","type":"ipv4","routes":[{"gateway":"172.16.129.1","netmask":"0.0.0.0","network":"0.0.0.0"}]},{"id":"eth1","ip_address":"10.1.1.6","link":"eth1","netmask":"255.255.255.0","network_id":"82539005-90a3-4b4e-a25c-6ac1314d19d7","type":"ipv4","routes":[{"gateway":"10.1.1.1","netmask":"0.0.0.0","network":"0.0.0.0"}]}],"services":[{"address":"10.0.32.1","type":"dns"},{"address":"8.8.8.8","type":"dns"}]}']}
{Cmd: sudo umount -d /root/iso via Host: 10.0.56.94} {returns: []}
{Cmd: sudo ls /root/iso via Host: 10.0.56.94} {returns: []}
{Cmd: ip address via Host: 10.0.56.94} {returns: ['1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000', '    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00', '    inet 127.0.0.1/8 scope host lo', '       valid_lft forever preferred_lft forever', '    inet6 ::1/128 scope host noprefixroute', '       valid_lft forever preferred_lft forever', '2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000', '    link/ether 1e:00:78:00:00:35 brd ff:ff:ff:ff:ff:ff', '    altname enX0', '    inet 172.16.129.14/24 brd 172.16.129.255 scope global eth0', '       valid_lft forever preferred_lft forever', '    inet6 fe80::1c00:78ff:fe00:35/64 scope link', '       valid_lft forever preferred_lft forever', '3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000', '    link/ether 02:01:00:cd:00:01 brd ff:ff:ff:ff:ff:ff', '    altname enX1', '    inet 10.1.1.6/24 brd 10.1.1.255 scope global eth1', '       valid_lft forever preferred_lft forever', '    inet6 fe80::1:ff:fecd:1/64 scope link', '       valid_lft forever preferred_lft forever']}
=== TestName: test_01_deployVMInSharedNetwork | Status : SUCCESS ===

=== Final results are now copied to: /marvin//MarvinLogs/test_network_4JTIHM ===

```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
