### PR TITLE
ssvm: delete temp directory while deleting entity download url

### DIFF
--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
@@ -16,7 +16,10 @@
 // under the License.
 package org.apache.cloudstack.storage.template;
 
+import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
+
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -30,10 +33,10 @@ import java.util.concurrent.Executors;
 
 import javax.naming.ConfigurationException;
 
-import com.cloud.agent.api.Answer;
-
 import org.apache.cloudstack.storage.resource.SecondaryStorageResource;
+import org.apache.commons.lang3.StringUtils;
 
+import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.storage.CreateEntityDownloadURLAnswer;
 import com.cloud.agent.api.storage.CreateEntityDownloadURLCommand;
 import com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand;
@@ -48,14 +51,16 @@ import com.cloud.storage.template.FtpTemplateUploader;
 import com.cloud.storage.template.TemplateUploader;
 import com.cloud.storage.template.TemplateUploader.Status;
 import com.cloud.storage.template.TemplateUploader.UploadCompleteCallback;
+import com.cloud.utils.FileUtil;
 import com.cloud.utils.NumbersUtil;
+import com.cloud.utils.UuidUtils;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
 
-import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
-
 public class UploadManagerImpl extends ManagerBase implements UploadManager {
+
+    protected static final String BASE_EXTRACT_DIR = "/var/www/html/userdata/";
 
     public class Completion implements UploadCompleteCallback {
         private final String jobId;
@@ -266,7 +271,7 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
             return new CreateEntityDownloadURLAnswer(errorString, CreateEntityDownloadURLAnswer.RESULT_FAILURE);
         }
         // Create the directory structure so that its visible under apache server root
-        String extractDir = "/var/www/html/userdata/";
+        String extractDir = BASE_EXTRACT_DIR;
         extractDir = extractDir + cmd.getFilepathInExtractURL() + File.separator;
         Script command = new Script("/bin/su", logger);
         command.add("-s");
@@ -330,12 +335,15 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         String extractUrl = cmd.getExtractUrl();
         String result;
         if (extractUrl != null) {
-            command.add("unlink /var/www/html/userdata/" + extractUrl.substring(extractUrl.lastIndexOf(File.separator) + 1));
+            String linkPath = extractUrl.substring(extractUrl.lastIndexOf(File.separator) + 1);
+            command.add("unlink " + BASE_EXTRACT_DIR + linkPath);
             result = command.execute();
             if (result != null) {
                 // FIXME - Ideally should bail out if you can't delete symlink. Not doing it right now.
                 // This is because the ssvm might already be destroyed and the symlinks do not exist.
                 logger.warn("Error in deleting symlink :" + result);
+            } else {
+                deleteEntitySymlinkRootPathIfNeeded(cmd, linkPath);
             }
         }
 
@@ -354,6 +362,30 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         }
 
         return new Answer(cmd, true, "");
+    }
+
+    protected void deleteEntitySymlinkRootPathIfNeeded(DeleteEntityDownloadURLCommand cmd, String linkPath) {
+        if (StringUtils.isEmpty(linkPath)) {
+            return;
+        }
+        String[] parts = linkPath.split("/");
+        if (parts.length == 0) {
+            return;
+        }
+        String rootDir = parts[0];
+        if (StringUtils.isEmpty(rootDir) || !UuidUtils.isUuid(rootDir)) {
+            return;
+        }
+        logger.info("Deleting symlink root directory: {} for {}", rootDir, cmd.getExtractUrl());
+        Path rootDirPath = Path.of(BASE_EXTRACT_DIR + rootDir);
+        String failMsg = "Failed to delete symlink root directory: {} for {}";
+        try {
+            if (!FileUtil.deleteRecursively(rootDirPath)) {
+                logger.warn(failMsg, rootDir, cmd.getExtractUrl());
+            }
+        } catch (IOException e) {
+            logger.warn(failMsg, rootDir, cmd.getExtractUrl(), e);
+        }
     }
 
     private String getInstallPath(String jobId) {

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
@@ -383,7 +383,7 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
             return;
         }
         logger.info("Deleting symlink root directory: {} for {}", rootDir, cmd.getExtractUrl());
