### PR TITLE
Fix regression in the `listBackupSchedule` API

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/backup/ListBackupScheduleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/backup/ListBackupScheduleCmd.java
@@ -59,7 +59,6 @@ public class ListBackupScheduleCmd extends BaseListProjectAndAccountResourcesCmd
     @Parameter(name = ApiConstants.VIRTUAL_MACHINE_ID,
             type = CommandType.UUID,
             entityType = UserVmResponse.class,
-            required = true,
             description = "ID of the Instance")
     private Long vmId;
 


### PR DESCRIPTION
### Description

PR #11587 changed the `virtualmachineid` parameter of the `listBackupSchedule` API to be optional. However, probably due to a conflict resolution, the change has been lost. As a consequence, the parameter is still required and when trying to access the view of backup schedules through the UI, an exception is thrown:

<img width="2003" height="555" alt="image" src="https://github.com/user-attachments/assets/53eb3a04-fc29-4102-9caf-7d8e3d5eb4bf" />

Therefore, this PR fixes this code regression.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

