### PR TITLE
Remove Domain/IP from Password Reset Link to custom Global Setting

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManager.java
+++ b/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManager.java
@@ -65,6 +65,11 @@ public interface UserPasswordResetManager {
             "Password for SMTP server for sending emails for resetting password for ACS users",
             false, ConfigKey.Scope.Global);
 
+    ConfigKey<String> UserPasswordResetDomainURL = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED,
+            String.class, "user.password.reset.mail.domain.url", null,
+            "Domain URL for reset password links sent to the user via email", true,
+            ConfigKey.Scope.Global);
+
     void setResetTokenAndSend(UserAccount userAccount);
 
     boolean validateAndResetPassword(UserAccount user, String token, String password);

--- a/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.cloudstack.config.ApiServiceConfiguration.ManagementServerAddresses;
 import static org.apache.cloudstack.resourcedetail.UserDetailVO.PasswordResetToken;
 import static org.apache.cloudstack.resourcedetail.UserDetailVO.PasswordResetTokenExpiryDate;
 

--- a/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
@@ -94,6 +94,7 @@ public class UserPasswordResetManagerImpl extends ManagerBase implements UserPas
                 UserPasswordResetSMTPUseAuth,
                 UserPasswordResetSMTPUsername,
                 UserPasswordResetSMTPPassword,
+                UserPasswordResetDomainURL,
                 PasswordResetMailTemplate
         };
     }
@@ -172,6 +173,7 @@ public class UserPasswordResetManagerImpl extends ManagerBase implements UserPas
         final String email = userAccount.getEmail();
         final String username = userAccount.getUsername();
         final String subject = "Password Reset Request";
+        final String domainUrl = UserPasswordResetDomainURL.value();
 
         String resetLink = String.format("/client/#/user/resetPassword?username=%s&token=%s",
                 username, resetToken);

--- a/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
@@ -68,7 +68,7 @@ public class UserPasswordResetManagerImpl extends ManagerBase implements UserPas
             new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, String.class,
             "user.password.reset.mail.template", "Hello {{username}}!\n" +
             "You have requested to reset your password. Please click the following link to reset your password:\n" +
-            "http://{{{resetLink}}}\n" +
+            "https://your_domain_here{{{resetLink}}}\n" +
             "If you did not request a password reset, please ignore this email.\n" +
             "\n" +
             "Regards,\n" +

--- a/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
@@ -68,7 +68,7 @@ public class UserPasswordResetManagerImpl extends ManagerBase implements UserPas
             new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, String.class,
             "user.password.reset.mail.template", "Hello {{username}}!\n" +
             "You have requested to reset your password. Please click the following link to reset your password:\n" +
-            "https://your_domain_here{{{resetLink}}}\n" +
+            "{{{domainUrl}}}{{{resetLink}}}\n" +
             "If you did not request a password reset, please ignore this email.\n" +
             "\n" +
             "Regards,\n" +

--- a/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/user/UserPasswordResetManagerImpl.java
@@ -174,8 +174,8 @@ public class UserPasswordResetManagerImpl extends ManagerBase implements UserPas
         final String username = userAccount.getUsername();
         final String subject = "Password Reset Request";
 
-        String resetLink = String.format("%s/client/#/user/resetPassword?username=%s&token=%s",
-                ManagementServerAddresses.value().split(",")[0], username, resetToken);
+        String resetLink = String.format("/client/#/user/resetPassword?username=%s&token=%s",
+                username, resetToken);
         String content = getMessageBody(userAccount, resetToken, resetLink);
 
         SMTPMailProperties mailProperties = new SMTPMailProperties();


### PR DESCRIPTION
### Description

This PR is a minor change on the `resetLink` generated when users self-serve resetting passwords as described in issue https://github.com/apache/cloudstack/issues/11378

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

It was not tested.

#### How did you try to break this feature and the system with this change?

I did not.