### PR TITLE
Fix snapshot physical size listing

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
@@ -172,10 +172,15 @@ public class SnapshotObject implements SnapshotInfo {
     @Override
     public long getPhysicalSize() {
         long physicalSize = 0;
-        SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findByStoreSnapshot(DataStoreRole.Image, store.getId(), snapshot.getId());
-        if (snapshotStore != null) {
-            physicalSize = snapshotStore.getPhysicalSize();
+        for (DataStoreRole role : List.of(DataStoreRole.Image, DataStoreRole.Primary)) {
+            logger.trace("Retrieving snapshot [{}] size from {} storage.", snapshot.getUuid(), role);
+            SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findByStoreSnapshot(role, store.getId(), snapshot.getId());
+            if (snapshotStore != null) {
+                return snapshotStore.getPhysicalSize();
+            }
+            logger.trace("Snapshot [{}] size not found on {} storage.", snapshot.getUuid(), role);
         }
+        logger.warn("Snapshot [{}] reference not found in any storage. There may be an inconsistency on the database.", snapshot.getUuid());
         return physicalSize;
     }
 


### PR DESCRIPTION
### Description

This PR fixes the snapshot physical size listing. Since #7873, the snapshot physical size has only been fetched from the secondary storage. This has two issues:
1. It is possible for the snapshot to be on the primary storage, and thus these snapshots always return size 0.
2. Up until #9270, at least in KVM, every snapshot that was copied to secondary storage also had a reference to the primary storage. As the SnapshotObject has the ID for the primary storage reference, when searching for the reference to get the size, we search for a reference that is in the storage with role Image, but the ID of a primary storage; thus, no reference is returned.

This PR fixes this behavior. Fixes #11442

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?