### PR TITLE
UI: Improve error handling for template upload notifications

### DIFF
--- a/ui/src/utils/plugins.js
+++ b/ui/src/utils/plugins.js
@@ -218,17 +218,18 @@ export const notifierPlugin = {
         if (error.response.status) {
           msg = `${i18n.global.t('message.request.failed')} (${error.response.status})`
         }
-        if (error.message) {
-          desc = error.message
-        }
-        if (error.response.headers && 'x-description' in error.response.headers) {
+        if (error.response.headers?.['x-description']) {
           desc = error.response.headers['x-description']
-        }
-        if (desc === '' && error.response.data) {
+        } else if (error.response.data) {
           const responseKey = _.findKey(error.response.data, 'errortext')
           if (responseKey) {
             desc = error.response.data[responseKey].errortext
+          } else if (typeof error.response.data === 'string') {
+            desc = error.response.data
           }
+        }
+        if (!desc && error.message) {
+          desc = error.message
         }
       }
       let countNotify = store.getters.countNotify

--- a/ui/src/views/image/RegisterOrUploadTemplate.vue
+++ b/ui/src/views/image/RegisterOrUploadTemplate.vue
@@ -638,11 +638,7 @@ export default {
         this.$emit('refresh-data')
         this.closeAction()
       }).catch(e => {
-        this.$notification.error({
-          message: this.$t('message.upload.failed'),
-          description: `${this.$t('message.upload.template.failed.description')} -  ${e}`,
-          duration: 0
-        })
+        this.$notifyError(e)
       })
     },
     fetchCustomHypervisorName () {


### PR DESCRIPTION
### Description

This PR fixes template upload error messages not being displayed in the UI. Previously, when template uploads failed _(e.g., file format mismatch)_, the UI would show a generic **"Request failed with status code 400"** message instead of the actual error message from the SSVM (Secondary Storage VM).

Fixes: https://github.com/apache/cloudstack/issues/11513

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### Broken: 
<img width="2441" height="1260" alt="image" src="https://github.com/user-attachments/assets/2b84925b-8b28-4971-a98d-6837c6299036" />

### Fixed: 
<img width="2441" height="1260" alt="Screenshot from 2026-01-12 17-20-18" src="https://github.com/user-attachments/assets/ccf3c506-2c0f-41e6-b97b-f97d35bd89e6" />

### How Has This Been Tested?

1. Navigated to Templates → Upload Template
2. Selected QCOW2 as format
3. Uploaded a file with wrong format (e.g., RAW disk image, text file, or corrupted QCOW2)
4. Verified error notification displays actual SSVM error message instead of generic "Request failed with status code 400"

