### PR TITLE
linstor: Provide /dev/drbd/by-res/ resource paths to CloudStack

### DIFF
--- a/plugins/storage/volume/linstor/CHANGELOG.md
+++ b/plugins/storage/volume/linstor/CHANGELOG.md
@@ -5,22 +5,24 @@ All notable changes to Linstor CloudStack plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-12-18]
+
+### Changed
+- Provide /dev/drbd/by-res/ resource paths to CloudStack for usage.
+
 ## [2025-10-03]
 
 ### Changed
-
 - Revert qcow2 snapshot now use sparse/discard options to convert on thin devices.
 
 ## [2025-08-05]
 
 ### Fixed
-
 - getVolumeStats wasn't correctly working if multiple Linstor clusters/primary storages are used.
 
 ## [2025-07-01]
 
 ### Fixed
-
 - Regression in 4.19.3 and 4.21.0 with templates from snapshots
 
 ## [2025-05-07]
@@ -31,25 +33,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2025-03-13]
 
 ### Fixed
-
 - Implemented missing delete datastore, to correctly cleanup on datastore removal
 
 ## [2025-02-21]
 
 ### Fixed
-
 - Always try to delete cs-...-rst resource before doing a snapshot backup
 
 ## [2025-01-27]
 
 ### Fixed
-
 - Use of multiple primary storages on the same linstor controller
 
 ## [2025-01-20]
 
 ### Fixed
-
 - Volume snapshots on zfs used the wrong dataset path to hide/unhide snapdev
 
 ## [2024-12-19]
@@ -60,13 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2024-12-13]
 
 ### Fixed
-
 - Linstor heartbeat check now also ask linstor-controller if there is no connection between nodes
 
 ## [2024-12-11]
 
 ### Fixed
-
 - Only set allow-two-primaries if a live migration is performed
 
 ## [2024-10-28]
@@ -79,17 +75,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2024-10-14]
 
 ### Added
-
 - Support for ISO direct download to primary storage
 
 ## [2024-10-04]
 
 ### Added
-
 - Enable qemu discard="unmap" for Linstor block disks
 
 ## [2024-08-27]
 
 ### Changed
-
 - Allow two primaries(+protocol c) is now set on resource-connection level instead of rd

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -232,7 +232,7 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
             makeResourceAvailable(api, foundRscName, false);
 
             if (!resources.isEmpty() && !resources.get(0).getVolumes().isEmpty()) {
-                final String devPath = resources.get(0).getVolumes().get(0).getDevicePath();
+                final String devPath = LinstorUtil.getDevicePathFromResource(resources.get(0));
                 logger.info("Linstor: Created drbd device: " + devPath);
                 final KVMPhysicalDisk kvmDisk = new KVMPhysicalDisk(devPath, name, pool);
                 kvmDisk.setFormat(QemuImg.PhysicalDiskFormat.RAW);
@@ -455,8 +455,9 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
     private Optional<ResourceWithVolumes> getResourceByPathOrName(
             final List<ResourceWithVolumes> resources, String path) {
         return resources.stream()
-            .filter(rsc -> getLinstorRscName(path).equalsIgnoreCase(rsc.getName()) || rsc.getVolumes().stream()
-                .anyMatch(v -> path.equals(v.getDevicePath())))
+            .filter(rsc -> getLinstorRscName(path).equalsIgnoreCase(rsc.getName()) ||
+                    path.equals(LinstorUtil.formatDrbdByResDevicePath(rsc.getName())) ||
+                    rsc.getVolumes().stream().anyMatch(v -> path.equals(v.getDevicePath())))
             .findFirst();
     }
 


### PR DESCRIPTION
### Description

Instead of providing the very basic `/dev/drbd{minorNr}` drbd block device path provide the
by-res path, that also includes the cloudstack volume.path

Prerequisite for #12218

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Spun up a fresh Linstor cluster, and checked the new path is used in the libvirt xml

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
