### PR TITLE
fixed label for aclname

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -44,6 +44,7 @@
 "label.accounttype": "Account type",
 "label.acl.export": "Export ACL rules",
 "label.acl.id": "ACL ID",
+"label.aclname": "ACL Name",
 "label.acl.rules": "ACL rules",
 "label.acl.reason.description": "Enter the reason behind an ACL rule.",
 "label.aclid": "ACL",


### PR DESCRIPTION
This pr fix the label issue

Create a vpc tier and associate a acl rule to it and check the network details

Before the fix 

<img width="611" height="161" alt="beforeacl" src="https://github.com/user-attachments/assets/afda0c1c-8714-443e-9ab4-80ea3a5dbeca" />


After fix 

<img width="667" height="90" alt="afteracl" src="https://github.com/user-attachments/assets/d8b337af-37b5-4b48-8e0c-6b00c103b804" />
