### PR TITLE
Support to list templates in ready state (new API parameter 'isready', similar to list ISOs)

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/iso/ListIsosCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/iso/ListIsosCmd.java
@@ -57,7 +57,7 @@ public class ListIsosCmd extends BaseListTaggedResourcesCmd implements UserCmd {
     @Parameter(name = ApiConstants.IS_PUBLIC, type = CommandType.BOOLEAN, description = "true if the ISO is publicly available to all users, false otherwise.")
     private Boolean publicIso;
 
-    @Parameter(name = ApiConstants.IS_READY, type = CommandType.BOOLEAN, description = "true if this ISO is ready to be deployed")
+    @Parameter(name = ApiConstants.IS_READY, type = CommandType.BOOLEAN, description = "list ISOs that are ready to be deployed")
     private Boolean ready;
 
     @Parameter(name = ApiConstants.ISO_FILTER,

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/ListTemplatesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/ListTemplatesCmd.java
@@ -126,6 +126,9 @@ public class ListTemplatesCmd extends BaseListTaggedResourcesCmd implements User
             since = "4.21.0")
     private Long extensionId;
 
+    @Parameter(name = ApiConstants.IS_READY, type = CommandType.BOOLEAN, description = "list templates that are ready to be deployed", since = "4.21.0")
+    private Boolean ready;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -195,6 +198,13 @@ public class ListTemplatesCmd extends BaseListTaggedResourcesCmd implements User
         boolean onlyReady =
             (templateFilter == TemplateFilter.featured) || (templateFilter == TemplateFilter.selfexecutable) || (templateFilter == TemplateFilter.sharedexecutable) ||
                 (templateFilter == TemplateFilter.executable && isAccountSpecific) || (templateFilter == TemplateFilter.community);
+
+        if (!onlyReady) {
+            if (isReady() != null && isReady().booleanValue() != onlyReady) {
+                onlyReady = isReady().booleanValue();
+            }
+        }
+
         return onlyReady;
     }
 
@@ -228,6 +238,10 @@ public class ListTemplatesCmd extends BaseListTaggedResourcesCmd implements User
 
     public Long getExtensionId() {
         return extensionId;
+    }
+
+    public Boolean isReady() {
+        return ready;
     }
 
     @Override

