### PR TITLE
api,server,ui: allow cleaning up external details for host and serviceoffering

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -1154,6 +1154,7 @@ public class ApiConstants {
     public static final String OVM3_CLUSTER = "ovm3cluster";
     public static final String OVM3_VIP = "ovm3vip";
     public static final String CLEAN_UP_DETAILS = "cleanupdetails";
+    public static final String CLEAN_UP_EXTERNAL_DETAILS = "cleanupexternaldetails";
     public static final String CLEAN_UP_PARAMETERS = "cleanupparameters";
     public static final String VIRTUAL_SIZE = "virtualsize";
     public static final String NETSCALER_CONTROLCENTER_ID = "netscalercontrolcenterid";

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/host/UpdateHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/host/UpdateHostCmd.java
@@ -72,6 +72,14 @@ public class UpdateHostCmd extends BaseCmd {
     @Parameter(name = ApiConstants.EXTERNAL_DETAILS, type = CommandType.MAP, description = "Details in key/value pairs using format externaldetails[i].keyname=keyvalue. Example: externaldetails[0].endpoint.url=urlvalue", since = "4.21.0")
     protected Map externalDetails;
 
+    @Parameter(name = ApiConstants.CLEAN_UP_EXTERNAL_DETAILS,
+            type = CommandType.BOOLEAN,
+            description = "Optional boolean field, which indicates if external details should be cleaned up or not " +
+                    "(If set to true, external details removed for this host, externaldetails field ignored; " +
+                    "if false or not set, no action)",
+            since = "4.22.0")
+    protected Boolean cleanupExternalDetails;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -110,6 +118,10 @@ public class UpdateHostCmd extends BaseCmd {
 
     public Map<String, String> getExternalDetails() {
         return convertExternalDetailsToMap(externalDetails);
+    }
+
+    public Boolean isCleanupExternalDetails() {
+        return cleanupExternalDetails;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateServiceOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateServiceOfferingCmd.java
@@ -101,6 +101,14 @@ public class UpdateServiceOfferingCmd extends BaseCmd {
             since = "4.21.0")
     private Map externalDetails;
 
+    @Parameter(name = ApiConstants.CLEAN_UP_EXTERNAL_DETAILS,
+            type = CommandType.BOOLEAN,
+            description = "Optional boolean field, which indicates if external details should be cleaned up or not " +
+                    "(If set to true, external details removed for this offering, externaldetails field ignored; " +
+                    "if false or not set, no action)",
+            since = "4.22.0")
+    protected Boolean cleanupExternalDetails;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -203,6 +211,10 @@ public class UpdateServiceOfferingCmd extends BaseCmd {
 
     public Map<String, String> getExternalDetails() {
         return convertExternalDetailsToMap(externalDetails);
+    }
+
+    public Boolean isCleanupExternalDetails() {
+        return cleanupExternalDetails;
     }
 
     /////////////////////////////////////////////////////

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDetailsDao.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDetailsDao.java
@@ -33,6 +33,8 @@ public interface HostDetailsDao extends GenericDao<DetailVO, Long> {
 
     List<DetailVO> findByName(String name);
 
+    void removeExternalDetails(long hostId);
+
     void replaceExternalDetails(long hostId, Map<String, String> details);
 
 }

--- a/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/api/UpdateExtensionCmd.java
+++ b/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/api/UpdateExtensionCmd.java
@@ -74,7 +74,7 @@ public class UpdateExtensionCmd extends BaseCmd {
     @Parameter(name = ApiConstants.CLEAN_UP_DETAILS,
             type = CommandType.BOOLEAN,
             description = "Optional boolean field, which indicates if details should be cleaned up or not " +
-                    "(If set to true, details removed for this action, details field ignored; " +
+                    "(If set to true, details removed for this extension, details field ignored; " +
                     "if false or not set, no action)")
     private Boolean cleanupDetails;
 

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3798,14 +3798,18 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     }
 
     protected boolean serviceOfferingExternalDetailsNeedUpdate(final Map<String, String> offeringDetails,
-               final Map<String, String> externalDetails) {
-        if (MapUtils.isEmpty(externalDetails)) {
+               final Map<String, String> externalDetails, final boolean cleanupExternalDetails) {
+        if (MapUtils.isEmpty(externalDetails) && !cleanupExternalDetails) {
             return false;
         }
 
         Map<String, String> existingExternalDetails = offeringDetails.entrySet().stream()
                 .filter(detail -> detail.getKey().startsWith(VmDetailConstants.EXTERNAL_DETAIL_PREFIX))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+       if (cleanupExternalDetails) {
+           return !MapUtils.isEmpty(existingExternalDetails);
+       }
 
         if (MapUtils.isEmpty(existingExternalDetails) || existingExternalDetails.size() != externalDetails.size()) {
             return true;
@@ -3836,6 +3840,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         ServiceOffering.State state = cmd.getState();
         boolean purgeResources = cmd.isPurgeResources();
         final Map<String, String> externalDetails = cmd.getExternalDetails();
+        final boolean cleanupExternalDetails = cmd.isCleanupExternalDetails();
 
         if (userId == null) {
             userId = Long.valueOf(User.UID_SYSTEM);
@@ -3929,7 +3934,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         final boolean updateNeeded = name != null || displayText != null || sortKey != null || storageTags != null || hostTags != null || state != null;
         final boolean serviceOfferingExternalDetailsNeedUpdate =
-                serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails);
+                serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, cleanupExternalDetails);
         final boolean detailsUpdateNeeded = !filteredDomainIds.equals(existingDomainIds) ||
                 !filteredZoneIds.equals(existingZoneIds) || purgeResources != existingPurgeResources ||
                 serviceOfferingExternalDetailsNeedUpdate;
@@ -4004,8 +4009,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 SearchCriteria<ServiceOfferingDetailsVO> externalDetailsRemoveSC = sb.create();
                 externalDetailsRemoveSC.setParameters("detailNameLike", VmDetailConstants.EXTERNAL_DETAIL_PREFIX + "%");
                 _serviceOfferingDetailsDao.remove(externalDetailsRemoveSC);
-                for (Map.Entry<String, String> entry : externalDetails.entrySet()) {
-                    detailsVO.add(new ServiceOfferingDetailsVO(id, entry.getKey(), entry.getValue(), true));
+                if (!cleanupExternalDetails) {
+                    for (Map.Entry<String, String> entry : externalDetails.entrySet()) {
+                        detailsVO.add(new ServiceOfferingDetailsVO(id, entry.getKey(), entry.getValue(), true));
+                    }
                 }
             }
         }

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -2793,12 +2793,15 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
     @Override
     public Host updateHost(final UpdateHostCmd cmd) throws NoTransitionException {
-        return updateHost(cmd.getId(), cmd.getName(), cmd.getOsCategoryId(),
-                cmd.getAllocationState(), cmd.getUrl(), cmd.getHostTags(), cmd.getIsTagARule(), cmd.getAnnotation(), false, cmd.getExternalDetails());
+        return updateHost(cmd.getId(), cmd.getName(), cmd.getOsCategoryId(), cmd.getAllocationState(), cmd.getUrl(),
+                cmd.getHostTags(), cmd.getIsTagARule(), cmd.getAnnotation(), false, cmd.getExternalDetails(),
+                cmd.isCleanupExternalDetails());
     }
 
     private Host updateHost(Long hostId, String name, Long guestOSCategoryId, String allocationState,
-                            String url, List<String> hostTags, Boolean isTagARule, String annotation, boolean isUpdateFromHostHealthCheck, Map<String, String> externalDetails) throws NoTransitionException {
+            String url, List<String> hostTags, Boolean isTagARule, String annotation,
+            boolean isUpdateFromHostHealthCheck, Map<String, String> externalDetails,
+            boolean cleanupExternalDetails) throws NoTransitionException {
         // Verify that the host exists
         final HostVO host = _hostDao.findById(hostId);
         if (host == null) {
@@ -2822,8 +2825,12 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             updateHostTags(host, hostId, hostTags, isTagARule);
         }
 
-        if (MapUtils.isNotEmpty(externalDetails)) {
-            _hostDetailsDao.replaceExternalDetails(hostId, externalDetails);
+        if (cleanupExternalDetails) {
+            _hostDetailsDao.removeExternalDetails(hostId);
+        } else {
+            if (MapUtils.isNotEmpty(externalDetails)) {
+                _hostDetailsDao.replaceExternalDetails(hostId, externalDetails);
+            }
         }
 
         if (url != null) {
@@ -2882,7 +2889,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
     @Override
     public Host autoUpdateHostAllocationState(Long hostId, ResourceState.Event resourceEvent) throws NoTransitionException {
-        return updateHost(hostId, null, null, resourceEvent.toString(), null, null, null, null, true, null);
+        return updateHost(hostId, null, null, resourceEvent.toString(), null, null, null, null, true, null, false);
     }
 
     @Override

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerImplTest.java
@@ -1052,9 +1052,39 @@ public class ConfigurationManagerImplTest {
         Map<String, String> offeringDetails = Map.of("key1", "value1");
         Map<String, String> externalDetails = Collections.emptyMap();
 
-        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails);
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, false);
 
         Assert.assertFalse(result);
+    }
+
+    @Test
+    public void serviceOfferingExternalDetailsNeedUpdateReturnsFalseWhenExternalDetailsIsEmptyAndCleanupTrue() {
+        Map<String, String> offeringDetails = Map.of("key1", "value1");
+        Map<String, String> externalDetails = Collections.emptyMap();
+
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, true);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void serviceOfferingExternalDetailsNeedUpdateReturnsTrueWhenExistingDetailsExistExternalDetailsIsEmptyAndCleanupTrue() {
+        Map<String, String> offeringDetails = Map.of("External:key1", "value1");
+        Map<String, String> externalDetails = Collections.emptyMap();
+
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, true);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void serviceOfferingExternalDetailsNeedUpdateReturnsTrueWhenExistingExternalDetailsExistValidExternalDetailsAndCleanupTrue() {
+        Map<String, String> offeringDetails = Map.of("External:key1", "value1");
+        Map<String, String> externalDetails = Collections.emptyMap();
+
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, true);
+
+        Assert.assertTrue(result);
     }
 
     @Test
@@ -1062,7 +1092,7 @@ public class ConfigurationManagerImplTest {
         Map<String, String> offeringDetails = Map.of("key1", "value1");
         Map<String, String> externalDetails = Map.of("External:key1", "value1");
 
-        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails);
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, false);
 
         Assert.assertTrue(result);
     }
@@ -1072,7 +1102,7 @@ public class ConfigurationManagerImplTest {
         Map<String, String> offeringDetails = Map.of("External:key1", "value1");
         Map<String, String> externalDetails = Map.of("External:key1", "value1", "External:key2", "value2");
 
-        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails);
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, false);
 
         Assert.assertTrue(result);
     }
@@ -1082,7 +1112,7 @@ public class ConfigurationManagerImplTest {
         Map<String, String> offeringDetails = Map.of("External:key1", "value1");
         Map<String, String> externalDetails = Map.of("External:key1", "differentValue");
 
-        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails);
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, false);
 
         Assert.assertTrue(result);
     }
