### PR TITLE
Fix NPE in NASBackupProvider when no running KVM host is available

### DIFF
--- a/plugins/backup/nas/src/main/java/org/apache/cloudstack/backup/NASBackupProvider.java
+++ b/plugins/backup/nas/src/main/java/org/apache/cloudstack/backup/NASBackupProvider.java
@@ -56,6 +56,7 @@ import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
@@ -63,7 +64,6 @@ import javax.inject.Inject;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import org.apache.commons.collections.CollectionUtils;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;


### PR DESCRIPTION
Rebased onto 4.22 as requested (previously #12680).

`ResourceManager.findOneRandomRunningHostByHypervisor()` can return null when no KVM host in the zone has status=Up (e.g. during management server startup, brief agent disconnections, or host state transitions).

`NASBackupProvider.syncBackupStorageStats()` and `deleteBackup()` call `host.getId()` without a null check, causing a NullPointerException that crashes the entire `BackupSyncTask` background job every sync interval.

This adds null checks in both methods:
- **syncBackupStorageStats**: log a warning and return early
- **deleteBackup**: throw `CloudRuntimeException` with a descriptive message