### PR TITLE
Fix KVM incremental snapshot removal when using multiple secondary storages

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
@@ -155,7 +155,9 @@ public class SnapshotObject implements SnapshotInfo {
     @Override
     public SnapshotInfo getChild() {
         QueryBuilder<SnapshotDataStoreVO> sc = QueryBuilder.create(SnapshotDataStoreVO.class);
-        sc.and(sc.entity().getDataStoreId(), Op.EQ, store.getId());
+        if (!HypervisorType.KVM.equals(snapshot.getHypervisorType())) {
+            sc.and(sc.entity().getDataStoreId(), Op.EQ, store.getId());
+        }
         sc.and(sc.entity().getRole(), Op.EQ, store.getRole());
         sc.and(sc.entity().getState(), Op.NIN, State.Destroying, State.Destroyed, State.Error);
         sc.and(sc.entity().getParentSnapshotId(), Op.EQ, getId());


### PR DESCRIPTION
### Description

When removing an incremental snapshot (For both KVM and XenServer), it is checked if the snapshot has a child or not. If it has, then the snapshot is not removed from the storage.

For KVM incremental snapshots, snapshots in the same chain may be on different secondary storages (within the same zone).

However, the child search process only considers snapshots from the same secondary storage as theirs. Therefore, if a snapshot has its parent snapshot on a different secondary storage, it will be completely removed, making the snapshot chain inconsistent.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I created 3 snapshots that were stored in the secondary storage `sec-nfs1`. I then set the storage `sec-nfs1` to read-only and created 2 more snapshots, which were stored in the secondary storage `sec-nfs2`.

Without the changes: when the third snapshot was removed, its state was set to `Destroyed`, and an error was thrown when trying to restore the fourth snapshot, indicating that the file for the third snapshot no longer existed.

```sql
MariaDB [cloud]> select id, store_id, snapshot_id, created, updated, store_role, parent_snapshot_id, install_path, state, kvm_checkpoint_path from snapshot_store_ref;
+-----+----------+-------------+---------------------+---------------------+------------+--------------------+------------------------------------------------------+-----------+--------------------------------------------------------------------------------------------------+
| id  | store_id | snapshot_id | created             | updated             | store_role | parent_snapshot_id | install_path                                         | state     | kvm_checkpoint_path                                                                              |
+-----+----------+-------------+---------------------+---------------------+------------+--------------------+------------------------------------------------------+-----------+--------------------------------------------------------------------------------------------------+
| 153 |        3 |         108 | 2025-05-08 15:00:01 | NULL                | Image      |                  0 | snapshots/2/809/90dbdda6-1c6e-41f6-ba77-3628df6ee7f4 | Ready     | /mnt/b9f36295-3bbe-3c7a-ac0c-778cf3c58994/checkpoints/2/809/90dbdda6-1c6e-41f6-ba77-3628df6ee7f4 |
| 155 |        3 |         109 | 2025-05-08 15:01:11 | NULL                | Image      |                108 | snapshots/2/809/3c70a9d1-0345-493a-bad4-64234e3d209c | Ready     | /mnt/b9f36295-3bbe-3c7a-ac0c-778cf3c58994/checkpoints/2/809/3c70a9d1-0345-493a-bad4-64234e3d209c |
| 157 |        3 |         110 | 2025-05-08 15:01:21 | 2025-05-08 15:06:07 | Image      |                109 | snapshots/2/809/4df03232-2685-4e35-ab15-6948644b33c7 | Destroyed | /mnt/b9f36295-3bbe-3c7a-ac0c-778cf3c58994/checkpoints/2/809/4df03232-2685-4e35-ab15-6948644b33c7 |
| 159 |        4 |         111 | 2025-05-08 15:05:37 | NULL                | Image      |                110 | snapshots/2/809/d7e1a290-2670-46dc-871e-8bf9468161ac | Ready     | /mnt/f0994169-be48-31f0-b7d0-449f54ff0c93/checkpoints/2/809/d7e1a290-2670-46dc-871e-8bf9468161ac |
| 161 |        4 |         112 | 2025-05-08 15:05:49 | NULL                | Image      |                111 | snapshots/2/809/c0d0bb47-847e-41bc-95f9-d39618d87414 | Ready     | /mnt/f0994169-be48-31f0-b7d0-449f54ff0c93/checkpoints/2/809/c0d0bb47-847e-41bc-95f9-d39618d87414 |
+-----+----------+-------------+---------------------+---------------------+------------+--------------------+------------------------------------------------------+-----------+--------------------------------------------------------------------------------------------------+
5 rows in set (0.000 sec)
```

With the changes: the third snapshot's state was set to `Hidden`, and it was possible to restore the fourth snapshot.

```sql
MariaDB [cloud]> select id, store_id, snapshot_id, created, updated, store_role, parent_snapshot_id, install_path, state, kvm_checkpoint_path from snapshot_store_ref where id > 165;
+-----+----------+-------------+---------------------+---------+------------+--------------------+------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------+
| id  | store_id | snapshot_id | created             | updated | store_role | parent_snapshot_id | install_path                                         | state  | kvm_checkpoint_path                                                                              |
+-----+----------+-------------+---------------------+---------+------------+--------------------+------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------+
| 167 |        3 |         115 | 2025-05-08 16:07:33 | NULL    | Image      |                  0 | snapshots/2/809/6eeeeeb0-0455-4893-9507-4f2a68878ba3 | Ready  | /mnt/b9f36295-3bbe-3c7a-ac0c-778cf3c58994/checkpoints/2/809/6eeeeeb0-0455-4893-9507-4f2a68878ba3 |
| 169 |        3 |         116 | 2025-05-08 16:08:18 | NULL    | Image      |                115 | snapshots/2/809/9cfa65a5-633e-4e66-97fa-399b5536f502 | Ready  | /mnt/b9f36295-3bbe-3c7a-ac0c-778cf3c58994/checkpoints/2/809/9cfa65a5-633e-4e66-97fa-399b5536f502 |
| 171 |        3 |         117 | 2025-05-08 16:11:57 | NULL    | Image      |                116 | snapshots/2/809/f33b702a-0995-4f95-9e8a-f035fe1939d4 | Hidden | /mnt/b9f36295-3bbe-3c7a-ac0c-778cf3c58994/checkpoints/2/809/f33b702a-0995-4f95-9e8a-f035fe1939d4 |
| 173 |        4 |         118 | 2025-05-08 16:13:12 | NULL    | Image      |                117 | snapshots/2/809/4e91f4bb-684c-4beb-8d9a-068ece3a7f08 | Ready  | /mnt/f0994169-be48-31f0-b7d0-449f54ff0c93/checkpoints/2/809/4e91f4bb-684c-4beb-8d9a-068ece3a7f08 |
| 175 |        4 |         119 | 2025-05-08 16:13:18 | NULL    | Image      |                118 | snapshots/2/809/ba61769b-59df-489f-87c1-a6c09a491eb0 | Ready  | /mnt/f0994169-be48-31f0-b7d0-449f54ff0c93/checkpoints/2/809/ba61769b-59df-489f-87c1-a6c09a491eb0 |
+-----+----------+-------------+---------------------+---------+------------+--------------------+------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------+
5 rows in set (0.000 sec)
```
