### PR TITLE
Mount the disabled storage pools by default

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
+++ b/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
@@ -182,7 +182,7 @@ public interface StorageManager extends StorageService {
     ConfigKey<Boolean> MountDisabledStoragePool = new ConfigKey<>(Boolean.class,
             "mount.disabled.storage.pool",
             "Storage",
-            "false",
+            Boolean.TRUE.toString(),
             "Mount all zone-wide or cluster-wide disabled storage pools after node reboot",
             true,
             ConfigKey.Scope.Cluster,


### PR DESCRIPTION
### Description

This PR updates the default value of the setting 'mount.disabled.storage.pool' to true, and mounts the disabled pools by default (for new installations only, old installation should explicitly update the setting to true if required). It keeps the disabled pools mounted (as these are restricted for further allocation only).

**Issue**

The disabled pools that are unmounted (and entries removed from _storage_pool_host_ref_ table) during host disconnection on management server / agent stop, are not re-mounted (and added back to _storage_pool_host_ref_ table) during host connection on management server / agent start, which is resulting in access issues for the existing volumes on them and impacting the VM/Volume operations.

**Background**

Further allocation of the pools is not allowed when the pools are disabled. The disabled pools are expected to be mounted by design (and host/pool entries to be added for the disabled pools in _storage_pool_host_ref_ table) for accessing the existing volumes. The setting 'mount.disabled.storage.pool' (introduced in 4.17.0.0) is false by default to keep the same behavior, and also doesn't allow mount of disabled pools. There was a discussion about mounting the disabled pools by default (and only unmount during pool maintenance) in the PR https://github.com/apache/cloudstack/pull/6164 (where the setting 'mount.disabled.storage.pool' is introduced), but it was not addressed.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Disable the pool and restart management server / agent, and notice that the pool is mounted (and host/pool entry exists in _storage_pool_host_ref_ table)

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
