### PR TITLE
Fix lscpu speed checking order

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
@@ -140,21 +140,21 @@ public class KVMHostInfo {
         long speed = 0L;
         LOGGER.info("Fetching CPU speed from command \"lscpu\".");
         try {
-            String command = "lscpu | grep -i 'Model name' | head -n 1 | grep -E -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
-            if(isHostS390x()) {
-                command = "lscpu | grep 'CPU dynamic MHz' | cut -d ':' -f 2 | tr -d ' ' | awk '{printf \"%.1f\\n\", $1 / 1000}'";
-            }
+            String command = "lscpu | grep -i 'CPU max MHz' | head -n 1 | sed 's/^.*: //' | xargs";
             String result = Script.runSimpleBashScript(command);
-            speed = (long) (Float.parseFloat(result) * 1000);
+            speed = (long) (Float.parseFloat(result));
             LOGGER.info(String.format("Command [%s] resulted in the value [%s] for CPU speed.", command, speed));
             return speed;
         } catch (NullPointerException | NumberFormatException e) {
             LOGGER.error(String.format("Unable to retrieve the CPU speed from lscpu."), e);
         }
         try {
-            String command = "lscpu | grep -i 'CPU max MHz' | head -n 1 | sed 's/^.*: //' | xargs";
+            String command = "lscpu | grep -i 'Model name' | head -n 1 | grep -E -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
+            if(isHostS390x()) {
+                command = "lscpu | grep 'CPU dynamic MHz' | cut -d ':' -f 2 | tr -d ' ' | awk '{printf \"%.1f\\n\", $1 / 1000}'";
+            }
             String result = Script.runSimpleBashScript(command);
-            speed = (long) (Float.parseFloat(result));
+            speed = (long) (Float.parseFloat(result) * 1000);
             LOGGER.info(String.format("Command [%s] resulted in the value [%s] for CPU speed.", command, speed));
             return speed;
         } catch (NullPointerException | NumberFormatException e) {

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
@@ -140,21 +140,21 @@ public class KVMHostInfo {
         long speed = 0L;
         LOGGER.info("Fetching CPU speed from command \"lscpu\".");
         try {
-            String command = "lscpu | grep -i 'Model name' | head -n 1 | egrep -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
-            if(isHostS390x()) {
-                command = "lscpu | grep 'CPU dynamic MHz' | cut -d ':' -f 2 | tr -d ' ' | awk '{printf \"%.1f\\n\", $1 / 1000}'";
-            }
+            String command = "lscpu | grep -i 'CPU max MHz' | head -n 1 | sed 's/^.*: //' | xargs";
             String result = Script.runSimpleBashScript(command);
-            speed = (long) (Float.parseFloat(result) * 1000);
+            speed = (long) (Float.parseFloat(result));
             LOGGER.info(String.format("Command [%s] resulted in the value [%s] for CPU speed.", command, speed));
             return speed;
         } catch (NullPointerException | NumberFormatException e) {
             LOGGER.error(String.format("Unable to retrieve the CPU speed from lscpu."), e);
         }
         try {
-            String command = "lscpu | grep -i 'CPU max MHz' | head -n 1 | sed 's/^.*: //' | xargs";
+            String command = "lscpu | grep -i 'Model name' | head -n 1 | egrep -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
+            if(isHostS390x()) {
+                command = "lscpu | grep 'CPU dynamic MHz' | cut -d ':' -f 2 | tr -d ' ' | awk '{printf \"%.1f\\n\", $1 / 1000}'";
+            }
             String result = Script.runSimpleBashScript(command);
-            speed = (long) (Float.parseFloat(result));
+            speed = (long) (Float.parseFloat(result) * 1000);
             LOGGER.info(String.format("Command [%s] resulted in the value [%s] for CPU speed.", command, speed));
             return speed;
         } catch (NullPointerException | NumberFormatException e) {


### PR DESCRIPTION
### Description

On KVM hosts, when agent checks the CPU speed it starts from lscpu before other mechanisms. It does a first check obtaining the CPU frequency from Model Name and if it's not specified in model name it takes from dynamic MHz option.

Dynamic MHz and frequency specified in model name can be different. Normally, dynamic MHz is bigger if the model name specifies. This means that we can have a registered host in CloudStack with a smaller frequency that it can achieve.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

The following host has been registered with a frequency of 2.4Ghz, which can achieve 3.4GHz. Here the commands that executes the `KVMHostInfo.java`:

<img width="1107" height="142" alt="imatge" src="https://github.com/user-attachments/assets/0efc3d9b-5f93-4e8d-bb29-5a77a144c15d" />


### How Has This Been Tested?

Overriding the lscpu command as the following and restarting the cloudstack agent shows the hosts in CloudStack control plane with the right frequency:

```
sudo mv /usr/bin/lscpu /usr/bin/lscpu.real
sudo tee /usr/bin/lscpu >/dev/null << 'EOF'
#!/bin/bash
# Wrapper per lscpu: elimina la freqüència del Model name
/usr/bin/lscpu.real "$@" | sed -E 's/(Model name:\s+.*)@ [0-9.]+[GM]Hz/\1/'
EOF

sudo chmod +x /usr/bin/lscpu
```
