### PR TITLE
Update System VM template Guest OS version

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java
@@ -106,7 +106,6 @@ public class SystemVmTemplateRegistration {
     private static final String storageScriptsDir = "scripts/storage/secondary";
     private static final Integer OTHER_LINUX_ID = 99;
     private static Integer LINUX_12_ID = 363;
-    private static final Integer LINUX_7_ID = 183;
     private static final Integer SCRIPT_TIMEOUT = 1800000;
     private static final Integer LOCK_WAIT_TIMEOUT = 1200;
     protected static final List<CPU.CPUArch> DOWNLOADABLE_TEMPLATE_ARCH_TYPES = Arrays.asList(
@@ -325,7 +324,7 @@ public class SystemVmTemplateRegistration {
 
     public static final Map<String, MetadataTemplateDetails> NewTemplateMap = new HashMap<>();
 
-    public static final Map<Hypervisor.HypervisorType, String> RouterTemplateConfigurationNames = new HashMap<Hypervisor.HypervisorType, String>() {
+    public static final Map<Hypervisor.HypervisorType, String> RouterTemplateConfigurationNames = new HashMap<>() {
         {
             put(Hypervisor.HypervisorType.KVM, "router.template.kvm");
             put(Hypervisor.HypervisorType.VMware, "router.template.vmware");
@@ -336,14 +335,14 @@ public class SystemVmTemplateRegistration {
         }
     };
 
-    public static Map<Hypervisor.HypervisorType, Integer> hypervisorGuestOsMap = new HashMap<Hypervisor.HypervisorType, Integer>() {
+    public static Map<Hypervisor.HypervisorType, Integer> hypervisorGuestOsMap = new HashMap<>() {
         {
             put(Hypervisor.HypervisorType.KVM, LINUX_12_ID);
             put(Hypervisor.HypervisorType.XenServer, OTHER_LINUX_ID);
             put(Hypervisor.HypervisorType.VMware, OTHER_LINUX_ID);
             put(Hypervisor.HypervisorType.Hyperv, LINUX_12_ID);
             put(Hypervisor.HypervisorType.LXC, LINUX_12_ID);
-            put(Hypervisor.HypervisorType.Ovm3, LINUX_7_ID);
+            put(Hypervisor.HypervisorType.Ovm3, LINUX_12_ID);
         }
     };
 
@@ -600,15 +599,20 @@ public class SystemVmTemplateRegistration {
         vmInstanceDao.updateSystemVmTemplateId(templateId, hypervisorType);
     }
 
-    public void updateSystemVmTemplateGuestOsId() {
-        String systemVmGuestOsName = "Debian GNU/Linux 12 (64-bit)";
-        GuestOSVO guestOS = guestOSDao.findOneByDisplayName(systemVmGuestOsName);
-        if (guestOS != null) {
-            LOGGER.debug("Updating SystemVM Template Guest OS [{}] id", systemVmGuestOsName);
-            SystemVmTemplateRegistration.LINUX_12_ID = Math.toIntExact(guestOS.getId());
-            hypervisorGuestOsMap.put(Hypervisor.HypervisorType.KVM, LINUX_12_ID);
-            hypervisorGuestOsMap.put(Hypervisor.HypervisorType.Hyperv, LINUX_12_ID);
-            hypervisorGuestOsMap.put(Hypervisor.HypervisorType.LXC, LINUX_12_ID);
+    private void updateSystemVmTemplateGuestOsId() {
+        String systemVmGuestOsName = "Debian GNU/Linux 12 (64-bit)"; // default
+        try {
+            GuestOSVO guestOS = guestOSDao.findOneByDisplayName(systemVmGuestOsName);
+            if (guestOS != null) {
+                LOGGER.debug("Updating SystemVM Template Guest OS [{}] id", systemVmGuestOsName);
+                SystemVmTemplateRegistration.LINUX_12_ID = Math.toIntExact(guestOS.getId());
+                hypervisorGuestOsMap.put(Hypervisor.HypervisorType.KVM, LINUX_12_ID);
+                hypervisorGuestOsMap.put(Hypervisor.HypervisorType.Hyperv, LINUX_12_ID);
+                hypervisorGuestOsMap.put(Hypervisor.HypervisorType.LXC, LINUX_12_ID);
+                hypervisorGuestOsMap.put(Hypervisor.HypervisorType.Ovm3, LINUX_12_ID);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Couldn't update SystemVM Template Guest OS id, due to {}", e.getMessage());
         }
     }
 
@@ -748,7 +752,6 @@ public class SystemVmTemplateRegistration {
         Long templateId = null;
         try {
             MetadataTemplateDetails templateDetails = getMetadataTemplateDetails(hypervisor, arch);
-            updateSystemVmTemplateGuestOsId();
             templateId = performTemplateRegistrationOperations(hypervisor, name,
                     templateDetails.getArch(), templateDetails.getUrl(),
                     templateDetails.getChecksum(), hypervisorImageFormat.get(hypervisor),
@@ -831,7 +834,8 @@ public class SystemVmTemplateRegistration {
                     section.get("filename"),
                     section.get("downloadurl"),
                     section.get("checksum"),
-                    hypervisorType.second()));
+                    hypervisorType.second(),
+                    section.get("guestos")));
         }
         Ini.Section defaultSection = ini.get("default");
         return defaultSection.get("version").trim();
@@ -983,6 +987,10 @@ public class SystemVmTemplateRegistration {
     private void updateRegisteredTemplateDetails(Long templateId, MetadataTemplateDetails templateDetails) {
         VMTemplateVO templateVO = vmTemplateDao.findById(templateId);
         templateVO.setTemplateType(Storage.TemplateType.SYSTEM);
+        GuestOSVO guestOS = guestOSDao.findOneByDisplayName(templateDetails.getGuestOs());
+        if (guestOS != null) {
+            templateVO.setGuestOSId(guestOS.getId());
+        }
         boolean updated = vmTemplateDao.update(templateVO.getId(), templateVO);
         if (!updated) {
             String errMsg = String.format("updateSystemVmTemplates:Exception while updating template with id %s to be marked as 'system'", templateId);
@@ -998,9 +1006,13 @@ public class SystemVmTemplateRegistration {
         updateConfigurationParams(configParams);
     }
 
-    private void updateTemplateUrlAndChecksum(VMTemplateVO templateVO, MetadataTemplateDetails templateDetails) {
+    private void updateTemplateUrlChecksumAndGuestOsId(VMTemplateVO templateVO, MetadataTemplateDetails templateDetails) {
         templateVO.setUrl(templateDetails.getUrl());
         templateVO.setChecksum(templateDetails.getChecksum());
+        GuestOSVO guestOS = guestOSDao.findOneByDisplayName(templateDetails.getGuestOs());
+        if (guestOS != null) {
+            templateVO.setGuestOSId(guestOS.getId());
+        }
         boolean updated = vmTemplateDao.update(templateVO.getId(), templateVO);
         if (!updated) {
             String errMsg = String.format("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type %s", templateDetails.getHypervisorType());
@@ -1038,7 +1050,7 @@ public class SystemVmTemplateRegistration {
                 VMTemplateVO templateVO = vmTemplateDao.findLatestTemplateByTypeAndHypervisorAndArch(
                         templateDetails.getHypervisorType(), templateDetails.getArch(), Storage.TemplateType.SYSTEM);
                 if (templateVO != null) {
-                    updateTemplateUrlAndChecksum(templateVO, templateDetails);
+                    updateTemplateUrlChecksumAndGuestOsId(templateVO, templateDetails);
                 }
             }
         }
@@ -1047,6 +1059,7 @@ public class SystemVmTemplateRegistration {
 
     public void updateSystemVmTemplates(final Connection conn) {
         LOGGER.debug("Updating System Vm template IDs");
+        updateSystemVmTemplateGuestOsId();
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
@@ -1094,15 +1107,17 @@ public class SystemVmTemplateRegistration {
         private final String checksum;
         private final CPU.CPUArch arch;
         private String downloadedFilePath;
+        private final String guestOs;
 
         MetadataTemplateDetails(Hypervisor.HypervisorType hypervisorType, String name, String filename, String url,
-                                String checksum, CPU.CPUArch arch) {
+                                String checksum, CPU.CPUArch arch, String guestOs) {
             this.hypervisorType = hypervisorType;
             this.name = name;
             this.filename = filename;
             this.url = url;
             this.checksum = checksum;
             this.arch = arch;
+            this.guestOs = guestOs;
         }
 
         public Hypervisor.HypervisorType getHypervisorType() {
@@ -1127,6 +1142,10 @@ public class SystemVmTemplateRegistration {
 
         public CPU.CPUArch getArch() {
             return arch;
+        }
+
+        public String getGuestOs() {
+            return guestOs;
         }
 
         public String getDownloadedFilePath() {

--- a/engine/schema/src/test/java/com/cloud/upgrade/SystemVmTemplateRegistrationTest.java
+++ b/engine/schema/src/test/java/com/cloud/upgrade/SystemVmTemplateRegistrationTest.java
@@ -192,7 +192,7 @@ public class SystemVmTemplateRegistrationTest {
     public void testValidateTemplateFile_fileNotFound() {
         SystemVmTemplateRegistration.MetadataTemplateDetails details =
                 new SystemVmTemplateRegistration.MetadataTemplateDetails(Hypervisor.HypervisorType.KVM,
-                        "name", "file", "url", "checksum", CPU.CPUArch.amd64);
+                        "name", "file", "url", "checksum", CPU.CPUArch.amd64, "guestos");
         SystemVmTemplateRegistration.NewTemplateMap.put(SystemVmTemplateRegistration.getHypervisorArchKey(
                 details.getHypervisorType(), details.getArch()), details);
         doReturn(null).when(systemVmTemplateRegistration).getTemplateFile(details);
@@ -209,7 +209,7 @@ public class SystemVmTemplateRegistrationTest {
     public void testValidateTemplateFile_checksumMismatch() {
         SystemVmTemplateRegistration.MetadataTemplateDetails details =
                 new SystemVmTemplateRegistration.MetadataTemplateDetails(Hypervisor.HypervisorType.KVM,
-                        "name", "file", "url", "checksum", CPU.CPUArch.amd64);
+                        "name", "file", "url", "checksum", CPU.CPUArch.amd64, "guestos");
         File dummyFile = new File("dummy.txt");
         SystemVmTemplateRegistration.NewTemplateMap.put(SystemVmTemplateRegistration.getHypervisorArchKey(
                 details.getHypervisorType(), details.getArch()), details);
@@ -228,7 +228,7 @@ public class SystemVmTemplateRegistrationTest {
     public void testValidateTemplateFile_success() {
         SystemVmTemplateRegistration.MetadataTemplateDetails details =
                 new SystemVmTemplateRegistration.MetadataTemplateDetails(Hypervisor.HypervisorType.KVM,
-                        "name", "file", "url", "checksum", CPU.CPUArch.amd64);
+                        "name", "file", "url", "checksum", CPU.CPUArch.amd64, "guestos");
         File dummyFile = new File("dummy.txt");
         SystemVmTemplateRegistration.NewTemplateMap.put(SystemVmTemplateRegistration.getHypervisorArchKey(
                 details.getHypervisorType(), details.getArch()), details);
@@ -285,7 +285,7 @@ public class SystemVmTemplateRegistrationTest {
         SystemVmTemplateRegistration.MetadataTemplateDetails details =
                 new SystemVmTemplateRegistration.MetadataTemplateDetails(Hypervisor.HypervisorType.KVM,
                         "name", "nonexistent.qcow2", "http://example.com/file.qcow2",
-                        "", CPU.CPUArch.arm64);
+                        "", CPU.CPUArch.arm64, "guestos");
         try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class);
              MockedStatic<HttpUtils> httpMock = Mockito.mockStatic(HttpUtils.class)) {
             filesMock.when(() -> Files.isWritable(any(Path.class))).thenReturn(true);
@@ -301,7 +301,7 @@ public class SystemVmTemplateRegistrationTest {
         SystemVmTemplateRegistration.MetadataTemplateDetails details =
                 new SystemVmTemplateRegistration.MetadataTemplateDetails(Hypervisor.HypervisorType.KVM,
                         "name", "file.qcow2", "http://example.com/file.qcow2",
-                        "", CPU.CPUArch.arm64);
+                        "", CPU.CPUArch.arm64, "guestos");
         try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class);
              MockedStatic<HttpUtils> httpMock = Mockito.mockStatic(HttpUtils.class)) {
             filesMock.when(() -> Files.isWritable(any(Path.class))).thenReturn(false);

--- a/engine/schema/templateConfig.sh
+++ b/engine/schema/templateConfig.sh
@@ -42,6 +42,15 @@ function getGenericName() {
   fi
 }
 
+function getGuestOS() {
+  hypervisor=$(echo "$1" | tr "[:upper:]" "[:lower:]")
+  if [[ "$hypervisor" == "vmware" || "$hypervisor" == "xenserver" ]]; then
+    echo "Other Linux (64-bit)"
+  else
+    echo "Debian GNU/Linux 12 (64-bit)"
+  fi
+}
+
 function getChecksum() {
   local fileData="$1"
   local hvName=$2
@@ -60,13 +69,14 @@ function createMetadataFile() {
     section="${template%%:*}"
     sectionHv="${section%%-*}"
     hvName=$(getGenericName $sectionHv)
+    guestos=$(getGuestOS $sectionHv)
 
     downloadurl="${template#*:}"
     arch=$(echo ${downloadurl#*"/systemvmtemplate-$VERSION-"} | cut -d'-' -f 1)
     templatename="systemvm-${sectionHv%.*}-${VERSION}-${arch}"
     checksum=$(getChecksum "$fileData" "$VERSION-${arch}-$hvName")
     filename=$(echo ${downloadurl##*'/'})
-    echo -e "["$section"]\ntemplatename = $templatename\nchecksum = $checksum\ndownloadurl = $downloadurl\nfilename = $filename\narch = $arch\n" >> $METADATAFILE
+    echo -e "["$section"]\ntemplatename = $templatename\nchecksum = $checksum\ndownloadurl = $downloadurl\nfilename = $filename\narch = $arch\nguestos = $guestos\n" >> $METADATAFILE
   done
 }
 


### PR DESCRIPTION
### Description

This PR updates System VM template Guest OS version, to Debian GNU/Linux 12 (64-bit). A new guestos field added to _metadata.ini_ file for systemvm templates.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Verified in fresh deployment.

<img width="964" height="253" alt="SystemVmTemplate-UpdatedVersion" src="https://github.com/user-attachments/assets/749ce2ad-8f8f-4192-9b48-29c029c88467" />

MS log, updating systemvm templates: 
```
[root@pr11291-t13954-kvm-ol8-mgmt1 ~]#  grep "SystemVmTemplateRegistration" /var/log/cloudstack/management/management-server.log 
2025-07-29 07:01:15,224 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Looking for file [ ./engine/schema/dist/systemvm-templates/metadata.ini ] in the classpath.
2025-07-29 07:01:15,224 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Looking for file [ /usr/share/cloudstack-management/templates/systemvm/metadata.ini ] in the classpath.
2025-07-29 07:02:32,550 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System Vm template IDs
2025-07-29 07:02:32,552 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating SystemVM Template Guest OS [Debian GNU/Linux 12 (64-bit)] id
2025-07-29 07:02:32,556 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: LXC
2025-07-29 07:02:32,560 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: LXC as it is not used, not failing upgrade
2025-07-29 07:02:32,580 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: VMware
2025-07-29 07:02:32,581 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: VMware as it is not used, not failing upgrade
2025-07-29 07:02:32,585 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: KVM, arch: x86_64
2025-07-29 07:02:32,587 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: KVM, arch: x86_64 as it is not used, not failing upgrade
2025-07-29 07:02:32,591 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: Ovm3
2025-07-29 07:02:32,592 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: Ovm3 as it is not used, not failing upgrade
2025-07-29 07:02:32,596 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: KVM, arch: aarch64
2025-07-29 07:02:32,597 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: KVM, arch: aarch64 as it is not used, not failing upgrade
2025-07-29 07:02:32,598 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: XenServer
2025-07-29 07:02:32,600 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: XenServer as it is not used, not failing upgrade
2025-07-29 07:02:32,603 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System VM template for hypervisor: Hyperv
2025-07-29 07:02:32,604 WARN  [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Cannot upgrade 4.20.2 system VM template for hypervisor: Hyperv as it is not used, not failing upgrade
2025-07-29 07:02:32,608 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Updating System Vm Template IDs Complete
2025-07-29 07:04:59,382 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Looking for file [ ./engine/schema/dist/systemvm-templates/metadata.ini ] in the classpath.
2025-07-29 07:04:59,383 DEBUG [c.c.u.SystemVmTemplateRegistration] (main:[]) (logid:) Looking for file [ /usr/share/cloudstack-management/templates/systemvm/metadata.ini ] in the classpath.
2025-07-29 07:19:25,624 INFO  [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) SystemVM template not seeded
2025-07-29 07:19:25,624 INFO  [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) Unmounting store
2025-07-29 07:19:25,808 ERROR [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) Failed to delete temporary directory: /tmp/tmp14565031384110649375
2025-07-29 07:19:28,653 DEBUG [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) Executing command [/usr/share/cloudstack-common/scripts/storage/secondary/setup-sysvm-tmplt -u 05c47bc3-876b-4c71-8e49-049c4051fe2e -f /usr/share/cloudstack-management/templates/systemvm/systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2 -h kvm -d /tmp/tmp14411309665781300192/template/tmpl/1/3 ].
2025-07-29 07:20:53,741 DEBUG [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) Successfully executed process [21559] for command [/usr/share/cloudstack-common/scripts/storage/secondary/setup-sysvm-tmplt -u 05c47bc3-876b-4c71-8e49-049c4051fe2e -f /usr/share/cloudstack-management/templates/systemvm/systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2 -h kvm -d /tmp/tmp14411309665781300192/template/tmpl/1/3 ].
2025-07-29 07:20:53,741 DEBUG [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) + [[ ! -u 05c47bc3-876b-4c71-8e49-049c4051fe2e -f /usr/share/cloudstack-management/templates/systemvm/systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2 -h kvm -d /tmp/tmp14411309665781300192/template/tmpl/1/3 =~ ^-.+ ]]
2025-07-29 07:20:53,764 INFO  [c.c.u.SystemVmTemplateRegistration] (qtp253011924-21:[ctx-03189f53, ctx-652c779d, ctx-596b744f]) (logid:fef01ef6) Unmounting store
[root@pr11291-t13954-kvm-ol8-mgmt1 ~]#
```

metadata.ini file:
```
[root@pr11291-t13954-kvm-ol8-mgmt1 ~]# cat /usr/share/cloudstack-management/templates/systemvm/metadata.ini

[default]
version = 4.20.2.0

[kvm-x86_64]
templatename = systemvm-kvm-4.20.2-x86_64
checksum = cacae9b108ad56c738e8bed90105804f
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2
filename = systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2
arch = x86_64
guestos = Debian GNU/Linux 12 (64-bit)

[kvm-aarch64]
templatename = systemvm-kvm-4.20.2-aarch64
checksum = 
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-aarch64-kvm.qcow2.bz2
filename = systemvmtemplate-4.20.2-aarch64-kvm.qcow2.bz2
arch = aarch64
guestos = Debian GNU/Linux 12 (64-bit)

[vmware]
templatename = systemvm-vmware-4.20.2-x86_64
checksum = f30a3233ae43c5e14a3fb0d932fd2d8b
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-x86_64-vmware.ova
filename = systemvmtemplate-4.20.2-x86_64-vmware.ova
arch = x86_64
guestos = Other Linux (64-bit)

[xenserver]
templatename = systemvm-xenserver-4.20.2-x86_64
checksum = eb9c3c4362c2152cf8a506c45057baaa
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-x86_64-xen.vhd.bz2
filename = systemvmtemplate-4.20.2-x86_64-xen.vhd.bz2
arch = x86_64
guestos = Other Linux (64-bit)

[hyperv]
templatename = systemvm-hyperv-4.20.2-x86_64
checksum = 0a505c21c240bc9d8a5c26fef8d3e6d1
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-x86_64-hyperv.vhd.zip
filename = systemvmtemplate-4.20.2-x86_64-hyperv.vhd.zip
arch = x86_64
guestos = Debian GNU/Linux 12 (64-bit)

[lxc]
templatename = systemvm-lxc-4.20.2-x86_64
checksum = cacae9b108ad56c738e8bed90105804f
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2
filename = systemvmtemplate-4.20.2-x86_64-kvm.qcow2.bz2
arch = x86_64
guestos = Debian GNU/Linux 12 (64-bit)

[ovm3]
templatename = systemvm-ovm3-4.20.2-x86_64
checksum = 8e0cf45de4943b9b136b9f6068ed4a21
downloadurl = https://download.cloudstack.org/systemvm/4.20/systemvmtemplate-4.20.2-x86_64-ovm.raw.bz2
filename = systemvmtemplate-4.20.2-x86_64-ovm.raw.bz2
arch = x86_64
guestos = Debian GNU/Linux 12 (64-bit)

[root@pr11291-t13954-kvm-ol8-mgmt1 ~]# 
```

DB:

```
mysql> SELECT * FROM cloud.guest_os WHERE display_name = 'Debian GNU/Linux 12 (64-bit)';
+-----+-------------+------+--------------------------------------+------------------------------+---------------------+---------+-----------------+---------+
| id  | category_id | name | uuid                                 | display_name                 | created             | removed | is_user_defined | display |
+-----+-------------+------+--------------------------------------+------------------------------+---------------------+---------+-----------------+---------+
| 363 |           2 | NULL | 3ac8ebcc-f487-461b-96fb-ba93395ce73e | Debian GNU/Linux 12 (64-bit) | 2025-07-29 07:02:18 | NULL    |               0 |       1 |
+-----+-------------+------+--------------------------------------+------------------------------+---------------------+---------+-----------------+---------+
1 row in set (0.00 sec)

mysql>
mysql> SELECT uuid, unique_name, name, type, format, hypervisor_type, guest_os_id, state, arch FROM cloud.vm_template WHERE type = 'SYSTEM' AND removed iS NULL;
+--------------------------------------+-------------+-------------------------------+--------+--------+-----------------+-------------+--------+--------+
| uuid                                 | unique_name | name                          | type   | format | hypervisor_type | guest_os_id | state  | arch   |
+--------------------------------------+-------------+-------------------------------+--------+--------+-----------------+-------------+--------+--------+
| c1bbe13c-6c49-11f0-9718-1e00790002af | routing-1   | SystemVM Template (XenServer) | SYSTEM | VHD    | XenServer       |          99 | Active | x86_64 |
| c1bc52fb-6c49-11f0-9718-1e00790002af | routing-3   | SystemVM Template (KVM)       | SYSTEM | QCOW2  | KVM             |         363 | Active | x86_64 |
| c1bc9c23-6c49-11f0-9718-1e00790002af | routing-8   | SystemVM Template (vSphere)   | SYSTEM | OVA    | VMware          |          99 | Active | x86_64 |
| c1bce509-6c49-11f0-9718-1e00790002af | routing-9   | SystemVM Template (HyperV)    | SYSTEM | VHD    | Hyperv          |         363 | Active | x86_64 |
| d96abd7a-6c49-11f0-9718-1e00790002af | routing-10  | SystemVM Template (LXC)       | SYSTEM | QCOW2  | LXC             |         363 | Active | x86_64 |
| e6ad9baf-6c49-11f0-9718-1e00790002af | routing-12  | SystemVM Template (Ovm3)      | SYSTEM | RAW    | Ovm3            |         363 | Active | x86_64 |
+--------------------------------------+-------------+-------------------------------+--------+--------+-----------------+-------------+--------+--------+
6 rows in set (0.00 sec)
mysql> SELECT * FROM cloud.guest_os WHERE id IN (SELECT guest_os_id FROM cloud.vm_template WHERE type = 'SYSTEM' AND removed iS NULL);
+-----+-------------+------+--------------------------------------+------------------------------+---------------------+---------+-----------------+---------+
| id  | category_id | name | uuid                                 | display_name                 | created             | removed | is_user_defined | display |
+-----+-------------+------+--------------------------------------+------------------------------+---------------------+---------+-----------------+---------+
|  99 |           7 | NULL | c1e143d7-6c49-11f0-9718-1e00790002af | Other Linux (64-bit)         | 2025-07-29 07:01:42 | NULL    |               0 |       1 |
| 363 |           2 | NULL | 3ac8ebcc-f487-461b-96fb-ba93395ce73e | Debian GNU/Linux 12 (64-bit) | 2025-07-29 07:02:18 | NULL    |               0 |       1 |
+-----+-------------+------+--------------------------------------+------------------------------+---------------------+---------+-----------------+---------+
2 rows in set (0.00 sec)
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
