### PR TITLE
Fix of deployment VM from a copied snapshot in another zone

### DIFF
--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
@@ -103,9 +103,10 @@ public final class StorPoolDownloadTemplateCommandWrapper extends CommandWrapper
             final QemuImgFile srcFile = new QemuImgFile(srcDisk.getPath(), srcDisk.getFormat());
 
             final QemuImg qemu = new QemuImg(cmd.getWaitInMillSeconds());
-            StorPoolStorageAdaptor.resize( Long.toString(srcDisk.getVirtualSize()), dst.getPath());
 
             if (dst instanceof TemplateObjectTO) {
+                StorPoolStorageAdaptor.resize( Long.toString(srcDisk.getVirtualSize()), dst.getPath());
+
                 ((TemplateObjectTO) dst).setSize(srcDisk.getVirtualSize());
             }
 

--- a/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
+++ b/plugins/storage/volume/storpool/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/StorPoolDownloadTemplateCommandWrapper.java
@@ -105,7 +105,7 @@ public final class StorPoolDownloadTemplateCommandWrapper extends CommandWrapper
             final QemuImg qemu = new QemuImg(cmd.getWaitInMillSeconds());
 
             if (dst instanceof TemplateObjectTO) {
-                StorPoolStorageAdaptor.resize( Long.toString(srcDisk.getVirtualSize()), dst.getPath());
+                StorPoolStorageAdaptor.resize(Long.toString(srcDisk.getVirtualSize()), dst.getPath());
 
                 ((TemplateObjectTO) dst).setSize(srcDisk.getVirtualSize());
             }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4195,15 +4195,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         DiskOfferingVO rootDiskOffering = _diskOfferingDao.findById(rootDiskOfferingId);
-        long volumesSize = 0;
-        if (volume != null) {
-            volumesSize = volume.getSize();
-        } else if (snapshot != null) {
-            VolumeVO volumeVO = _volsDao.findById(snapshot.getVolumeId());
-            volumesSize = volumeVO != null ? volumeVO.getSize() : 0;
-        } else {
-            volumesSize = configureCustomRootDiskSize(customParameters, template, hypervisorType, rootDiskOffering);
-        }
+        long volumesSize = configureCustomRootDiskSize(customParameters, template, hypervisorType, rootDiskOffering);
 
         if (rootDiskOffering.getEncrypt() && hypervisorType != HypervisorType.KVM) {
             throw new InvalidParameterValueException("Root volume encryption is not supported for hypervisor type " + hypervisorType);
@@ -6292,7 +6284,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             }
             _accountMgr.checkAccess(caller, null, true, volume);
             templateId = volume.getTemplateId();
-            overrideDiskOfferingId = volume.getDiskOfferingId();
         } else if (cmd.getSnapshotId() != null) {
             snapshot = _snapshotDao.findById(cmd.getSnapshotId());
             if (snapshot == null) {
@@ -6301,7 +6292,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             _accountMgr.checkAccess(caller, null, true, snapshot);
             VolumeInfo volumeOfSnapshot = getVolume(snapshot.getVolumeId(), templateId, true);
             templateId = volumeOfSnapshot.getTemplateId();
-            overrideDiskOfferingId = volumeOfSnapshot.getDiskOfferingId();
         }
 
         VirtualMachineTemplate template = null;


### PR DESCRIPTION
### Description

This PR fixes the deployment of a VM with a snapshot that is copied to another zone.
Fix for creating StorPool volume from a snapshot if the size in the offering is bigger than the snapshot size


<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
Manually tested 

