### PR TITLE
use 'ip' structured data to safely retrieve default route interface

### DIFF
--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -306,7 +306,7 @@ public class NetUtils {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");
             return defDev;
         }
-        return Script.runSimpleBashScript("/bin/ip -j a | /bin/jq -r '.[] | .addr_info | map(select(.local == \"'`/bin/ip -j r s default | /bin/jq -r '.[0] | .prefsrc'`'\")) | .[].label'");
+        return Script.runSimpleBashScript("ip -j a | jq -r '.[] | .addr_info | map(select(.local == \"'`ip -j r s default | jq -r '.[0] | .prefsrc'`'\")) | .[].label'");
     }
 
     public static String getLocalIPString() {

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -306,7 +306,7 @@ public class NetUtils {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");
             return defDev;
         }
-        return Script.runSimpleBashScript("ip route show default 0.0.0.0/0 | head -1 | awk '{print $5}'");
+        return Script.runSimpleBashScript("/bin/ip -j a | /bin/jq -r '.[] | .addr_info | map(select(.local == \"'`/bin/ip -j r s default | /bin/jq -r '.[0] | .prefsrc'`'\")) | .[].label'");
     }
 
     public static String getLocalIPString() {


### PR DESCRIPTION
Using ip route structured data allows to query safely the default route interface, no matter the output of the standard 'ip route' output.