### PR TITLE
Set snapCPG in online copy request to fix snapshot failures on cloned volumes

### DIFF
--- a/plugins/storage/volume/primera/src/main/java/org/apache/cloudstack/storage/datastore/adapter/primera/PrimeraAdapter.java
+++ b/plugins/storage/volume/primera/src/main/java/org/apache/cloudstack/storage/datastore/adapter/primera/PrimeraAdapter.java
@@ -384,6 +384,7 @@ public class PrimeraAdapter implements ProviderAdapter {
             // Online copy configuration: immediate clone with deduplication and compression
             parms.setOnline(true);
             parms.setDestCPG(cpg);
+            parms.setSnapCPG(snapCpg);
             parms.setTpvv(false);
             parms.setReduce(true);
             logger.debug("PrimeraAdapter: Configuring online copy - destination CPG: '{}', deduplication enabled, thin provisioning disabled", cpg);


### PR DESCRIPTION
### Description

The snapCPG parameter was missing from the online copy request parameters (PrimeraVolumeCopyRequestParameters), so the newly cloned volume was created without a snap CPG assignment. This caused subsequent snapshot operations on that volume to fail because Primera didn't know which CPG to allocate snapshot space from.

Fix: Added parms.setSnapCPG(snapCpg) to the online copy configuration in the copy() method, alongside the existing destCPG, tpvv, and reduce parameters.

Note: The direct create() path already set snapCPG correctly via request.setSnapCPG(snapCpg) — the gap was only in the online copy flow.



<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Tested using both HPE Primera and Alletra arrays. Verified that volumes created via online copy now have the correct snapCPG set and that snapshot operations succeed.

```bash
2026-04-02 16:01:44,866 DEBUG [o.a.c.s.d.a.p.PrimeraAdapter] (Work-Job-Executor-1:[ctx-846f217c, job-10462/job-10463, ctx-c0684397]) (logid:c8c0c67d) PrimeraAdapter: Starting volume copy operation - source volume: 'tpl-17-0-18-315', target volume: 'ROOT-882', requested new size: 21474836480 bytes (20480 MiB)
2026-04-02 16:01:44,868 DEBUG [o.a.c.s.d.a.p.PrimeraAdapter] (Work-Job-Executor-1:[ctx-846f217c, job-10462/job-10463, ctx-c0684397]) (logid:c8c0c67d) PrimeraAdapter: Generated external name 'vol-17-1-29-1139' for target volume
2026-04-02 16:01:44,885 DEBUG [o.a.c.s.d.a.p.PrimeraAdapter] (Work-Job-Executor-1:[ctx-846f217c, job-10462/job-10463, ctx-c0684397]) (logid:c8c0c67d) PrimeraAdapter: No size change required (both 21474836480 bytes) - using online copy method for faster cloning
2026-04-02 16:01:44,891 DEBUG [o.a.c.s.d.a.p.PrimeraAdapter] (Work-Job-Executor-1:[ctx-846f217c, job-10462/job-10463, ctx-c0684397]) (logid:c8c0c67d) PrimeraAdapter: Online copy mode - target volume 'ROOT-882' will be created automatically during clone operation
2026-04-02 16:01:44,891 DEBUG [o.a.c.s.d.a.p.PrimeraAdapter] (Work-Job-Executor-1:[ctx-846f217c, job-10462/job-10463, ctx-c0684397]) (logid:c8c0c67d) PrimeraAdapter: Configuring online copy - destination CPG: 'mycpg', snapCPG: 'mycpg', deduplication enabled, thin provisioning disabled
 
```


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
