### PR TITLE
Add VR's system offering to network listing

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -451,6 +451,7 @@ public class ApiConstants {
     public static final String SERIAL = "serial";
     public static final String SERVICE_IP = "serviceip";
     public static final String SERVICE_OFFERING_ID = "serviceofferingid";
+    public static final String SERVICE_OFFERING_NAME = "serviceofferingname";
     public static final String SESSIONKEY = "sessionkey";
     public static final String SHOW_CAPACITIES = "showcapacities";
     public static final String SHOW_REMOVED = "showremoved";

--- a/api/src/main/java/org/apache/cloudstack/api/response/NetworkOfferingResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NetworkOfferingResponse.java
@@ -91,6 +91,10 @@ public class NetworkOfferingResponse extends BaseResponseWithAnnotations {
     @Param(description = "The ID of the service offering used by virtual router provider")
     private String serviceOfferingId;
 
+    @SerializedName(ApiConstants.SERVICE_OFFERING_NAME)
+    @Param(description = "the name of the service offering used by virtual router provider")
+    private String serviceOfferingName;
+
     @SerializedName(ApiConstants.SERVICE)
     @Param(description = "The list of supported services", responseObject = ServiceResponse.class)
     private List<ServiceResponse> services;
@@ -329,5 +333,13 @@ public class NetworkOfferingResponse extends BaseResponseWithAnnotations {
 
     public void setRoutingMode(String routingMode) {
         this.routingMode = routingMode;
+    }
+
+    public String getServiceOfferingName() {
+        return serviceOfferingName;
+    }
+
+    public void setServiceOfferingName(String serviceOfferingName) {
+        this.serviceOfferingName = serviceOfferingName;
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2338,6 +2338,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             ServiceOffering soffering = ApiDBUtils.findServiceOfferingById(so);
             if (soffering != null) {
                 response.setServiceOfferingId(soffering.getUuid());
+                response.setServiceOfferingName(soffering.getName());
             }
         }
         Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listNetworkOfferingServices(offering.getId());

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2336,7 +2336,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         }
         if (so != null) {
             ServiceOffering soffering = ApiDBUtils.findServiceOfferingById(so);
-            if (soffering != null) {
+            if (soffering != null && _accountMgr.isRootAdmin(CallContext.current().getCallingAccountId())) {
                 response.setServiceOfferingId(soffering.getUuid());
                 response.setServiceOfferingName(soffering.getName());
             }

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -2484,6 +2484,7 @@
 "label.virtual.network": "Virtual Network",
 "label.virtual.networking": "Virtual Networking",
 "label.virtual.routers": "Virtual Routers",
+"label.virtual.routers.system.offering": "VR system offering",
 "label.virtualmachineid": "Instance ID",
 "label.virtualmachinename": "Instance name",
 "label.virtualsize": "Virtual Size",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -1729,6 +1729,7 @@
 "label.virtual.network": "Rede virtual",
 "label.virtual.networking": "Rede virtual",
 "label.virtual.routers": "Roteadores virtuais",
+  "label.virtual.routers.system.offering": "Oferta de sistema do roteador virtual",
 "label.virtualmachineid": "ID da VM",
 "label.virtualmachinename": "Nome da VM",
 "label.virtualsize": "Tamanho virtual",

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -208,7 +208,8 @@
         <router-link :to="{ path: '/physicalnetwork/' + record.physicalnetworkid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'serviceofferingname'">
-        <router-link :to="{ path: '/computeoffering/' + record.serviceofferingid }">{{ text }}</router-link>
+        <router-link v-if="$route.path === '/networkoffering'" :to="{ path: '/systemoffering/' + record.serviceofferingid, query:{issystem:'true'} }">{{ text }}</router-link>
+        <router-link v-else :to="{ path: '/computeoffering/' + record.serviceofferingid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'hypervisor'">
         <span v-if="$route.name === 'hypervisorcapability'">

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -427,6 +427,9 @@
         <status :text="record.enabled ? record.enabled.toString() : 'false'" />
         {{ record.enabled ? 'Enabled' : 'Disabled' }}
       </template>
+      <template v-if="column.key === 'egressdefaultpolicy'">
+        <span> {{ record.egressdefaultpolicy ? 'Allow' : 'Deny' }} </span>
+      </template>
       <template v-if="['created', 'sent', 'removed', 'effectiveDate', 'endDate', 'allocated'].includes(column.key) || (['startdate'].includes(column.key) && ['webhook'].includes($route.path.split('/')[1])) || (column.key === 'allocated' && ['asnumbers', 'publicip', 'ipv4subnets'].includes($route.meta.name) && text)">
         {{ text && $toLocaleDate(text) }}
       </template>

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -389,7 +389,13 @@ export default {
       docHelp: 'adminguide/networking.html#network-offerings',
       permission: ['listNetworkOfferings'],
       searchFilters: ['name', 'zoneid', 'domainid', 'tags'],
-      columns: ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'domain', 'zone', 'order'],
+      columns: () => {
+        const fields = ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'domain', 'zone', 'order']
+        if (store.getters.userInfo.roletype === 'Admin') {
+          fields.push({ field: 'serviceofferingname', customTitle: 'virtual.routers.system.offering' })
+        }
+        return fields
+      },
       details: ['name', 'id', 'displaytext', 'guestiptype', 'traffictype', 'internetprotocol', 'networkrate', 'ispersistent', 'egressdefaultpolicy', 'availability', 'conservemode', 'specifyvlan', 'routingmode', 'specifyasnumber', 'specifyipranges', 'supportspublicaccess', 'supportsstrechedl2subnet', 'forvpc', 'fornsx', 'networkmode', 'service', 'tags', 'domain', 'zone'],
       resourceType: 'NetworkOffering',
       tabs: [

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -392,7 +392,7 @@ export default {
       columns: () => {
         const fields = ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'domain', 'zone', 'order']
         if (store.getters.userInfo.roletype === 'Admin') {
-          fields.push({ field: 'serviceofferingname', customTitle: 'virtual.routers.system.offering' })
+          fields.splice(fields.length - 1, 0, { field: 'serviceofferingname', customTitle: 'virtual.routers.system.offering' })
         }
         return fields
       },

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -390,7 +390,7 @@ export default {
       permission: ['listNetworkOfferings'],
       searchFilters: ['name', 'zoneid', 'domainid', 'tags'],
       columns: () => {
-        const fields = ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'domain', 'zone', 'order']
+        const fields = ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'zone', 'egressdefaultpolicy', 'order']
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(fields.length - 1, 0, { field: 'serviceofferingname', customTitle: 'virtual.routers.system.offering' })
         }

--- a/ui/src/config/section/offering.js
+++ b/ui/src/config/section/offering.js
@@ -390,7 +390,7 @@ export default {
       permission: ['listNetworkOfferings'],
       searchFilters: ['name', 'zoneid', 'domainid', 'tags'],
       columns: () => {
-        const fields = ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'zone', 'egressdefaultpolicy', 'order']
+        const fields = ['name', 'state', 'guestiptype', 'traffictype', 'networkrate', 'domain', 'zone', 'egressdefaultpolicy', 'order']
         if (store.getters.userInfo.roletype === 'Admin') {
           fields.splice(fields.length - 1, 0, { field: 'serviceofferingname', customTitle: 'virtual.routers.system.offering' })
         }


### PR DESCRIPTION
### Description

When listing network offerings with the `listNetworkOfferings` API, the VR's system offering ID is already returned. However, this information is not present at the GUI. Thus, changes were made to the `listNetworkOfferings` response to also return the system offering's name, and to the GUI to display the network offering's system offering as a column.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<img width="2493" height="1323" alt="image" src="https://github.com/user-attachments/assets/ae700057-28ce-454a-9a47-3b2dffd1df6c" />

### How Has This Been Tested?

In a environment without the changes, the `Network Offerings` tab was accessed and I validated that there was no system offering information. With CloudMonkey, I called the `listNetworkOfferings` API and validated that the response contained only the system offering's ID.

Then, after installing the packages containing the PR changes, I called the `listNetworkOfferings` API and validated that the API response now also returned the service offering's name. 

```
{
      "displaytext": "Offering for Isolated networks with Source Nat service enabled",
      "name": "DefaultIsolatedNetworkOfferingWithSourceNatService",
      ...
      "serviceofferingid": "dde866be-b594-45c9-9a0f-f65b9f48ea0c",
      "serviceofferingname": "System Offering For Software Router",
}
```

Via the GUI, the `Network Offering` tab was accessed and I validated that the network offering's system offering was also being displayed correctly (as it can be seen in the `Screenshots` section of the message). I also validated that the link to the system offering's page was working successfully and redirecting to the correct system offering. 