### PR TITLE
Fix RESTRICTED_TOKENS typo: " javax" (leading space) fails to prevent javax binding

### DIFF
--- a/utils/src/main/java/org/apache/cloudstack/utils/jsinterpreter/JsInterpreter.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/jsinterpreter/JsInterpreter.java
@@ -62,7 +62,7 @@ public class JsInterpreter implements Closeable {
     protected Logger logger = LogManager.getLogger(JsInterpreter.class);
 
     protected static final List<String> RESTRICTED_TOKENS = Arrays.asList( "engine", "context", "factory",
-            "Java", "java", "Packages"," javax", "load", "loadWithNewGlobal", "print", "factory", "getClass",
+            "Java", "java", "Packages", "javax", "load", "loadWithNewGlobal", "print", "factory", "getClass",
             "runCommand", "Runtime", "exec", "ProcessBuilder", "Thread", "thread", "Threads", "Class", "class");
 
     protected ScriptEngine interpreter;


### PR DESCRIPTION
### Description

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
`RESTRICTED_TOKENS` is used to blacklist tokens for the JavaScript engine, used for rules etc. However, I saw that one of the entries `" javax"` has an accidental space in it, it should most likely be `"javax"`.

As far as I understand, the typo does not lead to any security impact as the `--no-java` flag disables `javax` access, so that's why I'm creating an issue here on GitHub, and not a vulnerability disclosure. Consider this more of a little cleanup of the code.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### How Has This Been Tested?

Test still pass. 