### PR TITLE
[4.22] Prevent unmanaging or reinstalling a VM if it is part of a CKS cluster

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManager.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManager.java
@@ -199,4 +199,9 @@ public interface UserVmManager extends UserVmService {
 
     Boolean getDestroyRootVolumeOnVmDestruction(Long domainId);
 
+    /**
+     * @return true if the VM is part of a CKS cluster, false otherwise.
+     */
+    boolean isVMPartOfAnyCKSCluster(VMInstanceVO vm);
+
 }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2352,6 +2352,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Vm with id " + vm.getUuid() + " is not in the right state");
         }
 
+        if (isVMPartOfAnyCKSCluster(vm)) {
+            throw new UnsupportedServiceException("Cannot recover VM with id = " + vm.getUuid() +
+                    " as it belongs to a CKS cluster. Please remove the VM from the CKS cluster before recovering.");
+        }
+
         if (logger.isDebugEnabled()) {
             logger.debug("Recovering vm {}", vm);
         }
@@ -9953,6 +9958,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     public Boolean getDestroyRootVolumeOnVmDestruction(Long domainId){
         return DestroyRootVolumeOnVmDestruction.valueIn(domainId);
+    }
+
+    @Override
+    public boolean isVMPartOfAnyCKSCluster(VMInstanceVO vm) {
+        return kubernetesServiceHelpers.get(0).findByVmId(vm.getId()) != null;
     }
 
     private void setVncPasswordForKvmIfAvailable(Map<String, String> customParameters, UserVmVO vm) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2352,11 +2352,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Vm with id " + vm.getUuid() + " is not in the right state");
         }
 
-        if (isVMPartOfAnyCKSCluster(vm)) {
-            throw new UnsupportedServiceException("Cannot recover VM with id = " + vm.getUuid() +
-                    " as it belongs to a CKS cluster. Please remove the VM from the CKS cluster before recovering.");
-        }
-
         if (logger.isDebugEnabled()) {
             logger.debug("Recovering vm {}", vm);
         }
@@ -8764,6 +8759,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     vm, Hypervisor.HypervisorType.External.name());
             throw new InvalidParameterValueException(String.format("Operation not supported for instance: %s",
                     vm.getName()));
+        }
+        if (isVMPartOfAnyCKSCluster(vm)) {
+            throw new UnsupportedServiceException("Cannot restore VM with id = " + vm.getUuid() +
+                    " as it belongs to a CKS cluster. Please remove the VM from the CKS cluster before restoring.");
         }
         _accountMgr.checkAccess(caller, null, true, vm);
 

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -71,7 +71,6 @@ import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.hypervisor.HypervisorGuruManager;
-import com.cloud.kubernetes.cluster.KubernetesServiceHelper;
 import com.cloud.network.Network;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.Networks;
@@ -314,12 +313,6 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     private DataStoreManager dataStoreManager;
     @Inject
     private ImportVmTasksManager importVmTasksManager;
-
-    private List<KubernetesServiceHelper> kubernetesServiceHelpers;
-
-    public void setKubernetesServiceHelpers(final List<KubernetesServiceHelper> kubernetesServiceHelpers) {
-        this.kubernetesServiceHelpers = kubernetesServiceHelpers;
-    }
 
     protected Gson gson;
 
@@ -2386,14 +2379,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                     " as there is an ISO attached. Please detach ISO before unmanaging.");
         }
 
