### PR TITLE
CKS: Fix issue with scaling down CKS Nodes when deployed in HA mode

### DIFF
--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterScaleWorkerTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterScaleWorkerTest.java
@@ -17,8 +17,8 @@
 package com.cloud.kubernetes.cluster.actionworkers;
 
 import com.cloud.kubernetes.cluster.KubernetesCluster;
-import com.cloud.kubernetes.cluster.KubernetesClusterManagerImpl;
 import com.cloud.kubernetes.cluster.KubernetesClusterVmMapVO;
+import com.cloud.kubernetes.cluster.KubernetesClusterManagerImpl;
 import com.cloud.kubernetes.cluster.dao.KubernetesClusterVmMapDao;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.service.ServiceOfferingVO;
@@ -29,15 +29,17 @@ import com.cloud.vm.dao.UserVmDao;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Arrays;
 import java.util.List;
 
-import static com.cloud.kubernetes.cluster.KubernetesServiceHelper.KubernetesClusterNodeType.DEFAULT;
 import static com.cloud.kubernetes.cluster.KubernetesServiceHelper.KubernetesClusterNodeType.CONTROL;
+import static com.cloud.kubernetes.cluster.KubernetesServiceHelper.KubernetesClusterNodeType.DEFAULT;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesClusterScaleWorkerTest {
@@ -124,5 +126,65 @@ public class KubernetesClusterScaleWorkerTest {
         long expectedMemory = remainingClusterMemory + (controlNodes * newMemory);
         Assert.assertEquals(expectedCores, newClusterCapacity.first().longValue());
         Assert.assertEquals(expectedMemory, newClusterCapacity.second().longValue());
+    }
+
+
+    @Test
+    public void testGetWorkerNodesToRemoveForDownsize_singleRemoval() {
+        KubernetesCluster kubernetesCluster = Mockito.mock(KubernetesCluster.class);
+        KubernetesClusterManagerImpl clusterManager = Mockito.mock(KubernetesClusterManagerImpl.class);
+        KubernetesClusterScaleWorker worker = new KubernetesClusterScaleWorker(kubernetesCluster, new java.util.HashMap<>(), 2L, null, false, null, null, clusterManager);
+        KubernetesClusterScaleWorker spyWorker = Mockito.spy(worker);
+
+        KubernetesClusterVmMapVO vm1 = Mockito.mock(KubernetesClusterVmMapVO.class);
+        Mockito.when(vm1.isExternalNode()).thenReturn(false);
+        Mockito.when(vm1.isControlNode()).thenReturn(false);
+        Mockito.when(vm1.isEtcdNode()).thenReturn(false);
+
+        KubernetesClusterVmMapVO vm2 = Mockito.mock(KubernetesClusterVmMapVO.class);
+        Mockito.when(vm2.isExternalNode()).thenReturn(false);
+        Mockito.when(vm2.isControlNode()).thenReturn(false);
+        Mockito.when(vm2.isEtcdNode()).thenReturn(false);
+
+        KubernetesClusterVmMapVO vm3 = Mockito.mock(KubernetesClusterVmMapVO.class);
+        Mockito.when(vm3.isExternalNode()).thenReturn(false);
+        Mockito.when(vm3.isControlNode()).thenReturn(false);
+        Mockito.when(vm3.isEtcdNode()).thenReturn(false);
+
+        Mockito.doReturn(Arrays.asList(vm1, vm2, vm3)).when(spyWorker).getKubernetesClusterVMMaps();
+
+        List<KubernetesClusterVmMapVO> toRemove = spyWorker.getWorkerNodesToRemove();
+
+        Assert.assertEquals(1, toRemove.size());
+        Assert.assertSame(vm3, toRemove.get(0));
+    }
+
+    @Test
+    public void testGetWorkerNodesToRemoveForDownsize_noRemoval() {
+        KubernetesCluster kubernetesCluster = Mockito.mock(KubernetesCluster.class);
+
+        KubernetesClusterScaleWorker worker = new KubernetesClusterScaleWorker(kubernetesCluster, new java.util.HashMap<>(), 3L, null, false, null, null, clusterManager);
+        KubernetesClusterScaleWorker spyWorker = Mockito.spy(worker);
+
+        KubernetesClusterVmMapVO vm1 = Mockito.mock(KubernetesClusterVmMapVO.class);
+        Mockito.when(vm1.isExternalNode()).thenReturn(false);
+        Mockito.when(vm1.isControlNode()).thenReturn(false);
+        Mockito.when(vm1.isEtcdNode()).thenReturn(false);
+
+        KubernetesClusterVmMapVO vm2 = Mockito.mock(KubernetesClusterVmMapVO.class);
+        Mockito.when(vm2.isExternalNode()).thenReturn(false);
+        Mockito.when(vm2.isControlNode()).thenReturn(false);
+        Mockito.when(vm2.isEtcdNode()).thenReturn(false);
+
+        KubernetesClusterVmMapVO vm3 = Mockito.mock(KubernetesClusterVmMapVO.class);
+        Mockito.when(vm3.isExternalNode()).thenReturn(false);
+        Mockito.when(vm3.isControlNode()).thenReturn(false);
+        Mockito.when(vm3.isEtcdNode()).thenReturn(false);
+
+        Mockito.doReturn(Arrays.asList(vm1, vm2, vm3)).when(spyWorker).getKubernetesClusterVMMaps();
+
+        List<KubernetesClusterVmMapVO> toRemove = spyWorker.getWorkerNodesToRemove();
+
+        Assert.assertTrue(toRemove.isEmpty());
     }
 }


### PR DESCRIPTION
### Description

This PR fixes: #12229 
Fixes issue when scaling down k8s clusters deployed in HA mode - indexing issue encountered.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale
#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
