### PR TITLE
[SolidFire] Fix inter-cluster VM migrations on zone-wide SolidFire pools

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/to/DiskTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/DiskTO.java
@@ -29,6 +29,8 @@ public class DiskTO {
     public static final String CHAP_TARGET_SECRET = "chapTargetSecret";
     public static final String SCSI_NAA_DEVICE_ID = "scsiNaaDeviceId";
     public static final String MANAGED = "managed";
+    public static final String SCOPE = "scope";
+    public static final String INTER_CLUSTER_MIGRATION = "interClusterMigration";
     public static final String IQN = "iqn";
     public static final String STORAGE_HOST = "storageHost";
     public static final String STORAGE_PORT = "storagePort";

--- a/core/src/main/java/com/cloud/agent/api/UnmountDatastoresCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/UnmountDatastoresCommand.java
@@ -1,0 +1,42 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.agent.api;
+
+import java.util.List;
+
+public class UnmountDatastoresCommand extends Command {
+    private List<String> datastorePools;
+
+    public UnmountDatastoresCommand() {
+
+    }
+
+    public UnmountDatastoresCommand(List<String> datastorePools) {
+        this.datastorePools = datastorePools;
+    }
+
+    public List<String> getDatastorePools() {
+        return datastorePools;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return false;
+    }
+}

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
@@ -124,7 +124,7 @@ public interface VolumeOrchestrationService {
 
     boolean storageMigration(VirtualMachineProfile vm, Map<Volume, StoragePool> volumeToPool) throws StorageUnavailableException;
 
-    void prepareForMigration(VirtualMachineProfile vm, DeployDestination dest);
+    void prepareForMigration(VirtualMachineProfile vm, DeployDestination dest, Long srcHostId);
 
     void prepare(VirtualMachineProfile vm, DeployDestination dest) throws StorageUnavailableException, InsufficientStorageCapacityException, ConcurrentOperationException, StorageAccessException;
 
@@ -178,4 +178,6 @@ public interface VolumeOrchestrationService {
      * Unmanage VM volumes
      */
     void unmanageVolumes(long vmId);
+
+    List<String> postMigrationReleaseDatastoresOnOriginHost(VirtualMachineProfile profile, long vmId);
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/PrimaryDataStoreDriver.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/PrimaryDataStoreDriver.java
@@ -183,4 +183,15 @@ public interface PrimaryDataStoreDriver extends DataStoreDriver {
     default boolean zoneWideVolumesAvailableWithoutClusterMotion() {
         return false;
     }
+
+    /**
+     * Disabled by default. Set to true if the data store driver needs to unmount/revoke volumes datastore on the
+     * origin host in case of:
+     * - zone wide storage
+     * - inter-cluster VM migration (without storage motion)
+     * - the hypervisor has restrictions on the number of mounted datastores per host/cluster
+     */
+    default boolean zoneWideVolumesDatastoreCleanupOnOriginHostAfterInterClusterMigration() {
+        return false;
+    }
 }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -1562,7 +1562,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
         }
 
         // Zone wide storage Solidfire inter-cluster VM migrations needs the destination host mount the LUN before migrating
-        if (storagePool.isManaged() && storagePool.getScope() != null && ScopeType.ZONE == storagePool.getScope()) {
+        if (storagePool.isManaged() && ScopeType.ZONE.equals(storagePool.getScope()) &&
+                isCleanupNeededOnOriginHostAfterInterClusterMigration(dataStore)) {
             details.put(DiskTO.SCOPE, storagePool.getScope().name());
             if (vmProfile.getHostId() != null && srcHostId != null) {
                 HostVO host = _hostDao.findById(vmProfile.getHostId());
@@ -1573,6 +1574,18 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
         }
 
         return details;
+    }
+
+    private boolean isCleanupNeededOnOriginHostAfterInterClusterMigration(DataStore dataStore) {
+        if (dataStore == null || dataStore.getDriver() == null) {
+            return false;
+        }
+
+        DataStoreDriver driver = dataStore.getDriver();
+        if (driver instanceof PrimaryDataStoreDriver) {
+            return ((PrimaryDataStoreDriver)driver).zoneWideVolumesDatastoreCleanupOnOriginHostAfterInterClusterMigration();
+        }
+        return false;
     }
 
     private void setIoDriverPolicy(Map<String, String> details, StoragePoolVO storagePool, VolumeVO volume) {

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -3038,7 +3038,7 @@ public class VmwareStorageProcessor implements StorageProcessor {
         }
     }
 
-    private void unmountVmfsDatastore(VmwareContext context, VmwareHypervisorHost hyperHost, String datastoreName,
+    public void unmountVmfsDatastore(VmwareContext context, VmwareHypervisorHost hyperHost, String datastoreName,
                                       List<Pair<ManagedObjectReference, String>> hosts) throws Exception {
         for (Pair<ManagedObjectReference, String> host : hosts) {
             HostMO hostMO = new HostMO(context, host.first());

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import com.cloud.agent.AgentManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.ChapInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.CreateCmdResult;
@@ -118,6 +119,7 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     @Inject private VolumeDao volumeDao;
     @Inject private VolumeDetailsDao volumeDetailsDao;
     @Inject private VolumeDataFactory volumeFactory;
+    @Inject private AgentManager agentManager;
 
     @Override
     public Map<String, String> getCapabilities() {
@@ -1680,6 +1682,16 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
     @Override
     public boolean zoneWideVolumesAvailableWithoutClusterMotion() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresAccessForMigration(DataObject dataObject) {
+        return true;
+    }
+
+    @Override
+    public boolean zoneWideVolumesDatastoreCleanupOnOriginHostAfterInterClusterMigration() {
         return true;
     }
 }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
@@ -1677,4 +1677,9 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     public boolean volumesRequireGrantAccessWhenUsed() {
         return true;
     }
+
+    @Override
+    public boolean zoneWideVolumesAvailableWithoutClusterMotion() {
+        return true;
+    }
 }


### PR DESCRIPTION
### Description

This PR addresses 2 bugs on the SolidFire 1:1 plugin using zone-wide storage:
- When trying to migrate VMs on different clusters within the same zone, CloudStack showed storage migration was required. This PR fixes that, not involving storage migration for inter-cluster migration within the same zone (#11297)
- Inter-cluster VM migration fails when the VM LUN was not mounted on the destination host. This PR addresses that by mounting the LUN on the destination host and unmounting it from the origin host after the migration succeeds.

Fixes: #11297 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
