### PR TITLE
Fix keyword parameter filtering in listBackupOfferings API

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -352,7 +352,7 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         final Filter searchFilter = new Filter(BackupOfferingVO.class, "id", true, cmd.getStartIndex(), cmd.getPageSizeVal());
         SearchBuilder<BackupOfferingVO> sb = backupOfferingDao.createSearchBuilder();
         sb.and("zone_id", sb.entity().getZoneId(), SearchCriteria.Op.EQ);
-        sb.and("name", sb.entity().getName(), SearchCriteria.Op.EQ);
+        sb.and("name", sb.entity().getName(), SearchCriteria.Op.LIKE);
 
         CallContext ctx = CallContext.current();
         final Account caller = ctx.getCallingAccount();


### PR DESCRIPTION
Fixes #12466

## Problem
The `keyword` parameter in the `listBackupOfferings` API was not filtering results. Regardless of the search term provided, the API returned empty results even when matching offerings existed.

## Root Cause
The SearchBuilder was using `SearchCriteria.Op.EQ` instead of `SearchCriteria.Op.LIKE` for the name field, preventing wildcard matching.

## Solution
- Changed SearchBuilder operation from `EQ` to `LIKE` for the name field
- Enables proper wildcard matching with `%` symbols for keyword search

## Testing
- Verified that `list backupofferings keyword=test` now returns matching results
- Confirmed backward compatibility with existing functionality

## Impact
- Fixes broken keyword search functionality
- Minimal change with maximum impact (1 line changed)
