### PR TITLE
Netris: Fix inactive VPCs deletion

### DIFF
--- a/plugins/network-elements/netris/src/main/java/org/apache/cloudstack/service/NetrisApiClientImpl.java
+++ b/plugins/network-elements/netris/src/main/java/org/apache/cloudstack/service/NetrisApiClientImpl.java
@@ -1131,16 +1131,17 @@ public class NetrisApiClientImpl implements NetrisApiClient {
     public boolean deleteVpc(DeleteNetrisVpcCommand cmd) {
         String suffix = String.valueOf(cmd.getId());
         String vpcName = NetrisResourceObjectUtils.retrieveNetrisResourceObjectName(cmd, NetrisResourceObjectUtils.NetrisObjectType.VPC);
-        VPCListing vpcResource = getVpcByNameAndTenant(vpcName);
-        if (vpcResource == null) {
-            logger.error("Could not find the Netris VPC resource with name {} and tenant ID {}", vpcName, tenantId);
-            return false;
-        }
         String snatRuleName = NetrisResourceObjectUtils.retrieveNetrisResourceObjectName(cmd, NetrisResourceObjectUtils.NetrisObjectType.SNAT, suffix);
         NatGetBody existingNatRule = netrisNatRuleExists(snatRuleName);
         boolean ruleExists = Objects.nonNull(existingNatRule);
         if (ruleExists) {
-            deleteNatRule(snatRuleName, existingNatRule.getId(), vpcResource.getName());
+            deleteNatRule(snatRuleName, existingNatRule.getId(), vpcName);
+        }
+
+        VPCListing vpcResource = getVpcByNameAndTenant(vpcName);
+        if (vpcResource == null) {
+            logger.warn("The Netris VPC resource with name {} and tenant ID {} does not exist, cannot be removed", vpcName, tenantId);
+            return true;
         }
 
         String vpcAllocationName = NetrisResourceObjectUtils.retrieveNetrisResourceObjectName(cmd, NetrisResourceObjectUtils.NetrisObjectType.IPAM_ALLOCATION, cmd.getCidr());


### PR DESCRIPTION
### Description

This PR addresses an issue with cleanup of inactive VPCs. For whatever reason, if a VPC isn't found on Netris end either due to some out of band operation or due to some other activity, deletion of the VPC fails reporting that it can't find the resource on Netris. This fix makes the check lenient by not failing the cleanup operation if the resource(VPC) isn't found on Netris end - it just logs it and proceeds to clean it up on CloudStack end.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
