### PR TITLE
nasbackup.sh: add LUKS encryption for backup files via -e flag

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -31,6 +31,7 @@ NAS_ADDRESS=""
 MOUNT_OPTS=""
 BACKUP_DIR=""
 DISK_PATHS=""
+ENCRYPT_PASSFILE=""
 logFile="/var/log/cloudstack/agent/agent.log"
 
 log() {
@@ -84,6 +85,33 @@ sanity_checks() {
   log -ne "Environment Sanity Checks successfully passed"
 }
 
+encrypt_backup() {
+  local backup_dir="$1"
+  if [[ -z "$ENCRYPT_PASSFILE" ]]; then
+    return
+  fi
+  if [[ ! -f "$ENCRYPT_PASSFILE" ]]; then
+    echo "Encryption passphrase file not found: $ENCRYPT_PASSFILE"
+    exit 1
+  fi
+  log -ne "Encrypting backup files with LUKS"
+  for img in "$backup_dir"/*.qcow2; do
+    [[ -f "$img" ]] || continue
+    local tmp_img="${img}.luks"
+    if qemu-img convert -O qcow2 \
+        --object "secret,id=sec0,file=$ENCRYPT_PASSFILE" \
+        -o "encrypt.format=luks,encrypt.key-secret=sec0" \
+        "$img" "$tmp_img" 2>&1 | tee -a "$logFile"; then
+      mv "$tmp_img" "$img"
+      log -ne "Encrypted: $img"
+    else
+      echo "Encryption failed for $img"
+      rm -f "$tmp_img"
+      exit 1
+    fi
+  done
+}
+
 ### Operation methods ###
 
 backup_running_vm() {
@@ -114,6 +142,8 @@ backup_running_vm() {
   rm -f $dest/backup.xml
   sync
 
+  encrypt_backup "$dest"
+
   # Print statistics
   virsh -c qemu:///system domjobinfo $VM --completed
   du -sb $dest | cut -f1
@@ -135,6 +165,8 @@ backup_stopped_vm() {
     name="datadisk"
   done
   sync
+
+  encrypt_backup "$dest"
 
   ls -l --numeric-uid-gid $dest | awk '{print $5}'
 }
@@ -165,7 +197,7 @@ mount_operation() {
 
 function usage {
   echo ""
-  echo "Usage: $0 -o <operation> -v|--vm <domain name> -t <storage type> -s <storage address> -m <mount options> -p <backup path> -d <disks path>"
+  echo "Usage: $0 -o <operation> -v|--vm <domain name> -t <storage type> -s <storage address> -m <mount options> -p <backup path> -d <disks path> [-e <passphrase file>]"
   echo ""
   exit 1
 }
@@ -204,6 +236,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     -d|--diskpaths)
       DISK_PATHS="$2"
+      shift
+      shift
+      ;;
+    -e|--encrypt)
+      ENCRYPT_PASSFILE="$2"
       shift
       shift
       ;;


### PR DESCRIPTION
## Summary
- Add `-e/--encrypt <passphrase-file>` flag that encrypts backup qcow2 files using LUKS encryption
- Uses `qemu-img convert` with `--object secret` and `encrypt.format=luks` — standard qcow2+LUKS format
- Passphrase is read from a file (not command-line) to avoid exposure in `/proc/*/cmdline`
- Applied after backup completes, for both running and stopped VM paths
- No encryption by default — existing behavior preserved

## Motivation
NAS backup targets are often shared storage accessible to multiple hosts and administrators. Unencrypted VM disk backups on NFS expose sensitive data (databases, credentials, user files) to anyone with NFS access.

LUKS-encrypted qcow2 is the standard QEMU encryption format, supported by all QEMU/libvirt tooling. The passphrase file can be managed by CloudStack and stored securely on the agent host (e.g. in `/etc/cloudstack/agent/`), separate from the backup data on NFS.

## Design
- The passphrase file path is passed via `-e` flag by the CloudStack agent
- `encrypt_backup()` iterates over all `.qcow2` files in the backup directory
- Each file is converted in-place: `qemu-img convert -O qcow2 --object secret ... -o encrypt.format=luks ...`
- On encryption failure, the backup fails (no silent fallback to unencrypted)
- For restore, the same passphrase file is needed to decrypt with `qemu-img convert`

## Test plan
- [ ] Backup without `-e` — verify no encryption, identical to current behavior
- [ ] Backup with `-e /path/to/passphrase` — verify qcow2 files are LUKS-encrypted (`qemu-img info` shows `encrypted: yes`)
- [ ] Backup with missing passphrase file — verify clean error and exit
- [ ] Decrypt and restore an encrypted backup with `qemu-img convert --object secret ...` — verify data integrity
- [ ] Verify encrypted backup cannot be read without passphrase