### PR TITLE
Change internal ID to UUID in user disable event

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/user/DisableUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/user/DisableUserCmd.java
@@ -78,12 +78,12 @@ public class DisableUserCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "disabling user: " + getId();
+        return "disabling user: " + this._uuidMgr.getUuid(User.class, getId());
     }
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("UserId: " + getId());
+        CallContext.current().setEventDetails("User ID: " + this._uuidMgr.getUuid(User.class, getId()));
         UserAccount user = _regionService.disableUser(this);
 
         if (user != null) {


### PR DESCRIPTION
### Description

During the user disablement process, created events contain the user internal ID instead of the user UUID. Therefore, this PR fixes this behaviour by changing the internal ID in the event descriptions to the user's UUID.  

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I built the packages with the changes and applied them to my local environment. In Apache CloudStack, I created a new user `user` in the `admin` account, then disabled it. In the events, I validated that the user's UUID were shown instead of the user's internal ID.  

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->