### PR TITLE
Fix: proper permissions for systemvm template registrations on hardened systems

### DIFF
--- a/scripts/storage/secondary/cloud-install-sys-tmplt
+++ b/scripts/storage/secondary/cloud-install-sys-tmplt
@@ -44,6 +44,7 @@ failed() {
 }
 
 #set -x
+umask 0022 # ensure we have the proper permissions even on hardened deployments
 mflag=
 fflag=
 ext="vhd"

--- a/scripts/storage/secondary/setup-sysvm-tmplt
+++ b/scripts/storage/secondary/setup-sysvm-tmplt
@@ -19,6 +19,7 @@
 
 # Usage: e.g. failed $? "this is an error"
 set -x
+umask 0022 # ensure we have the proper permissions even on hardened deployments
 
 failed() {
   local returnval=$1


### PR DESCRIPTION
### Description

Related to https://github.com/apache/cloudstack/issues/10029#issuecomment-2531599607

We have umask 0077 (via `/etc/login.defs`) on our hardened systems, so cloud-install-sys-tmplt is creating by default paths like below

```
$ ls -l /mnt/secondary/template/tmpl/
total 16
drwx------. 3 root root 4096 Nov 19 13:58 1
drwxrwxrwx. 7 root root 4096 Oct 31 09:42 2
drwxrwxrwx. 3 root root 4096 Oct 30 15:59 4
drwxr-xr-x. 2 root root 4096 Oct 31 10:21 5
$ ls -l /mnt/secondary/template/tmpl/1/
total 4
drwx------. 2 root root 4096 Nov 19 13:59 3
$ ls -l /mnt/secondary/template/tmpl/1/3/
total 549848
-rw-------. 1 root root 563032576 Nov 19 13:59 d23a1e19-c563-4f69-85ca-8721cf02082c.qcow2
-rw-------. 1 root root       287 Nov 19 13:59 template.properties
```

This results to the permissions problems later on, when trying to access the image.

`setup-sysvm-tmplt` needs that change most likely too, as this script is [called by cloudstack java code](https://github.com/apache/cloudstack/blob/6dc259c7dab7bee0c4ff731271c61e2f2ee97532/engine/schema/src/main/java/com/cloud/upgrade/SystemVmTemplateRegistration.java#L688) for systemvm image deployment

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I changed the files on my test deployment, removed everything on the secondary storage and reimported the systemvmimage

#### How did you try to break this feature and the system with this change?

It shouldn't break something, as umask 0022 is the common default umask and here it's valid only for the scope of executed script
