### PR TITLE
Domain is passed as a REGEX pattern, not a literal string.

### DIFF
--- a/server/src/main/java/com/cloud/user/DomainManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/DomainManagerImpl.java
@@ -91,6 +91,7 @@ import com.cloud.storage.dao.DiskOfferingDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.Pair;
+import com.cloud.utils.StringUtils;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.db.Filter;
@@ -107,8 +108,6 @@ import com.cloud.vm.ReservationContext;
 import com.cloud.vm.ReservationContextImpl;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.dao.VMInstanceDao;
-
-import org.apache.commons.lang3.StringUtils;
 
 @Component
 public class DomainManagerImpl extends ManagerBase implements DomainManager, DomainService {

--- a/server/src/main/java/com/cloud/user/DomainManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/DomainManagerImpl.java
@@ -1094,7 +1094,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
         for (Map.Entry<Long, List<String>> entry : idsOfDomainsWithResourcesUsedByDomainToBeMoved.entrySet()) {
             DomainVO domainWithResourceUsedByDomainToBeMoved = _domainDao.findById(entry.getKey());
 
-            Pattern pattern = Pattern.compile(domainWithResourceUsedByDomainToBeMoved.getPath().replace("/", "\\/").concat(".*"));
+            Pattern pattern = Pattern.compile(domainWithResourceUsedByDomainToBeMoved.getPath().replace("/", "\\/").concat(".*")); // This only scaped one Regex metacharacter (/). The wildcard `.` is more common and dangerous in my opinion. 
             Matcher matcher = pattern.matcher(newPathOfDomainToBeMoved);
             if (!matcher.matches()) {
                 domainsOfResourcesInaccessibleToNewParentDomain.put(domainWithResourceUsedByDomainToBeMoved, entry.getValue());

--- a/server/src/main/java/com/cloud/user/DomainManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/DomainManagerImpl.java
@@ -958,7 +958,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
         List<DomainVO> domainChildren = _domainDao.findAllChildren(domain.getPath(), domain.getId());
         // for each child, update the path
         for (DomainVO dom : domainChildren) {
-            dom.setPath(dom.getPath().replaceFirst(domain.getPath(), updatedDomainPrefix));
+            dom.setPath(StringUtils.replaceOnce(dom.getPath(), domain.getPath(), updatedDomainPrefix));
             _domainDao.update(dom.getId(), dom);
         }
     }


### PR DESCRIPTION
### Description

This change ensures consistency with how paths are parsed when updating a domain path.

The modified line was passing the domain name as a literal string, but it is actually interpreted as a regular expression internally.

I couldn’t find a way to exploit this issue, but it could still cause data corruption if a domain name accidentally contains regex metacharacters.

Note that this same technique is already used in a similar situation on line 1118.

A common example is when an organization uses its DNS name as the "domain" (tenant), like `company.com`.

In this case, the `.` (dot) is treated as a regex wildcard, meaning it can match any character...

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

<img width="406" height="235" alt="image" src="https://github.com/user-attachments/assets/f2fd80b1-a441-467f-98bb-c76c40afe5ca" />

### How Has This Been Tested?

This fix was not tested. I am not a Java developer, and I have no skill for such a thing.

#### How did you try to break this feature and the system with this change?

I could trigger, but I could not exploit this bug.

<img width="1405" height="842" alt="image" src="https://github.com/user-attachments/assets/82bc7895-3296-47ff-ae45-02c65cda6a67" />
