### PR TITLE
[KVM] CPU Features for System VMs

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -213,9 +213,15 @@ hypervisor.type=kvm
 # If null (default), defaults to the VM's OS architecture
 #guest.cpu.arch=
 
-# This param will require CPU features on the CPU section.
-# The features listed in this property must be separated by a blank space (e.g.: vmx vme)
+# Specifies required CPU features for end-user VMs (non-system VMs).
+# These features must be present on the host CPU for VM deployment.
+# Multiple features should be separated by whitespace (e.g.: vmx vme).
 #guest.cpu.features=
+
+# Specifies required CPU features for system VMs.
+# These features must be present on the host CPU for VM deployment.
+# Multiple features should be separated by whitespace (e.g.: vmx vme).
+#systemvm.guest.cpu.features=
 
 # Disables memory ballooning on VM guests for overcommit.
 # By default overcommit feature enables balloon and sets currentMemory to a minimum value.

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -390,13 +390,24 @@ public class AgentProperties{
     public static final Property<String> GUEST_CPU_ARCH = new Property<>("guest.cpu.arch", null, String.class);
 
     /**
-     * This param will require CPU features on the CPU section.<br>
-     * The features listed in this property must be separated by a blank space (see example below).<br>
+     * Specifies required CPU features for end-user VMs (non-system VMs).<br>
+     * These features must be present on the host CPU for VM deployment.<br>
+     * Multiple features should be separated by whitespace (see example below).<br>
      * Possible values: vmx vme <br>
      * Data type: String.<br>
      * Default value: <code>null</code>
      */
     public static final Property<String> GUEST_CPU_FEATURES = new Property<>("guest.cpu.features", null, String.class);
+
+    /**
+     * Specifies required CPU features for system VMs.<br>
+     * These features must be present on the host CPU for VM deployment.<br>
+     * Multiple features should be separated by whitespace (see example below).<br>
+     * Possible values: vmx vme <br>
+     * Data type: String.<br>
+     * Default value: <code>null</code>
+     */
+    public static final Property<String> SYSTEMVM_GUEST_CPU_FEATURES = new Property<>("systemvm.guest.cpu.features", null, String.class);
 
     /**
      * Disables memory ballooning on VM guests for overcommit.<br>

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -843,6 +843,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     protected List<String> cpuFeatures;
 
+    protected List<String> systemVmCpuFeatures;
+
     protected enum BridgeType {
         NATIVE, OPENVSWITCH, TUNGSTEN
     }
@@ -1283,15 +1285,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             params.put("guest.cpu.model", guestCpuModel);
         }
 
-        final String cpuFeatures = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.GUEST_CPU_FEATURES);
-        if (cpuFeatures != null) {
-            this.cpuFeatures = new ArrayList<String>();
-            for (final String feature: cpuFeatures.split(" ")) {
-                if (!feature.isEmpty()) {
-                    this.cpuFeatures.add(feature);
-                }
-            }
-        }
+        this.cpuFeatures = parseCpuFeatures(AgentPropertiesFileHandler.getPropertyValue(AgentProperties.GUEST_CPU_FEATURES));
+        this.systemVmCpuFeatures = parseCpuFeatures(AgentPropertiesFileHandler.getPropertyValue(AgentProperties.SYSTEMVM_GUEST_CPU_FEATURES));
 
         final String[] info = NetUtils.getNetworkParams(privateNic);
 
@@ -1395,6 +1390,22 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         setupMemoryBalloonStatsPeriod(conn);
 
         return true;
+    }
+
+    /**
+     * Parses a string containing whitespace-separated CPU feature names and converts it into a list.
+     *
+     * @param features A string containing whitespace-separated CPU feature names to be parsed.
+     * @return A list of CPU feature strings. Returns an empty list if {@code features} is null.
+     */
+    protected List<String> parseCpuFeatures(String features) {
+        if (features == null) {
+            return new ArrayList<>();
+        }
+
+        return Arrays.stream(features.split(" "))
+                .filter(feature -> !feature.isEmpty())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -2986,6 +2997,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.setModel(cpuModel);
         if (VirtualMachine.Type.User.equals(vmTO.getType())) {
             cmd.setFeatures(cpuFeatures);
+        } else if (vmTO.getType().isUsedBySystem()) {
+            cmd.setFeatures(systemVmCpuFeatures);
         }
         int vCpusInDef = vmTO.getVcpuMaxLimit() == null ? vcpus : vmTO.getVcpuMaxLimit();
         setCpuTopology(cmd, vCpusInDef, vmTO.getDetails());

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -6620,4 +6620,20 @@ public class LibvirtComputingResourceTest {
         Mockito.verify(libvirtComputingResourceSpy, Mockito.times(1)).recreateCheckpointsOfDisk(Mockito.any(), Mockito.any(), Mockito.any());
         Assert.assertTrue(result);
     }
+
+    @Test
+    public void parseCpuFeaturesTestReturnEmptyListWhenFeaturesIsNull() {
+        List<String> cpuFeatures = libvirtComputingResourceSpy.parseCpuFeatures(null);
+        Assert.assertEquals(0, cpuFeatures.size());
+    }
+
+    @Test
+    public void parseCpuFeaturesTestReturnListOfCpuFeaturesAndIgnoreMultipleWhitespacesAlongsideEachOther() {
+        List<String> cpuFeatures = libvirtComputingResourceSpy.parseCpuFeatures("  -mca    mce   -mmx  hle ");
+        Assert.assertEquals(4, cpuFeatures.size());
+        Assert.assertEquals("-mca", cpuFeatures.get(0));
+        Assert.assertEquals("mce", cpuFeatures.get(1));
+        Assert.assertEquals("-mmx", cpuFeatures.get(2));
+        Assert.assertEquals("hle", cpuFeatures.get(3));
+    }
 }


### PR DESCRIPTION
### Description

Currently, when defining the CPU configuration of VMs with KVM, the Apache CloudStack Agent executes the following workflow:

https://github.com/apache/cloudstack/blob/41b4f0afd5321e987973b615b566365e48228c6e/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java#L2980-L2993

As can be noticed, the CPU features are only considered for end-user VMs; they are completely ignored for system VMs. This can lead to system VMs deployment inconsistencies and errors. For instance, when it is required to disable CPU flags for a given CPU model, because the host CPU does not support such flags, an error similar to the following will be returned by Libvirt when trying to deploy system VMs:

```bash
Error while deploying VM. org.libvirt.LibvirtException: the CPU is incompatible with host CPU: Host CPU does not provide required features: hle, rtm, avx512-bf16, taa-no
```

Therefore, this PR proposes to add a new property, called `systemvm.guest.cpu.features`, to define CPU features for system VMs. This enhancement could be simply performed by removing the following `if` statement:

https://github.com/apache/cloudstack/blob/41b4f0afd5321e987973b615b566365e48228c6e/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java#L2987-L2989

IMHO, it would be better from a UX perspective. However, it would break backwards compatibility and, thus, the proposal is to introduce the new `systemvm.guest.cpu.features` property.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

1. Defined the following properties in the `agent.properties` of the KVM hosts:

```bash
guest.cpu.mode=custom
guest.cpu.model=Cooperlake
guest.cpu.features=-hle -rtm -avx512-bf16 -taa-no
```

2. Restarted the Apache CloudStack Agent and verified that the deployment of system VMs failed with the following error:

```bash
2025-06-05 15:09:14,122 WARN  [resource.wrapper.LibvirtStartCommandWrapper] (AgentRequest-Handler-2:[]) (logid:9fdcf003) LibvirtException org.libvirt.LibvirtException: the CPU is incompatible with host CPU: Host CPU does not provide required features: hle, rtm, avx512-bf16, taa-no
```

3. Added the `systemvm.guest.cpu.features` property:

```bash
guest.cpu.mode=custom
guest.cpu.model=Cooperlake
guest.cpu.features=-hle -rtm -avx512-bf16 -taa-no
systemvm.guest.cpu.features=-hle -rtm -avx512-bf16 -taa-no
```

4. Restarted the Apache CloudStack Agent and verified that the deployment of system VMs was successfully accomplished.

<details>

<summary><code>virsh dumpxml --domain v-8-VM</code></summary>

```xml
<domain type='kvm' id='6'>
  <name>v-8-VM</name>
  <uuid>5401be72-ff16-44b5-b43a-efb56004aac2</uuid>
  <description>Debian GNU/Linux 12 (64-bit)</description>
  <memory unit='KiB'>1048576</memory>
  <currentMemory unit='KiB'>1048576</currentMemory>
  <vcpu placement='static'>1</vcpu>
  <cputune>
    <shares>278</shares>
  </cputune>
  <resource>
    <partition>/machine</partition>
  </resource>
  <sysinfo type='smbios'>
    <system>
      <entry name='manufacturer'>Apache Software Foundation</entry>
      <entry name='product'>CloudStack KVM Hypervisor</entry>
      <entry name='serial'>5401be72-ff16-44b5-b43a-efb56004aac2</entry>
      <entry name='uuid'>5401be72-ff16-44b5-b43a-efb56004aac2</entry>
    </system>
  </sysinfo>
  <os>
    <type arch='x86_64' machine='pc-i440fx-8.2'>hvm</type>
    <boot dev='cdrom'/>
    <boot dev='hd'/>
    <smbios mode='sysinfo'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <pae/>
  </features>
  <cpu mode='custom' match='exact' check='full'>
    <model fallback='forbid'>Cooperlake</model>
    <topology sockets='1' dies='1' cores='1' threads='1'/>
    <feature policy='disable' name='hle'/>
    <feature policy='disable' name='rtm'/>
    <feature policy='disable' name='avx512-bf16'/>
    <feature policy='disable' name='taa-no'/>
    <feature policy='require' name='hypervisor'/>
  </cpu>
  <clock offset='utc'>
    <timer name='kvmclock'/>
  </clock>
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>destroy</on_crash>
  <devices>
    <emulator>/usr/bin/qemu-system-x86_64</emulator>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/cb058c32-08a7-36ab-a540-8cee5f1a6b9f/f6d19465-c40b-4e23-bc0e-1dd07b1da7dc' index='2'/>
      <backingStore type='file' index='3'>
        <format type='qcow2'/>
        <source file='/mnt/cb058c32-08a7-36ab-a540-8cee5f1a6b9f/b7933756-0b58-4270-9ce2-fcc13ab02b63'/>
        <backingStore/>
      </backingStore>
      <target dev='vda' bus='virtio'/>
      <serial>f6d19465c40b4e23bc0e</serial>
      <alias name='virtio-disk0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <driver name='qemu'/>
      <target dev='hdc' bus='ide'/>
      <readonly/>
      <alias name='ide0-1-0'/>
      <address type='drive' controller='0' bus='1' target='0' unit='0'/>
    </disk>
    <controller type='usb' index='0' model='piix3-uhci'>
      <alias name='usb'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
    </controller>
    <controller type='pci' index='0' model='pci-root'>
      <alias name='pci.0'/>
    </controller>
    <controller type='ide' index='0'>
      <alias name='ide'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
    </controller>
    <controller type='virtio-serial' index='0'>
      <alias name='virtio-serial0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </controller>
    <interface type='bridge'>
      <mac address='0e:00:a9:fe:0f:9e'/>
      <source bridge='cloud0'/>
      <target dev='vnet7'/>
      <model type='virtio'/>
      <link state='up'/>
      <alias name='net0'/>
      <rom bar='off' file=''/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='1e:00:b7:00:00:01'/>
      <source bridge='cloudbr0'/>
      <target dev='vnet8'/>
      <model type='virtio'/>
      <link state='up'/>
      <alias name='net1'/>
      <rom bar='off' file=''/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='1e:00:40:00:00:0b'/>
      <source bridge='cloudbr0'/>
      <target dev='vnet9'/>
      <model type='virtio'/>
      <link state='up'/>
      <alias name='net2'/>
      <rom bar='off' file=''/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
    </interface>
    <serial type='pty'>
      <source path='/dev/pts/2'/>
      <target type='isa-serial' port='0'>
        <model name='isa-serial'/>
      </target>
      <alias name='serial0'/>
    </serial>
    <console type='pty' tty='/dev/pts/2'>
      <source path='/dev/pts/2'/>
      <target type='serial' port='0'/>
      <alias name='serial0'/>
    </console>
    <channel type='unix'>
      <source mode='bind' path='/var/lib/libvirt/qemu/v-8-VM.org.qemu.guest_agent.0'/>
      <target type='virtio' name='org.qemu.guest_agent.0' state='connected'/>
      <alias name='channel0'/>
      <address type='virtio-serial' controller='0' bus='0' port='1'/>
    </channel>
    <input type='tablet' bus='usb'>
      <alias name='input0'/>
      <address type='usb' bus='0' port='1'/>
    </input>
    <input type='mouse' bus='ps2'>
      <alias name='input1'/>
    </input>
    <input type='keyboard' bus='ps2'>
      <alias name='input2'/>
    </input>
    <graphics type='vnc' port='5901' autoport='yes' listen='192.168.100.230'>
      <listen type='address' address='192.168.100.230'/>
    </graphics>
    <audio id='1' type='none'/>
    <video>
      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
      <alias name='video0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
    </video>
    <watchdog model='i6300esb' action='none'>
      <alias name='watchdog0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
    </watchdog>
    <memballoon model='virtio'>
      <alias name='balloon0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
    </memballoon>
  </devices>
  <seclabel type='dynamic' model='dac' relabel='yes'>
    <label>+0:+0</label>
    <imagelabel>+0:+0</imagelabel>
  </seclabel>
</domain>
```

</details>
