### PR TITLE
Change the global configuration `vm.network.throttling.rate` to be dynamic

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -112,6 +112,9 @@ public interface NetworkOrchestrationService {
     static final ConfigKey<Boolean> NSX_ENABLED = new ConfigKey<>(Boolean.class, "nsx.plugin.enable", "Advanced", "false",
             "Indicates whether to enable the NSX plugin", false, ConfigKey.Scope.Zone, null);
 
+    ConfigKey<Integer> VmNetworkThrottlingRate = new ConfigKey<Integer>("Network", Integer.class, "vm.network.throttling.rate", "200",
+            "Default data transfer rate in megabits per second allowed in User vm's default network.", true, ConfigKey.Scope.Zone);
+
     List<? extends Network> setupNetwork(Account owner, NetworkOffering offering, DeploymentPlan plan, String name, String displayText, boolean isDefault)
         throws ConcurrentOperationException;
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -4905,7 +4905,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[]{NetworkGcWait, NetworkGcInterval, NetworkLockTimeout, DeniedRoutes,
-                GuestDomainSuffix, NetworkThrottlingRate, MinVRVersion,
+                GuestDomainSuffix, NetworkThrottlingRate, VmNetworkThrottlingRate, MinVRVersion,
                 PromiscuousMode, MacAddressChanges, ForgedTransmits, MacLearning, RollingRestartEnabled,
                 TUNGSTEN_ENABLED, NSX_ENABLED };
     }

--- a/server/src/main/java/com/cloud/configuration/Config.java
+++ b/server/src/main/java/com/cloud/configuration/Config.java
@@ -299,15 +299,6 @@ public enum Config {
             "cloud-public",
             "Default network label to be used when fetching interface for GRE endpoints",
             null),
-    VmNetworkThrottlingRate(
-            "Network",
-            ManagementServer.class,
-            Integer.class,
-            "vm.network.throttling.rate",
-            "200",
-            "Default data transfer rate in megabits per second allowed in User vm's default network.",
-            null),
-
     SecurityGroupWorkCleanupInterval(
             "Network",
             ManagementServer.class,

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -7967,7 +7967,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             if (offering.getVmType() != null && offering.getVmType().equalsIgnoreCase(VirtualMachine.Type.DomainRouter.toString())) {
                 networkRate = NetworkOrchestrationService.NetworkThrottlingRate.valueIn(dataCenterId);
             } else {
-                networkRate = Integer.parseInt(_configDao.getValue(Config.VmNetworkThrottlingRate.key()));
+                networkRate = NetworkOrchestrationService.VmNetworkThrottlingRate.valueIn(dataCenterId);
             }
         }
 


### PR DESCRIPTION
### Description

ACS has the global configuration `vm.network.throttling.rate` that allows limiting the maximum bandwidth of the default NIC for end-user VMs when it is not defined in compute offerings. However, currently, the setting is static, implying the requirement of restarting the Management Servers after changing its value.
Given this scenario, changes have been applied to make the configuration dynamic. As a consequence, it is not required to restart the Management Servers after each value update; the updated value is automatically considered in the Apache CloudStack internal workflows.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

The default value of `vm.network.throttling.rate` is 200, and after changing its value to 100 the VM's domain XML presented the following change:

Before:

```
virsh dumpxml 4 | grep "bandwidth" -A 2
      <bandwidth>
        <inbound average='25000' peak='25000'/>
        <outbound average='25000' peak='25000'/>
      </bandwidth>
      <target dev='vnet10'/>
      <model type='virtio'/>

```

After:

```
 virsh dumpxml 5 | grep "bandwidth" -A 2
      <bandwidth>
        <inbound average='12500' peak='12500'/>
        <outbound average='12500' peak='12500'/>
      </bandwidth>
      <target dev='vnet11'/>
      <model type='virtio'/>

```
