### PR TITLE
[Vmware to KVM Migration] Display virt-v2v and ovftool versions for supported hosts for migration

### DIFF
--- a/api/src/main/java/com/cloud/host/Host.java
+++ b/api/src/main/java/com/cloud/host/Host.java
@@ -57,6 +57,10 @@ public interface Host extends StateObject<Status>, Identity, Partition, HAResour
     public static final String HOST_VOLUME_ENCRYPTION = "host.volume.encryption";
     public static final String HOST_INSTANCE_CONVERSION = "host.instance.conversion";
 
+    // Vmware to KVM Migration
+    String KVM_HOST_OVFTOOL_VERSION = "kvm.host.ovftool.version";
+    String KVM_HOST_VIRTV2V_VERSION = "kvm.host.virtv2v.version";
+
     /**
      * @return name of the machine.
      */

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -54,6 +54,7 @@ import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.ThreadContext;
 
@@ -703,11 +704,25 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
             Map<String, String> detailsMap = readyAnswer.getDetailsMap();
             if (detailsMap != null) {
                 String uefiEnabled = detailsMap.get(Host.HOST_UEFI_ENABLE);
+                String virtv2vVersion = detailsMap.get(Host.KVM_HOST_VIRTV2V_VERSION);
+                String ovftoolVersion = detailsMap.get(Host.KVM_HOST_OVFTOOL_VERSION);
                 logger.debug("Got HOST_UEFI_ENABLE [{}] for host [{}]:", uefiEnabled, host);
-                if (uefiEnabled != null) {
+                if (ObjectUtils.anyNotNull(uefiEnabled, virtv2vVersion, ovftoolVersion)) {
                     _hostDao.loadDetails(host);
+                    boolean updateNeeded = false;
                     if (!uefiEnabled.equals(host.getDetails().get(Host.HOST_UEFI_ENABLE))) {
                         host.getDetails().put(Host.HOST_UEFI_ENABLE, uefiEnabled);
+                        updateNeeded = true;
+                    }
+                    if (StringUtils.isNotBlank(virtv2vVersion) && !virtv2vVersion.equals(host.getDetails().get(Host.KVM_HOST_VIRTV2V_VERSION))) {
+                        host.getDetails().put(Host.KVM_HOST_VIRTV2V_VERSION, virtv2vVersion);
+                        updateNeeded = true;
+                    }
+                    if (StringUtils.isNotBlank(ovftoolVersion) && !ovftoolVersion.equals(host.getDetails().get(Host.KVM_HOST_OVFTOOL_VERSION))) {
+                        host.getDetails().put(Host.KVM_HOST_OVFTOOL_VERSION, ovftoolVersion);
+                        updateNeeded = true;
+                    }
+                    if (updateNeeded) {
                         _hostDao.saveDetails(host);
                     }
                 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -5368,8 +5368,17 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return exitValue == 0;
     }
 
+    public String getHostVirtV2vVersion() {
+        String cmd = String.format("%s | awk '{print $2}'", INSTANCE_CONVERSION_SUPPORTED_CHECK_CMD);
+        return Script.runSimpleBashScript(cmd);
+    }
+
+    public String getHostOvfToolVersion() {
+        return Script.runSimpleBashScript(OVF_EXPORT_TOOl_GET_VERSION_CMD);
+    }
+
     public boolean ovfExportToolSupportsParallelThreads() {
-        String ovfExportToolVersion = Script.runSimpleBashScript(OVF_EXPORT_TOOl_GET_VERSION_CMD);
+        String ovfExportToolVersion = getHostOvfToolVersion();
         if (StringUtils.isBlank(ovfExportToolVersion)) {
             return false;
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -47,6 +47,14 @@ public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyComman
             hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
         }
 
+        if (libvirtComputingResource.hostSupportsInstanceConversion()) {
+            hostDetails.put(Host.KVM_HOST_VIRTV2V_VERSION, libvirtComputingResource.getHostVirtV2vVersion());
+        }
+
+        if (libvirtComputingResource.hostSupportsOvfExport()) {
+            hostDetails.put(Host.KVM_HOST_OVFTOOL_VERSION, libvirtComputingResource.getHostOvfToolVersion());
+        }
+
         return new ReadyAnswer(command, hostDetails);
     }
 

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -948,7 +948,7 @@ export default {
             host.name = host.name + ' (virt-v2v=' + host.details['kvm.host.virtv2v.version'] + ')'
           }
           if (host.details['kvm.host.ovftool.version']) {
-            host.name = host.name + ' (ovftool=' + host.details['kvm.host.virtv2v.version'] + ')'
+            host.name = host.name + ' (ovftool=' + host.details['kvm.host.ovftool.version'] + ')'
           }
         })
       })

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -944,6 +944,12 @@ export default {
           } else {
             host.name = host.name + ' (' + this.$t('label.not.supported') + ')'
           }
+          if (host.details['kvm.host.virtv2v.version']) {
+            host.name = host.name + ' (virt-v2v=' + host.details['kvm.host.virtv2v.version'] + ')'
+          }
+          if (host.details['kvm.host.ovftool.version']) {
+            host.name = host.name + ' (ovftool=' + host.details['kvm.host.virtv2v.version'] + ')'
+          }
         })
       })
     },


### PR DESCRIPTION
### Description

This PR extends the VMware to KVM Migration tool by displaying the `virt-v2v` and `ovftool` versions (when available) on the UI and storing them as host details.

<img width="951" alt="Screenshot 2025-06-12 at 16 38 57" src="https://github.com/user-attachments/assets/a9ac4a40-c987-430c-bc85-45657648863e" />


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested on KVM env with 2 Ubuntu 24.04 hosts:
- Installed virt-v2v in one host -> Verified only virt-v2v version is listed when selecting a host for migration
- Installed ovftool on the same host -> Verify also ovftool is displayed when selecting a host for migration

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
