### PR TITLE
Fix VPC network offerings listing in isolated network creation form

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -3731,6 +3731,7 @@
 "message.warn.filetype": "jpg, jpeg, png, bmp and svg are the only supported image formats.",
 "message.warn.importing.instance.without.nic": "WARNING: This Instance is being imported without NICs and many Network resources will not be available. Consider creating a NIC via vCenter before importing or as soon as the Instance is imported.",
 "message.warn.zone.mtu.update": "Please note that this limit won't affect pre-existing Network's MTU settings",
+"message.warn.vpc.offerings": "VPC offerings will be shown only if the selected account has at least one VPC.",
 "message.webhook.deliveries.time.filter": "Webhook deliveries list can be filtered based on date-time. Select 'Custom' for specifying start and end date range.",
 "message.zone.creation.complete": "Zone creation complete.",
 "message.zone.detail.description": "Populate Zone details.",

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -3731,7 +3731,7 @@
 "message.warn.filetype": "jpg, jpeg, png, bmp and svg are the only supported image formats.",
 "message.warn.importing.instance.without.nic": "WARNING: This Instance is being imported without NICs and many Network resources will not be available. Consider creating a NIC via vCenter before importing or as soon as the Instance is imported.",
 "message.warn.zone.mtu.update": "Please note that this limit won't affect pre-existing Network's MTU settings",
-"message.warn.vpc.offerings": "VPC offerings will be shown only if the selected account has at least one VPC.",
+"message.warn.vpc.offerings": "VPC offerings will only be shown if the selected account has at least one VPC.",
 "message.webhook.deliveries.time.filter": "Webhook deliveries list can be filtered based on date-time. Select 'Custom' for specifying start and end date range.",
 "message.zone.creation.complete": "Zone creation complete.",
 "message.zone.detail.description": "Populate Zone details.",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -2510,6 +2510,7 @@
 "message.vr.alert.upon.network.offering.creation.others": "Como nenhum dos servi\u00e7os obrigat\u00f3rios para cria\u00e7\u00e3o do VR (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) foram habilitados, o VR n\u00e3o ser\u00e1 criado e a oferta de computa\u00e7\u00e3o n\u00e3o ser\u00e1 usada.",
 "message.warn.filetype": "jpg, jpeg, png, bmp e svg s\u00e3o os \u00fanicos formatos de imagem suportados",
 "message.warn.importing.instance.without.nic": "AVISO: essa inst\u00e2ncia est\u00e1 sendo importada sem NICs e muitos recursos de rede n\u00e3o estar\u00e3o dispon\u00edveis. Considere criar uma NIC antes de importar via VCenter ou assim que a inst\u00e2ncia for importada.",
+"message.warn.vpc.offerings": "Ofertas de VPC s\u00c3o exibidas somente caso a conta selecionada possua ao menos uma VPC.",
 "message.zone.creation.complete": "Cria\u00e7\u00e3o de zona completa",
 "message.zone.detail.description": "Preencha os detalhes da zona",
 "message.zone.detail.hint": "Uma zona \u00e9 a maior unidade organizacional no CloudStack, e normalmente corresponde a um \u00fanico datacenter. As zonas proporcionam isolamento f\u00edsico e redund\u00e2ncia. Uma zona consiste em um ou mais pods (cada um contendo hosts e servidores de armazenamento prim\u00e1rio) e um servidor de armazenamento secund\u00e1rio que \u00e9 compartilhado por todos os pods da zona.",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -2510,7 +2510,7 @@
 "message.vr.alert.upon.network.offering.creation.others": "Como nenhum dos servi\u00e7os obrigat\u00f3rios para cria\u00e7\u00e3o do VR (VPN, DHCP, DNS, Firewall, LB, UserData, SourceNat, StaticNat, PortForwarding) foram habilitados, o VR n\u00e3o ser\u00e1 criado e a oferta de computa\u00e7\u00e3o n\u00e3o ser\u00e1 usada.",
 "message.warn.filetype": "jpg, jpeg, png, bmp e svg s\u00e3o os \u00fanicos formatos de imagem suportados",
 "message.warn.importing.instance.without.nic": "AVISO: essa inst\u00e2ncia est\u00e1 sendo importada sem NICs e muitos recursos de rede n\u00e3o estar\u00e3o dispon\u00edveis. Considere criar uma NIC antes de importar via VCenter ou assim que a inst\u00e2ncia for importada.",
-"message.warn.vpc.offerings": "Ofertas de VPC s\u00c3o exibidas somente caso a conta selecionada possua ao menos uma VPC.",
+"message.warn.vpc.offerings": "Ofertas de VPC somente ser\u00c3o exibidas caso a conta selecionada possua ao menos uma VPC.",
 "message.zone.creation.complete": "Cria\u00e7\u00e3o de zona completa",
 "message.zone.detail.description": "Preencha os detalhes da zona",
 "message.zone.detail.hint": "Uma zona \u00e9 a maior unidade organizacional no CloudStack, e normalmente corresponde a um \u00fanico datacenter. As zonas proporcionam isolamento f\u00edsico e redund\u00e2ncia. Uma zona consiste em um ou mais pods (cada um contendo hosts e servidores de armazenamento prim\u00e1rio) e um servidor de armazenamento secund\u00e1rio que \u00e9 compartilhado por todos os pods da zona.",

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -96,6 +96,11 @@
                 {{ opt.displaytext || opt.name || opt.description }}
               </a-select-option>
             </a-select>
