### PR TITLE
Fix NPE during public IP listing when a removed network or VPC ID is informed for associatenetworkid parameter

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -44,6 +44,7 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.network.vpc.VpcVO;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.affinity.AffinityGroupProcessor;
@@ -2580,12 +2581,21 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if (associatedNetworkId != null) {
-            _accountMgr.checkAccess(caller, null, false, networkDao.findById(associatedNetworkId));
-            sc.setParameters("associatedNetworkIdEq", associatedNetworkId);
+            NetworkVO associatedNetwork = networkDao.findById(associatedNetworkId);
+
+            if (associatedNetwork != null) {
+                _accountMgr.checkAccess(caller, null, false, associatedNetwork);
+                sc.setParameters("associatedNetworkIdEq", associatedNetworkId);
+            }
         }
+
         if (vpcId != null) {
-            _accountMgr.checkAccess(caller, null, false, _vpcDao.findById(vpcId));
-            sc.setParameters("vpcId", vpcId);
+            VpcVO vpc = _vpcDao.findById(vpcId);
+
+            if (vpc != null) {
+                _accountMgr.checkAccess(caller, null, false, vpc);
+                sc.setParameters("vpcId", vpcId);
+            }
         }
 
         addrs = _publicIpAddressDao.search(sc, searchFilter); // Allocated

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -2612,13 +2612,16 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             }
             if (associatedNetworkId != null) {
                 NetworkVO guestNetwork = networkDao.findById(associatedNetworkId);
-                if (zoneId == null) {
-                    zoneId = guestNetwork.getDataCenterId();
-                } else if (zoneId != guestNetwork.getDataCenterId()) {
-                    InvalidParameterValueException ex = new InvalidParameterValueException("Please specify a valid associated network id in the specified zone.");
-                    throw ex;
+
+                if (guestNetwork != null) {
+                    if (zoneId == null) {
+                        zoneId = guestNetwork.getDataCenterId();
+                    } else if (zoneId != guestNetwork.getDataCenterId()) {
+                        InvalidParameterValueException ex = new InvalidParameterValueException("Please specify a valid associated network id in the specified zone.");
+                        throw ex;
+                    }
+                    owner = _accountDao.findById(guestNetwork.getAccountId());
                 }
-                owner = _accountDao.findById(guestNetwork.getAccountId());
             }
             List<DataCenterVO> dcList = new ArrayList<>();
             if (zoneId == null){


### PR DESCRIPTION
### Description

When listing public IPs associated to a network, the database query only considers records that are not marked as removed. If the ID of an removed resource is informed, a `null` value is returned in the database query. If the caller is a `User` type account, during the access checks the code tries to access one of the value's properties, resulting in an `NullPointerException`. 

A validation was added to this flow to prevent the property access when the resource is `null`, and the listing behavior was standardized. The same validation was added to handle removed VPCs, as the same behavior was presented for them.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

<details><summary>Behavior before the change</summary>

<img width="1133" height="58" alt="image" src="https://github.com/user-attachments/assets/cc99dd3d-3240-4c25-8852-b0309ef73358" />

</details>

<details><summary>Behavior after the change</summary>

<img width="1133" height="58" alt="image" src="https://github.com/user-attachments/assets/73492de8-8c97-4273-9f59-24a9a53320b4" />

</details>

### How Has This Been Tested?

First, I created an isolated network, informing a public IP address to be assigned as the network's source NAT. After that, the network was removed. Then, I authenticated with an `User` type account in CloudMonkey and called the `listPublicIpAddresses` API, informing the removed network's UUID as the `associatednetworkid` parameter. As expected, the exception was thrown.

<details><summary>Exception stack trace in Management Server's logs</summary>

```
2026-01-05 15:07:39,520 ERROR [c.c.a.ApiServer] (qtp1404565079-21:[ctx-8bd6ddc5, ctx-459e3280]) (logid:4b10ae2c) unhandled exception executing api command: [Ljava.lang.String;@1b1ed74b java.lang.NullPointerException: Cannot invoke "org.apache.cloudstack.acl.ControlledEntity.getDomainId()" because "entity" is null
	at com.cloud.user.AccountManagerImpl.checkAccess(AccountManagerImpl.java:738)
	at com.cloud.user.AccountManagerImpl.checkAccess(AccountManagerImpl.java:706)
	[...]
	at com.cloud.server.ManagementServerImpl.searchForIPAddresses(ManagementServerImpl.java:2651)
``` 

</details>

After applying the code with my changes to my local environment, the same steps were executed, and I validated that the behavior was fixed. The same steps were reproduced for removed VPCs. 

The code was also compiled with tests on Maven.