### PR TITLE
[Vmware to KVM Migration] Improve the Force MS option text

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1005,7 +1005,7 @@
 "label.for": "for",
 "label.forbidden": "Forbidden",
 "label.forced": "Force",
-"label.force.ms.to.import.vm.files": "Enable to force Management Server to export OVF from VMware to temporary storage. Disable to use KVM Host ovftool (if installed)",
+"label.force.ms.to.import.vm.files": "Enable to force OVF Download via Management Server. Disable to use KVM Host ovftool (if installed)",
 "label.force.stop": "Force stop",
 "label.force.reboot": "Force reboot",
 "label.forceencap": "Force UDP encapsulation of ESP packets",


### PR DESCRIPTION
### Description

This PR improves the text from the `Force MS download` option on the Vmware to KVM migration dialog:

<img width="1314" alt="Screenshot 2025-06-16 at 11 20 35" src="https://github.com/user-attachments/assets/e8ebb86f-fb86-48d3-a205-30ef08fc2f2e" />

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
