### PR TITLE
Replace deprecated 'egrep' commands with 'grep -E'.

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/KVMHostInfo.java
@@ -140,7 +140,7 @@ public class KVMHostInfo {
         long speed = 0L;
         LOGGER.info("Fetching CPU speed from command \"lscpu\".");
         try {
-            String command = "lscpu | grep -i 'Model name' | head -n 1 | egrep -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
+            String command = "lscpu | grep -i 'Model name' | head -n 1 | grep -E -o '[[:digit:]].[[:digit:]]+GHz' | sed 's/GHz//g'";
             if(isHostS390x()) {
                 command = "lscpu | grep 'CPU dynamic MHz' | cut -d ':' -f 2 | tr -d ' ' | awk '{printf \"%.1f\\n\", $1 / 1000}'";
             }

--- a/plugins/hypervisors/ovm3/src/test/resources/scripts/clean_primary.sh
+++ b/plugins/hypervisors/ovm3/src/test/resources/scripts/clean_primary.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-for i in `xm list | awk '{ print $1 }' | egrep -v "Name|Domain-0"`
+for i in `xm list | awk '{ print $1 }' | grep -E -v "Name|Domain-0"`
 do
     xm destroy $i
 done

--- a/plugins/hypervisors/ovm3/src/test/resources/scripts/clean_secondary.sh
+++ b/plugins/hypervisors/ovm3/src/test/resources/scripts/clean_secondary.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-for i in `xm list | awk '{ print $1 }' | egrep -v "Name|Domain-0"`
+for i in `xm list | awk '{ print $1 }' | grep -E -v "Name|Domain-0"`
 do
     xm destroy $i
 done

--- a/scripts/storage/multipath/connectVolume.sh
+++ b/scripts/storage/multipath/connectVolume.sh
@@ -100,7 +100,7 @@ while true; do
 done
 
 echo "$(date): Doing a recan to make sure we have proper current size locally"
-for device in $(multipath -ll 3${WWID} | egrep '^  ' | awk '{print $2}'); do
+for device in $(multipath -ll 3${WWID} | grep -E '^  ' | awk '{print $2}'); do
     echo "1" > /sys/bus/scsi/drivers/sd/${device}/rescan;
 done
 

--- a/scripts/storage/multipath/resizeVolume.sh
+++ b/scripts/storage/multipath/resizeVolume.sh
@@ -51,7 +51,7 @@ systemctl is-active multipathd || systemctl restart multipathd || {
 
 logger -t "CS_SCSI_VOL_RESIZE" "${WWID} resizing disk path at /dev/mapper/3${WWID} STARTING"
 
-for device in $(multipath -ll 3${WWID} | egrep '^  ' | awk '{print $2}'); do
+for device in $(multipath -ll 3${WWID} | grep -E '^  ' | awk '{print $2}'); do
     echo "1" > /sys/bus/scsi/drivers/sd/${device}/rescan;
 done
 

--- a/scripts/util/keystore-setup
+++ b/scripts/util/keystore-setup
@@ -75,7 +75,7 @@ keytool -genkey -storepass "$KS_PASS" -keypass "$KS_PASS" -alias "$ALIAS" -keyal
 # Generate CSR
 $LOGGER_CMD "Generating CSR"
 [ -f "$CSR_FILE" ] && rm -f "$CSR_FILE"
-addresses=$(ip address | grep inet | awk '{print $2}' | sed 's/\/.*//g' | grep -v '^169.254.' | grep -v '^127.0.0.1' | egrep -v '^::1|^fe80' | grep -v '^::1' | sed 's/^/ip:/g' | tr '\r\n' ',')
+addresses=$(ip address | grep inet | awk '{print $2}' | sed 's/\/.*//g' | grep -v '^169.254.' | grep -v '^127.0.0.1' | grep -E -v '^::1|^fe80' | grep -v '^::1' | sed 's/^/ip:/g' | tr '\r\n' ',')
 $LOGGER_CMD "Found following SAN addresses to add to CSR: ${addresses}"
 keytool -certreq -storepass "$KS_PASS" -alias "$ALIAS" -file "$CSR_FILE" -keystore "$KS_FILE" -ext san="$addresses" 2>&1 | $LOGGER_CMD
 if [ $? -ne 0 ];then

--- a/scripts/vm/network/ovs-pvlan-kvm-vm.sh
+++ b/scripts/vm/network/ovs-pvlan-kvm-vm.sh
@@ -112,7 +112,7 @@ find_port_group() {
 }
 
 # try to find the physical link to outside, only supports eth and em prefix now
-trunk_port=`ovs-ofctl show $br | egrep "\((eth|em)[0-9]" | cut -d '(' -f 1|tr -d ' '`
+trunk_port=`ovs-ofctl show $br | grep -E "\((eth|em)[0-9]" | cut -d '(' -f 1|tr -d ' '`
 vm_port=$(find_port $vm_mac)
 
 # craft the vlan headers. Adding 4096 as in hex, it must be of the form 0x1XXX

--- a/scripts/vm/network/ovs-pvlan-vm.sh
+++ b/scripts/vm/network/ovs-pvlan-vm.sh
@@ -87,7 +87,7 @@ then
 fi
 
 # try to find the physical link to outside, only supports eth and em prefix now
-trunk_port=`ovs-ofctl show $br | egrep "\((eth|em)[0-9]" | cut -d '(' -f 1|tr -d ' '`
+trunk_port=`ovs-ofctl show $br | grep -E "\((eth|em)[0-9]" | cut -d '(' -f 1|tr -d ' '`
 
 if [ "$op" == "add" ]
 then

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -986,7 +986,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             double totalcpucap = 0;
             if (StringUtils.isEmpty(cpucaps)) {
                 String totalCpus = Script.runSimpleBashScript("nproc --all| tr '\\n' \" \"");
-                String maxCpuSpeed = Script.runSimpleBashScript("lscpu | egrep 'CPU max MHz' | head -1 | cut -f 2 -d : | tr -d ' '| tr '\\n' \" \"");
+                String maxCpuSpeed = Script.runSimpleBashScript("lscpu | grep -E 'CPU max MHz' | head -1 | cut -f 2 -d : | tr -d ' '| tr '\\n' \" \"");
                 if (StringUtils.isNotEmpty(totalCpus) && StringUtils.isNotEmpty(maxCpuSpeed)) {
                     totalcpucap = Double.parseDouble(totalCpus) * Double.parseDouble(maxCpuSpeed);
                 }

--- a/systemvm/agent/scripts/ssvm-check.sh
+++ b/systemvm/agent/scripts/ssvm-check.sh
@@ -41,7 +41,7 @@ isCifs() {
 
 # ping dns server
 echo ================================================
-DNSSERVER=`egrep '^nameserver' /etc/resolv.conf  | awk '{print $2}'| head -1`
+DNSSERVER=`grep -E '^nameserver' /etc/resolv.conf  | awk '{print $2}'| head -1`
 echo "First DNS server is " $DNSSERVER
 ping -c 2  $DNSSERVER
 if [ $? -eq 0 ]

--- a/systemvm/debian/opt/cloud/bin/update_interface_config.sh
+++ b/systemvm/debian/opt/cloud/bin/update_interface_config.sh
@@ -31,7 +31,7 @@ get_interface() {
   for i in `seq 1 $(($timeout))`
   do
     #inf=$(ip route list ${1}/${2} | awk '{print $3}')
-    inf=$(ip addr show|egrep '^ *inet'|grep ${1}/${2} |grep brd|awk -- '{ print $NF; }')
+    inf=$(ip addr show|grep -E '^ *inet'|grep ${1}/${2} |grep brd|awk -- '{ print $NF; }')
     if [ ! -z $inf ]; then
       echo $inf
       break

--- a/test/integration/component/test_multiple_subnets_in_isolated_network.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network.py
@@ -210,9 +210,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.logger.debug("Skip as redundant_state is %s" % redundant_state)
             return
         elif redundant_state == "PRIMARY":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state DOWN" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state DOWN" |wc -l' % publicNics
         elif redundant_state == "BACKUP":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state UP" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state UP" |wc -l' % publicNics
         result = get_process_status(
             host.ipaddress,
             host.port,

--- a/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_isolated_network_rvr.py
@@ -210,9 +210,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.logger.debug("Skip as redundant_state is %s" % redundant_state)
             return
         elif redundant_state == "PRIMARY":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state DOWN" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state DOWN" |wc -l' % publicNics
         elif redundant_state == "BACKUP":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state UP" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state UP" |wc -l' % publicNics
         result = get_process_status(
             host.ipaddress,
             host.port,

--- a/test/integration/component/test_multiple_subnets_in_vpc.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc.py
@@ -214,9 +214,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.logger.debug("Skip as redundant_state is %s" % redundant_state)
             return
         elif redundant_state == "PRIMARY":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state DOWN" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state DOWN" |wc -l' % publicNics
         elif redundant_state == "BACKUP":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state UP" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state UP" |wc -l' % publicNics
         result = get_process_status(
             host.ipaddress,
             host.port,

--- a/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
+++ b/test/integration/component/test_multiple_subnets_in_vpc_rvr.py
@@ -214,9 +214,9 @@ class TestMultiplePublicIpSubnets(cloudstackTestCase):
             self.logger.debug("Skip as redundant_state is %s" % redundant_state)
             return
         elif redundant_state == "PRIMARY":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state DOWN" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state DOWN" |wc -l' % publicNics
         elif redundant_state == "BACKUP":
-            command = 'ip link show |grep BROADCAST | egrep "%s" |grep "state UP" |wc -l' % publicNics
+            command = 'ip link show |grep BROADCAST | grep -E "%s" |grep "state UP" |wc -l' % publicNics
         result = get_process_status(
             host.ipaddress,
             host.port,


### PR DESCRIPTION
### Description

This PR changes several instances where the deprecated `egrep` command is used in stead of `grep -E`.

There should be no functional difference between the two forms of this command.

In (at least) EL10 the usage of de deprecated form leads to errors like:
```
2025-12-19 09:31:26,588 ERROR [utils.linux.KVMHostInfo] (Agent-Handler-1:[]) (logid:) Unable to retrieve the CPU speed from lscpu. java.lang.NumberFormatException: For input string: "egrep: warning: egrep is obsolescent; using grep -E"
        at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(Unknown Source)
        at java.base/jdk.internal.math.FloatingDecimal.parseFloat(Unknown Source)
        at java.base/java.lang.Float.parseFloat(Unknown Source)
        at org.apache.cloudstack.utils.linux.KVMHostInfo.getCpuSpeedFromCommandLscpu(KVMHostInfo.java:148)
        at org.apache.cloudstack.utils.linux.KVMHostInfo.getCpuSpeed(KVMHostInfo.java:119)
        at org.apache.cloudstack.utils.linux.KVMHostInfo.getHostInfoFromLibvirt(KVMHostInfo.java:214)
        at org.apache.cloudstack.utils.linux.KVMHostInfo.<init>(KVMHostInfo.java:68)
        at com.cloud.hypervisor.kvm.resource.LibvirtComputingResource.initialize(LibvirtComputingResource.java:4167)
        at com.cloud.agent.Agent.sendStartup(Agent.java:556)
        at com.cloud.agent.Agent$ServerHandler.doTask(Agent.java:1314)
        at com.cloud.utils.nio.Task.call(Task.java:83)
        at com.cloud.utils.nio.Task.call(Task.java:29)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)

```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
Trivial change, there is no functional difference between `egrep` and `grep -E`.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
