### PR TITLE
[Vmware to KVM Migration] Preserve boot type and boot mode of instances to be migrated

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -728,6 +728,18 @@
             <span v-else>{{ resource.webhookname || resource.webhookid }}</span>
           </div>
         </div>
+        <div class="resource-detail-item" v-if="resource.boottype">
+          <div class="resource-detail-item__label">{{ $t('label.boottype') }}</div>
+          <div class="resource-detail-item__details">
+            <span>{{ resource.boottype }}</span>
+          </div>
+        </div>
+        <div class="resource-detail-item" v-if="resource.bootmode">
+          <div class="resource-detail-item__label">{{ $t('label.bootmode') }}</div>
+          <div class="resource-detail-item__details">
+            <span>{{ resource.bootmode }}</span>
+          </div>
+        </div>
         <div class="resource-detail-item" v-if="resource.managementserverid">
           <div class="resource-detail-item__label">{{ $t('label.management.servers') }}</div>
           <div class="resource-detail-item__details">


### PR DESCRIPTION
### Description

This PR ensures the converted/imported instances preserve the source VM boot mode and boot type.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Verify the source VM boot type and boot mode before importing:
![image](https://github.com/user-attachments/assets/3cb7d161-db0d-4249-8c86-241bb1fbf11b)
- Import Vmware VM using KVM host for conversion having virt-v2v and ovftool installed
- Verify the imported VM contains the expected boot mode and boot type:
<img width="1035" alt="Screenshot 2025-06-05 at 22 01 49" src="https://github.com/user-attachments/assets/554edf0a-efff-4726-bac5-5dc6d83de641" />



#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