--- a/ui/src/views/compute/AttachIso.vue
+++ b/ui/src/views/compute/AttachIso.vue
@@ -106,8 +106,8 @@ export default {
       const params = {
         listall: true,
         zoneid: this.resource.zoneid,
-        isready: true,
-        isofilter: isoFilter
+        isofilter: isoFilter,
+        isready: true
       }
       return new Promise((resolve, reject) => {
         getAPI('listIsos', params).then((response) => {

--- a/ui/src/views/compute/AutoScaleVmProfile.vue
+++ b/ui/src/views/compute/AutoScaleVmProfile.vue
@@ -424,9 +424,11 @@ export default {
       }
       if (isAdmin()) {
         params.templatefilter = 'all'
+        params.isready = true
       } else {
         params.templatefilter = 'executable'
       }
+      params.isready = true
       getAPI('listTemplates', params).then(json => {
         this.templatesList = json.listtemplatesresponse?.template || []
       })

--- a/ui/src/views/compute/AutoScaleVmProfile.vue
+++ b/ui/src/views/compute/AutoScaleVmProfile.vue
@@ -428,7 +428,6 @@ export default {
       } else {
         params.templatefilter = 'executable'
       }
-      params.isready = true
       getAPI('listTemplates', params).then(json => {
         this.templatesList = json.listtemplatesresponse?.template || []
       })

--- a/ui/src/views/compute/CreateAutoScaleVmGroup.vue
+++ b/ui/src/views/compute/CreateAutoScaleVmGroup.vue
@@ -1881,6 +1881,7 @@ export default {
           apiName = 'listTemplates'
           params.listall = true
           params.templatefilter = this.isNormalAndDomainUser ? 'executable' : 'all'
+          params.isready = true
           params.id = this.queryTemplateId
           this.dataPreFill.templateid = this.queryTemplateId
         } else if (this.queryNetworkId) {
@@ -2989,6 +2990,7 @@ export default {
         args.arch = this.selectedArchitecture
       }
       args.templatefilter = templateFilter
+      args.isready = true
       args.details = 'all'
       args.showicon = 'true'
       args.id = this.queryTemplateId

--- a/ui/src/views/compute/CreateKubernetesCluster.vue
+++ b/ui/src/views/compute/CreateKubernetesCluster.vue
@@ -671,7 +671,8 @@ export default {
       for (const filtername of filters) {
         const params = {
           templatefilter: filtername,
-          forcks: true
+          forcks: true,
+          isready: true
         }
         this.templateLoading = true
         getAPI('listTemplates', params).then(json => {

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1797,12 +1797,14 @@ export default {
           apiName = 'listTemplates'
           params.listall = true
           params.templatefilter = this.isNormalAndDomainUser ? 'executable' : 'all'
+          params.isready = true
           params.id = this.queryTemplateId
           this.dataPreFill.templateid = this.queryTemplateId
         } else if (this.queryIsoId) {
           apiName = 'listIsos'
           params.listall = true
           params.isofilter = this.isNormalAndDomainUser ? 'executable' : 'all'
+          params.isready = true
           params.id = this.queryIsoId
           this.dataPreFill.isoid = this.queryIsoId
         } else if (this.queryNetworkId) {
@@ -2609,6 +2611,7 @@ export default {
       args.domainid = store.getters.project?.id ? null : this.owner.domainid
       args.projectid = store.getters.project?.id || this.owner.projectid
       args.templatefilter = templateFilter
+      args.isready = true
       args.details = 'all'
       args.showicon = 'true'
       args.id = this.queryTemplateId
@@ -2644,6 +2647,7 @@ export default {
       args.domainid = store.getters.project?.id ? null : this.owner.domainid
       args.projectid = store.getters.project?.id || this.owner.projectid
       args.isoFilter = isoFilter
+      args.isready = true
       args.bootable = true
       args.showicon = 'true'
       args.id = this.queryIsoId

--- a/ui/src/views/compute/DeployVnfAppliance.vue
+++ b/ui/src/views/compute/DeployVnfAppliance.vue
@@ -2546,6 +2546,7 @@ export default {
         args.arch = this.selectedArchitecture
       }
       args.templatefilter = templateFilter
+      args.isready = true
       args.details = 'all'
       args.showicon = 'true'
       args.id = this.queryTemplateId

--- a/ui/src/views/compute/EditVM.vue
+++ b/ui/src/views/compute/EditVM.vue
@@ -285,6 +285,7 @@ export default {
       params.id = this.resource.templateid
       params.isrecursive = true
       params.templatefilter = 'all'
+      params.isready = true
       var apiName = 'listTemplates'
       getAPI(apiName, params).then(json => {
         const templateResponses = json.listtemplatesresponse.template

--- a/ui/src/views/compute/ReinstallVm.vue
+++ b/ui/src/views/compute/ReinstallVm.vue
@@ -367,6 +367,7 @@ export default {
       }
       args.zoneid = this.resource.zoneid
       args.templatefilter = templateFilter
+      args.isready = true
       if (this.resource.arch) {
         args.arch = this.resource.arch
       }

--- a/ui/src/views/compute/ResetUserData.vue
+++ b/ui/src/views/compute/ResetUserData.vue
@@ -245,6 +245,7 @@ export default {
       params.id = this.resource.templateid
       params.isrecursive = true
       params.templatefilter = 'all'
+      params.isready = true
       var apiName = 'listTemplates'
       getAPI(apiName, params).then(json => {
         const templateResponses = json.listtemplatesresponse.template

--- a/ui/src/views/compute/ScaleVM.vue
+++ b/ui/src/views/compute/ScaleVM.vue
@@ -189,6 +189,7 @@ export default {
       return new Promise((resolve, reject) => {
         getAPI('listTemplates', {
           templatefilter: 'all',
+          isready: true,
           id: this.resource.templateid
         }).then(response => {
           var template = response?.listtemplatesresponse?.template?.[0] || null

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -584,6 +584,7 @@ export default {
           isLoad: true,
           options: {
             templatefilter: 'all',
+            isready: true,
             hypervisor: this.cluster.hypervisortype,
             showicon: true
           },


### PR DESCRIPTION
### Description

This PR adds support to list templates in ready state (new API parameter 'isready', similar to list ISOs), and UI to display Templates/ISOs in ready state wherever applicable.

The latest UI in main uses templatefilter 'all' and oscategoryid to list the templates, which is listing not ready templates as well. Earlier UI listed the templates using the appropriate templatefilters (featured, executable, selfexecutable) which lists only  ready templates.

Fixes #11339  

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

- List ISOs

<img width="874" height="298" alt="ListISOs" src="https://github.com/user-attachments/assets/3dcfc9c9-a0be-4cff-b18f-a5a685c0a1c8" />

- List ISOs in Deploy Instance Form

<img width="838" height="542" alt="DeployVM-ListISO" src="https://github.com/user-attachments/assets/f11e7a3b-76fc-4d37-b167-08f894169b5b" />

- List Templates

<img width="863" height="366" alt="ListTemplates" src="https://github.com/user-attachments/assets/d0a618be-c767-468c-ba2b-7a1e80ef00a0" />


- List Templates in Deploy Instance Form

<img width="811" height="617" alt="DeployVM-ListTemplates" src="https://github.com/user-attachments/assets/04f68bad-a662-4b15-ad0a-59c928977ce7" />

<img width="1135" height="774" alt="DeployVM-ListTemplates-Debug" src="https://github.com/user-attachments/assets/96ae9803-a0b8-4c5a-bf1e-317c30ad8b17" />

### How Has This Been Tested?

Verified list templates / ISOs call while registering new template / ISO.

```
(localcloud) 🐱 > list isos isofilter=all bootable=true filter=id,name,status,isready,ostypename
{
  "count": 2,
  "iso": [
    {
      "id": "852ad01e-96cd-4488-94ca-878d2a473222",
      "isready": true,
      "name": "CentOS-7",
      "ostypename": "CentOS 7",
      "status": "Successfully Installed"
    },
    {
      "id": "862cc57a-ada0-45aa-9c60-8e55c59ef4c3",
      "isready": false,
      "name": "CentOS-7-NewISO",
      "ostypename": "CentOS 7",
      "status": "26% Downloaded"
    }
  ]
}

(localcloud) 🐱 > list isos isofilter=all bootable=true isready=true filter=id,name,status,isready,ostypename
{
  "count": 1,
  "iso": [
    {
      "id": "852ad01e-96cd-4488-94ca-878d2a473222",
      "isready": true,
      "name": "CentOS-7",
      "ostypename": "CentOS 7",
      "status": "Successfully Installed"
    }
  ]
}

(localcloud) 🐱 > list templates templatefilter=all filter=id,name,status,isready,ostypename
{
  "count": 4,
  "template": [
    {
      "id": "a4a63917-26e5-4840-b5b5-089464200f41",
      "isready": true,
      "name": "centos7",
      "ostypename": "CentOS 7",
      "status": "Download Complete"
    },
    {
      "id": "20f0bc6e-ca82-4421-9840-378bb0756064",
      "isready": false,
      "name": "CentOS-7-NewTmpl",
      "ostypename": "CentOS 7",
      "status": "19% Downloaded"
    },
    {
      "id": "b880c853-6d39-11f0-aba0-1e004200030e",
      "isready": true,
      "name": "SystemVM Template (KVM)",
      "ostypename": "Debian GNU/Linux 5.0 (64-bit)",
      "status": "Download Complete"
    },
    {
      "id": "b88233a8-6d39-11f0-aba0-1e004200030e",
      "isready": true,
      "name": "CentOS 5.5(64-bit) no GUI (KVM)",
      "ostypename": "CentOS 5.5 (64-bit)",
      "status": "Download Complete"
    }
  ]
}

(localcloud) 🐱 > list templates templatefilter=all isready=true filter=id,name,status,isready,ostypename
{
  "count": 3,
  "template": [
    {
      "id": "a4a63917-26e5-4840-b5b5-089464200f41",
      "isready": true,
      "name": "centos7",
      "ostypename": "CentOS 7",
      "status": "Download Complete"
    },
    {
      "id": "b880c853-6d39-11f0-aba0-1e004200030e",
      "isready": true,
      "name": "SystemVM Template (KVM)",
      "ostypename": "Debian GNU/Linux 5.0 (64-bit)",
      "status": "Download Complete"
    },
    {
      "id": "b88233a8-6d39-11f0-aba0-1e004200030e",
      "isready": true,
      "name": "CentOS 5.5(64-bit) no GUI (KVM)",
      "ostypename": "CentOS 5.5 (64-bit)",
      "status": "Download Complete"
    }
  ]
}
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
