### PR TITLE
Fix for Deleted userdata owned by a deleted account remains linked with the template

### DIFF
--- a/engine/schema/src/main/java/com/cloud/user/dao/UserDataDao.java
+++ b/engine/schema/src/main/java/com/cloud/user/dao/UserDataDao.java
@@ -19,6 +19,8 @@ package com.cloud.user.dao;
 import com.cloud.user.UserDataVO;
 import com.cloud.utils.db.GenericDao;
 
+import java.util.List;
+
 public interface UserDataDao extends GenericDao<UserDataVO, Long> {
 
     public UserDataVO findByUserData(long accountId, long domainId, String userData);
@@ -26,5 +28,7 @@ public interface UserDataDao extends GenericDao<UserDataVO, Long> {
     public UserDataVO findByName(long accountId, long domainId, String name);
 
     int removeByAccountId(long accountId);
+
+    List<UserDataVO> listByAccountId(long accountId);
 
 }

--- a/engine/schema/src/main/java/com/cloud/user/dao/UserDataDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/user/dao/UserDataDaoImpl.java
@@ -22,6 +22,8 @@ import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class UserDataDaoImpl extends GenericDaoBase<UserDataVO, Long> implements UserDataDao  {
 
@@ -69,5 +71,12 @@ public class UserDataDaoImpl extends GenericDaoBase<UserDataVO, Long> implements
         SearchCriteria<UserDataVO> sc = userdataSearch.create();
         sc.setParameters("accountId", accountId);
         return remove(sc);
+    }
+
+    @Override
+    public List<UserDataVO> listByAccountId(long accountId) {
+        SearchCriteria<UserDataVO> sc = userdataSearch.create();
+        sc.setParameters("accountId", accountId);
+        return listBy(sc);
     }
 }


### PR DESCRIPTION
### Description

This PR fixes an issue in which an account removed userdata remains linked to a template, after the account deletion (and its userdata).

Fixes: #9477 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
