### PR TITLE
Clear System VM IP from NICs for PublicNetworkGuru

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2326,7 +2326,8 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             for (final NetworkElement element : networkElements) {
                 if (providersToImplement.contains(element.getProvider())) {
                     if (!_networkModel.isProviderEnabledInPhysicalNetwork(_networkModel.getPhysicalNetworkId(network), element.getProvider().getName())) {
-                        throw new CloudRuntimeException(String.format("Service provider %s either doesn't exist or is not enabled in physical network: %s", element.getProvider().getName(), _physicalNetworkDao.findById(network.getPhysicalNetworkId())));
+                        throw new CloudRuntimeException("Service provider " + element.getProvider().getName() + " either doesn't exist or is not enabled in physical network id: "
+                                + network.getPhysicalNetworkId());
                     }
                     if (element instanceof NetworkMigrationResponder) {
                         if (!((NetworkMigrationResponder) element).prepareMigration(profile, network, vm, dest, context)) {
@@ -2633,6 +2634,10 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         final NetworkGuru guru = AdapterBase.getAdapterByName(networkGurus, network.getGuruName());
         guru.deallocate(network, profile, vm);
+        if (nic.getReservationStrategy() == Nic.ReservationStrategy.Create) {
+            applyProfileToNicForRelease(nic, profile);
+            _nicDao.update(nic.getId(), nic);
+        }
         if (BooleanUtils.isNotTrue(preserveNics)) {
             _nicDao.remove(nic.getId());
         }

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2326,8 +2326,8 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             for (final NetworkElement element : networkElements) {
                 if (providersToImplement.contains(element.getProvider())) {
                     if (!_networkModel.isProviderEnabledInPhysicalNetwork(_networkModel.getPhysicalNetworkId(network), element.getProvider().getName())) {
-                        throw new CloudRuntimeException("Service provider " + element.getProvider().getName() + " either doesn't exist or is not enabled in physical network id: "
-                                + network.getPhysicalNetworkId());
+                        throw new CloudRuntimeException(String.format("Service provider %s either doesn't exist or is not enabled in physical network: %s",
+                                element.getProvider().getName(), _physicalNetworkDao.findById(network.getPhysicalNetworkId())));
                     }
                     if (element instanceof NetworkMigrationResponder) {
                         if (!((NetworkMigrationResponder) element).prepareMigration(profile, network, vm, dest, context)) {


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/cloudstack/issues/10872
This PR cleanup the IP details for the public NIC associated to the systemVM to follow consistency with how control & management NICs are cleaned up
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

Before Fix:

On deleting SSVM id 3: (both public & control nic)
```mysql> select * from  nics where instance_id = 3\G
*************************** 1. row ***************************
            id: 7
          uuid: 77430159-8fd2-41c3-adbc-b999ed9d4ed5
   instance_id: 3
   mac_address: 1e:00:48:00:00:02
   ip4_address: 10.0.52.82
       netmask: 255.255.240.0
       gateway: 10.0.48.1
       ip_type: Ip4
 broadcast_uri: vlan://51
    network_id: 200
          mode: Static
         state: Deallocating
      strategy: Create
 reserver_name: PublicNetworkGuru
reservation_id: NULL
     device_id: 2
   update_time: NULL
 isolation_uri: vlan://51
   ip6_address: NULL
   default_nic: 1
       vm_type: SecondaryStorageVm
       created: 2025-11-05 11:40:27
       removed: 2025-11-05 12:27:51
   ip6_gateway: NULL
      ip6_cidr: NULL
  secondary_ip: 0
   display_nic: 1
           mtu: NULL
*************************** 2. row ***************************
            id: 8
          uuid: 476f87b8-c5fb-4f00-a9db-e6fc237f8450
   instance_id: 3
   mac_address: NULL
   ip4_address: NULL
       netmask: NULL
       gateway: NULL
       ip_type: NULL
 broadcast_uri: NULL
    network_id: 202
          mode: Static
         state: Deallocating
      strategy: Start
 reserver_name: ControlNetworkGuru
reservation_id: 8d17740d-353e-419f-941c-3cd4d818e49d
     device_id: 0
   update_time: NULL
 isolation_uri: NULL
   ip6_address: NULL
   default_nic: 0
       vm_type: SecondaryStorageVm
       created: 2025-11-05 11:40:27
       removed: 2025-11-05 12:27:51
   ip6_gateway: NULL
      ip6_cidr: NULL
  secondary_ip: 0
   display_nic: 1
           mtu: NULL
```

### How Has This Been Tested?

After fix:

On deleting SSVM id 3: (both public & control nic)

```
mysql> select * from  nics where instance_id = 10\G
*************************** 1. row ***************************
            id: 26
          uuid: f51c03aa-09c4-46e2-8d93-9fe5c413c3a0
   instance_id: 10
   mac_address: NULL
   ip4_address: NULL
       netmask: NULL
       gateway: NULL
       ip_type: NULL
 broadcast_uri: NULL
    network_id: 200
          mode: Static
         state: Deallocating
      strategy: Create
 reserver_name: PublicNetworkGuru
reservation_id: NULL
     device_id: 2
   update_time: NULL
 isolation_uri: NULL
   ip6_address: NULL
   default_nic: 1
       vm_type: SecondaryStorageVm
       created: 2025-11-05 16:31:22
       removed: 2025-11-05 17:18:25
   ip6_gateway: NULL
      ip6_cidr: NULL
  secondary_ip: 0
   display_nic: 1
           mtu: NULL
*************************** 2. row ***************************
            id: 27
          uuid: 93eb165c-a055-4eca-9c6c-185b3f6ab341
   instance_id: 10
   mac_address: NULL
   ip4_address: NULL
       netmask: NULL
       gateway: NULL
       ip_type: NULL
 broadcast_uri: NULL
    network_id: 202
          mode: Static
         state: Deallocating
      strategy: Start
 reserver_name: ControlNetworkGuru
reservation_id: 9156f5bb-2c3f-410a-8b1d-6c6059ca4ac0
     device_id: 0
   update_time: NULL
 isolation_uri: NULL
   ip6_address: NULL
   default_nic: 0
       vm_type: SecondaryStorageVm
       created: 2025-11-05 16:31:22
       removed: 2025-11-05 17:18:25
   ip6_gateway: NULL
      ip6_cidr: NULL
  secondary_ip: 0
   display_nic: 1
           mtu: NULL
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
