### PR TITLE
Add 'dataDiskController' VM setting/detail for KVM hypervisor

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -5061,6 +5061,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             options.put(VmDetailConstants.CPU_THREAD_PER_CORE, Collections.emptyList());
             options.put(VmDetailConstants.NIC_ADAPTER, Arrays.asList("e1000", "virtio", "rtl8139", "vmxnet3", "ne2k_pci"));
             options.put(VmDetailConstants.ROOT_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio", "virtio-blk"));
+            options.put(VmDetailConstants.DATA_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio", "virtio-blk"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
             options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
             options.put(VmDetailConstants.IO_POLICY, Arrays.asList("threads", "native", "io_uring", "storage_specific"));


### PR DESCRIPTION
### Description

This PR add 'dataDiskController' VM setting/detail for KVM hypervisor.

'dataDiskController' VM setting support added to KVM in 4.16.0, here: https://github.com/apache/cloudstack/pull/4569, but the option is not included in the VM settings shown for KVM hypervisor.

https://github.com/apache/cloudstack/blob/b394b5ba74e01b6b82580fc0152e676e5e4c16d0/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java#L4336-L4353

Fixes #12327 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Able to set dataDiskController setting for VM on KVM hypervisor.

<img width="1243" height="780" alt="VM_Setting_dataDiskController_options_KVM" src="https://github.com/user-attachments/assets/7876de13-fb4f-4d6e-9a4d-877973968a93" />

<img width="1207" height="767" alt="VM_Setting_dataDiskController-scsi_KVM" src="https://github.com/user-attachments/assets/fc1daa75-ef4a-4658-a4ca-863654e10e04" />

```
# virsh dumpxml i-2-3-VM 
<domain type='kvm' id='7'>
  <name>i-2-3-VM</name>
  <uuid>1b2491bb-7589-44a8-864c-c176422adf5d</uuid>
...
  <devices>
    <emulator>/usr/libexec/qemu-kvm</emulator>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/4d215758-18a9-335e-8c9d-ecb4d19c9d94/e6149bbd-9025-4692-b03e-520c0fddd249' index='3'/>
      <backingStore type='file' index='4'>
        <format type='qcow2'/>
        <source file='/mnt/4d215758-18a9-335e-8c9d-ecb4d19c9d94/f6e89dbd-e0a4-11f0-846d-1e00ea0001ad'/>
        <backingStore/>
      </backingStore>
      <target dev='vda' bus='virtio'/>
      <serial>e6149bbd90254692b03e</serial>
      <alias name='virtio-disk0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/4d215758-18a9-335e-8c9d-ecb4d19c9d94/14118dd4-66f9-4fee-95a8-85c5c92690d1' index='2'/>
      <backingStore/>
      <target dev='sdb' bus='scsi'/>
      <serial>14118dd466f94fee95a8</serial>
      <alias name='scsi0-0-0-1'/>
      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
    </disk>
...    
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
