### PR TITLE
Fix NSX SDK list handling to fetch all paginated results

### DIFF
--- a/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/service/PagedFetcher.java
+++ b/plugins/network-elements/nsx/src/main/java/org/apache/cloudstack/service/PagedFetcher.java
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+class PagedFetcher<R, T> {
+
+    private final Function<String, R> fetchPage;
+    private Function<R, String> cursorExtractor;
+    private Function<R, List<T>> itemsExtractor;
+    private BiConsumer<R, List<T>> itemsSetter;
+
+    static <R, T> PagedFetcher<R, T> withPageFetcher(Function<String, R> pageFetcher) {
+        return new PagedFetcher<>(pageFetcher);
+    }
+
+    PagedFetcher<R, T> cursorExtractor(Function<R, String> cursorProvider) {
+        this.cursorExtractor = cursorProvider;
+        return this;
+    }
+
+    PagedFetcher<R, T> itemsExtractor(Function<R, List<T>> resultsProvider) {
+        this.itemsExtractor = resultsProvider;
+        return this;
+    }
+
+    PagedFetcher<R, T> itemsSetter(BiConsumer<R, List<T>> resultsSetter) {
+        this.itemsSetter = resultsSetter;
+        return this;
+    }
+
+    private PagedFetcher(Function<String, R> pageFetcher) {
+        this.fetchPage = pageFetcher;
+    }
+
+    R fetchAll() {
+        Objects.requireNonNull(cursorExtractor, "Cursor extractor must be set");
+        Objects.requireNonNull(itemsExtractor, "Items extractor must be set");
+        Objects.requireNonNull(itemsSetter, "Items setter must be set");
+
+        R firstPage = fetchPage.apply(null);
+        String cursor = cursorExtractor.apply(firstPage);
+        if (cursor == null || cursor.isEmpty()) {
+            return firstPage;
+        }
+
+        List<T> firstResults = itemsExtractor.apply(firstPage);
+        List<T> allItems = firstResults != null
+                ? new ArrayList<>(firstResults)
+                : new ArrayList<>();
+        while (cursor != null && !cursor.isEmpty()) {
+            R nextPage = fetchPage.apply(cursor);
+            List<T> nextItems = itemsExtractor.apply(nextPage);
+            if (nextItems != null && !nextItems.isEmpty()) {
+                allItems.addAll(nextItems);
+            }
+            cursor = cursorExtractor.apply(nextPage);
+        }
+
+        itemsSetter.accept(firstPage, allItems);
+        return firstPage;
+    }
+}

--- a/plugins/network-elements/nsx/src/test/java/org/apache/cloudstack/service/PagedFetcherTest.java
+++ b/plugins/network-elements/nsx/src/test/java/org/apache/cloudstack/service/PagedFetcherTest.java
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.service;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class PagedFetcherTest {
+
+    private static class Page {
+        private String cursor;
+        private List<String> items;
+
+        Page(String cursor, List<String> items) {
+            this.cursor = cursor;
+            this.items = items;
+        }
+
+        String getCursor() {
+            return cursor;
+        }
+
+        List<String> getItems() {
+            return items;
+        }
+
+        void setItems(List<String> items) {
+            this.items = items;
+        }
+    }
+
+    @Test
+    public void testFetchAllWhenThereIsNoPagination() {
+        // given
+        Page firstPage = new Page(null, new ArrayList<>(List.of("a", "b")));
+        AtomicBoolean itemsSetterCalled = new AtomicBoolean(false);
+        PagedFetcher<Page, String> fetcher = PagedFetcher.<Page, String>withPageFetcher(
+                        cursor -> {
+                            assertNull(cursor);
+                            return firstPage;
+                        })
+                .cursorExtractor(Page::getCursor)
+                .itemsExtractor(Page::getItems)
+                .itemsSetter((page, items) -> itemsSetterCalled.set(true));
+
+        // when
+        Page result = fetcher.fetchAll();
+
+        // then
+        assertSame(firstPage, result);
+        assertEquals(List.of("a", "b"), result.getItems());
+        assertFalse("itemsSetter must not be called when there is no next page", itemsSetterCalled.get());
+    }
+
+    @Test
+    public void testFetchAllWhenThereIsNoPaginationAndEmptyCursor() {
+        // given
+        Page firstPage = new Page("", new ArrayList<>(List.of("x")));
+
+        AtomicBoolean itemsSetterCalled = new AtomicBoolean(false);
+
+        PagedFetcher<Page, String> fetcher = PagedFetcher
+                .<Page, String>withPageFetcher(cursor -> {
+                    assertNull(cursor);
+                    return firstPage;
+                })
+                .cursorExtractor(Page::getCursor)
+                .itemsExtractor(Page::getItems)
+                .itemsSetter((page, items) -> itemsSetterCalled.set(true));
+
+        // when
+        Page result = fetcher.fetchAll();
+
+        // then
+        assertSame(firstPage, result);
+        assertEquals(List.of("x"), result.getItems());
+        assertFalse("itemsSetter must not be called when there is no next page", itemsSetterCalled.get());
+    }
+
+    @Test
+    public void testFetchAllWhenMultiPages() {
+        // given
+        Page page1 = new Page("c1", new ArrayList<>(List.of("p1a", "p1b")));
+        Page page2 = new Page("c2", new ArrayList<>(List.of("p2a")));
+        Page page3 = new Page(null, new ArrayList<>(List.of("p3a", "p3b")));
+
+        Map<String, Page> pagesByCursor = new HashMap<>();
+        pagesByCursor.put(null, page1);
+        pagesByCursor.put("c1", page2);
+        pagesByCursor.put("c2", page3);
+
+        PagedFetcher<Page, String> fetcher = PagedFetcher
+                .<Page, String>withPageFetcher(pagesByCursor::get)
+                .cursorExtractor(Page::getCursor)
+                .itemsExtractor(Page::getItems)
+                .itemsSetter((page, items) -> {
+                    assertSame(page1, page);
+                    page.setItems(items);
+                });
+
+        // when
+        Page result = fetcher.fetchAll();
+
+        // then
+        assertSame("Result must be the first page object", page1, result);
+        assertEquals(List.of("p1a", "p1b", "p2a", "p3a", "p3b"), result.getItems());
+    }
+
+    @Test
+    public void testFetchAllFirstPageItemsNullSecondWithItems() {
+        // given
+        Page page1 = new Page("next", null);
+        Page page2 = new Page(null, new ArrayList<>(List.of("x", "y")));
+
+        Map<String, Page> pages = new HashMap<>();
+        pages.put(null, page1);
+        pages.put("next", page2);
+
+        PagedFetcher<Page, String> fetcher = PagedFetcher
+                .<Page, String>withPageFetcher(pages::get)
+                .cursorExtractor(Page::getCursor)
+                .itemsExtractor(Page::getItems)
+                .itemsSetter(Page::setItems);
+
+        // when
+        Page result = fetcher.fetchAll();
+
+        // then
+        assertSame(page1, result);
+        assertEquals(List.of("x", "y"), result.getItems());
+    }
+}


### PR DESCRIPTION
### Description

NSX SDK list operations are pageable: the API returns a non-null and non-empty

`cursor` field when more pages are available. The previous implementation only fetched the first page and ignored pagination.

This change updates the list retrieval flow to:
- follow the `cursor` chain until no further pages exist
- accumulate items from all pages
- return a single merged result to the caller

This ensures that list operations return the complete dataset rather than just the first page.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

