### PR TITLE
Fix vm cleanup iptables/ipset misleading error logs (Fixes #12770)

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -55,6 +55,42 @@ def execute(cmd):
         logging.exception('Command exited non-zero: %s', cmd)
         raise
 
+def iptables_chain_exists(chain):
+    """Check if iptables chain exists."""
+    try:
+        execute("iptables -S %s 2>/dev/null" % chain)
+        return True
+    except CalledProcessError as e:
+        if e.returncode == 1:
+            # Chain not found - normal for idempotent cleanup
+            logging.debug("iptables chain %s does not exist", chain)
+            return False
+        # Other exit codes are real errors
+        raise
+
+
+def ip6tables_chain_exists(chain):
+    """Check if ip6tables chain exists."""
+    try:
+        execute("ip6tables -S %s 2>/dev/null" % chain)
+        return True
+    except CalledProcessError as e:
+        if e.returncode == 1:
+            logging.debug("ip6tables chain %s does not exist", chain)
+            return False
+        raise
+
+
+def ipset_exists(setname):
+    """Check if ipset exists."""
+    try:
+        execute("ipset list %s 2>/dev/null" % setname)
+        return True
+    except CalledProcessError as e:
+        if e.returncode == 1:
+            logging.debug("ipset %s does not exist", setname)
+            return False
+        raise
 
 def can_bridge_firewall(privnic):
     try:
@@ -195,7 +231,7 @@ def destroy_network_rules_for_vm(vm_name, vif=None):
     vmchain = iptables_chain_name(vm_name)
     vmchain_egress = egress_chain_name(vm_name)
     vmchain_default = None
-    vm_ipsetname=ipset_chain_name(vm_name)
+    vm_ipsetname = ipset_chain_name(vm_name)
 
     delete_rules_for_vm_in_bridge_firewall_chain(vm_name)
     if 1 in [vm_name.startswith(c) for c in ['r-', 's-', 'v-']]:
@@ -208,40 +244,52 @@ def destroy_network_rules_for_vm(vm_name, vif=None):
 
     chains = [vmchain_default, vmchain, vmchain_egress]
     for chain in [_f for _f in chains if _f]:
-        try:
-            execute("iptables -F " + chain)
-            execute('ip6tables -F ' + chain)
-        except:
-            logging.debug("Ignoring failure to flush chain: " + chain)
+        # iptables
+        if iptables_chain_exists(chain):
+            try:
+                execute("iptables -F " + chain)
+                execute("iptables -X " + chain)
+            except Exception as e:
+                logging.error("Failed to flush/delete iptables chain %s: %s", chain, str(e))
+        else:
+            logging.debug("iptables chain %s does not exist, skipping", chain)
 
-    for chain in [_f for _f in chains if _f]:
-        try:
-            execute("iptables -X " + chain)
-            execute('ip6tables -X ' + chain)
-        except:
-            logging.debug("Ignoring failure to delete chain: " + chain)
+        # ip6tables
+        if ip6tables_chain_exists(chain):
+            try:
+                execute("ip6tables -F " + chain)
+                execute("ip6tables -X " + chain)
+            except Exception as e:
+                logging.error("Failed to flush/delete ip6tables chain %s: %s", chain, str(e))
+        else:
+            logging.debug("ip6tables chain %s does not exist, skipping", chain)
 
-    try:
-        for ipset in [vm_ipsetname, vm_ipsetname + '-6']:
-            execute('ipset -F ' + ipset)
-            execute('ipset -X ' + ipset)
-    except:
-        logging.debug("Ignoring failure to delete ipset " + vmchain)
+    for ipset in [vm_ipsetname, vm_ipsetname + '-6']:
+        if ipset_exists(ipset):
+            try:
+                execute('ipset -F ' + ipset)
+                execute('ipset -X ' + ipset)
+            except Exception as e:
+                logging.error("Failed to flush/delete ipset %s: %s", ipset, str(e))
+        else:
+            logging.debug("Ipset %s does not exist, skipping", ipset)
 
     if vif:
         try:
-            dnats = execute("""iptables -t nat -S | awk '/%s/ { sub(/-A/, "-D", $1) ; print }'""" % vif ).split("\n")
+            dnats = execute("""iptables -t nat -S | awk '/%s/ { sub(/-A/, "-D", $1) ; print }'""" % vif).split("\n")
             for dnat in [_f for _f in dnats if _f]:
                 try:
                     execute("iptables -t nat " + dnat)
-                except:
+                except Exception:
                     logging.debug("Ignoring failure to delete dnat: " + dnat)
-        except:
+        except Exception:
             pass
+
     remove_rule_log_for_vm(vm_name)
     remove_secip_log_for_vm(vm_name)
 
     return True
+
 
 
 def destroy_ebtables_rules(vm_name, vif):

--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -55,6 +55,42 @@ def execute(cmd):
         logging.exception('Command exited non-zero: %s', cmd)
         raise
 
+def iptables_chain_exists(chain):
+    """Check if iptables chain exists."""
+    try:
+        check_output("iptables -S %s 2>/dev/null" % chain, shell=True)
+        return True
+    except CalledProcessError as e:
+        if e.returncode == 1:
+            # Chain not found - normal for idempotent cleanup
+            logging.debug("iptables chain %s does not exist", chain)
+            return False
+        # Other exit codes are real errors
+        raise
+
+
+def ip6tables_chain_exists(chain):
+    """Check if ip6tables chain exists."""
+    try:
+        check_output("ip6tables -S %s 2>/dev/null" % chain, shell=True)
+        return True
+    except CalledProcessError as e:
+        if e.returncode == 1:
+            logging.debug("ip6tables chain %s does not exist", chain)
+            return False
+        raise
+
+
+def ipset_exists(setname):
+    """Check if ipset exists."""
+    try:
+        check_output("ipset list %s 2>/dev/null" % setname, shell=True)
+        return True
+    except CalledProcessError as e:
+        if e.returncode == 1:
+            logging.debug("ipset %s does not exist", setname)
+            return False
+        raise
 
 def can_bridge_firewall(privnic):
     try:
@@ -195,7 +231,7 @@ def destroy_network_rules_for_vm(vm_name, vif=None):
     vmchain = iptables_chain_name(vm_name)
     vmchain_egress = egress_chain_name(vm_name)
     vmchain_default = None
-    vm_ipsetname=ipset_chain_name(vm_name)
+    vm_ipsetname = ipset_chain_name(vm_name)
 
     delete_rules_for_vm_in_bridge_firewall_chain(vm_name)
     if 1 in [vm_name.startswith(c) for c in ['r-', 's-', 'v-']]:
@@ -208,40 +244,68 @@ def destroy_network_rules_for_vm(vm_name, vif=None):
 
     chains = [vmchain_default, vmchain, vmchain_egress]
     for chain in [_f for _f in chains if _f]:
-        try:
-            execute("iptables -F " + chain)
-            execute('ip6tables -F ' + chain)
-        except:
-            logging.debug("Ignoring failure to flush chain: " + chain)
+        # iptables
+        if iptables_chain_exists(chain):
+            try:
+                execute("iptables -F " + chain)
+                execute("iptables -X " + chain)
+            except Exception as e:
+                logging.error("Failed to flush/delete iptables chain %s: %s", chain, str(e))
+        else:
+            logging.debug("iptables chain %s does not exist, skipping", chain)
 
-    for chain in [_f for _f in chains if _f]:
+        # ip6tables
         try:
-            execute("iptables -X " + chain)
-            execute('ip6tables -X ' + chain)
-        except:
-            logging.debug("Ignoring failure to delete chain: " + chain)
+            exists = ip6tables_chain_exists(chain)
+        except CalledProcessError as e:
+            if e.returncode == 127:
+                logging.debug("ip6tables command not found while checking existence of %s, skipping ip6tables cleanup", chain)
+                continue
+            raise
 
-    try:
-        for ipset in [vm_ipsetname, vm_ipsetname + '-6']:
-            execute('ipset -F ' + ipset)
-            execute('ipset -X ' + ipset)
-    except:
-        logging.debug("Ignoring failure to delete ipset " + vmchain)
+        if exists:
+            try:
+                execute("ip6tables -F " + chain)
+                execute("ip6tables -X " + chain)
+            except Exception as e:
+                logging.error("Failed to flush/delete ip6tables chain %s: %s", chain, str(e))
+        else:
+            logging.debug("ip6tables chain %s does not exist, skipping", chain)
+
+    for ipset in [vm_ipsetname, vm_ipsetname + '-6']:
+        try:
+            exists = ipset_exists(ipset)
+        except CalledProcessError as e:
+            if e.returncode == 127:
+                logging.debug("ipset command not found while checking existence of %s, skipping ipset cleanup", ipset)
+                continue
+            raise
+
+        if exists:
+            try:
+                execute('ipset -F ' + ipset)
+                execute('ipset -X ' + ipset)
+            except Exception as e:
+                logging.error("Failed to flush/delete ipset %s: %s", ipset, str(e))
+        else:
+            logging.debug("Ipset %s does not exist, skipping", ipset)
 
     if vif:
         try:
-            dnats = execute("""iptables -t nat -S | awk '/%s/ { sub(/-A/, "-D", $1) ; print }'""" % vif ).split("\n")
+            dnats = execute("""iptables -t nat -S | awk '/%s/ { sub(/-A/, "-D", $1) ; print }'""" % vif).split("\n")
             for dnat in [_f for _f in dnats if _f]:
                 try:
                     execute("iptables -t nat " + dnat)
-                except:
+                except Exception:
                     logging.debug("Ignoring failure to delete dnat: " + dnat)
-        except:
+        except Exception:
             pass
+
     remove_rule_log_for_vm(vm_name)
     remove_secip_log_for_vm(vm_name)
 
     return True
+
 
 
 def destroy_ebtables_rules(vm_name, vif):


### PR DESCRIPTION
## Problem

During KVM VM cleanup, `security_group.py` tries to flush and delete iptables/ip6tables chains and ipsets unconditionally. If the chain or set has already been removed (for example, when cleanup is rerun or after partial failures), the underlying commands fail, and the agent logs misleading ERROR messages and stack traces, even though there is nothing left to clean up. This makes idempotent cleanup noisy and harder to debug. [web:2]

## Changes

- Added helper functions:
  - `iptables_chain_exists(chain)`
  - `ip6tables_chain_exists(chain)`
  - `ipset_exists(setname)`

  These use the existing `execute()` wrapper to check whether a chain or ipset exists. Exit code 1 (not found) is treated as a normal condition: it is logged at DEBUG and returns `False`, while other non‑zero exit codes are still raised as real errors. [file:69]

- Updated `destroy_network_rules_for_vm()` to:
  - Check iptables and ip6tables chain existence via the new helpers before flushing and deleting them.
  - Check IPv4 and IPv6 ipset existence before flushing and deleting them.
  - Log missing chains and ipsets at DEBUG level as “does not exist, skipping”.
  - Keep logging real failures when flushing/deleting chains or ipsets at ERROR level.
  - Preserve existing behavior for ebtables cleanup, DNAT rule removal, and rule/log file cleanup. [file:69]

## Result

- VM cleanup for KVM is now idempotent and no longer emits misleading ERROR logs when chains or ipsets are already gone.
- Real failures during cleanup are still surfaced as ERROR messages with details, improving signal‑to‑noise in agent logs. [file:69][web:2]
