### PR TITLE
UI: Fix volumes `SearchView`

### DIFF
--- a/ui/src/components/view/SearchView.vue
+++ b/ui/src/components/view/SearchView.vue
@@ -978,7 +978,7 @@ export default {
     },
     fetchVolumes (searchKeyword) {
       return new Promise((resolve, reject) => {
-        api('listvolumes', { listAll: true, isencrypted: searchKeyword }).then(json => {
+        api('listVolumes', { listAll: true, isencrypted: searchKeyword }).then(json => {
           const volumes = json.listvolumesresponse.volume
           resolve({
             type: 'isencrypted',


### PR DESCRIPTION
### Description

The `SearchView` component of the volumes page is currently performing an API call to `listvolumes`, and not to `listVolumes`. This is causing an error in the API request and, as a consequence, the zone, domain and account select fields of the form are not loading.

This PR fixes this bug.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Before:
![image](https://github.com/user-attachments/assets/d9a5b959-eb32-4241-b0eb-eb7638fdbcfa)

- After:
![image](https://github.com/user-attachments/assets/948462ab-5782-4369-a83c-e28ae56f1763)

