### PR TITLE
Move console proxy related global settings to Zone level

### DIFF
--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -229,6 +229,10 @@ public class ConfigKey<T> {
         this(type, name, category, defaultValue, description, isDynamic, Scope.Global, null);
     }
 
+    public ConfigKey(String category, Class<T> type, String name, String defaultValue, String description, Scope scope, boolean isDynamic) {
+        this(type, name, category, defaultValue, description, isDynamic, scope, null);
+    }
+
     public ConfigKey(String category, Class<T> type, String name, String defaultValue, String description, boolean isDynamic, Kind kind, String options) {
         this(type, name, category, defaultValue, description, isDynamic, Scope.Global, null, null, null, null, null, kind, options);
     }

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -229,10 +229,6 @@ public class ConfigKey<T> {
         this(type, name, category, defaultValue, description, isDynamic, Scope.Global, null);
     }
 
-    public ConfigKey(String category, Class<T> type, String name, String defaultValue, String description, Scope scope, boolean isDynamic) {
-        this(type, name, category, defaultValue, description, isDynamic, scope, null);
-    }
-
     public ConfigKey(String category, Class<T> type, String name, String defaultValue, String description, boolean isDynamic, Kind kind, String options) {
         this(type, name, category, defaultValue, description, isDynamic, Scope.Global, null, null, null, null, null, kind, options);
     }

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -403,9 +403,6 @@ public enum Config {
             "service monitoring in router enable/disable option, default false", null),
 
 
