### PR TITLE
Update physical size for the snapshots of the volumes on ceph primary storage

### DIFF
--- a/core/src/main/java/org/apache/cloudstack/storage/to/SnapshotObjectTO.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/to/SnapshotObjectTO.java
@@ -44,9 +44,7 @@ public class SnapshotObjectTO extends DownloadableObjectTO implements DataTO {
     private Long physicalSize = (long) 0;
     private long accountId;
 
-
     public SnapshotObjectTO() {
-
     }
 
     public SnapshotObjectTO(SnapshotInfo snapshot) {

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
@@ -358,13 +358,16 @@ public class SnapshotObject implements SnapshotInfo {
             if (answer instanceof CreateObjectAnswer) {
                 SnapshotObjectTO snapshotTO = (SnapshotObjectTO)((CreateObjectAnswer)answer).getData();
                 snapshotStore.setInstallPath(snapshotTO.getPath());
+                if (snapshotTO.getPhysicalSize() != null && snapshotTO.getPhysicalSize() > 0L) {
+                    snapshotStore.setPhysicalSize(snapshotTO.getPhysicalSize());
+                }
                 snapshotStoreDao.update(snapshotStore.getId(), snapshotStore);
             } else if (answer instanceof CopyCmdAnswer) {
                 SnapshotObjectTO snapshotTO = (SnapshotObjectTO)((CopyCmdAnswer)answer).getNewData();
                 snapshotStore.setInstallPath(snapshotTO.getPath());
                 if (snapshotTO.getPhysicalSize() != null) {
                     // For S3 delta snapshot, physical size is currently not set
-                snapshotStore.setPhysicalSize(snapshotTO.getPhysicalSize());
+                    snapshotStore.setPhysicalSize(snapshotTO.getPhysicalSize());
                 }
                 if (snapshotTO.getParentSnapshotPath() == null) {
                     snapshotStore.setParentSnapshotId(0L);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1836,7 +1836,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         for (final String ifNamePattern : ifNamePatterns) {
             commonPattern.append("|(").append(ifNamePattern).append(".*)");
         }
-        if(fname.matches(commonPattern.toString())) {
+        if (fname.matches(commonPattern.toString())) {
             return true;
         }
         return false;
@@ -2128,11 +2128,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final Pattern pattern = Pattern.compile("(\\D+)(\\d+)(\\D*)(\\d*)(\\D*)(\\d*)");
         final Matcher matcher = pattern.matcher(pif);
         LOGGER.debug("getting broadcast uri for pif " + pif + " and bridge " + brName);
-        if(matcher.find()) {
+        if (matcher.find()) {
             if (brName.startsWith("brvx")){
                 return BroadcastDomainType.Vxlan.toUri(matcher.group(2)).toString();
-            }
-            else{
+            } else {
                 if (!matcher.group(6).isEmpty()) {
                     return BroadcastDomainType.Vlan.toUri(matcher.group(6)).toString();
                 } else if (!matcher.group(4).isEmpty()) {
@@ -3331,7 +3330,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 } else if (volume.getType() == Volume.Type.DATADISK) {
                     final KVMPhysicalDisk physicalDisk = storagePoolManager.getPhysicalDisk(store.getPoolType(), store.getUuid(), data.getPath());
                     final KVMStoragePool pool = physicalDisk.getPool();
-                    if(StoragePoolType.RBD.equals(pool.getType())) {
+                    if (StoragePoolType.RBD.equals(pool.getType())) {
                         final int devId = volume.getDiskSeq().intValue();
                         final String device = mapRbdDevice(physicalDisk);
                         if (device != null) {
@@ -4778,7 +4777,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
 
         for (int i = 0; i < memoryStats.length; i++) {
-            if(memoryStats[i].getTag() == UNUSEDMEMORY) {
+            if (memoryStats[i].getTag() == UNUSEDMEMORY) {
                 freeMemory = memoryStats[i].getValue();
                 break;
             }
@@ -5244,12 +5243,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return hypervisorType;
     }
 
-    public String mapRbdDevice(final KVMPhysicalDisk disk){
+    public String mapRbdDevice(final KVMPhysicalDisk disk) {
         final KVMStoragePool pool = disk.getPool();
         //Check if rbd image is already mapped
         final String[] splitPoolImage = disk.getPath().split("/");
         String device = Script.runSimpleBashScript("rbd showmapped | grep \""+splitPoolImage[0]+"[ ]*"+splitPoolImage[1]+"\" | grep -o \"[^ ]*[ ]*$\"");
-        if(device == null) {
+        if (device == null) {
             //If not mapped, map and return mapped device
             Script.runSimpleBashScript("rbd map " + disk.getPath() + " --id " + pool.getAuthUserName());
             device = Script.runSimpleBashScript("rbd showmapped | grep \""+splitPoolImage[0]+"[ ]*"+splitPoolImage[1]+"\" | grep -o \"[^ ]*[ ]*$\"");


### PR DESCRIPTION
### Description

This PR updates the physical size for the snapshots of the volumes on ceph primary storage, and has some code improvements .

This requires _ceph-common_ package to be installed on the KVM hosts, to get the physical size of the snapshot using rbd cmd. If not installed, it'll fallback to the current behavior.

Doc PR: https://github.com/apache/cloudstack-documentation/pull/622

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested the snapshots for the volumes on ceph primary storage with the config 'snapshot.backup.to.secondary' - true & false. Notice the physical size is properly set in both the cases.

<img width="1450" height="643" alt="SnapshotsWithCephPrimaryStorage" src="https://github.com/user-attachments/assets/0c22b170-fcc8-406c-99c8-bd7c02e862ed" />

DB:

```
mysql> SELECT id, uuid, name, pool_id, instance_id, size, state, created FROM cloud.volumes WHERE id IN (8,9);
+----+--------------------------------------+--------+---------+-------------+------------+-------+---------------------+
| id | uuid                                 | name   | pool_id | instance_id | size       | state | created             |
+----+--------------------------------------+--------+---------+-------------+------------+-------+---------------------+
|  8 | e29110ce-ffab-4a27-b2ad-6d87905039d8 | ROOT-8 |       2 |           8 | 8589934592 | Ready | 2026-01-16 07:48:17 |
|  9 | d2a9e77a-9a41-4427-8511-f8c365d8b581 | ROOT-9 |       2 |           9 | 8589934592 | Ready | 2026-01-19 10:57:20 |
+----+--------------------------------------+--------+---------+-------------+------------+-------+---------------------+
2 rows in set (0.00 sec)

mysql> SELECT id, uuid, name, volume_id, size, status, created FROM cloud.snapshots WHERE removed IS NULL AND volume_id IN (8,9);
+----+--------------------------------------+-------------------+-----------+------------+----------+---------------------+
| id | uuid                                 | name              | volume_id | size       | status   | created             |
+----+--------------------------------------+-------------------+-----------+------------+----------+---------------------+
|  1 | 55b8b9c4-0779-4614-8cfe-505d345f9e16 | ROOT-8-Snap01     |         8 | 8589934592 | BackedUp | 2026-01-16 08:03:57 |
|  2 | 9e6f7ef9-c278-4e1a-a6dc-5ad575c295b3 | ROOT-8-Snap02-Pri |         8 | 8589934592 | BackedUp | 2026-01-16 08:08:38 |
|  3 | 2eb7aef8-6b91-4cce-bf42-11756639f9f4 | ROOT-8-Snap03-Pri |         8 | 8589934592 | BackedUp | 2026-01-16 09:26:47 |
|  4 | f076ad82-e189-425e-857f-76a678622519 | ROOT-8-Snap04-Pri |         8 | 8589934592 | BackedUp | 2026-01-16 14:46:33 |
|  5 | 3319a00c-b22e-466d-93df-657bca3f75b3 | ROOT-8-Snap05-Pri |         8 | 8589934592 | BackedUp | 2026-01-16 21:19:59 |
|  6 | cab273ac-128b-4c22-a026-88afbaf1c617 | ROOT-8-Snap06-Pri |         8 | 8589934592 | BackedUp | 2026-01-16 22:07:08 |
|  7 | a645f0eb-bcb5-4207-983d-ceaa20586910 | ROOT-8-Snap07-Pri |         8 | 8589934592 | BackedUp | 2026-01-16 22:31:25 |
|  8 | 46798347-044a-482d-bbc8-ca9ef4d2b5e6 | ROOT-8-Snap08-Pri |         8 | 8589934592 | BackedUp | 2026-01-19 08:47:20 |
|  9 | 59719b8b-9d6f-431c-9f16-1979ee1742a6 | ROOT-8-Snap09-Sec |         8 | 8589934592 | BackedUp | 2026-01-19 08:52:45 |
| 10 | 269cf711-b766-4128-afb4-3d7eee137b80 | ROOT-8-Snap10-Sec |         8 | 8589934592 | BackedUp | 2026-01-19 08:54:31 |
| 11 | 63cae549-4e88-41a6-bebb-d75675d573b3 | ROOT-9-Snap01     |         9 | 8589934592 | BackedUp | 2026-01-19 11:02:51 |
| 12 | 5f7120f8-3adc-465d-92eb-608604f2ec75 | ROOT-9-Snap02-Pri |         9 | 8589934592 | BackedUp | 2026-01-19 11:07:21 |
+----+--------------------------------------+-------------------+-----------+------------+----------+---------------------+
12 rows in set (0.00 sec)

mysql> SELECT ssref.volume_id, s.name, snapshot_id, store_id, store_role,ssref.size, physical_size, install_path, state, ssref.created FROM cloud.snapshot_store_ref ssref JOIN cloud.snapshots s ON ssref.snapshot_id = s.id WHERE s.volume_id IN (8,9);
+-----------+-------------------+-------------+----------+------------+------------+---------------+--------------------------------------------------------------------------------------+-------+---------------------+
| volume_id | name              | snapshot_id | store_id | store_role | size       | physical_size | install_path                                                                         | state | created             |
+-----------+-------------------+-------------+----------+------------+------------+---------------+--------------------------------------------------------------------------------------+-------+---------------------+
|         8 | ROOT-8-Snap01     |           1 |        2 | Primary    | 8589934592 |    8589934592 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/1d27eef6-2e9d-4456-a0e9-953a3bb3bcd1 | Ready | 2026-01-16 08:03:59 |
|         8 | ROOT-8-Snap01     |           1 |        1 | Image      | 8589934592 |    1673134080 | snapshots/2/8/1d27eef6-2e9d-4456-a0e9-953a3bb3bcd1                                   | Ready | 2026-01-16 08:04:00 |
|         8 | ROOT-8-Snap02-Pri |           2 |        2 | Primary    | 8589934592 |    8589934592 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/5cc25049-375f-4299-a541-ac2bd7ea0654 | Ready | 2026-01-16 08:08:40 |
|         8 | ROOT-8-Snap03-Pri |           3 |        2 | Primary    | 8589934592 |    8589934592 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/082fa72d-2ec9-44e2-aea5-c13b87decf70 | Ready | 2026-01-16 09:26:48 |
|         8 | ROOT-8-Snap04-Pri |           4 |        2 | Primary    | 8589934592 |    8589934592 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/d2e2d6d5-ff66-46f1-be7b-76e0504e965d | Ready | 2026-01-16 14:46:34 |
|         8 | ROOT-8-Snap05-Pri |           5 |        2 | Primary    | 8589934592 |    8589934592 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/08453f18-c3f7-41db-bf9b-b6f87427726e | Ready | 2026-01-16 21:20:00 |
|         8 | ROOT-8-Snap06-Pri |           6 |        2 | Primary    | 8589934592 |    8589934592 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/672c796a-edd5-45fd-ab5a-60283e5ce67a | Ready | 2026-01-16 22:07:10 |
|         8 | ROOT-8-Snap07-Pri |           7 |        2 | Primary    | 8589934592 |      12582912 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/e06f1646-0561-411e-ab69-cbb1679bcd0b | Ready | 2026-01-16 22:31:26 |
|         8 | ROOT-8-Snap08-Pri |           8 |        2 | Primary    | 8589934592 |     633339904 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/dce4c78e-04cc-40d7-a5c1-dec6e834c32b | Ready | 2026-01-19 08:47:22 |
|         8 | ROOT-8-Snap09-Sec |           9 |        2 | Primary    | 8589934592 |     230686720 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/8af3d334-b609-4baf-88ef-a73505953217 | Ready | 2026-01-19 08:52:46 |
|         8 | ROOT-8-Snap09-Sec |           9 |        1 | Image      | 8589934592 |    1791361024 | snapshots/2/8/8af3d334-b609-4baf-88ef-a73505953217                                   | Ready | 2026-01-19 08:53:17 |
|         8 | ROOT-8-Snap10-Sec |          10 |        2 | Primary    | 8589934592 |     222298112 | cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8/ddcc1b75-57e9-4f9a-b09a-34e784752543 | Ready | 2026-01-19 08:54:32 |
|         8 | ROOT-8-Snap10-Sec |          10 |        1 | Image      | 8589934592 |    1793064960 | snapshots/2/8/ddcc1b75-57e9-4f9a-b09a-34e784752543                                   | Ready | 2026-01-19 08:55:03 |
|         9 | ROOT-9-Snap01     |          11 |        2 | Primary    | 8589934592 |     247463936 | cloudstack/d2a9e77a-9a41-4427-8511-f8c365d8b581/f169b209-c16c-4691-ba04-52fb3699320b | Ready | 2026-01-19 11:02:52 |
|         9 | ROOT-9-Snap01     |          11 |        1 | Image      | 8589934592 |    1673003008 | snapshots/4/9/f169b209-c16c-4691-ba04-52fb3699320b                                   | Ready | 2026-01-19 11:02:53 |
|         9 | ROOT-9-Snap02-Pri |          12 |        2 | Primary    | 8589934592 |      20971520 | cloudstack/d2a9e77a-9a41-4427-8511-f8c365d8b581/35d0b7f7-fbc9-405b-8796-903656085293 | Ready | 2026-01-19 11:07:23 |
+-----------+-------------------+-------------+----------+------------+------------+---------------+--------------------------------------------------------------------------------------+-------+---------------------+
16 rows in set (0.00 sec)
```

Ceph Dashboard:

ROOT-8 Volume =>

<img width="1442" height="664" alt="CephVolume_e29110ce-ffab-4a27-b2ad-6d87905039d8_Snapshots" src="https://github.com/user-attachments/assets/fb97bcb6-0522-4dc7-99da-4e8eff07ea25" />

ROOT-9 Volume =>

<img width="1444" height="393" alt="CephVolume_d2a9e77a-9a41-4427-8511-f8c365d8b581_Snapshots" src="https://github.com/user-attachments/assets/dc19001b-bb81-4c0f-b252-5eadc8f13cfa" />

Ceph cmd output:

ROOT-8 Volume =>
```
root@ceph1:~# rbd du cloudstack/e29110ce-ffab-4a27-b2ad-6d87905039d8
NAME                                                                       PROVISIONED  USED   
e29110ce-ffab-4a27-b2ad-6d87905039d8@1d27eef6-2e9d-4456-a0e9-953a3bb3bcd1        8 GiB  1.4 GiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@5cc25049-375f-4299-a541-ac2bd7ea0654        8 GiB   12 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@082fa72d-2ec9-44e2-aea5-c13b87decf70        8 GiB  760 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@d2e2d6d5-ff66-46f1-be7b-76e0504e965d        8 GiB   96 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@08453f18-c3f7-41db-bf9b-b6f87427726e        8 GiB   96 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@672c796a-edd5-45fd-ab5a-60283e5ce67a        8 GiB   84 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@e06f1646-0561-411e-ab69-cbb1679bcd0b        8 GiB   12 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@dce4c78e-04cc-40d7-a5c1-dec6e834c32b        8 GiB  604 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@8af3d334-b609-4baf-88ef-a73505953217        8 GiB  220 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8@ddcc1b75-57e9-4f9a-b09a-34e784752543        8 GiB  212 MiB
e29110ce-ffab-4a27-b2ad-6d87905039d8                                             8 GiB  144 MiB
<TOTAL>                                                                          8 GiB  3.6 GiB
 ```
 
 ROOT-9 Volume =>
 ```
root@ceph1:~# rbd du cloudstack/d2a9e77a-9a41-4427-8511-f8c365d8b581
NAME                                                                       PROVISIONED  USED   
d2a9e77a-9a41-4427-8511-f8c365d8b581@f169b209-c16c-4691-ba04-52fb3699320b        8 GiB  696 MiB
d2a9e77a-9a41-4427-8511-f8c365d8b581@35d0b7f7-fbc9-405b-8796-903656085293        8 GiB   20 MiB
d2a9e77a-9a41-4427-8511-f8c365d8b581                                             8 GiB  700 MiB
<TOTAL>                                                                          8 GiB  1.4 GiB
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
