### PR TITLE
Enhance DHCP functionality by adding lease timeout support

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/routing/DhcpEntryCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/routing/DhcpEntryCommand.java
@@ -36,6 +36,7 @@ public class DhcpEntryCommand extends NetworkElementCommand {
     private boolean isDefault;
     boolean executeInSequence = false;
     boolean remove;
+    Long leaseTime;
 
     public boolean isRemove() {
         return remove;
@@ -151,5 +152,13 @@ public class DhcpEntryCommand extends NetworkElementCommand {
 
     public void setDefault(boolean isDefault) {
         this.isDefault = isDefault;
+    }
+
+    public Long getLeaseTime() {
+        return leaseTime;
+    }
+
+    public void setLeaseTime(Long leaseTime) {
+        this.leaseTime = leaseTime;
     }
 }

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/DhcpEntryConfigItem.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/DhcpEntryConfigItem.java
@@ -35,7 +35,7 @@ public class DhcpEntryConfigItem extends AbstractConfigItemFacade {
         final DhcpEntryCommand command = (DhcpEntryCommand) cmd;
 
         final VmDhcpConfig vmDhcpConfig = new VmDhcpConfig(command.getVmName(), command.getVmMac(), command.getVmIpAddress(), command.getVmIp6Address(), command.getDuid(), command.getDefaultDns(),
-                command.getDefaultRouter(), command.getStaticRoutes(), command.isDefault(), command.isRemove());
+                command.getDefaultRouter(), command.getStaticRoutes(), command.isDefault(), command.isRemove(), command.getLeaseTime());
 
         return generateConfigItems(vmDhcpConfig);
     }

--- a/core/src/main/java/com/cloud/agent/resource/virtualnetwork/model/VmDhcpConfig.java
+++ b/core/src/main/java/com/cloud/agent/resource/virtualnetwork/model/VmDhcpConfig.java
@@ -29,6 +29,7 @@ public class VmDhcpConfig extends ConfigBase {
     private String defaultGateway;
     private String staticRoutes;
     private boolean defaultEntry;
+    private Long leaseTime;
 
     // Indicate if the entry should be removed when set to true
     private boolean remove;
@@ -39,6 +40,11 @@ public class VmDhcpConfig extends ConfigBase {
 
     public VmDhcpConfig(String hostName, String macAddress, String ipv4Address, String ipv6Address, String ipv6Duid, String dnsAddresses, String defaultGateway,
             String staticRoutes, boolean defaultEntry, boolean remove) {
+        this(hostName, macAddress, ipv4Address, ipv6Address, ipv6Duid, dnsAddresses, defaultGateway, staticRoutes, defaultEntry, remove, null);
+    }
+
+    public VmDhcpConfig(String hostName, String macAddress, String ipv4Address, String ipv6Address, String ipv6Duid, String dnsAddresses, String defaultGateway,
+            String staticRoutes, boolean defaultEntry, boolean remove, Long leaseTime) {
         super(VM_DHCP);
         this.hostName = hostName;
         this.macAddress = macAddress;
@@ -50,6 +56,7 @@ public class VmDhcpConfig extends ConfigBase {
         this.staticRoutes = staticRoutes;
         this.defaultEntry = defaultEntry;
         this.remove = remove;
+        this.leaseTime = leaseTime;
     }
 
     public String getHostName() {
@@ -130,6 +137,14 @@ public class VmDhcpConfig extends ConfigBase {
 
     public void setDefaultEntry(boolean defaultEntry) {
         this.defaultEntry = defaultEntry;
+    }
+
+    public Long getLeaseTime() {
+        return leaseTime;
+    }
+
+    public void setLeaseTime(Long leaseTime) {
+        this.leaseTime = leaseTime;
     }
 
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -91,6 +91,10 @@ public interface NetworkOrchestrationService {
     ConfigKey<Integer> NetworkThrottlingRate = new ConfigKey<>("Network", Integer.class, NetworkThrottlingRateCK, "200",
             "Default data transfer rate in megabits per second allowed in network.", true, ConfigKey.Scope.Zone);
 
+    ConfigKey<Integer> DhcpLeaseTimeout = new ConfigKey<>("Network", Integer.class, "dhcp.lease.timeout", "0",
+            "DHCP lease time in seconds for VMs. Use 0 for infinite lease time (default). A non-zero value sets the lease duration in seconds.",
+            true, ConfigKey.Scope.Zone, "0-");
+
     ConfigKey<Boolean> PromiscuousMode = new ConfigKey<>("Advanced", Boolean.class, "network.promiscuous.mode", "false",
             "Whether to allow or deny promiscuous mode on NICs for applicable network elements such as for vswitch/dvswitch portgroups.", true);
 

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -93,7 +93,7 @@ public interface NetworkOrchestrationService {
 
     ConfigKey<Integer> DhcpLeaseTimeout = new ConfigKey<>("Network", Integer.class, "dhcp.lease.timeout", "0",
             "DHCP lease time in seconds for VMs. Use 0 for infinite lease time (default). A non-zero value sets the lease duration in seconds.",
-            true, ConfigKey.Scope.Zone, "0-");
+            true, ConfigKey.Scope.Zone);
 
     ConfigKey<Boolean> PromiscuousMode = new ConfigKey<>("Advanced", Boolean.class, "network.promiscuous.mode", "false",
             "Whether to allow or deny promiscuous mode on NICs for applicable network elements such as for vswitch/dvswitch portgroups.", true);

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -4916,7 +4916,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[]{NetworkGcWait, NetworkGcInterval, NetworkLockTimeout, DeniedRoutes,
-                GuestDomainSuffix, NetworkThrottlingRate, MinVRVersion,
+                GuestDomainSuffix, NetworkThrottlingRate, MinVRVersion, DhcpLeaseTimeout,
                 PromiscuousMode, MacAddressChanges, ForgedTransmits, MacLearning, RollingRestartEnabled,
                 TUNGSTEN_ENABLED, NSX_ENABLED, NETRIS_ENABLED, NETWORK_LB_HAPROXY_MAX_CONN};
     }

--- a/scripts/network/exdhcp/dnsmasq_edithosts.sh
+++ b/scripts/network/exdhcp/dnsmasq_edithosts.sh
@@ -21,6 +21,7 @@
 # $1 : the mac address
 # $2 : the associated ip address
 # $3 : the hostname
+# $4 : the lease time (optional, defaults to 'infinite')
 
 wait_for_dnsmasq () {
   local _pid=$(pidof dnsmasq)
@@ -41,11 +42,17 @@ no_dhcp_release=$?
 [ ! -f /etc/dhcphosts.txt ] && touch /etc/dhcphosts.txt
 [ ! -f /var/lib/misc/dnsmasq.leases ] && touch /var/lib/misc/dnsmasq.leases
 
+# Set lease time, default to 'infinite', convert 0 to 'infinite'
+lease_time=${4:-infinite}
+if [ "$lease_time" = "0" ]; then
+  lease_time=infinite
+fi
+
 sed -i  /$1/d /etc/dhcphosts.txt
 sed -i  /$2,/d /etc/dhcphosts.txt
 sed -i  /$3,/d /etc/dhcphosts.txt
 
-echo "$1,$2,$3,infinite" >>/etc/dhcphosts.txt
+echo "$1,$2,$3,$lease_time" >>/etc/dhcphosts.txt
 
 #release previous dhcp lease if present
 if [ $no_dhcp_release -eq 0 ]

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -351,6 +351,15 @@ public enum Config {
             ConfigKey.Kind.CSV,
             null),
 
+    DhcpLeaseTimeout(
+            "Network",
+            ManagementServer.class,
+            Integer.class,
+            "dhcp.lease.timeout",
+            "0",
+            "DHCP lease time in seconds for VMs. Use 0 for infinite lease time (default). A non-zero value sets the lease duration in seconds.",
+            null),
+
     //VPN
     RemoteAccessVpnPskLength(
             "Network",

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -351,15 +351,6 @@ public enum Config {
             ConfigKey.Kind.CSV,
             null),
 
-    DhcpLeaseTimeout(
-            "Network",
-            ManagementServer.class,
-            Integer.class,
-            "dhcp.lease.timeout",
-            "0",
-            "DHCP lease time in seconds for VMs. Use 0 for infinite lease time (default). A non-zero value sets the lease duration in seconds.",
-            null),
-
     //VPN
     RemoteAccessVpnPskLength(
             "Network",

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -296,9 +296,8 @@ public class CommandSetupHelper {
         dhcpCommand.setDefault(nic.isDefaultNic());
         dhcpCommand.setRemove(remove);
 
-        // Set DHCP lease timeout from global config (0 = infinite)
-        String leaseTimeStr = _configDao.getValue(Config.DhcpLeaseTimeout.key());
-        Long leaseTime = (leaseTimeStr != null) ? Long.parseLong(leaseTimeStr) : 0L;
+        // Set DHCP lease timeout from zone-scoped config (0 = infinite)
+        Long leaseTime = (long) NetworkOrchestrationService.DhcpLeaseTimeout.valueIn(router.getDataCenterId());
         dhcpCommand.setLeaseTime(leaseTime);
 
         dhcpCommand.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -296,6 +296,11 @@ public class CommandSetupHelper {
         dhcpCommand.setDefault(nic.isDefaultNic());
         dhcpCommand.setRemove(remove);
 
+        // Set DHCP lease timeout from global config (0 = infinite)
+        String leaseTimeStr = _configDao.getValue(Config.DhcpLeaseTimeout.key());
+        Long leaseTime = (leaseTimeStr != null) ? Long.parseLong(leaseTimeStr) : 0L;
+        dhcpCommand.setLeaseTime(leaseTime);
+
         dhcpCommand.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
         dhcpCommand.setAccessDetail(NetworkElementCommand.ROUTER_NAME, router.getInstanceName());
         dhcpCommand.setAccessDetail(NetworkElementCommand.ROUTER_GUEST_IP, _routerControlHelper.getRouterIpInNetwork(nic.getNetworkId(), router.getId()));

--- a/server/src/test/java/com/cloud/network/router/CommandSetupHelperTest.java
+++ b/server/src/test/java/com/cloud/network/router/CommandSetupHelperTest.java
@@ -294,25 +294,15 @@ public class CommandSetupHelperTest {
         // Test that positive values are accepted
         ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
         Assert.assertNotNull("ConfigKey should not be null", configKey);
-        // Verify the validator allows positive values
-        String validator = configKey.range();
-        Assert.assertNotNull("Validator should not be null", validator);
-        Assert.assertEquals("Validator should be '0-' (>= 0)", "0-", validator);
-    }
-
-    @Test
-    public void testDhcpLeaseTimeoutValidatorRejectsNegative() {
-        // Test that the validator is configured to reject negative values
-        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
-        String validator = configKey.range();
-        Assert.assertEquals("Validator should enforce minimum of 0", "0-", validator);
+        // Verify the config key exists and has expected default
+        Assert.assertEquals("ConfigKey default should be 0", "0", configKey.defaultValue());
     }
 
     @Test
     public void testDhcpLeaseTimeoutHasZoneScope() {
         // Test that the ConfigKey has Zone scope
         ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
-        Assert.assertEquals("ConfigKey should have Zone scope", ConfigKey.Scope.Zone, configKey.scope());
+        Assert.assertTrue("ConfigKey should have Zone scope", configKey.getScopes().contains(ConfigKey.Scope.Zone));
     }
 
     @Test

--- a/server/src/test/java/com/cloud/network/router/CommandSetupHelperTest.java
+++ b/server/src/test/java/com/cloud/network/router/CommandSetupHelperTest.java
@@ -46,6 +46,8 @@ import com.cloud.utils.net.Ip;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.dao.NicDao;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.network.BgpPeerVO;
 import org.apache.cloudstack.network.dao.BgpPeerDetailsDao;
 import org.junit.Assert;
@@ -270,5 +272,53 @@ public class CommandSetupHelperTest {
         Command cmd = cmds.toCommands()[0];
         Assert.assertTrue(cmd instanceof SetBgpPeersCommand);
         Assert.assertEquals(4, ((SetBgpPeersCommand) cmd).getBpgPeers().length);
+    }
+
+    @Test
+    public void testDhcpLeaseTimeoutDefaultValue() {
+        // Test that the default value is 0 (infinite)
+        Integer defaultValue = NetworkOrchestrationService.DhcpLeaseTimeout.value();
+        Assert.assertEquals("Default DHCP lease timeout should be 0 (infinite)", 0, defaultValue.intValue());
+    }
+
+    @Test
+    public void testDhcpLeaseTimeoutAcceptsZero() {
+        // Test that 0 value is accepted (infinite lease)
+        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
+        Assert.assertNotNull("ConfigKey should not be null", configKey);
+        Assert.assertEquals("ConfigKey default should be 0", "0", configKey.defaultValue());
+    }
+
+    @Test
+    public void testDhcpLeaseTimeoutAcceptsPositiveValues() {
+        // Test that positive values are accepted
+        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
+        Assert.assertNotNull("ConfigKey should not be null", configKey);
+        // Verify the validator allows positive values
+        String validator = configKey.range();
+        Assert.assertNotNull("Validator should not be null", validator);
+        Assert.assertEquals("Validator should be '0-' (>= 0)", "0-", validator);
+    }
+
+    @Test
+    public void testDhcpLeaseTimeoutValidatorRejectsNegative() {
+        // Test that the validator is configured to reject negative values
+        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
+        String validator = configKey.range();
+        Assert.assertEquals("Validator should enforce minimum of 0", "0-", validator);
+    }
+
+    @Test
+    public void testDhcpLeaseTimeoutHasZoneScope() {
+        // Test that the ConfigKey has Zone scope
+        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
+        Assert.assertEquals("ConfigKey should have Zone scope", ConfigKey.Scope.Zone, configKey.scope());
+    }
+
+    @Test
+    public void testDhcpLeaseTimeoutIsDynamic() {
+        // Test that the ConfigKey is dynamic (can be updated at runtime)
+        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
+        Assert.assertTrue("ConfigKey should be dynamic", configKey.isDynamic());
     }
 }

--- a/server/src/test/java/com/cloud/network/router/DhcpLeaseTimeoutIntegrationTest.java
+++ b/server/src/test/java/com/cloud/network/router/DhcpLeaseTimeoutIntegrationTest.java
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network.router;
+
+import com.cloud.agent.api.routing.DhcpEntryCommand;
+import com.cloud.agent.manager.Commands;
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.network.NetworkModel;
+import com.cloud.network.dao.NetworkDao;
+import com.cloud.network.dao.NetworkDetailsDao;
+import com.cloud.offerings.dao.NetworkOfferingDao;
+import com.cloud.offerings.dao.NetworkOfferingDetailsDao;
+import com.cloud.user.UserVmVO;
+import com.cloud.vm.NicVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.dao.NicDao;
+import com.cloud.vm.dao.UserVmDao;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for DHCP lease timeout functionality.
+ * Tests the end-to-end flow from ConfigKey through DhcpEntryCommand creation.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DhcpLeaseTimeoutIntegrationTest {
+
+    @InjectMocks
+    protected CommandSetupHelper commandSetupHelper = new CommandSetupHelper();
+
+    @Mock
+    NicDao nicDao;
+    @Mock
+    NetworkDao networkDao;
+    @Mock
+    NetworkModel networkModel;
+    @Mock
+    NetworkOfferingDao networkOfferingDao;
+    @Mock
+    NetworkOfferingDetailsDao networkOfferingDetailsDao;
+    @Mock
+    NetworkDetailsDao networkDetailsDao;
+    @Mock
+    RouterControlHelper routerControlHelper;
+    @Mock
+    DataCenterDao dcDao;
+    @Mock
+    UserVmDao userVmDao;
+
+    private VirtualRouter mockRouter;
+    private UserVmVO mockVm;
+    private NicVO mockNic;
+    private DataCenterVO mockDc;
+
+    @Before
+    public void setUp() {
+        ReflectionTestUtils.setField(commandSetupHelper, "_nicDao", nicDao);
+        ReflectionTestUtils.setField(commandSetupHelper, "_networkDao", networkDao);
+        ReflectionTestUtils.setField(commandSetupHelper, "_networkModel", networkModel);
+        ReflectionTestUtils.setField(commandSetupHelper, "_networkOfferingDao", networkOfferingDao);
+        ReflectionTestUtils.setField(commandSetupHelper, "networkOfferingDetailsDao", networkOfferingDetailsDao);
+        ReflectionTestUtils.setField(commandSetupHelper, "networkDetailsDao", networkDetailsDao);
+        ReflectionTestUtils.setField(commandSetupHelper, "_routerControlHelper", routerControlHelper);
+        ReflectionTestUtils.setField(commandSetupHelper, "_dcDao", dcDao);
+
+        // Create common mocks
+        mockRouter = Mockito.mock(VirtualRouter.class);
+        mockVm = Mockito.mock(UserVmVO.class);
+        mockNic = Mockito.mock(NicVO.class);
+        mockDc = Mockito.mock(DataCenterVO.class);
+
+        // Setup default mock behaviors
+        when(mockRouter.getId()).thenReturn(100L);
+        when(mockRouter.getInstanceName()).thenReturn("r-100-VM");
+        when(mockRouter.getDataCenterId()).thenReturn(1L);
+
+        when(mockVm.getId()).thenReturn(200L);
+        when(mockVm.getHostName()).thenReturn("test-vm");
+
+        when(mockNic.getId()).thenReturn(300L);
+        when(mockNic.getMacAddress()).thenReturn("02:00:0a:0b:0c:0d");
+        when(mockNic.getIPv4Address()).thenReturn("10.1.1.10");
+        when(mockNic.getIPv6Address()).thenReturn(null);
+        when(mockNic.getNetworkId()).thenReturn(400L);
+        when(mockNic.isDefaultNic()).thenReturn(true);
+
+        when(dcDao.findById(anyLong())).thenReturn(mockDc);
+        when(routerControlHelper.getRouterControlIp(anyLong())).thenReturn("10.1.1.1");
+        when(routerControlHelper.getRouterIpInNetwork(anyLong(), anyLong())).thenReturn("10.1.1.1");
+        when(networkModel.getExecuteInSeqNtwkElmtCmd()).thenReturn(false);
+    }
+
+    @Test
+    public void testDhcpEntryCommandContainsLeaseTime() {
+        // Test that DhcpEntryCommand includes the lease time from ConfigKey
+        Commands cmds = new Commands(null);
+        commandSetupHelper.createDhcpEntryCommand(mockRouter, mockVm, mockNic, false, cmds);
+
+        Assert.assertEquals("Should have one DHCP command", 1, cmds.size());
+        DhcpEntryCommand dhcpCmd = (DhcpEntryCommand) cmds.toCommands()[0];
+        Assert.assertNotNull("DHCP command should not be null", dhcpCmd);
+        Assert.assertNotNull("Lease time should not be null", dhcpCmd.getLeaseTime());
+        
+        // Default value should be 0 (infinite)
+        Assert.assertEquals("Default lease time should be 0", Long.valueOf(0L), dhcpCmd.getLeaseTime());
+    }
+
+    @Test
+    public void testDhcpEntryCommandUsesZoneScopedValue() {
+        // Test that the command uses zone-scoped configuration
+        Long zoneId = mockRouter.getDataCenterId();
+        Integer expectedLeaseTime = NetworkOrchestrationService.DhcpLeaseTimeout.valueIn(zoneId);
+
+        Commands cmds = new Commands(null);
+        commandSetupHelper.createDhcpEntryCommand(mockRouter, mockVm, mockNic, false, cmds);
+
+        DhcpEntryCommand dhcpCmd = (DhcpEntryCommand) cmds.toCommands()[0];
+        Assert.assertEquals("Lease time should match zone-scoped config",
+                expectedLeaseTime.longValue(), dhcpCmd.getLeaseTime().longValue());
+    }
+
+    @Test
+    public void testInfiniteLeaseWithZeroValue() {
+        // Test that 0 value represents infinite lease
+        ConfigKey<Integer> configKey = NetworkOrchestrationService.DhcpLeaseTimeout;
+        Assert.assertEquals("Default value should be 0 for infinite lease", "0", configKey.defaultValue());
+
+        Commands cmds = new Commands(null);
+        commandSetupHelper.createDhcpEntryCommand(mockRouter, mockVm, mockNic, false, cmds);
+
+        DhcpEntryCommand dhcpCmd = (DhcpEntryCommand) cmds.toCommands()[0];
+        Assert.assertEquals("Lease time 0 represents infinite lease", Long.valueOf(0L), dhcpCmd.getLeaseTime());
+    }
+
+    @Test
+    public void testDhcpCommandForNonDefaultNic() {
+        // Test DHCP command creation for non-default NIC
+        when(mockNic.isDefaultNic()).thenReturn(false);
+
+        Commands cmds = new Commands(null);
+        commandSetupHelper.createDhcpEntryCommand(mockRouter, mockVm, mockNic, false, cmds);
+
+        DhcpEntryCommand dhcpCmd = (DhcpEntryCommand) cmds.toCommands()[0];
+        Assert.assertNotNull("DHCP command should be created for non-default NIC", dhcpCmd);
+        Assert.assertNotNull("Lease time should be set even for non-default NIC", dhcpCmd.getLeaseTime());
+        Assert.assertFalse("Command should reflect non-default NIC", dhcpCmd.isDefault());
+    }
+
+    @Test
+    public void testDhcpCommandWithRemoveFlag() {
+        // Test DHCP command with remove flag set
+        Commands cmds = new Commands(null);
+        commandSetupHelper.createDhcpEntryCommand(mockRouter, mockVm, mockNic, true, cmds);
+
+        DhcpEntryCommand dhcpCmd = (DhcpEntryCommand) cmds.toCommands()[0];
+        Assert.assertNotNull("DHCP command should be created even with remove flag", dhcpCmd);
+        Assert.assertTrue("Remove flag should be set", dhcpCmd.isRemove());
+        // Lease time should still be included even for removal
+        Assert.assertNotNull("Lease time should be present even for removal", dhcpCmd.getLeaseTime());
+    }
+}

--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -199,12 +199,14 @@ class CsDhcp(CsDataBag):
 
     def add(self, entry):
         self.add_host(entry['ipv4_address'], entry['host_name'])
-        # Lease time set to "infinite" since we properly control all DHCP/DNS config via CloudStack.
+        # Lease time is configurable via CloudStack global config dhcp.lease.timeout
+        # 0 = infinite (default), otherwise the value represents seconds
         # Infinite time helps avoid some edge cases which could cause DHCPNAK being sent to VMs since
         # (RHEL) system lose routes when they receive DHCPNAK.
         # When VM is expunged, its active lease and DHCP/DNS config is properly removed from related files in VR,
         # so the infinite duration of lease does not cause any issues or garbage.
-        lease = 'infinite'
+        lease_time = entry.get('lease_time', 0)
+        lease = 'infinite' if lease_time == 0 else str(lease_time)
 
         if entry['default_entry']:
             self.dhcp_hosts.add("%s,%s,%s,%s" % (entry['mac_address'],

--- a/systemvm/debian/opt/cloud/bin/edithosts.sh
+++ b/systemvm/debian/opt/cloud/bin/edithosts.sh
@@ -21,7 +21,7 @@
 # edithosts.sh -- edit the dhcphosts file on the routing domain
 
 usage() {
-  printf "Usage: %s: -m <MAC address> -4 <IPv4 address> -6 <IPv6 address> -h <hostname> -d <default router> -n <name server address> -s <Routes> -u <DUID> [-N]\n" $(basename $0) >&2
+  printf "Usage: %s: -m <MAC address> -4 <IPv4 address> -6 <IPv6 address> -h <hostname> -d <default router> -n <name server address> -s <Routes> -u <DUID> -l <lease time> [-N]\n" $(basename $0) >&2
 }
 
 mac=
@@ -33,8 +33,9 @@ dns=
 routes=
 duid=
 nondefault=
+lease_time=infinite
 
-while getopts 'm:4:h:d:n:s:6:u:N' OPTION
+while getopts 'm:4:h:d:n:s:6:u:l:N' OPTION
 do
   case $OPTION in
   m)    mac="$OPTARG"
@@ -52,6 +53,8 @@ do
   n)    dns="$OPTARG"
         ;;
   s)    routes="$OPTARG"
+        ;;
+  l)    lease_time="$OPTARG"
         ;;
   N)    nondefault=1
         ;;
@@ -124,17 +127,21 @@ fi
 sed -i  /$host,/d $DHCP_HOSTS
 
 #put in the new entry
+# If lease_time is 0, use 'infinite', otherwise use the value
+if [ "$lease_time" = "0" ]; then
+  lease_time=infinite
+fi
 if [ $ipv4 ]
 then
-  echo "$mac,$ipv4,$host,infinite" >>$DHCP_HOSTS
+  echo "$mac,$ipv4,$host,$lease_time" >>$DHCP_HOSTS
 fi
 if [ $ipv6 ]
 then
   if [ $nondefault ]
   then
-    echo "id:$duid,set:nondefault6,[$ipv6],$host,infinite" >>$DHCP_HOSTS
+    echo "id:$duid,set:nondefault6,[$ipv6],$host,$lease_time" >>$DHCP_HOSTS
   else
-    echo "id:$duid,[$ipv6],$host,infinite" >>$DHCP_HOSTS
+    echo "id:$duid,[$ipv6],$host,$lease_time" >>$DHCP_HOSTS
   fi
 fi
 


### PR DESCRIPTION
### Description

This PR enhances the feature added in https://github.com/apache/cloudstack/pull/3662 to allow for non-infinite dhcp lease times.

So we do not break current installs, we keep the 'infinite' lease time as default but allow for a config to change the lease times to non-infinite values.

We've had issues with VMs with the lease set to infinite where they never check to see if their IP is still available, so we get IP conflicts. In our environment, with a combination of very short lived and long lived VMs and constrained IP address, we have to rely on IP address re-use and lease timeouts. This change allows us to configure our IP lease timeouts without modifying default behavior. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial