### PR TITLE
Ceph Object Store: Use "us-east-1" as the default signing region to avoid setting location constraint

### DIFF
--- a/plugins/storage/object/ceph/src/main/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImpl.java
+++ b/plugins/storage/object/ceph/src/main/java/org/apache/cloudstack/storage/datastore/driver/CephObjectStoreDriverImpl.java
@@ -350,7 +350,7 @@ public class CephObjectStoreDriverImpl extends BaseObjectStoreDriverImpl {
                         new AWSStaticCredentialsProvider(
                                 new BasicAWSCredentials(accessKey, secretKey)))
                 .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(url, null))
+                        new AwsClientBuilder.EndpointConfiguration(url, "us-east-1"))
                 .build();
 
         if (client == null) {


### PR DESCRIPTION
### Description

Fixes #12130 

```
        AmazonS3 client = AmazonS3ClientBuilder.standard()
                .enablePathStyleAccess()
                .withCredentials(
                        new AWSStaticCredentialsProvider(
                                new BasicAWSCredentials(accessKey, secretKey)))
                .withEndpointConfiguration(
                        new AwsClientBuilder.EndpointConfiguration(url, "auto"))
                .build();
```

Using **"auto"** as the signingRegion in AwsClientBuilder forces the s3 client to infer region from the url and set it as LocationConstraint while sending the request which is not required for ceph and causes the issue ` The specified location-constraint is not valid`

In PR https://github.com/apache/cloudstack/pull/10772, the signing_region was changed to **null** which avoids setting location constraint for some endpoints but not all.
Setting the signing_region as "us-east-1" fixes it for all endpoints as the AWSClient SDK treats "us-east-1" as default and doesn't set any location constraints.

The table below describes what happens to createBucket with different endpoints and signing_regions.


| signing_region →<br>endpoint ↓    | "auto" | null | "us-east-1" |
|--------------------------------|------|------|-----------|
| s3.amazonaws.com               | error| pass | pass      |
| s3.us-east-1.amazonaws.com     | error| pass | pass      |
| s3.testdomain.com              | error| error| pass      |
| s3.us-east-1.testdomain.com    | error| pass | pass      |
| test.testdomain.com            | pass | pass | pass      |
| s3.amazonaws.testdomain.com    | error| error| pass      |
| s3.testdomain.amazonaws.com    | error| error| pass      |

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested  createBucket with different endpoints and signing_regions.


| signing_region →<br>endpoint ↓    | "auto" | null | "us-east-1" |
|--------------------------------|------|------|-----------|
| s3.amazonaws.com               | error| pass | pass      |
| s3.us-east-1.amazonaws.com     | error| pass | pass      |
| s3.testdomain.com              | error| error| pass      |
| s3.us-east-1.testdomain.com    | error| pass | pass      |
| test.testdomain.com            | pass | pass | pass      |
| s3.amazonaws.testdomain.com    | error| error| pass      |
| s3.testdomain.amazonaws.com    | error| error| pass      |

Tested other bucket lifecycles as well.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
