### PR TITLE
Improves the network offering creation form

### DIFF
--- a/ui/src/views/offering/AddNetworkOffering.vue
+++ b/ui/src/views/offering/AddNetworkOffering.vue
@@ -113,6 +113,16 @@
         </a-row>
         <a-row :gutter="12">
           <a-col :md="12" :lg="12">
+            <a-form-item name="specifyipranges" ref="specifyipranges" v-if="guestType === 'isolated'">
+              <template #label>
+                <tooltip-label :title="$t('label.specifyipranges')" :tooltip="apiParams.specifyipranges.description"/>
+              </template>
+              <a-switch v-model:checked="form.specifyipranges" />
+            </a-form-item>
+          </a-col>
+        </a-row>
+        <a-row :gutter="12">
+          <a-col :md="12" :lg="12">
             <a-form-item name="forvpc" ref="forvpc" v-if="guestType === 'isolated'">
               <template #label>
                 <tooltip-label :title="$t('label.vpc')" :tooltip="apiParams.forvpc.description"/>
@@ -681,7 +691,8 @@ export default {
         isolation: 'dedicated',
         conservemode: true,
         availability: 'optional',
-        egressdefaultpolicy: 'deny',
+        specifyipranges: false,
+        egressdefaultpolicy: 'allow',
         ispublic: this.isPublic,
         nsxsupportlb: true,
         routingmode: 'static'
@@ -1043,7 +1054,7 @@ export default {
 
         var keys = Object.keys(values)
         const detailsKey = ['promiscuousmode', 'macaddresschanges', 'forgedtransmits', 'maclearning']
-        const ignoredKeys = [...detailsKey, 'state', 'status', 'allocationstate', 'forvpc', 'lbType', 'specifyvlan', 'ispublic', 'domainid', 'zoneid', 'egressdefaultpolicy', 'isolation', 'supportspublicaccess']
+        const ignoredKeys = [...detailsKey, 'state', 'status', 'allocationstate', 'forvpc', 'lbType', 'specifyvlan', 'ispublic', 'domainid', 'zoneid', 'egressdefaultpolicy', 'isolation', 'supportspublicaccess', 'specifyipranges']
         keys.forEach(function (key, keyIndex) {
           if (!ignoredKeys.includes(key) &&
             values[key] != null && values[key] !== undefined &&
@@ -1062,6 +1073,9 @@ export default {
           if (values.specifyvlan === true) {
             params.specifyvlan = true
           }
+
+          params.specifyipranges = values.specifyipranges
+
           if (values.ispersistent) {
             params.ispersistent = true
           } else { // Isolated Network with Non-persistent network
@@ -1078,6 +1092,7 @@ export default {
           }
           // Conserve mode is irrelevant on L2 network offerings as there are no resources to conserve, do not pass it, true by default on server side
           delete params.conservemode
+          delete params.specifyipranges
         }
 
         if (values.forvpc === true) {

--- a/ui/src/views/offering/AddNetworkOffering.vue
+++ b/ui/src/views/offering/AddNetworkOffering.vue
@@ -692,7 +692,7 @@ export default {
         conservemode: true,
         availability: 'optional',
         specifyipranges: false,
-        egressdefaultpolicy: 'allow',
+        egressdefaultpolicy: 'deny',
         ispublic: this.isPublic,
         nsxsupportlb: true,
         routingmode: 'static'

--- a/ui/src/views/offering/AddNetworkOffering.vue
+++ b/ui/src/views/offering/AddNetworkOffering.vue
@@ -113,7 +113,7 @@
         </a-row>
         <a-row :gutter="12">
           <a-col :md="12" :lg="12">
-            <a-form-item name="specifyipranges" ref="specifyipranges" v-if="guestType === 'isolated'">
+            <a-form-item name="specifyipranges" ref="specifyipranges" v-if="guestType === 'isolated' && !sourceNatServiceChecked">
               <template #label>
                 <tooltip-label :title="$t('label.specifyipranges')" :tooltip="apiParams.specifyipranges.description"/>
               </template>


### PR DESCRIPTION
### Description

Currently, when creating a new network offering through the CloudStack graphical interface it is not possible to specify the `specifyipranges` parameter. 

This PR made modifications to add the `specifyipranges` field to the form .

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

In the CloudStack graphical interface, I opened the create new network offering form and checked the new `specifyipranges` parameter was only in the `Isolated` guest type . After creating the new network offering, I created a new network and it was observed in the form that the fields to specify the IPs ranges were present.