-        if (isVmPartOfCKSCluster(vmVO)) {
+        if (userVmManager.isVMPartOfAnyCKSCluster(vmVO)) {
             throw new UnsupportedServiceException("Cannot unmanage VM with id = " + vmVO.getUuid() +
                     " as it belongs to a CKS cluster. Please remove the VM from the CKS cluster before unmanaging.");
         }
-    }
-
-    private boolean isVmPartOfCKSCluster(VMInstanceVO vmVO) {
-        return kubernetesServiceHelpers.get(0).findByVmId(vmVO.getId()) != null;
     }
 
     private boolean hasVolumeSnapshotsPriorToUnmanageVM(VMInstanceVO vmVO) {

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -71,6 +71,7 @@ import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.hypervisor.HypervisorGuruManager;
+import com.cloud.kubernetes.cluster.KubernetesServiceHelper;
 import com.cloud.network.Network;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.Networks;
@@ -313,6 +314,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     private DataStoreManager dataStoreManager;
     @Inject
     private ImportVmTasksManager importVmTasksManager;
+    @Inject
+    private KubernetesServiceHelper kubernetesServiceHelper;
 
     protected Gson gson;
 
@@ -2365,6 +2368,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
      * Perform validations before attempting to unmanage a VM from CloudStack:
      * - VM must not have any associated volume snapshot
      * - VM must not have an attached ISO
+     * - VM must not belong to any CKS cluster
+     * @throws UnsupportedServiceException in case any of the validations above fail
      */
     void performUnmanageVMInstancePrechecks(VMInstanceVO vmVO) {
         if (hasVolumeSnapshotsPriorToUnmanageVM(vmVO)) {
@@ -2376,6 +2381,15 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             throw new UnsupportedServiceException("Cannot unmanage VM with id = " + vmVO.getUuid() +
                     " as there is an ISO attached. Please detach ISO before unmanaging.");
         }
+
+        if (belongsToCksCluster(vmVO)) {
+            throw new UnsupportedServiceException("Cannot unmanage VM with id = " + vmVO.getUuid() +
+                    " as it belongs to a CKS cluster. Please remove the VM from the CKS cluster before unmanaging.");
+        }
+    }
+
+    private boolean belongsToCksCluster(VMInstanceVO vmVO) {
+        return kubernetesServiceHelper.findByVmId(vmVO.getId()) != null;
     }
 
     private boolean hasVolumeSnapshotsPriorToUnmanageVM(VMInstanceVO vmVO) {

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -123,6 +123,7 @@ import com.cloud.uservm.UserVm;
 import com.cloud.utils.LogUtils;
 import com.cloud.utils.Pair;
 import com.cloud.utils.UuidUtils;
+import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
@@ -314,8 +315,12 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     private DataStoreManager dataStoreManager;
     @Inject
     private ImportVmTasksManager importVmTasksManager;
-    @Inject
+
     private KubernetesServiceHelper kubernetesServiceHelper;
+
+    private void setKubernetesServiceHelper(KubernetesServiceHelper helper) {
+        this.kubernetesServiceHelper = helper;
+    }
 
     protected Gson gson;
 
@@ -2389,6 +2394,9 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     }
 
     private boolean isVmPartOfCKSCluster(VMInstanceVO vmVO) {
+        if (kubernetesServiceHelper == null) {
+            setKubernetesServiceHelper(ComponentContext.getComponent(KubernetesServiceHelper.class));
+        }
         return kubernetesServiceHelper.findByVmId(vmVO.getId()) != null;
     }
 

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -2382,13 +2382,13 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                     " as there is an ISO attached. Please detach ISO before unmanaging.");
         }
 
-        if (belongsToCksCluster(vmVO)) {
+        if (isVmPartOfCKSCluster(vmVO)) {
             throw new UnsupportedServiceException("Cannot unmanage VM with id = " + vmVO.getUuid() +
                     " as it belongs to a CKS cluster. Please remove the VM from the CKS cluster before unmanaging.");
         }
     }
 
