### PR TITLE
docs: revise INSTALL.md with updated Maven setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,12 +18,12 @@ Install tools and dependencies used for development:
     # yum -y install git java-17-openjdk java-17-openjdk-devel \
       mysql mysql-server mkisofs git gcc python MySQL-python openssh-clients wget
 
-Set up Maven (3.9.9):
+Set up Maven (3.9.10):
 
-    # wget https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
-    # tar -zxvf apache-maven-3.9.9-bin.tar.gz -C /usr/local
+    # wget https://downloads.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
+    # sudo tar -zxvf apache-maven-3.9.10-bin.tar.gz -C /usr/local
     # cd /usr/local
-    # ln -s apache-maven-3.9.9 maven
+    # sudo ln -s apache-maven-3.9.10 maven
     # echo export M2_HOME=/usr/local/maven >> ~/.bashrc # or .zshrc or .profile
     # echo export PATH=/usr/local/maven/bin:${PATH} >> ~/.bashrc # or .zshrc or .profile
     # source ~/.bashrc

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ Install tools and dependencies used for development:
 
 Set up Maven (3.9.10):
 
-    # wget https://downloads.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
+    # wget https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
     # sudo tar -zxvf apache-maven-3.9.10-bin.tar.gz -C /usr/local
     # cd /usr/local
     # sudo ln -s apache-maven-3.9.10 maven


### PR DESCRIPTION
### Description

This PR updates the Maven installation instructions in INSTALL.md.
While following the setup steps to build CloudStack locally as a new contributor, I found that the provided download link for Maven 3.9.9 is no longer active, and the version itself is not listed on the [official Apache Maven distribution site](https://dlcdn.apache.org/maven/maven-3/).
I’ve updated the instructions to use Maven 3.9.10, which is the most up-to-date version at the time of writing.

Additionally, I added sudo to the tar and ln commands since those require root permission when extracting to or linking under /usr/local.

This small patch improves the onboarding experience for new developers setting up their environment.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ab95b05e-a07e-4f01-8688-d654474db4fb)

### How Has This Been Tested?
I manually tested by following the updated instructions to set up Maven 3.9.10 on a fresh environment. 

#### How did you try to break this feature and the system with this change?
Maven 3.x on [official Apache Maven distribution site](https://dlcdn.apache.org/maven/maven-3/).
