### PR TITLE
agent: increase timeout for host arch retrieval

### DIFF
--- a/agent/src/main/java/com/cloud/agent/Agent.java
+++ b/agent/src/main/java/com/cloud/agent/Agent.java
@@ -93,7 +93,6 @@ import com.cloud.utils.nio.Link;
 import com.cloud.utils.nio.NioClient;
 import com.cloud.utils.nio.NioConnection;
 import com.cloud.utils.nio.Task;
-import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.Script;
 
 /**
@@ -598,9 +597,9 @@ public class Agent implements HandlerFactory, IAgentControl, AgentStatusUpdater 
     }
 
     protected String getAgentArch() {
-        final Script command = new Script("/usr/bin/arch", 500, logger);
-        final OutputInterpreter.OneLineParser parser = new OutputInterpreter.OneLineParser();
-        return command.execute(parser);
+        String arch = Script.runSimpleBashScript(Script.getExecutableAbsolutePath("arch"), 1000);
+        logger.debug("Arch for agent: {} found: {}", _name, arch);
+        return arch;
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
@@ -58,7 +58,7 @@ public class KVMHostInfo {
     private long reservedMemory;
     private long overCommitMemory;
     private List<String> capabilities = new ArrayList<>();
-    private static String cpuArchCommand = "/usr/bin/arch";
+    private static String cpuArchRetrieveExecutable = "arch";
     private static List<String> cpuInfoFreqFileNames = List.of("/sys/devices/system/cpu/cpu0/cpufreq/base_frequency","/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq");
 
     public KVMHostInfo(long reservedMemory, long overCommitMemory, long manualSpeed, int reservedCpus) {
@@ -248,6 +248,6 @@ public class KVMHostInfo {
 
     private String getCPUArchFromCommand() {
         LOGGER.info("Fetching host CPU arch");
-        return Script.runSimpleBashScript(cpuArchCommand);
+        return Script.runSimpleBashScript(Script.getExecutableAbsolutePath(cpuArchRetrieveExecutable));
     }
 }


### PR DESCRIPTION
### Description

Increases timeout for agent/host arch retrieval
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Without change (getting errors like the following):
```
2025-07-21 11:51:01,233 DEBUG [cloud.agent.Agent] (Agent-Handler-1:[]) (logid:) Successfully executed process [1282816] for command [/usr/bin/arch ].
2025-07-21 11:51:01,234 DEBUG [cloud.agent.Agent] (Agent-Handler-1:[]) (logid:) Executing command [/usr/bin/arch ].
2025-07-21 11:51:01,236 DEBUG [cloud.agent.Agent] (Agent-Handler-1:[]) (logid:) Successfully executed process [1282817] for command [/usr/bin/arch ].
2025-07-21 11:51:03,113 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:1a7aaa2d) Request:Seq 2-6273232805950390281:  { Cmd , MgmtId: 32988452618506, via: 2, Ver: v1, Flags: 100111, [{"com.cloud.agent.api.ReadyCommand":{"dcId":"1","hostId":"2","hostUuid":"cd51c3cc-ea1c-4396-9fcf-37beec4bd032","hostName":"pr9752-t13627-kvm-ol8-kvm2","enableHumanReadableSizes":"true","arch":"x86_64","wait":"0","bypassHostMaintenance":"false"}}] }
2025-07-21 11:51:03,117 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:1a7aaa2d) Executing command [/usr/bin/arch ].
2025-07-21 11:51:03,120 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:1a7aaa2d) Successfully executed process [1282865] for command [/usr/bin/arch ].
2025-07-21 11:51:03,121 ERROR [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:1a7aaa2d) Unexpected arch null, expected x86_64
```

With change (no errors):
```
2025-07-21 12:02:53,353 DEBUG [cloud.agent.Agent] (Agent-Handler-1:[]) (logid:) Arch for agent: pr9752-t13627-kvm-ol8-kvm2 found: x86_64
2025-07-21 12:02:53,353 DEBUG [utils.script.Script] (Agent-Handler-1:[]) (logid:) Executing command [/bin/bash -c /usr/bin/arch ].
2025-07-21 12:02:53,361 DEBUG [utils.script.Script] (Agent-Handler-1:[]) (logid:) Successfully executed process [1284377] for command [/bin/bash -c /usr/bin/arch ].
2025-07-21 12:02:53,361 DEBUG [cloud.agent.Agent] (Agent-Handler-1:[]) (logid:) Arch for agent: pr9752-t13627-kvm-ol8-kvm2 found: x86_64
2025-07-21 12:02:53,400 DEBUG [cloud.agent.Agent] (Agent-Handler-1:[]) (logid:) Sending Startup: Seq 2-0:  { Cmd , MgmtId: -1, via: 2, Ver: v1, Flags: 1, [{"com.cloud.agent.api.StartupRoutingCommand":{"cpuSockets":"3","cpus":"3","speed":"2100","cpuArch":"x86_64","memory":"7259144192","dom0MinMemory":"1073741824","poolSync":"false","supportsClonedVolumes":"false","caps":"hvm,snapshot","pool":"/root","hypervisorType":"KVM","hostDetails":{"Host.OS.Kernel.Version":"5.4.17-2136.309.5.1.el8uek.x86_64","com.cloud.network.Networks.RouterPrivateIpStrategy":"HostLocal","Host.OS.Version":"8.6","host.volume.encryption":"true","host.instance.conversion":"false","secured":"true","Host.OS":"Red Hat Enterprise Linux"},"hostTags":[],"groupDetails":{},"type":"Routing","dataCenter":"1","pod":"1","cluster":"1","guid":"40bf71dd-b5c2-344b-8258-09361013f3a4-LibvirtComputingResource","name":"pr9752-t13627-kvm-ol8-kvm2","id":"2","version":"4.21.0.0-SNAPSHOT","iqn":"iqn.1988-12.com.oracle:67eb595b8924","publicIpAddress":"192.168.255.254","publicNetmask":"255.255.255.252","publicMacAddress":"02:00:58:0c:ae:71","privateIpAddress":"10.0.33.41","privateMacAddress":"1e:00:38:00:01:bc","privateNetmask":"255.255.240.0","storageIpAddress":"10.0.33.41","storageNetmask":"255.255.240.0","storageMacAddress":"1e:00:38:00:01:bc","resourceName":"LibvirtComputingResource","gatewayIpAddress":"10.0.32.1","msHostList":"10.0.32.119@static","connectionTransferred":"false","arch":"x86_64","wait":"0","bypassHostMaintenance":"false"}},{"com.cloud.agent.api.StartupStorageCommand":{"totalSize":"(0 bytes) 0","poolInfo":{"uuid":"4a2cdb94-e70f-4cbc-936a-03e5a36f2884","host":"10.0.33.41","localPath":"/var/lib/libvirt/images","hostPath":"/var/lib/libvirt/images","poolType":"Filesystem","capacityBytes":"(18.99 GB) 20386414592","availableBytes":"(14.11 GB) 15153868800"},"resourceType":"STORAGE_POOL","hostDetails":{},"type":"Storage","dataCenter":"1","pod":"1","guid":"40bf71dd-b5c2-344b-8258-09361013f3a4-LibvirtComputingResource","name":"pr9752-t13627-kvm-ol8-kvm2","id":"2","version":"4.21.0.0-SNAPSHOT","resourceName":"LibvirtComputingResource","msHostList":"10.0.32.119@static","connectionTransferred":"false","arch":"x86_64","wait":"0","bypassHostMaintenance":"false"}}] }
2025-07-21 12:02:55,249 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:f370cdcb) Request:Seq 2-3945434748553265161:  { Cmd , MgmtId: 32988452618506, via: 2, Ver: v1, Flags: 100111, [{"com.cloud.agent.api.ReadyCommand":{"dcId":"1","hostId":"2","hostUuid":"cd51c3cc-ea1c-4396-9fcf-37beec4bd032","hostName":"pr9752-t13627-kvm-ol8-kvm2","enableHumanReadableSizes":"true","arch":"x86_64","wait":"0","bypassHostMaintenance":"false"}}] }
2025-07-21 12:02:55,253 DEBUG [utils.script.Script] (AgentRequest-Handler-2:[]) (logid:f370cdcb) Executing command [/bin/bash -c /usr/bin/arch ].
2025-07-21 12:02:55,262 DEBUG [utils.script.Script] (AgentRequest-Handler-2:[]) (logid:f370cdcb) Successfully executed process [1284425] for command [/bin/bash -c /usr/bin/arch ].
2025-07-21 12:02:55,262 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:f370cdcb) Arch for agent: pr9752-t13627-kvm-ol8-kvm2 found: x86_64
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
