### PR TITLE
Block volume shrink on Xen

### DIFF
--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixResizeVolumeCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixResizeVolumeCommandWrapper.java
@@ -49,9 +49,12 @@ public final class CitrixResizeVolumeCommandWrapper extends CommandWrapper<Resiz
 
         try {
 
-            if (command.getCurrentSize() >= newSize) {
-                logger.info("No need to resize volume: " + volId +", current size " + toHumanReadableSize(command.getCurrentSize()) + " is same as  new size " + toHumanReadableSize(newSize));
+            if (command.getCurrentSize() == newSize) {
+                logger.info("No need to resize volume [{}], current size [{}] is same as new size [{}].", volId, toHumanReadableSize(command.getCurrentSize()), toHumanReadableSize(newSize));
                 return new ResizeVolumeAnswer(command, true, "success", newSize);
+            } else if (command.getCurrentSize() > newSize) {
+                logger.error("XenServer does not support volume shrink. Volume [{}] current size [{}] is smaller than new size [{}]", volId, toHumanReadableSize(command.getCurrentSize()), toHumanReadableSize(newSize));
+                return new ResizeVolumeAnswer(command, false, "operation not supported");
             }
             if (command.isManaged()) {
                 resizeSr(conn, command);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2429,6 +2429,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     throw new InvalidParameterValueException("Going from existing size of " + currentSize + " to size of " + newSize + " would shrink the volume."
                             + "Need to sign off by supplying the shrinkok parameter with value of true.");
                 }
+                if (ApiDBUtils.getHypervisorTypeFromFormat(volume.getDataCenterId(), volume.getFormat()) == HypervisorType.XenServer) {
+                    throw new InvalidParameterValueException("Shrink volume is not supported for the XenServer hypervisor.");
+                }
             }
         }
         /* Check resource limit for this account */

--- a/ui/src/views/storage/ChangeOfferingForVolume.vue
+++ b/ui/src/views/storage/ChangeOfferingForVolume.vue
@@ -90,7 +90,7 @@
         :checked="autoMigrate"
         @change="val => { autoMigrate = val }"/>
     </a-form-item>
-    <a-form-item name="shrinkOk" ref="shrinkOk" :label="$t('label.shrinkok')">
+    <a-form-item name="shrinkOk" ref="shrinkOk" :label="$t('label.shrinkok')" v-if="!['XenServer'].includes(resource.hypervisor)">
       <a-switch
         v-model:checked="form.shrinkOk"
         :checked="shrinkOk"


### PR DESCRIPTION
### Description

On version `4.16.1.0` PR #5829 blocked volume shrinking via UI when using XenServer. However, this change was not sufficient, as the user may still use the APIs directly to try to shrink their volume. Furthermore, via UI, it is still possible to inform the shrink option when changing disk offerings. This PR removes that option from the UI; also, the `resizeVolume` and `changeOfferingForVolume` APIs were changed to block this type of operation when using XenServer, similar to what is done when using QCOW2.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
Here’s the English translation of your Markdown content:

---

### Test Description

Via UI, I validated that the shrink option no longer appears for XenServer volumes:

* Before:
  ![image](https://github.com/user-attachments/assets/1b8e8f85-1f74-4fad-8782-f5defbd3dbba)

* After:
 ![image](https://github.com/user-attachments/assets/269edd19-c033-4058-b71f-aef7c60c469d)

Via CMK, I validated that both APIs block the use of the parameter for XenServer:

```
(labinterno) 🐱 > change offeringforvolume id=53abae9c-ec2f-4ce3-964d-11981348d2e6 diskofferingid=9aac832e-cdc0-429a-87b5-7b6209111a5d size=10 shrinkok=true
{
  "jobid": "a674a9ae-4ec9-45eb-b2fb-6ee438c60645"
}
(labinterno) 🐱 > query asyncjobresult jobid=a674a9ae-4ec9-45eb-b2fb-6ee438c60645
...
  "errorcode": 431,
  "errortext": "Shrink volume is not supported for the XenServer hypervisor."
...
```

```
(labinterno) 🐱 > resize volume id=53abae9c-ec2f-4ce3-964d-11981348d2e6 size=28 shrinkok=true
{
  "jobid": "954da1c8-e107-41d4-a64c-5e15bfeec676"
}
(labinterno) 🐱 > query asyncjobresult jobid=954da1c8-e107-41d4-a64c-5e15bfeec676
...
  "errorcode": 432,
  "errortext": "Shrink volume is not supported for the XenServer hypervisor."
...
```

I also verified that the APIs still work correctly without using shrink:

```
(labinterno) 🐱 > change offeringforvolume id=53abae9c-ec2f-4ce3-964d-11981348d2e6 diskofferingid=9aac832e-cdc0-429a-87b5-7b6209111a5d size=100 shrinkok=true
{
  "jobid": "59934dc9-a6e8-42cc-802f-43004d705e2f"
}
(labinterno) 🐱 > query asyncjobresult jobid=59934dc9-a6e8-42cc-802f-43004d705e2f
...
  "jobresultcode": 0,
  "jobstatus": 1,
...
```

```
(labinterno) 🐱 > resize volume id=53abae9c-ec2f-4ce3-964d-11981348d2e6 size=30
{
  "jobid": "5848d956-75b3-43bb-acbc-5c3caf3cc9c4"
}
(labinterno) 🐱 > query asyncjobresult jobid=5848d956-75b3-43bb-acbc-5c3caf3cc9c4
...
  "jobresultcode": 0,
  "jobstatus": 1,
...
```