### PR TITLE
Fix: NPE thrown on VMware to KVM migration tasks listing for removed VMs

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/ImportVmTasksManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/ImportVmTasksManagerImpl.java
@@ -209,7 +209,10 @@ public class ImportVmTasksManagerImpl implements ImportVmTasksManager {
         }
         if (task.getVmId() != null) {
             UserVmVO userVm = userVmDao.findById(task.getVmId());
-            response.setVirtualMachineId(userVm.getUuid());
+            if (userVm != null) {
+                // Migrated VM could have been removed from CloudStack after the migration
+                response.setVirtualMachineId(userVm.getUuid());
+            }
         }
         response.setCreated(task.getCreated());
         response.setLastUpdated(task.getUpdated());


### PR DESCRIPTION
### Description

This PR fixes an issue while listing migration tasks if some of the migrated VMs are removed after the migration, resulting on not being able to list the past migration tasks.

Completed migrations:
<img width="2714" height="874" alt="image" src="https://github.com/user-attachments/assets/d6d32132-41fd-42a7-8e60-a2badd8699d9" />

After removing one of the migrated VMs, the listing failed:
<img width="2714" height="974" alt="image" src="https://github.com/user-attachments/assets/5d77deb5-9958-4827-83eb-be02be98b070" />

After the fix:
<img width="1371" height="441" alt="Screenshot 2025-10-22 at 2 24 06 PM" src="https://github.com/user-attachments/assets/22ee8844-e6d3-4c03-95e7-1dd06af036ad" />


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Migrate VMware VM to KVM
- Remove VM
- List 'All' or 'Completed' tasks

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
