### PR TITLE
[KVM] Reorder migration logs to prevent populating agent logs on migrations

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -260,10 +260,10 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             boolean isMigrateDowntimeSet = false;
 
             final int migrateWait = libvirtComputingResource.getMigrateWait();
-            logger.info("vm.migrate.wait value set to: {}for VM: {}", migrateWait, vmName);
+            logger.info("vm.migrate.wait value set to: {} secs for VM: {}", migrateWait, vmName);
 
             final int migratePauseAfter = libvirtComputingResource.getMigratePauseAfter();
-            logger.info("vm.migrate.pauseafter value set to: {} for VM: {}", migratePauseAfter, vmName);
+            logger.info("vm.migrate.pauseafter value set to: {} ms for VM: {}", migratePauseAfter, vmName);
 
             while (!executor.isTerminated()) {
                 Thread.sleep(100);


### PR DESCRIPTION
### Description

This PR improves the KVM migration logging, preventing to populate the agent logs on migrations after the improvements added on #12332 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Before the fix:

````
2026-03-24 23:03:38,857 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:38,857 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:38,957 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) Waiting for migration of i-2-25-VM to complete, waited 23000ms
2026-03-24 23:03:38,957 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:38,957 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,057 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,057 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,157 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,157 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,257 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,258 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,358 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,358 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,458 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,458 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,558 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,558 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,658 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,658 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,758 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,758 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,858 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,858 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:39,959 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) Waiting for migration of i-2-25-VM to complete, waited 24000ms
2026-03-24 23:03:39,959 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:39,959 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,059 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,059 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,159 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,159 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,259 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,259 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,359 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,359 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,459 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,460 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,560 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,560 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,660 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,660 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,760 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,760 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,860 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,860 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:40,960 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) Waiting for migration of i-2-25-VM to complete, waited 25000ms
2026-03-24 23:03:40,960 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:40,960 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,061 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,061 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,161 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,161 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,261 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,261 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,361 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,361 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,461 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,461 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,561 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,561 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,661 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,662 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,762 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,762 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,862 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,862 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,963 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) Waiting for migration of i-2-25-VM to complete, waited 26000ms
2026-03-24 23:03:41,963 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:03:41,963 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:03:41,963 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-1:[]) (logid:21bbbf9b) Migration thread of VM [i-2-25-VM] finished.

````

After the fix:

````
2026-03-24 23:11:02,899 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) vm.migrate.wait value set to: 3600for VM: i-2-25-VM
2026-03-24 23:11:02,899 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) vm.migrate.pauseafter value set to: -1 for VM: i-2-25-VM
2026-03-24 23:11:02,899 DEBUG [kvm.resource.MigrateKVMAsync] (pool-3-thread-1:[]) (logid:) Setting VIR_MIGRATE_NON_SHARED_INC for linked clone migration.
2026-03-24 23:11:02,900 DEBUG [kvm.resource.MigrateKVMAsync] (pool-3-thread-1:[]) (logid:) Migrating [i-2-25-VM] with flags [2185], destination [10.1.35.71] and speed [1000]. The disks with the following labels will be migrated [[vda]].
2026-03-24 23:11:03,902 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 1000ms
2026-03-24 23:11:04,903 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 2000ms
2026-03-24 23:11:05,904 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 3000ms
2026-03-24 23:11:06,905 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 4000ms
2026-03-24 23:11:07,907 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 5000ms
2026-03-24 23:11:08,908 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 6000ms
2026-03-24 23:11:09,909 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 7000ms
2026-03-24 23:11:10,910 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 8000ms
2026-03-24 23:11:11,911 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Waiting for migration of i-2-25-VM to complete, waited 9000ms
2026-03-24 23:11:12,312 INFO  [resource.wrapper.LibvirtMigrateCommandWrapper] (AgentRequest-Handler-5:[]) (logid:604bf08f) Migration thread of VM [i-2-25-VM] finished.
````

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
