### PR TITLE
nasbackup.sh: add bandwidth throttle via -b flag

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -31,6 +31,7 @@ NAS_ADDRESS=""
 MOUNT_OPTS=""
 BACKUP_DIR=""
 DISK_PATHS=""
+BANDWIDTH=""
 logFile="/var/log/cloudstack/agent/agent.log"
 
 log() {
@@ -102,6 +103,14 @@ backup_running_vm() {
   # Start push backup
   virsh -c qemu:///system backup-begin --domain $VM --backupxml $dest/backup.xml > /dev/null 2>/dev/null
 
+  # Throttle backup bandwidth if requested (MiB/s per disk)
+  if [[ -n "$BANDWIDTH" ]]; then
+    for disk in $(virsh -c qemu:///system domblklist $VM --details 2>/dev/null | awk '/disk/{print$3}'); do
+      virsh -c qemu:///system blockjob $VM $disk --bandwidth "${BANDWIDTH}" 2>/dev/null || true
+    done
+    log -ne "Backup bandwidth limited to ${BANDWIDTH} MiB/s per disk for $VM"
+  fi
+
   # Backup domain information
   virsh -c qemu:///system dumpxml $VM > $dest/domain-config.xml 2>/dev/null
   virsh -c qemu:///system dominfo $VM > $dest/dominfo.xml 2>/dev/null
@@ -131,7 +140,7 @@ backup_stopped_vm() {
   name="root"
   for disk in $DISK_PATHS; do
     volUuid="${disk##*/}"
-    qemu-img convert -O qcow2 $disk $dest/$name.$volUuid.qcow2  | tee -a "$logFile"
+    ionice -c 3 qemu-img convert $([[ -n "$BANDWIDTH" ]] && echo "-r" "${BANDWIDTH}M") -O qcow2 $disk $dest/$name.$volUuid.qcow2  | tee -a "$logFile"
     name="datadisk"
   done
   sync
@@ -165,7 +174,7 @@ mount_operation() {
 
 function usage {
   echo ""
-  echo "Usage: $0 -o <operation> -v|--vm <domain name> -t <storage type> -s <storage address> -m <mount options> -p <backup path> -d <disks path>"
+  echo "Usage: $0 -o <operation> -v|--vm <domain name> -t <storage type> -s <storage address> -m <mount options> -p <backup path> -d <disks path> [-b <MiB/s>]"
   echo ""
   exit 1
 }
@@ -204,6 +213,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     -d|--diskpaths)
       DISK_PATHS="$2"
+      shift
+      shift
+      ;;
+    -b|--bandwidth)
+      BANDWIDTH="$2"
       shift
       shift
       ;;


### PR DESCRIPTION
## Summary
- Add `-b/--bandwidth` flag (MiB/s) to limit backup I/O impact on production workloads
- Running VMs: throttles QEMU push backup via `virsh blockjob --bandwidth` per disk
- Stopped VMs: uses `qemu-img convert -r` rate limit + `ionice -c 3` (idle I/O class)
- No bandwidth limit by default — existing behavior preserved

## Motivation
Backup jobs on shared storage can saturate I/O bandwidth and degrade performance for production VMs on the same host or NAS. This is especially problematic during business hours or when multiple VMs are being backed up concurrently.

The bandwidth limit can be passed by the CloudStack agent based on a global or per-repository setting, giving admins control over backup impact.

## Test plan
- [ ] Backup without `-b` — verify no throttling, identical to current behavior
- [ ] Backup running VM with `-b 50` — verify `blockjob --bandwidth` applied, check `domjobinfo` shows throttled rate
- [ ] Backup stopped VM with `-b 50` — verify `ionice -c 3` and `-r 50M` in process list
- [ ] Verify backup completes successfully with throttling enabled