### PR TITLE
Fix data being replicated on VM's metadata file in VR

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -908,6 +908,7 @@ class CsVmMetadata(CsDataBag):
             if os.path.exists(metamanifest):
                 fh = open(metamanifest, "a+")
                 self.__exflock(fh)
+                fh.seek(0)
                 if file not in fh.read():
                     fh.write(file + '\n')
                 self.__unflock(fh)


### PR DESCRIPTION
### Description

While creating VMs, ACS configures HTTPd on the VR to serve metadata files to be consumed by CloudInit. However, the file `/var/www/html/meta-data/<vm-ip>/metadata` is appended with the same content every time a VM is started through CloudStack, causing the file to have replicated lines; as VMs are created/started, this file grows _ad infinitum_, consuming the VR's storage, and making Apache HTTPd consume more memory than it should. 

This PR intends to fix this metadata replication on the VRs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Without the changes:
1. I created a network;
2. I created a VM;
3. I checked the VM's metadata file in the VR, and observed that it had only a single entry for each attribute;
4. I checked the metadata in the VM;
5. I stopped the VM;
6. I started the VM again;
7. I checked that the VM's metadata file in the VR had duplicated entries for every attribute;
8. I checked the metadata in the VM;


With the changes:
1. I created a network;
2. I created a VM;
3. I checked the VM's metadata file in the VR, and observed that it had only a single entry for each attribute;
4. I checked the metadata in the VM;
5. I stopped the VM;
6. I started the VM again;
7. I checked the VM's metadata file in the VR, and observed that it had only a single entry for each attribute;
8. I checked the metadata in the VM;