-    private boolean belongsToCksCluster(VMInstanceVO vmVO) {
+    private boolean isVmPartOfCKSCluster(VMInstanceVO vmVO) {
         return kubernetesServiceHelper.findByVmId(vmVO.getId()) != null;
     }
 

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -123,7 +123,6 @@ import com.cloud.uservm.UserVm;
 import com.cloud.utils.LogUtils;
 import com.cloud.utils.Pair;
 import com.cloud.utils.UuidUtils;
-import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
@@ -316,10 +315,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     @Inject
     private ImportVmTasksManager importVmTasksManager;
 
-    private KubernetesServiceHelper kubernetesServiceHelper;
+    private List<KubernetesServiceHelper> kubernetesServiceHelpers;
 
-    private void setKubernetesServiceHelper(KubernetesServiceHelper helper) {
-        this.kubernetesServiceHelper = helper;
+    public void setKubernetesServiceHelpers(final List<KubernetesServiceHelper> kubernetesServiceHelpers) {
+        this.kubernetesServiceHelpers = kubernetesServiceHelpers;
     }
 
     protected Gson gson;
@@ -2394,10 +2393,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     }
 
     private boolean isVmPartOfCKSCluster(VMInstanceVO vmVO) {
-        if (kubernetesServiceHelper == null) {
-            setKubernetesServiceHelper(ComponentContext.getComponent(KubernetesServiceHelper.class));
-        }
-        return kubernetesServiceHelper.findByVmId(vmVO.getId()) != null;
+        return kubernetesServiceHelpers.get(0).findByVmId(vmVO.getId()) != null;
     }
 
     private boolean hasVolumeSnapshotsPriorToUnmanageVM(VMInstanceVO vmVO) {

--- a/server/src/main/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
+++ b/server/src/main/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
@@ -35,7 +35,9 @@
         <property name="name" value="LXCGuru" />
     </bean>
 
-    <bean id="vmImportService" class="org.apache.cloudstack.vm.UnmanagedVMsManagerImpl" />
+    <bean id="vmImportService" class="org.apache.cloudstack.vm.UnmanagedVMsManagerImpl">
+        <property name="kubernetesServiceHelpers" value="#{kubernetesServiceHelperRegistry.registered}" />
+    </bean>
 
     <bean id="importVmTasksManager" class="org.apache.cloudstack.vm.ImportVmTasksManagerImpl" />
 

--- a/server/src/main/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
+++ b/server/src/main/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
@@ -35,9 +35,7 @@
         <property name="name" value="LXCGuru" />
     </bean>
 
-    <bean id="vmImportService" class="org.apache.cloudstack.vm.UnmanagedVMsManagerImpl">
-        <property name="kubernetesServiceHelpers" value="#{kubernetesServiceHelperRegistry.registered}" />
-    </bean>
+    <bean id="vmImportService" class="org.apache.cloudstack.vm.UnmanagedVMsManagerImpl" />
 
     <bean id="importVmTasksManager" class="org.apache.cloudstack.vm.ImportVmTasksManagerImpl" />
 

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import com.cloud.kubernetes.cluster.KubernetesServiceHelper;
 import com.cloud.storage.dao.SnapshotPolicyDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker;
@@ -1475,6 +1476,9 @@ public class UserVmManagerImplTest {
         when(cmd.getVmId()).thenReturn(vmId);
         when(cmd.getTemplateId()).thenReturn(2L);
         when(userVmDao.findById(vmId)).thenReturn(userVmVoMock);
+        KubernetesServiceHelper helper = mock(KubernetesServiceHelper.class);
+        when(helper.findByVmId(anyLong())).thenReturn(null);
+        userVmManagerImpl.setKubernetesServiceHelpers(Collections.singletonList(helper));
 
         userVmManagerImpl.restoreVM(cmd);
     }

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -39,13 +39,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.cloud.kubernetes.cluster.KubernetesServiceHelper;
 import com.cloud.offering.DiskOffering;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.vm.ImportVMTaskVO;
-import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ResponseGenerator;
 import org.apache.cloudstack.api.ResponseObject;
@@ -248,8 +246,6 @@ public class UnmanagedVMsManagerImplTest {
     @Mock
     private ImportVmTasksManager importVmTasksManager;
     @Mock
-    private KubernetesServiceHelper kubernetesServiceHelper;
-    @Mock
     private SnapshotDao snapshotDao;
 
     @Mock
@@ -288,8 +284,6 @@ public class UnmanagedVMsManagerImplTest {
         AccountVO account = new AccountVO("admin", 1L, "", Account.Type.ADMIN, "uuid");
         UserVO user = new UserVO(1, "adminuser", "password", "firstname", "lastName", "email", "timezone", UUID.randomUUID().toString(), User.Source.UNKNOWN);
         CallContext.register(user, account);
-
-        unmanagedVMsManager.setKubernetesServiceHelpers(List.of(kubernetesServiceHelper));
 
         instance = new UnmanagedInstanceTO();
         instance.setName("TestInstance");
@@ -623,7 +617,7 @@ public class UnmanagedVMsManagerImplTest {
         when(userVmVO.getIsoId()).thenReturn(null);
         when(userVmDao.findById(anyLong())).thenReturn(userVmVO);
         when(vmDao.findById(virtualMachineId)).thenReturn(virtualMachine);
-        when(kubernetesServiceHelper.findByVmId(virtualMachineId)).thenReturn(mock(ControlledEntity.class));
+        when(userVmManager.isVMPartOfAnyCKSCluster(virtualMachine)).thenReturn(true);
         unmanagedVMsManager.unmanageVMInstance(virtualMachineId, null, false);
     }
 

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -289,6 +289,8 @@ public class UnmanagedVMsManagerImplTest {
         UserVO user = new UserVO(1, "adminuser", "password", "firstname", "lastName", "email", "timezone", UUID.randomUUID().toString(), User.Source.UNKNOWN);
         CallContext.register(user, account);
 
+        unmanagedVMsManager.setKubernetesServiceHelpers(List.of(kubernetesServiceHelper));
+
         instance = new UnmanagedInstanceTO();
         instance.setName("TestInstance");
         instance.setCpuCores(2);

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -38,8 +39,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.cloud.kubernetes.cluster.KubernetesServiceHelper;
 import com.cloud.offering.DiskOffering;
+import com.cloud.storage.Snapshot;
+import com.cloud.storage.SnapshotVO;
+import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.vm.ImportVMTaskVO;
+import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ResponseGenerator;
 import org.apache.cloudstack.api.ResponseObject;
@@ -241,6 +247,10 @@ public class UnmanagedVMsManagerImplTest {
     private StoragePoolHostDao storagePoolHostDao;
     @Mock
     private ImportVmTasksManager importVmTasksManager;
+    @Mock
+    private KubernetesServiceHelper kubernetesServiceHelper;
+    @Mock
+    private SnapshotDao snapshotDao;
 
     @Mock
     private VMInstanceVO virtualMachine;
@@ -565,6 +575,53 @@ public class UnmanagedVMsManagerImplTest {
         UserVmVO userVmVO = mock(UserVmVO.class);
         when(userVmDao.findById(anyLong())).thenReturn(userVmVO);
         Mockito.doNothing().when(unmanagedVMsManager).performUnmanageVMInstancePrechecks(any());
+        unmanagedVMsManager.unmanageVMInstance(virtualMachineId, null, false);
+    }
+
+    @Test(expected = UnsupportedServiceException.class)
+    public void testUnmanageVMInstanceWithVolumeSnapshotsFail() {
+        when(virtualMachine.getType()).thenReturn(VirtualMachine.Type.User);
+        when(virtualMachine.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        when(virtualMachine.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(virtualMachine.getId()).thenReturn(virtualMachineId);
+        UserVmVO userVmVO = mock(UserVmVO.class);
+        when(userVmDao.findById(anyLong())).thenReturn(userVmVO);
+        when(vmDao.findById(virtualMachineId)).thenReturn(virtualMachine);
+        VolumeVO volumeVO = mock(VolumeVO.class);
+        long volumeId = 20L;
+        when(volumeVO.getId()).thenReturn(volumeId);
+        SnapshotVO snapshotVO = mock(SnapshotVO.class);
+        when(snapshotVO.getState()).thenReturn(Snapshot.State.BackedUp);
+        when(snapshotDao.listByVolumeId(volumeId)).thenReturn(Collections.singletonList(snapshotVO));
+        when(volumeDao.findByInstance(virtualMachineId)).thenReturn(Collections.singletonList(volumeVO));
+        unmanagedVMsManager.unmanageVMInstance(virtualMachineId, null, false);
+    }
+
+    @Test(expected = UnsupportedServiceException.class)
+    public void testUnmanageVMInstanceWithAssociatedIsoFail() {
+        when(virtualMachine.getType()).thenReturn(VirtualMachine.Type.User);
+        when(virtualMachine.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        when(virtualMachine.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(virtualMachine.getId()).thenReturn(virtualMachineId);
+        UserVmVO userVmVO = mock(UserVmVO.class);
+        when(userVmVO.getIsoId()).thenReturn(null);
+        when(userVmDao.findById(anyLong())).thenReturn(userVmVO);
+        when(vmDao.findById(virtualMachineId)).thenReturn(virtualMachine);
+        when(userVmVO.getIsoId()).thenReturn(1L);
+        unmanagedVMsManager.unmanageVMInstance(virtualMachineId, null, false);
+    }
+
+    @Test(expected = UnsupportedServiceException.class)
+    public void testUnmanageVMInstanceBelongingToCksClusterFail() {
+        when(virtualMachine.getType()).thenReturn(VirtualMachine.Type.User);
+        when(virtualMachine.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        when(virtualMachine.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(virtualMachine.getId()).thenReturn(virtualMachineId);
+        UserVmVO userVmVO = mock(UserVmVO.class);
+        when(userVmVO.getIsoId()).thenReturn(null);
+        when(userVmDao.findById(anyLong())).thenReturn(userVmVO);
+        when(vmDao.findById(virtualMachineId)).thenReturn(virtualMachine);
+        when(kubernetesServiceHelper.findByVmId(virtualMachineId)).thenReturn(mock(ControlledEntity.class));
         unmanagedVMsManager.unmanageVMInstance(virtualMachineId, null, false);
     }
 


### PR DESCRIPTION
### Description

This PR prevents unmanaging or reinstalling a VM if it belongs to a CKS cluster, with a descriptive message

Fixes: #12783 
Fixes: #12837 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
