### PR TITLE
Fix KVM import/unmanage support for SharedMountPoint pools

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/storage/volume/VolumeImportUnmanageService.java
+++ b/api/src/main/java/org/apache/cloudstack/storage/volume/VolumeImportUnmanageService.java
@@ -37,7 +37,7 @@ public interface VolumeImportUnmanageService extends PluggableService, Configura
             Arrays.asList(Hypervisor.HypervisorType.KVM, Hypervisor.HypervisorType.VMware);
 
     List<Storage.StoragePoolType> SUPPORTED_STORAGE_POOL_TYPES_FOR_KVM = Arrays.asList(Storage.StoragePoolType.NetworkFilesystem,
-            Storage.StoragePoolType.Filesystem, Storage.StoragePoolType.RBD);
+            Storage.StoragePoolType.Filesystem, Storage.StoragePoolType.RBD, Storage.StoragePoolType.SharedMountPoint);
 
     ConfigKey<Boolean> AllowImportVolumeWithBackingFile = new ConfigKey<>(Boolean.class,
             "allow.import.volume.with.backing.file",

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVolumesOnStorageCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVolumesOnStorageCommandWrapper.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 public final class LibvirtGetVolumesOnStorageCommandWrapper extends CommandWrapper<GetVolumesOnStorageCommand, Answer, LibvirtComputingResource> {
 
     static final List<StoragePoolType> STORAGE_POOL_TYPES_SUPPORTED_BY_QEMU_IMG = Arrays.asList(StoragePoolType.NetworkFilesystem,
-            StoragePoolType.Filesystem, StoragePoolType.RBD);
+            StoragePoolType.Filesystem, StoragePoolType.RBD, StoragePoolType.SharedMountPoint);
 
     @Override
     public Answer execute(final GetVolumesOnStorageCommand command, final LibvirtComputingResource libvirtComputingResource) {


### PR DESCRIPTION
## Summary
- allow SharedMountPoint in KVM supported pool types for import/unmanage validation
- allow SharedMountPoint in KVM qemu-img supported pool types used by volume listing for import

## Issue
Fixes #12954

## Testing
- not run (targeted code-path change only)