@@ -1092,7 +1122,7 @@ public class ConfigurationManagerImplTest {
         Map<String, String> offeringDetails = Map.of("External:key1", "value1", "External:key2", "value2");
         Map<String, String> externalDetails = Map.of("External:key1", "value1", "External:key2", "value2");
 
-        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails);
+        boolean result = configurationManagerImplSpy.serviceOfferingExternalDetailsNeedUpdate(offeringDetails, externalDetails, false);
 
         Assert.assertFalse(result);
     }

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1772,9 +1772,22 @@ export default {
                 params[key] = param.opts[input].name
               }
             } else if (param.type === 'map' && typeof input === 'object') {
-              Object.entries(values.externaldetails).forEach(([key, value]) => {
-                params[param.name + '[0].' + key] = value
-              })
+              const details = values[key]
+              if (details && Object.keys(details).length > 0) {
+                Object.entries(details).forEach(([k, v]) => {
+                  params[key + '[0].' + k] = v
+                })
+              } else {
+                if (['details', 'externaldetails'].includes(key)) {
+                  const updateApiParams = this.$getApiParams(action.api)
+                  const cleanupKey = 'cleanup' + key
+                  if (cleanupKey in updateApiParams) {
+                    params[cleanupKey] = true
+                    break
+                  }
+                }
+                params[key] = {}
+              }
             } else {
               params[key] = input
             }

--- a/ui/src/views/infra/HostUpdate.vue
+++ b/ui/src/views/infra/HostUpdate.vue
@@ -198,10 +198,12 @@ export default {
         if (values.istagarule !== undefined) {
           params.istagarule = values.istagarule
         }
-        if (values.externaldetails) {
+        if (values.externaldetails && Object.keys(values.externaldetails).length > 0) {
           Object.entries(values.externaldetails).forEach(([key, value]) => {
             params['externaldetails[0].' + key] = value
           })
+        } else {
+          params.cleanupexternaldetails = true
         }
         this.loading = true
 


### PR DESCRIPTION
### Description

Adds parameter - 'cleanupexternaldetails' for updateHost and updateServiceOffering API to allow cleaning up external details.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
