### PR TITLE
Fix/prometheus metadata sorting

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -664,8 +664,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         int isDedicated;
         String hosttags;
 
-        public ItemVMCore(final String zn, final String zu, final String hn, final String hu, final String hip,
-                          final String fl, final Long cr, final int dedicated, final String tags) {
+        public ItemVMCore(final String zn, final String zu, final String hn, final String hu, final String hip, final String fl, final Long cr, final int dedicated, final String tags) {
             super("cloudstack_host_vms_cores_total",
                   "Total number of VM cores on hosts",
                   "gauge");


### PR DESCRIPTION
### Description

This PR adds Prometheus metadata to all metrics types. Therefor Prometheus can include the TYPE and HELP information when scraping the endpoint.

See more details in #12110.

Fixes: #12110

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I've tested the code change with a simplistic setup (didn't got all running,  @abh1sar could you test it together more fully with your extra Prometheus metrics as my dev environment is still not working correctly)
I've successfully seen that the TYPE and HELP information is added to the nicely sorted list of metrics the exporter provides.

#### How did you try to break this feature and the system with this change?

I've enabled the Prometheus exporter and queried the endpoint multiple times to see the data came out like this:
```
# Cloudstack Prometheus Metrics
# HELP cloudstack_domain_limit_cpu_cores_total Total CPU core limit across all domains
# TYPE cloudstack_domain_limit_cpu_cores_total gauge
cloudstack_domain_limit_cpu_cores_total 0
# HELP cloudstack_domain_limit_memory_mibs_total Total memory limit in MiB across all domains
# TYPE cloudstack_domain_limit_memory_mibs_total gauge
cloudstack_domain_limit_memory_mibs_total 0
# HELP cloudstack_domain_resource_count Resource usage count per domain
# TYPE cloudstack_domain_resource_count gauge
cloudstack_domain_resource_count{domain="/", type="memory"} 0
cloudstack_domain_resource_count{domain="/", type="cpu"} 0
cloudstack_domain_resource_count{domain="/", type="gpu"} 0
cloudstack_domain_resource_count{domain="/", type="primary_storage"} 0
```
