### PR TITLE
ceph: fix SignatureDoesNotMatch by using correct secret key when create bucket

### DIFF
--- a/plugins/storage/object/ceph/src/main/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImpl.java
+++ b/plugins/storage/object/ceph/src/main/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImpl.java
@@ -193,19 +193,19 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
             policyConfig = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
         }
 
-        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getAccessKey());
+        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getSecretKey());
         client.setBucketPolicy(new SetBucketPolicyRequest(bucket.getName(), policyConfig));
     }
 
     @Override
     public BucketPolicy getBucketPolicy(BucketTO bucket, long storeId) {
-        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getAccessKey());
+        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getSecretKey());
         return client.getBucketPolicy(new GetBucketPolicyRequest(bucket.getName()));
     }
 
     @Override
     public void deleteBucketPolicy(BucketTO bucket, long storeId) {
-        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getAccessKey());
+        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getSecretKey());
         client.deleteBucketPolicy(new DeleteBucketPolicyRequest(bucket.getName()));
     }
 
@@ -255,7 +255,7 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
 
     @Override
     public boolean setBucketVersioning(BucketTO bucket, long storeId) {
-        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getAccessKey());
+        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getSecretKey());
         try {
             BucketVersioningConfiguration configuration =
                     new BucketVersioningConfiguration().withStatus("Enabled");
@@ -272,7 +272,7 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
 
     @Override
     public boolean deleteBucketVersioning(BucketTO bucket, long storeId) {
-        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getAccessKey());
+        AmazonS3 client = getS3Client(getStoreURL(storeId), bucket.getAccessKey(), bucket.getSecretKey());
         try {
             BucketVersioningConfiguration configuration =
                     new BucketVersioningConfiguration().withStatus("Suspended");


### PR DESCRIPTION
### Description

This PR fixes an issue in the `CephObjectStoreDriverImpl` where the AWS S3 client was incorrectly initialized using the access key in place of both the access and secret key. This caused `SignatureDoesNotMatch` errors during bucket operations such as creation and policy updates when interacting with Ceph RGW using Signature V4.

**Fix:**
Replaced incorrect usage:
```java
getS3Client(url, bucket.getAccessKey(), bucket.getAccessKey())

Impact:
Without this fix, CloudStack fails to perform S3 operations against Ceph RGW due to invalid signature generation, making the object storage integration unusable from the UI/API.

Steps to reproduce:

Configure a Ceph RGW object store in CloudStack.

Attempt to create a bucket via the UI or API.

Observe SignatureDoesNotMatch errors in management server logs.

Types of changes
 Bug fix (non-breaking change which fixes an issue)

 Breaking change (fix or feature that would cause existing functionality to change)

 New feature (non-breaking change which adds functionality)

 Enhancement (improves an existing feature and functionality)

 Cleanup (Code refactoring and cleanup, that may add test cases)

 build/CI

 test (unit or integration test code)
 
 Feature/Enhancement Scale or Bug Severity
Bug Severity
Minor to moderate – affects integration functionality with Ceph RGW for object storage.