### PR TITLE
api,server,extensions: allow updating extension resource map details

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/cluster/UpdateClusterCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/cluster/UpdateClusterCmd.java
@@ -16,6 +16,8 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.cluster;
 
+import java.util.Map;
+
 import com.cloud.cpu.CPU;
 import org.apache.cloudstack.api.ApiCommandResourceType;
 
@@ -59,6 +61,12 @@ public class UpdateClusterCmd extends BaseCmd {
             description = "the CPU arch of the cluster. Valid options are: x86_64, aarch64",
             since = "4.20")
     private String arch;
+
+    @Parameter(name = ApiConstants.EXTERNAL_DETAILS,
+            type = CommandType.MAP,
+            description = "Details in key/value pairs to be added to the extension-resource mapping. Use the format externaldetails[i].<key>=<value>. Example: externaldetails[0].endpoint.url=https://example.com",
+            since = "4.21.0")
+    protected Map externalDetails;
 
     public String getClusterName() {
         return clusterName;
@@ -120,6 +128,10 @@ public class UpdateClusterCmd extends BaseCmd {
             return null;
         }
         return CPU.CPUArch.fromType(arch);
+    }
+
+    public Map<String, String> getExternalDetails() {
+        return convertDetailsToMap(externalDetails);
     }
 
     @Override

--- a/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/manager/ExtensionsManager.java
+++ b/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/manager/ExtensionsManager.java
@@ -46,6 +46,7 @@ import org.apache.cloudstack.framework.extensions.command.ExtensionServerActionB
 
 import com.cloud.host.Host;
 import com.cloud.org.Cluster;
+import com.cloud.utils.Pair;
 import com.cloud.utils.component.Manager;
 
 public interface ExtensionsManager extends Manager {
@@ -87,4 +88,9 @@ public interface ExtensionsManager extends Manager {
     Map<String, Map<String, String>> getExternalAccessDetails(Host host, Map<String, String> vmDetails);
 
     String handleExtensionServerCommands(ExtensionServerActionBaseCommand cmd);
+
+    Pair<Boolean, ExtensionResourceMap> extensionResourceMapDetailsNeedUpdate(final long resourceId,
+                      final ExtensionResourceMap.ResourceType resourceType, final Map<String, String> details);
+
+    void updateExtensionResourceMapDetails(final long extensionResourceMapId, final Map<String, String> details);
 }

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -189,6 +189,7 @@ import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
+import com.cloud.utils.Pair;
 import com.cloud.utils.StringUtils;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.UriUtils;
@@ -223,8 +224,8 @@ import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.VirtualMachineProfileImpl;
 import com.cloud.vm.VmDetailConstants;
-import com.cloud.vm.dao.VMInstanceDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.cloud.vm.dao.VMInstanceDetailsDao;
 import com.google.gson.Gson;
 
 @Component
@@ -1224,9 +1225,18 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         String managedstate = cmd.getManagedstate();
         String name = cmd.getClusterName();
         CPU.CPUArch arch = cmd.getArch();
+        final Map<String, String> externalDetails = cmd.getExternalDetails();
 
         // Verify cluster information and update the cluster if needed
         boolean doUpdate = false;
+        Pair<Boolean, ExtensionResourceMap> needDetailsUpdateMapPair =
+                extensionsManager.extensionResourceMapDetailsNeedUpdate(cluster.getId(),
+                ExtensionResourceMap.ResourceType.Cluster, externalDetails);
+        if (Boolean.TRUE.equals(needDetailsUpdateMapPair.first()) && needDetailsUpdateMapPair.second() == null) {
+            throw new InvalidParameterValueException(
+                    String.format("Cluster: %s is not registered with any extension, details cannot be updated",
+                            cluster.getName()));
+        }
 
         if (StringUtils.isNotBlank(name)) {
             if(cluster.getHypervisorType() == HypervisorType.VMware) {
@@ -1309,6 +1319,11 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         if (doUpdate) {
             _clusterDao.update(cluster.getId(), cluster);
+        }
+
+        if (Boolean.TRUE.equals(needDetailsUpdateMapPair.first())) {
+            ExtensionResourceMap extensionResourceMap = needDetailsUpdateMapPair.second();
+            extensionsManager.updateExtensionResourceMapDetails(extensionResourceMap.getId(), externalDetails);
         }
 
         if (newManagedState != null && !newManagedState.equals(oldManagedState)) {

--- a/ui/src/views/extension/ExternalConfigurationDetails.vue
+++ b/ui/src/views/extension/ExternalConfigurationDetails.vue
@@ -94,7 +94,8 @@ export default {
   },
   methods: {
     fetchData () {
-      if (!['cluster'].includes(this.$route.meta.name)) {
+      if (!['cluster'].includes(this.$route.meta.name) || !this.resource.extensionid) {
+        this.extension = {}
         return
       }
       this.loading = true

--- a/ui/src/views/infra/ClusterUpdate.vue
+++ b/ui/src/views/infra/ClusterUpdate.vue
@@ -181,15 +181,11 @@ export default {
         details: 'resource'
       }
       getAPI('listExtensions', params).then(json => {
-        this.extension = json.listextensionsresponse.extension[0]
-        if (!this.extension?.resources) {
-          return null
+        const resources = json?.listextensionsresponse?.extension?.[0]?.resources || []
+        const resourceMap = resources.find(r => r.id === this.resource.id)
+        if (resourceMap && resourceMap.details && typeof resourceMap.details === 'object') {
+          this.form.externaldetails = resourceMap.details
         }
-        const resourceMap = this.extension.resources.find(r => r.id === this.resource.id)
-        if (!resourceMap || !resourceMap.details || typeof resourceMap.details !== 'object') {
-          this.form.externaldetails = null
-        }
-        this.form.externaldetails = resourceMap.details
       }).catch(error => {
         this.$notifyError(error)
       }).finally(() => {
@@ -199,7 +195,6 @@ export default {
     handleSubmit () {
       this.formRef.value.validate().then(() => {
         const values = toRaw(this.form)
-        console.log(values)
         const params = {}
         params.id = this.resource.id
         params.clustername = values.name


### PR DESCRIPTION
### Description

This PR makes changes to allow updating details for an extension resource mapping, as other places where external metadata is added already allow updation. Currently, extensions only support Cluster to be registered therefore, changes have been added to updateCluster functionality.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
