### PR TITLE
Allow cleaning up of networks stuck in Implementing state

### DIFF
--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -970,17 +970,22 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
 
                     logger.trace("End cleanup expired async-jobs");
 
-                    // 3) Cleanup orphaned networks stuck in Implementing state without async jobs
-                    try {
-                        cleanupOrphanedNetworks();
-                    } catch (Throwable e) {
-                        logger.error("Unexpected exception when trying to cleanup orphaned networks", e);
-                    }
+                    cleanupNetworksStuckInImplementing();
+
                 } catch (Throwable e) {
                     logger.error("Unexpected exception when trying to execute queue item, ", e);
                 }
             }
         };
+    }
+
+    private void cleanupNetworksStuckInImplementing() {
+        // Cleanup orphaned networks stuck in Implementing state without async jobs
+        try {
+            cleanupOrphanedNetworks();
+        } catch (Throwable e) {
+            logger.error("Unexpected exception when trying to cleanup orphaned networks", e);
+        }
     }
 
     @DB


### PR DESCRIPTION
### Description

This PR fixes: #12249 
This PR allows cleanup of Networks that have been stuck in Implementing state for more than the `job.expire.minutes` setting and has no async jobs associated. 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

1. Created a network
2. Created a VM in that network and cleaned up the VM
3. Set network (manually in DB) to Implementing state 
4. Observe logs (temporarily placed one of the trace logs in the code as debug)

```
...
Found 1 networks in Implementing state, checking for orphaned networks
2026-01-12 16:43:58,432 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (AsyncJobMgr-Heartbeat-1:[ctx-abe618b0]) (logid:5ee73b3f) Network 204 in Implementing state is only 9 minutes old (threshold: 10 minutes), skipping cleanup
..
 Found 1 networks in Implementing state, checking for orphaned networks
2026-01-12 16:44:08,434 WARN  [o.a.c.f.j.i.AsyncJobManagerImpl] (AsyncJobMgr-Heartbeat-1:[ctx-5012868f]) (logid:8c11718f) Found orphaned network 204 in Implementing state without async job. Network created: 2026-01-12T16:34:05.000+0000, age: 10 minutes, expiration threshold: 10 minutes. Transitioning to Shutdown state.

...
<img width="1621" height="147" alt="image" src="https://github.com/user-attachments/assets/8aadf16e-c022-4502-b88f-7c090a18e5f3" />

Moves network to Shutdown state and from there the networks can be deleted.
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
