### PR TITLE
Fix infrastructure leak in template from volume creation error message

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -476,8 +476,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         }
 
         if (imageStore == null) {
-            logger.error("Cannot find an image store for zone [{}].", zoneId);
-            throw new CloudRuntimeException("Failed to create template. Please contact the cloud administrator.");
+            throwExceptionForImageStoreObtentionFailure(zoneId, "upload volume");
         }
 
         return imageStore;
@@ -1397,7 +1396,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_ISO_DELETE, eventDescription = "Deleting ISO", async = true)
-    public boolean deleteIso(DeleteIsoCmd cmd) {
+    public boolean deleteIso (DeleteIsoCmd cmd) {
         Long templateId = cmd.getId();
         Account caller = CallContext.current().getCallingAccount();
         Long zoneId = cmd.getZoneId();
@@ -1703,8 +1702,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             }
             DataStore store = _dataStoreMgr.getImageStoreWithFreeCapacity(zoneId);
             if (store == null) {
-                logger.error("Cannot find an image store for zone [{}].", zoneId);
-                throw new CloudRuntimeException("Failed to create template. Please contact the cloud administrator.");
+                throwExceptionForImageStoreObtentionFailure(zoneId, "create template");
             }
             AsyncCallFuture<TemplateApiResult> future = null;
 
@@ -2480,5 +2478,10 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         _tmpltDao.update(template.getId(), template);
 
         return _tmpltDao.findById(template.getId());
+    }
+
+    private void throwExceptionForImageStoreObtentionFailure(Long zoneId, String operation) {
+        logger.error("Cannot find an image store for zone [{}].", zoneId);
+        throw new CloudRuntimeException(String.format("Failed to %s. Please contact the cloud administrator.", operation));
     }
 }

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1396,7 +1396,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_ISO_DELETE, eventDescription = "Deleting ISO", async = true)
-    public boolean deleteIso (DeleteIsoCmd cmd) {
+    public boolean deleteIso(DeleteIsoCmd cmd) {
         Long templateId = cmd.getId();
         Account caller = CallContext.current().getCallingAccount();
         Long zoneId = cmd.getZoneId();

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -476,7 +476,8 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         }
 
         if (imageStore == null) {
-            throw new CloudRuntimeException(String.format("Cannot find an image store for zone [%s].", zoneId));
+            logger.error("Cannot find an image store for zone [{}].", zoneId);
+            throw new CloudRuntimeException("Failed to create template. Please contact the cloud administrator.");
         }
 
         return imageStore;
@@ -1702,7 +1703,8 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             }
             DataStore store = _dataStoreMgr.getImageStoreWithFreeCapacity(zoneId);
             if (store == null) {
-                throw new CloudRuntimeException("cannot find an image store for zone " + zoneId);
+                logger.error("Cannot find an image store for zone [{}].", zoneId);
+                throw new CloudRuntimeException("Failed to create template. Please contact the cloud administrator.");
             }
             AsyncCallFuture<TemplateApiResult> future = null;
 

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -2481,7 +2481,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
     }
 
     private void throwExceptionForImageStoreObtentionFailure(Long zoneId, String operation) {
-        logger.error("Cannot find an image store for zone [{}].", zoneId);
+        logger.error("Cannot find an image store for zone [{}] while trying to {}.", zoneId, operation);
         throw new CloudRuntimeException(String.format("Failed to %s. Please contact the cloud administrator.", operation));
     }
 }


### PR DESCRIPTION
### Description

Currently, if an error occurs when trying to obtain a secondary storage for the creation of a template from a volume, or when uploading a volume, the message from the thrown exception exposes the zone's internal ID.  Thus, the exception message was changed, and the descriptive message was moved to the logs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

In an environment with only one secondary storage, I set it as `read-only`. Then, I tried to create a template from a volume. An exception was thrown, informing that an error had occurred, but no infrastructure leak was present. I accessed the logs, and validated that the log with more information was shown, as well as the new exception message.

```
2026-02-16 13:01:37,560 ERROR [c.c.t.TemplateManagerImpl] (API-Job-Executor-11:[ctx-5f80938b, job-46, ctx-c87d05bc]) (logid:8879f16f) Cannot find an image store for zone [1].


2026-02-16 13:01:37,576 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-11:[ctx-5f80938b, job-46]) (logid:8879f16f) Unexpected exception while executing org.apache.cloudstack.api.command.admin.template.CreateTemplateCmdByAdmin com.cloud.utils.exception.CloudRuntimeException: Failed to create template. Please contact the cloud administrator.
```