### PR TITLE
Usage parsers refactoring

### DIFF
--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -34,10 +34,9 @@ import java.util.concurrent.TimeUnit;
 
 import com.cloud.network.Network;
 import com.cloud.usage.dao.UsageNetworksDao;
-import com.cloud.usage.parser.NetworksUsageParser;
+import com.cloud.usage.parser.UsageParser;
 import com.cloud.network.vpc.Vpc;
 import com.cloud.usage.dao.UsageVpcDao;
-import com.cloud.usage.parser.VpcUsageParser;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 import javax.persistence.EntityExistsException;
@@ -75,21 +74,6 @@ import com.cloud.usage.dao.UsageVMSnapshotOnPrimaryDao;
 import com.cloud.usage.dao.UsageVPNUserDao;
 import com.cloud.usage.dao.UsageVmDiskDao;
 import com.cloud.usage.dao.UsageVolumeDao;
-import com.cloud.usage.parser.BackupUsageParser;
-import com.cloud.usage.parser.BucketUsageParser;
-import com.cloud.usage.parser.IPAddressUsageParser;
-import com.cloud.usage.parser.LoadBalancerUsageParser;
-import com.cloud.usage.parser.NetworkOfferingUsageParser;
-import com.cloud.usage.parser.NetworkUsageParser;
-import com.cloud.usage.parser.PortForwardingUsageParser;
-import com.cloud.usage.parser.SecurityGroupUsageParser;
-import com.cloud.usage.parser.StorageUsageParser;
-import com.cloud.usage.parser.VMInstanceUsageParser;
-import com.cloud.usage.parser.VMSnapshotOnPrimaryParser;
-import com.cloud.usage.parser.VMSnapshotUsageParser;
-import com.cloud.usage.parser.VPNUserUsageParser;
-import com.cloud.usage.parser.VmDiskUsageParser;
-import com.cloud.usage.parser.VolumeUsageParser;
 import com.cloud.user.Account;
 import com.cloud.user.AccountVO;
 import com.cloud.user.UserStatisticsVO;
@@ -180,6 +164,9 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     @Inject
     private UsageVpcDao usageVpcDao;
 
+    @Inject
+    private List<UsageParser> usageParsers;
+
     private String _version = null;
     private final Calendar _jobExecTime = Calendar.getInstance();
     private int _aggregationDuration = 0;
@@ -198,6 +185,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     private Future _heartbeat = null;
     private Future _sanity = null;
     private boolean  usageSnapshotSelection = false;
