### PR TITLE
Fix local storage pool disconnect issue

### DIFF
--- a/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
+++ b/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
@@ -168,7 +168,6 @@ public class StoragePoolMonitor implements Listener {
                     throw new ConnectionException(true, String.format("Unable to prepare OCFS2 nodes for pool %s", pool));
                 }
 
-                Long hostId = host.getId();
                 if (logger.isDebugEnabled()) {
                     logger.debug("Host {} connected, connecting host to shared pool {} and sending storage pool information ...", host, pool);
                 }
@@ -185,6 +184,9 @@ public class StoragePoolMonitor implements Listener {
             // Disconnect any pools which are not expected to be connected
             for (StoragePoolHostVO poolToDisconnect: previouslyConnectedPools) {
                 StoragePoolVO pool = _poolDao.findById(poolToDisconnect.getPoolId());
+                if (!pool.isShared()) {
+                    continue;
+                }
                 try {
                     _storageManager.disconnectHostFromSharedPool(host, pool);
                     _storagePoolHostDao.deleteStoragePoolHostDetails(host.getId(), pool.getId());


### PR DESCRIPTION
### Description

This PR fixes the issue #11104 which is a regression from https://github.com/apache/cloudstack/pull/10381. Prior to the PR https://github.com/apache/cloudstack/pull/10381 local storage connection management is skipped in StoragePoolMonitor. Here in this PR, added the same workflow.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

1. Had an environment with a KVM host and local storage
2. Tried restarting the KVM agent
3. Before this fix, local storage is disconnected on host, so was unable to use the local storage even though it shows in UI. Now with the fix, storage connection remains the same and I'm able to use the storage for volume provisioning.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
