### PR TITLE
server: prevent vm schedule update failure for time when not changed

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/schedule/VMScheduleManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/schedule/VMScheduleManagerImpl.java
@@ -18,6 +18,30 @@
  */
 package org.apache.cloudstack.vm.schedule;
 
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.TimeZone;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.api.ApiCommandResourceType;
+import org.apache.cloudstack.api.command.user.vm.CreateVMScheduleCmd;
+import org.apache.cloudstack.api.command.user.vm.DeleteVMScheduleCmd;
+import org.apache.cloudstack.api.command.user.vm.ListVMScheduleCmd;
+import org.apache.cloudstack.api.command.user.vm.UpdateVMScheduleCmd;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.api.response.VMScheduleResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.vm.schedule.dao.VMScheduleDao;
+import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.scheduling.support.CronExpression;
+
 import com.cloud.api.query.MutualExclusiveIdsManagerBase;
 import com.cloud.event.ActionEvent;
 import com.cloud.event.EventTypes;
@@ -32,27 +56,6 @@ import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
-import org.apache.cloudstack.api.ApiCommandResourceType;
-import org.apache.cloudstack.api.command.user.vm.CreateVMScheduleCmd;
-import org.apache.cloudstack.api.command.user.vm.DeleteVMScheduleCmd;
-import org.apache.cloudstack.api.command.user.vm.ListVMScheduleCmd;
-import org.apache.cloudstack.api.command.user.vm.UpdateVMScheduleCmd;
-import org.apache.cloudstack.api.response.ListResponse;
-import org.apache.cloudstack.api.response.VMScheduleResponse;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.vm.schedule.dao.VMScheduleDao;
-import org.apache.commons.lang.time.DateUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-import org.springframework.scheduling.support.CronExpression;
-
-import javax.inject.Inject;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.TimeZone;
 
 public class VMScheduleManagerImpl extends MutualExclusiveIdsManagerBase implements VMScheduleManager, PluggableService {
 
@@ -208,6 +211,9 @@ public class VMScheduleManagerImpl extends MutualExclusiveIdsManagerBase impleme
         Date cmdStartDate = cmd.getStartDate();
         Date cmdEndDate = cmd.getEndDate();
         Boolean enabled = cmd.getEnabled();
+        final String originalTimeZone = vmSchedule.getTimeZone();
+        final Date originalStartDate = vmSchedule.getStartDate();
+        final Date originalEndDate = vmSchedule.getEndDate();
 
         TimeZone timeZone;
         String timeZoneId;
@@ -234,7 +240,13 @@ public class VMScheduleManagerImpl extends MutualExclusiveIdsManagerBase impleme
             startDate = Date.from(DateUtil.getZoneDateTime(cmdStartDate, timeZone.toZoneId()).toInstant());
         }
 
-        validateStartDateEndDate(Objects.requireNonNullElse(startDate, DateUtils.addMinutes(new Date(), 1)), endDate, timeZone);
+        if (ObjectUtils.anyNotNull(cmdStartDate, cmdEndDate, cmdTimeZone) &&
+                (!Objects.equals(originalTimeZone, timeZoneId) ||
+                        !Objects.equals(originalStartDate, startDate) ||
+                        !Objects.equals(originalEndDate, endDate))) {
+            validateStartDateEndDate(Objects.requireNonNullElse(startDate, DateUtils.addMinutes(new Date(), 1)),
+                    endDate, timeZone);
+        }
 
         if (enabled != null) {
             vmSchedule.setEnabled(enabled);


### PR DESCRIPTION
### Description

Fixes #11175

Behaviour introduced in #7397 always validates start-end times during update even when they are not changed which leads to failure to enable/disable schedule if the start time has passed.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
