### PR TITLE
[UI] Fix display of disk size and IOPS fields in the scale VM form

### DIFF
--- a/ui/src/views/compute/ScaleVM.vue
+++ b/ui/src/views/compute/ScaleVM.vue
@@ -226,8 +226,8 @@ export default {
         api('listDiskOfferings', {
           id: this.selectedOffering.diskofferingid
         }).then(response => {
-          const diskOfferings = response.listdiskofferingsresponse.diskoffering || []
-          if (this.diskOfferings) {
+          const diskOfferings = response?.listdiskofferingsresponse?.diskoffering || []
+          if (diskOfferings?.length > 0) {
             this.selectedDiskOffering = diskOfferings[0]
           }
         }).catch(error => {


### PR DESCRIPTION
### Description

When scaling VMs, it is possible to change the disk offering for the VMs' ROOT disk if the global setting `allow.diskoffering.change.during.scale.vm` is true. To change the disk offering, the new selected compute offering for the VM must have the disk offering attached to it.

However, for custom disk offerings (custom size and/or IOPS), it is not possible to currently define the values of the size and IOPS fields in the UI form:

<img width="1330" height="512" alt="image" src="https://github.com/user-attachments/assets/b51e83c5-864f-4c89-98e5-2680569f994f" />

Thus, this PR proposes to fix the scale VM UI form to display the custom disk size and IOPS fields.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

- Before:

<img width="1330" height="512" alt="image" src="https://github.com/user-attachments/assets/b51e83c5-864f-4c89-98e5-2680569f994f" />

- After:

<img width="1332" height="624" alt="image" src="https://github.com/user-attachments/assets/12bc5415-4e44-424d-8f38-7df9f2a3a15a" />

### How Has This Been Tested?

- Verified that it is possible to define a custom disk size and IOPS for custom disk offerings.
- Verified that the fields are not displayed for non-custom disk offerings.