### PR TITLE
Show volume UUIDs in the backup details page

### DIFF
--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -65,7 +65,7 @@
           <div v-else-if="$route.meta.name === 'backup' && item === 'volumes'">
             <div v-for="(volume, idx) in JSON.parse(dataResource[item])" :key="idx">
               <router-link v-if="!dataResource['vmbackupofferingremoved']" :to="{ path: '/volume/' + volume.uuid }">{{ volume.type }} - {{ volume.uuid }}</router-link>
-              <span v-else>{{ volume.type }} - {{ volume.path }}</span> ({{ parseFloat(volume.size / (1024.0 * 1024.0 * 1024.0)).toFixed(1) }} GB)
+              <span v-else>{{ volume.type }} - {{ volume.uuid }}</span> ({{ parseFloat(volume.size / (1024.0 * 1024.0 * 1024.0)).toFixed(1) }} GB)
             </div>
           </div>
           <div v-else-if="$route.meta.name === 'computeoffering' && item === 'rootdisksize'">


### PR DESCRIPTION
### Description

When accessing the details of a backup in the UI, all the volumes that are part of the backup are listed. However, the listing displays a UUID that does not identify the volume, but it's path in the storage, which can cause confusion for users. This PR changed the listing details to display the UUID of the volumes.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details> <summary> Backup volumes before changes: </summary>

Volume path:
<img width="955" height="590" alt="image" src="https://github.com/user-attachments/assets/884eb09f-8b0a-4904-ac5a-aeaf350f69ac" />

Backup volume:
<img width="963" height="159" alt="image" src="https://github.com/user-attachments/assets/b2d919a1-f5da-4b3b-b082-b98c85e25ce6" />

</details>

<details> <summary> Backup volumes after changes: </summary>

Volume path:
<img width="955" height="590" alt="image" src="https://github.com/user-attachments/assets/884eb09f-8b0a-4904-ac5a-aeaf350f69ac" />

Backup volume:
<img width="963" height="159" alt="image" src="https://github.com/user-attachments/assets/a7ffac40-bb18-440a-b9c6-9b74c89230af" />

</details>

### How Has This Been Tested?

I created a VM to perform the tests and assigned it a backup offering. After that I created a backup and verified that the volumes UUID had been changed to their respective UUID in the backup details.

#### How did you try to break this feature and the system with this change?