### PR TITLE
Fix primary storage removal logs with detached volumes

### DIFF
--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -1558,14 +1558,18 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
 
     protected String getStoragePoolNonDestroyedVolumesLog(long storagePoolId) {
         StringBuilder sb = new StringBuilder();
-        List<VolumeVO> nonDestroyedVols = volumeDao.findByPoolId(storagePoolId, null).stream().filter(vol -> vol.getState() != Volume.State.Destroy).collect(Collectors.toList());
+        List<VolumeVO> nonDestroyedVols = volumeDao.findByPoolId(storagePoolId, null);
         VMInstanceVO volInstance;
         List<String> logMessageInfo = new ArrayList<>();
 
         sb.append("[");
         for (VolumeVO vol : nonDestroyedVols) {
             volInstance = _vmInstanceDao.findById(vol.getInstanceId());
-            logMessageInfo.add(String.format("Volume [%s] (attached to VM [%s])", vol.getUuid(), volInstance.getUuid()));
+            if (volInstance != null) {
+                logMessageInfo.add(String.format("Volume [%s] (attached to VM [%s])", vol.getUuid(), volInstance.getUuid()));
+            } else {
+                logMessageInfo.add(String.format("Volume [%s]", vol.getUuid()));
+            }
         }
         sb.append(String.join(", ", logMessageInfo));
         sb.append("]");


### PR DESCRIPTION
### Description

Currently, when attempting to remove a primary storage with a detached ready volume, a NPE is thrown. Therefore, instead of informing users of the undestroyed volumes in the storage pool through the logs, ACS is throwing a generic exception without much information.

This PR intends to fix this bug.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

1. I created a VM and attached a `DATADISK` volume to it, which was created in the `pri-nfs` storage pool.
2. I detached the volume and enabled the `pri-nfs` maintenance mode.
3. After the storage entered maintenance mode, I tried to remove it and observed the NPE.

```
2025-10-09 11:42:08,608 ERROR [c.c.a.ApiServer] (qtp1070044969-23:[ctx-fecf6a51, ctx-de782f4a]) (logid:5d87fe7b) unhandled exception executing api command: [Ljava.lang.String;@38e7b06f java.lang.NullPointerException: Cannot invoke "com.cloud.vm.VMInstanceVO.getUuid()" because "volInstance" is null
        at com.cloud.storage.StorageManagerImpl.getStoragePoolNonDestroyedVolumesLog(StorageManagerImpl.java:1802)
        at com.cloud.storage.StorageManagerImpl.lambda$deleteDataStoreInternal$2(StorageManagerImpl.java:1769)
```

With the patch, I checked that the NPE no longer occurs.

```
2025-10-09 11:54:13,768 DEBUG [c.c.s.StorageManagerImpl] (qtp1390913202-28:[ctx-b34c3b23, ctx-8fc056a9]) (logid:23462342) Cannot delete storage pool StoragePool {"id":9,"name":"pri-nfs","poolType":"NetworkFilesystem","uuid":"be7199ad-50ac-329d-81a1-8315ae3149c2"} as the following non-destroyed volumes are on it: [Volume [637e6255-1a74-498f-9a63-36a365742d49] (attached to VM [233da21f-8e28-492c-b5b2-12cae4b933da]), Volume [970f9b5f-7af3-4f91-9eab-ac1e62c1270d] (attached to VM [3774b718-8c06-492c-ac1d-e7f273bc6616]), Volume [3f41346d-f78c-46d7-adac-4664b0970ac3] (attached to VM [bec81d39-696b-437c-a4d0-6bccc7eaab1d]), Volume [615e135e-166e-4953-ae07-c8fc4280a2ad]].
2025-10-09 11:54:13,769 ERROR [c.c.a.ApiServer] (qtp1390913202-28:[ctx-b34c3b23, ctx-8fc056a9]) (logid:23462342) unhandled exception executing api command: [Ljava.lang.String;@29300213 com.cloud.utils.exception.CloudRuntimeException: Cannot delete pool StoragePool {"id":9,"name":"pri-nfs","poolType":"NetworkFilesystem","uuid":"be7199ad-50ac-329d-81a1-8315ae3149c2"} as there are non-destroyed volumes associated to this pool.
	at com.cloud.storage.StorageManagerImpl.deleteDataStoreInternal(StorageManagerImpl.java:1770)
	at com.cloud.storage.StorageManagerImpl.deletePool(StorageManagerImpl.java:1693)
```

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
