### PR TITLE
Fix for No VMs start after Renew Host Security Keys due to wrong qemu group reading

### DIFF
--- a/scripts/util/keystore-cert-import
+++ b/scripts/util/keystore-cert-import
@@ -122,7 +122,7 @@ if [ -f "$LIBVIRTD_FILE" ]; then
     ln -sf /etc/pki/libvirt/private/serverkey.pem /etc/pki/libvirt-vnc/server-key.pem
     cloudstack-setup-agent -s > /dev/null
 
-    QEMU_GROUP=$(sed -n 's/^group=//p' /etc/libvirt/qemu.conf | awk -F'"' '{print $2}' | tail -n1)
+    QEMU_GROUP=$(sed -n 's/^group\s*=//p' /etc/libvirt/qemu.conf | awk -F'=' '{print $1}' | tr -d '"' |tr -d ' ' | tail -n1)
     if [ ! -z "${QEMU_GROUP// }" ]; then
       chgrp $QEMU_GROUP /etc/pki/libvirt /etc/pki/libvirt-vnc /etc/pki/CA /etc/pki/libvirt/private /etc/pki/libvirt/servercert.pem /etc/pki/libvirt/private/serverkey.pem /etc/pki/CA/cacert.pem /etc/pki/libvirt-vnc/ca-cert.pem /etc/pki/libvirt-vnc/server-cert.pem /etc/pki/libvirt-vnc/server-key.pem
       chmod 750 /etc/pki/libvirt /etc/pki/libvirt-vnc /etc/pki/CA /etc/pki/libvirt/private /etc/pki/libvirt/servercert.pem /etc/pki/libvirt/private/serverkey.pem /etc/pki/CA/cacert.pem /etc/pki/libvirt-vnc/ca-cert.pem /etc/pki/libvirt-vnc/server-cert.pem /etc/pki/libvirt-vnc/server-key.pem

--- a/scripts/util/keystore-cert-import
+++ b/scripts/util/keystore-cert-import
@@ -122,7 +122,7 @@ if [ -f "$LIBVIRTD_FILE" ]; then
     ln -sf /etc/pki/libvirt/private/serverkey.pem /etc/pki/libvirt-vnc/server-key.pem
     cloudstack-setup-agent -s > /dev/null
 
-    QEMU_GROUP=$(sed -n 's/^group\s*=//p' /etc/libvirt/qemu.conf | awk -F'=' '{print $1}' | tr -d '"' |tr -d ' ' | tail -n1)
+    QEMU_GROUP=$(sed -n 's/^group\s*=//p' /etc/libvirt/qemu.conf | tr -d '"' | tr -d ' ' | tr -d "'" | tail -n1)
     if [ ! -z "${QEMU_GROUP// }" ]; then
       chgrp $QEMU_GROUP /etc/pki/libvirt /etc/pki/libvirt-vnc /etc/pki/CA /etc/pki/libvirt/private /etc/pki/libvirt/servercert.pem /etc/pki/libvirt/private/serverkey.pem /etc/pki/CA/cacert.pem /etc/pki/libvirt-vnc/ca-cert.pem /etc/pki/libvirt-vnc/server-cert.pem /etc/pki/libvirt-vnc/server-key.pem
       chmod 750 /etc/pki/libvirt /etc/pki/libvirt-vnc /etc/pki/CA /etc/pki/libvirt/private /etc/pki/libvirt/servercert.pem /etc/pki/libvirt/private/serverkey.pem /etc/pki/CA/cacert.pem /etc/pki/libvirt-vnc/ca-cert.pem /etc/pki/libvirt-vnc/server-cert.pem /etc/pki/libvirt-vnc/server-key.pem


### PR DESCRIPTION
### Description

This PR fixes reading the libvirt/qemu group name from the libvirtd qemu config file including spaces and quotes,
which is used during the deployment of Host Security Keys.
This PR fixes [https://github.com/apache/cloudstack/issues/11144](https://github.com/apache/cloudstack/issues/11144)

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested renewal of Host Security Keys on Ubuntu 24.04 hosts and stopping and starting VMs afterwards.

#### How did you try to break this feature and the system with this change?

