### PR TITLE
UI: Show security group selection in Basic zone VM deployment

### DIFF
--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -459,6 +459,9 @@
                     :value="securitygroupids"
                     :loading="loading.networks"
                     :preFillContent="dataPreFill"
+                    :domainId="owner.domainid"
+                    :account="owner.account"
+                    :projectId="owner.projectid"
                     @select-security-group-item="($event) => updateSecurityGroups($event)"></security-group-selection>
                 </template>
               </a-step>
@@ -1501,6 +1504,9 @@ export default {
       return tabList
     },
     showSecurityGroupSection () {
+      if (this.zone && this.zone.networktype === 'Basic') {
+        return true
+      }
       if (this.networks.length < 1) {
         return false
       }

--- a/ui/src/views/compute/wizard/SecurityGroupSelection.vue
+++ b/ui/src/views/compute/wizard/SecurityGroupSelection.vue
@@ -75,6 +75,18 @@ export default {
     preFillContent: {
       type: Object,
       default: () => {}
+    },
+    domainId: {
+      type: String,
+      default: () => ''
+    },
+    account: {
+      type: String,
+      default: () => ''
+    },
+    projectId: {
+      type: String,
+      default: () => ''
     }
   },
   data () {
@@ -102,6 +114,9 @@ export default {
     }
   },
   computed: {
+    ownerParams () {
+      return `${this.domainId}-${this.account}-${this.projectId}`
+    },
     rowSelection () {
       return {
         type: 'checkbox',
@@ -120,6 +135,11 @@ export default {
       if (newValue && !_.isEqual(newValue, oldValue)) {
         this.selectedRowKeys = newValue
       }
+    },
+    ownerParams () {
+      this.selectedRowKeys = []
+      this.$emit('select-security-group-item', null)
+      this.fetchData()
     },
     loading () {
       if (!this.loading) {
@@ -140,9 +160,9 @@ export default {
   methods: {
     fetchData () {
       const params = {
-        projectid: this.$store.getters.project ? this.$store.getters.project.id : null,
-        domainid: this.$store.getters.project && this.$store.getters.project.id ? null : this.$store.getters.userInfo.domainid,
-        account: this.$store.getters.project && this.$store.getters.project.id ? null : this.$store.getters.userInfo.account,
+        projectid: this.projectId || (this.$store.getters.project ? this.$store.getters.project.id : null),
+        domainid: this.projectId || (this.$store.getters.project && this.$store.getters.project.id) ? null : (this.domainId || this.$store.getters.userInfo.domainid),
+        account: this.projectId || (this.$store.getters.project && this.$store.getters.project.id) ? null : (this.account || this.$store.getters.userInfo.account),
         page: this.page,
         pageSize: this.pageSize
       }


### PR DESCRIPTION
### Description

The Deploy VM wizard does not show the Security Groups selection step in Basic zones. 

Fixes: #11685

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Screen-recording

https://github.com/user-attachments/assets/42c7c432-5940-4da3-9a12-407cbf27a606


### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

1. Created a Basic zone and verified the Security Groups step now appears in the Deploy VM wizard
2. Tested cross-domain deployment as root admin and verified SGs from the target domain/account are listed correctly