### PR TITLE
nasbackup.sh: add optional backup compression via -c flag

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -31,6 +31,7 @@ NAS_ADDRESS=""
 MOUNT_OPTS=""
 BACKUP_DIR=""
 DISK_PATHS=""
+COMPRESS=""
 logFile="/var/log/cloudstack/agent/agent.log"
 
 log() {
@@ -112,6 +113,21 @@ backup_running_vm() {
     sleep 5
   done
   rm -f $dest/backup.xml
+
+  # Compress backup files if requested
+  if [[ "$COMPRESS" == "true" ]]; then
+    log -ne "Compressing backup files for $VM"
+    for img in "$dest"/*.qcow2; do
+      [[ -f "$img" ]] || continue
+      local tmp_img="${img}.tmp"
+      if qemu-img convert -c -O qcow2 "$img" "$tmp_img" 2>&1 | tee -a "$logFile"; then
+        mv "$tmp_img" "$img"
+      else
+        log -ne "Warning: compression failed for $img, keeping uncompressed"
+        rm -f "$tmp_img"
+      fi
+    done
+  fi
   sync
 
   # Print statistics
@@ -131,7 +147,7 @@ backup_stopped_vm() {
   name="root"
   for disk in $DISK_PATHS; do
     volUuid="${disk##*/}"
-    qemu-img convert -O qcow2 $disk $dest/$name.$volUuid.qcow2  | tee -a "$logFile"
+    qemu-img convert $([[ "$COMPRESS" == "true" ]] && echo "-c") -O qcow2 $disk $dest/$name.$volUuid.qcow2  | tee -a "$logFile"
     name="datadisk"
   done
   sync
@@ -165,7 +181,7 @@ mount_operation() {
 
 function usage {
   echo ""
-  echo "Usage: $0 -o <operation> -v|--vm <domain name> -t <storage type> -s <storage address> -m <mount options> -p <backup path> -d <disks path>"
+  echo "Usage: $0 -o <operation> -v|--vm <domain name> -t <storage type> -s <storage address> -m <mount options> -p <backup path> -d <disks path> [-c]"
   echo ""
   exit 1
 }
@@ -205,6 +221,10 @@ while [[ $# -gt 0 ]]; do
     -d|--diskpaths)
       DISK_PATHS="$2"
       shift
+      shift
+      ;;
+    -c|--compress)
+      COMPRESS="true"
       shift
       ;;
     -h|--help)


### PR DESCRIPTION
## Summary
- Add `-c/--compress` flag to produce compressed qcow2 backup files, reducing NAS storage usage
- For stopped VMs: passes `-c` to `qemu-img convert` directly (single pass, no extra I/O)
- For running VMs: re-compresses push backup output with `qemu-img convert -c` after backup completes
- Compression is off by default to preserve existing behavior

## Motivation
NAS backup storage fills up quickly with large VM disks. qcow2 compression typically achieves 40-60% size reduction with minimal CPU overhead, extending backup retention without additional storage.

The `-c` flag can be passed by the CloudStack agent when the admin enables compression in the backup repository settings, giving per-repository control.

## Test plan
- [ ] Backup stopped VM without `-c` — verify identical behavior to current
- [ ] Backup stopped VM with `-c` — verify compressed qcow2 output (check with `qemu-img info`)
- [ ] Backup running VM with `-c` — verify post-backup compression, smaller file sizes
- [ ] Verify compression failure on one disk doesn't abort backup (keeps uncompressed copy)