### PR TITLE
Remove volume size check in restoreBackupToVM

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -1284,17 +1284,6 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
             throw new CloudRuntimeException("Unable to create Instance from backup as the backup has a different number of disks than the Instance");
         }
 
-        int index = 0;
-        for (VolumeVO vmVolume: vmVolumes) {
-            Backup.VolumeInfo backupVolume = backupVolumes.get(index);
-            if (vmVolume.getSize() < backupVolume.getSize()) {
-                throw new CloudRuntimeException(String.format(
-                    "Instance volume size %d[GiB] for volume (%s) is less than the backed-up volume size %d[GiB] for backed-up volume (%s).",
-                    vmVolume.getSize(), vmVolume.getUuid(), backupVolume.getSize(), backupVolume.getUuid()));
-            }
-            index++;
-        }
-
         BackupOffering offering = backupOfferingDao.findByIdIncludingRemoved(backup.getBackupOfferingId());
         if (offering == null) {
             throw new CloudRuntimeException("Failed to find backup offering");


### PR DESCRIPTION
### Description

This PR fixes #11383

PR #11258 addressed a bug in backup restore where the data disk was created before the root disk. As part of the fix, it ensured that the list of backed-up volumes stored in the backup table is sorted by deviceId (rather than the id from the volumes table), and also re-sorted the volumes by deviceId during restore to correctly align with the backed-up volume paths.

In the “Create new instance from backup” feature, the new instance is provisioned using the volumes listed in the backup metadata. Starting with version 4.21, these volumes are sorted by deviceId. However, in 4.20, there may be backups where the data volume appears before the root volume. When such a backup is used after upgrading to 4.21, the volume size comparison after instance creation fails because:
	•	The root volume is always allocated first during instance creation.
	•	This results in volumeDao.findByInstance(vmId) returning volumes with root volume first.
	•	But in the older backup metadata (4.20), the data volume appears first.
	•	This mismatch causes a false failure in the post-creation volume size check.

Importantly, this issue does not affect the actual restore process, since volumes are re-sorted by deviceId before restore. Also, a volume size check is already performed in allocateVMFromBackup (before Instance creation) — where the order matches the backup data — and it passes correctly there.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):
<img width="1701" height="951" alt="screen1" src="https://github.com/user-attachments/assets/e473a179-5d65-433d-91ad-31b8a7cb4b54" />

Before fix : 
<img width="513" height="285" alt="screen2" src="https://github.com/user-attachments/assets/93913794-e0b4-4b50-b1b4-db40b2cd8ccd" />

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
