### PR TITLE
Consider secondary storage selectors during cold volume migration

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/storage/heuristics/HeuristicRuleHelper.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/heuristics/HeuristicRuleHelper.java
@@ -117,8 +117,8 @@ public class HeuristicRuleHelper {
                 accountId = ((SnapshotInfo) obj).getAccountId();
                 break;
             case VOLUME:
-                presetVariables.setVolume(setVolumePresetVariable((VolumeVO) obj));
-                accountId = ((VolumeVO) obj).getAccountId();
+                presetVariables.setVolume(setVolumePresetVariable((com.cloud.storage.Volume) obj));
+                accountId = ((com.cloud.storage.Volume) obj).getAccountId();
                 break;
         }
         presetVariables.setAccount(setAccountPresetVariable(accountId));
@@ -191,14 +191,14 @@ public class HeuristicRuleHelper {
         return template;
     }
 
-    protected Volume setVolumePresetVariable(VolumeVO volumeVO) {
-        Volume volume = new Volume();
+    protected Volume setVolumePresetVariable(com.cloud.storage.Volume volumeVO) {
+        Volume volumePresetVariable = new Volume();
 
-        volume.setName(volumeVO.getName());
-        volume.setFormat(volumeVO.getFormat());
-        volume.setSize(volumeVO.getSize());
+        volumePresetVariable.setName(volumeVO.getName());
+        volumePresetVariable.setFormat(volumeVO.getFormat());
+        volumePresetVariable.setSize(volumeVO.getSize());
 
-        return volume;
+        return volumePresetVariable;
     }
 
     protected Snapshot setSnapshotPresetVariable(SnapshotInfo snapshotInfo) {


### PR DESCRIPTION
### Description

The secondary storage selectors allow operators to specify, for instance, that volumes should go to a specific secondary storage A. Thus, when uploading a volume, it will always be downloaded to secondary storage A.

The cold volume migration moves volumes to a secondary storage before moving them to the destination primary storage. This process does not consider the secondary storage selectors. However, some companies want to dedicate specific secondary storages for cold migration.

To address this, this PR makes the cold volume migration process consider the secondary storage selectors.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?

1. Without any secondary storage selector, I began the cold migration of a volume. I validated that the most free secondary storage was used for migration.

2. I created a secondary storage selector directing volumes to a specific secondary storage, and began the cold migration of another volume. I validated that the specified secondary storage was used for the migration.