### PR TITLE
Fix primary storage maintenance on xcpng

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/ModifyStoragePoolAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/ModifyStoragePoolAnswer.java
@@ -46,6 +46,10 @@ public class ModifyStoragePoolAnswer extends Answer {
         templateInfo = tInfo;
     }
 
+    public ModifyStoragePoolAnswer(final Command command, final boolean success, final String details) {
+        super(command, success, details);
+    }
+
     public void setPoolInfo(StoragePoolInfo poolInfo) {
         this.poolInfo = poolInfo;
     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixModifyStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixModifyStoragePoolCommandWrapper.java
@@ -59,7 +59,7 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
                 if (capacity == -1) {
                     final String msg = "Pool capacity is -1! pool: " + pool.getHost() + pool.getPath();
                     logger.warn(msg);
-                    return new Answer(command, false, msg);
+                    return new ModifyStoragePoolAnswer(command, false, msg);
                 }
                 final Map<String, TemplateProp> tInfo = new HashMap<String, TemplateProp>();
                 final ModifyStoragePoolAnswer answer = new ModifyStoragePoolAnswer(command, capacity, available, tInfo);
@@ -68,12 +68,12 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
                 final String msg = "ModifyStoragePoolCommand add XenAPIException:" + e.toString() + " host:" + citrixResourceBase.getHost().getUuid() + " pool: " + pool.getHost()
                         + pool.getPath();
                 logger.warn(msg, e);
-                return new Answer(command, false, msg);
+                return new ModifyStoragePoolAnswer(command, false, msg);
             } catch (final Exception e) {
                 final String msg = "ModifyStoragePoolCommand add XenAPIException:" + e.getMessage() + " host:" + citrixResourceBase.getHost().getUuid() + " pool: "
                         + pool.getHost() + pool.getPath();
                 logger.warn(msg, e);
-                return new Answer(command, false, msg);
+                return new ModifyStoragePoolAnswer(command, false, msg);
             }
         } else {
             try {
@@ -85,17 +85,17 @@ public final class CitrixModifyStoragePoolCommandWrapper extends CommandWrapper<
                 if (result == null || !result.split("#")[1].equals("0")) {
                     throw new CloudRuntimeException("Unable to remove heartbeat file entry for SR " + srUuid + " due to " + result);
                 }
-                return new Answer(command, true, "success");
+                return new ModifyStoragePoolAnswer(command, true, "success");
             } catch (final XenAPIException e) {
                 final String msg = "ModifyStoragePoolCommand remove XenAPIException:" + e.toString() + " host:" + citrixResourceBase.getHost().getUuid() + " pool: "
                         + pool.getHost() + pool.getPath();
                 logger.warn(msg, e);
-                return new Answer(command, false, msg);
+                return new ModifyStoragePoolAnswer(command, false, msg);
             } catch (final Exception e) {
                 final String msg = "ModifyStoragePoolCommand remove XenAPIException:" + e.getMessage() + " host:" + citrixResourceBase.getHost().getUuid() + " pool: "
                         + pool.getHost() + pool.getPath();
                 logger.warn(msg, e);
-                return new Answer(command, false, msg);
+                return new ModifyStoragePoolAnswer(command, false, msg);
             }
         }
     }


### PR DESCRIPTION
### Description

Enable maintenance mode is erroring out on XCP-ng

<img width="408" height="217" alt="Screenshot 2026-02-24 at 10 47 04 AM" src="https://github.com/user-attachments/assets/5e099ec2-d6c2-45e9-b31d-428dcd6646d2" />

```
2026-02-24 04:44:49,881 ERROR [c.c.s.StoragePoolAutomationImpl] (API-Job-Executor-7:[ctx-b02dbbf9, job-515, ctx-8a343d55]) (logid:4e4cc86b) Exception in enabling primary storage maintenance: java.lang.ClassCastException: class com.cloud.agent.api.Answer cannot be cast to class com.cloud.agent.api.ModifyStoragePoolAnswer (com.cloud.agent.api.Answer and com.cloud.agent.api.ModifyStoragePoolAnswer are in unnamed module of loader 'app')
        at com.cloud.storage.StoragePoolAutomationImpl.removeHeartbeatForHostsFromPool(StoragePoolAutomationImpl.java:255)
        at com.cloud.storage.StoragePoolAutomationImpl.maintain(StoragePoolAutomationImpl.java:86)
        at org.apache.cloudstack.storage.datastore.lifecycle.CloudStackPrimaryDataStoreLifeCycleImpl.maintain(CloudStackPrimaryDataStoreLifeCycleImpl.java:444)

```
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
1. Add a NFS primary storage 
2. Put it in maintenance (Throws error without the fix)
3. Delete the primary storage

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
