### PR TITLE
[UI] Deploy VM: Restore preselection of the first available template

### DIFF
--- a/ui/src/views/compute/wizard/OsBasedImageRadioGroup.vue
+++ b/ui/src/views/compute/wizard/OsBasedImageRadioGroup.vue
@@ -145,6 +145,11 @@ export default {
     selected (newVal, oldVal) {
       if (newVal === oldVal) return
       this.onSelectTemplateIso()
+    },
+    imagesList () {
+      if (this.value === '' && this.imagesList && this.imagesList.length > 0) {
+        this.onClickRow(this.imagesList[0])
+      }
     }
   },
   emits: ['emit-update-image', 'handle-search-filter'],


### PR DESCRIPTION
### Description

This PR restores the previous behavior on the Deploy VM view to select the first available template listed (has now changed on main branch)

Before the fix:
<img width="957" height="453" alt="Screenshot 2025-07-15 at 14 36 34" src="https://github.com/user-attachments/assets/32b9a2df-6773-47e4-a31b-a019a0ae798f" />

After the fix:
<img width="957" height="453" alt="Screenshot 2025-07-15 at 14 37 00" src="https://github.com/user-attachments/assets/95fad92f-2da7-4c26-89ed-1f4b21d84d45" />

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Registered some templates
- Tested Deploy VM view

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
