### PR TITLE
[4.20] Fix keyword parameter filtering in listBackupOfferings API

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -239,7 +239,8 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         final Filter searchFilter = new Filter(BackupOfferingVO.class, "id", true, cmd.getStartIndex(), cmd.getPageSizeVal());
         SearchBuilder<BackupOfferingVO> sb = backupOfferingDao.createSearchBuilder();
         sb.and("zone_id", sb.entity().getZoneId(), SearchCriteria.Op.EQ);
-        sb.and("name", sb.entity().getName(), SearchCriteria.Op.EQ);
+        sb.and("name", sb.entity().getName(), SearchCriteria.Op.LIKE);
+
         CallContext ctx = CallContext.current();
         final Account caller = ctx.getCallingAccount();
         if (Account.Type.NORMAL == caller.getType()) {


### PR DESCRIPTION
Backport of #12480 to 4.20 branch

Fixes #12466

## Problem
The keyword parameter in the listBackupOfferings API was not filtering results.

## Solution
Changed SearchBuilder operation from EQ to LIKE for the name field in BackupManagerImpl.java

## Testing
Already tested and approved in #12480 by @harikrishna-patnala

## Related
- Original PR: #12480
- Issue: #12466