### PR TITLE
Fix duplicate RUNNING_VM helper record creation on repeated VM.START events

### DIFF
--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -1133,6 +1133,26 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 Long templateId = event.getTemplateId();
                 String hypervisorType = event.getResourceType();
 
+
+
+            SearchCriteria<UsageVMInstanceVO> runningSc =
+                _usageInstanceDao.createSearchCriteria();
+runningSc.addAnd("vmInstanceId", SearchCriteria.Op.EQ, vmId);
+runningSc.addAnd("usageType", SearchCriteria.Op.EQ, UsageTypes.RUNNING_VM);
+runningSc.addAnd("endDate", SearchCriteria.Op.NULL);
+
+List<UsageVMInstanceVO> existingRunning =
+        _usageInstanceDao.search(runningSc, null);
+
+if (existingRunning != null && !existingRunning.isEmpty()) {
+    logger.warn(String.format(
+        "Duplicate VM.START event detected for VM [%d] at [%s], skipping helper record creation.",
+        vmId, event.getCreateDate()));
+    return;
+}
+
+
+
                 // add this VM to the usage helper table
                 UsageVMInstanceVO usageInstanceNew =
                         new UsageVMInstanceVO(UsageTypes.RUNNING_VM, zoneId, event.getAccountId(), vmId, vmName, soId, templateId, hypervisorType, event.getCreateDate(),


### PR DESCRIPTION
### Description

Repeated `VM.START` events for the same VM could result in duplicate
`RUNNING_VM` helper usage records being created in the usage database.

This PR adds a defensive check in `UsageManagerImpl#createVMHelperEvent`
to detect an existing active `RUNNING_VM` usage record (same VM instance,
`endDate = NULL`) and skip helper record creation when a duplicate START
event is received.

A regression test has been added to ensure that duplicate `RUNNING_VM`
helper records are not created when repeated `VM.START` events are
processed.

Fixes: #12590

### Expected behavior

Only one active `RUNNING_VM` usage helper record should exist per VM at
any given time.

### Actual behavior

Multiple `RUNNING_VM` helper records could be created for the same VM
when duplicate `VM.START` events were processed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test (unit or integration test code)

### Bug Severity

- [x] Minor

### How Has This Been Tested?

- Added a unit test in `UsageManagerImplTest` to verify that duplicate
  `RUNNING_VM` helper records are not created when repeated `VM.START`
  events are handled.
- Built and tested the `cloud-usage` module successfully using Maven.

#### How did you try to break this feature and the system with this change?

- Simulated repeated `VM.START` events for the same VM instance to ensure
  that helper record creation is skipped when an active `RUNNING_VM`
  record already exists.
