### PR TITLE
Regression 4.21.0: cloud-setup-databases errors out on --schema-only

### DIFF
--- a/setup/bindir/cloud-setup-databases.in
+++ b/setup/bindir/cloud-setup-databases.in
@@ -239,7 +239,7 @@ for full help
             ("DROP USER 'cloud'@'%' ;", "DO NULL;")
         )
 
-        if self.areCloudDatabasesCreated() and not self.options.forcerecreate:
+        if self.areCloudDatabasesCreated() and not self.options.forcerecreate and not self.options.schemaonly:
             self.errorAndExit("Aborting script as the databases (cloud, cloud_usage) already exist.\n" \
                               "Please use the --force-recreate parameter if you want to recreate the schemas.")
 


### PR DESCRIPTION
### Description
PR #11239 introduced a regression when initializing the cloudstack database when the schema already exists and passes the `--schema-only` command line option.

This PR fixes that issue.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

Not very readable, but here's the output from my ansible playbook on the failure:
```
TASK [service_cloudstack : Setup cloudstack database on bootstrap node] **************************************************************************************************************************************************************
task path: /Users/bhouse/svn/ansible-scripts/roles/service_cloudstack/tasks/cloudstack-mgmt.yml:166
fatal: [node1.testenv.bradhouse.dev]: FAILED! => {"changed": true, "cmd": "cloudstack-setup-databases 'cloudstack:CloudDBPass@10.10.100.10' --schema-only --mshost=10.10.100.2 --encrypt-type=file --managementserver-secretkey='Test123$' --database-secretkey='ThisIsADbKey'", "delta": "0:00:00.227846", "end": "2025-09-10 12:46:58.209302", "msg": "non-zero return code", "rc": 1, "start": "2025-09-10 12:46:57.981456", "stderr": "\n\nWe apologize for below error:\n***************************************************************\nAborting script as the databases (cloud, cloud_usage) already exist.\nPlease use the --force-recreate parameter if you want to recreate the schemas.\n***************************************************************\nPlease run:\n\n    cloudstack-setup-databases -h\n\nfor full help", "stderr_lines": ["", "", "We apologize for below error:", "***************************************************************", "Aborting script as the databases (cloud, cloud_usage) already exist.", "Please use the --force-recreate parameter if you want to recreate the schemas.", "***************************************************************", "Please run:", "", "    cloudstack-setup-databases -h", "", "for full help"], "stdout": "Mysql user name:cloudstack                                                      [ \u001b[92mOK\u001b[0m ]\nMysql user password:******                                                      [ \u001b[92mOK\u001b[0m ]\nMysql server ip:10.10.100.10                                                    [ \u001b[92mOK\u001b[0m ]\nMysql server port:3306                                                          [ \u001b[92mOK\u001b[0m ]\nUsing specified cluster management server node IP 10.10.100.2                   [ \u001b[92mOK\u001b[0m ]\nChecking Cloud database files ...                                               [ \u001b[92mOK\u001b[0m ]\nChecking local machine hostname ...                                             [ \u001b[92mOK\u001b[0m ]\nChecking SELinux setup ...                                                      [ \u001b[92mOK\u001b[0m ]\nPreparing /etc/cloudstack/management/db.properties                              [ \u001b[92mOK\u001b[0m ]", "stdout_lines": ["Mysql user name:cloudstack                                                      [ \u001b[92mOK\u001b[0m ]", "Mysql user password:******                                                      [ \u001b[92mOK\u001b[0m ]", "Mysql server ip:10.10.100.10                                                    [ \u001b[92mOK\u001b[0m ]", "Mysql server port:3306                                                          [ \u001b[92mOK\u001b[0m ]", "Using specified cluster management server node IP 10.10.100.2                   [ \u001b[92mOK\u001b[0m ]", "Checking Cloud database files ...                                               [ \u001b[92mOK\u001b[0m ]", "Checking local machine hostname ...                                             [ \u001b[92mOK\u001b[0m ]", "Checking SELinux setup ...                                                      [ \u001b[92mOK\u001b[0m ]", "Preparing /etc/cloudstack/management/db.properties                              [ \u001b[92mOK\u001b[0m ]"]}
```

### How Has This Been Tested?

Tested by manually patching a live system being set up.

#### How did you try to break this feature and the system with this change?

N/A