### PR TITLE
UI: Fix ISO Hypervisor selection

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -148,7 +148,7 @@
                       @handle-image-search-filter="filters => fetchImages(filters)"
                       @update-image="updateFieldValue"
                       @update-disk-size="updateFieldValue"
-                      @change-iso-hypervisor="value => hypervisor = value" />
+                      @change-iso-hypervisor="value => form.hypervisor = value" />
                     <a-card
                       v-else
                       :tabList="imageTypeList"

--- a/ui/src/views/compute/wizard/OsBasedImageSelection.vue
+++ b/ui/src/views/compute/wizard/OsBasedImageSelection.vue
@@ -112,7 +112,7 @@
           v-model:value="localSelectedIsoHypervisor"
           :preFillContent="preFillContent"
           :options="isoHypervisorItems"
-          @change="handleIsoHypervisorChange()"
+          @change="handleIsoHypervisorChange"
           showSearch
           optionFilterProp="label"
           :filterOption="filterOption" />
@@ -325,8 +325,8 @@ export default {
     emitUpdateDiskSize (decorator, value) {
       this.$emit('update-disk-size', decorator, value)
     },
-    handleIsoHypervisorChange () {
-      this.$emit('change-iso-hypervisor', this.localIsoHypervisor)
+    handleIsoHypervisorChange (hypervisor) {
+      this.$emit('change-iso-hypervisor', hypervisor)
     }
   }
 }

--- a/ui/src/views/infra/zone/ZoneWizardRegisterTemplate.vue
+++ b/ui/src/views/infra/zone/ZoneWizardRegisterTemplate.vue
@@ -63,7 +63,7 @@
   </template>
 
 <script>
-import { api } from '@/api'
+import { getAPI, postAPI } from '@/api'
 import { genericCompare } from '@/utils/sort.js'
 import OsLogo from '@/components/widgets/OsLogo'
 
@@ -164,7 +164,7 @@ export default {
         params.directdownload = true
       }
       return new Promise((resolve, reject) => {
-        api('registerTemplate', params).then(json => {
+        postAPI('registerTemplate', params).then(json => {
           const result = json.registertemplateresponse.template[0]
           resolve(result)
         }).catch(error => {
@@ -225,7 +225,7 @@ export default {
       let osTypeId = this.defaultOsTypeId
       this.loading = true
       try {
-        const json = await api('listOsTypes', { keyword: osName, filter: 'name,id' })
+        const json = await getAPI('listOsTypes', { keyword: osName, filter: 'name,id' })
         if (json && json.listostypesresponse && json.listostypesresponse.ostype && json.listostypesresponse.ostype.length > 0) {
           osTypeId = json.listostypesresponse.ostype[0].id
         }


### PR DESCRIPTION
### Description

When deploying an Instance from an ISO in a multi hypervisor env, hypervisor type selection is ignored and it selects the first hypervisor from the list.
This PR fixes the above bug which was introduced in https://github.com/apache/cloudstack/pull/10773

Apart from the above, this PR updates the older api to getAPI & postAPI for `ZoneWizardRegisterTemplate`.

<details><summary>Generated summary</summary>
<p>

This pull request introduces updates to improve the handling of hypervisor changes in the UI and refactors API calls in the `ZoneWizardRegisterTemplate.vue` component for better code clarity and consistency. The most important changes include modifying event handlers for hypervisor updates, refactoring API utility usage, and ensuring proper state updates.

### UI Improvements for Hypervisor Handling:

* [`ui/src/views/compute/DeployVM.vue`](diffhunk://#diff-8008c55fcf5cea1128c96959a8e0602e2a6585d439666dc2f7556dc59e106de7L151-R151): Updated the `@change-iso-hypervisor` event to correctly update the `form.hypervisor` property instead of a standalone `hypervisor` variable.
* [`ui/src/views/compute/wizard/OsBasedImageSelection.vue`](diffhunk://#diff-632bffe25763ad5d0831607102fbbde81200b6f0038344c3e9f0ce759d37f9acL115-R115): Simplified the `@change` event binding for `handleIsoHypervisorChange` by removing the unnecessary parentheses.
* [`ui/src/views/compute/wizard/OsBasedImageSelection.vue`](diffhunk://#diff-632bffe25763ad5d0831607102fbbde81200b6f0038344c3e9f0ce759d37f9acL328-R329): Refactored the `handleIsoHypervisorChange` method to accept a `hypervisor` parameter directly, ensuring the emitted event receives the correct value.

### API Refactoring:

* [`ui/src/views/infra/zone/ZoneWizardRegisterTemplate.vue`](diffhunk://#diff-6f5b107a98877a597cee638f328e1dd6ba6c5e40f7cd0868827dde599bb85be3L66-R66): Replaced the generic `api` import with `getAPI` and `postAPI` for clearer intent in API calls.
* [`ui/src/views/infra/zone/ZoneWizardRegisterTemplate.vue`](diffhunk://#diff-6f5b107a98877a597cee638f328e1dd6ba6c5e40f7cd0868827dde599bb85be3L167-R167): Updated `registerTemplate` to use `postAPI` and `listOsTypes` to use `getAPI`, aligning with the new API utility functions. [[1]](diffhunk://#diff-6f5b107a98877a597cee638f328e1dd6ba6c5e40f7cd0868827dde599bb85be3L167-R167) [[2]](diffhunk://#diff-6f5b107a98877a597cee638f328e1dd6ba6c5e40f7cd0868827dde599bb85be3L228-R228)

</p>
</details> 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
