### PR TITLE
noVNC: Show a dot cursor when the cursor is not visible

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -516,7 +516,7 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
             sb.append("/ajax?token=" + token);
         } else {
             sb.append("/resource/noVNC/vnc.html")
-                    .append("?autoconnect=true")
+                    .append("?autoconnect=true&show_dot=true")
                     .append("&port=" + vncPort)
                     .append("&token=" + token);
             if (requiresVncOverWebSocketConnection(vm, hostVo) && details != null && details.getValue() != null) {


### PR DESCRIPTION
### Description

When a VM doesn't provide a local cursor, or provides a fully-transparent (invisible) cursor, a dot is shown in the noVNC console after this change.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):
The dot in the red box in below image
<img width="563" height="157" alt="Screenshot From 2025-08-08 15-52-43" src="https://github.com/user-attachments/assets/4cf3ee0e-d7d4-4222-a58d-741cb1c65ede" />

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
