### PR TITLE
IPv6 firewall: accept packets from related and established connections

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -232,7 +232,7 @@ class CsNetfilters(object):
         if hook == "input" or hook == "output":
             CsHelper.execute("nft add rule %s %s %s icmpv6 type { echo-request, echo-reply, \
                 nd-neighbor-solicit, nd-router-advert, nd-neighbor-advert } accept" % (address_family, table, chain))
-        if hook == "input" or hook == "forward":
+        elif hook == "forward":
             CsHelper.execute("nft add rule %s %s %s ct state established,related accept" % (address_family, table, chain))
 
     def add_ip4_chain(self, address_family, table, chain, hook, action):

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -232,6 +232,8 @@ class CsNetfilters(object):
         if hook == "input" or hook == "output":
             CsHelper.execute("nft add rule %s %s %s icmpv6 type { echo-request, echo-reply, \
                 nd-neighbor-solicit, nd-router-advert, nd-neighbor-advert } accept" % (address_family, table, chain))
+        if hook == "input" or hook == "forward":
+            CsHelper.execute("nft add rule %s %s %s ct state established,related accept" % (address_family, table, chain))
 
     def add_ip4_chain(self, address_family, table, chain, hook, action):
         chain_policy = ""


### PR DESCRIPTION
### Description

The VR's firewall service automatically accepts packets from related and established connections when using IPv4. However, it does not for IPv6. Due to this, even if the egress rules allow a VM to send requests to a machine from outside the isolated network, it will not receive the response unless operators have allowed all ingress for the (sometimes dynamically allocated) port.

This PR adds a rule to the VR's IPv6 forward chain accepting response traffic (ingress from related and established connections), even if the operator has not explicitly allowed all ingress for the ports, thus matching the IPv4 firewall's behavior.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor


### How Has This Been Tested?

1. I introduced an IPv6 range to my environment.

2. I created a network offering for IPv6.

3. I created an isolated network with the network offering.

4. I added a VM to the network.

Then, I performed the following tests:

1. I validated that the VR had nftables rules in the forward and input chains allowing the ingress of related packets and packets from established connections.

2. Inside the VM, I tried to download a file from a machine outside the isolated network using IPv6. I validated that the download did not begin, because the egress traffic was not allowed.

3. I allowed the egress for ports 80 and 443.

4. Inside the VM, I tried to download a file from a machine outside the isolated network using IPv6 again. This time, the file was download successfully. Before the changes, the file would not be downloaded, because the VR was rejecting the response traffic.

5. I tried to login into the VM using SSH and IPv6. I validated that it was not possible because the ingress traffic for port 22 was not allowed.

6. I allowed ingress for port 22, and tried to login into the VM using SSH and IPv6 one more time. This time, I was able to access the VM successfully.