### PR TITLE
server: consistent domainpath in api responses

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -530,6 +530,15 @@ public class ApiResponseHelper implements ResponseGenerator {
     @Inject
     ResourceIconManager resourceIconManager;
 
+    public static String getPrettyDomainPath(String path) {
+        if (path == null) {
+            return null;
+        }
+        StringBuilder domainPath = new StringBuilder("ROOT");
+        (domainPath.append(path)).deleteCharAt(domainPath.length() - 1);
+        return domainPath.toString();
+    }
+
     @Override
     public UserResponse createUserResponse(User user) {
         UserAccountJoinVO vUser = ApiDBUtils.newUserView(user);
@@ -567,9 +576,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         if (parentDomain != null) {
             domainResponse.setParentDomainId(parentDomain.getUuid());
         }
-        StringBuilder domainPath = new StringBuilder("ROOT");
-        (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
-        domainResponse.setPath(domainPath.toString());
+        domainResponse.setPath(getPrettyDomainPath(domain.getPath()));
         if (domain.getParent() != null) {
             domainResponse.setParentDomainName(ApiDBUtils.findDomainById(domain.getParent()).getName());
         }
@@ -2761,10 +2768,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 Domain domain = ApiDBUtils.findDomainById(domainNetworkDetails.first());
                 if (domain != null) {
                     response.setDomainId(domain.getUuid());
-
-                    StringBuilder domainPath = new StringBuilder("ROOT");
-                    (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
-                    response.setDomainPath(domainPath.toString());
+                    response.setDomainPath(getPrettyDomainPath(domain.getPath()));
                 }
             }
             response.setSubdomainAccess(domainNetworkDetails.second());
@@ -3049,7 +3053,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(object.getDomainId());
         response.setDomainId(domain.getUuid());
         response.setDomainName(domain.getName());
-        response.setDomainPath(domain.getPath());
+        response.setDomainPath(getPrettyDomainPath(domain.getPath()));
     }
 
     private void populateOwner(ControlledViewEntityResponse response, ControlledEntity object) {

--- a/server/src/main/java/com/cloud/api/query/dao/AccountJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/AccountJoinDaoImpl.java
@@ -32,6 +32,7 @@ import org.apache.cloudstack.api.response.ResourceLimitAndCountResponse;
 import org.apache.cloudstack.api.response.UserResponse;
 
 import com.cloud.api.ApiDBUtils;
+import com.cloud.api.ApiResponseHelper;
 import com.cloud.api.query.ViewResponseHelper;
 import com.cloud.api.query.vo.AccountJoinVO;
 import com.cloud.api.query.vo.UserAccountJoinVO;
@@ -74,9 +75,7 @@ public class AccountJoinDaoImpl extends GenericDaoBase<AccountJoinVO, Long> impl
         accountResponse.setAccountType(account.getType().ordinal());
         accountResponse.setDomainId(account.getDomainUuid());
         accountResponse.setDomainName(account.getDomainName());
-        StringBuilder domainPath = new StringBuilder("ROOT");
-        (domainPath.append(account.getDomainPath())).deleteCharAt(domainPath.length() - 1);
-        accountResponse.setDomainPath(domainPath.toString());
+        accountResponse.setDomainPath(ApiResponseHelper.getPrettyDomainPath(account.getDomainPath()));
         accountResponse.setState(account.getState().toString());
         accountResponse.setCreated(account.getCreated());
         accountResponse.setNetworkDomain(account.getNetworkDomain());

--- a/server/src/main/java/com/cloud/api/query/dao/AsyncJobJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/AsyncJobJoinDaoImpl.java
@@ -28,6 +28,7 @@ import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.response.AsyncJobResponse;
 import org.apache.cloudstack.framework.jobs.AsyncJob;
 
+import com.cloud.api.ApiResponseHelper;
 import com.cloud.api.ApiSerializerHelper;
 import com.cloud.api.SerializationContext;
 import com.cloud.api.query.vo.AsyncJobJoinVO;
@@ -60,9 +61,7 @@ public class AsyncJobJoinDaoImpl extends GenericDaoBase<AsyncJobJoinVO, Long> im
         jobResponse.setAccountId(job.getAccountUuid());
         jobResponse.setAccount(job.getAccountName());
         jobResponse.setDomainId(job.getDomainUuid());
-        StringBuilder domainPath = new StringBuilder("ROOT");
-        (domainPath.append(job.getDomainPath())).deleteCharAt(domainPath.length() - 1);
-        jobResponse.setDomainPath(domainPath.toString());
+        jobResponse.setDomainPath(ApiResponseHelper.getPrettyDomainPath(job.getDomainPath()));
         jobResponse.setUserId(job.getUserUuid());
         jobResponse.setCmd(job.getCmd());
         jobResponse.setCreated(job.getCreated());

--- a/server/src/main/java/com/cloud/api/query/dao/DomainJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DomainJoinDaoImpl.java
@@ -21,6 +21,7 @@ import java.util.EnumSet;
 import java.util.List;
 
 
+import com.cloud.api.ApiResponseHelper;
 import com.cloud.configuration.Resource;
 import com.cloud.user.AccountManager;
 import org.apache.cloudstack.annotation.AnnotationService;
@@ -79,9 +80,7 @@ public class DomainJoinDaoImpl extends GenericDaoBase<DomainJoinVO, Long> implem
         if (domain.getParentUuid() != null) {
             domainResponse.setParentDomainId(domain.getParentUuid());
         }
-        StringBuilder domainPath = new StringBuilder("ROOT");
-        (domainPath.append(domain.getPath())).deleteCharAt(domainPath.length() - 1);
-        domainResponse.setPath(domainPath.toString());
+        domainResponse.setPath(ApiResponseHelper.getPrettyDomainPath(domain.getPath()));
         if (domain.getParent() != null) {
             domainResponse.setParentDomainName(domain.getParentName());
         }


### PR DESCRIPTION
### Description

Currently, some APIs return domainpath as 'ROOT/domain1/domain2' while other return it as '/domain1/domain2'. This PR makes the response consistent.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
Before:

```
(localcloud) 🐱 > list networks listall=true filter=id,name,domainpath
{
  "count": 2,
  "network": [
    {
      "domainpath": "/d1/d11/",
      "id": "5f58ee16-9140-4241-a50f-3c079b9717e1",
      "name": "d11user-network"
    },
    {
      "domainpath": "/",
      "id": "67c1bb61-1155-4b49-9288-543abd95e7ce",
      "name": "abc"
    }
  ]
}

```

After:

```
(localcloud) 🐱 > list networks listall=true filter=id,name,domainpath
{
  "count": 2,
  "network": [
    {
      "domainpath": "ROOT/d1/d11",
      "id": "5f58ee16-9140-4241-a50f-3c079b9717e1",
      "name": "d11user-network"
    },
    {
      "domainpath": "ROOT",
      "id": "67c1bb61-1155-4b49-9288-543abd95e7ce",
      "name": "abc"
    }
  ]
}

```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