-        Path rootDirPath = Path.of(BASE_EXTRACT_PATH + rootDir);
+        Path rootDirPath = Path.of(BASE_EXTRACT_PATH, rootDir);
         String failMsg = "Failed to delete symlink root directory: {} for {}";
         try {
             if (!FileUtil.deleteRecursively(rootDirPath)) {

--- a/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/template/UploadManagerImplTest.java
+++ b/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/template/UploadManagerImplTest.java
@@ -75,4 +75,11 @@ public class UploadManagerImplTest {
         uploadManager.deleteEntitySymlinkRootDirectoryIfNeeded(mock(DeleteEntityDownloadURLCommand.class), validLinkPath);
         fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), times(1));
     }
+
+    @Test
+    public void deletesSymlinkRootDirectoryWhenNoFile() {
+        String validLinkPath = "123e4567-e89b-12d3-a456-426614174000";
+        uploadManager.deleteEntitySymlinkRootDirectoryIfNeeded(mock(DeleteEntityDownloadURLCommand.class), validLinkPath);
+        fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), times(1));
+    }
 }

--- a/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/template/UploadManagerImplTest.java
+++ b/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/template/UploadManagerImplTest.java
@@ -58,21 +58,21 @@ public class UploadManagerImplTest {
     @Test
     public void doesNotDeleteWhenLinkPathIsEmpty() {
         String emptyLinkPath = "";
-        uploadManager.deleteEntitySymlinkRootPathIfNeeded(mock(DeleteEntityDownloadURLCommand.class), emptyLinkPath);
+        uploadManager.deleteEntitySymlinkRootDirectoryIfNeeded(mock(DeleteEntityDownloadURLCommand.class), emptyLinkPath);
         fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), never());
     }
 
     @Test
     public void doesNotDeleteWhenRootDirIsNotUuid() {
         String invalidLinkPath = "invalidRootDir/file";
-        uploadManager.deleteEntitySymlinkRootPathIfNeeded(mock(DeleteEntityDownloadURLCommand.class), invalidLinkPath);
+        uploadManager.deleteEntitySymlinkRootDirectoryIfNeeded(mock(DeleteEntityDownloadURLCommand.class), invalidLinkPath);
         fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), never());
     }
 
     @Test
     public void deletesSymlinkRootDirectoryWhenValidUuid() {
         String validLinkPath = "123e4567-e89b-12d3-a456-426614174000/file";
-        uploadManager.deleteEntitySymlinkRootPathIfNeeded(mock(DeleteEntityDownloadURLCommand.class), validLinkPath);
+        uploadManager.deleteEntitySymlinkRootDirectoryIfNeeded(mock(DeleteEntityDownloadURLCommand.class), validLinkPath);
         fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), times(1));
     }
 }

--- a/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/template/UploadManagerImplTest.java
+++ b/services/secondary-storage/server/src/test/java/org/apache/cloudstack/storage/template/UploadManagerImplTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.storage.template;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand;
+import com.cloud.utils.FileUtil;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UploadManagerImplTest {
+
+    @InjectMocks
+    UploadManagerImpl uploadManager;
+
+    MockedStatic<FileUtil> fileUtilMock;
+
+    @Before
+    public void setup() {
+        fileUtilMock = mockStatic(FileUtil.class, Mockito.CALLS_REAL_METHODS);
+        fileUtilMock.when(() -> FileUtil.deleteRecursively(any(Path.class))).thenReturn(true);
+    }
+
+    @After
+    public void tearDown() {
+        fileUtilMock.close();
+    }
+
+    @Test
+    public void doesNotDeleteWhenLinkPathIsEmpty() {
+        String emptyLinkPath = "";
+        uploadManager.deleteEntitySymlinkRootPathIfNeeded(mock(DeleteEntityDownloadURLCommand.class), emptyLinkPath);
+        fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), never());
+    }
+
+    @Test
+    public void doesNotDeleteWhenRootDirIsNotUuid() {
+        String invalidLinkPath = "invalidRootDir/file";
+        uploadManager.deleteEntitySymlinkRootPathIfNeeded(mock(DeleteEntityDownloadURLCommand.class), invalidLinkPath);
+        fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), never());
+    }
+
+    @Test
+    public void deletesSymlinkRootDirectoryWhenValidUuid() {
+        String validLinkPath = "123e4567-e89b-12d3-a456-426614174000/file";
+        uploadManager.deleteEntitySymlinkRootPathIfNeeded(mock(DeleteEntityDownloadURLCommand.class), validLinkPath);
+        fileUtilMock.verify(() -> FileUtil.deleteRecursively(any(Path.class)), times(1));
+    }
+}

