### PR TITLE
Changed error message when snapshot is not on secondary when trying to perform download

### DIFF
--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -578,8 +578,9 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         }
 
         if (ObjectUtils.anyNull(chosenStore, snapshotDataStoreReference)) {
-            logger.error("Snapshot [{}] not found in any secondary storage.", snapshot);
-            throw new InvalidParameterValueException("Snapshot not found.");
+            String errorMessage = String.format("Snapshot [%s] not found in any secondary storage. The snapshot may be on primary storage, where it cannot be downloaded.", snapshot.getUuid());
+            logger.error(errorMessage);
+            throw new InvalidParameterValueException(errorMessage);
         }
 
         snapshotSrv.syncVolumeSnapshotsToRegionStore(snapshot.getVolumeId(), chosenStore);


### PR DESCRIPTION
### Description

Currently, when trying to download a snapshot that is in primary storage, the error message `Snapshot not found` is shown, which may lead users into thinking that the snapshot does not exist in any storage anymore. This PR changes the message to `Snapshot not found in any secondary storage. The snapshot may be on primary storage, where it cannot be downloaded`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### How Has This Been Tested?

A VM was created to perform the tests. After that `Global Settings` tab was accessed and the configuration `snapshot.backup.to.secondary` was set to `false`. After this change, I took a volume snapshot and tried to download it, and it was possible to validate that the shown message was changed.