### PR TITLE
Avoid unnecessary SSH key regeneration

### DIFF
--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -616,7 +616,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             }
             // FIXME: take a global database lock here for safety.
             boolean onWindows = isOnWindows();
-            if(!onWindows) {
+            if (!onWindows && !(privkeyfile.exists() && pubkeyfile.exists())) {
                 Script.runSimpleBashScript("if [ -f " + privkeyfile + " ]; then rm -f " + privkeyfile + "; fi; ssh-keygen -t ecdsa -m PEM -N '' -f " + privkeyfile + " -q 2>/dev/null || ssh-keygen -t ecdsa -N '' -f " + privkeyfile + " -q");
             }
 


### PR DESCRIPTION
### Description

This PR addresses an issue https://github.com/apache/cloudstack/issues/12055 where SSH keys were being unnecessarily regenerated, even when valid keys already existed on disk.

When both the public and private key files are present at the expected file paths but missing from the database, CloudStack will now reuse the existing keys on disk instead of regenerating them. The existing keys are injected into the database, ensuring consistency without overwriting the  configured keys.


### Impact

Prevents loss of existing SSH keys in environments.
Ensures smoother setup by reusing valid keys already present on disk.
No impact on normal operation or production deployments.



<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Verified behavior in single node MS  with pre-existing SSH key files but no DB entries.
Confirmed that no new keys are generated and the existing keys are properly persisted in the database.

### Before Fix 

<img width="2027" height="1085" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/ea2969c4-4ee0-4319-b754-ba89585c2163" />
<img width="2027" height="1085" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/8946ad9e-634f-4ece-bbb8-de54ef784d89" />
<img width="2032" height="1100" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/d16b031e-7d50-47c4-b67a-67c3008c06ce" />


### After Fix 

<img width="2032" height="1099" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/cf3179de-72a6-429e-b01f-8f30f50094c6" />








<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
