### PR TITLE
Storage pool monitor disconnect improvements

### DIFF
--- a/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
+++ b/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import com.cloud.storage.StorageManager;
+import com.cloud.utils.Profiler;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProvider;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProviderManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.HypervisorHostListener;
@@ -144,12 +145,13 @@ public class StoragePoolMonitor implements Listener {
     }
 
     @Override
-    public synchronized boolean processDisconnect(long agentId, Status state) {
+    public boolean processDisconnect(long agentId, Status state) {
         return processDisconnect(agentId, null, null, state);
     }
 
     @Override
-    public synchronized boolean processDisconnect(long agentId, String uuid, String name, Status state) {
+    public boolean processDisconnect(long agentId, String uuid, String name, Status state) {
+        logger.debug("Starting disconnect for Agent [id: {}, uuid: {}, name: {}]", agentId, uuid, name);
         Host host = _storageManager.getHost(agentId);
         if (host == null) {
             logger.warn("Agent [id: {}, uuid: {}, name: {}] not found, not disconnecting pools", agentId, uuid, name);
@@ -157,38 +159,52 @@ public class StoragePoolMonitor implements Listener {
         }
 
         if (host.getType() != Host.Type.Routing) {
+            logger.debug("Host [id: {}, uuid: {}, name: {}] is not of type {}, skip", agentId, uuid, name, Host.Type.Routing);
             return false;
         }
 
+        logger.debug("Looking for connected Storage Pools for Host [id: {}, uuid: {}, name: {}]", agentId, uuid, name);
         List<StoragePoolHostVO> storagePoolHosts = _storageManager.findStoragePoolsConnectedToHost(host.getId());
         if (storagePoolHosts == null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("No pools to disconnect for host: {}", host);
-            }
+            logger.debug("No pools to disconnect for host: {}", host);
             return true;
         }
 
+        logger.debug("Found {} pools to disconnect for host: {}", storagePoolHosts.size(), host);
         boolean disconnectResult = true;
-        for (StoragePoolHostVO storagePoolHost : storagePoolHosts) {
+        int storagePoolHostsSize = storagePoolHosts.size();
+        for (int i = 0; i < storagePoolHostsSize; i++) {
+            StoragePoolHostVO storagePoolHost = storagePoolHosts.get(i);
+            logger.debug("Processing disconnect from Storage Pool {} ({} of {}) for host: {}", storagePoolHost.getPoolId(), i, storagePoolHostsSize, host);
             StoragePoolVO pool = _poolDao.findById(storagePoolHost.getPoolId());
             if (pool == null) {
+                logger.debug("No Storage Pool found with id {} ({} of {}) for host: {}", storagePoolHost.getPoolId(), i, storagePoolHostsSize, host);
                 continue;
             }
 
             if (!pool.isShared()) {
+                logger.debug("Storage Pool {} ({}) ({} of {}) is not shared for host: {}, ignore disconnect", pool.getName(), pool.getUuid(), i, storagePoolHostsSize, host);
                 continue;
             }
 
             // Handle only PowerFlex pool for now, not to impact other pools behavior
             if (pool.getPoolType() != StoragePoolType.PowerFlex) {
+                logger.debug("Storage Pool {} ({}) ({} of {}) is not of type {} for host: {}, ignore disconnect", pool.getName(), pool.getUuid(), i, storagePoolHostsSize, pool.getPoolType(), host);
                 continue;
             }
 
+            logger.debug("Sending disconnect to Storage Pool {} ({}) ({} of {}) for host: {}", pool.getName(), pool.getUuid(), i, storagePoolHostsSize, host);
+            Profiler disconnectProfiler = new Profiler();
             try {
+                disconnectProfiler.start();
                 _storageManager.disconnectHostFromSharedPool(host, pool);
             } catch (Exception e) {
                 logger.error("Unable to disconnect host {} from storage pool {} due to {}", host, pool, e.toString());
                 disconnectResult = false;
+            } finally {
+                disconnectProfiler.stop();
+                long disconnectDuration = disconnectProfiler.getDurationInMillis() / 1000;
+                logger.debug("Finished disconnect with result {} from Storage Pool {} ({}) ({} of {}) for host: {}, duration: {} secs", disconnectResult, pool.getName(), pool.getUuid(), i, storagePoolHostsSize, host, disconnectDuration);
             }
         }
 


### PR DESCRIPTION
### Description

The PRs improves the following in storage pool monitor disconnect process.

- Removes unwanted synchronize as it blocks disconnect for all hosts on management server
- Improves logs for the disconnect process 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