+            <a-alert type="warning" v-if="!this.hasVPC">
+              <template #message>
+                <span v-html="$t('message.warn.vpc.offerings')"/>
+              </template>
+            </a-alert>
           </a-form-item>
           <a-form-item ref="asnumber" name="asnumber" v-if="isASNumberRequired()">
             <template #label>
@@ -369,7 +374,8 @@ export default {
       setMTU: false,
       asNumberLoading: false,
       selectedAsNumber: 0,
-      asNumbersZone: []
+      asNumbersZone: [],
+      hasVPC: true
     }
   },
   watch: {
@@ -515,13 +521,17 @@ export default {
       if (this.vpc !== null) { // from VPC section
         this.fetchNetworkOfferingData(true)
       } else { // from guest network section
-        var params = {}
+        var params = {
+          account: this.owner.account,
+          projectid: this.owner.projectid,
+          domainid: this.owner.domainid
+        }
         this.networkOfferingLoading = true
         if ('listVPCs' in this.$store.getters.apis) {
           api('listVPCs', params).then(json => {
             const listVPCs = json.listvpcsresponse.vpc
-            var vpcAvailable = this.arrayHasItems(listVPCs)
-            if (vpcAvailable === false) {
+            this.hasVPC = this.arrayHasItems(listVPCs)
+            if (this.hasVPC === false) {
               this.fetchNetworkOfferingData(false)
             } else {
               this.fetchNetworkOfferingData()

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -521,7 +521,7 @@ export default {
       if (this.vpc !== null) { // from VPC section
         this.fetchNetworkOfferingData(true)
       } else { // from guest network section
-        var params = {
+        const params = {
           account: this.owner.account,
           projectid: this.owner.projectid,
           domainid: this.owner.domainid
@@ -531,7 +531,7 @@ export default {
           api('listVPCs', params).then(json => {
             const listVPCs = json.listvpcsresponse.vpc
             this.hasVPC = this.arrayHasItems(listVPCs)
-            if (this.hasVPC === false) {
+            if (!this.hasVPC) {
               this.fetchNetworkOfferingData(false)
             } else {
               this.fetchNetworkOfferingData()
@@ -544,7 +544,7 @@ export default {
     },
     fetchNetworkOfferingData (forVpc) {
       this.networkOfferingLoading = true
-      var params = {
+      const params = {
         zoneid: this.selectedZone.id,
         guestiptype: 'Isolated',
         state: 'Enabled'
@@ -587,7 +587,7 @@ export default {
     },
     fetchVpcData () {
       this.vpcLoading = true
-      var params = {
+      const params = {
         listAll: true,
         details: 'min'
       }
@@ -610,14 +610,14 @@ export default {
         const formRaw = toRaw(this.form)
         const values = this.handleRemoveFields(formRaw)
         this.actionLoading = true
-        var params = {
+        const params = {
           zoneId: this.selectedZone.id,
           name: values.name,
           displayText: values.displaytext,
           networkOfferingId: this.selectedNetworkOffering.id
         }
-        var usefulFields = ['gateway', 'netmask', 'cidrsize', 'startip', 'startipv4', 'endip', 'endipv4', 'dns1', 'dns2', 'ip6dns1', 'ip6dns2', 'sourcenatipaddress', 'externalid', 'vpcid', 'vlan', 'networkdomain']
-        for (var field of usefulFields) {
+        const usefulFields = ['gateway', 'netmask', 'cidrsize', 'startip', 'startipv4', 'endip', 'endipv4', 'dns1', 'dns2', 'ip6dns1', 'ip6dns2', 'sourcenatipaddress', 'externalid', 'vpcid', 'vlan', 'networkdomain']
+        for (const field of usefulFields) {
           if (this.isValidTextValueForKey(values, field)) {
             params[field] = values[field]
           }


### PR DESCRIPTION
### Description

Currently, when creating a new isolated network, it is possible to assign it as a VPC tier. The VPC assignment field is shown only when a VPC network offering is selected. However, it was noticed that VPC network offerings are listed only if the current user has at least one VPC. Otherwise, VPC network offering were not listed and it was necessary to access another account that has a VPC or create a dummy VPC.

Changes were made,to list offerings based on the form selected account instead of the current user. Besides that, an warning was added below the network offerings field informing that VPC network offerings will be shown only if the selected account has at least one VPC.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

Warning message:

<img width="650" height="462" alt="image" src="https://github.com/user-attachments/assets/1b003c9c-8907-4f1d-ac1c-a34186af50e3" />

<details><summary>No VPC user offerings</summary>

<img width="651" height="523" alt="image" src="https://github.com/user-attachments/assets/219bc3c5-9d25-43f7-bd56-042a20d3e585" />

</details>

No warning shown for account that has a VPC:

<img width="644" height="429" alt="image" src="https://github.com/user-attachments/assets/88489e4e-8342-486c-8a9c-ed6bae9e1ff1" />

<details><summary>VPC network offerings listed for a account that has a VPC</summary>

<img width="651" height="612" alt="image" src="https://github.com/user-attachments/assets/19b90fb0-9629-427f-b170-60bfc62f00a6" />

</details>

### How Has This Been Tested?

Logged in with the `admin` account, I created a VPC  to the `radm` account. Then, I accessed the isolated network creation form and validated that the VPC offerings were not shown (because the current account did not had a VPC). Then, I applied the PR changes to my local environment. 

With the changes applied, the isolated network form was accessed again, and it was possible to see the warning message. When the `radm` was selected in the form,  the warning message was hidden and the VPC offerings were listed successfully.

The same tests were reproduced for projects. 