### PR TITLE
nasbackup.sh: verify backup integrity with qemu-img check

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -84,6 +84,25 @@ sanity_checks() {
   log -ne "Environment Sanity Checks successfully passed"
 }
 
+verify_backup() {
+  local backup_dir="$1"
+  local failed=0
+  for img in "$backup_dir"/*.qcow2; do
+    [[ -f "$img" ]] || continue
+    if ! qemu-img check "$img" > /dev/null 2>&1; then
+      echo "Backup verification failed for $img"
+      log -ne "Backup verification FAILED: $img"
+      failed=1
+    else
+      log -ne "Backup verification passed: $img"
+    fi
+  done
+  if [[ $failed -ne 0 ]]; then
+    echo "One or more backup files failed verification"
+    exit 1
+  fi
+}
+
 ### Operation methods ###
 
 backup_running_vm() {
@@ -114,6 +133,8 @@ backup_running_vm() {
   rm -f $dest/backup.xml
   sync
 
+  verify_backup "$dest"
+
   # Print statistics
   virsh -c qemu:///system domjobinfo $VM --completed
   du -sb $dest | cut -f1
@@ -135,6 +156,8 @@ backup_stopped_vm() {
     name="datadisk"
   done
   sync
+
+  verify_backup "$dest"
 
   ls -l --numeric-uid-gid $dest | awk '{print $5}'
 }


### PR DESCRIPTION
## Summary
- Add `verify_backup()` function that runs `qemu-img check` on all qcow2 backup files after backup completes
- Catches corrupt or truncated backup files (e.g. from NFS I/O errors, storage full, or interrupted writes) before reporting success to CloudStack
- Applied to both running VM (push backup) and stopped VM (qemu-img convert) backup paths

## Motivation
Without verification, a backup that was silently corrupted by NFS errors or disk full conditions is reported as successful. The admin only discovers the corruption when attempting to restore — which is the worst possible time. `qemu-img check` is fast (reads metadata only, not full data) and catches structural corruption.

## Test plan
- [ ] Backup running VM — verify `qemu-img check` passes in agent log
- [ ] Backup stopped VM — verify check passes
- [ ] Manually corrupt a qcow2 file and run verify — confirm it catches the corruption and exits non-zero