### PR TITLE
Notify user if template upgrade is not required

### DIFF
--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -3358,6 +3358,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                 jobIds.add(jobId);
             } else {
                 logger.debug("Router: {} is already at the latest version. No upgrade required", router);
+                throw new CloudRuntimeException("Router is already at the latest version. No upgrade required");
             }
         }
         return jobIds;


### PR DESCRIPTION
### Description

This PR adds a notification in case Router is with latest template version . As of now it shows Upgrade is done, which gives wrong impression if no upgrade is performed.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):
Before:
![Screenshot 2026-01-21 at 1 01 43 PM](https://github.com/user-attachments/assets/0b0e760e-e46c-457a-a864-cace27b6cb33)

After:
![Screenshot 2026-01-21 at 1 46 36 PM](https://github.com/user-attachments/assets/998cb377-0ab9-44d4-bead-433f8ed3538e)

Log message:
![Screenshot 2026-01-21 at 1 59 23 PM](https://github.com/user-attachments/assets/d89cd1a8-d755-42aa-8b5b-6e4649a6850b)


### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
