### PR TITLE
optimize: avoid redundant DB call when account matches calling account

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/event/UsageEventUtils.java
+++ b/engine/components-api/src/main/java/com/cloud/event/UsageEventUtils.java
@@ -26,6 +26,8 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.cloud.network.Network;
+
+import org.apache.cloudstack.context.CallContext;
 import org.apache.commons.collections.MapUtils;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
@@ -214,7 +216,9 @@ public class UsageEventUtils {
             return; // no provider is configured to provide events distributor, so just return
         }
 
-        Account account = s_accountDao.findById(accountId);
+        Account account = (accountId == CallContext.current().getCallingAccountId())
+                ? CallContext.current().getCallingAccount()
+                : s_accountDao.findById(accountId);
         DataCenterVO dc = s_dcDao.findById(zoneId);
 
         // if account has been deleted, this might be called during cleanup of resources and results in null pointer

--- a/server/src/main/java/com/cloud/event/ActionEventUtils.java
+++ b/server/src/main/java/com/cloud/event/ActionEventUtils.java
@@ -227,7 +227,9 @@ public class ActionEventUtils {
 
         Map<String, String> eventDescription = new HashMap<String, String>();
         Project project = s_projectDao.findByProjectAccountId(accountId);
-        Account account = s_accountDao.findById(accountId);
+        Account account = (accountId == CallContext.current().getCallingAccountId())
+                ? CallContext.current().getCallingAccount()
+                : s_accountDao.findById(accountId);
         User user = s_userDao.findById(userId);
         // if account has been deleted, this might be called during cleanup of resources and results in null pointer
         if (account == null)

--- a/server/src/test/java/com/cloud/event/ActionEventInterceptorTest.java
+++ b/server/src/test/java/com/cloud/event/ActionEventInterceptorTest.java
@@ -175,8 +175,6 @@ public class ActionEventInterceptorTest {
         user = new UserVO(1, "testuser", "password", "firstname", "lastName", "email", "timezone",
                 UUID.randomUUID().toString(), User.Source.UNKNOWN);
         CallContext.register(user, account);
-
-        Mockito.when(accountDao.findById(ACCOUNT_ID)).thenReturn(account);
     }
 
     /**

--- a/server/src/test/java/com/cloud/event/ActionEventUtilsTest.java
+++ b/server/src/test/java/com/cloud/event/ActionEventUtilsTest.java
@@ -177,9 +177,8 @@ public class ActionEventUtilsTest {
         account.setId(ACCOUNT_ID);
         user = new UserVO(1, "testuser", "password", "firstname", "lastName", "email", "timezone",
                 UUID.randomUUID().toString(), User.Source.UNKNOWN);
-
-        Mockito.when(accountDao.findById(ACCOUNT_ID)).thenReturn(account);
         Mockito.when(userDao.findById(USER_ID)).thenReturn(user);
+        CallContext.register(user, account);
     }
 
     /**
@@ -204,12 +203,11 @@ public class ActionEventUtilsTest {
         utils.init();
 
         componentContextMocked.close();
+        CallContext.unregister();
     }
 
     @Test
     public void testPopulateFirstClassEntities() {
-        CallContext.register(user, account);
-
         //Inject some entity UUIDs into the call context
         String instanceUuid = UUID.randomUUID().toString();
         String ipUuid = UUID.randomUUID().toString();
@@ -231,8 +229,6 @@ public class ActionEventUtilsTest {
         Assert.assertTrue(json.has("IpAddress"));
         Assert.assertEquals(json.get("VirtualMachine").getAsString(), instanceUuid);
         Assert.assertEquals(json.get("IpAddress").getAsString(), ipUuid);
-
-        CallContext.unregister();
     }
 
     private void checkEventResourceAndUnregisterContext(Long resourceId, String resourceUuid, String resourceType) {
@@ -248,14 +244,10 @@ public class ActionEventUtilsTest {
         EventVO eventVO = persistedEvents.get(0);
         Assert.assertEquals(eventVO.getResourceType(), resourceType);
         Assert.assertEquals(eventVO.getResourceId(), resourceId);
-
-        CallContext.unregister();
     }
 
     @Test
     public void testPublishedEventResource() {
-        CallContext.register(user, account);
-
         final Long resourceId = 1L;
         final String resourceType = ApiCommandResourceType.VirtualMachine.toString();
         final String resourceUuid = UUID.randomUUID().toString();
@@ -270,8 +262,6 @@ public class ActionEventUtilsTest {
 
     @Test
     public void testPublishedEventResourceWithCallContext() {
-        CallContext.register(user, account);
-
         final Long resourceId = 1L;
         final String resourceType = ApiCommandResourceType.VirtualMachine.toString();
         final String resourceUuid = UUID.randomUUID().toString();
@@ -287,8 +277,6 @@ public class ActionEventUtilsTest {
 
     @Test
     public void testScheduledEvent() {
-        CallContext.register(user, account);
-
         final Long resourceId = 1L;
         final String resourceType = ApiCommandResourceType.VirtualMachine.toString();
         final String resourceUuid = UUID.randomUUID().toString();
@@ -304,14 +292,10 @@ public class ActionEventUtilsTest {
         Assert.assertEquals(persistedEvents.size(), 1);
         EventVO eventVO = persistedEvents.get(0);
         Assert.assertEquals(eventVO.getState(), com.cloud.event.Event.State.Scheduled);
-
-        CallContext.unregister();
     }
 
     @Test
     public void testCreatedEvent() {
-        CallContext.register(user, account);
-
         final Long resourceId = 1L;
         final String resourceType = ApiCommandResourceType.VirtualMachine.toString();
         final String resourceUuid = UUID.randomUUID().toString();
@@ -327,14 +311,10 @@ public class ActionEventUtilsTest {
         Assert.assertEquals(persistedEvents.size(), 1);
         EventVO eventVO = persistedEvents.get(0);
         Assert.assertEquals(eventVO.getState(), com.cloud.event.Event.State.Created);
-
-        CallContext.unregister();
     }
 
     @Test
     public void testNestedEvent() {
-        CallContext.register(user, account);
-
         final Long resourceId = 1L;
         final String resourceType = ApiCommandResourceType.VirtualMachine.toString();
         final String resourceUuid = UUID.randomUUID().toString();
@@ -344,14 +324,10 @@ public class ActionEventUtilsTest {
         Assert.assertEquals(persistedEvents.size(), 1);
         EventVO eventVO = persistedEvents.get(0);
         Assert.assertEquals(eventVO.getState(), com.cloud.event.Event.State.Started);
-
-        CallContext.unregister();
     }
 
     @Test
     public void testSnapshotEventResource() {
-        CallContext.register(user, account);
-
         final Long snapshotResourceId = 100L;
         final String snapshotResourceType = ApiCommandResourceType.Snapshot.toString();
         final String snapshotResourceUuid = UUID.randomUUID().toString();
@@ -366,7 +342,6 @@ public class ActionEventUtilsTest {
 
     @Test
     public void testVmSnapshotEventResource() {
-        CallContext.register(user, account);
 
         final Long vmSnapshotResourceId = 100L;
         final String vmSnapshotResourceType = ApiCommandResourceType.VmSnapshot.toString();


### PR DESCRIPTION
### Description

Use Account object from call context when possible

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
