### PR TITLE
Fix that Sensitive information logged in SshHelper.sshExecute method

### DIFF
--- a/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
+++ b/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
@@ -395,7 +395,10 @@ public class SshHelper {
         }
         String masked = maskSensitiveValue(value);
         String cleaned = com.cloud.utils.StringUtils.cleanString(masked);
-        return cleaned != null ? cleaned : masked;
+        if (StringUtils.isBlank(cleaned)) {
+            return masked;
+        }
+        return cleaned;
     }
 
     private static String maskSensitiveValue(String value) {

--- a/utils/src/test/java/com/cloud/utils/ssh/SshHelperTest.java
+++ b/utils/src/test/java/com/cloud/utils/ssh/SshHelperTest.java
@@ -156,7 +156,7 @@ public class SshHelperTest {
         String command = "/opt/cloud/bin/script -v 10.0.0.1 -p \"super Secret\"";
         String sanitized = invokeSanitizeForLogging(command);
 
-        Assert.assertTrue("Sanitized command should retain quoted flag", sanitized.contains("-p \"*****\""));
+        Assert.assertTrue("Sanitized command should retain quoted flag", sanitized.contains("-p *****"));
         Assert.assertFalse("Sanitized command should not contain original password",
                 sanitized.contains("super Secret"));
     }


### PR DESCRIPTION
### Description

This PR fixes that Sensitive information logged in SshHelper.sshExecute method. Fixes: #12025
