### PR TITLE
Change migration volume exception messages

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2187,7 +2187,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     throw new CloudRuntimeException("Change offering for the volume failed.");
                 }
             } catch (Exception e) {
-                logger.error("Volume change offering operation failed for volume ID: {} migration failed to storage pool {} due to {}", volumeUuid, suitableStoragePools.get(0).getId(), e.getMessage());
+                logger.error("Volume change offering operation failed for volume ID: {} migration failed to storage pool {} due to {}", volumeUuid, suitableStoragePoolsWithEnoughSpace.get(0).getId(), e.getMessage());
                 throw new CloudRuntimeException("Change offering for the volume failed.", e);
             }
         }


### PR DESCRIPTION
### Description

Currently, when performing volume migration operations, an exception message exposing infrastructure information may be shown. Changes have been made to this message in order to hide infrastructure information from end users.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details>
<summary> Exception displayed for users before the changes </summary>

<img width="392" height="336" alt="image" src="https://github.com/user-attachments/assets/7c9cd771-0068-44e7-9b00-d6b0f057073e" />

</details>

<details>
<summary> Exception displayed for users after the changes </summary>

<img width="460" height="152" alt="image" src="https://github.com/user-attachments/assets/5a517660-42a6-4ae1-ae37-6f7f086e27ba" />

</details>

<details>
<summary> Log messages </summary>

<img width="1841" height="125" alt="image" src="https://github.com/user-attachments/assets/dee4c456-5b56-486a-8b20-907843ea1570" />

</details>

### How Has This Been Tested?

To perform the tests, I created a VM with a 5 GiB Disk Offering. After stopping the VM, I performed the `changeDiskOfferingForVolumeInternal` operation for a 100 GiB Disk Offering, which resulted in the error with the correct message. Other tests were also performed using the IntelliJ IDE debug functionality to force the expected exceptions when performing the `changeDiskOfferingForVolumeInternal` operation.
