### PR TITLE
KVM: fix delete vm snapshot if it does not exist with a Stopped vm

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteVMSnapshotCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteVMSnapshotCommandWrapper.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.commons.lang3.StringUtils;
 import org.libvirt.Connect;
 import org.libvirt.Domain;
 import org.libvirt.DomainInfo;
@@ -104,7 +105,7 @@ public final class LibvirtDeleteVMSnapshotCommandWrapper extends CommandWrapper<
                     commands.add(new String[]{Script.getExecutableAbsolutePath("awk"), "-F", " ", "{print $2}"});
                     commands.add(new String[]{Script.getExecutableAbsolutePath("grep"), "^" + sanitizeBashCommandArgument(cmd.getTarget().getSnapshotName()) + "$"});
                     String qemu_img_snapshot = Script.executePipedCommands(commands, 0).second();
-                    if (qemu_img_snapshot == null) {
+                    if (StringUtils.isEmpty(qemu_img_snapshot)) {
                         logger.info("Cannot find snapshot " + cmd.getTarget().getSnapshotName() + " in file " + rootDisk.getPath() + ", return true");
                         return new DeleteVMSnapshotAnswer(cmd, cmd.getVolumeTOs());
                     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteVMSnapshotCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteVMSnapshotCommandWrapper.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
-import org.apache.commons.lang3.StringUtils;
 import org.libvirt.Connect;
 import org.libvirt.Domain;
 import org.libvirt.DomainInfo;
@@ -41,6 +40,7 @@ import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.Volume;
+import com.cloud.utils.StringUtils;
 import com.cloud.utils.script.Script;
 
 @ResourceWrapper(handles =  DeleteVMSnapshotCommand.class)


### PR DESCRIPTION
### Description

This PR fixes #11673


Steps to reproduce the issue
- deploy vm in kvm environments
- create vm snapshot
- delete the vm snapshot by `qemu-img snapshot -d <snapshot name> <qcow2 image path of vm>
- stop the vm
- delete the vm snapshot on cloudstack GUI

Prior to this PR
```
2025-09-19T12:14:05,455 DEBUG [utils.script.Script] (Script-7:[]) (logid:) Piped commands executed successfully
2025-09-19T12:14:05,455 DEBUG [utils.script.Script] (AgentRequest-Handler-2:[]) (logid:) Executing command [/usr/bin/qemu-img snapshot -d i-2-23-VM_VS_20250919102815 /mnt/92a06402-16ab-35e8-950e-d84499c5e942/57c64582-aa4b-4329-bf18-9bcb14dffd57 ].
2025-09-19T12:14:05,594 WARN  [utils.script.Script] (AgentRequest-Handler-2:[]) (logid:) Execution of process [983177] for command [/usr/bin/qemu-img snapshot -d i-2-23-VM_VS_20250919102815 /mnt/92a06402-16ab-35e8-950e-d84499c5e942/57c64582-aa4b-4329-bf18-9bcb14dffd57 ] failed.
2025-09-19T12:14:05,594 DEBUG [utils.script.Script] (AgentRequest-Handler-2:[]) (logid:) Exit value of process [983177] for command [/usr/bin/qemu-img snapshot -d i-2-23-VM_VS_20250919102815 /mnt/92a06402-16ab-35e8-950e-d84499c5e942/57c64582-aa4b-4329-bf18-9bcb14dffd57 ] is [1].
2025-09-19T12:14:05,594 WARN  [utils.script.Script] (AgentRequest-Handler-2:[]) (logid:) Process [983177] for command [/usr/bin/qemu-img snapshot -d i-2-23-VM_VS_20250919102815 /mnt/92a06402-16ab-35e8-950e-d84499c5e942/57c64582-aa4b-4329-bf18-9bcb14dffd57 ] encountered the error: [1].
2025-09-19T12:14:05,595 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-2:[]) (logid:) Seq 1-8671962557478622109:  { Ans: , MgmtId: 32986372244225, via: 1, Ver: v1, Flags: 10, [{"com.cloud.agent.api.DeleteVMSnapshotAnswer":{"result":"false","details":"Delete VM Snapshot Failed due to can not remove snapshot from image file /mnt/92a06402-16ab-35e8-950e-d84499c5e942/57c64582-aa4b-4329-bf18-9bcb14dffd57 : 1","wait":"0","bypassHostMaintenance":"false"}}] }

```

With this PR
```
2025-09-19T12:59:29,526 DEBUG [utils.script.Script] (Script-9:[]) (logid:) Piped commands executed successfully
2025-09-19T12:59:29,527 DEBUG [resource.wrapper.LibvirtDeleteVMSnapshotCommandWrapper] (AgentRequest-Handler-5:[]) (logid:) qemu_img_snapshot =
2025-09-19T12:59:29,528 INFO  [resource.wrapper.LibvirtDeleteVMSnapshotCommandWrapper] (AgentRequest-Handler-5:[]) (logid:) Cannot find snapshot i-2-23-VM_VS_20250919102815 in file /mnt/92a06402-16ab-35e8-950e-d84499c5e942/57c64582-aa4b-4329-bf18-9bcb14dffd57, return true
```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
