### PR TITLE
[DB] Add force recreate parameter to cloudstack-setup-databases script

### DIFF
--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -129,6 +129,12 @@ class DBDeployer(object):
         (value, index) = self.dbDotProperties[key]
         return value
 
+    def areCloudDatabasesCreated(self):
+        cmd = "SELECT CASE WHEN COUNT(DISTINCT SCHEMA_NAME) >= 1 THEN 1 ELSE 0 END AS schema_exists \
+              FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME IN ('cloud', 'cloud_usage');"
+        databases = self.runMysql(cmd, "databases", self.rootuser != None)
+        return databases.replace("schema_exists", "").strip() == "1"
+
     def runMysql(self, text, table, isRoot=False):
         kwargs = {}
         if not isRoot:
@@ -151,7 +157,7 @@ class DBDeployer(object):
             open(self.tmpMysqlFile, 'w').write(text)
             mysqlCmds.append('<')
             mysqlCmds.append(self.tmpMysqlFile)
-            runCmd(mysqlCmds)
+            return runCmd(mysqlCmds)
 
         except Exception as e:
             err = '''Encountering an error when executing mysql script
@@ -232,6 +238,10 @@ for full help
             ("DROP USER 'cloud'@'localhost' ;", "DO NULL;"),
             ("DROP USER 'cloud'@'%' ;", "DO NULL;")
         )
+
+        if self.areCloudDatabasesCreated() and not self.options.forcerecreate:
+            self.errorAndExit("Aborting script as the databases (cloud, cloud_usage) already exist.\n" \
+                              "Please use the --force-recreate parameter if you want to recreate the schemas.")
 
         scriptsToRun = ["create-database","create-schema", "create-database-premium","create-schema-premium"]
         if self.options.schemaonly:
@@ -610,6 +620,9 @@ for example:
                           help="Creates the db schema without having to pass root credentials - " \
                                "Please note: The databases (cloud, cloud_usage) and user (cloud) has to be configured " \
                                "manually prior to running this script when using this flag.")
+        self.parser.add_option("--force-recreate", action="store_true", dest="forcerecreate", default=False,
+                               help="Force recreation of the existing DB schemas. This option is disabled by default." \
+                               "Please note: The databases (cloud, cloud_usage) and its tables data will be lost and recreated.")
 
         self.parser.add_option("-a", "--auto", action="store", type="string", dest="serversetup", default="",
                           help="Path to an XML file describing an automated unattended cloud setup")


### PR DESCRIPTION
### Description

This PR adds a new parameter `--force-recreate` to the `cloudstack-setup-databases` script, to prevent the recreation of existing databases and prevent accidental data loss.
Fixes: #11202 

Documentation PR: https://github.com/apache/cloudstack-documentation/pull/534

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Tested without passing the `--force-recreate` parameter having already defined `cloud` and `cloud_usage` databases:

````
# cloudstack-setup-databases cloud:cloud@10.0.34.102 --deploy-as=root:XXX -i 10.0.34.102
Mysql user name:cloud                                                           [ OK ]
Mysql user password:******                                                      [ OK ]
Mysql server ip:10.0.34.102                                                     [ OK ]
Mysql server port:3306                                                          [ OK ]
Mysql root user name:root                                                       [ OK ]
Mysql root user password:******                                                 [ OK ]
Using specified cluster management server node IP 10.0.34.102                   [ OK ]
Checking Cloud database files ...                                               [ OK ]
Checking local machine hostname ...                                             [ OK ]
Checking SELinux setup ...                                                      [ OK ]
Preparing /etc/cloudstack/management/db.properties                              [ OK ]


We apologize for below error:
***************************************************************
Aborting script as the databases (cloud, cloud_usage) already exist.
Please use the --force-recreation parameter if you want to recreate the schemas.
***************************************************************
Please run:

    cloudstack-setup-databases -h

for full help
````

- Tested passing the `--force-recreate` parameter having already defined `cloud` and `cloud_usage` databases:

````
# cloudstack-setup-databases cloud:cloud@10.0.34.102 --deploy-as=root:XXX -i 10.0.34.102 --force-recreate
Mysql user name:cloud                                                           [ OK ]
Mysql user password:******                                                      [ OK ]
Mysql server ip:10.0.34.102                                                     [ OK ]
Mysql server port:3306                                                          [ OK ]
Mysql root user name:root                                                       [ OK ]
Mysql root user password:******                                                 [ OK ]
Using specified cluster management server node IP 10.0.34.102                   [ OK ]
Checking Cloud database files ...                                               [ OK ]
Checking local machine hostname ...                                             [ OK ]
Checking SELinux setup ...                                                      [ OK ]
Preparing /etc/cloudstack/management/db.properties                              [ OK ]
Applying /usr/share/cloudstack-management/setup/create-database.sql             [ OK ]
Applying /usr/share/cloudstack-management/setup/create-schema.sql               [ OK ]
Applying /usr/share/cloudstack-management/setup/create-database-premium.sql     [ OK ]
Applying /usr/share/cloudstack-management/setup/create-schema-premium.sql       [ OK ]
Applying /usr/share/cloudstack-management/setup/server-setup.sql                [ OK ]
Applying /usr/share/cloudstack-management/setup/templates.sql                   [ OK ]
Processing encryption ...                                                       [ OK ]
Finalizing setup ...                                                            [ OK ]

CloudStack has successfully initialized database, you can check your database configuration in /etc/cloudstack/management/db.properties
````

- Dropped `cloud` database manually
- Invoked the script with and without the parameter:

````
# cloudstack-setup-databases cloud:cloud@10.0.34.102 --deploy-as=root:XXX -i 10.0.34.102
Mysql user name:cloud                                                           [ OK ]
Mysql user password:******                                                      [ OK ]
Mysql server ip:10.0.34.102                                                     [ OK ]
Mysql server port:3306                                                          [ OK ]
Mysql root user name:root                                                       [ OK ]
Mysql root user password:******                                                 [ OK ]
Using specified cluster management server node IP 10.0.34.102                   [ OK ]
Checking Cloud database files ...                                               [ OK ]
Checking local machine hostname ...                                             [ OK ]
Checking SELinux setup ...                                                      [ OK ]
Preparing /etc/cloudstack/management/db.properties                              [ OK ]


We apologize for below error:
***************************************************************
Aborting script as the databases (cloud, cloud_usage) already exist.
Please use the --force-recreation parameter if you want to recreate the schemas.
***************************************************************
Please run:

    cloudstack-setup-databases -h

for full help
# cloudstack-setup-databases cloud:cloud@10.0.34.102 --deploy-as=root:XXX -i 10.0.34.102 --force-recreate
Mysql user name:cloud                                                           [ OK ]
Mysql user password:******                                                      [ OK ]
Mysql server ip:10.0.34.102                                                     [ OK ]
Mysql server port:3306                                                          [ OK ]
Mysql root user name:root                                                       [ OK ]
Mysql root user password:******                                                 [ OK ]
Using specified cluster management server node IP 10.0.34.102                   [ OK ]
Checking Cloud database files ...                                               [ OK ]
Checking local machine hostname ...                                             [ OK ]
Checking SELinux setup ...                                                      [ OK ]
Preparing /etc/cloudstack/management/db.properties                              [ OK ]
Applying /usr/share/cloudstack-management/setup/create-database.sql             [ OK ]
Applying /usr/share/cloudstack-management/setup/create-schema.sql               [ OK ]
Applying /usr/share/cloudstack-management/setup/create-database-premium.sql     [ OK ]
Applying /usr/share/cloudstack-management/setup/create-schema-premium.sql       [ OK ]
Applying /usr/share/cloudstack-management/setup/server-setup.sql                [ OK ]
Applying /usr/share/cloudstack-management/setup/templates.sql                   [ OK ]
Processing encryption ...                                                       [ OK ]
Finalizing setup ...                                                            [ OK ]

CloudStack has successfully initialized database, you can check your database configuration in /etc/cloudstack/management/db.properties
````

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
