### PR TITLE
VPC: fix Python exception processing static routes with next hop when private gateway is also present

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -603,7 +603,7 @@ class CsIP:
                     if item == "id":
                         continue
                     static_route = static_routes.get_bag()[item]
-                    if static_route['ip_address'] == self.address['public_ip'] and not static_route['revoke']:
+                    if 'ip_address' in static_route and static_route['ip_address'] == self.address['public_ip'] and not static_route['revoke']:
                         self.fw.append(["mangle", "",
                                         "-A PREROUTING -m state --state NEW -i %s -s %s ! -d %s/32 -j ACL_OUTBOUND_%s" %
                                         (self.dev, static_route['network'], static_route['ip_address'], self.dev)])


### PR DESCRIPTION
### Description

static routes that don't reference a private gateway don't have an ip_address and therefore will throw a key error:
```
root@r-359-VM:/var/cache/cloud# update_config.py ip_associations.json.7407b8bd-21c6-4d99-aae0-f2193412650c
Traceback (most recent call last):
  File "/opt/cloud/bin/update_config.py", line 147, in <module>
    process_file()
  File "/opt/cloud/bin/update_config.py", line 57, in process_file
    finish_config()
  File "/opt/cloud/bin/update_config.py", line 42, in finish_config
    returncode = configure.main(sys.argv)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cloud/bin/configure.py", line 1647, in main
    config.address().process()
  File "/opt/cloud/bin/cs/CsAddress.py", line 138, in process
    ip.configure(address)
  File "/opt/cloud/bin/cs/CsAddress.py", line 348, in configure
    self.post_configure(address)
  File "/opt/cloud/bin/cs/CsAddress.py", line 370, in post_configure
    self.post_config_change("add")
  File "/opt/cloud/bin/cs/CsAddress.py", line 824, in post_config_change
    self.fw_vpcrouter()
  File "/opt/cloud/bin/cs/CsAddress.py", line 606, in fw_vpcrouter
    if static_route['ip_address'] == self.address['public_ip'] and not static_route['revoke']:
       ~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'ip_address'
```

Example static routes:
```
root@r-359-VM:/var/cache/cloud# cat /etc/cloudstack/staticroutes.json
{
  "10.10.48.0/20": {
    "gateway": "10.252.240.10",
    "network": "10.10.48.0/20",
    "revoke": false
  },
  "10.250.0.0/16": {
    "gateway": "10.252.240.10",
    "network": "10.250.0.0/16",
    "revoke": false
  },
  "id": "staticroutes"
}
```

Fixes #11965

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [x] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested in a production environment by manually editing the file and observe the changes no longer cause an exception.

#### How did you try to break this feature and the system with this change?


