### PR TITLE
ipmi: Uncensor port on sanitised logs

### DIFF
--- a/plugins/outofbandmanagement-drivers/ipmitool/src/main/java/org/apache/cloudstack/outofbandmanagement/driver/ipmitool/IpmitoolOutOfBandManagementDriver.java
+++ b/plugins/outofbandmanagement-drivers/ipmitool/src/main/java/org/apache/cloudstack/outofbandmanagement/driver/ipmitool/IpmitoolOutOfBandManagementDriver.java
@@ -120,7 +120,7 @@ public final class IpmitoolOutOfBandManagementDriver extends AdapterBase impleme
 
         final OutOfBandManagementDriverResponse response = IPMITOOL.executeCommands(ipmiToolCommands, cmd.getTimeout());
 
-        String oneLineCommand = StringUtils.join(IPMITOOL.getSanatisedCommandStrings(ipmiToolCommands), " ");
+        String oneLineCommand = StringUtils.join(IPMITOOL.getSanitisedCommandStrings(ipmiToolCommands), " ");
         String result = response.getResult().trim();
 
         if (response.isSuccess()) {

--- a/plugins/outofbandmanagement-drivers/ipmitool/src/main/java/org/apache/cloudstack/outofbandmanagement/driver/ipmitool/IpmitoolWrapper.java
+++ b/plugins/outofbandmanagement-drivers/ipmitool/src/main/java/org/apache/cloudstack/outofbandmanagement/driver/ipmitool/IpmitoolWrapper.java
@@ -158,7 +158,7 @@ public final class IpmitoolWrapper {
     public OutOfBandManagementDriverResponse executeCommands(final List<String> commands, final Duration timeOut) {
         final ProcessResult result = RUNNER.executeCommands(commands, timeOut);
         if (logger.isTraceEnabled()) {
-            List<String> cleanedCommands = getSanatisedCommandStrings(commands);
+            List<String> cleanedCommands = getSanitisedCommandStrings(commands);
             logger.trace("Executed ipmitool process with commands: {}\nIpmitool execution standard output: {}\nIpmitool execution error output: {}",
                     StringUtils.join(cleanedCommands, ", "),
                     result.getStdOutput(),
@@ -167,7 +167,7 @@ public final class IpmitoolWrapper {
         return new OutOfBandManagementDriverResponse(result.getStdOutput(), result.getStdError(), result.isSuccess());
     }
 
-    List<String> getSanatisedCommandStrings(List<String> commands) {
+    List<String> getSanitisedCommandStrings(List<String> commands) {
         List<String> cleanedCommands = new ArrayList<>();
         int maskNextCommand = 0;
         for (String command : commands) {
@@ -176,7 +176,7 @@ public final class IpmitoolWrapper {
                 maskNextCommand--;
                 continue;
             }
-            if (command.equalsIgnoreCase("-P")) {
+            if (command.equals("-P")) {
                 maskNextCommand = 1;
             } else if (command.toLowerCase().endsWith("password")) {
                 maskNextCommand = 2;


### PR DESCRIPTION
### Description

When using IPMI, the password is censored before being shown in the logs, this censorship, however, filters for the `-P` parameter, ignoring case. This causes the port to be censored for no reason, as its parameter is `-p`. This PR uncensors the port while maintaining the censorship on the password, as well as fixes a typo in the method's name.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

The logs changed are used in two places, I checked both instances and verified that the port was no longer censored but the password still was.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
