### PR TITLE
Fix API deleteTrafficType not filtering physical network II

### DIFF
--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
@@ -598,7 +598,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
     public List<NetworkVO> listByPhysicalNetworkTrafficType(final long physicalNetworkId, final TrafficType trafficType) {
         final SearchCriteria<NetworkVO> sc = AllFieldsSearch.create();
         sc.setParameters("trafficType", trafficType);
-        sc.setParameters("physicalNetwork", physicalNetworkId);
+        sc.setParameters("physicalNetworkId", physicalNetworkId);
         return listBy(sc);
     }
 

--- a/engine/schema/src/test/java/com/cloud/network/dao/NetworkDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/network/dao/NetworkDaoImplTest.java
@@ -22,14 +22,12 @@ package com.cloud.network.dao;
 import com.cloud.network.Networks;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
-import com.cloud.utils.db.TransactionLegacy;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
 
 import java.util.List;
 
@@ -46,26 +44,21 @@ public class NetworkDaoImplTest {
     List<NetworkVO> listNetworkVoMock;
 
     @Test
-    public void listByPhysicalNetworkTrafficTypeTestSetParametersValidation() throws Exception {
+    public void listByPhysicalNetworkTrafficTypeTestSetParametersValidation() {
         NetworkDaoImpl networkDaoImplSpy = Mockito.spy(NetworkDaoImpl.class);
-        TransactionLegacy txn = TransactionLegacy.open("runNetworkDaoImplTest");
-        try {
-            networkDaoImplSpy.AllFieldsSearch = searchBuilderNetworkVoMock;
-            Mockito.doReturn(searchCriteriaNetworkVoMock).when(searchBuilderNetworkVoMock).create();
-            Mockito.doNothing().when(searchCriteriaNetworkVoMock).setParameters(Mockito.anyString(), Mockito.any());
-            Mockito.doReturn(listNetworkVoMock).when(networkDaoImplSpy).listBy(Mockito.any(SearchCriteria.class));
+        networkDaoImplSpy.AllFieldsSearch = searchBuilderNetworkVoMock;
+        Mockito.doReturn(searchCriteriaNetworkVoMock).when(searchBuilderNetworkVoMock).create();
+        Mockito.doNothing().when(searchCriteriaNetworkVoMock).setParameters(Mockito.anyString(), Mockito.any());
+        Mockito.doReturn(listNetworkVoMock).when(networkDaoImplSpy).listBy(Mockito.any(SearchCriteria.class));
 
-            long expectedPhysicalNetwork = 2513l;
+        long expectedPhysicalNetwork = 2513l;
 
-            for (Networks.TrafficType trafficType : Networks.TrafficType.values()) {
-                List<NetworkVO> result = networkDaoImplSpy.listByPhysicalNetworkTrafficType(expectedPhysicalNetwork, trafficType);
-                Assert.assertEquals(listNetworkVoMock, result);
-                Mockito.verify(searchCriteriaNetworkVoMock).setParameters("trafficType", trafficType);
-            }
-
-            Mockito.verify(searchCriteriaNetworkVoMock, Mockito.times(Networks.TrafficType.values().length)).setParameters("physicalNetwork", expectedPhysicalNetwork);
-        } finally {
-            txn.close();
+        for (Networks.TrafficType trafficType : Networks.TrafficType.values()) {
+            List<NetworkVO> result = networkDaoImplSpy.listByPhysicalNetworkTrafficType(expectedPhysicalNetwork, trafficType);
+            Assert.assertEquals(listNetworkVoMock, result);
+            Mockito.verify(searchCriteriaNetworkVoMock).setParameters("trafficType", trafficType);
         }
+
+        Mockito.verify(searchCriteriaNetworkVoMock, Mockito.times(Networks.TrafficType.values().length)).setParameters("physicalNetworkId", expectedPhysicalNetwork);
     }
 }


### PR DESCRIPTION
### Description

While deleting a traffic type, ACS checks whether there are any networks associated with it. However, if we have several physical networks containing a traffic type, ACS does not filter the physical network to do the validation. For instance, if we have two (2) physical networks containing the traffic type `Guest`, the first one having networks related to it, and the second not having networks related to it, if we try to remove the traffic type `Guest` from the second physical network, ACS give us the message `The Traffic Type is not deletable because there are existing networks with this traffic type:Guest`.

The API `deleteTrafficType` was designed to filter the physical network where the traffic type is, however, the filtering is not applied correctly. This PR intends to fix this typo to honor the API behavior. This bug was fixed once with #6510; however, it was reintroduced with #6781. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### How Has This Been Tested?

To test the fix, I executed the following steps on an advanced zone:

- create 2 physical networks (`A` and `B`);
- add the `Guest` traffic type in physical network `A`;
- create a network and a VM on the network;
- add the `Guest` traffic type in physical network `B`.

Without the changes, I tried to remove the `Guest` traffic type from physical networks `A` and `B`; for both, ACS returned the error message `The Traffic Type is not deletable because there are existing networks with this traffic type:Guest`. 

With the changes, I tried to remove the `Guest` traffic type from physical networks `A` and `B`; for `A`, ACS returned the error message `The Traffic Type is not deletable because there are existing networks with this traffic type:Guest`; for `B`, it was removed correctly. 
