### PR TITLE
[Fix] VMware to KVM migration instances listing failure

### DIFF
--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/BaseMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/BaseMO.java
@@ -226,7 +226,7 @@ public class BaseMO {
             } else if (objProp.getName().equals("config.bootOptions")) {
                 VirtualMachineBootOptions bootOptions = (VirtualMachineBootOptions) objProp.getVal();
                 String bootMode = "LEGACY";
-                if (bootOptions != null && bootOptions.isEfiSecureBootEnabled()) {
+                if (bootOptions != null && Boolean.TRUE.equals(bootOptions.isEfiSecureBootEnabled())) {
                     bootMode = "SECURE";
                 }
                 vm.setBootMode(bootMode);

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -819,7 +819,7 @@ public class VmwareHelper {
                 instance.setBootType(firmware.equalsIgnoreCase("efi") ? "UEFI" : "BIOS");
                 VirtualMachineBootOptions bootOptions = configInfo.getBootOptions();
                 String bootMode = "LEGACY";
-                if (bootOptions != null && bootOptions.isEfiSecureBootEnabled()) {
+                if (bootOptions != null && Boolean.TRUE.equals(bootOptions.isEfiSecureBootEnabled())) {
                     bootMode = "SECURE";
                 }
                 instance.setBootMode(bootMode);


### PR DESCRIPTION
### Description

This PR fixes instances listing from VMware vCenters for migration to KVM due to NPE on EFI settings on some VMware VMs

Fixes: #12647 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Changes tested by @rosi-achmad on https://github.com/apache/cloudstack/issues/12647#issuecomment-3994839253

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
