### PR TITLE
Fix user password reset mail template value 

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-42200to42210.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42200to42210.sql
@@ -44,8 +44,7 @@ ALTER TABLE `cloud`.`backups` DROP COLUMN `backup_interval_type`;
 
 -- Update `user.password.reset.mail.template` configuration value to match new logic
 UPDATE `cloud`.`configuration`
-SET value = 'Hello {{username}}!\nYou have requested to reset your password. Please click the following link to reset your password:\n{{{resetLink}}}\nIf you did not request a password reset,please ignore this email.\n\nRegards,\nThe CloudStack Team'
-WHERE name = 'user.password.reset.mail.template' AND value IN (
-    'Hello {{username}}!\nYou have requested to reset your password. Please click the following link to reset your password:\nhttp://{{{resetLink}}}\nIf you did not request a password reset,please ignore this email.\n\nRegards,\nThe CloudStack Team',
-    'Hello {{username}}!\nYou have requested to reset your password. Please click the following link to reset your password:\n{{{domainUrl}}}{{{resetLink}}}\nIf you did not request a password reset,please ignore this email.\n\nRegards,\nThe CloudStack Team'
-);
+SET value = CONCAT_WS('\n', 'Hello {{username}}!', 'You have requested to reset your password. Please click the following link to reset your password:', '{{{resetLink}}}', 'If you did not request a password reset, please ignore this email.', '', 'Regards,', 'The CloudStack Team')
+WHERE name = 'user.password.reset.mail.template'
+  AND value IN (CONCAT_WS('\n', 'Hello {{username}}!', 'You have requested to reset your password. Please click the following link to reset your password:', 'http://{{{resetLink}}}', 'If you did not request a password reset, please ignore this email.', '', 'Regards,', 'The CloudStack Team'), CONCAT_WS('\n', 'Hello {{username}}!', 'You have requested to reset your password. Please click the following link to reset your password:', '{{{domainUrl}}}{{{resetLink}}}', 'If you did not request a password reset, please ignore this email.', '', 'Regards,', 'The CloudStack Team'));
+


### PR DESCRIPTION
### Description

The #11379 and #12078 PRs changed the user password email template, stored in the `user.password.reset.mail.template` configuration value. However, these changes were only made to the configuration's default value, and the database's configuration value was not changed. This caused environments that were deployed before the `4.22.0.0` release to face errors due to outdated configuration values, such as the duplicated HTTP protocol in the URL. 

This PR adds a step in the `4.22.0.0` version to `4.22.1.0` version update script to update the `user.password.reset.mail.template` configuration value to the current value, if its current value matches one of the old defaults. The step changes the configuration's value only if the current value is one of the outdated default ones, keeping customized templates untouched.

<details><summary>Old default templates</summary>

- With HTTP:

```
Hello {{username}}!
You have requested to reset your password. Please click the following link to reset your password:
http://{{{resetLink}}}
If you did not request a password reset,please ignore this email.

Regards,
The CloudStack Team
```

- With `domainUrl`:

```
Hello {{username}}!
You have requested to reset your password. Please click the following link to reset your password:
{{{domainUrl}}}{{{resetLink}}}
If you did not request a password reset,please ignore this email.

Regards,
The CloudStack Team
```

</details>

<details><summary>New default template</summary>

```
Hello {{username}}!
You have requested to reset your password. Please click the following link to reset your password:
{{{resetLink}}}
If you did not request a password reset,please ignore this email.

Regards,
The CloudStack Team
```

</details>

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

In an environment where the `user.password.reset.mail.template` configuration had the `http://` value, I manually executed the query to replace the configuration's value, and asserted that the value was changed accordingly. Then, I updated the configuration to the `{{{domainUrl}}}` outdated template, and manually executed the query one more time. The configuration's value was updated to the current template successfully.

In order to test ACS' automatic update behavior, the query was inserted to the version update SQL file, and the packages with the changes were installed in an environment previous to the `4.22.1.0` version. The correct behavior was observed for both of the outdated templates.

With the environment updated in the previous step, a password reset email was sent, and I validated that the template was working properly. 