--- a/utils/src/main/java/com/cloud/utils/FileUtil.java
+++ b/utils/src/main/java/com/cloud/utils/FileUtil.java
@@ -160,4 +160,19 @@ public class FileUtil {
     public static String readResourceFile(String resource) throws IOException {
         return IOUtils.toString(Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResourceAsStream(resource)), com.cloud.utils.StringUtils.getPreferredCharset());
     }
+
+    public static boolean deleteRecursively(Path path) throws IOException {
+        LOGGER.debug("Deleting path: {}", path);
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> entries = Files.list(path)) {
+                List<Path> list = entries.collect(Collectors.toList());
+                for (Path entry : list) {
+                    if (!deleteRecursively(entry)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return Files.deleteIfExists(path);
+    }
 }


### PR DESCRIPTION
### Description

When expired entity URLs are cleaned up, orphan directories are left behind. This change tries to delete the base temporary directory while cleanup.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Download link for a volume expires and server calls DeleteEntityDownloadURLCommand

**Before**

```
2026-01-31T07:36:09,043 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-5:[]) Request:Seq 4-7227995926952935435:  { Cmd , MgmtId: 90520731363323, via: 4, Ver: v1, Flags: 100111, [{"com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand":{"path":"volumes/2/4/97b241b4-4d31-469f-b4a4-a2fcab2606ff.qcow2","extractUrl":"http://172.120.1.2/userdata/88a99588-c0e0-4691-96c7-c7e6534d9fbe/t-dd.qcow2","type":"VOLUME","parentPath":"c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065","accountId":"0","wait":"0","bypassHostMaintenance":"false"}}] }
2026-01-31T07:36:09,044 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-5:[]) Processing command: com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand
2026-01-31T07:36:09,044 DEBUG [storage.resource.NfsSecondaryStorageResource] (AgentRequest-Handler-5:[]) Executing command "DeleteEntityDownloadURLCommand" [{"path":"volumes/2/4/97b241b4-4d31-469f-b4a4-a2fcab2606ff.qcow2","extractUrl":"http://172.120.1.2/userdata/88a99588-c0e0-4691-96c7-c7e6534d9fbe/t-dd.qcow2","type":"VOLUME","parentPath":"c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065","accountId":0,"contextMap":{},"wait":0,"bypassHostMaintenance":false}].
2026-01-31T07:36:09,044 WARN  [storage.template.UploadManagerImpl] (AgentRequest-Handler-5:[]) handleDeleteEntityDownloadURLCommand Path:volumes/2/4/97b241b4-4d31-469f-b4a4-a2fcab2606ff.qcow2 Type:VOLUME
2026-01-31T07:36:09,045 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-5:[]) Executing command [/bin/bash -c unlink /var/www/html/userdata/88a99588-c0e0-4691-96c7-c7e6534d9fbe/t-dd.qcow2 ].
2026-01-31T07:36:09,054 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-5:[]) Successfully executed process [5938] for command [/bin/bash -c unlink /var/www/html/userdata/88a99588-c0e0-4691-96c7-c7e6534d9fbe/t-dd.qcow2 ].
2026-01-31T07:36:09,054 WARN  [storage.template.UploadManagerImpl] (AgentRequest-Handler-5:[]) Deleted volume /mnt/SecStorage/c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065/volumes/2/4/97b241b4-4d31-469f-b4a4-a2fcab2606ff.qcow2
2026-01-31T07:36:09,055 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-5:[]) Executing command [/bin/bash -c rm -rf /mnt/SecStorage/c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065/volumes/2/4/97b241b4-4d31-469f-b4a4-a2fcab2606ff.qcow2 ].
2026-01-31T07:36:09,063 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-5:[]) Successfully executed process [5939] for command [/bin/bash -c rm -rf /mnt/SecStorage/c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065/volumes/2/4/97b241b4-4d31-469f-b4a4-a2fcab2606ff.qcow2 ].
2026-01-31T07:36:09,063 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-5:[]) Seq 4-7227995926952935435:  { Ans: , MgmtId: 90520731363323, via: 4, Ver: v1, Flags: 110, [{"com.cloud.agent.api.Answer":{"result":"true","details":"","wait":"0","bypassHostMaintenance":"false"}}]


root@s-2-VM:/var/www/html/userdata# ls -lrt
total 20
drwxr-xr-x 2 www-data www-data 4096 Jan 31 06:08 9142b6e3-f6c6-48de-86b6-6003eb147d2c
drwxr-xr-x 2 www-data www-data 4096 Jan 31 06:10 85378760-8b68-4c60-81fc-11ddbe59fd85
drwxr-xr-x 2 www-data www-data 4096 Jan 31 06:28 a3276a6b-03aa-44d0-aeef-183da3b214c4
drwxr-xr-x 2 www-data www-data 4096 Jan 31 06:35 0cfcf0a0-58f8-471b-8864-9b8a2b754da3
drwxr-xr-x 2 www-data www-data 4096 Jan 31 07:36 88a99588-c0e0-4691-96c7-c7e6534d9fbe
root@s-2-VM:/var/www/html/userdata# ls -lrt 88a99588-c0e0-4691-96c7-c7e6534d9fbe
total 0
```

**After**

```
2026-01-31T19:38:40,034 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-4:[]) Request:Seq 4-3413728517546836680:  { Cmd , MgmtId: 90520731363323, via: 4, Ver: v1, Flags: 100111, [{"com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand":{"path":"volumes/2/4/b5c47a87-6193-4d78-ab1f-1ade1422c296.qcow2","extractUrl":"http://172.120.1.2/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5/t-dd.qcow2","type":"VOLUME","parentPath":"c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065","accountId":"0","wait":"0","bypassHostMaintenance":"false"}}] }
2026-01-31T19:38:40,035 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-4:[]) Processing command: com.cloud.agent.api.storage.DeleteEntityDownloadURLCommand
2026-01-31T19:38:40,035 DEBUG [storage.resource.NfsSecondaryStorageResource] (AgentRequest-Handler-4:[]) Executing command "DeleteEntityDownloadURLCommand" [{"path":"volumes/2/4/b5c47a87-6193-4d78-ab1f-1ade1422c296.qcow2","extractUrl":"http://172.120.1.2/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5/t-dd.qcow2","type":"VOLUME","parentPath":"c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065","accountId":0,"contextMap":{},"wait":0,"bypassHostMaintenance":false}].
2026-01-31T19:38:40,035 WARN  [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) handleDeleteEntityDownloadURLCommand Path:volumes/2/4/b5c47a87-6193-4d78-ab1f-1ade1422c296.qcow2 Type:VOLUME
2026-01-31T19:38:40,036 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) Executing command [/bin/bash -c unlink /var/www/html/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5/t-dd.qcow2 ].
2026-01-31T19:38:40,039 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) Successfully executed process [8782] for command [/bin/bash -c unlink /var/www/html/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5/t-dd.qcow2 ].
2026-01-31T19:38:40,039 INFO  [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) Deleting symlink root directory: d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5 for http://172.120.1.2/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5/t-dd.qcow2
2026-01-31T19:38:40,039 DEBUG [cloud.utils.FileUtil] (AgentRequest-Handler-4:[]) Deleting path: /var/www/html/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5
2026-01-31T19:38:40,040 WARN  [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) Deleted volume /mnt/SecStorage/c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065/volumes/2/4/b5c47a87-6193-4d78-ab1f-1ade1422c296.qcow2
2026-01-31T19:38:40,040 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) Executing command [/bin/bash -c rm -rf /mnt/SecStorage/c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065/volumes/2/4/b5c47a87-6193-4d78-ab1f-1ade1422c296.qcow2 ].
2026-01-31T19:38:40,048 DEBUG [storage.template.UploadManagerImpl] (AgentRequest-Handler-4:[]) Successfully executed process [8783] for command [/bin/bash -c rm -rf /mnt/SecStorage/c794fe3b-bedb-3e8e-a5c6-c5a2b28a2065/volumes/2/4/b5c47a87-6193-4d78-ab1f-1ade1422c296.qcow2 ].
2026-01-31T19:38:40,049 DEBUG [cloud.agent.Agent] (AgentRequest-Handler-4:[]) Seq 4-3413728517546836680:  { Ans: , MgmtId: 90520731363323, via: 4, Ver: v1, Flags: 110, [{"com.cloud.agent.api.Answer":{"result":"true","details":"","wait":"0","bypassHostMaintenance":"false"}}]


root@s-2-VM:~# ls -lrt /var/www/html/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5
ls: cannot access '/var/www/html/userdata/d3a9b2ea-b212-4480-bca4-0dc1d9d3e6a5': No such file or directory
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
