### PR TITLE
fix: support SharedMountPoint volume checks for importVm

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVolumeCommandWrapper.java
@@ -47,7 +47,10 @@ import java.util.Map;
 @ResourceWrapper(handles = CheckVolumeCommand.class)
 public final class LibvirtCheckVolumeCommandWrapper extends CommandWrapper<CheckVolumeCommand, Answer, LibvirtComputingResource> {
 
-    private static final List<Storage.StoragePoolType> STORAGE_POOL_TYPES_SUPPORTED = Arrays.asList(Storage.StoragePoolType.Filesystem, Storage.StoragePoolType.NetworkFilesystem);
+    private static final List<Storage.StoragePoolType> STORAGE_POOL_TYPES_SUPPORTED = Arrays.asList(
+            Storage.StoragePoolType.Filesystem,
+            Storage.StoragePoolType.NetworkFilesystem,
+            Storage.StoragePoolType.SharedMountPoint);
 
     @Override
     public Answer execute(final CheckVolumeCommand command, final LibvirtComputingResource libvirtComputingResource) {


### PR DESCRIPTION
## Summary
- allow KVM CheckVolumeCommand validation for SharedMountPoint pools used by importVm
- keep SharedMountPoint aligned with the existing file-based storage handling used for NFS/filesystem pools

Fixes apache/cloudstack#12944

## Testing
- Not run locally in this environment (mvn not available)
