### PR TITLE
Fix account deletion blocked by deleted project admin mappings (4.20)

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2110,15 +2110,30 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return deleteAccount(account, callerUserId, caller);
     }
 
-    protected void checkIfAccountManagesProjects(long accountId) {
-        List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
-        if (!CollectionUtils.isEmpty(managedProjectIds)) {
-            throw new InvalidParameterValueException(String.format(
-                    "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
-                    accountId, managedProjectIds
-            ));
+protected void checkIfAccountManagesProjects(long accountId) {
+    List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
+
+    if (CollectionUtils.isEmpty(managedProjectIds)) {
+        return;
+    }
+
+    List<Long> activeManagedProjects = new ArrayList<>();
+
+    for (Long projectId : managedProjectIds) {
+        ProjectVO project = _projectDao.findById(projectId);
+        if (project != null && project.getRemoved() == null) {
+            activeManagedProjects.add(projectId);
         }
     }
+
+    if (!activeManagedProjects.isEmpty()) {
+        throw new InvalidParameterValueException(String.format(
+                "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
+                accountId, activeManagedProjects
+        ));
+    }
+}
+
 
     protected boolean isDeleteNeeded(AccountVO account, long accountId, Account caller) {
         if (account == null) {

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
+
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.Role;
@@ -75,6 +77,7 @@ import com.cloud.vm.UserVmManagerImpl;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.snapshot.VMSnapshotVO;
+import com.cloud.projects.ProjectVO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AccountManagerImplTest extends AccountManagetImplTestBase {
@@ -1589,4 +1592,22 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
 
         accountManagerImpl.checkCallerApiPermissionsForUserOrAccountOperations(accountMock);
     }
+
+    @Test
+    public void testCheckIfAccountManagesOnlyDeletedProjectsDoesNotThrow() {
+        long accountId = 42L;
+        long projectId = 100L;
+
+        Mockito.when(projectAccountDao.listAdministratedProjectIds(accountId))
+                .thenReturn(List.of(projectId));
+
+        ProjectVO deletedProject = Mockito.mock(ProjectVO.class);
+        Mockito.when(deletedProject.getRemoved()).thenReturn(new Date());
+
+        Mockito.when(projectDao.findById(projectId))
+                .thenReturn(deletedProject);
+
+        accountManager.checkIfAccountManagesProjects(accountId);
+    }
+
 }


### PR DESCRIPTION
### Description

Backport of #12607 to the 4.20 branch.

This change fixes an issue where account deletion was blocked if the account
was listed as an administrator of projects that were already removed
(removed is not null).

The fix ensures that only active projects are considered when checking
whether an account manages projects, allowing deletion when only deleted
projects are associated.

Includes the same defensive check and unit test added in the main branch.

Rebased to 4.20 as requested by @DaanHoogland.

Fixes #12601

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test (unit test code)
