### PR TITLE
kvm: implement Hyper-V enlightenments correctly to allow running HyperV on KVM

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2547,11 +2547,23 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected void enlightenWindowsVm(VirtualMachineTO vmTO, FeaturesDef features) {
         if (vmTO.getOs().contains("Windows PV")) {
             // If OS is Windows PV, then enable the features. Features supported on Windows 2008 and later
+            // https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_and_managing_windows_virtual_machines/optimizing-windows-virtual-machines#enabling-hyper-v-enlightenments
             LibvirtVMDef.HyperVEnlightenmentFeatureDef hyv = new LibvirtVMDef.HyperVEnlightenmentFeatureDef();
             hyv.setFeature("relaxed", true);
             hyv.setFeature("vapic", true);
             hyv.setFeature("spinlocks", true);
-            hyv.setRetries(8096);
+            hyv.setRetries(8191);
+            hyv.setFeature("vendor_id", true);
+            hyv.setFeature("vpindex", true);
+            hyv.setFeature("runtime", true);
+            hyv.setFeature("synic", true);
+            hyv.setFeature("frequencies", true);
+            hyv.setFeature("reset", true);
+            hyv.setFeature("tlbflush", true);
+            hyv.setFeature("reenlightenment", true);
+            hyv.setFeature("stimer", true);
+            hyv.setFeature("ipi", true);
+            hyv.setFeature("evmcs", true);
             features.addHyperVFeature(hyv);
             LOGGER.info("Enabling KVM Enlightment Features to VM domain " + vmTO.getUuid());
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -390,12 +390,12 @@ public class LibvirtVMDef {
                 feaBuilder.append("<");
                 feaBuilder.append(e.getKey());
 
-                if(e.getKey().equals("spinlocks"))       feaBuilder.append(" state='" + e.getValue() + "' retries='" + getRetries() + "'");
-                else if(e.getKey().equals("vendor_id"))  feaBuilder.append(" state='" + e.getValue() + "' value='KVM Hv'");
-                else if(e.getKey().equals("stimer"))     feaBuilder.append(" state='" + e.getValue() + "'><direct state='" + e.getValue() + "'/>");
-                else                                     feaBuilder.append(" state='" + e.getValue() + "'");
+                if (e.getKey().equals("spinlocks"))       feaBuilder.append(" state='" + e.getValue() + "' retries='" + getRetries() + "'");
+                else if (e.getKey().equals("vendor_id"))  feaBuilder.append(" state='" + e.getValue() + "' value='KVM Hv'");
+                else if (e.getKey().equals("stimer"))     feaBuilder.append(" state='" + e.getValue() + "'><direct state='" + e.getValue() + "'/>");
+                else                                      feaBuilder.append(" state='" + e.getValue() + "'");
 
-                if(e.getKey().equals("stimer")) feaBuilder.append("</stimer>\n");
+                if (e.getKey().equals("stimer")) feaBuilder.append("</stimer>\n");
                 else feaBuilder.append("/>\n");
             }
             feaBuilder.append("</hyperv>\n");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -334,7 +334,18 @@ public class LibvirtVMDef {
         enum Enlight {
             RELAX("relaxed"),
             VAPIC("vapic"),
-            SPIN("spinlocks");
+            SPIN("spinlocks"),
+            VENDOR_ID("vendor_id"),
+            VPINDEX("vpindex"),
+            RUNTIME("runtime"),
+            SYNIC("synic"),
+            FREQ("frequencies"),
+            RESET("reset"),
+            TLBFLUSH("tlbflush"),
+            REENLIGHTEN("reenlightenment"),
+            STIMER("stimer"),
+            IPI("ipi"),
+            EVMCS("evmcs");
 
             private final String featureName;
             Enlight(String featureName) { this.featureName = featureName; }
@@ -379,10 +390,13 @@ public class LibvirtVMDef {
                 feaBuilder.append("<");
                 feaBuilder.append(e.getKey());
 
-                if(e.getKey().equals("spinlocks"))  feaBuilder.append(" state='" + e.getValue() + "' retries='" + getRetries() + "'");
-                else                                feaBuilder.append(" state='" + e.getValue() + "'");
+                if(e.getKey().equals("spinlocks"))       feaBuilder.append(" state='" + e.getValue() + "' retries='" + getRetries() + "'");
+                else if(e.getKey().equals("vendor_id"))  feaBuilder.append(" state='" + e.getValue() + "' value='KVM Hv'");
+                else if(e.getKey().equals("stimer"))     feaBuilder.append(" state='" + e.getValue() + "'><direct state='" + e.getValue() + "'/>");
+                else                                     feaBuilder.append(" state='" + e.getValue() + "'");
 
-                feaBuilder.append("/>\n");
+                if(e.getKey().equals("stimer")) feaBuilder.append("</stimer>\n");
+                else feaBuilder.append("/>\n");
             }
             feaBuilder.append("</hyperv>\n");
             return feaBuilder.toString();


### PR DESCRIPTION
This implements Hyper-V enlightenments as per the RHEL docs: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_and_managing_windows_virtual_machines/optimizing-windows-virtual-machines#enabling-hyper-v-enlightenments

This is enabled only when the guest OS is set to Windows PV.

This PR is followup of findings and improvements from https://github.com/apache/cloudstack/issues/10650#issuecomment-3073443483

Tested on: ACS 4.20.1 with Ubuntu 22.04/KVM with Windows 10 ISO, installed Windows 10 VM

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial
