### PR TITLE
List templates and ISOs by domain

### DIFF
--- a/ui/src/components/view/InfoCard.vue
+++ b/ui/src/components/view/InfoCard.vue
@@ -1162,6 +1162,9 @@ export default {
         if (item.name === 'template') {
           query.templatefilter = 'self'
           query.filter = 'self'
+        } else if (item.name === 'iso') {
+          query.isofilter = 'self'
+          query.filter = 'self'
         }
 
         if (item.param === 'account') {

--- a/ui/src/config/section/domain.js
+++ b/ui/src/config/section/domain.js
@@ -48,7 +48,7 @@ export default {
     name: 'template',
     title: 'label.templates',
     param: 'domainid'
-  },,
+  },
   {
     name: 'iso',
     title: 'label.isos',

--- a/ui/src/config/section/domain.js
+++ b/ui/src/config/section/domain.js
@@ -48,6 +48,11 @@ export default {
     name: 'template',
     title: 'label.templates',
     param: 'domainid'
+  },,
+  {
+    name: 'iso',
+    title: 'label.isos',
+    param: 'domainid'
   }],
   tabs: [
     {


### PR DESCRIPTION
### Description

Currently, it is not possible to list the templates and ISOs of a specific domain. When executing the `listTemplates` and `listIsos` APIs only specifying a `domainid`, all templates/ISOs that the caller has access to are listed; the `domainid` parameter is completely ignored.

Therefore, this PR proposes to add support for listing templates and ISOs by domain. To achieve that, the `listTemplates` and `listIsos` APIs should be called defining the `templatefilter` and `isofilter` parameters to either `self` or `selfexecutable`. Furthermore, the `isrecursive` parameter can be used, to list templates and ISOs recursively by domain.

---

Fixes #10392, #10393

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<img width="691" height="699" alt="image" src="https://github.com/user-attachments/assets/1178e01d-f493-4ab7-9dd5-09e502cb9d7d" />

<img width="1437" height="431" alt="image" src="https://github.com/user-attachments/assets/cb62934f-fc50-4014-9815-cb49eb1175c7" />


### How Has This Been Tested?

- Verified that domain access validation is correctly performed
- Verified that it is possible to list templates and ISOs by domain when specifying the `templatefilter` and `isofilter` parameters to either `self` or `selfexecutable`
- Verified that templates and ISOs are recursively listed when the `isrecursive` parameter is specified as true