### PR TITLE
VPC restart cleanup for Public networks with multi-CIDR data

### DIFF
--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -600,9 +600,7 @@ public class NetworkVO implements Network {
             return true;
         }
 
-        return NetUtils.isNetworkAWithinNetworkB(
-                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(cidr),
-                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(that.cidr));
+        return NetUtils.isNetworkAWithinNetworkB(cidr, that.cidr);
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -600,9 +600,10 @@ public class NetworkVO implements Network {
             return true;
         }
 
-        return NetUtils.isNetworkAWithinNetworkB(
-                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(cidr),
-                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(that.cidr));
+        final String normalizedCidr = com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(cidr);
+        final String normalizedThatCidr = com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(that.cidr);
+
+        return NetUtils.isNetworkAWithinNetworkB(normalizedCidr, normalizedThatCidr);
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -600,7 +600,9 @@ public class NetworkVO implements Network {
             return true;
         }
 
-        return NetUtils.isNetworkAWithinNetworkB(cidr, that.cidr);
+        return NetUtils.isNetworkAWithinNetworkB(
+                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(cidr),
+                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(that.cidr));
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -600,10 +600,9 @@ public class NetworkVO implements Network {
             return true;
         }
 
-        final String normalizedCidr = com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(cidr);
-        final String normalizedThatCidr = com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(that.cidr);
-
-        return NetUtils.isNetworkAWithinNetworkB(normalizedCidr, normalizedThatCidr);
+        return NetUtils.isNetworkAWithinNetworkB(
+                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(cidr),
+                com.cloud.utils.StringUtils.getFirstValueFromCommaSeparatedString(that.cidr));
     }
 
     @Override

--- a/engine/schema/src/main/resources/META-INF/db/schema-42200to42210.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42200to42210.sql
@@ -33,3 +33,12 @@ UPDATE `cloud`.`alert` SET type = 34 WHERE name = 'ALERT.VR.PRIVATE.IFACE.MTU';
 
 -- Update configuration 'kvm.ssh.to.agent' description and is_dynamic fields
 UPDATE `cloud`.`configuration` SET description = 'True if the management server will restart the agent service via SSH into the KVM hosts after or during maintenance operations', is_dynamic = 1 WHERE name = 'kvm.ssh.to.agent';
+
+-- Sanitize legacy network-level addressing fields for Public networks
+UPDATE `cloud`.`networks`
+SET `broadcast_uri` = NULL,
+	`gateway` = NULL,
+	`cidr` = NULL,
+	`ip6_gateway` = NULL,
+	`ip6_cidr` = NULL
+WHERE `traffic_type` = 'Public';

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -5425,7 +5425,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final VlanVO vlan = commitVlanAndIpRange(zoneId, networkId, physicalNetworkId, podId, startIP, endIP, vlanGateway, vlanNetmask, vlanId, domain, vlanOwner, vlanIp6Gateway, vlanIp6Cidr,
                 ipv4, zone, vlanType, ipv6Range, ipRange, forSystemVms, provider);
 
-        if (vlan != null) {
+        if (vlan != null && network.getTrafficType() != TrafficType.Public) {
             if (ipv4) {
                 addCidrAndGatewayForIpv4(networkId, vlanGateway, vlanNetmask);
             } else if (ipv6) {
@@ -6504,11 +6504,14 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             final boolean ipv4 = deletedVlan.getVlanGateway() != null;
             final boolean ipv6 = deletedVlan.getIp6Gateway() != null;
             final long networkId = deletedVlan.getNetworkId();
+            final NetworkVO networkVO = _networkDao.findById(networkId);
 
-            if (ipv4) {
-                removeCidrAndGatewayForIpv4(networkId, deletedVlan);
-            } else if (ipv6) {
-                removeCidrAndGatewayForIpv6(networkId, deletedVlan);
+            if (networkVO != null && networkVO.getTrafficType() != TrafficType.Public) {
+                if (ipv4) {
+                    removeCidrAndGatewayForIpv4(networkId, deletedVlan);
+                } else if (ipv6) {
+                    removeCidrAndGatewayForIpv6(networkId, deletedVlan);
+                }
             }
 
             messageBus.publish(_name, MESSAGE_DELETE_VLAN_IP_RANGE_EVENT, PublishScope.LOCAL, deletedVlan);


### PR DESCRIPTION
 #12621
Fix VPC restart with multi-CIDR networks: handle comma-separated CIDR in NetworkVO.equals()

When a network has multiple CIDRs (e.g. '192.168.2.0/24,160.0.0.0/24'), NetworkVO.equals() passes the raw comma-separated string to NetUtils.isNetworkAWithinNetworkB() which expects a single CIDR, causing 'cidr is not formatted correctly' error during VPC restart with cleanup=true.

Extract only the first CIDR value before passing to NetUtils.

### Description
This PR addresses VPC restart failures during cleanup in environments where Public networks contain legacy aggregated network data (multiple values stored in network-level CIDR and gateway fields).


This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

 Bug fix (non-breaking change which fixes an issue)


#### Bug Severity

- [x] Major

### Screenshots (if appropriate):

### How Has This Been Tested?
- Reproduced the issue on a CloudStack 4.21.0.0 environment with two public IP ranges
  on different VLANs assigned to the same VPC
- Applied the fix and confirmed VPC restart with cleanup=true completes successfully
- Verified unit tests pass for NetworkVO.equals() with both single and comma-separated CIDRs

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
