### PR TITLE
NAS backup: resume paused VM on backup failure and fix missing exit

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -142,7 +142,8 @@ backup_running_vm() {
         break ;;
       Failed)
         echo "Virsh backup job failed"
-        cleanup ;;
+        cleanup
+        exit 1 ;;
     esac
     sleep 5
   done
@@ -178,6 +179,7 @@ backup_stopped_vm() {
     if ! qemu-img convert -O qcow2 "$disk" "$output" > "$logFile" 2> >(cat >&2); then
       echo "qemu-img convert failed for $disk $output"
       cleanup
+      exit 1
     fi
     name="datadisk"
   done
@@ -221,6 +223,19 @@ mount_operation() {
 
 cleanup() {
   local status=0
+
+  # Resume the VM if it was paused during backup to prevent it from
+  # remaining indefinitely paused when the backup job fails (e.g. due
+  # to storage full or I/O errors on the backup target)
+  local vm_state
+  vm_state=$(virsh -c qemu:///system domstate "$VM" 2>/dev/null)
+  if [[ "$vm_state" == "paused" ]]; then
+    log -ne "Resuming paused VM $VM during backup cleanup"
+    if ! virsh -c qemu:///system resume "$VM" > /dev/null 2>&1; then
+      echo "Failed to resume VM $VM"
+      status=1
+    fi
+  fi
 
   rm -rf "$dest" || { echo "Failed to delete $dest"; status=1; }
   umount "$mount_point" || { echo "Failed to unmount $mount_point"; status=1; }

--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -228,7 +228,7 @@ cleanup() {
   # remaining indefinitely paused when the backup job fails (e.g. due
   # to storage full or I/O errors on the backup target)
   local vm_state
-  vm_state=$(virsh -c qemu:///system domstate "$VM" 2>/dev/null)
+  vm_state=$(virsh -c qemu:///system domstate "$VM" 2>/dev/null || true)
   if [[ "$vm_state" == "paused" ]]; then
     log -ne "Resuming paused VM $VM during backup cleanup"
     if ! virsh -c qemu:///system resume "$VM" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Fixes #12821 — KVM VMs remain indefinitely paused when NAS backup job fails.

When `virsh backup-begin` executes a push backup, QEMU pauses the domain for a consistent snapshot. If the backup write fails (e.g. NFS storage full), `nasbackup.sh` calls `cleanup()` but:

1. **Never resumes the paused VM** — `cleanup()` only removes files and unmounts
2. **Never exits the monitoring loop** — missing `exit` after `cleanup()` in the `Failed` case causes an infinite loop
3. **Same missing exit in `backup_stopped_vm()`** — `qemu-img convert` failure calls `cleanup()` but continues processing

### Changes

- **`cleanup()`**: Added VM state detection via `virsh domstate` and automatic `virsh resume` if the VM is found paused, ensuring the VM is always resumed during error handling
- **`backup_running_vm()`**: Added `exit 1` after `cleanup()` in the `Failed` backup job case to terminate the infinite monitoring loop
- **`backup_stopped_vm()`**: Added `exit 1` after `cleanup()` on `qemu-img convert` failure

### Evidence

In production, NFS backup storage filling to 100% caused 8 VMs to become paused simultaneously across 3 KVM hosts. Some VMs remained paused for over 6 hours. CloudStack UI showed them as "Running" while they were actually paused at the KVM level, requiring manual `virsh resume` on each host.

### Note

The pattern of checking and resuming paused VMs already exists in the Java layer — see `LibvirtBackupSnapshotCommandWrapper.java:186-188` and `KVMStorageProcessor.java:2268-2272` — but was missing from the shell script that actually manages the backup lifecycle.

## Test plan

- [ ] Trigger NAS backup on a running VM with sufficient storage — verify backup completes and VM stays running
- [ ] Trigger NAS backup with NFS storage at 100% — verify backup fails but VM is resumed automatically
- [ ] Trigger NAS backup on a stopped VM with a bad disk path — verify cleanup exits properly
- [ ] Verify `cleanup()` correctly resumes VM before removing temp files and unmounting

🤖 Generated with [Claude Code](https://claude.com/claude-code)