### PR TITLE
[PowerFlex] Fix the config 'powerflex.connect.on.demand' description

### DIFF
--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManager.java
@@ -28,7 +28,7 @@ public interface ScaleIOSDCManager {
     ConfigKey<Boolean> ConnectOnDemand = new ConfigKey<>("Storage",
             Boolean.class,
             "powerflex.connect.on.demand",
-            Boolean.FALSE.toString(),
+            Boolean.TRUE.toString(),
             "When true, connects PowerFlex client on Host when first Volume is mapped to SDC & client connections configured 'storage.pool.connected.clients.limit' are within the limit and disconnects when last Volume is unmapped from SDC; " +
                     "and When false, connects PowerFlex client on Host when host connects to storage pool & client connections configured 'storage.pool.connected.clients.limit' are within the limit and disconnects when host disconnects from storage pool & no volumes mapped to SDC.",
             Boolean.TRUE,

--- a/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
+++ b/plugins/storage/volume/scaleio/src/main/java/org/apache/cloudstack/storage/datastore/manager/ScaleIOSDCManagerImpl.java
@@ -61,15 +61,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 public class ScaleIOSDCManagerImpl implements ScaleIOSDCManager, Configurable {
     private Logger logger = LogManager.getLogger(getClass());
 
-    static ConfigKey<Boolean> ConnectOnDemand = new ConfigKey<>("Storage",
-            Boolean.class,
-            "powerflex.connect.on.demand",
-            Boolean.TRUE.toString(),
-            "Connect PowerFlex client on Host when first Volume is mapped to SDC and disconnect when last Volume is unmapped from SDC," +
-                    " otherwise no action (that is connection remains in the same state whichever it is, connected or disconnected).",
-            Boolean.TRUE,
-            ConfigKey.Scope.Zone);
-
     @Inject
     AgentManager agentManager;
     @Inject


### PR DESCRIPTION
### Description

This PR fixes the config 'powerflex.connect.on.demand' description.

The configuration description was updated here: https://github.com/apache/cloudstack/pull/9903 (for behavior change in 4.21.0), it seems the description reverted to previous behavior due to forward merge of PR: https://github.com/apache/cloudstack/pull/11554.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Verified the config 'powerflex.connect.on.demand' description.

Before:

<img width="1434" height="373" alt="Config-PowerFlexConnectOnDemand-Before" src="https://github.com/user-attachments/assets/fd7dcc59-2e1f-46b1-83b1-89f1bde3b8bd" />


After:

<img width="1452" height="424" alt="Config-PowerFlexConnectOnDemand-After" src="https://github.com/user-attachments/assets/e15d12e0-19c5-49d1-a100-aa85de18e9d3" />


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
