### PR TITLE
Changes to the error message displayed during the removal of public templates that are used

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1374,8 +1374,8 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         else {
             vmInstanceVOList = _vmInstanceDao.listNonExpungedByTemplate(templateId);
         }
-        if(!cmd.isForced() && CollectionUtils.isNotEmpty(vmInstanceVOList)) {
-            String message = String.format("Unable to delete template [%s] because there are VM [%d] instances using it.", template, vmInstanceVOList.size());
+        if (!cmd.isForced() && CollectionUtils.isNotEmpty(vmInstanceVOList)) {
+            String message = String.format("Unable to delete template [%s] because there are [%d] VM instances using it.", template, vmInstanceVOList.size());
             String instancesListMessage = String.format(" Instances list: [%s].", StringUtils.join(vmInstanceVOList, ","));
 
             logger.warn("{}{}", message, instancesListMessage);


### PR DESCRIPTION
### Description

During the removal of public templates, if it is being used by VMs, an error message is displayed informing that the removal could not proceed because it is being used by VMs, and the list of VMs using it is returned. However, sometimes the user that is trying to remove the template does not have access to these resources. Thus, the error message was changed, in order to return the list of VMs only to users with `RootAdmin` accounts and for the others users, the message only states that the template is being used by VMs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details><summary>Exception message for <code>User</code> type accounts</summary>

<img width="387" height="104" alt="image" src="https://github.com/user-attachments/assets/e0ac66a9-b028-473b-96b2-7aa767fd9a5f" />

</details>

<details><summary>Exception message for <code>Root Admin</code> type accounts</summary>

<img width="388" height="191" alt="image" src="https://github.com/user-attachments/assets/244efffe-5622-4642-961f-4a9f0c8d0872" />

</details>

### How Has This Been Tested?

First, two `User` type accounts were created:  `templateAcc` and `instanceAcc`. The `templateAcc` account was accessed and a public template was registered. After that, the `instanceAcc` was accessed and a VM was deployed using the template registered by `templateAcc`.

Logged in as `templateAcc` again, I tried to remove the registered template, and it was possible to validate that the error message was displayed without the VMs list. By logging in with a `Root Admin` account, it was possible to validate that the error message contained the VMs lists. Through the Management Server's logs it was also possible to validate that the  log message displayed the VMs list:

<details><summary>Updated log message</summary>

```
2025-12-17 12:58:08,815 [management] WARN  [c.c.t.TemplateManagerImpl:1360] (API-Job-Executor-1:[ctx-106b8b79, job-448, ctx-e8ca5865]) (logid:c41a7e6a) Unable to delete template with ID 210, because there are VM instances using it. Instances list: [VM instance {"id":33,"instanceName":"i-13-33-VM","type":"User","uuid":"a15065e6-5422-4eca-ae8a-e4f0d8887a99"}].
```

</details>