### PR TITLE
Fix repository mount failure during restore due to path format handling

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapper.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -52,7 +53,6 @@ import java.util.Objects;
 @ResourceWrapper(handles = RestoreBackupCommand.class)
 public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBackupCommand, Answer, LibvirtComputingResource> {
     private static final String BACKUP_TEMP_FILE_PREFIX = "csbackup";
-    private static final String MOUNT_COMMAND = "sudo mount -t %s %s %s";
     private static final String UMOUNT_COMMAND = "sudo umount %s";
     private static final String FILE_PATH_PLACEHOLDER = "%s/%s";
     private static final String ATTACH_QCOW2_DISK_COMMAND = " virsh attach-disk %s %s %s --driver qemu --subdriver qcow2 --cache none";
@@ -197,7 +197,7 @@ public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBa
 
     private String mountBackupDirectory(String backupRepoAddress, String backupRepoType, String mountOptions, Integer mountTimeout) {
         String randomChars = RandomStringUtils.random(5, true, false);
-        String mountDirectory = String.format("%s.%s",BACKUP_TEMP_FILE_PREFIX , randomChars);
+        String mountDirectory = String.format("%s.%s", BACKUP_TEMP_FILE_PREFIX, randomChars);
 
         try {
             mountDirectory = Files.createTempDirectory(mountDirectory).toString();
@@ -206,23 +206,35 @@ public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBa
             throw new CloudRuntimeException("Failed to create the tmp mount directory for restore on the KVM host");
         }
 
-        String mount = String.format(MOUNT_COMMAND, backupRepoType, backupRepoAddress, mountDirectory);
-        if ("cifs".equals(backupRepoType)) {
+        if ("cifs".equalsIgnoreCase(backupRepoType)) {
             if (Objects.isNull(mountOptions) || mountOptions.trim().isEmpty()) {
                 mountOptions = "nobrl";
             } else {
                 mountOptions += ",nobrl";
             }
         }
-        if (Objects.nonNull(mountOptions) && !mountOptions.trim().isEmpty()) {
-            mount += " -o " + mountOptions;
-        }
 
-        int exitValue = Script.runSimpleBashScriptForExitValue(mount, mountTimeout, false);
-        if (exitValue != 0) {
-            logger.error("Failed to mount repository {} of type {} to the directory {}", backupRepoAddress, backupRepoType, mountDirectory);
+        List<String[]> commands = new ArrayList<>();
+        List<String> cmd = new ArrayList<>();
+        cmd.add("sudo");
+        cmd.add("mount");
+        cmd.add("-t");
+        cmd.add(backupRepoType);
+        cmd.add(backupRepoAddress);
+        cmd.add(mountDirectory);
+        if (Objects.nonNull(mountOptions) && !mountOptions.trim().isEmpty()) {
+            cmd.add("-o");
+            cmd.add(mountOptions);
+        }
+        commands.add(cmd.toArray(new String[0]));
+
+        Pair<Integer, String> result = Script.executePipedCommands(commands, mountTimeout);
+        if (result.first() != 0) {
+            logger.error("Failed to mount repository {} of type {} to the directory {}. Error: {}",
+                    backupRepoAddress, backupRepoType, mountDirectory, result.second());
             throw new CloudRuntimeException("Failed to mount the backup repository on the KVM host");
         }
+
         return mountDirectory;
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapper.java
@@ -214,6 +214,13 @@ public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBa
             }
         }
 
+        executeMount(backupRepoAddress, backupRepoType, mountOptions, mountDirectory, mountTimeout);
+
+        return mountDirectory;
+    }
+
+    private void executeMount(String backupRepoAddress, String backupRepoType, String mountOptions,
+                              String mountDirectory, Integer mountTimeout) {
         List<String[]> commands = new ArrayList<>();
         List<String> cmd = new ArrayList<>();
         cmd.add("sudo");
@@ -234,8 +241,6 @@ public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBa
                     backupRepoAddress, backupRepoType, mountDirectory, result.second());
             throw new CloudRuntimeException("Failed to mount the backup repository on the KVM host");
         }
-
-        return mountDirectory;
     }
 
     private void unmountBackupDirectory(String backupDirectory) {

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapperTest.java
@@ -18,6 +18,7 @@ package com.cloud.hypervisor.kvm.resource.wrapper;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.utils.Pair;
 import com.cloud.storage.Storage;
 import com.cloud.utils.script.Script;
 import com.cloud.vm.VirtualMachine;
@@ -83,6 +84,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenReturn(0); // Mount success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
@@ -126,6 +129,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenReturn(0); // Mount success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
@@ -165,6 +170,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenReturn(0); // Mount success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
@@ -207,6 +214,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenReturn(0); // Mount success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
@@ -251,8 +260,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
-                scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
-                        .thenReturn(1); // Mount failure
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(1, "Failed"));
 
                 Answer result = wrapper.execute(command, libvirtComputingResource);
 
@@ -290,6 +299,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenReturn(0); // Mount success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
@@ -339,8 +350,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
-                scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
-                        .thenReturn(0); // Mount success
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
                         .thenAnswer(invocation -> {
                             String command = invocation.getArgument(0);
@@ -390,6 +401,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenAnswer(invocation -> {
                             String command = invocation.getArgument(0);
@@ -449,6 +462,8 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
                         .thenAnswer(invocation -> {
                             String command = invocation.getArgument(0);
@@ -551,6 +566,10 @@ public class LibvirtRestoreBackupCommandWrapperTest {
             filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
 
             try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                Mockito.when(Script.executePipedCommands(Mockito.anyList(), Mockito.anyLong()))
+                        .thenReturn(new Pair<>(0, "success"));
+                scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))
+                        .thenReturn(0); // Mount success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString()))
                         .thenReturn(0); // All commands success
                 scriptMock.when(() -> Script.runSimpleBashScriptForExitValue(anyString(), anyInt(), any(Boolean.class)))


### PR DESCRIPTION
### Description

This PR addresses an issue mentioned here https://github.com/apache/cloudstack/issues/12669

Here we are addressing the mount operation to be same as it does during backup

https://github.com/shapeblue/cloudstack/blob/b7a11cb203aeb9458460e3ce06090172b3a814d1/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtTakeBackupCommandWrapper.java#L71-L84

```
        List<String[]> commands = new ArrayList<>();
        commands.add(new String[]{
                libvirtComputingResource.getNasBackupPath(),
                "-o", "backup",
                "-v", vmName,
                "-t", backupRepoType,
                "-s", backupRepoAddress,
                "-m", Objects.nonNull(mountOptions) ? mountOptions : "",
                "-p", backupPath,
                "-q", command.getQuiesce() != null && command.getQuiesce() ? "true" : "false",
                "-d", diskPaths.isEmpty() ? "" : String.join(",", diskPaths)
        });

        Pair<Integer, String> result = Script.executePipedCommands(commands, libvirtComputingResource.getCmdsTimeout());
```


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
