### PR TITLE
Handle non-OvsFetchInterfaceAnswer in OVS tunnel manager

### DIFF
--- a/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/OvsTunnelManagerImpl.java
+++ b/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/OvsTunnelManagerImpl.java
@@ -171,17 +171,31 @@ public class OvsTunnelManagerImpl extends ManagerBase implements OvsTunnelManage
     }
 
     private String handleFetchInterfaceAnswer(Answer[] answers, Long hostId) {
-        OvsFetchInterfaceAnswer ans = (OvsFetchInterfaceAnswer)answers[0];
+        if (answers == null || answers.length == 0 || answers[0] == null) {
+            logger.warn("No answer returned for OvsFetchInterfaceCommand from host " + hostId);
+            return null;
+        }
+
+        Answer answer = answers[0];
+
+        if (!(answer instanceof OvsFetchInterfaceAnswer)) {
+            logger.warn("Expected OvsFetchInterfaceAnswer from host " + hostId +
+            " but got " + answer.getClass().getSimpleName() +
+            " with details: " + answer.getDetails());
+            return null;
+        }
+
+        OvsFetchInterfaceAnswer ans = (OvsFetchInterfaceAnswer) answer;
+
         if (ans.getResult()) {
-            if (ans.getIp() != null && !("".equals(ans.getIp()))) {
+            if (ans.getIp() != null && !ans.getIp().isEmpty()) {
                 OvsTunnelInterfaceVO ti = createInterfaceRecord(ans.getIp(),
-                        ans.getNetmask(), ans.getMac(), hostId, ans.getLabel());
+                    ans.getNetmask(), ans.getMac(), hostId, ans.getLabel());
                 return ti.getIp();
             }
         }
-        // Fetch interface failed!
-        logger.warn("Unable to fetch the IP address for the GRE tunnel endpoint"
-                + ans.getDetails());
+
+        logger.warn("Unable to fetch the IP address for the GRE tunnel endpoint: " + ans.getDetails());
         return null;
     }
 


### PR DESCRIPTION
When starting a GRE isolated network on XCP-ng, the management server can fail with a ClassCastException like UnsupportedAnswer cannot be cast to OvsFetchInterfaceAnswer in OvsTunnelManagerImpl.handleFetchInterfaceAnswer. This happens when the agent returns an UnsupportedAnswer (or another Answer type) for OvsFetchInterfaceCommand, but the code unconditionally casts the first Answer to OvsFetchInterfaceAnswer.

Root cause

handleFetchInterfaceAnswer assumed answers[0] is always an OvsFetchInterfaceAnswer and directly cast it without checking for null, array length, or actual runtime type. When the hypervisor agent responds with a different Answer implementation (e.g. UnsupportedAnswer), this results in a ClassCastException and the GRE tunnel setup fails.

Solution

Add null and length checks for the Answer[] to handle missing or empty responses.

Check answers[0] with instanceof OvsFetchInterfaceAnswer before casting.

If the answer is not an OvsFetchInterfaceAnswer, log a clear warning with the actual type and details, and return null instead of throwing a ClassCastException.

Preserve the existing success path when a successful OvsFetchInterfaceAnswer with a non-empty IP address is returned.

Testing

Local build on 4.22:

bash
mvn -pl api,server -am -DskipTests clean install

Addresses #12815