### PR TITLE
Clean up backup references to their schedules when the schedules are deleted

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/BackupScheduleDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/BackupScheduleDao.java
@@ -21,20 +21,14 @@ import java.util.Date;
 import java.util.List;
 
 import com.cloud.utils.DateUtil;
-import org.apache.cloudstack.api.response.BackupScheduleResponse;
-import org.apache.cloudstack.backup.BackupSchedule;
 import org.apache.cloudstack.backup.BackupScheduleVO;
 
 import com.cloud.utils.db.GenericDao;
 
 public interface BackupScheduleDao extends GenericDao<BackupScheduleVO, Long> {
-    BackupScheduleVO findByVM(Long vmId);
-
     List<BackupScheduleVO> listByVM(Long vmId);
 
     BackupScheduleVO findByVMAndIntervalType(Long vmId, DateUtil.IntervalType intervalType);
 
     List<BackupScheduleVO> getSchedulesToExecute(Date currentTimestamp);
-
-    BackupScheduleResponse newBackupScheduleResponse(BackupSchedule schedule);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/BackupScheduleDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/BackupScheduleDaoImpl.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.db.DB;
@@ -33,13 +32,8 @@ import org.apache.cloudstack.backup.BackupScheduleVO;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
-import com.cloud.vm.dao.VMInstanceDao;
 
 public class BackupScheduleDaoImpl extends GenericDaoBase<BackupScheduleVO, Long> implements BackupScheduleDao {
-
-    @Inject
-    VMInstanceDao vmInstanceDao;
-
     private SearchBuilder<BackupScheduleVO> backupScheduleSearch;
     private SearchBuilder<BackupScheduleVO> executableSchedulesSearch;
 
@@ -93,6 +87,7 @@ public class BackupScheduleDaoImpl extends GenericDaoBase<BackupScheduleVO, Long
             preparedStatement.executeUpdate();
             return super.remove(id);
         } catch (SQLException e) {
+            logger.warn("Unable to clean up backup schedules references from the backups table.", e);
             return false;
         }
     }

--- a/engine/schema/src/main/resources/META-INF/db/schema-42200to42210.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42200to42210.sql
@@ -38,3 +38,6 @@ UPDATE `cloud`.`vm_template` SET guest_os_id = 99 WHERE name = 'kvm-default-vm-i
 
 -- Update existing vm_template records with NULL type to "USER"
 UPDATE `cloud`.`vm_template` SET `type` = 'USER' WHERE `type` IS NULL;
+
+-- Drops the unused "backup_interval_type" column of the "cloud.backups" table
+ALTER TABLE `cloud`.`backups` DROP COLUMN `backup_interval_type`;

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -45,7 +45,6 @@ import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.AsyncJobResponse;
 import org.apache.cloudstack.api.response.BackupOfferingResponse;
-import org.apache.cloudstack.api.response.BackupScheduleResponse;
 import org.apache.cloudstack.api.response.DiskOfferingResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.DomainRouterResponse;
@@ -76,7 +75,6 @@ import org.apache.cloudstack.api.response.VpcOfferingResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.backup.BackupOffering;
 import org.apache.cloudstack.backup.BackupRepository;
-import org.apache.cloudstack.backup.BackupSchedule;
 import org.apache.cloudstack.backup.dao.BackupDao;
 import org.apache.cloudstack.backup.dao.BackupOfferingDao;
 import org.apache.cloudstack.backup.dao.BackupRepositoryDao;
@@ -2297,10 +2295,6 @@ public class ApiDBUtils {
 
     public static ResourceIconVO getResourceIconByResourceUUID(String resourceUUID, ResourceObjectType resourceType) {
         return s_resourceIconDao.findByResourceUuid(resourceUUID, resourceType);
-    }
-
-    public static BackupScheduleResponse newBackupScheduleResponse(BackupSchedule schedule) {
-        return s_backupScheduleDao.newBackupScheduleResponse(schedule);
     }
 
     public static BackupOfferingResponse newBackupOfferingResponse(BackupOffering offering) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -5042,7 +5042,25 @@ public class ApiResponseHelper implements ResponseGenerator {
 
     @Override
     public BackupScheduleResponse createBackupScheduleResponse(BackupSchedule schedule) {
-        return ApiDBUtils.newBackupScheduleResponse(schedule);
+        BackupScheduleResponse response = new BackupScheduleResponse();
+        response.setId(schedule.getUuid());
+        response.setIntervalType(schedule.getScheduleType());
+        response.setSchedule(schedule.getSchedule());
+        response.setTimezone(schedule.getTimezone());
+        response.setMaxBackups(schedule.getMaxBackups());
+
+        if (schedule.getQuiesceVM() != null) {
+            response.setQuiesceVM(schedule.getQuiesceVM());
+        }
+
+        VMInstanceVO vm = ApiDBUtils.findVMInstanceById(schedule.getVmId());
+        if (vm != null) {
+            response.setVmId(vm.getUuid());
+            response.setVmName(vm.getHostName());
+        }
+
+        response.setObjectName("backupschedule");
+        return response;
     }
 
     @Override


### PR DESCRIPTION
### Description

Currently, the `cloud.backups` table references a backup schedule through the `backup_schedule_id` field. It is only populated when a backup is created from a schedule. For _ad hoc_ backups, the field's value is kept as `NULL`.

Additionally, when backup schedules are deleted via the `deleteBackupSchedule` API, their corresponding entries are expunged from the DB. However, the backups' references to the schedules are not cleaned up and, thus, these references remain indefinitely in the `cloud.backups` table. It is important to highlight that, although the clean up process is not performed, it does not cause any bugs/side effects.

Therefore, this PR proposes to clean up such references before deleting backup schedules from the DB. The PR also cleans up some pieces of the code related with backup schedules, removing unused methods, moving methods' definitions to appropriate layers of the project and dropping the unused `backup_interval_type` column from the `cloud.backups` table (see #11223).

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

1. Created a backup schedule and waited for some backups to be created from it
2. Deleted the backup schedule
3. Verified that the schedule's backups did not have references pointing to the schedule anymore
