### PR TITLE
Fix listCapacity sort by usage

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/resource/ListCapacityCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/resource/ListCapacityCmd.java
@@ -127,15 +127,15 @@ public class ListCapacityCmd extends BaseListCmd {
         Collections.sort(capacityResponses, new Comparator<CapacityResponse>() {
             public int compare(CapacityResponse resp1, CapacityResponse resp2) {
                 int res = resp1.getZoneName().compareTo(resp2.getZoneName());
+                // Group by zone
                 if (res != 0) {
                     return res;
-                } else if (getSortBy() != null) {
-                    return 0;
-                } else {
-                    return resp1.getCapacityType().compareTo(resp2.getCapacityType());
                 }
+                // Sort by capacity type only if not already sorted by usage
+                return (getSortBy() != null) ? 0 : resp1.getCapacityType().compareTo(resp2.getCapacityType());
             }
         });
+
 
         response.setResponses(capacityResponses);
         response.setResponseName(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/resource/ListCapacityCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/resource/ListCapacityCmd.java
@@ -129,6 +129,8 @@ public class ListCapacityCmd extends BaseListCmd {
                 int res = resp1.getZoneName().compareTo(resp2.getZoneName());
                 if (res != 0) {
                     return res;
+                } else if (getSortBy() != null) {
+                    return 0;
                 } else {
                     return resp1.getCapacityType().compareTo(resp2.getCapacityType());
                 }


### PR DESCRIPTION
### Description

This PR fixes listCapacity api's sort by usage parameter.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
Before:
```
(localhost) 🐱 > list capacity  sortby="usage"                                                                                                                                                                                                                                                                  [21/495]
{                                                                             
  "capacity": [                                                               
    {                                                                         
      "capacitytotal": 6997340160,                                            
      "capacityused": 5368709120,                                             
      "name": "MEMORY",                                                       
      "percentused": "76.72",                                                 
      "type": 0,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 14400,                                                 
      "capacityused": 4500,                                                   
      "name": "CPU",                                                          
      "percentused": "31.25",                                                 
      "type": 1,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 0,                                                     
      "capacityused": 0,                                                      
      "name": "STORAGE",                                                      
      "percentused": "0",                                                     
      "type": 2,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 1572431986688,                                         
      "capacityused": 0,                                                      
      "name": "STORAGE_ALLOCATED",                                            
      "percentused": "0",                                                     
      "type": 3,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 125,                                                   
      "capacityused": 5,                                                      
      "name": "VIRTUAL_NETWORK_PUBLIC_IP",                                    
      "percentused": "4",                                                     
      "type": 4,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 125,                                                   
      "capacityused": 2,                                                      
      "name": "PRIVATE_IP",                                                   
      "percentused": "1.6",                                                   
      "type": 5,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 0,                                                     
      "capacityused": 0,                                                      
      "name": "SECONDARY_STORAGE",                                            
      "percentused": "0",                                                     
      "type": 6,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 100,                                                   
      "capacityused": 3,                                                      
      "name": "VLAN",                                                         
      "percentused": "3",                                                     
      "type": 7,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 0,                                                     
      "capacityused": 0,                                                      
      "name": "GPU",                                                          
      "percentused": "0",                                                     
      "type": 19,                                                             
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                 
```

After:
```
(localhost) 🐱 > list capacity  sortby="usage"                                
{                                                                             
  "capacity": [                                                               
    {                                                                         
      "capacitytotal": 4,                                                     
      "capacityused": 9,                                                      
      "name": "CPU_CORE",                                                     
      "percentused": "225",                                                   
      "type": 90,                                                             
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 6997340160,                                            
      "capacityused": 5368709120,                                             
      "name": "MEMORY",                                                       
      "percentused": "76.72",                                                 
      "type": 0,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 393107996672,                                          
      "capacityused": 301029392384,                                           
      "name": "SECONDARY_STORAGE",                                            
      "percentused": "76.58",                                                 
      "type": 6,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 786215993344,                                          
      "capacityused": 602058784768,                                           
      "name": "STORAGE",                                                      
      "percentused": "76.58",                                                 
      "type": 2,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 393107996672,                                          
      "capacityused": 301026246656,                                           
      "name": "BACKUP_STORAGE",                                               
      "percentused": "76.58",                                                 
      "type": 21,                                                             
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 14400,                                                 
      "capacityused": 4500,                                                   
      "name": "CPU",                                                          
      "percentused": "31.25",                                                 
      "type": 1,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 125,                                                   
      "capacityused": 5,                                                      
      "name": "VIRTUAL_NETWORK_PUBLIC_IP",                                    
      "percentused": "4",                                                     
      "type": 4,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 1572431986688,                                         
      "capacityused": 60574728480,                                            
      "name": "STORAGE_ALLOCATED",                                            
      "percentused": "3.85",                                                  
      "type": 3,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                                        
    {                                                                         
      "capacitytotal": 100,                                                   
      "capacityused": 3,                                                      
      "name": "VLAN",                                                         
      "percentused": "3",                                                     
      "type": 7,                                                              
      "zoneid": "16cc239c-adbc-49cf-b100-4e3ce08ab858",                       
      "zonename": "DC"                                                        
    },                                                               
```
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
