### PR TITLE
Sanitize the rbd file cmd parameter logs during qemu-img convert (through Script)

### DIFF
--- a/utils/src/main/java/com/cloud/utils/script/Script.java
+++ b/utils/src/main/java/com/cloud/utils/script/Script.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -157,13 +158,7 @@ public class Script implements Callable<String> {
         boolean obscureParam = false;
         for (int i = 0; i < command.length; i++) {
             String cmd = command[i];
-            if (StringUtils.isNotEmpty(cmd) && cmd.startsWith("vi://")) {
-                String[] tokens = cmd.split("@");
-                if (tokens.length >= 2) {
-                    builder.append("vi://").append("******@").append(tokens[1]).append(" ");
-                } else {
-                    builder.append("vi://").append("******").append(" ");
-                }
+            if (sanitizeViCmdParameter(cmd, builder) || sanitizeRbdFileFormatCmdParameter(cmd, builder)) {
                 continue;
             }
             if (obscureParam) {
@@ -179,6 +174,41 @@ public class Script implements Callable<String> {
             }
         }
         return builder.toString();
+    }
+
+    private boolean sanitizeViCmdParameter(String cmd, StringBuilder builder) {
+        if (StringUtils.isEmpty(cmd) || !cmd.startsWith("vi://")) {
+            return false;
+        }
+
+        String[] tokens = cmd.split("@");
+        if (tokens.length >= 2) {
+            builder.append("vi://").append("******@").append(tokens[1]).append(" ");
+        } else {
+            builder.append("vi://").append("******").append(" ");
+        }
+        return true;
+    }
+
+    private boolean sanitizeRbdFileFormatCmdParameter(String cmd, StringBuilder builder) {
+        if (StringUtils.isEmpty(cmd) || !cmd.startsWith("rbd:") || !cmd.contains("key=")) {
+            return false;
+        }
+
+        String[] tokens = cmd.split("key=");
+        if (tokens.length != 2) {
+            return false;
+        }
+
+        String tokenWithKey = tokens[1];
+        String[] options = tokenWithKey.split(":");
+        if (options.length > 1) {
+            String optionsAfterKey = String.join(":", Arrays.copyOfRange(options, 1, options.length));
+            builder.append(tokens[0]).append("key=").append("******").append(":").append(optionsAfterKey).append(" ");
+        } else {
+            builder.append(tokens[0]).append("key=").append("******").append(" ");
+        }
+        return true;
     }
 
     public long getTimeout() {


### PR DESCRIPTION
### Description

This PR sanitises the rbd file cmd parameter logs during qemu-img convert (through Script).

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Verified logs using deploy instance and migrate volume on ceph/rbd storage.

```
2025-10-08 08:53:16,375 DEBUG [utils.script.Script] (AgentRequest-Handler-3:[]) (logid:) Executing command [qemu-img convert -O raw -U --image-opts driver=qcow2,file.filename=/mnt/36a52cb4-35af-3fa2-8c7f-5bde0254737e/0c364cce-8288-3a92-9234-4ffde372aec7.qcow2 rbd:cloudstack/a31a9020-a406-11f0-b615-1e00b300036f:mon_host=10.0.33.201:auth_supported=cephx:id=cloudstack:key=******:rbd_default_format=2:client_mount_timeout=30 ].
2025-10-08 08:55:12,502 DEBUG [utils.script.Script] (AgentRequest-Handler-3:[]) (logid:) Successfully executed process [30511] for command [qemu-img convert -O raw -U --image-opts driver=qcow2,file.filename=/mnt/36a52cb4-35af-3fa2-8c7f-5bde0254737e/0c364cce-8288-3a92-9234-4ffde372aec7.qcow2 rbd:cloudstack/a31a9020-a406-11f0-b615-1e00b300036f:mon_host=10.0.33.201:auth_supported=cephx:id=cloudstack:key=******:rbd_default_format=2:client_mount_timeout=30 ].

2025-10-08 08:59:52,365 DEBUG [utils.script.Script] (AgentRequest-Handler-1:[]) (logid:) Executing command [qemu-img convert -O qcow2 -U rbd:cloudstack/83e1deb7-afff-4d51-b0cd-5e2390427a30:mon_host=10.0.33.201:auth_supported=cephx:id=cloudstack:key=******:rbd_default_format=2:client_mount_timeout=30 /mnt/529b3b91-2f25-301c-8a4b-4867d3cd2224/654ce284-f1ad-4635-a7ac-a5cc1b43fc1d.qcow2 ].
2025-10-08 09:00:14,170 DEBUG [utils.script.Script] (AgentRequest-Handler-1:[]) (logid:) Successfully executed process [33557] for command [qemu-img convert -O qcow2 -U rbd:cloudstack/83e1deb7-afff-4d51-b0cd-5e2390427a30:mon_host=10.0.33.201:auth_supported=cephx:id=cloudstack:key=******:rbd_default_format=2:client_mount_timeout=30 /mnt/529b3b91-2f25-301c-8a4b-4867d3cd2224/654ce284-f1ad-4635-a7ac-a5cc1b43fc1d.qcow2 ].

```
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
