### PR TITLE
Change to display if public IPs are reserved in the  tab

### DIFF
--- a/ui/src/views/infra/network/IpRangesTabPublic.vue
+++ b/ui/src/views/infra/network/IpRangesTabPublic.vue
@@ -47,6 +47,9 @@
         <template v-if="column.key === 'endip'">
           {{ record.endip || record.endipv6 }}
         </template>
+        <template v-if="column.key === 'systemvms'">
+          {{ record.systemvms || record.forsystemvms }}
+        </template>
         <template v-if="column.key === 'account' && !basicGuestNetwork">
           <a-button @click="() => handleOpenAccountModal(record)">{{ record.domain === undefined ? `${$t('label.system.ip.pool')}` : `[ ${record.domain}] ${record.account === undefined ? '' : record.account}` }}</a-button>
         </template>
@@ -127,10 +130,6 @@
         <div style="margin-bottom: 10px;">
           <div class="list__label">{{ $t('label.domain') }}</div>
           <div>{{ selectedItem.domain }}</div>
-        </div>
-        <div style="margin-bottom: 10px;">
-          <div class="list__label">{{ $t('label.system.vms') }}</div>
-          <div>{{ selectedItem.forsystemvms }}</div>
         </div>
       </div>
 
@@ -448,6 +447,10 @@ export default {
         {
           key: 'endip',
           title: this.$t('label.endip')
+        },
+        {
+          key: 'systemvms',
+          title: this.$t('label.reserved.system.ip')
         },
         {
           key: 'actions',


### PR DESCRIPTION


### Description

Currently, it is possible to check whether a range of public IPs is reserved for system VMs or not; however, this information can be hard to find since it’s located in a sub-menu with a name that doesn’t relate to the topic. Thus, this PR moves this information directly to the ranges listing in the `Public` tab under the Traffic types of a physical network.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details><summary> IP range before the changes: </summary>
<img width="1987" height="302" alt="Captura de tela de 2025-12-30 09-48-15" src="https://github.com/user-attachments/assets/ae5fb328-e0f5-4c26-82db-78751dc84ff6" />
</details>

<details><summary> IP range after the changes: </summary>
<img width="2067" height="293" alt="Captura de tela de 2025-12-30 09-53-13" src="https://github.com/user-attachments/assets/e006bdde-db45-4b4f-9704-a7291f69bcfd" />
</details>

### How Has This Been Tested?

I added two new IP ranges to a `Public` traffic type in a physical network, one being dedicated to system VMs, while the other was not. When the traffic type details was accessed, it was possible to validate that the dedicated range appeared as `true` in the `Reserved system IP` column, while the other one appeared as `false`.
