### PR TITLE
PowerFlex/ScaleIO - MDM and host SDC connection enhancements

### DIFF
--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -833,7 +833,7 @@ public class AgentProperties{
         private T defaultValue;
         private Class<T> typeClass;
 
-        Property(String name, T value) {
+        public Property(String name, T value) {
             init(name, value);
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtModifyStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtModifyStoragePoolCommandWrapper.java
@@ -31,6 +31,7 @@ import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
 import com.cloud.storage.template.TemplateProp;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 @ResourceWrapper(handles =  ModifyStoragePoolCommand.class)
 public final class LibvirtModifyStoragePoolCommandWrapper extends CommandWrapper<ModifyStoragePoolCommand, Answer, LibvirtComputingResource> {
@@ -49,11 +50,16 @@ public final class LibvirtModifyStoragePoolCommandWrapper extends CommandWrapper
             return answer;
         }
 
-        final KVMStoragePool storagepool =
-                storagePoolMgr.createStoragePool(command.getPool().getUuid(), command.getPool().getHost(), command.getPool().getPort(), command.getPool().getPath(), command.getPool()
-                        .getUserInfo(), command.getPool().getType(), command.getDetails());
-        if (storagepool == null) {
-            return new Answer(command, false, " Failed to create storage pool");
+        final KVMStoragePool storagepool;
+        try {
+            storagepool =
+                    storagePoolMgr.createStoragePool(command.getPool().getUuid(), command.getPool().getHost(), command.getPool().getPort(), command.getPool().getPath(), command.getPool()
+                            .getUserInfo(), command.getPool().getType(), command.getDetails());
+            if (storagepool == null) {
+                return new Answer(command, false, " Failed to create storage pool");
+            }
+        } catch (CloudRuntimeException e) {
+            return new Answer(command, false, String.format("Failed to create storage pool: %s", e.getLocalizedMessage()));
         }
 
         final Map<String, TemplateProp> tInfo = new HashMap<String, TemplateProp>();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
@@ -178,7 +178,6 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
      * @throws CloudRuntimeException in case if Storage Pool is not operate-able
      */
     private void validateMdmState(Map<String, String> details) {
-
         String configKey = ScaleIOSDCManager.ValidateMdmsOnConnect.key();
         String configValue = details.get(configKey);
 
@@ -689,8 +688,7 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
                 if (!ScaleIOUtil.isMdmPresent(mdmAddresses[0])) {
                     return new Pair<>(true, "MDM not added, no need to unprepare the SDC client");
                 } else {
-                    String configKey =
-                            details.get(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key());
+                    String configKey = ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key();
                     String configValue = details.get(configKey);
 
                     if (StringUtils.isEmpty(configValue)) {
@@ -698,7 +696,7 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
                     } else {
                         LOGGER.debug(String.format("Configuration key %s provided as %s", configKey, configValue));
                     }
-                    Boolean blockUnprepare = Boolean.valueOf(configKey);
+                    Boolean blockUnprepare = Boolean.valueOf(configValue);
                     if (!ScaleIOUtil.isRemoveMdmCliSupported() && !ScaleIOUtil.getVolumeIds().isEmpty() && Boolean.TRUE.equals(blockUnprepare)) {
                         return new Pair<>(false, "Failed to remove MDMs, SDC client requires service to be restarted, but there are Volumes attached to the Host");
                     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
@@ -791,7 +791,9 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
 
         int numberOfTries = 5;
         int timeBetweenTries = 1000; // Try more frequently (every sec) and return early when SDC Id or Guid found
+        int attempt = 1;
         do {
+            logger.debug("Get SDC details, attempt #{}", attempt);
             String sdcId = ScaleIOUtil.getSdcId(storageSystemId);
             if (sdcId != null) {
                 sdcDetails.put(ScaleIOGatewayClient.SDC_ID, sdcId);
@@ -809,6 +811,7 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
             } catch (Exception ignore) {
             }
             numberOfTries--;
+            attempt++;
         } while (numberOfTries > 0);
 
         return sdcDetails;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
@@ -688,8 +688,20 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
             if (mdmAddresses.length > 0) {
                 if (!ScaleIOUtil.isMdmPresent(mdmAddresses[0])) {
                     return new Pair<>(true, "MDM not added, no need to unprepare the SDC client");
-                } else if (!ScaleIOUtil.isRemoveMdmCliSupported() && !ScaleIOUtil.getVolumeIds().isEmpty()) {
-                    return new Pair<>(false, "Failed to remove MDMs, SDC client requires service to be restarted, but there are Volumes attached to the Host");
+                } else {
+                    String configKey =
+                            details.get(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key());
+                    String configValue = details.get(configKey);
+
+                    if (StringUtils.isEmpty(configValue)) {
+                        LOGGER.debug(String.format("Configuration key %s not provided", configKey));
+                    } else {
+                        LOGGER.debug(String.format("Configuration key %s provided as %s", configKey, configValue));
+                    }
+                    Boolean blockUnprepare = Boolean.valueOf(configKey);
+                    if (!ScaleIOUtil.isRemoveMdmCliSupported() && !ScaleIOUtil.getVolumeIds().isEmpty() && Boolean.TRUE.equals(blockUnprepare)) {
+                        return new Pair<>(false, "Failed to remove MDMs, SDC client requires service to be restarted, but there are Volumes attached to the Host");
+                    }
                 }
 
                 ScaleIOUtil.removeMdms(mdmAddresses);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
@@ -40,6 +40,7 @@ import org.apache.cloudstack.utils.qemu.QemuImg;
 import org.apache.cloudstack.utils.qemu.QemuImgException;
 import org.apache.cloudstack.utils.qemu.QemuImgFile;
 import org.apache.cloudstack.utils.qemu.QemuObject;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -643,12 +644,13 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
         }
 
         if (!ScaleIOUtil.isSDCServiceActive()) {
+            logger.debug("SDC service is not active on host, starting it");
             if (!ScaleIOUtil.startSDCService()) {
                 return new Ternary<>(false, null, "Couldn't start SDC service on host");
             }
         }
 
-        if (details != null && details.containsKey(ScaleIOGatewayClient.STORAGE_POOL_MDMS)) {
+        if (MapUtils.isNotEmpty(details) && details.containsKey(ScaleIOGatewayClient.STORAGE_POOL_MDMS)) {
             // Assuming SDC service is started, add mdms
             String mdms = details.get(ScaleIOGatewayClient.STORAGE_POOL_MDMS);
             String[] mdmAddresses = mdms.split(",");
@@ -667,7 +669,12 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
             }
         }
 
-        return new Ternary<>( true, getSDCDetails(details), "Prepared client successfully");
+        Map<String, String> sdcDetails = getSDCDetails(details);
+        if (MapUtils.isEmpty(sdcDetails)) {
+            return new Ternary<>(false, null, "Couldn't get the SDC details on the host");
+        }
+
+        return new Ternary<>(true, sdcDetails, "Prepared client successfully");
     }
 
     public Pair<Boolean, String> unprepareStorageClient(String uuid, Map<String, String> details) {
@@ -758,20 +765,37 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
 
     private Map<String, String> getSDCDetails(Map<String, String> details) {
         Map<String, String> sdcDetails = new HashMap<String, String>();
-        if (details == null || !details.containsKey(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID))  {
+        if (MapUtils.isEmpty(details) || !details.containsKey(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID))  {
             return sdcDetails;
         }
 
         String storageSystemId = details.get(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
-        String sdcId = ScaleIOUtil.getSdcId(storageSystemId);
-        if (sdcId != null) {
-            sdcDetails.put(ScaleIOGatewayClient.SDC_ID, sdcId);
-        } else {
+        if (StringUtils.isEmpty(storageSystemId)) {
+            return sdcDetails;
+        }
+
+        int waitTimeInSecs = 5;
+        int timeBetweenTries = 1000; // Try more frequently (every sec) and return early when SDC Id or Guid found
+        do {
+            String sdcId = ScaleIOUtil.getSdcId(storageSystemId);
+            if (sdcId != null) {
+                sdcDetails.put(ScaleIOGatewayClient.SDC_ID, sdcId);
+                return sdcDetails;
+            }
+
             String sdcGuId = ScaleIOUtil.getSdcGuid();
             if (sdcGuId != null) {
                 sdcDetails.put(ScaleIOGatewayClient.SDC_GUID, sdcGuId);
+                return sdcDetails;
             }
-        }
+
+            try {
+                Thread.sleep(timeBetweenTries);
+            } catch (Exception ignore) {
+            }
+            waitTimeInSecs--;
+        } while (waitTimeInSecs > 0);
+
         return sdcDetails;
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptor.java
@@ -183,16 +183,16 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
 
         // be as much verbose as possible, otherwise it will be difficult to troubleshoot operational issue without logs
         if (StringUtils.isEmpty(configValue)) {
-            LOGGER.debug(String.format("Skipped ScaleIO validation as property %s not sent by Management Server", configKey));
+            logger.debug(String.format("Skipped ScaleIO validation as property %s not sent by Management Server", configKey));
         } else if (Boolean.valueOf(configValue).equals(Boolean.FALSE)) {
-            LOGGER.debug(String.format("Skipped ScaleIO validation as property %s received as %s", configKey, configValue));
+            logger.debug(String.format("Skipped ScaleIO validation as property %s received as %s", configKey, configValue));
         } else {
             Collection<String> mdmsConfig = ScaleIOUtil.getMdmsFromConfig();
             Collection<String> mdmsCli = ScaleIOUtil.getMdmsFromCli();
             if (!mdmsCli.equals(mdmsConfig)) {
                 String msg = String.format("MDM addresses from memory and configuration file don't match. " +
                         "Memory values: %s, configuration file values: %s", mdmsCli, mdmsConfig);
-                LOGGER.warn(msg);
+                logger.warn(msg);
                 throw new CloudRuntimeException(msg);
             }
         }
@@ -661,7 +661,7 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
                 if (!ScaleIOUtil.isMdmPresent(mdmAddresses[0])) {
                     return new Ternary<>(false, null, "Failed to add MDMs");
                 } else {
-                    LOGGER.debug(String.format("MDMs %s added to storage pool %s", mdms, uuid));
+                    logger.debug(String.format("MDMs %s added to storage pool %s", mdms, uuid));
                     applyTimeout(details);
                 }
             }
@@ -692,9 +692,9 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
                     String configValue = details.get(configKey);
 
                     if (StringUtils.isEmpty(configValue)) {
-                        LOGGER.debug(String.format("Configuration key %s not provided", configKey));
+                        logger.debug(String.format("Configuration key %s not provided", configKey));
                     } else {
-                        LOGGER.debug(String.format("Configuration key %s provided as %s", configKey, configValue));
+                        logger.debug(String.format("Configuration key %s provided as %s", configKey, configValue));
                     }
                     Boolean blockUnprepare = Boolean.valueOf(configValue);
                     if (!ScaleIOUtil.isRemoveMdmCliSupported() && !ScaleIOUtil.getVolumeIds().isEmpty() && Boolean.TRUE.equals(blockUnprepare)) {
@@ -706,7 +706,7 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
                 if (ScaleIOUtil.isMdmPresent(mdmAddresses[0])) {
                     return new Pair<>(false, "Failed to remove MDMs, unable to unprepare the SDC client");
                 } else {
-                    LOGGER.debug(String.format("MDMs %s removed from storage pool %s", mdms, uuid));
+                    logger.debug(String.format("MDMs %s removed from storage pool %s", mdms, uuid));
                     applyTimeout(details);
                 }
             }
@@ -735,24 +735,24 @@ public class ScaleIOStorageAdaptor implements StorageAdaptor {
         String configValue = details.get(configKey);
 
         if (StringUtils.isEmpty(configValue)) {
-            LOGGER.debug(String.format("Apply timeout value not defined in property %s, skip", configKey));
+            logger.debug(String.format("Apply timeout value not defined in property %s, skip", configKey));
             return;
         }
         long timeoutMs;
         try {
             timeoutMs = Long.parseLong(configValue);
         } catch (NumberFormatException e) {
-            LOGGER.warn(String.format("Invalid apply timeout value defined in property %s, skip", configKey), e);
+            logger.warn(String.format("Invalid apply timeout value defined in property %s, skip", configKey), e);
             return;
         }
         if (timeoutMs < 1) {
-            LOGGER.warn(String.format("Apply timeout value is too small (%s ms), skipping", timeoutMs));
+            logger.warn(String.format("Apply timeout value is too small (%s ms), skipping", timeoutMs));
             return;
         }
         try {
             Thread.sleep(timeoutMs);
         } catch (InterruptedException e) {
-            LOGGER.warn(String.format("Apply timeout %s ms interrupted", timeoutMs), e);
+            logger.warn(String.format("Apply timeout %s ms interrupted", timeoutMs), e);
         }
     }
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
@@ -180,7 +180,7 @@ public class ScaleIOStorageAdaptorTest {
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, "1.1.1.1,2.2.2.2");
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl status scini"))).thenReturn(3);
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl is-enabled scini"))).thenReturn(0);
-        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-3.3.3.3 [1]-4.4.4.4");
+        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-3.3.3.3 [1]-4.4.4.4");
 
         Pair<Boolean, String> result = scaleIOStorageAdaptor.unprepareStorageClient(poolUuid, details);
 
@@ -196,9 +196,9 @@ public class ScaleIOStorageAdaptorTest {
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl is-enabled scini"))).thenReturn(0);
         when(Script.executeCommand(Mockito.eq("sed -i '/1.1.1.1\\,/d' /etc/emc/scaleio/drv_cfg.txt"))).thenReturn(new Pair<>(null, null));
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl restart scini"))).thenReturn(0);
-        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-1.1.1.1 [1]-2.2.2.2");
+        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-1.1.1.1 [1]-2.2.2.2");
         when(Script.executeCommand(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg"))).thenReturn(new Pair<>(null, null));
-        when(Script.executeCommand(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_vols --file /etc/emc/scaleio/drv_cfg.txt"))).thenReturn(new Pair<>("", null));
+        when(Script.executeCommand(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_vols"))).thenReturn(new Pair<>("", null));
 
 
         Pair<Boolean, String> result = scaleIOStorageAdaptor.unprepareStorageClient(poolUuid, details);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
@@ -180,7 +180,7 @@ public class ScaleIOStorageAdaptorTest {
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, "1.1.1.1,2.2.2.2");
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl status scini"))).thenReturn(3);
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl is-enabled scini"))).thenReturn(0);
-        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-3.3.3.3 [1]-4.4.4.4");
+        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-3.3.3.3 [1]-4.4.4.4");
 
         Pair<Boolean, String> result = scaleIOStorageAdaptor.unprepareStorageClient(poolUuid, details);
 
@@ -195,7 +195,10 @@ public class ScaleIOStorageAdaptorTest {
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl status scini"))).thenReturn(3);
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl is-enabled scini"))).thenReturn(0);
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl restart scini"))).thenReturn(0);
-        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-1.1.1.1 [1]-2.2.2.2");
+        when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-1.1.1.1 [1]-2.2.2.2");
+        when(Script.executeCommand(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg"))).thenReturn(new Pair<>(null, null));
+        when(Script.executeCommand(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_vols --file /etc/emc/scaleio/drv_cfg.txt"))).thenReturn(new Pair<>("", null));
+
 
         Pair<Boolean, String> result = scaleIOStorageAdaptor.unprepareStorageClient(poolUuid, details);
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStorageAdaptorTest.java
@@ -194,6 +194,7 @@ public class ScaleIOStorageAdaptorTest {
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, "1.1.1.1,2.2.2.2");
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl status scini"))).thenReturn(3);
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl is-enabled scini"))).thenReturn(0);
+        when(Script.executeCommand(Mockito.eq("sed -i '/1.1.1.1\\,/d' /etc/emc/scaleio/drv_cfg.txt"))).thenReturn(new Pair<>(null, null));
         when(Script.runSimpleBashScriptForExitValue(Mockito.eq("systemctl restart scini"))).thenReturn(0);
         when(Script.runSimpleBashScript(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 1.1.1.1"))).thenReturn("MDM-ID 71fd458f0775010f SDC ID 4421a91a00000000 INSTALLATION ID 204930df2cbcaf8e IPs [0]-1.1.1.1 [1]-2.2.2.2");
         when(Script.executeCommand(Mockito.eq("/opt/emc/scaleio/sdc/bin/drv_cfg"))).thenReturn(new Pair<>(null, null));

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStoragePoolTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStoragePoolTest.java
@@ -96,7 +96,7 @@ public class ScaleIOStoragePoolTest {
 
         try (MockedStatic<Script> ignored = Mockito.mockStatic(Script.class)) {
             when(Script.runSimpleBashScript(
-                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
+                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
                     sdcId);
 
             ScaleIOStoragePool pool1 = new ScaleIOStoragePool(uuid, "192.168.1.19", 443, "a519be2f00000000", type,
@@ -117,9 +117,9 @@ public class ScaleIOStoragePoolTest {
 
         try (MockedStatic<Script> ignored = Mockito.mockStatic(Script.class)) {
             when(Script.runSimpleBashScript(
-                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
+                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
                     null);
-            when(Script.runSimpleBashScript("/opt/emc/scaleio/sdc/bin/drv_cfg --query_guid")).thenReturn(sdcGuid);
+            when(Script.runSimpleBashScript("/opt/emc/scaleio/sdc/bin/drv_cfg --query_guid --file /etc/emc/scaleio/drv_cfg.txt")).thenReturn(sdcGuid);
 
             ScaleIOStoragePool pool1 = new ScaleIOStoragePool(uuid, "192.168.1.19", 443, "a519be2f00000000", type,
                     details, adapter);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStoragePoolTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/ScaleIOStoragePoolTest.java
@@ -96,7 +96,7 @@ public class ScaleIOStoragePoolTest {
 
         try (MockedStatic<Script> ignored = Mockito.mockStatic(Script.class)) {
             when(Script.runSimpleBashScript(
-                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
+                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
                     sdcId);
 
             ScaleIOStoragePool pool1 = new ScaleIOStoragePool(uuid, "192.168.1.19", 443, "a519be2f00000000", type,
@@ -117,9 +117,9 @@ public class ScaleIOStoragePoolTest {
 
         try (MockedStatic<Script> ignored = Mockito.mockStatic(Script.class)) {
             when(Script.runSimpleBashScript(
-                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms --file /etc/emc/scaleio/drv_cfg.txt|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
+                    "/opt/emc/scaleio/sdc/bin/drv_cfg --query_mdms|grep 218ce1797566a00f|awk '{print $5}'")).thenReturn(
                     null);
-            when(Script.runSimpleBashScript("/opt/emc/scaleio/sdc/bin/drv_cfg --query_guid --file /etc/emc/scaleio/drv_cfg.txt")).thenReturn(sdcGuid);
+            when(Script.runSimpleBashScript("/opt/emc/scaleio/sdc/bin/drv_cfg --query_guid")).thenReturn(sdcGuid);
 
             ScaleIOStoragePool pool1 = new ScaleIOStoragePool(uuid, "192.168.1.19", 443, "a519be2f00000000", type,
                     details, adapter);

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/client/ScaleIOGatewayClient.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/client/ScaleIOGatewayClient.java
@@ -38,6 +38,9 @@ public interface ScaleIOGatewayClient {
     String GATEWAY_API_PASSWORD = "powerflex.gw.password";
     String STORAGE_POOL_NAME = "powerflex.storagepool.name";
     String STORAGE_POOL_SYSTEM_ID = "powerflex.storagepool.system.id";
+    /**
+     * Storage Pool Metadata Management (MDM) IP address(es).
+     */
     String STORAGE_POOL_MDMS = "powerflex.storagepool.mdms";
     String SDC_ID = "powerflex.sdc.id";
     String SDC_GUID = "powerflex.sdc.guid";

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
@@ -309,6 +309,7 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
         details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
         StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
         if (systemIdDetail != null) {
             details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
@@ -332,6 +333,7 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
             details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
             details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
             details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
+            details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
             sdcManager = ComponentContext.inject(sdcManager);
             if (sdcManager.areSDCConnectionsWithinLimit(store.getId())) {
                 StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
@@ -306,7 +306,8 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
         Map<String, String> details = new HashMap<>();
         StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
         if (storagePoolVO != null) {
-            populateScaleIOConfiguration(details, storagePoolVO.getDataCenterId());
+            sdcManager = ComponentContext.inject(sdcManager);
+            sdcManager.populateSdcSettings(details, storagePoolVO.getDataCenterId());
             StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
             if (systemIdDetail != null) {
                 details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
@@ -328,11 +329,11 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
         Map<String, String> details = new HashMap<>();
         StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
         if (storagePoolVO != null) {
-            populateScaleIOConfiguration(details, storagePoolVO.getDataCenterId());
+            sdcManager = ComponentContext.inject(sdcManager);
+            sdcManager.populateSdcSettings(details, storagePoolVO.getDataCenterId());
             StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
             if (systemIdDetail != null) {
                 details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
-                sdcManager = ComponentContext.inject(sdcManager);
                 if (sdcManager.areSDCConnectionsWithinLimit(store.getId())) {
                     details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(storagePoolVO.getDataCenterId())));
                     StoragePoolDetailVO mdmsDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_MDMS);
@@ -410,15 +411,5 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
 
     private static boolean isSupportedHypervisorType(Hypervisor.HypervisorType hypervisorType) {
         return Hypervisor.HypervisorType.KVM.equals(hypervisorType);
-    }
-
-    private void populateScaleIOConfiguration(Map<String, String> details, long dataCenterId) {
-        if (details == null) {
-            details = new HashMap<>();
-        }
-
-        details.put(ScaleIOSDCManager.MdmsChangeApplyWaitTime.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyWaitTime.valueIn(dataCenterId)));
-        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(dataCenterId)));
-        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(dataCenterId)));
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
@@ -307,16 +307,20 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
     @Override
     public boolean maintain(DataStore store) {
         Map<String,String> details = new HashMap<>();
-        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
-        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
-        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
-        StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
-        if (systemIdDetail != null) {
-            details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
-            StoragePoolDetailVO mdmsDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_MDMS);
-            if (mdmsDetail != null) {
-                details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdmsDetail.getValue());
-                details.put(ScaleIOSDCManager.ConnectOnDemand.key(), "false");
+        StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
+        if (storagePoolVO != null) {
+            details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(storagePoolVO.getDataCenterId())));
+            details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(storagePoolVO.getDataCenterId())));
+            details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(storagePoolVO.getDataCenterId())));
+
+            StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
+            if (systemIdDetail != null) {
+                details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
+                StoragePoolDetailVO mdmsDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_MDMS);
+                if (mdmsDetail != null) {
+                    details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdmsDetail.getValue());
+                    details.put(ScaleIOSDCManager.ConnectOnDemand.key(), "false");
+                }
             }
         }
 
@@ -328,16 +332,17 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
     @Override
     public boolean cancelMaintain(DataStore store) {
         Map<String,String> details = new HashMap<>();
-        StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
-        if (systemIdDetail != null) {
-            details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
-            details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
-            details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
-            details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
-            sdcManager = ComponentContext.inject(sdcManager);
-            if (sdcManager.areSDCConnectionsWithinLimit(store.getId())) {
-                StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
-                if (storagePoolVO != null) {
+        StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
+        if (storagePoolVO != null) {
+            details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(storagePoolVO.getDataCenterId())));
+            details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(storagePoolVO.getDataCenterId())));
+            details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(storagePoolVO.getDataCenterId())));
+
+            StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
+            if (systemIdDetail != null) {
+                details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
+                sdcManager = ComponentContext.inject(sdcManager);
+                if (sdcManager.areSDCConnectionsWithinLimit(store.getId())) {
                     details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(storagePoolVO.getDataCenterId())));
                     StoragePoolDetailVO mdmsDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_MDMS);
                     if (mdmsDetail != null) {

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
@@ -417,7 +417,7 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
             details = new HashMap<>();
         }
 
-        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(dataCenterId)));
+        details.put(ScaleIOSDCManager.MdmsChangeApplyWaitTime.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyWaitTime.valueIn(dataCenterId)));
         details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(dataCenterId)));
         details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(dataCenterId)));
     }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import com.cloud.host.HostVO;
-import com.cloud.storage.dao.StoragePoolAndAccessGroupMapDao;
 import org.apache.cloudstack.api.ApiConstants;
 import com.cloud.utils.StringUtils;
 import org.apache.cloudstack.engine.subsystem.api.storage.ClusterScope;
@@ -105,8 +104,6 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
     @Inject
     private AgentManager agentMgr;
     private ScaleIOSDCManager sdcManager;
-    @Inject
-    private StoragePoolAndAccessGroupMapDao storagePoolAndAccessGroupMapDao;
 
     public ScaleIOPrimaryDataStoreLifeCycle() {
         sdcManager = new ScaleIOSDCManagerImpl();
@@ -306,13 +303,10 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
 
     @Override
     public boolean maintain(DataStore store) {
-        Map<String,String> details = new HashMap<>();
+        Map<String, String> details = new HashMap<>();
         StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
         if (storagePoolVO != null) {
-            details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(storagePoolVO.getDataCenterId())));
-            details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(storagePoolVO.getDataCenterId())));
-            details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(storagePoolVO.getDataCenterId())));
-
+            populateScaleIOConfiguration(details, storagePoolVO.getDataCenterId());
             StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
             if (systemIdDetail != null) {
                 details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
@@ -331,13 +325,10 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
 
     @Override
     public boolean cancelMaintain(DataStore store) {
-        Map<String,String> details = new HashMap<>();
+        Map<String, String> details = new HashMap<>();
         StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());
         if (storagePoolVO != null) {
-            details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(storagePoolVO.getDataCenterId())));
-            details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(storagePoolVO.getDataCenterId())));
-            details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(storagePoolVO.getDataCenterId())));
-
+            populateScaleIOConfiguration(details, storagePoolVO.getDataCenterId());
             StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
             if (systemIdDetail != null) {
                 details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
@@ -419,5 +410,15 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
 
     private static boolean isSupportedHypervisorType(Hypervisor.HypervisorType hypervisorType) {
         return Hypervisor.HypervisorType.KVM.equals(hypervisorType);
+    }
+
+    private void populateScaleIOConfiguration(Map<String, String> details, long dataCenterId) {
+        if (details == null) {
+            details = new HashMap<>();
+        }
+
+        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(dataCenterId)));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(dataCenterId)));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(dataCenterId)));
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/ScaleIOPrimaryDataStoreLifeCycle.java
@@ -307,6 +307,8 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
     @Override
     public boolean maintain(DataStore store) {
         Map<String,String> details = new HashMap<>();
+        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
         StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
         if (systemIdDetail != null) {
             details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
@@ -328,6 +330,8 @@ public class ScaleIOPrimaryDataStoreLifeCycle extends BasePrimaryDataStoreLifeCy
         StoragePoolDetailVO systemIdDetail = storagePoolDetailsDao.findDetail(store.getId(), ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID);
         if (systemIdDetail != null) {
             details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemIdDetail.getValue());
+            details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
+            details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
             sdcManager = ComponentContext.inject(sdcManager);
             if (sdcManager.areSDCConnectionsWithinLimit(store.getId())) {
                 StoragePoolVO storagePoolVO = primaryDataStoreDao.findById(store.getId());

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -50,6 +50,13 @@ public interface ScaleIOSDCManager {
             "Flag to validate MDMs on Host, present in configuration file and in CLI, default value: false",
             Boolean.TRUE);
 
+    ConfigKey<Boolean> BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached = new ConfigKey<>("Storage",
+            Boolean.class,
+            "powerflex.block.sdc.unprepare.if.service.restart.needed.and.volumes.attached",
+            Boolean.FALSE.toString(),
+            "Block Storage Client un-preparation if SDC service restart needed but there are Volumes attached to the Host",
+            Boolean.TRUE);
+
     /**
      * Checks SDC connections limit.
      * @param storagePoolId the storage pool id

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -40,7 +40,7 @@ public interface ScaleIOSDCManager {
             Integer.class,
             "powerflex.mdm.change.apply.timeout.ms",
             "1000",
-            "Timeout for Host to wait after MDM changes made on Host until changes will be applied, default value: 1000 ms",
+            "Timeout (in ms) for Host to wait after MDM changes made on Host until changes will be applied, default value: 1000 ms",
             Boolean.TRUE);
 
     ConfigKey<Boolean> ValidateMdmsOnConnect = new ConfigKey<>("Storage",

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -36,11 +36,11 @@ public interface ScaleIOSDCManager {
      * Timeout for Host to wait after MDM changes made on Host until changes will be applied.
      * Needed to avoid cases when Storage Pool is not connected yet, but Agent already starts to use Storage Pool.
      */
-    ConfigKey<Integer> MdmsChangeApplyTimeout = new ConfigKey<>("Storage",
+    ConfigKey<Integer> MdmsChangeApplyWaitTime = new ConfigKey<>("Storage",
             Integer.class,
-            "powerflex.mdm.change.apply.timeout.ms",
+            "powerflex.mdm.change.apply.wait",
             "1000",
-            "Timeout (in ms) for Host to wait after MDM changes made on Host until changes will be applied, default value: 1000 ms",
+            "Time (in ms) to wait after MDM addition, and before & after MDM removal changes made on the Host, default value: 1000 ms",
             Boolean.TRUE,
             ConfigKey.Scope.Zone);
 
@@ -48,7 +48,7 @@ public interface ScaleIOSDCManager {
             Boolean.class,
             "powerflex.mdm.validate.on.connect",
             Boolean.FALSE.toString(),
-            "Flag to validate MDMs on Host, present in configuration file and in CLI, default value: false",
+            "Flag to validate PowerFlex MDMs on the host, present in Configuration File and in CLI during storage pool registration in agent, default value: false",
             Boolean.TRUE,
             ConfigKey.Scope.Zone);
 
@@ -56,7 +56,7 @@ public interface ScaleIOSDCManager {
             Boolean.class,
             "powerflex.block.sdc.unprepare",
             Boolean.FALSE.toString(),
-            "Block Storage Client un-preparation if SDC service restart needed but there are Volumes attached to the Host",
+            "Block storage client un-preparation if SDC service restart needed after PowerFlex MDM removal (i.e. no support for --remove_mdm in drv_cfg cmd) when there are Volumes mapped to the Host",
             Boolean.TRUE,
             ConfigKey.Scope.Zone);
 

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -33,6 +33,24 @@ public interface ScaleIOSDCManager {
             ConfigKey.Scope.Zone);
 
     /**
+     * Timeout for Host to wait after MDM changes made on Host until changes will be applied.
+     * Needed to avoid cases when Storage Pool is not connected yet, but Agent already starts to use Storage Pool.
+     */
+    ConfigKey<Integer> MdmsChangeApplyTimeout = new ConfigKey<>("Storage",
+            Integer.class,
+            "powerflex.mdm.change.apply.timeout.ms",
+            "1000",
+            "Timeout for Host to wait after MDM changes made on Host until changes will be applied, default value: 1000 ms",
+            Boolean.TRUE);
+
+    ConfigKey<Boolean> ValidateMdmsOnConnect = new ConfigKey<>("Storage",
+            Boolean.class,
+            "powerflex.mdm.validate.on.connect",
+            Boolean.FALSE.toString(),
+            "Flag to validate MDMs on Host, present in configuration file and in CLI, default value: false",
+            Boolean.TRUE);
+
+    /**
      * Checks SDC connections limit.
      * @param storagePoolId the storage pool id
      * @return true if SDC connections are within limit

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -22,6 +22,8 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 
 import com.cloud.host.Host;
 
+import java.util.Map;
+
 public interface ScaleIOSDCManager {
     ConfigKey<Boolean> ConnectOnDemand = new ConfigKey<>("Storage",
             Boolean.class,
@@ -121,4 +123,11 @@ public interface ScaleIOSDCManager {
      * @return Comma-separated list of MDM IPs of the pool
      */
     String getMdms(long poolId);
+
+    /**
+     * Adds the SDC settings to the details map.
+     * @param details the details map to add the settings
+     * @param dataCenterId the datacenter id for the settings
+     */
+    void populateSdcSettings(Map<String, String> details, long dataCenterId);
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -41,21 +41,24 @@ public interface ScaleIOSDCManager {
             "powerflex.mdm.change.apply.timeout.ms",
             "1000",
             "Timeout (in ms) for Host to wait after MDM changes made on Host until changes will be applied, default value: 1000 ms",
-            Boolean.TRUE);
+            Boolean.TRUE,
+            ConfigKey.Scope.Zone);
 
     ConfigKey<Boolean> ValidateMdmsOnConnect = new ConfigKey<>("Storage",
             Boolean.class,
             "powerflex.mdm.validate.on.connect",
             Boolean.FALSE.toString(),
             "Flag to validate MDMs on Host, present in configuration file and in CLI, default value: false",
-            Boolean.TRUE);
+            Boolean.TRUE,
+            ConfigKey.Scope.Zone);
 
     ConfigKey<Boolean> BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached = new ConfigKey<>("Storage",
             Boolean.class,
             "powerflex.block.sdc.unprepare",
             Boolean.FALSE.toString(),
             "Block Storage Client un-preparation if SDC service restart needed but there are Volumes attached to the Host",
-            Boolean.TRUE);
+            Boolean.TRUE,
+            ConfigKey.Scope.Zone);
 
     /**
      * Checks SDC connections limit.

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -39,8 +39,8 @@ public interface ScaleIOSDCManager {
     ConfigKey<Integer> MdmsChangeApplyWaitTime = new ConfigKey<>("Storage",
             Integer.class,
             "powerflex.mdm.change.apply.wait",
-            "1000",
-            "Time (in ms) to wait after MDM addition, and before & after MDM removal changes made on the Host, default value: 1000 ms",
+            "3000",
+            "Time (in ms) to wait after MDM addition, and before & after MDM removal changes made on the Host, default value: 3000 ms",
             Boolean.TRUE,
             ConfigKey.Scope.Zone);
 

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -52,7 +52,7 @@ public interface ScaleIOSDCManager {
 
     ConfigKey<Boolean> BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached = new ConfigKey<>("Storage",
             Boolean.class,
-            "powerflex.block.sdc.unprepare.if.service.restart.needed.and.volumes.attached",
+            "powerflex.block.sdc.unprepare",
             Boolean.FALSE.toString(),
             "Block Storage Client un-preparation if SDC service restart needed but there are Volumes attached to the Host",
             Boolean.TRUE);

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -204,9 +204,11 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
 
     private String prepareSDCOnHost(Host host, DataStore dataStore, String systemId, String mdms) {
         logger.debug("Preparing SDC on the host {}", host);
-        Map<String,String> details = new HashMap<>();
+        Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
+        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.value()));
+
         PrepareStorageClientCommand cmd = new PrepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
         cmd.setWait(timeoutSeconds);
@@ -324,6 +326,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         logger.debug(String.format("Unpreparing SDC on the host %s (%s)", host.getId(), host.getName()));
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
+        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.value()));
         UnprepareStorageClientCommand cmd = new UnprepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
         cmd.setWait(timeoutSeconds);
@@ -477,6 +480,6 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey[]{ConnectOnDemand};
+        return new ConfigKey[]{ConnectOnDemand, MdmsChangeApplyTimeout, ValidateMdmsOnConnect};
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -207,7 +207,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
-        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.valueIn(host.getDataCenterId())));
+        details.put(MdmsChangeApplyWaitTime.key(), String.valueOf(MdmsChangeApplyWaitTime.valueIn(host.getDataCenterId())));
 
         PrepareStorageClientCommand cmd = new PrepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
@@ -325,7 +325,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         logger.debug(String.format("Unpreparing SDC on the host %s (%s)", host.getId(), host.getName()));
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
-        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.valueIn(host.getDataCenterId())));
+        details.put(MdmsChangeApplyWaitTime.key(), String.valueOf(MdmsChangeApplyWaitTime.valueIn(host.getDataCenterId())));
         UnprepareStorageClientCommand cmd = new UnprepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
         cmd.setWait(timeoutSeconds);
@@ -492,6 +492,6 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey[]{ConnectOnDemand, MdmsChangeApplyTimeout, ValidateMdmsOnConnect, BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached};
+        return new ConfigKey[]{ConnectOnDemand, MdmsChangeApplyWaitTime, ValidateMdmsOnConnect, BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached};
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -207,7 +207,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
-        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.value()));
+        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.valueIn(host.getDataCenterId())));
 
         PrepareStorageClientCommand cmd = new PrepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
@@ -326,7 +326,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         logger.debug(String.format("Unpreparing SDC on the host %s (%s)", host.getId(), host.getName()));
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
-        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.value()));
+        details.put(MdmsChangeApplyTimeout.key(), String.valueOf(MdmsChangeApplyTimeout.valueIn(host.getDataCenterId())));
         UnprepareStorageClientCommand cmd = new UnprepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
         cmd.setWait(timeoutSeconds);

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -207,8 +207,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
-        details.put(MdmsChangeApplyWaitTime.key(), String.valueOf(MdmsChangeApplyWaitTime.valueIn(host.getDataCenterId())));
-
+        populateSdcSettings(details, host.getDataCenterId());
         PrepareStorageClientCommand cmd = new PrepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
         cmd.setWait(timeoutSeconds);
@@ -325,7 +324,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         logger.debug(String.format("Unpreparing SDC on the host %s (%s)", host.getId(), host.getName()));
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_MDMS, mdms);
-        details.put(MdmsChangeApplyWaitTime.key(), String.valueOf(MdmsChangeApplyWaitTime.valueIn(host.getDataCenterId())));
+        populateSdcSettings(details, host.getDataCenterId());
         UnprepareStorageClientCommand cmd = new UnprepareStorageClientCommand(((PrimaryDataStore) dataStore).getPoolType(), dataStore.getUuid(), details);
         int timeoutSeconds = 60;
         cmd.setWait(timeoutSeconds);
@@ -483,6 +482,17 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
             throw new CloudRuntimeException("Unable to find the storage pool with id " + storagePoolId);
         }
         return ScaleIOGatewayClientConnectionPool.getInstance().getClient(storagePool, storagePoolDetailsDao);
+    }
+
+    @Override
+    public void populateSdcSettings(Map<String, String> details, long dataCenterId) {
+        if (details == null) {
+            details = new HashMap<>();
+        }
+
+        details.put(ScaleIOSDCManager.MdmsChangeApplyWaitTime.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyWaitTime.valueIn(dataCenterId)));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(dataCenterId)));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(dataCenterId)));
     }
 
     @Override

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -183,12 +183,13 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
                     storagePoolHost.setLocalPath(sdcId);
                     storagePoolHostDao.update(storagePoolHost.getId(), storagePoolHost);
                 }
+
+                int waitTimeInSecs = 15; // Wait for 15 secs (usual tests with SDC service start took 10-15 secs)
+                if (isHostSdcConnected(sdcId, dataStore, waitTimeInSecs)) {
+                    return sdcId;
+                }
             }
 
-            int waitTimeInSecs = 15; // Wait for 15 secs (usual tests with SDC service start took 10-15 secs)
-            if (isHostSdcConnected(sdcId, dataStore, waitTimeInSecs)) {
-                return sdcId;
-            }
             return null;
         } finally {
             if (storageSystemIdLock != null) {
@@ -248,7 +249,7 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
         }
 
         if (StringUtils.isBlank(sdcId)) {
-            logger.warn("Couldn't retrieve PowerFlex storage SDC details from the host: {}, try (re)install SDC and restart agent", host);
+            logger.warn("Couldn't retrieve PowerFlex storage SDC details from the host: {}, add MDMs if On-demand connect disabled or try (re)install SDC & restart agent", host);
             return null;
         }
 

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -480,6 +480,6 @@ public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey[]{ConnectOnDemand, MdmsChangeApplyTimeout, ValidateMdmsOnConnect};
+        return new ConfigKey[]{ConnectOnDemand, MdmsChangeApplyTimeout, ValidateMdmsOnConnect, BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached};
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -253,7 +253,7 @@ public class ScaleIOHostListener implements HypervisorHostListener {
             details = new HashMap<>();
         }
 
-        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(dataCenterId)));
+        details.put(ScaleIOSDCManager.MdmsChangeApplyWaitTime.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyWaitTime.valueIn(dataCenterId)));
         details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(dataCenterId)));
         details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(dataCenterId)));
     }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -113,6 +113,7 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
         details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
         details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.areSDCConnectionsWithinLimit(poolId)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));
@@ -207,6 +208,7 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
         details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
         details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.canUnprepareSDC(host, dataStore)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -111,9 +111,9 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
-        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
-        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
-        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
+        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(host.getDataCenterId())));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(host.getDataCenterId())));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(host.getDataCenterId())));
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.areSDCConnectionsWithinLimit(poolId)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));
@@ -206,9 +206,9 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
-        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
-        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
-        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.value()));
+        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.valueIn(host.getDataCenterId())));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(host.getDataCenterId())));
+        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(host.getDataCenterId())));
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.canUnprepareSDC(host, dataStore)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -111,6 +111,8 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
+        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.areSDCConnectionsWithinLimit(poolId)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));
@@ -203,6 +205,8 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String,String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
+        details.put(ScaleIOSDCManager.MdmsChangeApplyTimeout.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyTimeout.value()));
+        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.value()));
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.canUnprepareSDC(host, dataStore)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -109,7 +109,7 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
-        populateScaleIOConfiguration(details,host.getDataCenterId());
+        populateScaleIOConfiguration(details, host.getDataCenterId());
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.areSDCConnectionsWithinLimit(poolId)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));
@@ -202,7 +202,7 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
-        populateScaleIOConfiguration(details,host.getDataCenterId());
+        populateScaleIOConfiguration(details, host.getDataCenterId());
         _sdcManager = ComponentContext.inject(_sdcManager);
         if (_sdcManager.canUnprepareSDC(host, dataStore)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -136,7 +136,7 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
 
         if (StringUtils.isBlank(sdcId)) {
-            String msg = String.format("Couldn't retrieve PowerFlex storage SDC details from the host: %s, (re)install SDC and restart agent", host);
+            String msg = String.format("Couldn't retrieve PowerFlex storage SDC details from the host: %s, add MDMs if On-demand connect disabled or try (re)install SDC & restart agent", host);
             logger.warn(msg);
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_HOST, host.getDataCenterId(), host.getPodId(), "SDC details not found on host: " + host.getUuid(), msg);
             return null;

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/provider/ScaleIOHostListener.java
@@ -109,8 +109,8 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
-        populateScaleIOConfiguration(details, host.getDataCenterId());
         _sdcManager = ComponentContext.inject(_sdcManager);
+        _sdcManager.populateSdcSettings(details, host.getDataCenterId());
         if (_sdcManager.areSDCConnectionsWithinLimit(poolId)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));
             String mdms = _sdcManager.getMdms(poolId);
@@ -202,8 +202,8 @@ public class ScaleIOHostListener implements HypervisorHostListener {
         }
         Map<String, String> details = new HashMap<>();
         details.put(ScaleIOGatewayClient.STORAGE_POOL_SYSTEM_ID, systemId);
-        populateScaleIOConfiguration(details, host.getDataCenterId());
         _sdcManager = ComponentContext.inject(_sdcManager);
+        _sdcManager.populateSdcSettings(details, host.getDataCenterId());
         if (_sdcManager.canUnprepareSDC(host, dataStore)) {
             details.put(ScaleIOSDCManager.ConnectOnDemand.key(), String.valueOf(ScaleIOSDCManager.ConnectOnDemand.valueIn(host.getDataCenterId())));
             String mdms = _sdcManager.getMdms(poolId);
@@ -246,15 +246,5 @@ public class ScaleIOHostListener implements HypervisorHostListener {
             poolDetails = String.format("%s (id: %d, uuid: %s)", storagePool.getName(), storagePool.getId(), storagePool.getUuid());
         }
         return poolDetails;
-    }
-
-    private void populateScaleIOConfiguration(Map<String, String> details, long dataCenterId) {
-        if (details == null) {
-            details = new HashMap<>();
-        }
-
-        details.put(ScaleIOSDCManager.MdmsChangeApplyWaitTime.key(), String.valueOf(ScaleIOSDCManager.MdmsChangeApplyWaitTime.valueIn(dataCenterId)));
-        details.put(ScaleIOSDCManager.ValidateMdmsOnConnect.key(), String.valueOf(ScaleIOSDCManager.ValidateMdmsOnConnect.valueIn(dataCenterId)));
-        details.put(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.key(), String.valueOf(ScaleIOSDCManager.BlockSdcUnprepareIfRestartNeededAndVolumesAreAttached.valueIn(dataCenterId)));
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -214,7 +214,9 @@ public class ScaleIOUtil {
             // remove MDM via CLI if it is supported
             if (removeMdmCliSupported) {
                 removeMdm(mdmAddress);
-                changesApplied = true;
+                if (removeMdm(mdmAddress)) {
+                    changesApplied = true;
+                }
             } else {
                 String command = String.format(REMOVE_MDM_CMD_TEMPLATE, mdmAddress, DRV_CFG_FILE);
                 Script.runSimpleBashScript(command);

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -245,7 +245,7 @@ public class ScaleIOUtil {
     /**
      * Returns MDM entries from {@link ScaleIOUtil#DRV_CFG_FILE}.
      */
-    public static Collection<String> getMdmsFromConfig() {
+    public static Collection<String> getMdmsFromConfigFile() {
         List<String> configFileLines;
         try {
             configFileLines = Files.readAllLines(Path.of(DRV_CFG_FILE));
@@ -284,9 +284,9 @@ public class ScaleIOUtil {
     }
 
     /**
-     * Returns MDM entries from CLI using {@code --query_mdms}.
+     * Returns MDM entries from CLI Cmd using {@code --query_mdms}.
      */
-    public static Collection<String> getMdmsFromCli() {
+    public static Collection<String> getMdmsFromCliCmd() {
         String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD;
         Pair<String, String> result = Script.executeCommand(command);
         String stdOut = result.first();

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -109,7 +109,7 @@ public class ScaleIOUtil {
     private static final String REMOVE_MDMS_CMD = "drv_cfg " + REMOVE_MDM_PARAMETER;
 
     /**
-     * Command to get back "Usage" response. As of ow it is just drv_cfg without parameters.
+     * Command to get back "Usage" response. As of now it is just drv_cfg without parameters.
      */
     private static final String USAGE_CMD = "drv_cfg";
 
@@ -260,7 +260,7 @@ public class ScaleIOUtil {
      * Returns Volume Ids from {@link ScaleIOUtil#DRV_CFG_FILE}.
      */
     public static Collection<String> getVolumeIds() {
-        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD + " --file " + DRV_CFG_FILE;
+        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD;
         Pair<String, String> result = Script.executeCommand(command);
         String stdOut = result.first();
 
@@ -279,7 +279,7 @@ public class ScaleIOUtil {
      * Returns MDM entries from CLI using {@code --query_mdms}.
      */
     public static Collection<String> getMdmsFromCli() {
-        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD + " --file " + DRV_CFG_FILE;
+        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD;
         Pair<String, String> result = Script.executeCommand(command);
         String stdOut = result.first();
 
@@ -317,7 +317,7 @@ public class ScaleIOUtil {
         String stdOut = result.second();
 
         /*
-         * Check whether stderr or stdout contains mdm removal parameter.
+         * Check whether stderr or stdout contains mdm removal "--remove_mdm" parameter.
          *
          * Current version returns "Usage" in stderr, check stdout as well in case this will be changed in the future,
          * as returned "Usage" is not an error.
@@ -330,7 +330,7 @@ public class ScaleIOUtil {
      */
     public static boolean isMdmPresent(String mdmAddress) {
         //query_mdms outputs "MDM-ID <System/MDM-Id> SDC ID <SDC-Id> INSTALLATION ID <Installation-Id> IPs [0]-x.x.x.x [1]-x.x.x.x" for a MDM with ID: <MDM-Id>
-        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD + " --file " + DRV_CFG_FILE;
+        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD;
         queryMdmsCmd += "|grep " + mdmAddress;
         String result = Script.runSimpleBashScript(queryMdmsCmd);
 
@@ -354,7 +354,7 @@ public class ScaleIOUtil {
 
     public static void rescanForNewVolumes() {
         // Detecting new volumes
-        String rescanCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.RESCAN_CMD + " --file " + DRV_CFG_FILE;
+        String rescanCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.RESCAN_CMD;
 
         String result = Script.runSimpleBashScript(rescanCmd);
         if (result == null) {
@@ -364,7 +364,7 @@ public class ScaleIOUtil {
 
     public static String getSystemIdForVolume(String volumeId) {
         //query_vols outputs "VOL-ID <VolumeID> MDM-ID <SystemID>" for a volume with ID: <VolumeID>
-        String queryDiskCmd = SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD + " --file " + DRV_CFG_FILE;
+        String queryDiskCmd = SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD;
         queryDiskCmd += "|grep " + volumeId + "|awk '{print $4}'";
 
         String result = Script.runSimpleBashScript(queryDiskCmd);
@@ -382,7 +382,7 @@ public class ScaleIOUtil {
     }
 
     public static String getSdcGuid() {
-        String queryGuidCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_GUID_CMD + " --file " + DRV_CFG_FILE;
+        String queryGuidCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_GUID_CMD;
         String result = Script.runSimpleBashScript(queryGuidCmd);
         if (result == null) {
             LOGGER.warn("Failed to get SDC guid");
@@ -404,7 +404,7 @@ public class ScaleIOUtil {
 
     public static String getSdcId(String mdmId) {
         //query_mdms outputs "MDM-ID <System/MDM-Id> SDC ID <SDC-Id> INSTALLATION ID <Installation-Id> IPs [0]-x.x.x.x [1]-x.x.x.x" for a MDM with ID: <MDM-Id>
-        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD + " --file " + DRV_CFG_FILE;
+        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD;
         queryMdmsCmd += "|grep " + mdmId + "|awk '{print $5}'";
         String result = Script.runSimpleBashScript(queryMdmsCmd);
         if (result == null) {

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -17,15 +17,25 @@
 
 package org.apache.cloudstack.storage.datastore.util;
 
-import java.util.List;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.cloud.utils.Pair;
 import com.cloud.utils.UuidUtils;
 import com.cloud.utils.script.Script;
 import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ScaleIOUtil {
     protected static Logger LOGGER = LogManager.getLogger(ScaleIOUtil.class);
@@ -39,7 +49,7 @@ public class ScaleIOUtil {
     public static final String VMSNAPSHOT_PREFIX = "vmsnap";
 
     public static final int IDENTIFIER_LENGTH = 16;
-    public static final Long MINIMUM_ALLOWED_IOPS_LIMIT = Long.valueOf(10);
+    public static final Long MINIMUM_ALLOWED_IOPS_LIMIT = 10L;
 
     public static final String DISK_PATH = "/dev/disk/by-id";
     public static final String DISK_NAME_PREFIX = "emc-vol-";
@@ -63,9 +73,10 @@ public class ScaleIOUtil {
     private static final String SDC_SERVICE_ENABLE_CMD = "systemctl enable scini";
 
     public static final String CONNECTED_SDC_COUNT_STAT = "ConnectedSDCCount";
+
     /**
      * Cmd for querying volumes in SDC
-     * Sample output for cmd: drv_cfg --query_vols:
+     * Sample output for cmd {@code drv_cfg --query_vols}:
      * Retrieved 2 volume(s)
      * VOL-ID 6c33633100000009 MDM-ID 218ce1797566a00f
      * VOL-ID 6c3362a30000000a MDM-ID 218ce1797566a00f
@@ -74,14 +85,14 @@ public class ScaleIOUtil {
 
     /**
      * Cmd for querying guid in SDC
-     * Sample output for cmd: drv_cfg --query_guid:
+     * Sample output for cmd {@code drv_cfg --query_guid}:
      * B0E3BFB8-C20B-43BF-93C8-13339E85AA50
      */
     private static final String QUERY_GUID_CMD = "drv_cfg --query_guid";
 
     /**
      * Cmd for querying MDMs in SDC
-     * Sample output for cmd: drv_cfg --query_mdms:
+     * Sample output for cmd {@code drv_cfg --query_mdms}:
      * Retrieved 2 mdm(s)
      * MDM-ID 3ef46cbf2aaf5d0f SDC ID 6b18479c00000003 INSTALLATION ID 68ab55462cbb3ae4 IPs [0]-x.x.x.x [1]-x.x.x.x
      * MDM-ID 2e706b2740ec200f SDC ID 301b852c00000003 INSTALLATION ID 33f8662e7a5c1e6c IPs [0]-x.x.x.x [1]-x.x.x.x
@@ -89,61 +100,246 @@ public class ScaleIOUtil {
     private static final String QUERY_MDMS_CMD = "drv_cfg --query_mdms";
 
     private static final String ADD_MDMS_CMD = "drv_cfg --add_mdm";
+
+    private static final String REMOVE_MDM_PARAMETER = "--remove_mdm";
+
+    /**
+     * Calls the kernel module to remove MDM.
+     */
+    private static final String REMOVE_MDMS_CMD = "drv_cfg " + REMOVE_MDM_PARAMETER;
+
+    /**
+     * Command to get back "Usage" response. As of ow it is just drv_cfg without parameters.
+     */
+    private static final String USAGE_CMD = "drv_cfg";
+
     private static final String DRV_CFG_FILE = "/etc/emc/scaleio/drv_cfg.txt";
 
-    public static void addMdms(List<String> mdmAddresses) {
-        if (CollectionUtils.isEmpty(mdmAddresses)) {
-            return;
+    /**
+     * Sample Command - sed -i '/x.x.x.x\,/d' /etc/emc/scaleio/drv_cfg.txt
+     */
+    private static final String REMOVE_MDM_CMD_TEMPLATE = "sed -i '/%s\\,/d' %s";
+
+    /**
+     * Patterns to parse {@link ScaleIOUtil#DRV_CFG_FILE} and {@code --query_mdms} command output.
+     * The format is:
+     * MDM-ID {HEX_ID} SDC ID {HEX_ID} INSTALLATION ID {HEX_ID} IPs [{DEC_INC_NUMBER}]-{IP_ADDRESS} [{DEC_INC_NUMBER}]-{IP_ADDRESS} ...
+     */
+    private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\r?\\n");
+    /**
+     * Pattern to find "IPs" substring in {@link ScaleIOUtil#QUERY_MDMS_CMD} command output.
+     * The output format is:
+     * MDM-ID {HEX_ID} SDC ID {HEX_ID} INSTALLATION ID {HEX_ID} IPs [{DEC_INC_NUMBER}]-{IP_ADDRESS} [{DEC_INC_NUMBER}]-{IP_ADDRESS} ...
+     */
+    private static final Pattern USAGE_IPS_LINE_PATTERN = Pattern.compile("IPs\\s*(.*)$");
+    /**
+     * Pattern to find individual IP address in {@link ScaleIOUtil#QUERY_MDMS_CMD} command output.
+     */
+    private static final Pattern USAGE_IP_TOKEN_PATTERN = Pattern.compile("(\\s*\\[\\d\\]\\-)([^\\s$]+)");
+
+    /**
+     * Pattern to find Volume ID in {@link  ScaleIOUtil#QUERY_VOLUMES_CMD}
+     */
+    private static final Pattern VOLUME_ID_TOKEN_PATTERN = Pattern.compile("VOL-ID\\s*([^\\s$]+)");
+    /**
+     * Pattern to find MDM entries line in {@link ScaleIOUtil#DRV_CFG_FILE}.
+     */
+    private static final Pattern DRV_CFG_MDM_LINE_PATTERN = Pattern.compile("^mdm\\s*([0-9A-F:\\.,]+)$", Pattern.CASE_INSENSITIVE);
+    /**
+     * Pattern to split comma separated string of IP addresses (space aware).
+     */
+    private static final Pattern DRV_CFG_MDM_IPS_PATTERN = Pattern.compile("\\s*,\\s*");
+
+    public static boolean addMdms(String... mdmAddresses) {
+        if (mdmAddresses.length < 1) {
+            return false;
         }
         // Sample Cmd - /opt/emc/scaleio/sdc/bin/drv_cfg --add_mdm --ip x.x.x.x,x.x.x.x --file /etc/emc/scaleio/drv_cfg.txt
-        String addMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.ADD_MDMS_CMD;
-        addMdmsCmd += " --ip " + String.join(",", mdmAddresses);
-        addMdmsCmd += " --file " + DRV_CFG_FILE;
-        String result = Script.runSimpleBashScript(addMdmsCmd);
-        if (result == null) {
-            LOGGER.warn("Failed to add mdms");
-        }
+        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.ADD_MDMS_CMD;
+        command += " --ip " + String.join(",", mdmAddresses);
+        command += " --file " + DRV_CFG_FILE;
+        return runCmd(command);
     }
 
-    public static void removeMdms(List<String> mdmAddresses) {
-        if (CollectionUtils.isEmpty(mdmAddresses)) {
-            return;
+    /**
+     * Remove MDM via ScaleIO via CLI.
+     *
+     * @param mdmAddress MDM address to remove
+     * @return true if IP address successfully removed
+     */
+    private static boolean removeMdm(String mdmAddress) {
+        // Sample Cmd - /opt/emc/scaleio/sdc/bin/drv_cfg --remove_mdm --ip x.x.x.x,x.x.x.x --file /etc/emc/scaleio/drv_cfg.txt
+        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.REMOVE_MDMS_CMD;
+        command += " --ip " + String.join(",", mdmAddress);
+        command += " --file " + DRV_CFG_FILE;
+        return runCmd(command);
+    }
+
+    /**
+     * Run command, log command result and return {@link Boolean#TRUE} if command succeeded.
+     * FIXME: may need to do refactoring and replace static method callss with dynamic.
+     */
+    private static boolean runCmd(String command) {
+        Pair<String, String> result = Script.executeCommand(command);
+        String stdOut = result.first();
+        String stdErr = result.second();
+        boolean succeeded = StringUtils.isEmpty(stdErr);
+        if (succeeded) {
+            LOGGER.debug(String.format("Successfully executed command '%s': %s", command, stdOut));
+        } else {
+            LOGGER.warn(String.format("Failed to execute command '%s': %s", command, stdErr));
         }
-        // (i) Remove MDMs from config file (ii) Restart scini
-        //  Sample Cmd - sed -i '/x.x.x.x\,/d' /etc/emc/scaleio/drv_cfg.txt
+        return succeeded;
+    }
+
+    /**
+     * Remove MDMs either via ScaleIO CLI (if supported) or by updating configuration file.
+     *
+     * @param mdmAddresses MDM addresses
+     * @return returns {@link Boolean#TRUE} if changes were applied to the configuration
+     */
+    public static boolean removeMdms(String... mdmAddresses) {
+        if (mdmAddresses.length < 1) {
+            return false;
+        }
+
+        boolean changesApplied = false;
+        boolean removeMdmCliSupported = isRemoveMdmCliSupported();
         boolean restartSDC = false;
-        String removeMdmsCmdFormat = "sed -i '/%s\\,/d' %s";
         for (String mdmAddress : mdmAddresses) {
-            if (mdmAdded(mdmAddress)) {
-                restartSDC = true;
+            // continue to next address if current MDM is not present in configuratino
+            if (!isMdmPresent(mdmAddress)) {
+                continue;
             }
-            String removeMdmsCmd = String.format(removeMdmsCmdFormat, mdmAddress, DRV_CFG_FILE);
-            Script.runSimpleBashScript(removeMdmsCmd);
+            // remove MDM via CLI if it is supported
+            if (removeMdmCliSupported) {
+                removeMdm(mdmAddress);
+                changesApplied = true;
+            } else {
+                String command = String.format(REMOVE_MDM_CMD_TEMPLATE, mdmAddress, DRV_CFG_FILE);
+                Script.runSimpleBashScript(command);
+                // restart SDC needed only if configuration file modified manually (not by CLI)
+                restartSDC = true;
+                changesApplied = true;
+            }
         }
         if (restartSDC) {
             restartSDCService();
         }
+        return changesApplied;
     }
 
-    public static boolean mdmAdded(String mdmAddress) {
+    /**
+     * Returns MDM entries from {@link ScaleIOUtil#DRV_CFG_FILE}.
+     */
+    public static Collection<String> getMdmsFromConfig() {
+        List<String> configFileLines;
+        try {
+            configFileLines = Files.readAllLines(Path.of(DRV_CFG_FILE));
+        } catch (IOException e) {
+            LOGGER.error(String.format("Failed to read MDMs from %s", DRV_CFG_FILE), e);
+            return List.of();
+        }
+        Set<String> mdms = new LinkedHashSet<>();
+        for (String line : configFileLines) {
+            Matcher mdmLineMatcher = DRV_CFG_MDM_LINE_PATTERN.matcher(line);
+            if(mdmLineMatcher.find() && mdmLineMatcher.groupCount() > 0) {
+                String mdmLine = mdmLineMatcher.group(1);
+                String[] mdmValues = DRV_CFG_MDM_IPS_PATTERN.split(mdmLine);
+                mdms.addAll(Arrays.asList(mdmValues));
+            }
+        }
+        return mdms;
+    }
+    /**
+     * Returns Volume Ids from {@link ScaleIOUtil#DRV_CFG_FILE}.
+     */
+    public static Collection<String> getVolumeIds() {
+        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD + " --file " + DRV_CFG_FILE;
+        Pair<String, String> result = Script.executeCommand(command);
+        String stdOut = result.first();
+
+        Set<String> volumeIds = new LinkedHashSet<>();
+        String[] stdOutLines = NEW_LINE_PATTERN.split(stdOut);
+        for (String line : stdOutLines) {
+            Matcher volumeIdMatcher = VOLUME_ID_TOKEN_PATTERN.matcher(line);
+            if (volumeIdMatcher.find() && volumeIdMatcher.groupCount() > 0) {
+                volumeIds.add(volumeIdMatcher.group(1));
+            }
+        }
+        return volumeIds;
+    }
+
+    /**
+     * Returns MDM entries from CLI using {@code --query_mdms}.
+     */
+    public static Collection<String> getMdmsFromCli() {
+        String command = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD + " --file " + DRV_CFG_FILE;
+        Pair<String, String> result = Script.executeCommand(command);
+        String stdOut = result.first();
+
+        Set<String> mdms = new LinkedHashSet<>();
+        String[] stdOutLines = NEW_LINE_PATTERN.split(stdOut);
+        for (String line : stdOutLines) {
+            Matcher ipsLineMatcher = USAGE_IPS_LINE_PATTERN.matcher(line);
+            if (ipsLineMatcher.find() && ipsLineMatcher.groupCount() > 0) {
+                String ipToken = ipsLineMatcher.group(1);
+                Matcher ipMatcher = USAGE_IP_TOKEN_PATTERN.matcher(ipToken);
+                while (ipMatcher.find()) {
+                    if (ipMatcher.groupCount() > 1) {
+                        mdms.add(ipMatcher.group(2));
+                    }
+                }
+            }
+        }
+        return mdms;
+    }
+
+    /**
+     * Returns {@link Boolean#TRUE} if ScaleIO CLI tool (drv_cfg) supports MDMs removal.
+     */
+    public static boolean isRemoveMdmCliSupported() {
+        /*
+         * New version of drv_cfg supports remove mdm API.
+         * Instead of defining supported version and checking it, the logic is to check drv_cfg "Usage" output
+         * and see whether remove_mdm command supported.
+         * The "Usage" returned if tool executed without parameters or with invalid parameters.
+         */
+        String command = SDC_HOME_PATH + "/bin/" + USAGE_CMD;
+
+        Pair<String, String> result = Script.executeCommand(command);
+        String stdErr = result.first();
+        String stdOut = result.second();
+
+        /*
+         * Check whether stderr or stdout contains mdm removal parameter.
+         *
+         * Current version returns "Usage" in stderr, check stdout as well in case this will be changed in the future,
+         * as returned "Usage" is not an error.
+         */
+        return (stdOut + stdErr).toLowerCase().contains(REMOVE_MDM_PARAMETER);
+    }
+
+    /**
+     * Returns true if provided MDM address is present in configuration.
+     */
+    public static boolean isMdmPresent(String mdmAddress) {
         //query_mdms outputs "MDM-ID <System/MDM-Id> SDC ID <SDC-Id> INSTALLATION ID <Installation-Id> IPs [0]-x.x.x.x [1]-x.x.x.x" for a MDM with ID: <MDM-Id>
-        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD;
+        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD + " --file " + DRV_CFG_FILE;
         queryMdmsCmd += "|grep " + mdmAddress;
         String result = Script.runSimpleBashScript(queryMdmsCmd);
-        if (StringUtils.isNotBlank(result) && result.contains(mdmAddress)) {
-            return true;
-        }
-        return false;
+
+        return StringUtils.isNotBlank(result) && result.contains(mdmAddress);
     }
 
     public static String getSdcHomePath() {
-        String sdcHomePath = DEFAULT_SDC_HOME_PATH;
         String sdcHomePropertyCmdFormat = "sed -n '/%s/p' '%s' 2>/dev/null  | sed 's/%s=//g' 2>/dev/null";
         String sdcHomeCmd = String.format(sdcHomePropertyCmdFormat, SDC_HOME_PARAMETER, AGENT_PROPERTIES_FILE, SDC_HOME_PARAMETER);
-
         String result = Script.runSimpleBashScript(sdcHomeCmd);
+        String sdcHomePath;
         if (result == null) {
-            LOGGER.warn("Failed to get sdc home path from agent.properties, fallback to default path");
+            sdcHomePath = DEFAULT_SDC_HOME_PATH;
+            LOGGER.warn(String.format("Failed to get sdc home path from agent.properties, fallback to default path %s", sdcHomePath));
         } else {
             sdcHomePath = result;
         }
@@ -151,9 +347,9 @@ public class ScaleIOUtil {
         return sdcHomePath;
     }
 
-    public static final void rescanForNewVolumes() {
+    public static void rescanForNewVolumes() {
         // Detecting new volumes
-        String rescanCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.RESCAN_CMD;
+        String rescanCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.RESCAN_CMD + " --file " + DRV_CFG_FILE;
 
         String result = Script.runSimpleBashScript(rescanCmd);
         if (result == null) {
@@ -161,9 +357,9 @@ public class ScaleIOUtil {
         }
     }
 
-    public static final String getSystemIdForVolume(String volumeId) {
+    public static String getSystemIdForVolume(String volumeId) {
         //query_vols outputs "VOL-ID <VolumeID> MDM-ID <SystemID>" for a volume with ID: <VolumeID>
-        String queryDiskCmd = SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD;
+        String queryDiskCmd = SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_VOLUMES_CMD + " --file " + DRV_CFG_FILE;
         queryDiskCmd += "|grep " + volumeId + "|awk '{print $4}'";
 
         String result = Script.runSimpleBashScript(queryDiskCmd);
@@ -181,7 +377,7 @@ public class ScaleIOUtil {
     }
 
     public static String getSdcGuid() {
-        String queryGuidCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_GUID_CMD;
+        String queryGuidCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_GUID_CMD + " --file " + DRV_CFG_FILE;
         String result = Script.runSimpleBashScript(queryGuidCmd);
         if (result == null) {
             LOGGER.warn("Failed to get SDC guid");
@@ -203,7 +399,7 @@ public class ScaleIOUtil {
 
     public static String getSdcId(String mdmId) {
         //query_mdms outputs "MDM-ID <System/MDM-Id> SDC ID <SDC-Id> INSTALLATION ID <Installation-Id> IPs [0]-x.x.x.x [1]-x.x.x.x" for a MDM with ID: <MDM-Id>
-        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD;
+        String queryMdmsCmd = ScaleIOUtil.SDC_HOME_PATH + "/bin/" + ScaleIOUtil.QUERY_MDMS_CMD + " --file " + DRV_CFG_FILE;
         queryMdmsCmd += "|grep " + mdmId + "|awk '{print $5}'";
         String result = Script.runSimpleBashScript(queryMdmsCmd);
         if (result == null) {
@@ -225,7 +421,7 @@ public class ScaleIOUtil {
         return result;
     }
 
-    public static final String getVolumePath(String volumePathWithName) {
+    public static String getVolumePath(String volumePathWithName) {
         if (StringUtils.isEmpty(volumePathWithName)) {
             return volumePathWithName;
         }
@@ -237,7 +433,7 @@ public class ScaleIOUtil {
         return volumePathWithName;
     }
 
-    public static final String updatedPathWithVolumeName(String volumePath, String volumeName) {
+    public static String updatedPathWithVolumeName(String volumePath, String volumeName) {
         if (StringUtils.isAnyEmpty(volumePath, volumeName)) {
             return volumePath;
         }
@@ -278,5 +474,40 @@ public class ScaleIOUtil {
     public static boolean restartSDCService() {
         int exitValue = Script.runSimpleBashScriptForExitValue(SDC_SERVICE_RESTART_CMD);
         return exitValue == 0;
+    }
+
+    /**
+     * Represents {@link ScaleIOUtil#DRV_CFG_FILE} MDM entry (SDC and Installation Ids are skipped).
+     */
+    public static class MdmEntry {
+        private String mdmId;
+        private Collection<String> ips;
+
+        /**
+         * MDM entry constructor.
+         *
+         * @param mdmId MDM Id
+         * @param ips   IP Addresses
+         */
+        public MdmEntry(String mdmId, Collection<String> ips) {
+            this.mdmId = mdmId;
+            this.ips = ips;
+        }
+
+        public String getMdmId() {
+            return mdmId;
+        }
+
+        public void setMdmId(String mdmId) {
+            this.mdmId = mdmId;
+        }
+
+        public Collection<String> getIps() {
+            return ips;
+        }
+
+        public void setIps(Collection<String> ips) {
+            this.ips = ips;
+        }
     }
 }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -213,16 +213,19 @@ public class ScaleIOUtil {
             }
             // remove MDM via CLI if it is supported
             if (removeMdmCliSupported) {
-                removeMdm(mdmAddress);
                 if (removeMdm(mdmAddress)) {
                     changesApplied = true;
                 }
             } else {
                 String command = String.format(REMOVE_MDM_CMD_TEMPLATE, mdmAddress, DRV_CFG_FILE);
-                Script.runSimpleBashScript(command);
-                // restart SDC needed only if configuration file modified manually (not by CLI)
-                restartSDC = true;
-                changesApplied = true;
+                String stdErr = Script.executeCommand(command).second();
+                if(StringUtils.isEmpty(stdErr)) {
+                    // restart SDC needed only if configuration file modified manually (not by CLI)
+                    restartSDC = true;
+                    changesApplied = true;
+                } else {
+                    LOGGER.error(String.format("Failed to remove MDM %s from %s: %s", mdmAddress, DRV_CFG_FILE, stdErr));
+                }
             }
         }
         if (restartSDC) {

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.cloudstack.storage.datastore.util;
 
+import com.cloud.agent.properties.AgentProperties;
+import com.cloud.agent.properties.AgentPropertiesFileHandler;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
@@ -72,6 +74,13 @@ public class ScaleIOUtil {
     private static final String SDC_SERVICE_ENABLE_CMD = "systemctl enable scini";
 
     public static final String CONNECTED_SDC_COUNT_STAT = "ConnectedSDCCount";
+
+    /**
+     * Time (in seconds) to wait after SDC service 'scini' start/restart/stop.<br>
+     * Data type: Integer.<br>
+     * Default value: <code>3</code>
+     */
+    public static final AgentProperties.Property<Integer> SDC_SERVICE_ACTION_WAIT = new AgentProperties.Property<>("powerflex.sdc.service.wait", 3);
 
     /**
      * Cmd for querying volumes in SDC
@@ -470,7 +479,7 @@ public class ScaleIOUtil {
         if (exitValue != 0) {
             return false;
         }
-        waitForSecs(3);
+        waitForSdcServiceActionToComplete();
         return true;
     }
 
@@ -479,7 +488,7 @@ public class ScaleIOUtil {
         if (exitValue != 0) {
             return false;
         }
-        waitForSecs(1);
+        waitForSdcServiceActionToComplete();
         return true;
     }
 
@@ -488,16 +497,19 @@ public class ScaleIOUtil {
         if (exitValue != 0) {
             return false;
         }
-        waitForSecs(3);
+        waitForSdcServiceActionToComplete();
         return true;
     }
 
-    private static void waitForSecs(long waitTimeInSecs) {
+    private static void waitForSdcServiceActionToComplete() {
+        // Wait for the SDC service to settle after start/restart/stop and reaches a stable state
+        int waitTimeInSecs = AgentPropertiesFileHandler.getPropertyValue(SDC_SERVICE_ACTION_WAIT);
         if (waitTimeInSecs < 0) {
-            waitTimeInSecs = 1;
+            waitTimeInSecs = SDC_SERVICE_ACTION_WAIT.getDefaultValue();
         }
         try {
-            Thread.sleep(waitTimeInSecs * 1000);
+            LOGGER.debug(String.format("Waiting for %d secs after SDC service action, to reach a stable state", waitTimeInSecs));
+            Thread.sleep(waitTimeInSecs * 1000L);
         } catch (InterruptedException ignore) {
         }
     }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -206,7 +206,7 @@ public class ScaleIOUtil {
         boolean removeMdmCliSupported = isRemoveMdmCliSupported();
         boolean restartSDC = false;
         for (String mdmAddress : mdmAddresses) {
-            // continue to next address if current MDM is not present in configuratino
+            // continue to next address if current MDM is not present in configuration
             if (!isMdmPresent(mdmAddress)) {
                 continue;
             }

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -176,7 +176,7 @@ public class ScaleIOUtil {
 
     /**
      * Run command, log command result and return {@link Boolean#TRUE} if command succeeded.
-     * FIXME: may need to do refactoring and replace static method callss with dynamic.
+     * FIXME: may need to do refactoring and replace static method calls with dynamic.
      */
     private static boolean runCmd(String command) {
         Pair<String, String> result = Script.executeCommand(command);
@@ -467,17 +467,39 @@ public class ScaleIOUtil {
 
     public static boolean startSDCService() {
         int exitValue = Script.runSimpleBashScriptForExitValue(SDC_SERVICE_START_CMD);
-        return exitValue == 0;
+        if (exitValue != 0) {
+            return false;
+        }
+        waitForSecs(3);
+        return true;
     }
 
     public static boolean stopSDCService() {
         int exitValue = Script.runSimpleBashScriptForExitValue(SDC_SERVICE_STOP_CMD);
-        return exitValue == 0;
+        if (exitValue != 0) {
+            return false;
+        }
+        waitForSecs(1);
+        return true;
     }
 
     public static boolean restartSDCService() {
         int exitValue = Script.runSimpleBashScriptForExitValue(SDC_SERVICE_RESTART_CMD);
-        return exitValue == 0;
+        if (exitValue != 0) {
+            return false;
+        }
+        waitForSecs(3);
+        return true;
+    }
+
+    private static void waitForSecs(long waitTimeInSecs) {
+        if (waitTimeInSecs < 0) {
+            waitTimeInSecs = 1;
+        }
+        try {
+            Thread.sleep(waitTimeInSecs * 1000);
+        } catch (InterruptedException ignore) {
+        }
     }
 
     /**

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -321,8 +321,8 @@ public class ScaleIOUtil {
         String command = SDC_HOME_PATH + "/bin/" + USAGE_CMD;
 
         Pair<String, String> result = Script.executeCommand(command);
-        String stdErr = result.first();
-        String stdOut = result.second();
+        String stdOut = result.first();
+        String stdErr = result.second();
 
         /*
          * Check whether stderr or stdout contains mdm removal "--remove_mdm" parameter.

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/util/ScaleIOUtil.java
@@ -17,7 +17,6 @@
 
 package org.apache.cloudstack.storage.datastore.util;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 

--- a/utils/src/main/java/com/cloud/utils/script/Script.java
+++ b/utils/src/main/java/com/cloud/utils/script/Script.java
@@ -687,7 +687,7 @@ public class Script implements Callable<String> {
         OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
         String stdErr = script.execute(parser);
         String stdOut = parser.getLines();
-        return new Pair(stdOut, stdErr);
+        return new Pair<>(stdOut, stdErr);
     }
 
     public static int executeCommandForExitValue(long timeout, String... command) {

--- a/utils/src/main/java/com/cloud/utils/script/Script.java
+++ b/utils/src/main/java/com/cloud/utils/script/Script.java
@@ -687,6 +687,7 @@ public class Script implements Callable<String> {
         OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
         String stdErr = script.execute(parser);
         String stdOut = parser.getLines();
+        LOGGER.debug(String.format("Command [%s] result - stdout: [%s], stderr: [%s]", command, stdOut, stdErr));
         return new Pair<>(stdOut, stdErr);
     }
 

--- a/utils/src/main/java/com/cloud/utils/script/Script.java
+++ b/utils/src/main/java/com/cloud/utils/script/Script.java
@@ -671,6 +671,25 @@ public class Script implements Callable<String> {
         return runScript(getScriptForCommandRun(command));
     }
 
+    /**
+     * Execute command and return standard output and standard error.
+     *
+     * @param command OS command to be executed
+     * @return {@link Pair} with standard output as first and standard error as second field
+     */
+    public static Pair<String, String> executeCommand(String command) {
+        // wrap command into bash
+        Script script = new Script("/bin/bash");
+        script.add("-c");
+        script.add(command);
+
+        // parse all lines from the output
+        OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
+        String stdErr = script.execute(parser);
+        String stdOut = parser.getLines();
+        return new Pair(stdOut, stdErr);
+    }
+
     public static int executeCommandForExitValue(long timeout, String... command) {
         return runScriptForExitValue(getScriptForCommandRun(timeout, command));
     }


### PR DESCRIPTION
### Description

This PR enhances the PowerFlex/ScaleIO MDM  and host SDC connections, includes the following changes (and some code improvements).

- Introduced timeout configuration 'powerflex.mdm.change.apply.wait' (Default value: 1000 ms) at zone scope, to wait after MDM addition, and before & after MDM removal changes made on Host with ScaleIO SDC. Also, Changes to apply the wait time after making MDM changes for ScaleIO in prepare and unprepare logic.

- Introduced configuration flag 'powerflex.block.sdc.unprepare' (Default is false) at zone scope, to enable/disable blocking unprepare ScaleIO SDC connection when SDC client restart required (upon PowerFlex MDM removal i.e. no support for _--remove_mdm_ in _drv_cfg_ cmd) and there are volumes attached to the Host. Added validation to fail Host disconnect from Storage Pool if there are Volumes attached and SDC client MDM removal requires scini service to be restarted.

- Introduced configuration flag 'powerflex.mdm.validate.on.connect' (Default is false) at zone scope, to enable/disable validation of MDM addresses on Host, in the Configuration File and in CLI cmd (_drv_cfg --query_mdms_) output matches or not, during storage pool registration in agent.

- Added detection of MDM removal support via CLI. If MDM removal support via CLI supported then use CLI, Otherwise fall back to edit drv_cfg.txt and restart scini as earlier. Tested with _/opt/emc/scaleio/sdc/bin/drv_cfg --version_: DellEMC PowerFlex Version: R3_6.4000.124, with cmd: _/opt/emc/scaleio/sdc/bin/drv_cfg --remove_mdm_. 

- Added agent property 'powerflex.sdc.service.wait' for the time (in secs) to wait after SDC service start/restart/stop, and retries to fetch SDC id/guid.

- Updated to allow unprepare SDC when there are no volumes mapped on the host for other connected pools (with same SDC Id, i.e pools of same PowerFlex storage cluster).


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested the new settings, and PowerFlex SDC connections (MDM add/remove) with VM & Volume operations.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
