### PR TITLE
Add cleanup for tiers dropdown on assignVirtualMachine API form

### DIFF
--- a/ui/src/views/compute/AssignInstance.vue
+++ b/ui/src/views/compute/AssignInstance.vue
@@ -107,6 +107,7 @@ export default {
       this.fetchNetworks()
     },
     fetchNetworks () {
+      this.selectedNetwork = null
       this.loading = true
       var params = {
         domainId: this.selectedDomain,


### PR DESCRIPTION
### Description

On the `assignVirtualMachine` API form, when switching domains or accounts, the selected tier field isn't being cleaned up. For example, with the `nw` tier of `admin` account selected, when selecting the `user` account, the `nw` tier remains as the selected one.

Therefore, a fix was made in order to refresh the selected tier field whenever another domain or account is selected.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

A new `User` account and a new `domain-test` domain with a `Domain Admin` account inside were created, as well as tiers for both accounts.
1. Selected the `admin` account and `nw` tier;
2. Selected the `user` account and verified that the selected tier field was cleaned up on the form and the list was refreshed;
3. Selected the `domain-test` and verified that the selected tier field was cleaned up on the form and the list was refresh again. 