### PR TITLE
Fix NPE in case host UEFI detail is not set on agent connection

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -710,7 +710,7 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 if (ObjectUtils.anyNotNull(uefiEnabled, virtv2vVersion, ovftoolVersion)) {
                     _hostDao.loadDetails(host);
                     boolean updateNeeded = false;
-                    if (!uefiEnabled.equals(host.getDetails().get(Host.HOST_UEFI_ENABLE))) {
+                    if (StringUtils.isNotBlank(uefiEnabled) && !uefiEnabled.equals(host.getDetails().get(Host.HOST_UEFI_ENABLE))) {
                         host.getDetails().put(Host.HOST_UEFI_ENABLE, uefiEnabled);
                         updateNeeded = true;
                     }


### PR DESCRIPTION
### Description

This PR fixes an NPE observed on KVM agent connection when:
- the host details doesn't include the one with name `'host.uefi.enable'` and
- virt-v2v and/or ovftool are installed on the host

````
2025-09-10 16:22:32,648 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:cd17e03c) Request:Seq -1--1:  { Cmd , MgmtId: -1, via: -1, Ver: v1, Flags: 111, [{"com.cloud.agent.api.ReadyCommand":{"_details":"java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "uefiEnabled" is null","wait":"0","bypassHostMaintenance":"false"}}] }
2025-09-10 16:22:32,648 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:cd17e03c) Processing command: com.cloud.agent.api.ReadyCommand
2025-09-10 16:22:32,648 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:cd17e03c) Not ready to connect to mgt server: java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "uefiEnabled" is null
2025-09-10 16:22:32,648 INFO  [cloud.agent.Agent] (AgentShutdownThread:[]) (logid:) Stopping the agent: Reason = sig.kill
2025-09-10 16:22:32,649 DEBUG [cloud.agent.Agent] (AgentShutdownThread:[]) (logid:) Sending shutdown to management server
2025-09-10 16:22:32,696 DEBUG [utils.nio.NioClient] (Agent-NioConnectionHandler-1:[]) (logid:) Location 1: Socket Socket[addr=/10.4.19.4,port=8250,localport=54680] closed on read.  Probably -1 returned: Connection closed with -1 on reading size.
2025-09-10 16:22:32,697 DEBUG [utils.nio.NioClient] (Agent-NioConnectionHandler-1:[]) (logid:) Closing socket Socket[addr=/10.4.19.4,port=8250,localport=54680]

````

Fixes: #11604 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
