### PR TITLE
kvm,utils/test,config/test: fix flaky unit tests

### DIFF
--- a/server/src/test/java/org/apache/cloudstack/vm/schedule/VMSchedulerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/schedule/VMSchedulerImplTest.java
@@ -247,8 +247,9 @@ public class VMSchedulerImplTest {
 
     @Test
     public void testScheduleNextJobScheduleCurrentSchedule() {
-        Date now = DateUtils.setSeconds(new Date(), 0);
-        Date expectedScheduledTime = DateUtils.round(DateUtils.addMinutes(now, 1), Calendar.MINUTE);
+        Date now = DateUtils.round(new Date(), Calendar.MINUTE);
+        Date expectedScheduledTime = DateUtils.addMinutes(now, 1);
+
         UserVm vm = Mockito.mock(UserVm.class);
 
         VMScheduleVO vmSchedule = Mockito.mock(VMScheduleVO.class);
@@ -257,7 +258,8 @@ public class VMSchedulerImplTest {
         Mockito.when(vmSchedule.getTimeZoneId()).thenReturn(TimeZone.getTimeZone("UTC").toZoneId());
         Mockito.when(vmSchedule.getStartDate()).thenReturn(DateUtils.addDays(now, -1));
         Mockito.when(userVmManager.getUserVm(Mockito.anyLong())).thenReturn(vm);
-        Date actualScheduledTime = vmScheduler.scheduleNextJob(vmSchedule, new Date());
+
+        Date actualScheduledTime = vmScheduler.scheduleNextJob(vmSchedule, now);
 
         Assert.assertEquals(expectedScheduledTime, actualScheduledTime);
     }

--- a/utils/src/test/java/org/apache/cloudstack/utils/cache/LazyCacheTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/cache/LazyCacheTest.java
@@ -30,7 +30,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LazyCacheTest {
-    private final long expireSeconds = 1;
+    private final long expireSeconds = 2;
     private final String cacheValuePrefix = "ComputedValueFor:";
     private LazyCache<String, String> cache;
     private Function<String, String> mockLoader;


### PR DESCRIPTION
### Description

Fixes flakiness in unit test causing packaging failures.
Improves disconnect hook handling for KVM

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [x] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### Failures see

```
14:31:39 [ERROR]   LazyCacheTest.testLoaderNotCalledIfPresent:63 
14:31:39 function.apply("key2");
14:31:39 Wanted 1 time:
14:31:39 -> at org.apache.cloudstack.utils.cache.LazyCacheTest.testLoaderNotCalledIfPresent(LazyCacheTest.java:63)
14:31:39 But was 2 times:
14:31:39 -> at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$3(LocalLoadingCache.java:183)
14:31:39 -> at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$3(LocalLoadingCache.java:183)

...

16:51:51 [ERROR] Failures: 
16:51:51 [ERROR]   LazyCacheTest.testMaximumSize:113 
16:51:51 function.apply("key7");
16:51:51 Wanted 2 times:
16:51:51 -> at org.apache.cloudstack.utils.cache.LazyCacheTest.testMaximumSize(LazyCacheTest.java:113)
16:51:51 But was 1 time:
16:51:51 -> at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$3(LocalLoadingCache.java:183)
16:51:51 
16:51:51 [INFO] 
16:51:51 [ERROR] Tests run: 2696, Failures: 1, Errors: 0, Skipped: 1
```

```
10:20:17 [ERROR] Failures: 
10:20:17 [ERROR]   ConfigKeyScheduledExecutionWrapperTest.scheduleDynamicTest:110 Runnable ran four times per second
10:20:17 Expected: one of {<7>, <8>}
10:20:17      but: was <9>
10:20:17 [INFO] 
10:20:17 [ERROR] Tests run: 27, Failures: 1, Errors: 0, Skipped: 0

...

12:55:18 [ERROR] Failures: 
12:55:18 [ERROR]   ConfigKeyScheduledExecutionWrapperTest.scheduleDynamicTest:110 Runnable ran four times per second
12:55:18 Expected: one of {<7>, <8>}
12:55:18      but: was <6>
12:55:18 [INFO] 
12:55:18 [ERROR] Tests run: 27, Failures: 1, Errors: 0, Skipped: 0
```

```
17:07:14 [ERROR] Failures: 
17:07:14 [ERROR]   DisconnectHooksTest.addAndRunTwoHooksWithTimeout:166
17:07:14 [INFO] 
17:07:14 [ERROR] Tests run: 576, Failures: 1, Errors: 0, Skipped: 2
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
