### PR TITLE
ui: fix tab name in query params

### DIFF
--- a/ui/src/components/view/ResourceView.vue
+++ b/ui/src/components/view/ResourceView.vue
@@ -33,17 +33,17 @@
             :is="tabs[0].component"
             :resource="resource"
             :loading="loading"
-            :tab="tabs[0].name" />
+            :tab="tabName(tabs[0])" />
         </keep-alive>
         <a-tabs
           v-else
           style="width: 100%; margin-top: -12px"
           :animated="false"
-          :activeKey="activeTab || tabs[0].name"
+          :activeKey="activeTab || tabName(tabs[0])"
           @change="onTabChange" >
-          <template v-for="tab in tabs" :key="tab.name">
+          <template v-for="tab in tabs" :key="tabName(tab)">
             <a-tab-pane
-              :key="tab.name"
+              :key="tabName(tab)"
               :tab="$t('label.' + tabName(tab))"
               v-if="showTab(tab)">
               <keep-alive>
@@ -183,12 +183,12 @@ export default {
         return
       }
       if (!this.historyTab || !this.$route.meta.tabs || this.$route.meta.tabs.length === 0) {
-        this.activeTab = this.tabs[0].name
+        this.activeTab = this.tabName(this.tabs[0])
         return
       }
-      const tabIdx = this.$route.meta.tabs.findIndex(tab => tab.name === this.historyTab)
+      const tabIdx = this.$route.meta.tabs.findIndex(tab => this.tabName(tab) === this.historyTab)
       if (tabIdx === -1) {
-        this.activeTab = this.tabs[0].name
+        this.activeTab = this.tabName(this.tabs[0])
       } else {
         this.activeTab = this.historyTab
       }


### PR DESCRIPTION
### Description

When name of a tab is defined as function then query params are wrongly set on selection of the tab. This PR fixes the behaviour by always checking the type of name defined.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

Check URL in browser address bar,

<img width="1224" height="515" alt="image" src="https://github.com/user-attachments/assets/1e4f9d37-fd04-4b2a-a814-e6e68a625d59" />

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