+
     private static TimeZone usageAggregationTimeZone = TimeZone.getTimeZone("GMT");
 
     public UsageManagerImpl() {
@@ -954,114 +942,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     private boolean parseHelperTables(AccountVO account, Date currentStartDate, Date currentEndDate) {
         boolean parsed = false;
 
-        parsed = VMInstanceUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("vm usage instances successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
+        for (UsageParser parser : usageParsers) {
+            parsed = parser.doParsing(account, currentStartDate, currentEndDate);
+
+            logger.debug("{} usage was {} parsed for [{}].", parser.getParserName(), parsed ? "successfully" : "not successfully", account);
         }
 
-        parsed = NetworkUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("network usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = VmDiskUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("vm disk usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = VolumeUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("volume usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = StorageUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("storage usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = SecurityGroupUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("Security Group usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = LoadBalancerUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("load balancer usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = PortForwardingUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("port forwarding usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = NetworkOfferingUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("network offering usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-
-        parsed = IPAddressUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("IPAddress usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-        parsed = VPNUserUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("VPN user usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-        parsed = VMSnapshotUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("VM Snapshot usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-        parsed = VMSnapshotOnPrimaryParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("VM Snapshot on primary usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-        parsed = BackupUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("VM Backup usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-        parsed = BucketUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (logger.isDebugEnabled()) {
-            if (!parsed) {
-                logger.debug("Bucket usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
-            }
-        }
-        parsed = NetworksUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (!parsed) {
-            logger.debug("Networks usage not parsed for account [{}}].", account);
-        }
-
-        parsed = VpcUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (!parsed) {
-            logger.debug(String.format("VPC usage failed to parse for account [%s].", account));
-        }
         return parsed;
     }
 

--- a/usage/src/main/java/com/cloud/usage/parser/BucketUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/BucketUsageParser.java
@@ -19,47 +19,32 @@ package com.cloud.usage.parser;
 import com.cloud.usage.BucketStatisticsVO;
 import com.cloud.usage.UsageVO;
 import com.cloud.usage.dao.BucketStatisticsDao;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.user.AccountVO;
 import org.apache.cloudstack.usage.UsageTypes;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 @Component
-public class BucketUsageParser {
-    public static final Logger LOGGER = LogManager.getLogger(BucketUsageParser.class);
-
-    private static UsageDao s_usageDao;
-    private static BucketStatisticsDao s_bucketStatisticsDao;
-
+public class BucketUsageParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private BucketStatisticsDao _bucketStatisticsDao;
+    private BucketStatisticsDao bucketStatisticsDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_bucketStatisticsDao = _bucketStatisticsDao;
+    @Override
+    public String getParserName() {
+        return "Bucket";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing all Bucket usage events for account {}", account);
-        }
-
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
 
-        List<BucketStatisticsVO> BucketStatisticsVOs = s_bucketStatisticsDao.listBy(account.getId());
+        List<BucketStatisticsVO> BucketStatisticsVOs = bucketStatisticsDao.listBy(account.getId());
 
         List<UsageVO> usageRecords = new ArrayList<>();
         for (BucketStatisticsVO bucketStatistics : BucketStatisticsVOs) {
@@ -72,7 +57,7 @@ public class BucketUsageParser {
             }
         }
 
-        s_usageDao.saveUsageRecords(usageRecords);
+        usageDao.saveUsageRecords(usageRecords);
 
         return true;
     }

--- a/usage/src/main/java/com/cloud/usage/parser/IPAddressUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/IPAddressUsageParser.java
@@ -22,46 +22,32 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.usage.UsageManagerImpl;
 import com.cloud.utils.DateUtil;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.usage.UsageTypes;
 
 import com.cloud.usage.UsageIPAddressVO;
 import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageIPAddressDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.Pair;
 
 @Component
-public class IPAddressUsageParser {
-    protected static Logger LOGGER = LogManager.getLogger(IPAddressUsageParser.class);
-
-    private static UsageDao s_usageDao;
-    private static UsageIPAddressDao s_usageIPAddressDao;
-
+public class IPAddressUsageParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private UsageIPAddressDao _usageIPAddressDao;
+    private UsageIPAddressDao usageIPAddressDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_usageIPAddressDao = _usageIPAddressDao;
+    @Override
+    public String getParserName() {
+        return "IP Address";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing IP Address usage for account: " + account.getId());
-        }
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
@@ -71,10 +57,10 @@ public class IPAddressUsageParser {
         //     - look for an entry for accountId with end date in the given range
         //     - look for an entry for accountId with end date null (currently running vm or owned IP)
         //     - look for an entry for accountId with start date before given range *and* end date after given range
-        List<UsageIPAddressVO> usageIPAddress = s_usageIPAddressDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate);
+        List<UsageIPAddressVO> usageIPAddress = usageIPAddressDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate);
 
         if (usageIPAddress.isEmpty()) {
-            LOGGER.debug("No IP Address usage for this period");
+            logger.debug("No IP Address usage for this period");
             return true;
         }
 
@@ -128,7 +114,7 @@ public class IPAddressUsageParser {
         return true;
     }
 
-    private static void updateIpUsageData(Map<String, Pair<Long, Long>> usageDataMap, String key, long ipId, long duration) {
+    private void updateIpUsageData(Map<String, Pair<Long, Long>> usageDataMap, String key, long ipId, long duration) {
         Pair<Long, Long> ipUsageInfo = usageDataMap.get(key);
         if (ipUsageInfo == null) {
             ipUsageInfo = new Pair<Long, Long>(new Long(ipId), new Long(duration));
@@ -140,18 +126,17 @@ public class IPAddressUsageParser {
         usageDataMap.put(key, ipUsageInfo);
     }
 
-    private static void createUsageRecord(long zoneId, long runningTime, Date startDate, Date endDate, AccountVO account, long ipId, String ipAddress,
+    private void createUsageRecord(long zoneId, long runningTime, Date startDate, Date endDate, AccountVO account, long ipId, String ipAddress,
         boolean isSourceNat, boolean isSystem, boolean isHidden) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Total usage time " + runningTime + "ms");
-        }
+
+        logger.debug("Total usage time {} ms" , runningTime);
 
         float usage = runningTime / 1000f / 60f / 60f;
 
         DecimalFormat dFormat = new DecimalFormat("#.######");
         String usageDisplay = dFormat.format(usage);
 
-        LOGGER.debug("Creating IP usage record with id [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
+        logger.debug("Creating IP usage record with id [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
                 ipId, usageDisplay, DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), startDate),
                 DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), endDate), account.getId());
 
@@ -162,7 +147,7 @@ public class IPAddressUsageParser {
         UsageVO usageRecord =
             new UsageVO(zoneId, account.getAccountId(), account.getDomainId(), usageDesc, usageDisplay + " Hrs", UsageTypes.IP_ADDRESS, new Double(usage), ipId,
                 (isSystem ? 1 : 0), (isSourceNat ? "SourceNat" : ""), startDate, endDate, isHidden);
-        s_usageDao.persist(usageRecord);
+        usageDao.persist(usageRecord);
     }
 
     private static class IpInfo {

--- a/usage/src/main/java/com/cloud/usage/parser/LoadBalancerUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/LoadBalancerUsageParser.java
@@ -22,46 +22,32 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.usage.UsageManagerImpl;
 import com.cloud.utils.DateUtil;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.usage.UsageTypes;
 
 import com.cloud.usage.UsageLoadBalancerPolicyVO;
 import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageLoadBalancerPolicyDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.Pair;
 
 @Component
-public class LoadBalancerUsageParser {
-    protected static Logger LOGGER = LogManager.getLogger(LoadBalancerUsageParser.class);
-
-    private static UsageDao s_usageDao;
-    private static UsageLoadBalancerPolicyDao s_usageLoadBalancerPolicyDao;
-
+public class LoadBalancerUsageParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private UsageLoadBalancerPolicyDao _usageLoadBalancerPolicyDao;
+    private UsageLoadBalancerPolicyDao usageLoadBalancerPolicyDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_usageLoadBalancerPolicyDao = _usageLoadBalancerPolicyDao;
+    @Override
+    public String getParserName() {
+        return "Load Balancer Policy";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing all LoadBalancerPolicy usage events for account: " + account.getId());
-        }
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
@@ -71,10 +57,10 @@ public class LoadBalancerUsageParser {
         //     - look for an entry for accountId with end date in the given range
         //     - look for an entry for accountId with end date null (currently running vm or owned IP)
         //     - look for an entry for accountId with start date before given range *and* end date after given range
-        List<UsageLoadBalancerPolicyVO> usageLBs = s_usageLoadBalancerPolicyDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate, false, 0);
+        List<UsageLoadBalancerPolicyVO> usageLBs = usageLoadBalancerPolicyDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate, false, 0);
 
         if (usageLBs.isEmpty()) {
-            LOGGER.debug("No load balancer usage events for this period");
+            logger.debug("No Load Balancer usage events for this period");
             return true;
         }
 
@@ -125,7 +111,7 @@ public class LoadBalancerUsageParser {
         return true;
     }
 
-    private static void updateLBUsageData(Map<String, Pair<Long, Long>> usageDataMap, String key, long lbId, long duration) {
+    private void updateLBUsageData(Map<String, Pair<Long, Long>> usageDataMap, String key, long lbId, long duration) {
         Pair<Long, Long> lbUsageInfo = usageDataMap.get(key);
         if (lbUsageInfo == null) {
             lbUsageInfo = new Pair<Long, Long>(new Long(lbId), new Long(duration));
@@ -137,18 +123,18 @@ public class LoadBalancerUsageParser {
         usageDataMap.put(key, lbUsageInfo);
     }
 
-    private static void createUsageRecord(int type, long runningTime, Date startDate, Date endDate, AccountVO account, long lbId, long zoneId) {
+    private void createUsageRecord(int type, long runningTime, Date startDate, Date endDate, AccountVO account, long lbId, long zoneId) {
         // Our smallest increment is hourly for now
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Total running time " + runningTime + "ms");
-        }
+
+        logger.debug("Total running time {} ms", runningTime);
+
 
         float usage = runningTime / 1000f / 60f / 60f;
 
         DecimalFormat dFormat = new DecimalFormat("#.######");
         String usageDisplay = dFormat.format(usage);
 
-        LOGGER.debug("Creating usage record for load balancer with id [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
+        logger.debug("Creating usage record for load balancer with id [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
                 lbId, usageDisplay, DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), startDate),
                 DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), endDate), account.getId());
 
@@ -159,7 +145,7 @@ public class LoadBalancerUsageParser {
         UsageVO usageRecord =
             new UsageVO(zoneId, account.getId(), account.getDomainId(), usageDesc, usageDisplay + " Hrs", type, new Double(usage), null, null, null, null, lbId, null,
                 startDate, endDate);
-        s_usageDao.persist(usageRecord);
+        usageDao.persist(usageRecord);
     }
 
     private static class LBInfo {

--- a/usage/src/main/java/com/cloud/usage/parser/NetworkUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/NetworkUsageParser.java
@@ -22,20 +22,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.usage.UsageManagerImpl;
 import com.cloud.utils.DateUtil;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.usage.UsageTypes;
 
 import com.cloud.usage.UsageNetworkVO;
 import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageNetworkDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.db.SearchCriteria;
@@ -43,38 +39,27 @@ import com.cloud.utils.db.SearchCriteria;
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 @Component
-public class NetworkUsageParser {
-    protected static Logger LOGGER = LogManager.getLogger(NetworkUsageParser.class);
-
-    private static UsageDao s_usageDao;
-    private static UsageNetworkDao s_usageNetworkDao;
-
+public class NetworkUsageParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private UsageNetworkDao _usageNetworkDao;
+    private UsageNetworkDao usageNetworkDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_usageNetworkDao = _usageNetworkDao;
+    @Override
+    public String getParserName() {
+        return "Network";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing all Network usage events for account: " + account.getId());
-        }
-
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
 
         // - query usage_network table for all entries for userId with
         // event_date in the given range
-        SearchCriteria<UsageNetworkVO> sc = s_usageNetworkDao.createSearchCriteria();
+        SearchCriteria<UsageNetworkVO> sc = usageNetworkDao.createSearchCriteria();
         sc.addAnd("accountId", SearchCriteria.Op.EQ, account.getId());
         sc.addAnd("eventTimeMillis", SearchCriteria.Op.BETWEEN, startDate.getTime(), endDate.getTime());
-        List<UsageNetworkVO> usageNetworkVOs = s_usageNetworkDao.search(sc, null);
+        List<UsageNetworkVO> usageNetworkVOs = usageNetworkDao.search(sc, null);
 
         Map<String, NetworkInfo> networkUsageByZone = new HashMap<String, NetworkInfo>();
 
@@ -105,7 +90,7 @@ public class NetworkUsageParser {
             long totalBytesReceived = networkInfo.getBytesRcvd();
 
             if ((totalBytesSent > 0L) || (totalBytesReceived > 0L)) {
-                LOGGER.debug("Creating usage record, total bytes sent [{}], total bytes received [{}], startDate [{}], and endDate [{}], for account [{}] in " +
+                logger.debug("Creating usage record, total bytes sent [{}], total bytes received [{}], startDate [{}], and endDate [{}], for account [{}] in " +
                                 "availability zone [{}].", toHumanReadableSize(totalBytesSent), toHumanReadableSize(totalBytesReceived),
                         DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), startDate),
                         DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), endDate), account.getId(), networkInfo.getZoneId());
@@ -135,13 +120,11 @@ public class NetworkUsageParser {
                 usageRecords.add(usageRecord);
             } else {
                 // Don't charge anything if there were zero bytes processed
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("No usage record (0 bytes used) generated for account: " + account.getId());
-                }
+                logger.debug("No usage record (0 bytes used) generated for account: [{}]", account.getUuid());
             }
         }
 
-        s_usageDao.saveUsageRecords(usageRecords);
+        usageDao.saveUsageRecords(usageRecords);
 
         return true;
     }

--- a/usage/src/main/java/com/cloud/usage/parser/NetworksUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/NetworksUsageParser.java
@@ -18,16 +18,12 @@ package com.cloud.usage.parser;
 
 import com.cloud.usage.UsageNetworksVO;
 import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageNetworksDao;
 import com.cloud.user.AccountVO;
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.usage.UsageTypes;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import java.text.DecimalFormat;
@@ -35,32 +31,24 @@ import java.util.Date;
 import java.util.List;
 
 @Component
-public class NetworksUsageParser {
-    private static final Logger LOGGER = LogManager.getLogger(NetworksUsageParser.class.getName());
-
+public class NetworksUsageParser extends UsageParser {
     @Inject
     private UsageNetworksDao networksDao;
-    @Inject
-    private UsageDao usageDao;
 
-    private static UsageDao staticUsageDao;
-    private static UsageNetworksDao staticNetworksDao;
-
-    @PostConstruct
-    void init() {
-        staticUsageDao = usageDao;
-        staticNetworksDao = networksDao;
+    @Override
+    public String getParserName() {
+        return "Networks";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        LOGGER.debug("Parsing all networks usage events for account {}", account);
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
 
-        final List<UsageNetworksVO> usageNetworksVO = staticNetworksDao.getUsageRecords(account.getId(), startDate, endDate);
+        final List<UsageNetworksVO> usageNetworksVO = networksDao.getUsageRecords(account.getId(), startDate, endDate);
         if (CollectionUtils.isEmpty(usageNetworksVO)) {
-            LOGGER.debug(String.format("Cannot find any VPC usage for account [%s] in period between [%s] and [%s].", account, startDate, endDate));
+            logger.debug("Cannot find any VPC usage for account [{}] in period between [{}] and [{}].", account, startDate, endDate);
             return true;
         }
 
@@ -83,8 +71,8 @@ public class NetworksUsageParser {
 
             long networkId = usageNetwork.getNetworkId();
             long networkOfferingId = usageNetwork.getNetworkOfferingId();
-            LOGGER.debug(String.format("Creating network usage record with id [%s], network offering [%s], usage [%s], startDate [%s], and endDate [%s], for account [%s].",
-                    networkId, networkOfferingId, usageDisplay, startDate, endDate, account));
+            logger.debug("Creating network usage record with id [{}], network offering [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
+                    networkId, networkOfferingId, usageDisplay, startDate, endDate, account.getId());
 
             String description = String.format("Network usage for network ID: %d, network offering: %d", usageNetwork.getNetworkId(), usageNetwork.getNetworkOfferingId());
             UsageVO usageRecord =
@@ -92,7 +80,7 @@ public class NetworksUsageParser {
                             UsageTypes.NETWORK, (double) usage, null, null, usageNetwork.getNetworkOfferingId(), null, usageNetwork.getNetworkId(),
                             (long)0, null, startDate, endDate);
             usageRecord.setState(usageNetwork.getState());
-            staticUsageDao.persist(usageRecord);
+            usageDao.persist(usageRecord);
         }
 
         return true;

--- a/usage/src/main/java/com/cloud/usage/parser/SecurityGroupUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/SecurityGroupUsageParser.java
@@ -22,46 +22,32 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.usage.UsageManagerImpl;
 import com.cloud.utils.DateUtil;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.usage.UsageTypes;
 
 import com.cloud.usage.UsageSecurityGroupVO;
 import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageSecurityGroupDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.Pair;
 
 @Component
-public class SecurityGroupUsageParser {
-    protected static Logger LOGGER = LogManager.getLogger(SecurityGroupUsageParser.class);
-
-    private static UsageDao s_usageDao;
-    private static UsageSecurityGroupDao s_usageSecurityGroupDao;
-
+public class SecurityGroupUsageParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private UsageSecurityGroupDao _usageSecurityGroupDao;
+    private UsageSecurityGroupDao usageSecurityGroupDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_usageSecurityGroupDao = _usageSecurityGroupDao;
+    @Override
+    public String getParserName() {
+        return "Security Group";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing all SecurityGroup usage events for account: " + account.getId());
-        }
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
@@ -71,10 +57,10 @@ public class SecurityGroupUsageParser {
         //     - look for an entry for accountId with end date in the given range
         //     - look for an entry for accountId with end date null (currently running vm or owned IP)
         //     - look for an entry for accountId with start date before given range *and* end date after given range
-        List<UsageSecurityGroupVO> usageSGs = s_usageSecurityGroupDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate, false, 0);
+        List<UsageSecurityGroupVO> usageSGs = usageSecurityGroupDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate, false, 0);
 
         if (usageSGs.isEmpty()) {
-            LOGGER.debug("No SecurityGroup usage events for this period");
+            logger.debug("No SecurityGroup usage events for this period");
             return true;
         }
 
@@ -126,7 +112,7 @@ public class SecurityGroupUsageParser {
         return true;
     }
 
-    private static void updateSGUsageData(Map<String, Pair<Long, Long>> usageDataMap, String key, long vmId, long duration) {
+    private void updateSGUsageData(Map<String, Pair<Long, Long>> usageDataMap, String key, long vmId, long duration) {
         Pair<Long, Long> sgUsageInfo = usageDataMap.get(key);
         if (sgUsageInfo == null) {
             sgUsageInfo = new Pair<Long, Long>(new Long(vmId), new Long(duration));
@@ -138,18 +124,16 @@ public class SecurityGroupUsageParser {
         usageDataMap.put(key, sgUsageInfo);
     }
 
-    private static void createUsageRecord(int type, long runningTime, Date startDate, Date endDate, AccountVO account, long vmId, long sgId, long zoneId) {
+    private void createUsageRecord(int type, long runningTime, Date startDate, Date endDate, AccountVO account, long vmId, long sgId, long zoneId) {
         // Our smallest increment is hourly for now
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Total running time " + runningTime + "ms");
-        }
+        logger.debug("Total running time {} ms", runningTime);
 
         float usage = runningTime / 1000f / 60f / 60f;
 
         DecimalFormat dFormat = new DecimalFormat("#.######");
         String usageDisplay = dFormat.format(usage);
 
-        LOGGER.debug("Creating security group usage record for id [{}], vm [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
+        logger.debug("Creating security group usage record for id [{}], vm [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
                 sgId, vmId, usageDisplay, DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), startDate),
                 DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), endDate), account.getId());
 
@@ -159,7 +143,7 @@ public class SecurityGroupUsageParser {
         UsageVO usageRecord =
             new UsageVO(zoneId, account.getId(), account.getDomainId(), usageDesc, usageDisplay + " Hrs", type, new Double(usage), vmId, null, null, null, sgId, null,
                 startDate, endDate);
-        s_usageDao.persist(usageRecord);
+        usageDao.persist(usageRecord);
     }
 
     private static class SGInfo {

--- a/usage/src/main/java/com/cloud/usage/parser/UsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/UsageParser.java
@@ -16,21 +16,30 @@
 // under the License.
 package com.cloud.usage.parser;
 
+import com.cloud.usage.dao.UsageDao;
+import com.cloud.user.AccountVO;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.inject.Inject;
 import java.util.Date;
 
+public abstract class UsageParser {
+    Logger logger = LogManager.getLogger(getClass());
 
-import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+    @Inject
+    UsageDao usageDao;
 
-public abstract class UsageParser extends ManagedContextRunnable {
-
-    @Override
-    protected void runInContext() {
-        try {
-            parse(null);
-        } catch (Exception e) {
-            logger.warn("Error while parsing usage events", e);
-        }
+    private void beforeParse(AccountVO account) {
+        logger.debug("Parsing all {} usage events for account: [{}]", getParserName(), account.getUuid());
     }
 
-    public abstract void parse(Date endDate);
+    public abstract String getParserName();
+
+    protected abstract boolean parse(AccountVO account, Date startDate, Date endDate);
+
+    public boolean doParsing(AccountVO account, Date startDate, Date endDate) {
+        beforeParse(account);
+        return parse(account, startDate, endDate);
+    }
 }

--- a/usage/src/main/java/com/cloud/usage/parser/VMSnapshotOnPrimaryParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/VMSnapshotOnPrimaryParser.java
@@ -22,65 +22,51 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.usage.UsageManagerImpl;
 import com.cloud.utils.DateUtil;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.usage.UsageTypes;
 
 import com.cloud.usage.UsageSnapshotOnPrimaryVO;
 import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageVMSnapshotOnPrimaryDao;
 import com.cloud.user.AccountVO;
 
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 @Component
-public class VMSnapshotOnPrimaryParser {
-    protected static Logger LOGGER = LogManager.getLogger(VMSnapshotOnPrimaryParser.class);
-
-    private static UsageDao s_usageDao;
-    private static UsageVMSnapshotOnPrimaryDao s_usageSnapshotOnPrimaryDao;
-
+public class VMSnapshotOnPrimaryParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private UsageVMSnapshotOnPrimaryDao _usageSnapshotOnPrimaryDao;
+    private UsageVMSnapshotOnPrimaryDao usageSnapshotOnPrimaryDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_usageSnapshotOnPrimaryDao = _usageSnapshotOnPrimaryDao;
+    @Override
+    public String getParserName() {
+        return "VM Snapshot on Primary";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing all VmSnapshot on primary usage events for account: " + account.getId());
-        }
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
 
-        List<UsageSnapshotOnPrimaryVO> usageUsageVMSnapshots = s_usageSnapshotOnPrimaryDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate);
+        List<UsageSnapshotOnPrimaryVO> usageUsageVMSnapshots = usageSnapshotOnPrimaryDao.getUsageRecords(account.getId(), account.getDomainId(), startDate, endDate);
 
         if (usageUsageVMSnapshots.isEmpty()) {
-            LOGGER.debug("No VM snapshot on primary usage events for this period");
+            logger.debug("No VM snapshot on primary usage events for this period");
             return true;
         }
 
         Map<String, UsageSnapshotOnPrimaryVO> unprocessedUsage = new HashMap<String, UsageSnapshotOnPrimaryVO>();
         for (UsageSnapshotOnPrimaryVO usageRec : usageUsageVMSnapshots) {
-            LOGGER.debug("usageRec for VMsnap on primary " + usageRec.toString());
+            logger.debug("usageRec for VMsnap on primary [{}]", usageRec.toString());
             String key = usageRec.getName();
             if (usageRec.getPhysicalSize() == 0) {
                 usageRec.setDeleted(new Date());
-                s_usageSnapshotOnPrimaryDao.updateDeleted(usageRec);
+                usageSnapshotOnPrimaryDao.updateDeleted(usageRec);
             } else {
                 unprocessedUsage.put(key, usageRec);
             }
@@ -95,7 +81,7 @@ public class VMSnapshotOnPrimaryParser {
             Date endDateEffective = endDate;
             if (usageRec.getDeleted() != null && usageRec.getDeleted().before(endDate)){
                 endDateEffective = usageRec.getDeleted();
-                LOGGER.debug("Remoevd vm snapshot found endDateEffective " + endDateEffective + " period end data " + endDate);
+                logger.debug("Removed vm snapshot found endDateEffective [{}] period end data [{}]", endDateEffective, endDate);
             }
             long duration = (endDateEffective.getTime() - created.getTime()) + 1;
             createUsageRecord(UsageTypes.VM_SNAPSHOT_ON_PRIMARY, duration, created, endDateEffective, account, usageRec.getVolumeId(), usageRec.getName(), usageRec.getZoneId(),
@@ -105,19 +91,17 @@ public class VMSnapshotOnPrimaryParser {
         return true;
     }
 
-    private static void createUsageRecord(int usageType, long runningTime, Date startDate, Date endDate, AccountVO account, long vmId, String name, long zoneId, long virtualSize,
+    private void createUsageRecord(int usageType, long runningTime, Date startDate, Date endDate, AccountVO account, long vmId, String name, long zoneId, long virtualSize,
                                           long physicalSize, Long vmSnapshotId) {
         // Our smallest increment is hourly for now
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Total running time " + runningTime + "ms");
-        }
+        logger.debug("Total running time {} ms", runningTime);
 
         float usage = runningTime / 1000f / 60f / 60f;
 
         DecimalFormat dFormat = new DecimalFormat("#.######");
         String usageDisplay = dFormat.format(usage);
 
-        LOGGER.debug("Creating usage record for VMSnapshot with id [{}] in primary, vm [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
+        logger.debug("Creating usage record for VMSnapshot with id [{}] in primary, vm [{}], usage [{}], startDate [{}], and endDate [{}], for account [{}].",
                 vmSnapshotId, vmId, usageDisplay, DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), startDate),
                 DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), endDate), account.getId());
 
@@ -127,7 +111,7 @@ public class VMSnapshotOnPrimaryParser {
 
         UsageVO usageRecord = new UsageVO(zoneId, account.getId(), account.getDomainId(), usageDesc, usageDisplay + " Hrs", usageType, new Double(usage), vmId, name, null, null,
                 vmSnapshotId, physicalSize, virtualSize, startDate, endDate);
-        s_usageDao.persist(usageRecord);
+        usageDao.persist(usageRecord);
     }
 
 }

--- a/usage/src/main/java/com/cloud/usage/parser/VmDiskUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/VmDiskUsageParser.java
@@ -22,20 +22,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.usage.UsageManagerImpl;
 import com.cloud.utils.DateUtil;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.usage.UsageTypes;
 
 import com.cloud.usage.UsageVO;
 import com.cloud.usage.UsageVmDiskVO;
-import com.cloud.usage.dao.UsageDao;
 import com.cloud.usage.dao.UsageVmDiskDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.db.SearchCriteria;
@@ -43,38 +39,27 @@ import com.cloud.utils.db.SearchCriteria;
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 @Component
-public class VmDiskUsageParser {
-    protected static Logger LOGGER = LogManager.getLogger(VmDiskUsageParser.class);
-
-    private static UsageDao s_usageDao;
-    private static UsageVmDiskDao s_usageVmDiskDao;
-
+public class VmDiskUsageParser extends UsageParser {
     @Inject
-    private UsageDao _usageDao;
-    @Inject
-    private UsageVmDiskDao _usageVmDiskDao;
+    private UsageVmDiskDao usageVmDiskDao;
 
-    @PostConstruct
-    void init() {
-        s_usageDao = _usageDao;
-        s_usageVmDiskDao = _usageVmDiskDao;
+    @Override
+    public String getParserName() {
+        return "VM Disk";
     }
 
-    public static boolean parse(AccountVO account, Date startDate, Date endDate) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Parsing all Vm Disk usage events for account: " + account.getId());
-        }
-
+    @Override
+    protected boolean parse(AccountVO account, Date startDate, Date endDate) {
         if ((endDate == null) || endDate.after(new Date())) {
             endDate = new Date();
         }
 
         // - query usage_disk table for all entries for userId with
         // event_date in the given range
-        SearchCriteria<UsageVmDiskVO> sc = s_usageVmDiskDao.createSearchCriteria();
+        SearchCriteria<UsageVmDiskVO> sc = usageVmDiskDao.createSearchCriteria();
         sc.addAnd("accountId", SearchCriteria.Op.EQ, account.getId());
         sc.addAnd("eventTimeMillis", SearchCriteria.Op.BETWEEN, startDate.getTime(), endDate.getTime());
-        List<UsageVmDiskVO> usageVmDiskVOs = s_usageVmDiskDao.search(sc, null);
+        List<UsageVmDiskVO> usageVmDiskVOs = usageVmDiskDao.search(sc, null);
 
         Map<String, VmDiskInfo> vmDiskUsageByZone = new HashMap<String, VmDiskInfo>();
 
@@ -110,7 +95,7 @@ public class VmDiskUsageParser {
             long bytesWrite = vmDiskInfo.getBytesWrite();
 
             if ((ioRead > 0L) || (ioWrite > 0L) || (bytesRead > 0L) || (bytesWrite > 0L)) {
-                LOGGER.debug("Creating vm disk usage record, io read [{}], io write [{}], bytes read [{}], bytes write [{}], startDate [{}], and endDate [{}], " +
+                logger.debug("Creating vm disk usage record, io read [{}], io write [{}], bytes read [{}], bytes write [{}], startDate [{}], and endDate [{}], " +
                                 "for account [{}] in availability zone [{}].", toHumanReadableSize(ioRead), toHumanReadableSize(ioWrite), toHumanReadableSize(bytesRead),
                         toHumanReadableSize(bytesWrite), DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), startDate),
                         DateUtil.displayDateInTimezone(UsageManagerImpl.getUsageAggregationTimeZone(), endDate), account.getId(), vmDiskInfo.getZoneId());
@@ -162,13 +147,11 @@ public class VmDiskUsageParser {
 
             } else {
                 // Don't charge anything if there were zero bytes processed
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("No vm disk usage record (0 bytes used) generated for account: " + account.getId());
-                }
+                logger.debug("No vm disk usage record (0 bytes used) generated for account: [{}]", account.getId());
             }
         }
 
-        s_usageDao.saveUsageRecords(usageRecords);
+        usageDao.saveUsageRecords(usageRecords);
 
         return true;
     }


### PR DESCRIPTION
### Description

Currently, all Usage parsers implement a static method with an identical signature, which is invoked by the `UsageManagerImpl#parseHelperTables()` method. This PR refactors these parser classes by standardizing them to extend the `UsageParser` class and requiring an override of the `parse` method, improving code consistency, maintainability, and extensibility. 

Additionally, by leveraging Spring Dependency Injection, it was possible to provide a major cleanup in the `UsageManagerImpl#parseHelperTables()` method, by injecting all `UsageParser` implementations into a list, then iterating over it and calling the `parse` method. The parse log was also improved to provide better information about the parsing result, the object being parsed and the target account. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)  <!-- seria bug fix? -->
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

1. First, I triggered the Usage job execution without the changes and validated that the current logs contained minimal information about the process. 
2. Then, installed the packages with the changes in my local env. 
3. After the update, I triggered the Usage job again and accompanied the process via debug, to ensure that all the implementations were being injected correctly, and the enhanced log was being displayed after each parser execution.

Update log example [^null]:

```
2025-06-03 13:55:51,183 DEBUG [usage.parser.VMSnapshotUsageParser] (Usage-Job-1:[]) (logid:) Parsing all VM Snapshot usage events for account: [null]
2025-06-03 13:55:51,186 DEBUG [usage.parser.VMSnapshotUsageParser] (Usage-Job-1:[]) (logid:) No VM snapshot usage events for this period
2025-06-03 13:55:51,186 DEBUG [cloud.usage.UsageManagerImpl_EnhancerByCloudStack_fe18a690] (Usage-Job-1:[]) (logid:) VM Snapshot usage was successfully parsed for [Account [{"accountName":"system","id":1,"uuid":null}]].
```

[^null]: During the tests, I validated that the `UUID` column of `cloud_usage.accounts` is set to NULL after the accounts import from the `cloud` database. An issue was mapped to fix this behaviour (#11077)