### PR TITLE
[KVM] Allow passing the OS type machine for KVM XML domains through VM setting

### DIFF
--- a/api/src/main/java/com/cloud/vm/VmDetailConstants.java
+++ b/api/src/main/java/com/cloud/vm/VmDetailConstants.java
@@ -41,7 +41,7 @@ public interface VmDetailConstants {
     String KVM_VNC_PORT = "kvm.vnc.port";
     String KVM_VNC_ADDRESS = "kvm.vnc.address";
     String KVM_VNC_PASSWORD = "kvm.vnc.password";
-    String KVM_GUEST_OS_TYPE_MACHINE = "kvm.guest.os.type.machine";
+    String KVM_GUEST_OS_MACHINE_TYPE = "kvm.guest.os.machine.type";
 
     // KVM specific, custom virtual GPU hardware
     String VIDEO_HARDWARE = "video.hardware";

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3292,8 +3292,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 }
             }
             guest.setIothreads(customParams.containsKey(VmDetailConstants.IOTHREADS));
-            if (customParams.containsKey(VmDetailConstants.KVM_GUEST_OS_TYPE_MACHINE)) {
-                guest.setMachineType(customParams.get(VmDetailConstants.KVM_GUEST_OS_TYPE_MACHINE));
+            if (customParams.containsKey(VmDetailConstants.KVM_GUEST_OS_MACHINE_TYPE)) {
+                guest.setMachineType(customParams.get(VmDetailConstants.KVM_GUEST_OS_MACHINE_TYPE));
             }
         }
         guest.setUuid(uuid);


### PR DESCRIPTION
### Description

This PR allows passing the OS type machine for KVM XML domains through the VM setting with name: `kvm.guest.os.machine.type`.

Fixes: #11512 

Documentation PR: https://github.com/apache/cloudstack-documentation/pull/559

Specifically, this allows fixing UUID retrieval of Windows VMs on Ubuntu 24 when passing the machine type = 'pc-i440fx-8.0' (see https://github.com/apache/cloudstack/issues/11512 and https://gitlab.com/libvirt/libvirt/-/issues/807#note_2724045702)

<img width="1000" height="536" alt="Screenshot 2025-09-03 at 1 05 01 PM" src="https://github.com/user-attachments/assets/9ed189eb-1510-4677-86b2-cf665de3ce8e" />

````
# virsh dumpxml 108 | grep machine
    <partition>/machine</partition>
    <type arch='x86_64' machine='pc-i440fx-8.0'>hvm</type>
````

<img width="1027" height="219" alt="Screenshot 2025-09-03 at 11 58 40 AM" src="https://github.com/user-attachments/assets/3e57a186-7218-40d3-88c5-324e15d0b7fd" />


<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested on Ubuntu 24 KVM host - deploying Windows VM and retrieving the UUID through the wmic command

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
