### PR TITLE
[4.20] Fix account deletion blocked by deleted project admin mappings

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2098,15 +2098,30 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return deleteAccount(account, callerUserId, caller);
     }
 
-    protected void checkIfAccountManagesProjects(long accountId) {
-        List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
-        if (!CollectionUtils.isEmpty(managedProjectIds)) {
-            throw new InvalidParameterValueException(String.format(
-                    "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
-                    accountId, managedProjectIds
-            ));
+protected void checkIfAccountManagesProjects(long accountId) {
+    List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
+
+    if (CollectionUtils.isEmpty(managedProjectIds)) {
+        return;
+    }
+
+    List<Long> activeManagedProjects = new ArrayList<>();
+
+    for (Long projectId : managedProjectIds) {
+        ProjectVO project = _projectDao.findById(projectId);
+        if (project != null && project.getRemoved() == null) {
+            activeManagedProjects.add(projectId);
         }
     }
+
+    if (!activeManagedProjects.isEmpty()) {
+        throw new InvalidParameterValueException(String.format(
+                "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
+                accountId, activeManagedProjects
+        ));
+    }
+}
+
 
     protected boolean isDeleteNeeded(AccountVO account, long accountId, Account caller) {
         if (account == null) {

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2115,10 +2115,12 @@ protected void checkIfAccountManagesProjects(long accountId) {
     }
 
     if (!activeManagedProjects.isEmpty()) {
-        throw new InvalidParameterValueException(String.format(
+        throw new InvalidParameterValueException(
+            String.format(
                 "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
                 accountId, activeManagedProjects
-        ));
+        )
+    );
     }
 }
 

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2098,31 +2098,30 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return deleteAccount(account, callerUserId, caller);
     }
 
-protected void checkIfAccountManagesProjects(long accountId) {
-    List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
+    protected void checkIfAccountManagesProjects(long accountId) {
+        List<Long> managedProjectIds = _projectAccountDao.listAdministratedProjectIds(accountId);
 
-    if (CollectionUtils.isEmpty(managedProjectIds)) {
-        return;
-    }
+        if (CollectionUtils.isEmpty(managedProjectIds)) {
+            return;
+        }
 
-    List<Long> activeManagedProjects = new ArrayList<>();
+        List<Long> activeManagedProjects = new ArrayList<>();
 
-    for (Long projectId : managedProjectIds) {
-        ProjectVO project = _projectDao.findById(projectId);
-        if (project != null && project.getRemoved() == null) {
-            activeManagedProjects.add(projectId);
+        for (Long projectId : managedProjectIds) {
+            ProjectVO project = _projectDao.findById(projectId);
+            if (project != null && project.getRemoved() == null) {
+                activeManagedProjects.add(projectId);
+            }
+        }
+
+        if (!activeManagedProjects.isEmpty()) {
+            throw new InvalidParameterValueException(
+                String.format(
+                    "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
+                    accountId, activeManagedProjects
+            ));
         }
     }
-
-    if (!activeManagedProjects.isEmpty()) {
-        throw new InvalidParameterValueException(
-            String.format(
-                "Unable to delete account [%s], because it manages the following project(s): %s. Please, remove the account from these projects or demote it to a regular project role first.",
-                accountId, activeManagedProjects
-        )
-    );
-    }
-}
 
 
     protected boolean isDeleteNeeded(AccountVO account, long accountId, Account caller) {

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -45,6 +45,7 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.resourcedetail.UserDetailVO;
 import org.apache.cloudstack.webhook.WebhookHelper;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -26,8 +26,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Date;
-
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.Role;
@@ -75,12 +73,8 @@ import com.cloud.vm.UserVmManagerImpl;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.snapshot.VMSnapshotVO;
-import com.cloud.projects.ProjectVO;
 
 public class AccountManagerImplTest extends AccountManagentImplTestBase {
-
-    @InjectMocks
-    private AccountManagerImpl accountManagerImpl;
 
     @Mock
     private UserVmManagerImpl _vmMgr;
@@ -120,15 +114,8 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
     @Mock
     private ProjectAccountVO projectAccountVO;
-
     @Mock
     private Project project;
-
-    @Mock
-    private ProjectAccountDao _projectAccountDao;
-
-    @Mock
-    private ProjectDao _projectDao;
 
     @Mock
     PasswordPolicyImpl passwordPolicyMock;
@@ -1594,23 +1581,4 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
         accountManagerImpl.checkCallerApiPermissionsForUserOrAccountOperations(accountMock);
     }
-
-    @Test
-    public void testCheckIfAccountManagesOnlyDeletedProjectsDoesNotThrow() {
-        long accountId = 42L;
-        long projectId = 100L;
-
-        Mockito.when(_projectAccountDao.listAdministratedProjectIds(accountId))
-                .thenReturn(List.of(projectId));
-
-        ProjectVO deletedProject = Mockito.mock(ProjectVO.class);
-        Mockito.when(deletedProject.getRemoved()).thenReturn(new Date());
-
-        Mockito.when(_projectDao.findById(projectId))
-                .thenReturn(deletedProject);
-
-        accountManagerImpl.checkIfAccountManagesProjects(accountId);
-
-    }
-
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -45,7 +45,6 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.resourcedetail.UserDetailVO;
 import org.apache.cloudstack.webhook.WebhookHelper;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -54,7 +53,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.junit.After;
 
 import com.cloud.acl.DomainChecker;
 import com.cloud.api.auth.SetupUserTwoFactorAuthenticationCmd;
@@ -75,6 +73,7 @@ import com.cloud.vm.UserVmManagerImpl;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.snapshot.VMSnapshotVO;
+import com.cloud.projects.ProjectVO;
 
 public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
@@ -1390,6 +1389,9 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
         List<Long> managedProjectIds = List.of(1L);
 
         Mockito.when(_projectAccountDao.listAdministratedProjectIds(accountId)).thenReturn(managedProjectIds);
+        ProjectVO project = Mockito.mock(ProjectVO.class);
+        Mockito.when(project.getRemoved()).thenReturn(null);
+        Mockito.when(_projectDao.findById(1L)).thenReturn(project);
         accountManagerImpl.checkIfAccountManagesProjects(accountId);
     }
 

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -79,6 +79,9 @@ import com.cloud.projects.ProjectVO;
 
 public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
+    @InjectMocks
+    private AccountManagerImpl accountManagerImpl;
+
     @Mock
     private UserVmManagerImpl _vmMgr;
     @Mock
@@ -117,8 +120,15 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
     @Mock
     private ProjectAccountVO projectAccountVO;
+
     @Mock
     private Project project;
+
+    @Mock
+    private ProjectAccountDao _projectAccountDao;
+
+    @Mock
+    private ProjectDao _projectDao;
 
     @Mock
     PasswordPolicyImpl passwordPolicyMock;
@@ -1590,16 +1600,17 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
         long accountId = 42L;
         long projectId = 100L;
 
-        Mockito.when(projectAccountDao.listAdministratedProjectIds(accountId))
+        Mockito.when(_projectAccountDao.listAdministratedProjectIds(accountId))
                 .thenReturn(List.of(projectId));
 
         ProjectVO deletedProject = Mockito.mock(ProjectVO.class);
         Mockito.when(deletedProject.getRemoved()).thenReturn(new Date());
 
-        Mockito.when(projectDao.findById(projectId))
+        Mockito.when(_projectDao.findById(projectId))
                 .thenReturn(deletedProject);
 
-        accountManager.checkIfAccountManagesProjects(accountId);
+        accountManagerImpl.checkIfAccountManagesProjects(accountId);
+
     }
 
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
+
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.Role;
@@ -73,6 +75,7 @@ import com.cloud.vm.UserVmManagerImpl;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.snapshot.VMSnapshotVO;
+import com.cloud.projects.ProjectVO;
 
 public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
@@ -1581,4 +1584,22 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
         accountManagerImpl.checkCallerApiPermissionsForUserOrAccountOperations(accountMock);
     }
+
+    @Test
+    public void testCheckIfAccountManagesOnlyDeletedProjectsDoesNotThrow() {
+        long accountId = 42L;
+        long projectId = 100L;
+
+        Mockito.when(projectAccountDao.listAdministratedProjectIds(accountId))
+                .thenReturn(List.of(projectId));
+
+        ProjectVO deletedProject = Mockito.mock(ProjectVO.class);
+        Mockito.when(deletedProject.getRemoved()).thenReturn(new Date());
+
+        Mockito.when(projectDao.findById(projectId))
+                .thenReturn(deletedProject);
+
+        accountManager.checkIfAccountManagesProjects(accountId);
+    }
+
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -54,6 +54,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.junit.After;
 
 import com.cloud.acl.DomainChecker;
 import com.cloud.api.auth.SetupUserTwoFactorAuthenticationCmd;


### PR DESCRIPTION
### Description

Backport of #12607 to the 4.20 branch.

This change fixes an issue where account deletion was blocked if the account
was listed as an administrator of projects that were already removed
(removed is not null).

The fix ensures that only active projects are considered when checking
whether an account manages projects, allowing deletion when only deleted
projects are associated.

Includes the same defensive check and unit test added in the main branch.

Rebased to 4.20 as requested by @DaanHoogland 

Fixes #12601

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test (unit test code)