-    // Console Proxy
-
-
     // Snapshots
 
     SnapshotPollInterval(
@@ -1498,14 +1495,6 @@ public enum Config {
             "eip.use.multiple.netscalers",
             "false",
             "Should be set to true, if there will be multiple NetScaler devices providing EIP service in a zone",
-            null),
-    ConsoleProxyServiceOffering(
-            "Advanced",
-            ManagementServer.class,
-            String.class,
-            "consoleproxy.service.offering",
-            null,
-            "Uuid of the service offering used by console proxy; if NULL - system offering will be used",
             null),
     SecondaryStorageServiceOffering(
             "Advanced",

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -25,7 +25,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.framework.config.ConfigKey;
 
 import com.cloud.agent.AgentManager;
-import com.cloud.consoleproxy.ConsoleProxyManager;
 import com.cloud.ha.HighAvailabilityManager;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.network.router.VpcVirtualNetworkApplianceManager;
@@ -405,94 +404,7 @@ public enum Config {
 
 
     // Console Proxy
-    ConsoleProxyCapacityStandby(
-            "Console Proxy",
-            AgentManager.class,
-            String.class,
-            "consoleproxy.capacity.standby",
-            "10",
-            "The minimal number of console proxy viewer sessions that system is able to serve immediately(standby capacity)",
-            null),
-    ConsoleProxyCapacityScanInterval(
-            "Console Proxy",
-            AgentManager.class,
-            String.class,
-            "consoleproxy.capacityscan.interval",
-            "30000",
-            "The time interval(in millisecond) to scan whether or not system needs more console proxy to ensure minimal standby capacity",
-            null),
-    ConsoleProxyCmdPort(
-            "Console Proxy",
-            AgentManager.class,
-            Integer.class,
-            "consoleproxy.cmd.port",
-            "8001",
-            "Console proxy command port that is used to communicate with management server",
-            null),
-    ConsoleProxyRestart(
-        "Console Proxy",
-        AgentManager.class,
-        Boolean.class,
-        "consoleproxy.restart",
-        "true",
-        "Console proxy restart flag, defaulted to true",
-        null),
-    ConsoleProxyUrlDomain(
-        "Console Proxy",
-        AgentManager.class,
-        String.class,
-        "consoleproxy.url.domain",
-        "",
-        "Console proxy url domain",
-        "domainName,privateip"),
-    ConsoleProxySessionMax(
-            "Console Proxy",
-            AgentManager.class,
-            Integer.class,
-            "consoleproxy.session.max",
-            String.valueOf(ConsoleProxyManager.DEFAULT_PROXY_CAPACITY),
-            "The max number of viewer sessions console proxy is configured to serve for",
-            null),
-    ConsoleProxySessionTimeout(
-            "Console Proxy",
-            AgentManager.class,
-            Integer.class,
-            "consoleproxy.session.timeout",
-            "300000",
-            "Timeout(in milliseconds) that console proxy tries to maintain a viewer session before it times out the session for no activity",
-            null),
-    ConsoleProxyDisableRpFilter(
-            "Console Proxy",
-            AgentManager.class,
-            Boolean.class,
-            "consoleproxy.disable.rpfilter",
-            "true",
-            "disable rp_filter on console proxy VM public interface",
-            null),
-    ConsoleProxyLaunchMax(
-            "Console Proxy",
-            AgentManager.class,
-            Integer.class,
-            "consoleproxy.launch.max",
-            "10",
-            "maximum number of console proxy instances per zone can be launched",
-            null),
-    ConsoleProxyManagementState(
-            "Console Proxy",
-            AgentManager.class,
-            String.class,
-            "consoleproxy.management.state",
-            com.cloud.consoleproxy.ConsoleProxyManagementState.Auto.toString(),
-            "console proxy service management state",
-            null),
-    ConsoleProxyManagementLastState(
-            "Console Proxy",
-            AgentManager.class,
-            String.class,
-            "consoleproxy.management.state.last",
-            com.cloud.consoleproxy.ConsoleProxyManagementState.Auto.toString(),
-            "last console proxy service management state",
-            null),
+
 
     // Snapshots
 
@@ -1798,6 +1710,7 @@ public enum Config {
     StatsOutPutGraphiteHost("Advanced", ManagementServer.class, String.class, "stats.output.uri", "", "URI to additionally send StatsCollector statistics to", null),
 
     SSVMPSK("Hidden", ManagementServer.class, String.class, "upload.post.secret.key", "", "PSK with SSVM", null);
+
 
     private final String _category;
     private final Class<?> _componentClass;

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.consoleproxy.ConsoleProxyManager;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.affinity.AffinityGroup;
@@ -573,7 +574,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         configValuesForValidation.add("event.purge.interval");
         configValuesForValidation.add("account.cleanup.interval");
         configValuesForValidation.add("alert.wait");
-        configValuesForValidation.add("consoleproxy.capacityscan.interval");
+        configValuesForValidation.add(ConsoleProxyManager.ConsoleProxyCapacityScanInterval.key());
         configValuesForValidation.add("expunge.interval");
         configValuesForValidation.add("host.stats.interval");
         configValuesForValidation.add("network.gc.interval");

--- a/server/src/main/java/com/cloud/consoleproxy/AgentBasedConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/AgentBasedConsoleProxyManager.java
@@ -120,12 +120,12 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
             _consoleProxyPort = NumbersUtil.parseInt(value, ConsoleProxyManager.DEFAULT_PROXY_VNC_PORT);
         }
 
-        value = configs.get(ConsoleProxySslEnabled.key());
-        if (value != null && value.equalsIgnoreCase("true")) {
+        Boolean sslEnabled = ConsoleProxySslEnabled.value();
+        if (Boolean.TRUE.equals(sslEnabled)) {
             _sslEnabled = true;
         }
 
-        _consoleProxyUrlDomain = configs.get("consoleproxy.url.domain");
+        _consoleProxyUrlDomain = ConsoleProxyUrlDomain.value();
 
         _listener = new ConsoleProxyListener(new AgentBasedAgentHook(_instanceDao, _hostDao, _configDao, _ksMgr,
                 _agentMgr, _keysMgr, consoleAccessManager));
@@ -166,6 +166,8 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
                 urlPort = host.getProxyPort().intValue();
             }
 
+            _sslEnabled = ConsoleProxySslEnabled.valueIn(dataCenterId);
+            _consoleProxyUrlDomain = ConsoleProxyUrlDomain.valueIn(dataCenterId);
             return new ConsoleProxyInfo(_sslEnabled, publicIp, _consoleProxyPort, urlPort, _consoleProxyUrlDomain);
         } else {
             logger.warn("Host that VM is running is no longer available, console access to VM {} will be temporarily unavailable.", userVm);

--- a/server/src/main/java/com/cloud/consoleproxy/AgentBasedConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/AgentBasedConsoleProxyManager.java
@@ -191,7 +191,7 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
     }
 
     @Override
-    public int getVncPort() {
+    public int getVncPort(Long dataCenterId) {
         return _consoleProxyPort;
     }
 

--- a/server/src/main/java/com/cloud/consoleproxy/AgentHookBase.java
+++ b/server/src/main/java/com/cloud/consoleproxy/AgentHookBase.java
@@ -20,6 +20,7 @@ package com.cloud.consoleproxy;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Date;
+import java.util.Objects;
 
 import org.apache.cloudstack.consoleproxy.ConsoleAccessManager;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -214,7 +215,9 @@ public abstract class AgentHookBase implements AgentHook {
 
             HostVO consoleProxyHost = findConsoleProxyHost(startupCmd);
 
-            assert (consoleProxyHost != null);
+            if (Objects.isNull(consoleProxyHost)) {
+                throw new IllegalStateException("Console proxy host is null");
+            }
 
             Long datacenterId = consoleProxyHost.getDataCenterId();
             String consoleProxyUrlDomain = ConsoleProxyManager.ConsoleProxyUrlDomain.valueIn(datacenterId);

--- a/server/src/main/java/com/cloud/consoleproxy/AgentHookBase.java
+++ b/server/src/main/java/com/cloud/consoleproxy/AgentHookBase.java
@@ -41,7 +41,6 @@ import com.cloud.agent.api.GetVncPortCommand;
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupProxyCommand;
 import com.cloud.agent.api.proxy.StartConsoleProxyAgentHttpHandlerCommand;
-import com.cloud.configuration.Config;
 import com.cloud.exception.AgentUnavailableException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.host.Host;
@@ -213,10 +212,14 @@ public abstract class AgentHookBase implements AgentHook {
 
             byte[] ksBits = null;
 
-            String consoleProxyUrlDomain = _configDao.getValue(Config.ConsoleProxyUrlDomain.key());
-            String consoleProxySslEnabled = _configDao.getValue(ConsoleProxyManager.ConsoleProxySslEnabled.key());
-            if (!StringUtils.isEmpty(consoleProxyUrlDomain) && !StringUtils.isEmpty(consoleProxySslEnabled)
-                    && consoleProxySslEnabled.equalsIgnoreCase("true")) {
+            HostVO consoleProxyHost = findConsoleProxyHost(startupCmd);
+
+            assert (consoleProxyHost != null);
+
+            Long datacenterId = consoleProxyHost.getDataCenterId();
+            String consoleProxyUrlDomain = ConsoleProxyManager.ConsoleProxyUrlDomain.valueIn(datacenterId);
+            Boolean consoleProxySslEnabled = ConsoleProxyManager.ConsoleProxySslEnabled.valueIn(datacenterId);
+            if (!StringUtils.isEmpty(consoleProxyUrlDomain) && Boolean.TRUE.equals(consoleProxySslEnabled)) {
                 ksBits = _ksMgr.getKeystoreBits(ConsoleProxyManager.CERTIFICATE_NAME, ConsoleProxyManager.CERTIFICATE_NAME, storePassword);
                 //ks manager raises exception if ksBits are null, hence no need to explicltly handle the condition
             } else {
@@ -227,9 +230,6 @@ public abstract class AgentHookBase implements AgentHook {
             cmd.setEncryptorPassword(getEncryptorPassword());
             cmd.setIsSourceIpCheckEnabled(Boolean.parseBoolean(_configDao.getValue(ConsoleProxyManager.NoVncConsoleSourceIpCheckEnabled.key())));
 
-            HostVO consoleProxyHost = findConsoleProxyHost(startupCmd);
-
-            assert (consoleProxyHost != null);
             if (consoleProxyHost != null) {
                 Answer answer = _agentMgr.send(consoleProxyHost.getId(), cmd);
                 if (answer == null || !answer.getResult()) {

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -56,6 +56,9 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
     ConfigKey<Boolean> NoVncConsoleSourceIpCheckEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "novnc.console.sourceip.check.enabled", "false",
         "If true, The source IP to access novnc console must be same as the IP in request to management server for console URL. Needs to reconnect CPVM to management server when this changes (via restart CPVM, or management server, or cloud service in CPVM)", false);
 
+    ConfigKey<String> ConsoleProxyServiceOffering = new ConfigKey<>(String.class, "consoleproxy.service.offering", "Console Proxy", null,
+            "Uuid of the service offering used by console proxy; if NULL - system offering will be used", false, ConfigKey.Scope.Zone, null);
+
     ConfigKey<String> ConsoleProxyCapacityStandby = new ConfigKey<>(String.class, "consoleproxy.capacity.standby", "Console Proxy", String.valueOf(DEFAULT_STANDBY_CAPACITY),
             "The minimal number of console proxy viewer sessions that system is able to serve immediately(standby capacity)", false, ConfigKey.Scope.Zone, null);
 

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -56,11 +56,11 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
     ConfigKey<Boolean> NoVncConsoleSourceIpCheckEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "novnc.console.sourceip.check.enabled", "false",
         "If true, The source IP to access novnc console must be same as the IP in request to management server for console URL. Needs to reconnect CPVM to management server when this changes (via restart CPVM, or management server, or cloud service in CPVM)", false);
 
-    ConfigKey<String> ConsoleProxyCapacityStandby = new ConfigKey<>(String.class, "consoleproxy.capacity.standby", "Console Proxy", "10",
+    ConfigKey<String> ConsoleProxyCapacityStandby = new ConfigKey<>(String.class, "consoleproxy.capacity.standby", "Console Proxy", String.valueOf(DEFAULT_STANDBY_CAPACITY),
             "The minimal number of console proxy viewer sessions that system is able to serve immediately(standby capacity)", false, ConfigKey.Scope.Zone, null);
 
     ConfigKey<String> ConsoleProxyCapacityScanInterval = new ConfigKey<>(String.class, "consoleproxy.capacityscan.interval", "Console Proxy", "30000",
-            "The time interval(in millisecond) to scan whether or not system needs more console proxy to ensure minimal standby capacity", false, ConfigKey.Scope.Zone, null);
+            "The time interval(in millisecond) to scan whether or not system needs more console proxy to ensure minimal standby capacity", false, null);
 
     ConfigKey<Integer> ConsoleProxyCmdPort = new ConfigKey<>(Integer.class, "consoleproxy.cmd.port", "Console Proxy", String.valueOf(DEFAULT_PROXY_CMD_PORT),
             "Console proxy command port that is used to communicate with management server", false, ConfigKey.Scope.Zone, null);
@@ -74,7 +74,7 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
     ConfigKey<Integer> ConsoleProxySessionMax = new ConfigKey<>(Integer.class, "consoleproxy.session.max", "Console Proxy", String.valueOf(DEFAULT_PROXY_CAPACITY),
             "The max number of viewer sessions console proxy is configured to serve for", false, ConfigKey.Scope.Zone, null);
 
-    ConfigKey<Integer> ConsoleProxySessionTimeout = new ConfigKey<>(Integer.class, "consoleproxy.session.timeout", "Console Proxy", "300000",
+    ConfigKey<Integer> ConsoleProxySessionTimeout = new ConfigKey<>(Integer.class, "consoleproxy.session.timeout", "Console Proxy", String.valueOf(DEFAULT_PROXY_SESSION_TIMEOUT),
             "Timeout(in milliseconds) that console proxy tries to maintain a viewer session before it times out the session for no activity", false, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Boolean> ConsoleProxyDisableRpFilter = new ConfigKey<>(Boolean.class, "consoleproxy.disable.rpfilter", "Console Proxy", "true",
@@ -108,6 +108,6 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
 
     boolean destroyProxy(long proxyVmId);
 
-    int getVncPort();
+    int getVncPort(Long dataCenterId);
 
 }

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -16,7 +16,9 @@
 // under the License.
 package com.cloud.consoleproxy;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.cloudstack.framework.config.ConfigKey;
 
@@ -46,13 +48,47 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
     String CERTIFICATE_NAME = "CPVMCertificate";
 
     ConfigKey<Boolean> ConsoleProxySslEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "consoleproxy.sslEnabled", "false",
-            "Enable SSL for console proxy", false);
+            "Enable SSL for console proxy", ConfigKey.Scope.Zone, false);
 
     ConfigKey<Boolean> NoVncConsoleDefault = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "novnc.console.default", "true",
-        "If true, noVNC console will be default console for virtual machines", true);
+        "If true, noVNC console will be default console for virtual machines", ConfigKey.Scope.Zone, true);
 
     ConfigKey<Boolean> NoVncConsoleSourceIpCheckEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "novnc.console.sourceip.check.enabled", "false",
         "If true, The source IP to access novnc console must be same as the IP in request to management server for console URL. Needs to reconnect CPVM to management server when this changes (via restart CPVM, or management server, or cloud service in CPVM)", false);
+
+    ConfigKey<String> ConsoleProxyCapacityStandby = new ConfigKey<>(String.class, "consoleproxy.capacity.standby", "Console Proxy", "10",
+            "The minimal number of console proxy viewer sessions that system is able to serve immediately(standby capacity)", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<String> ConsoleProxyCapacityScanInterval = new ConfigKey<>(String.class, "consoleproxy.capacityscan.interval", "Console Proxy", "30000",
+            "The time interval(in millisecond) to scan whether or not system needs more console proxy to ensure minimal standby capacity", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<Integer> ConsoleProxyCmdPort = new ConfigKey<>(Integer.class, "consoleproxy.cmd.port", "Console Proxy", String.valueOf(DEFAULT_PROXY_CMD_PORT),
+            "Console proxy command port that is used to communicate with management server", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<Boolean> ConsoleProxyRestart = new ConfigKey<>(Boolean.class, "consoleproxy.restart", "Console Proxy", "true",
+            "Console proxy restart flag, defaults to true", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<String> ConsoleProxyUrlDomain = new ConfigKey<>(String.class, "consoleproxy.url.domain", "Console Proxy", "",
+            "Console proxy url domain - domainName,privateip", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<Integer> ConsoleProxySessionMax = new ConfigKey<>(Integer.class, "consoleproxy.session.max", "Console Proxy", String.valueOf(DEFAULT_PROXY_CAPACITY),
+            "The max number of viewer sessions console proxy is configured to serve for", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<Integer> ConsoleProxySessionTimeout = new ConfigKey<>(Integer.class, "consoleproxy.session.timeout", "Console Proxy", "300000",
+            "Timeout(in milliseconds) that console proxy tries to maintain a viewer session before it times out the session for no activity", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<Boolean> ConsoleProxyDisableRpFilter = new ConfigKey<>(Boolean.class, "consoleproxy.disable.rpfilter", "Console Proxy", "true",
+            "disable rp_filter on console proxy VM public interface", false, ConfigKey.Scope.Zone, null);
+
+    ConfigKey<Integer> ConsoleProxyLaunchMax = new ConfigKey<>(Integer.class, "consoleproxy.launch.max", "Console Proxy", "10",
+            "maximum number of console proxy instances per zone can be launched", false, ConfigKey.Scope.Zone, null);
+
+    String consoleProxyManagementStates = Arrays.stream(com.cloud.consoleproxy.ConsoleProxyManagementState.values()).map(Enum::name).collect(Collectors.joining(","));
+    ConfigKey<String> ConsoleProxyServiceManagementState = new ConfigKey<String>(ConfigKey.CATEGORY_ADVANCED, String.class, "consoleproxy.management.state", com.cloud.consoleproxy.ConsoleProxyManagementState.Auto.toString(),
+            "console proxy service management state", false, ConfigKey.Kind.Select, consoleProxyManagementStates);
+
+    ConfigKey<String> ConsoleProxyManagementLastState = new ConfigKey<String>(ConfigKey.CATEGORY_ADVANCED, String.class, "consoleproxy.management.state.last", com.cloud.consoleproxy.ConsoleProxyManagementState.Auto.toString(),
+            "last console proxy service management state", false, ConfigKey.Kind.Select, consoleProxyManagementStates);
 
     void setManagementState(ConsoleProxyManagementState state);
 

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -57,7 +57,7 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
         "If true, The source IP to access novnc console must be same as the IP in request to management server for console URL. Needs to reconnect CPVM to management server when this changes (via restart CPVM, or management server, or cloud service in CPVM)", false);
 
     ConfigKey<String> ConsoleProxyServiceOffering = new ConfigKey<>(String.class, "consoleproxy.service.offering", "Console Proxy", null,
-            "Uuid of the service offering used by console proxy; if NULL - system offering will be used", false, ConfigKey.Scope.Zone, null);
+            "Uuid of the service offering used by console proxy; if NULL - system offering will be used", true, ConfigKey.Scope.Zone, null);
 
     ConfigKey<String> ConsoleProxyCapacityStandby = new ConfigKey<>(String.class, "consoleproxy.capacity.standby", "Console Proxy", String.valueOf(DEFAULT_STANDBY_CAPACITY),
             "The minimal number of console proxy viewer sessions that system is able to serve immediately(standby capacity)", false, ConfigKey.Scope.Zone, null);
@@ -69,7 +69,7 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
             "Console proxy command port that is used to communicate with management server", false, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Boolean> ConsoleProxyRestart = new ConfigKey<>(Boolean.class, "consoleproxy.restart", "Console Proxy", "true",
-            "Console proxy restart flag, defaults to true", false, ConfigKey.Scope.Zone, null);
+            "Console proxy restart flag, defaults to true", true, ConfigKey.Scope.Zone, null);
 
     ConfigKey<String> ConsoleProxyUrlDomain = new ConfigKey<>(String.class, "consoleproxy.url.domain", "Console Proxy", "",
             "Console proxy url domain - domainName,privateip", false, ConfigKey.Scope.Zone, null);
@@ -81,7 +81,7 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
             "Timeout(in milliseconds) that console proxy tries to maintain a viewer session before it times out the session for no activity", false, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Boolean> ConsoleProxyDisableRpFilter = new ConfigKey<>(Boolean.class, "consoleproxy.disable.rpfilter", "Console Proxy", "true",
-            "disable rp_filter on console proxy VM public interface", false, ConfigKey.Scope.Zone, null);
+            "disable rp_filter on console proxy VM public interface", true, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Integer> ConsoleProxyLaunchMax = new ConfigKey<>(Integer.class, "consoleproxy.launch.max", "Console Proxy", "10",
             "maximum number of console proxy instances per zone can be launched", false, ConfigKey.Scope.Zone, null);

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -47,11 +47,11 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
     String ALERT_SUBJECT = "proxy-alert";
     String CERTIFICATE_NAME = "CPVMCertificate";
 
-    ConfigKey<Boolean> ConsoleProxySslEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "consoleproxy.sslEnabled", "false",
-            "Enable SSL for console proxy", ConfigKey.Scope.Zone, false);
+    ConfigKey<Boolean> ConsoleProxySslEnabled = new ConfigKey<>(Boolean.class, "consoleproxy.sslEnabled",  ConfigKey.CATEGORY_ADVANCED, "false",
+            "Enable SSL for console proxy", false, ConfigKey.Scope.Zone, null);
 
-    ConfigKey<Boolean> NoVncConsoleDefault = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "novnc.console.default", "true",
-        "If true, noVNC console will be default console for virtual machines", ConfigKey.Scope.Zone, true);
+    ConfigKey<Boolean> NoVncConsoleDefault = new ConfigKey<>(Boolean.class, "novnc.console.default", ConfigKey.CATEGORY_ADVANCED, "true",
+        "If true, noVNC console will be default console for virtual machines", false, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Boolean> NoVncConsoleSourceIpCheckEnabled = new ConfigKey<>(ConfigKey.CATEGORY_ADVANCED, Boolean.class, "novnc.console.sourceip.check.enabled", "false",
         "If true, The source IP to access novnc console must be same as the IP in request to management server for console URL. Needs to reconnect CPVM to management server when this changes (via restart CPVM, or management server, or cloud service in CPVM)", false);

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -75,10 +75,10 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
             "Console proxy url domain - domainName,privateip", false, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Integer> ConsoleProxySessionMax = new ConfigKey<>(Integer.class, "consoleproxy.session.max", "Console Proxy", String.valueOf(DEFAULT_PROXY_CAPACITY),
-            "The max number of viewer sessions console proxy is configured to serve for", false, ConfigKey.Scope.Zone, null);
+            "The max number of viewer sessions console proxy is configured to serve for", true, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Integer> ConsoleProxySessionTimeout = new ConfigKey<>(Integer.class, "consoleproxy.session.timeout", "Console Proxy", String.valueOf(DEFAULT_PROXY_SESSION_TIMEOUT),
-            "Timeout(in milliseconds) that console proxy tries to maintain a viewer session before it times out the session for no activity", false, ConfigKey.Scope.Zone, null);
+            "Timeout(in milliseconds) that console proxy tries to maintain a viewer session before it times out the session for no activity", true, ConfigKey.Scope.Zone, null);
 
     ConfigKey<Boolean> ConsoleProxyDisableRpFilter = new ConfigKey<>(Boolean.class, "consoleproxy.disable.rpfilter", "Console Proxy", "true",
             "disable rp_filter on console proxy VM public interface", true, ConfigKey.Scope.Zone, null);

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -1570,7 +1570,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] { ConsoleProxySslEnabled, NoVncConsoleDefault, NoVncConsoleSourceIpCheckEnabled,
+        return new ConfigKey<?>[] { ConsoleProxySslEnabled, NoVncConsoleDefault, NoVncConsoleSourceIpCheckEnabled, ConsoleProxyServiceOffering,
                 ConsoleProxyCapacityStandby, ConsoleProxyCapacityScanInterval, ConsoleProxyCmdPort, ConsoleProxyRestart, ConsoleProxyUrlDomain, ConsoleProxySessionMax, ConsoleProxySessionTimeout, ConsoleProxyDisableRpFilter, ConsoleProxyLaunchMax,
                 ConsoleProxyManagementLastState, ConsoleProxyServiceManagementState };
     }

--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -476,7 +476,7 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
         ConsoleProxyClientParam param = generateConsoleProxyClientParam(parsedHostInfo, port, sid, tag, ticket,
                 sessionUuid, addr, extraSecurityToken, vm, hostVo, details, portInfo, host, displayName);
         String token = encryptor.encryptObject(ConsoleProxyClientParam.class, param);
-        int vncPort = consoleProxyManager.getVncPort();
+        int vncPort = consoleProxyManager.getVncPort(vm.getDataCenterId());
 
         String url = generateConsoleAccessUrl(rootUrl, param, token, vncPort, vm, hostVo, details);
 

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
@@ -851,30 +851,6 @@ public class ConfigurationManagerImplTest {
     }
 
     @Test
-    public void shouldValidateConfigRangeTestValueIsNullReturnFalse() {
-        boolean result = configurationManagerImplSpy.shouldValidateConfigRange(Config.ConsoleProxyUrlDomain.name(), null, Config.ConsoleProxyUrlDomain);
-        Assert.assertFalse(result);
-    }
-
-    @Test
-    public void shouldValidateConfigRangeTestConfigIsNullReturnFalse() {
-        boolean result = configurationManagerImplSpy.shouldValidateConfigRange("", "test", null);
-        Assert.assertFalse(result);
-    }
-
-    @Test
-    public void shouldValidateConfigRangeTestConfigDoesNotHaveARangeReturnFalse() {
-        boolean result = configurationManagerImplSpy.shouldValidateConfigRange(Config.ConsoleProxySessionMax.name(), "test", Config.ConsoleProxySessionMax);
-        Assert.assertFalse(result);
-    }
-
-    @Test
-    public void shouldValidateConfigRangeTestValueIsNotNullAndConfigHasRangeReturnTrue() {
-        boolean result = configurationManagerImplSpy.shouldValidateConfigRange(Config.ConsoleProxySessionMax.name(), "test", Config.ConsoleProxyUrlDomain);
-        Assert.assertTrue(result);
-    }
-
-    @Test
     public void testResetConfigurations() {
         Long poolId = 1L;
         ResetCfgCmd cmd = Mockito.mock(ResetCfgCmd.class);

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/PremiumSecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/PremiumSecondaryStorageManagerImpl.java
@@ -28,6 +28,7 @@ import javax.naming.ConfigurationException;
 
 import com.cloud.agent.api.Command;
 import com.cloud.configuration.Config;
+import com.cloud.consoleproxy.ConsoleProxyManager;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
@@ -121,8 +122,8 @@ public class PremiumSecondaryStorageManagerImpl extends SecondaryStorageManagerI
         boolean suspendAutoLoading = !reserveStandbyCapacity();
         if (!suspendAutoLoading) {
             // this is a hacking, has nothing to do with console proxy, it is just a flag that primary storage is being under maintenance mode
-            String restart = _configDao.getValue("consoleproxy.restart");
-            if (restart != null && restart.equalsIgnoreCase("false")) {
+            Boolean restart = ConsoleProxyManager.ConsoleProxyRestart.valueIn(dataCenterId);
+            if (Boolean.FALSE.equals(restart)) {
                 logger.debug("Capacity scan disabled purposefully, consoleproxy.restart = false. This happens when the primarystorage is in maintenance mode");
                 suspendAutoLoading = true;
             }


### PR DESCRIPTION
### Description

This PR moves console proxy related global settings to Zone level as CPVM in a zone level resource, and it makes sense to have these settings at the zone level
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

For dev-testing, I added logs in the `ConsoleProxyManagerImpl::scanPool` method that's called every 30sec to check the zone & global level values to identify if they are correctly set:

When no zone level values are set: 
```
2025-08-22 14:47:54,358 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Configuration values for CPVM in zone 1: 
2025-08-22 14:47:54,359 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) SSL enabled: Zone level: false - Global level: false
2025-08-22 14:47:54,361 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) NoVNC console default: Zone level: true - Global level: true
2025-08-22 14:47:54,363 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy service offering: Zone level: null - Global level: null
2025-08-22 14:47:54,365 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy standby capacity: Zone level: 10 - Global level: 10
2025-08-22 14:47:54,366 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy capacity scan interval: Zone level: 30000 - Global level: 30000
2025-08-22 14:47:54,367 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy command port: Zone level: 8001 - Global level: 8001
2025-08-22 14:47:54,368 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy restart: Zone level: true - Global level: true
2025-08-22 14:47:54,369 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy URL domain: Zone level:  - Global level: 
2025-08-22 14:47:54,371 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy session max: Zone level: 50 - Global level: 50
2025-08-22 14:47:54,372 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy session timeout: Zone level: 300000 - Global level: 300000
2025-08-22 14:47:54,373 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy disable rp filter: Zone level: true - Global level: true
2025-08-22 14:47:54,374 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) Console proxy launch max: Zone level: 10 - Global level: 10
2025-08-22 14:47:54,374 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-7dea5014]) (logid:6c106e9c) 
```


After changing zone-level values:
```
2025-08-22 15:03:38,200 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Configuration values for CPVM in zone 1: 
2025-08-22 15:03:38,201 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) SSL enabled: Zone level: false - Global level: false
2025-08-22 15:03:38,202 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) NoVNC console default: Zone level: false - Global level: true
2025-08-22 15:03:38,203 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy service offering: Zone level: null - Global level: null
2025-08-22 15:03:38,205 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy standby capacity: Zone level: 5 - Global level: 10
2025-08-22 15:03:38,206 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy capacity scan interval: Zone level: 30000 - Global level: 30000
2025-08-22 15:03:38,207 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy command port: Zone level: 8010 - Global level: 8001
2025-08-22 15:03:38,208 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy restart: Zone level: false - Global level: true
2025-08-22 15:03:38,209 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy URL domain: Zone level: shapeblue.com - Global level: 
2025-08-22 15:03:38,209 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy session max: Zone level: 35 - Global level: 50
2025-08-22 15:03:38,210 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy session timeout: Zone level: 100000 - Global level: 300000
2025-08-22 15:03:38,211 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy disable rp filter: Zone level: false - Global level: true
2025-08-22 15:03:38,212 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) Console proxy launch max: Zone level: 5 - Global level: 10
2025-08-22 15:03:38,212 DEBUG [c.c.c.ConsoleProxyManagerImpl] (consoleproxy-1:[ctx-56bf2911]) (logid:0c7de63d) 
```

Testing console proxy service offering value by:
- Changing value at zone level and deploying a CPVM without restart picks a new one
- remove the existing default offering for cpvm such that there are no more offerings - and observe on recreation it creates a new one (as expected)

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
