### PR TITLE
Fix: API Thread held forever during force deleting across MS

### DIFF
--- a/core/src/main/java/com/cloud/agent/api/PropagateResourceEventCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/PropagateResourceEventCommand.java
@@ -24,6 +24,8 @@ import com.cloud.resource.ResourceState;
 public class PropagateResourceEventCommand extends Command {
     long hostId;
     ResourceState.Event event;
+    boolean forced;
+    boolean forceDeleteStorage;
 
     protected PropagateResourceEventCommand() {
 
@@ -34,12 +36,27 @@ public class PropagateResourceEventCommand extends Command {
         this.event = event;
     }
 
+    public PropagateResourceEventCommand(long hostId, ResourceState.Event event, boolean forced, boolean forceDeleteStorage) {
+        this.hostId = hostId;
+        this.event = event;
+        this.forced = forced;
+        this.forceDeleteStorage = forceDeleteStorage;
+    }
+
     public long getHostId() {
         return hostId;
     }
 
     public ResourceState.Event getEvent() {
         return event;
+    }
+
+    public boolean isForced() {
+        return forced;
+    }
+
+    public boolean isForceDeleteStorage() {
+        return forceDeleteStorage;
     }
 
     @Override

--- a/engine/components-api/src/main/java/com/cloud/resource/ResourceManager.java
+++ b/engine/components-api/src/main/java/com/cloud/resource/ResourceManager.java
@@ -122,6 +122,8 @@ public interface ResourceManager extends ResourceService, Configurable {
 
     public boolean executeUserRequest(long hostId, ResourceState.Event event) throws AgentUnavailableException;
 
+    boolean executeUserRequest(long hostId, ResourceState.Event event, boolean isForced, boolean isForceDeleteStorage) throws AgentUnavailableException;
+
     boolean resourceStateTransitTo(Host host, Event event, long msId) throws NoTransitionException;
 
     boolean umanageHost(long hostId);

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
@@ -1313,7 +1313,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                     logger.warn("Agent is unavailable", ex);
                     return null;
                 } catch (final RuntimeException ex) {
-                    s_logger.error(String.format("Failed to execute propagated event %s for host %d", cmd.getEvent().name(), cmd.getHostId()), ex);
+                    logger.error(String.format("Failed to execute propagated event %s for host %d", cmd.getEvent().name(), cmd.getHostId()), ex);
                     final Answer[] answers = new Answer[1];
                     String details = ex.getMessage();
                     if (details == null || details.isEmpty()) {

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
@@ -1307,11 +1307,20 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
                 boolean result;
                 try {
-                    result = _resourceMgr.executeUserRequest(cmd.getHostId(), cmd.getEvent());
+                    result = _resourceMgr.executeUserRequest(cmd.getHostId(), cmd.getEvent(), cmd.isForced(), cmd.isForceDeleteStorage());
                     logger.debug("Result is {}", result);
                 } catch (final AgentUnavailableException ex) {
                     logger.warn("Agent is unavailable", ex);
                     return null;
+                } catch (final RuntimeException ex) {
+                    s_logger.error(String.format("Failed to execute propagated event %s for host %d", cmd.getEvent().name(), cmd.getHostId()), ex);
+                    final Answer[] answers = new Answer[1];
+                    String details = ex.getMessage();
+                    if (details == null || details.isEmpty()) {
+                        details = ex.toString();
+                    }
+                    answers[0] = new Answer(cmd, false, details);
+                    return _gson.toJson(answers);
                 }
 
                 final Answer[] answers = new Answer[1];

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -1169,7 +1169,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     @Override
     public boolean deleteHost(final long hostId, final boolean isForced, final boolean isForceDeleteStorage) {
         try {
-            final Boolean result = propagateResourceEvent(hostId, ResourceState.Event.DeleteHost);
+            final Boolean result = propagateResourceEvent(hostId, ResourceState.Event.DeleteHost, isForced, isForceDeleteStorage);
             if (result != null) {
                 return result;
             }
@@ -3902,13 +3902,18 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     }
 
     @Override
-    public boolean executeUserRequest(final long hostId, final ResourceState.Event event) {
+    public boolean executeUserRequest(final long hostId, final ResourceState.Event event) throws AgentUnavailableException {
+        return executeUserRequest(hostId, event, false, false);
+    }
+
+    @Override
+    public boolean executeUserRequest(final long hostId, final ResourceState.Event event, final boolean isForced, final boolean isForceDeleteStorage) throws AgentUnavailableException {
         if (event == ResourceState.Event.AdminAskMaintenance) {
             return doMaintain(hostId);
         } else if (event == ResourceState.Event.AdminCancelMaintenance) {
             return doCancelMaintenance(hostId);
         } else if (event == ResourceState.Event.DeleteHost) {
-            return doDeleteHost(hostId, false, false);
+            return doDeleteHost(hostId, isForced, isForceDeleteStorage);
         } else if (event == ResourceState.Event.Unmanaged) {
             return doUmanageHost(hostId);
         } else if (event == ResourceState.Event.UpdatePassword) {
@@ -4028,6 +4033,10 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     }
 
     public Boolean propagateResourceEvent(final long agentId, final ResourceState.Event event) throws AgentUnavailableException {
+        return propagateResourceEvent(agentId, event, false, false);
+    }
+
+    public Boolean propagateResourceEvent(final long agentId, final ResourceState.Event event, final boolean isForced, final boolean isForceDeleteStorage) throws AgentUnavailableException {
         final String msPeer = getPeerName(agentId);
         if (msPeer == null) {
             return null;
@@ -4035,7 +4044,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         logger.debug("Propagating resource request event:" + event.toString() + " to agent:" + agentId);
         final Command[] cmds = new Command[1];
-        cmds[0] = new PropagateResourceEventCommand(agentId, event);
+        cmds[0] = new PropagateResourceEventCommand(agentId, event, isForced, isForceDeleteStorage);
 
         final String AnsStr = _clusterMgr.execute(msPeer, agentId, _gson.toJson(cmds), true);
         if (AnsStr == null) {
@@ -4046,6 +4055,13 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         if (logger.isDebugEnabled()) {
             logger.debug("Result for agent change is " + answers[0].getResult());
+        }
+
+        if (!answers[0].getResult()) {
+            final String details = answers[0].getDetails();
+            if (details != null && !details.isEmpty()) {
+                throw new CloudRuntimeException(String.format("Failed to propagate resource event %s for host %d on peer %s: %s", event, agentId, msPeer, details));
+            }
         }
 
         return answers[0].getResult();

--- a/server/src/test/java/com/cloud/resource/MockResourceManagerImpl.java
+++ b/server/src/test/java/com/cloud/resource/MockResourceManagerImpl.java
@@ -318,6 +318,11 @@ public class MockResourceManagerImpl extends ManagerBase implements ResourceMana
         return false;
     }
 
+    @Override
+    public boolean executeUserRequest(long hostId, Event event, boolean isForced, boolean isForceDeleteStorage) throws AgentUnavailableException {
+        return false;
+    }
+
     /* (non-Javadoc)
      * @see com.cloud.resource.ResourceManager#resourceStateTransitTo(com.cloud.host.Host, com.cloud.resource.ResourceState.Event, long)
      */

--- a/server/src/test/java/com/cloud/resource/ResourceManagerImplTest.java
+++ b/server/src/test/java/com/cloud/resource/ResourceManagerImplTest.java
@@ -1184,4 +1184,31 @@ public class ResourceManagerImplTest {
         Mockito.verify(host).setStorageAccessGroups("group1,group2");
         Mockito.verify(hostDao).update(hostId, host);
     }
+
+    @Test
+    public void executeUserRequestDeleteHostPassesForcedFlags() throws Exception {
+        Mockito.doReturn(true).when(resourceManager).doDeleteHost(anyLong(), anyBoolean(), anyBoolean());
+
+        resourceManager.executeUserRequest(hostId, ResourceState.Event.DeleteHost, true, true);
+
+        Mockito.verify(resourceManager).doDeleteHost(hostId, true, true);
+    }
+
+    @Test
+    public void executeUserRequestDeleteHostPassesNonForcedFlags() throws Exception {
+        Mockito.doReturn(true).when(resourceManager).doDeleteHost(anyLong(), anyBoolean(), anyBoolean());
+
+        resourceManager.executeUserRequest(hostId, ResourceState.Event.DeleteHost, false, false);
+
+        Mockito.verify(resourceManager).doDeleteHost(hostId, false, false);
+    }
+
+    @Test
+    public void executeUserRequestDefaultOverloadPassesFalseForDeleteHost() throws Exception {
+        Mockito.doReturn(true).when(resourceManager).doDeleteHost(anyLong(), anyBoolean(), anyBoolean());
+
+        resourceManager.executeUserRequest(hostId, ResourceState.Event.DeleteHost);
+
+        Mockito.verify(resourceManager).doDeleteHost(hostId, false, false);
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes indefinite hang on deleteHost operation for multiple management server environments. In a multi-management-server (clustered) environment, a forced deleteHost API call causes the calling MS to hang indefinitely, eventually exhausting API threads and rendering the entire environment unresponsive (502 gateway errors).

Fixed by adding:

- Propagate isForced and isForceDeleteStorage flags across management servers via PropagateResourceEventCommand
- Catch RuntimeException in ClusterDispatcher.dispatch() so that unexpected failures return a proper error response instead of silently hanging

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
