### PR TITLE
Allow updating of Load Balancer source CIDR list

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
@@ -65,7 +65,7 @@ public class UpdateLoadBalancerRuleCmd extends BaseAsyncCustomIdCmd {
     @Parameter(name = ApiConstants.PROTOCOL, type = CommandType.STRING, description = "The protocol for the LB")
     private String lbProtocol;
 
-    @Parameter(name = ApiConstants.CIDR_LIST, type = CommandType.LIST, collectionType = CommandType.STRING, description = "the cidr list to forward traffic from")
+    @Parameter(name = ApiConstants.CIDR_LIST, type = CommandType.LIST, collectionType = CommandType.STRING, description = "the cidr list to forward traffic from", since = "4.22")
     private List<String> cidrList;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
@@ -33,6 +33,7 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.network.rules.LoadBalancer;
 import com.cloud.user.Account;
+import java.util.List;
 
 @APICommand(name = "updateLoadBalancerRule", description = "Updates load balancer", responseObject = LoadBalancerResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
@@ -64,6 +65,9 @@ public class UpdateLoadBalancerRuleCmd extends BaseAsyncCustomIdCmd {
     @Parameter(name = ApiConstants.PROTOCOL, type = CommandType.STRING, description = "The protocol for the LB")
     private String lbProtocol;
 
+    @Parameter(name = ApiConstants.CIDR_LIST, type = CommandType.LIST, collectionType = CommandType.STRING, description = "the cidr list to forward traffic from")
+    private List<String> cidrList;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -92,6 +96,9 @@ public class UpdateLoadBalancerRuleCmd extends BaseAsyncCustomIdCmd {
        return lbProtocol;
     }
 
+    public List<String> getCidrList() {
+        return cidrList;
+    }
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////
     /////////////////////////////////////////////////////

--- a/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
@@ -148,7 +148,7 @@ public class LoadBalancerVO extends FirewallRuleVO implements LoadBalancer {
     /**
      *  Sets the CIDR list associated with this load balancer rule.
      *
-     *  @param cidrList a comma-separated list of CIDR strings, e.g. "1.2.3.4/24,1.2.3.5/24" or and empty string e.g. "" to clear the restrictions
+     *  @param cidrList a comma-separated list of CIDR strings, e.g. "1.2.3.4/24,1.2.3.5/24" or an empty string e.g. "" to clear the restrictions
      */
     public void setCidrList(String cidrList) {
         this.cidrList = cidrList;

--- a/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
@@ -144,4 +144,8 @@ public class LoadBalancerVO extends FirewallRuleVO implements LoadBalancer {
                 ReflectionToStringBuilderUtils.reflectOnlySelectedFields(
                         this, "id", "uuid", "name", "purpose", "state"));
     }
+
+    public void setCidrList(String cidrList) {
+        this.cidrList = cidrList;
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
@@ -145,6 +145,11 @@ public class LoadBalancerVO extends FirewallRuleVO implements LoadBalancer {
                         this, "id", "uuid", "name", "purpose", "state"));
     }
 
+    /**
+     *  Sets the CIDR list associated with this load balancer rule.
+     *
+     *  @param cidrList a comma-separated list of CIDR strings, e.g. "1.2.3.4/24,1.2.3.5/24" or and empty string e.g. "" to clear the restrictions
+     */
     public void setCidrList(String cidrList) {
         this.cidrList = cidrList;
     }

--- a/engine/schema/src/test/java/com/cloud/network/dao/LoadBalancerVOTest.java
+++ b/engine/schema/src/test/java/com/cloud/network/dao/LoadBalancerVOTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.network.dao;
 
 import org.junit.Test;

--- a/engine/schema/src/test/java/com/cloud/network/dao/LoadBalancerVOTest.java
+++ b/engine/schema/src/test/java/com/cloud/network/dao/LoadBalancerVOTest.java
@@ -1,0 +1,29 @@
+package com.cloud.network.dao;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class LoadBalancerVOTest {
+    @Test
+    public void testSetCidrList() {
+        LoadBalancerVO loadBalancer = new LoadBalancerVO();
+        String cidrList = "192.168.1.0/24,10.0.0.0/16";
+        loadBalancer.setCidrList(cidrList);
+        assertEquals(cidrList, loadBalancer.getCidrList());
+    }
+
+    @Test
+    public void testSetCidrListEmpty() {
+        LoadBalancerVO loadBalancer = new LoadBalancerVO();
+        loadBalancer.setCidrList("");
+        assertEquals("", loadBalancer.getCidrList());
+    }
+
+    @Test
+    public void testSetCidrListNull() {
+        LoadBalancerVO loadBalancer = new LoadBalancerVO();
+        loadBalancer.setCidrList(null);
+        assertNull(loadBalancer.getCidrList());
+    }
+}

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -18,7 +18,6 @@ package com.cloud.network.lb;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -18,6 +18,7 @@ package com.cloud.network.lb;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -2306,9 +2306,6 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     if (lbBackup.getAlgorithm() != null) {
                         lb.setAlgorithm(lbBackup.getAlgorithm());
                     }
-                    if (lbBackup.getLbProtocol() != null) {
-                        lb.setLbProtocol(lbBackup.getLbProtocol());
-                    }
 
                     lb.setCidrList(lbBackup.getCidrList());
                     lb.setState(lbBackup.getState());


### PR DESCRIPTION
## Switching base to `main` from `4.19` , SEE #10968  for Comment history

### Description

This PR will allow  the updating of a loadbalancer rules `CIDR list` via the API.
    * Should fix https://github.com/apache/cloudstack/issues/9313
  
I have tested this code in `4.19`, `4.20`, and `main` branches via simulator and all works

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):
Before, the Source CIDR list was blank (Simulator env)
![image](https://github.com/user-attachments/assets/faa3ef18-4111-4805-a52e-0ada303164ad)
```
(localcloud) :penguin: > list loadbalancerrules
{
  "count": 1,
  "loadbalancerrule": [
    {
      "account": "admin",
      "algorithm": "roundrobin",
      "cidrlist": "",
      "domain": "ROOT",
      "domainid": "5b6a2947-416b-11f0-9a39-564a8191c23c",
      "domainpath": "/",
      "fordisplay": true,
      "id": "0d8e3cb9-767b-45f3-834d-3f9ce85df901",
      "name": "newlbtest",
      "networkid": "5bb3ecfb-cde3-4821-8822-0c4c8a8e9559",
      "privateport": "3306",
      "protocol": "tcp",
      "publicip": "192.168.2.10",
      "publicipid": "9b2638d7-7330-49c7-9d6e-5b5777f6ca16",
      "publicport": "3306",
      "state": "Add",
      "tags": [],
      "zoneid": "7cb86a09-676e-4f00-ad39-012f0eb2e69d",
      "zonename": "Sandbox-simulator"
    }
  ]
}
(localcloud) :penguin: > update loadbalancerrule id="0d8e3cb9-767b-45f3-834d-3f9ce85df901" cidrlist="1.2.3.4/32"
{
  "loadbalancer": {
    "account": "admin",
    "algorithm": "roundrobin",
    "cidrlist": "1.2.3.4/32",
    "domain": "ROOT",
    "domainid": "5b6a2947-416b-11f0-9a39-564a8191c23c",
    "domainpath": "/",
    "fordisplay": true,
    "id": "0d8e3cb9-767b-45f3-834d-3f9ce85df901",
    "name": "newlbtest",
    "networkid": "5bb3ecfb-cde3-4821-8822-0c4c8a8e9559",
    "privateport": "3306",
    "protocol": "tcp",
    "publicip": "192.168.2.10",
    "publicipid": "9b2638d7-7330-49c7-9d6e-5b5777f6ca16",
    "publicport": "3306",
    "state": "Add",
    "tags": [],
    "zoneid": "7cb86a09-676e-4f00-ad39-012f0eb2e69d",
    "zonename": "Sandbox-simulator"
  }
}
(localcloud) :penguin: > update loadbalancerrule id="0d8e3cb9-767b-45f3-834d-3f9ce85df901" cidrlist=
{
  "loadbalancer": {
    "account": "admin",
    "algorithm": "roundrobin",
    "cidrlist": "",
    "domain": "ROOT",
    "domainid": "5b6a2947-416b-11f0-9a39-564a8191c23c",
    "domainpath": "/",
    "fordisplay": true,
    "id": "0d8e3cb9-767b-45f3-834d-3f9ce85df901",
    "name": "newlbtest",
    "networkid": "5bb3ecfb-cde3-4821-8822-0c4c8a8e9559",
    "privateport": "3306",
    "protocol": "tcp",
    "publicip": "192.168.2.10",
    "publicipid": "9b2638d7-7330-49c7-9d6e-5b5777f6ca16",
    "publicport": "3306",
    "state": "Add",
    "tags": [],
    "zoneid": "7cb86a09-676e-4f00-ad39-012f0eb2e69d",
    "zonename": "Sandbox-simulator"
  }
}

```

Tested on `actual test environment` and below is where you can see when it was restricted it didn't connect to mysql, but when opened up and CIDR set to 0.0.0.0/0 it worked.  I tested with specific Public IP in CIDR as well (x.x.0.118/32) and this works and you can see in the virtual router for haproxy it set the ACL.

**Restricted with wrong IP in source CIDR of LB**
```
⮡ $ mysql -h x.x.x.110 -u root -p
Enter password:
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 104
```
**With correct source CIDR or 0.0.0.0/0**
```
$ mysql -h x.x.x.110 -u root -p
Enter password:
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 4730216
Server version: 8.0.33 MySQL Community Server - GPL

Copyright (c) 2000, 2024, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> quit
Bye
```
![image](https://github.com/user-attachments/assets/3a0d89e9-aa5e-43f8-b409-9c27bb1e876c)

![image](https://github.com/user-attachments/assets/072f1a25-1584-4cb9-873e-b7806bf223dd)


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

Ran multiple tests with Cloudmonkey against simulator and actual test environment. See above for testing info



<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->