### PR TITLE
server,ui: prevent role change for default accounts

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1398,6 +1398,9 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
      - New role should not be of type Admin with domain other than ROOT domain
      */
     protected void validateRoleChange(Account account, Role role, Account caller) {
+        if (account.getRoleId() == role.getId()) {
+            return;
+        }
         Role currentRole = roleService.findRole(account.getRoleId());
         Role callerRole = roleService.findRole(caller.getRoleId());
         String errorMsg = String.format("Unable to update account role to %s, ", role.getName());
@@ -1412,6 +1415,9 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                         currentRole.getRoleType().ordinal() < callerRole.getRoleType().ordinal())) {
             throw new PermissionDeniedException(String.format("%s as either current or new role has higher " +
                     "privileges than the caller", errorMsg));
+        }
+        if (account.isDefault()) {
+            throw new PermissionDeniedException(String.format("%s as the account is a default account", errorMsg));
         }
         if (role.getRoleType().equals(RoleType.Admin) && account.getDomainId() != Domain.ROOT_DOMAIN) {
             throw new PermissionDeniedException(String.format("%s as the user does not belong to the ROOT domain",

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1398,7 +1398,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
      - New role should not be of type Admin with domain other than ROOT domain
      */
     protected void validateRoleChange(Account account, Role role, Account caller) {
-        if (account.getRoleId() == role.getId()) {
+        if (account.getRoleId() != null && account.getRoleId().equals(role.getId())) {
             return;
         }
         Role currentRole = roleService.findRole(account.getRoleId());

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -1365,6 +1365,22 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
         accountManagerImpl.validateRoleChange(account, newRole, caller);
     }
 
+    @Test(expected = PermissionDeniedException.class)
+    public void testValidateRoleAdminCannotChangeDefaultAdmin() {
+        Account account = Mockito.mock(Account.class);
+        Mockito.when(account.isDefault()).thenReturn(true);
+        Mockito.when(account.getRoleId()).thenReturn(1L);
+        Role newRole = Mockito.mock(Role.class);
+        Mockito.when(newRole.getRoleType()).thenReturn(RoleType.User);
+        Role callerRole = Mockito.mock(Role.class);
+        Mockito.when(callerRole.getRoleType()).thenReturn(RoleType.Admin);
+        Account caller = Mockito.mock(Account.class);
+        Mockito.when(caller.getRoleId()).thenReturn(2L);
+        Mockito.when(roleService.findRole(1L)).thenReturn(Mockito.mock(Role.class));
+        Mockito.when(roleService.findRole(2L)).thenReturn(callerRole);
+        accountManagerImpl.validateRoleChange(account, newRole, caller);
+    }
+
     @Test
     public void checkIfAccountManagesProjectsTestNotThrowExceptionWhenTheAccountIsNotAProjectAdministrator() {
         long accountId = 1L;

--- a/ui/src/views/iam/EditAccount.vue
+++ b/ui/src/views/iam/EditAccount.vue
@@ -40,7 +40,7 @@
             v-model:value="form.networkdomain"
             :placeholder="apiParams.networkdomain.description" />
         </a-form-item>
-        <a-form-item ref="roleid" name="roleid">
+        <a-form-item ref="roleid" name="roleid" v-if="!resource.isdefault">
           <template #label>
             <tooltip-label :title="$t('label.role')" :tooltip="apiParams.roleid.description"/>
           </template>
@@ -145,10 +145,12 @@ export default {
         const params = {
           newname: values.newname,
           networkdomain: values.networkdomain,
-          roleid: values.roleid,
           apikeyaccess: values.apikeyaccess,
           account: this.account,
           domainid: this.domainId
+        }
+        if (values.roleid) {
+          params.roleid = values.roleid
         }
         if (this.isValidValueForKey(values, 'networkdomain') && values.networkdomain.length > 0) {
           params.networkdomain = values.networkdomain


### PR DESCRIPTION
### Description

Fixes #10931

Role for default accounts shouldn't be changed. Appropriate error should be returned by the server and UI should not present option for them.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
