### PR TITLE
docs: fix outdated Maven subtitle in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ Install tools and dependencies used for development:
     # yum -y install git java-17-openjdk java-17-openjdk-devel \
       mysql mysql-server mkisofs git gcc python MySQL-python openssh-clients wget
 
-Set up Maven (3.6.0):
+Set up Maven (3.9.9):
 
     # wget https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
     # tar -zxvf apache-maven-3.9.9-bin.tar.gz -C /usr/local


### PR DESCRIPTION
### Description

This PR updates the Maven setup subtitle in INSTALL.md to reflect the correct version (3.9.9), aligning it with the updated download URL introduced in [PR #10800](https://github.com/apache/cloudstack/pull/10800).

In that PR, the download link for Maven was correctly updated from 3.6.0 to 3.9.9, but the subtitle above the instructions still referenced the older version (3.6.0). This follow-up change ensures consistency and clarity.


<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested by reviewing the Markdown.
