### PR TITLE
Fix upgrade router template operation failure displayed on the UI

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/UpgradeRouterTemplateResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UpgradeRouterTemplateResponse.java
@@ -16,27 +16,10 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.google.gson.annotations.SerializedName;
-
-import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.EntityReference;
 import org.apache.cloudstack.jobs.JobInfo;
 
-import com.cloud.serializer.Param;
-
 @EntityReference(value = JobInfo.class)
-@SuppressWarnings("unused")
 public class UpgradeRouterTemplateResponse extends BaseResponse {
-    @SerializedName(ApiConstants.JOB_ID)
-    @Param(description = "the id of AsyncJob")
-    private String asyncJobId;
-
-    public String getAsyncJobId() {
-        return asyncJobId;
-    }
-
-    public void setAsyncJobId(String asyncJobId) {
-        this.asyncJobId = asyncJobId;
-    }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -4994,7 +4994,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         for (Long jobId : jobIds) {
             UpgradeRouterTemplateResponse routerResponse = new UpgradeRouterTemplateResponse();
             AsyncJob job = _entityMgr.findById(AsyncJob.class, jobId);
-            routerResponse.setAsyncJobId((job.getUuid()));
+            routerResponse.setJobId((job.getUuid()));
             routerResponse.setObjectName("asyncjobs");
             responses.add(routerResponse);
         }


### PR DESCRIPTION
### Description

This PR fixes an UI issue when triggering the 'Upgrade router template' operation:

<img width="2862" height="1270" alt="image" src="https://github.com/user-attachments/assets/2aad0649-fee8-41f8-976a-6a46345a3573" />

Despite the UI error, the process was started properly and the router template was updated, but this PR addresses the error that causes the error displayed.

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Upgrade from 4.20.2
- Upgrade routers template

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
