### PR TITLE
KVM NAS backup: resume VM and exit on backup failure

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -141,7 +141,8 @@ backup_running_vm() {
         break ;;
       Failed)
         echo "Virsh backup job failed"
-        cleanup ;;
+        cleanup
+        exit 1 ;;
     esac
     sleep 5
   done
@@ -177,6 +178,7 @@ backup_stopped_vm() {
     if ! qemu-img convert -O qcow2 "$disk" "$output" > "$logFile" 2> >(cat >&2); then
       echo "qemu-img convert failed for $disk $output"
       cleanup
+      exit 1
     fi
     name="datadisk"
   done
@@ -220,6 +222,20 @@ mount_operation() {
 
 cleanup() {
   local status=0
+
+  # Resume the VM if it was paused (e.g. by virsh backup-begin)
+  if [[ -n "$VM" ]]; then
+    local vm_state
+    vm_state=$(virsh -c qemu:///system domstate "$VM" 2>/dev/null)
+    if [[ "$vm_state" == "paused" ]]; then
+      if virsh -c qemu:///system resume "$VM" > /dev/null 2>&1; then
+        log -ne "Resumed VM $VM after backup failure"
+      else
+        echo "Failed to resume VM $VM - manual intervention required (virsh resume $VM)"
+        status=1
+      fi
+    fi
+  fi
 
   rm -rf "$dest" || { echo "Failed to delete $dest"; status=1; }
   umount "$mount_point" || { echo "Failed to unmount $mount_point"; status=1; }


### PR DESCRIPTION
## Summary

Fix three bugs in `nasbackup.sh` that caused VMs to remain **paused indefinitely** when backup jobs fail (e.g. storage full, I/O error):

1. **Infinite polling loop**: `backup_running_vm()` falls through the `Failed` case without exiting, causing the script to poll the already-failed job forever. Fixed by adding `exit 1` after cleanup.

2. **Continued processing after failure**: `backup_stopped_vm()` continues processing subsequent disks after `qemu-img convert` fails. Fixed by adding `exit 1` after cleanup.

3. **VM never resumed**: `cleanup()` removes temp files and unmounts but never resumes the VM that was paused by `virsh backup-begin`. Fixed by adding a VM state check and `virsh resume` at the top of `cleanup()`.

## Root Cause

When `virsh backup-begin` starts a backup, the VM may be paused. If the backup fails for any reason (storage full, network issue, I/O error), the script's cleanup path never calls `virsh resume`, leaving the VM paused until manual intervention.

## Test Plan

- [ ] Trigger a backup with insufficient NAS storage — verify VM is resumed after failure
- [ ] Trigger a backup with NAS unmounted mid-backup — verify VM is resumed
- [ ] Normal backup completes successfully (no regression)
- [ ] Verify `qemu-img convert` failure on stopped VM exits cleanly

Fixes #12821