### PR TITLE
Update error message when no snapshot strategy is found

### DIFF
--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -2795,6 +2795,8 @@ public class VolumeServiceImpl implements VolumeService {
         } catch (CloudRuntimeException cre) {
             logger.error("Take snapshot: {} failed", volume, cre);
             throw cre;
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
         } catch (Exception e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("unknown exception while taking snapshot for volume {} was caught", volume, e);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3814,10 +3814,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_SNAPSHOT_CREATE, eventDescription = "taking snapshot", async = true)
-    public Snapshot takeSnapshot(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm,
-         Snapshot.LocationType locationType, boolean asyncBackup, Map<String, String> tags, List<Long> zoneIds, List<Long> poolIds, Boolean useStorageReplication)
-
-    throws ResourceAllocationException {
+    public Snapshot takeSnapshot(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm, Snapshot.LocationType locationType, boolean asyncBackup,
+            Map<String, String> tags, List<Long> zoneIds, List<Long> poolIds, Boolean useStorageReplication) throws ResourceAllocationException {
         final Snapshot snapshot = takeSnapshotInternal(volumeId, policyId, snapshotId, account, quiescevm, locationType, asyncBackup, zoneIds, poolIds, useStorageReplication);
         if (snapshot != null && MapUtils.isNotEmpty(tags)) {
             taggedResourceService.createTags(Collections.singletonList(snapshot.getUuid()), ResourceTag.ResourceObjectType.Snapshot, tags, null);

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -1621,7 +1621,8 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             if (snapshotStrategy == null) {
                 _snapshotDao.remove(snapshotId);
                 logger.debug("No strategy found for creation of snapshot [{}], removing its record from the database.", snapshot);
-                throw new CloudRuntimeException(String.format("Can't find snapshot strategy to deal with snapshot:%s", snapshot.getSnapshotVO()));
+                throw new UnsupportedOperationException(String.format("Unable to find a snapshot strategy to create snapshot [%s] of volume [%s]. Please check the logs.",
+                        snapshot.getSnapshotVO(), volume.getUuid()));
             }
 
             SnapshotInfo snapshotOnPrimary = snapshotStrategy.takeSnapshot(snapshot);
@@ -1672,7 +1673,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             } catch (Exception e) {
                 logger.debug("post process snapshot failed", e);
             }
-        } catch (CloudRuntimeException cre) {
+        } catch (CloudRuntimeException | UnsupportedOperationException cre) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Failed to create snapshot" + cre.getLocalizedMessage());
             }


### PR DESCRIPTION
### Description

This PR updates the error message shown when no snapshot strategy is found.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
I created a disk-only VM snapshot using the KvmFileBasedStorageVmSnapshotStrategy and then tried to create a volume snapshot. I got the following error, as expected:

```
Failed to create snapshot due to unsupported operation: Unable to find a snapshot strategy to create snapshot [Snapshot {"id":541,"name":"t1_DATA-295_20250815133205","state":"Allocated","uuid":"7a7e0b5e-3aa0-4a50-84d3-d62446950938","version":"2.2","volumeId":317}] of volume [7663349b-c3f7-4e71-bef3-8a87352cae40]. Please check the logs.
```
