### PR TITLE
ui: add cache for oslogo request using osId

### DIFF
--- a/ui/src/views/compute/wizard/OsBasedImageRadioGroup.vue
+++ b/ui/src/views/compute/wizard/OsBasedImageRadioGroup.vue
@@ -42,7 +42,8 @@
               class="radio-group__os-logo"
               size="2x"
               :osId="item.ostypeid"
-              :os-name="item.osName" />
+              :os-name="item.osName"
+              :use-cache="true" />
             &nbsp;
             {{ item.displaytext }}
             <span v-if="item?.projectid">


### PR DESCRIPTION
### Description

When OsLogo component is used in the items of a list having same OS type it was causing listOsTypes API call multiple time. This change allows caching request and response value for 30 seconds. Caching behaviour is controlled using `useCache` flag.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
