### PR TITLE
Honour consoleproxy.session.timeout for noVNC sessions (fixes #12810)

### DIFF
--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -80,8 +80,8 @@ public class ConsoleProxy {
     static String factoryClzName;
     static boolean standaloneStart = false;
 
-    // New: session timeout in milliseconds, default 300000 (5 minutes)
-    static int sessionTimeoutMillis = 300000;
+    // Session timeout in milliseconds, default 300000 (5 minutes)
+    public static int sessionTimeoutMillis = 300000;
 
     static String encryptorPassword = "Dummy";
     static final String[] skipProperties = new String[]{"certificate", "cacertificate", "keystore_password", "privatekey"};
@@ -169,15 +169,21 @@ public class ConsoleProxy {
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
         }
 
-        // New: read consoleproxy.session.timeout (milliseconds)
+        // Read consoleproxy.session.timeout (milliseconds)
         s = conf.getProperty("consoleproxy.session.timeout");
         if (s != null) {
             try {
-                sessionTimeoutMillis = Integer.parseInt(s);
-                LOGGER.info("Setting consoleproxy.session.timeout=" + sessionTimeoutMillis);
+                int parsedTimeout = Integer.parseInt(s);
+                if (parsedTimeout < 1000) {
+                    LOGGER.warn("Invalid value for consoleproxy.session.timeout: " + s +
+                            " (must be >= 1000 ms), keeping default " + sessionTimeoutMillis + " ms");
+                } else {
+                    sessionTimeoutMillis = parsedTimeout;
+                    LOGGER.info("Setting consoleproxy.session.timeout=" + sessionTimeoutMillis + " ms");
+                }
             } catch (NumberFormatException e) {
                 LOGGER.warn("Invalid value for consoleproxy.session.timeout: " + s +
-                        ", using default " + sessionTimeoutMillis, e);
+                        ", keeping default " + sessionTimeoutMillis + " ms", e);
             }
         }
     }
@@ -394,7 +400,7 @@ public class ConsoleProxy {
             LOGGER.info("HTTP command port is disabled");
         }
 
-        ConsoleProxyGCThread cthread = new ConsoleProxyGCThread(connectionMap, removedSessionsSet /*, sessionTimeoutMillis */);
+        ConsoleProxyGCThread cthread = new ConsoleProxyGCThread(connectionMap, removedSessionsSet);
         cthread.setName("Console Proxy GC Thread");
         cthread.start();
     }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -80,11 +80,8 @@ public class ConsoleProxy {
     static String factoryClzName;
     static boolean standaloneStart = false;
 
-    // Session timeout in milliseconds, default 300000 (5 minutes)
-    public static int sessionTimeoutMillis = 300000;
-
     static String encryptorPassword = "Dummy";
-    static final String[] skipProperties = new String[]{"certificate", "cacertificate", "keystore_password", "privatekey"};
+    static final String[] skipProperties = new String[] {"certificate", "cacertificate", "keystore_password", "privatekey"};
 
     static Set<String> allowedSessions = new HashSet<>();
 
@@ -95,11 +92,13 @@ public class ConsoleProxy {
     private static void configLog4j() {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         URL configUrl = loader.getResource("/conf/log4j-cloud.xml");
-        if (configUrl == null)
+        if (configUrl == null) {
             configUrl = ClassLoader.getSystemResource("log4j-cloud.xml");
+        }
 
-        if (configUrl == null)
+        if (configUrl == null) {
             configUrl = ClassLoader.getSystemResource("conf/log4j-cloud.xml");
+        }
 
         if (configUrl != null) {
             try {
@@ -123,20 +122,21 @@ public class ConsoleProxy {
 
     private static void configProxy(Properties conf) {
         LOGGER.info("Configure console proxy...");
-        for (Object key : conf.keySet()) {
-            LOGGER.info("Property " + (String)key + ": " + conf.getProperty((String)key));
-            if (!ArrayUtils.contains(skipProperties, key)) {
-                LOGGER.info("Property " + (String)key + ": " + conf.getProperty((String)key));
+        if (conf != null) {
+            for (Object key : conf.keySet()) {
+                if (!ArrayUtils.contains(skipProperties, key)) {
+                    LOGGER.info("Property " + (String) key + ": " + conf.getProperty((String) key));
+                }
             }
         }
 
-        String s = conf.getProperty("consoleproxy.httpListenPort");
+        String s = conf != null ? conf.getProperty("consoleproxy.httpListenPort") : null;
         if (s != null) {
             httpListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpListenPort=" + s);
         }
 
-        s = conf.getProperty("premium");
+        s = conf != null ? conf.getProperty("premium") : null;
         if (s != null && s.equalsIgnoreCase("true")) {
             LOGGER.info("Premium setting will override settings from consoleproxy.properties, listen at port 443");
             httpListenPort = 443;
@@ -145,46 +145,28 @@ public class ConsoleProxy {
             factoryClzName = ConsoleProxyBaseServerFactoryImpl.class.getName();
         }
 
-        s = conf.getProperty("consoleproxy.httpCmdListenPort");
+        s = conf != null ? conf.getProperty("consoleproxy.httpCmdListenPort") : null;
         if (s != null) {
             httpCmdListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpCmdListenPort=" + s);
         }
 
-        s = conf.getProperty("consoleproxy.reconnectMaxRetry");
+        s = conf != null ? conf.getProperty("consoleproxy.reconnectMaxRetry") : null;
         if (s != null) {
             reconnectMaxRetry = Integer.parseInt(s);
             LOGGER.info("Setting reconnectMaxRetry=" + reconnectMaxRetry);
         }
 
-        s = conf.getProperty("consoleproxy.readTimeoutSeconds");
+        s = conf != null ? conf.getProperty("consoleproxy.readTimeoutSeconds") : null;
         if (s != null) {
             readTimeoutSeconds = Integer.parseInt(s);
             LOGGER.info("Setting readTimeoutSeconds=" + readTimeoutSeconds);
         }
 
-        s = conf.getProperty("consoleproxy.defaultBufferSize");
+        s = conf != null ? conf.getProperty("consoleproxy.defaultBufferSize") : null;
         if (s != null) {
             defaultBufferSize = Integer.parseInt(s);
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
-        }
-
-        // Read consoleproxy.session.timeout (milliseconds)
-        s = conf.getProperty("consoleproxy.session.timeout");
-        if (s != null) {
-            try {
-                int parsedTimeout = Integer.parseInt(s);
-                if (parsedTimeout < 1000) {
-                    LOGGER.warn("Invalid value for consoleproxy.session.timeout: " + s +
-                            " (must be >= 1000 ms), keeping default " + sessionTimeoutMillis + " ms");
-                } else {
-                    sessionTimeoutMillis = parsedTimeout;
-                    LOGGER.info("Setting consoleproxy.session.timeout=" + sessionTimeoutMillis + " ms");
-                }
-            } catch (NumberFormatException e) {
-                LOGGER.warn("Invalid value for consoleproxy.session.timeout: " + s +
-                        ", keeping default " + sessionTimeoutMillis + " ms", e);
-            }
         }
     }
 
@@ -192,7 +174,7 @@ public class ConsoleProxy {
         try {
             Class<?> clz = Class.forName(factoryClzName);
             try {
-                ConsoleProxyServerFactory factory = (ConsoleProxyServerFactory)clz.newInstance();
+                ConsoleProxyServerFactory factory = (ConsoleProxyServerFactory) clz.newInstance();
                 factory.init(ConsoleProxy.ksBits, ConsoleProxy.ksPassword);
                 return factory;
             } catch (InstantiationException e) {
@@ -215,11 +197,11 @@ public class ConsoleProxy {
         authResult.setHost(param.getClientHostAddress());
         authResult.setPort(param.getClientHostPort());
 
-        if (org.apache.commons.lang3.StringUtils.isNotBlank(param.getExtraSecurityToken())) {
+        if (StringUtils.isNotBlank(param.getExtraSecurityToken())) {
             String extraToken = param.getExtraSecurityToken();
             String clientProvidedToken = param.getClientProvidedExtraSecurityToken();
-            LOGGER.debug(String.format("Extra security validation for the console access, provided %s " +
-                    "to validate against %s", clientProvidedToken, extraToken));
+            LOGGER.debug(String.format("Extra security validation for the console access, provided %s to validate against %s",
+                    clientProvidedToken, extraToken));
 
             if (!extraToken.equals(clientProvidedToken)) {
                 LOGGER.error("The provided extra token does not match the expected value for this console endpoint");
@@ -251,20 +233,21 @@ public class ConsoleProxy {
             Object result;
             try {
                 result =
-                        authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()), param.getClientTag(),
-                                param.getClientHostPassword(), param.getTicket(), reauthentication, param.getSessionUuid(), param.getClientIp());
+                        authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()),
+                                param.getClientTag(), param.getClientHostPassword(), param.getTicket(), reauthentication,
+                                param.getSessionUuid(), param.getClientIp());
             } catch (IllegalAccessException e) {
-                LOGGER.error("Unable to invoke authenticateConsoleAccess due to IllegalAccessException" + " for vm: " + param.getClientTag(), e);
+                LOGGER.error("Unable to invoke authenticateConsoleAccess due to IllegalAccessException for vm: " + param.getClientTag(), e);
                 authResult.setSuccess(false);
                 return authResult;
             } catch (InvocationTargetException e) {
-                LOGGER.error("Unable to invoke authenticateConsoleAccess due to InvocationTargetException " + " for vm: " + param.getClientTag(), e);
+                LOGGER.error("Unable to invoke authenticateConsoleAccess due to InvocationTargetException for vm: " + param.getClientTag(), e);
                 authResult.setSuccess(false);
                 return authResult;
             }
 
             if (result != null && result instanceof String) {
-                authResult = new Gson().fromJson((String)result, ConsoleProxyAuthenticationResult.class);
+                authResult = new Gson().fromJson((String) result, ConsoleProxyAuthenticationResult.class);
             } else {
                 LOGGER.error("Invalid authentication return object " + result + " for vm: " + param.getClientTag() + ", decline the access");
                 authResult.setSuccess(false);
@@ -304,7 +287,8 @@ public class ConsoleProxy {
         }
     }
 
-    public static void startWithContext(Properties conf, Object context, byte[] ksBits, String ksPassword, String password, Boolean isSourceIpCheckEnabled) {
+    public static void startWithContext(Properties conf, Object context, byte[] ksBits, String ksPassword,
+                                        String password, Boolean isSourceIpCheckEnabled) {
         setEncryptorPassword(password);
         configLog4j();
         LOGGER.info("Start console proxy with context");
@@ -344,33 +328,39 @@ public class ConsoleProxy {
         Properties props = new Properties();
         if (confs == null) {
             final File file = PropertiesUtil.findConfigFile("consoleproxy.properties");
-            if (file == null)
+            if (file == null) {
                 LOGGER.info("Can't load consoleproxy.properties from classpath, will use default configuration");
-            else
+            } else {
                 try {
                     confs = new FileInputStream(file);
                 } catch (FileNotFoundException e) {
                     LOGGER.info("Ignoring file not found exception and using defaults");
                 }
+            }
         }
         if (confs != null) {
             try {
                 props.load(confs);
 
+                if (conf == null) {
+                    conf = new Properties();
+                }
                 for (Object key : props.keySet()) {
                     // give properties passed via context high priority, treat properties from consoleproxy.properties
                     // as default values
-                    if (conf.get(key) == null)
+                    if (conf.get(key) == null) {
                         conf.put(key, props.get(key));
+                    }
                 }
             } catch (Exception e) {
                 LOGGER.error(e.toString(), e);
+            } finally {
+                try {
+                    confs.close();
+                } catch (IOException e) {
+                    LOGGER.error("Failed to close consoleproxy.properties : " + e.toString(), e);
+                }
             }
-        }
-        try {
-            confs.close();
-        } catch (IOException e) {
-            LOGGER.error("Failed to close consolepropxy.properties : " + e.toString(), e);
         }
 
         start(conf);
@@ -492,8 +482,8 @@ public class ConsoleProxy {
                 LOGGER.info("The rfb thread died, reinitializing the viewer " + viewer);
                 viewer.initClient(param);
             } else if (!param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
-                LOGGER.warn("Bad sid detected(VNC port may be reused). sid in session: " + viewer.getClientHostPassword() + ", sid in request: " +
-                        param.getClientHostPassword());
+                LOGGER.warn("Bad sid detected(VNC port may be reused). sid in session: " + viewer.getClientHostPassword() +
+                        ", sid in request: " + param.getClientHostPassword());
                 viewer.initClient(param);
             }
         }
@@ -502,8 +492,9 @@ public class ConsoleProxy {
             ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
             String loadInfo = statsCollector.getStatsReport();
             reportLoadInfo(loadInfo);
-            if (LOGGER.isDebugEnabled())
+            if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Report load change : " + loadInfo);
+            }
         }
 
         return viewer;
@@ -527,13 +518,15 @@ public class ConsoleProxy {
                 // protected against malicious attack by modifying URL content
                 if (ajaxSession != null) {
                     long ajaxSessionIdFromUrl = Long.parseLong(ajaxSession);
-                    if (ajaxSessionIdFromUrl != viewer.getAjaxSessionId())
+                    if (ajaxSessionIdFromUrl != viewer.getAjaxSessionId()) {
                         throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": modified AJAX session id");
+                    }
                 }
 
-                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty() ||
-                        !param.getClientHostPassword().equals(viewer.getClientHostPassword()))
+                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
+                        || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
+                }
 
                 if (!viewer.isFrontEndAlive()) {
 
@@ -547,8 +540,9 @@ public class ConsoleProxy {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
                 String loadInfo = statsCollector.getStatsReport();
                 reportLoadInfo(loadInfo);
-                if (LOGGER.isDebugEnabled())
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Report load change : " + loadInfo);
+                }
             }
             return viewer;
         }
@@ -584,9 +578,11 @@ public class ConsoleProxy {
         ConsoleProxyAuthenticationResult authResult = authenticateConsoleAccess(param, false);
 
         if (authResult == null || !authResult.isSuccess()) {
-            LOGGER.warn("External authenticator failed authentication request for vm " + param.getClientTag() + " with sid " + param.getClientHostPassword());
+            LOGGER.warn("External authenticator failed authentication request for vm " + param.getClientTag()
+                    + " with sid " + param.getClientHostPassword());
 
-            throw new AuthenticationException("External authenticator failed request for vm " + param.getClientTag() + " with sid " + param.getClientHostPassword());
+            throw new AuthenticationException("External authenticator failed request for vm " + param.getClientTag()
+                    + " with sid " + param.getClientHostPassword());
         }
     }
 
@@ -614,7 +610,7 @@ public class ConsoleProxy {
     }
 
     public static ConsoleProxyNoVncClient getNoVncViewer(ConsoleProxyClientParam param, String ajaxSession,
-            Session session) throws AuthenticationException {
+                                                         Session session) throws AuthenticationException {
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
         LOGGER.debug("Getting NoVNC viewer for {}. Session requires new viewer: {}, client tag: {}. session UUID: {}",
@@ -629,9 +625,10 @@ public class ConsoleProxy {
                 connectionMap.put(clientKey, viewer);
                 reportLoadChange = true;
             } else {
-                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty() ||
-                        !param.getClientHostPassword().equals(viewer.getClientHostPassword()))
+                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
+                        || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
+                }
 
                 try {
                     authenticationExternally(param);
@@ -641,7 +638,7 @@ public class ConsoleProxy {
                 }
                 LOGGER.info("Initializing new novnc client and disconnecting existing session");
                 try {
-                    ((ConsoleProxyNoVncClient)viewer).getSession().disconnect();
+                    ((ConsoleProxyNoVncClient) viewer).getSession().disconnect();
                 } catch (IOException e) {
                     LOGGER.error("Exception while disconnect session of novnc viewer object: " + viewer, e);
                 }
@@ -656,10 +653,11 @@ public class ConsoleProxy {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
                 String loadInfo = statsCollector.getStatsReport();
                 reportLoadInfo(loadInfo);
-                if (LOGGER.isDebugEnabled())
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Report load change : " + loadInfo);
+                }
             }
-            return (ConsoleProxyNoVncClient)viewer;
+            return (ConsoleProxyNoVncClient) viewer;
         }
     }
 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -80,6 +80,9 @@ public class ConsoleProxy {
     static String factoryClzName;
     static boolean standaloneStart = false;
 
+    // New: session timeout in milliseconds, default 300000 (5 minutes)
+    static int sessionTimeoutMillis = 300000;
+
     static String encryptorPassword = "Dummy";
     static final String[] skipProperties = new String[]{"certificate", "cacertificate", "keystore_password", "privatekey"};
 
@@ -164,6 +167,18 @@ public class ConsoleProxy {
         if (s != null) {
             defaultBufferSize = Integer.parseInt(s);
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
+        }
+
+        // New: read consoleproxy.session.timeout (milliseconds)
+        s = conf.getProperty("consoleproxy.session.timeout");
+        if (s != null) {
+            try {
+                sessionTimeoutMillis = Integer.parseInt(s);
+                LOGGER.info("Setting consoleproxy.session.timeout=" + sessionTimeoutMillis);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid value for consoleproxy.session.timeout: " + s +
+                        ", using default " + sessionTimeoutMillis, e);
+            }
         }
     }
 
@@ -379,7 +394,7 @@ public class ConsoleProxy {
             LOGGER.info("HTTP command port is disabled");
         }
 
-        ConsoleProxyGCThread cthread = new ConsoleProxyGCThread(connectionMap, removedSessionsSet);
+        ConsoleProxyGCThread cthread = new ConsoleProxyGCThread(connectionMap, removedSessionsSet /*, sessionTimeoutMillis */);
         cthread.setName("Console Proxy GC Thread");
         cthread.start();
     }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.LogManager;
 public class ConsoleProxyGCThread extends Thread {
     protected Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
 
-    private final static int MAX_SESSION_IDLE_SECONDS = 180;
+    private final static int DEFAULT_MAX_SESSION_IDLE_SECONDS = 180;
 
     private final Map<String, ConsoleProxyClient> connMap;
     private final Set<String> removedSessionsSet;
@@ -43,6 +43,13 @@ public class ConsoleProxyGCThread extends Thread {
     public ConsoleProxyGCThread(Map<String, ConsoleProxyClient> connMap, Set<String> removedSet) {
         this.connMap = connMap;
         this.removedSessionsSet = removedSet;
+    }
+
+    private int getMaxSessionIdleSeconds() {
+        if (ConsoleProxy.sessionTimeoutMillis <= 0) {
+            return DEFAULT_MAX_SESSION_IDLE_SECONDS;
+        }
+        return ConsoleProxy.sessionTimeoutMillis / 1000;
     }
 
     private void cleanupLogging() {
@@ -92,7 +99,7 @@ public class ConsoleProxyGCThread extends Thread {
                 }
 
                 long seconds_unused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
-                if (seconds_unused < MAX_SESSION_IDLE_SECONDS) {
+                if (seconds_unused < getMaxSessionIdleSeconds()) {
                     continue;
                 }
 

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -16,17 +16,14 @@
 // under the License.
 package com.cloud.consoleproxy;
 
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
 
 /**
  *
@@ -35,105 +32,90 @@ import org.apache.logging.log4j.LogManager;
  * management software
  */
 public class ConsoleProxyGCThread extends Thread {
-    protected Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
+    private static final Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
 
-
-    private final static int DEFAULT_MAX_SESSION_IDLE_SECONDS = 180;
-
+    /**
+     * Maximum time (in seconds) a console session is allowed to be idle before it is closed.
+     * This value should be kept in sync with ConsoleProxy.VIEWER_LINGER_SECONDS.
+     */
+    private static final int MAX_SESSION_IDLE_SECONDS = 180;
 
     private final Map<String, ConsoleProxyClient> connMap;
     private final Set<String> removedSessionsSet;
     private long lastLogScan = 0;
-
 
     public ConsoleProxyGCThread(Map<String, ConsoleProxyClient> connMap, Set<String> removedSet) {
         this.connMap = connMap;
         this.removedSessionsSet = removedSet;
     }
 
-
-    private int getMaxSessionIdleSeconds() {
-        if (ConsoleProxy.sessionTimeoutMillis <= 0) {
-            return DEFAULT_MAX_SESSION_IDLE_SECONDS;
-        }
-        return Math.max(1, ConsoleProxy.sessionTimeoutMillis / 1000);
-    }
-
-
     private void cleanupLogging() {
-        if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000)
+        if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000) {
             return;
-
+        }
 
         lastLogScan = System.currentTimeMillis();
 
-
         File logDir = new File("./logs");
-        File files[] = logDir.listFiles();
+        File[] files = logDir.listFiles();
         if (files != null) {
             for (File file : files) {
                 if (System.currentTimeMillis() - file.lastModified() >= 86400000L) {
                     try {
                         file.delete();
                     } catch (Throwable e) {
-                        logger.info("[ignored]"
-                                + "failed to delete file: " + e.getLocalizedMessage());
+                        logger.info("[ignored] failed to delete file: " + e.getLocalizedMessage());
                     }
                 }
             }
         }
     }
 
-
     @Override
     public void run() {
 
-
         boolean bReportLoad = false;
         long lastReportTick = System.currentTimeMillis();
-
 
         while (true) {
             cleanupLogging();
             bReportLoad = false;
 
-
             if (logger.isDebugEnabled()) {
-                logger.debug(String.format("connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
+                logger.debug(String.format("ConsoleProxyGCThread loop: connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
             }
-            Set<String> e = connMap.keySet();
-            Iterator<String> iterator = e.iterator();
+            Set<String> keys = connMap.keySet();
+            Iterator<String> iterator = keys.iterator();
             while (iterator.hasNext()) {
                 String key;
                 ConsoleProxyClient client;
-
 
                 synchronized (connMap) {
                     key = iterator.next();
                     client = connMap.get(key);
                 }
 
-
-                long seconds_unused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
-                if (seconds_unused < getMaxSessionIdleSeconds()) {
+                if (client == null) {
                     continue;
                 }
 
+                long secondsUnused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
+                if (secondsUnused < MAX_SESSION_IDLE_SECONDS) {
+                    continue;
+                }
 
                 synchronized (connMap) {
                     connMap.remove(key);
                     bReportLoad = true;
                 }
 
-
                 // close the server connection
-                logger.info("Dropping " + client + " which has not been used for " + seconds_unused + " seconds");
+                logger.info("Dropping " + client + " which has not been used for " + secondsUnused + " seconds");
                 client.closeClient();
             }
 
-
             if (bReportLoad || System.currentTimeMillis() - lastReportTick > 5000) {
-                // report load changes
+                // report load changes, including removed sessions since last report
                 ConsoleProxyClientStatsCollector collector = new ConsoleProxyClientStatsCollector(connMap);
                 collector.setRemovedSessions(new ArrayList<>(removedSessionsSet));
                 String loadInfo = collector.getStatsReport();
@@ -143,17 +125,15 @@ public class ConsoleProxyGCThread extends Thread {
                     removedSessionsSet.clear();
                 }
 
-
                 if (logger.isDebugEnabled()) {
                     logger.debug("Report load change : " + loadInfo);
                 }
             }
 
-
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException ex) {
-                logger.debug("[ignored] Console proxy was interrupted during GC.");
+                logger.debug("[ignored] Console proxy GC thread interrupted.", ex);
             }
         }
     }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -16,14 +16,17 @@
 // under the License.
 package com.cloud.consoleproxy;
 
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+
 
 /**
  *
@@ -34,29 +37,36 @@ import org.apache.logging.log4j.LogManager;
 public class ConsoleProxyGCThread extends Thread {
     protected Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
 
+
     private final static int DEFAULT_MAX_SESSION_IDLE_SECONDS = 180;
+
 
     private final Map<String, ConsoleProxyClient> connMap;
     private final Set<String> removedSessionsSet;
     private long lastLogScan = 0;
+
 
     public ConsoleProxyGCThread(Map<String, ConsoleProxyClient> connMap, Set<String> removedSet) {
         this.connMap = connMap;
         this.removedSessionsSet = removedSet;
     }
 
+
     private int getMaxSessionIdleSeconds() {
         if (ConsoleProxy.sessionTimeoutMillis <= 0) {
             return DEFAULT_MAX_SESSION_IDLE_SECONDS;
         }
-        return ConsoleProxy.sessionTimeoutMillis / 1000;
+        return Math.max(1, ConsoleProxy.sessionTimeoutMillis / 1000);
     }
+
 
     private void cleanupLogging() {
         if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000)
             return;
 
+
         lastLogScan = System.currentTimeMillis();
+
 
         File logDir = new File("./logs");
         File files[] = logDir.listFiles();
@@ -74,15 +84,19 @@ public class ConsoleProxyGCThread extends Thread {
         }
     }
 
+
     @Override
     public void run() {
+
 
         boolean bReportLoad = false;
         long lastReportTick = System.currentTimeMillis();
 
+
         while (true) {
             cleanupLogging();
             bReportLoad = false;
+
 
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
@@ -93,25 +107,30 @@ public class ConsoleProxyGCThread extends Thread {
                 String key;
                 ConsoleProxyClient client;
 
+
                 synchronized (connMap) {
                     key = iterator.next();
                     client = connMap.get(key);
                 }
+
 
                 long seconds_unused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
                 if (seconds_unused < getMaxSessionIdleSeconds()) {
                     continue;
                 }
 
+
                 synchronized (connMap) {
                     connMap.remove(key);
                     bReportLoad = true;
                 }
 
+
                 // close the server connection
                 logger.info("Dropping " + client + " which has not been used for " + seconds_unused + " seconds");
                 client.closeClient();
             }
+
 
             if (bReportLoad || System.currentTimeMillis() - lastReportTick > 5000) {
                 // report load changes
@@ -124,10 +143,12 @@ public class ConsoleProxyGCThread extends Thread {
                     removedSessionsSet.clear();
                 }
 
+
                 if (logger.isDebugEnabled()) {
                     logger.debug("Report load change : " + loadInfo);
                 }
             }
+
 
             try {
                 Thread.sleep(5000);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -16,19 +16,15 @@
 // under the License.
 package com.cloud.consoleproxy;
 
-
 import java.io.IOException;
 import java.util.Map;
-
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.websocket.api.Session;
@@ -41,30 +37,25 @@ import org.eclipse.jetty.websocket.api.extensions.Frame;
 import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
-
 @WebSocket
 public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
+    private static final Logger logger = LogManager.getLogger(ConsoleProxyNoVNCHandler.class);
 
     private ConsoleProxyNoVncClient viewer = null;
-    protected Logger logger = LogManager.getLogger(getClass());
-
 
     public ConsoleProxyNoVNCHandler() {
         super();
     }
-
 
     @Override
     public void configure(WebSocketServletFactory webSocketServletFactory) {
         webSocketServletFactory.register(ConsoleProxyNoVNCHandler.class);
     }
 
-
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
-
 
         if (this.getWebSocketFactory().isUpgradeRequest(request, response)) {
             response.addHeader("Sec-WebSocket-Protocol", "binary");
@@ -73,22 +64,18 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
                 return;
             }
 
-
             if (response.isCommitted()) {
                 return;
             }
         }
 
-
         super.handle(target, baseRequest, request, response);
     }
-
 
     @OnWebSocketConnect
     public void onConnect(final Session session) throws IOException, InterruptedException {
         String queries = session.getUpgradeRequest().getQueryString();
         Map<String, String> queryMap = ConsoleProxyHttpHandlerHelper.getQueryMap(queries);
-
 
         String host = queryMap.get("host");
         String portStr = queryMap.get("port");
@@ -109,18 +96,14 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         String clientIp = session.getRemoteAddress().getAddress().getHostAddress();
         boolean sessionRequiresNewViewer = Boolean.parseBoolean(queryMap.get("sessionRequiresNewViewer"));
 
-
-        if (tag == null)
+        if (tag == null) {
             tag = "";
+        }
 
-
-        long ajaxSessionId = 0;
         int port;
-
-
-        if (host == null || portStr == null || sid == null)
-            throw new IllegalArgumentException();
-
+        if (host == null || portStr == null || sid == null) {
+            throw new IllegalArgumentException("Missing required console connection parameters");
+        }
 
         try {
             port = Integer.parseInt(portStr);
@@ -129,32 +112,20 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             throw new IllegalArgumentException(e);
         }
 
-
         if (ajaxSessionIdStr != null) {
             try {
-                ajaxSessionId = Long.parseLong(ajaxSessionIdStr);
+                Long.parseLong(ajaxSessionIdStr);
             } catch (NumberFormatException e) {
                 logger.error("Invalid ajaxSessionId (sess) value in query string: {}. Expected a number.", ajaxSessionIdStr, e);
                 throw new IllegalArgumentException(e);
             }
         }
 
-
         if (!checkSessionSourceIp(session, sourceIP, clientIp)) {
             return;
         }
 
-
         try {
-            if (ConsoleProxy.sessionTimeoutMillis > 0) {
-                session.setIdleTimeout(ConsoleProxy.sessionTimeoutMillis);
-                logger.debug("Set noVNC WebSocket idle timeout to {} ms for session UUID: {}.",
-                        ConsoleProxy.sessionTimeoutMillis, sessionUuid);
-            } else {
-                logger.debug("Using default noVNC WebSocket idle timeout for session UUID: {}.", sessionUuid);
-            }
-
-
             ConsoleProxyClientParam param = new ConsoleProxyClientParam();
             param.setClientHostAddress(host);
             param.setClientHostPort(port);
@@ -174,17 +145,17 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             param.setClientIp(clientIp);
             param.setSessionRequiresNewViewer(sessionRequiresNewViewer);
 
-
             if (queryMap.containsKey("extraSecurityToken")) {
                 param.setExtraSecurityToken(queryMap.get("extraSecurityToken"));
             }
             if (queryMap.containsKey("extra")) {
                 param.setClientProvidedExtraSecurityToken(queryMap.get("extra"));
             }
+
             viewer = ConsoleProxy.getNoVncViewer(param, ajaxSessionIdStr, session);
             logger.info("Viewer has been created successfully [session UUID: {}, client IP: {}].", sessionUuid, clientIp);
         } catch (Exception e) {
-            logger.error("Failed to create viewer [session UUID: {}, client IP: {}] due to {}.", sessionUuid, clientIp, e.getMessage(), e);
+            logger.error("Failed to create viewer [session UUID: {}, client IP: {}].", sessionUuid, clientIp, e);
             return;
         } finally {
             if (viewer == null) {
@@ -193,8 +164,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         }
     }
 
-
-    private boolean checkSessionSourceIp(final Session session, final String sourceIP, String sessionSourceIP) throws IOException {
+    private boolean checkSessionSourceIp(final Session session, final String sourceIP, final String sessionSourceIP) throws IOException {
         logger.info("Verifying session source IP {} from WebSocket connection request.", sessionSourceIP);
         if (ConsoleProxy.isSourceIpCheckEnabled && (sessionSourceIP == null || !sessionSourceIP.equals(sourceIP))) {
             logger.warn("Failed to access console as the source IP to request the console is {}.", sourceIP);
@@ -205,34 +175,30 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         return true;
     }
 
-
     @OnWebSocketClose
     public void onClose(Session session, int statusCode, String reason) throws IOException, InterruptedException {
         String sessionSourceIp = session.getRemoteAddress().getAddress().getHostAddress();
-        logger.debug("Closing WebSocket session [source IP: {}, status code: {}].", sessionSourceIp, statusCode);
+        logger.debug("Closing WebSocket session [source IP: {}, status code: {}, reason: {}].", sessionSourceIp, statusCode, reason);
         if (viewer != null) {
             ConsoleProxy.removeViewer(viewer);
         }
         logger.debug("WebSocket session [source IP: {}, status code: {}] closed successfully.", sessionSourceIp, statusCode);
     }
 
-
     @OnWebSocketFrame
     public void onFrame(Frame f) throws IOException {
         if (viewer == null) {
-            logger.warn("Ignoring WebSocket frame because viewer is not initialized yet.");
+            logger.debug("Ignoring WebSocket frame because viewer is not initialized yet.");
             return;
         }
         logger.trace("Sending client [ID: {}] frame of {} bytes.", viewer.getClientId(), f.getPayloadLength());
         viewer.sendClientFrame(f);
     }
 
-
     @OnWebSocketError
     public void onError(Throwable cause) {
         if (viewer != null) {
-            logger.error("Error on WebSocket [client ID: {}, session UUID: {}].",
-                    viewer.getClientId(), viewer.getSessionUuid(), cause);
+            logger.error("Error on WebSocket [client ID: {}, session UUID: {}].", viewer.getClientId(), viewer.getSessionUuid(), cause);
         } else {
             logger.error("Error on WebSocket before viewer initialization.", cause);
         }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -16,15 +16,19 @@
 // under the License.
 package com.cloud.consoleproxy;
 
+
 import java.io.IOException;
 import java.util.Map;
+
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.websocket.api.Session;
@@ -37,24 +41,30 @@ import org.eclipse.jetty.websocket.api.extensions.Frame;
 import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
+
 @WebSocket
 public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
+
 
     private ConsoleProxyNoVncClient viewer = null;
     protected Logger logger = LogManager.getLogger(getClass());
 
+
     public ConsoleProxyNoVNCHandler() {
         super();
     }
+
 
     @Override
     public void configure(WebSocketServletFactory webSocketServletFactory) {
         webSocketServletFactory.register(ConsoleProxyNoVNCHandler.class);
     }
 
+
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
+
 
         if (this.getWebSocketFactory().isUpgradeRequest(request, response)) {
             response.addHeader("Sec-WebSocket-Protocol", "binary");
@@ -63,18 +73,22 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
                 return;
             }
 
+
             if (response.isCommitted()) {
                 return;
             }
         }
 
+
         super.handle(target, baseRequest, request, response);
     }
+
 
     @OnWebSocketConnect
     public void onConnect(final Session session) throws IOException, InterruptedException {
         String queries = session.getUpgradeRequest().getQueryString();
         Map<String, String> queryMap = ConsoleProxyHttpHandlerHelper.getQueryMap(queries);
+
 
         String host = queryMap.get("host");
         String portStr = queryMap.get("port");
@@ -95,14 +109,18 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         String clientIp = session.getRemoteAddress().getAddress().getHostAddress();
         boolean sessionRequiresNewViewer = Boolean.parseBoolean(queryMap.get("sessionRequiresNewViewer"));
 
+
         if (tag == null)
             tag = "";
+
 
         long ajaxSessionId = 0;
         int port;
 
+
         if (host == null || portStr == null || sid == null)
             throw new IllegalArgumentException();
+
 
         try {
             port = Integer.parseInt(portStr);
@@ -110,6 +128,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             logger.error("Invalid port value in query string: {}. Expected a number.", portStr, e);
             throw new IllegalArgumentException(e);
         }
+
 
         if (ajaxSessionIdStr != null) {
             try {
@@ -120,14 +139,21 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             }
         }
 
+
         if (!checkSessionSourceIp(session, sourceIP, clientIp)) {
             return;
         }
 
+
         try {
-            session.setIdleTimeout(ConsoleProxy.sessionTimeoutMillis);
-            logger.debug("Set noVNC WebSocket idle timeout to {} ms for session UUID: {}.",
-                    ConsoleProxy.sessionTimeoutMillis, sessionUuid);
+            if (ConsoleProxy.sessionTimeoutMillis > 0) {
+                session.setIdleTimeout(ConsoleProxy.sessionTimeoutMillis);
+                logger.debug("Set noVNC WebSocket idle timeout to {} ms for session UUID: {}.",
+                        ConsoleProxy.sessionTimeoutMillis, sessionUuid);
+            } else {
+                logger.debug("Using default noVNC WebSocket idle timeout for session UUID: {}.", sessionUuid);
+            }
+
 
             ConsoleProxyClientParam param = new ConsoleProxyClientParam();
             param.setClientHostAddress(host);
@@ -148,6 +174,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             param.setClientIp(clientIp);
             param.setSessionRequiresNewViewer(sessionRequiresNewViewer);
 
+
             if (queryMap.containsKey("extraSecurityToken")) {
                 param.setExtraSecurityToken(queryMap.get("extraSecurityToken"));
             }
@@ -166,6 +193,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         }
     }
 
+
     private boolean checkSessionSourceIp(final Session session, final String sourceIP, String sessionSourceIP) throws IOException {
         logger.info("Verifying session source IP {} from WebSocket connection request.", sessionSourceIP);
         if (ConsoleProxy.isSourceIpCheckEnabled && (sessionSourceIP == null || !sessionSourceIP.equals(sourceIP))) {
@@ -177,6 +205,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         return true;
     }
 
+
     @OnWebSocketClose
     public void onClose(Session session, int statusCode, String reason) throws IOException, InterruptedException {
         String sessionSourceIp = session.getRemoteAddress().getAddress().getHostAddress();
@@ -187,6 +216,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         logger.debug("WebSocket session [source IP: {}, status code: {}] closed successfully.", sessionSourceIp, statusCode);
     }
 
+
     @OnWebSocketFrame
     public void onFrame(Frame f) throws IOException {
         if (viewer == null) {
@@ -196,6 +226,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         logger.trace("Sending client [ID: {}] frame of {} bytes.", viewer.getClientId(), f.getPayloadLength());
         viewer.sendClientFrame(f);
     }
+
 
     @OnWebSocketError
     public void onError(Throwable cause) {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -125,6 +125,10 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         }
 
         try {
+            session.setIdleTimeout(ConsoleProxy.sessionTimeoutMillis);
+            logger.debug("Set noVNC WebSocket idle timeout to {} ms for session UUID: {}.",
+                    ConsoleProxy.sessionTimeoutMillis, sessionUuid);
+
             ConsoleProxyClientParam param = new ConsoleProxyClientParam();
             param.setClientHostAddress(host);
             param.setClientHostPort(port);
@@ -185,12 +189,21 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
     @OnWebSocketFrame
     public void onFrame(Frame f) throws IOException {
+        if (viewer == null) {
+            logger.warn("Ignoring WebSocket frame because viewer is not initialized yet.");
+            return;
+        }
         logger.trace("Sending client [ID: {}] frame of {} bytes.", viewer.getClientId(), f.getPayloadLength());
         viewer.sendClientFrame(f);
     }
 
     @OnWebSocketError
     public void onError(Throwable cause) {
-        logger.error("Error on WebSocket [client ID: {}, session UUID: {}].", cause, viewer.getClientId(), viewer.getSessionUuid());
+        if (viewer != null) {
+            logger.error("Error on WebSocket [client ID: {}, session UUID: {}].",
+                    viewer.getClientId(), viewer.getSessionUuid(), cause);
+        } else {
+            logger.error("Error on WebSocket before viewer initialization.", cause);
+        }
     }
 }


### PR DESCRIPTION
Fixes #12810.

Changes:

- services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
  - Add static field sessionTimeoutMillis with a default of 300000 ms (5 minutes).
  - Read the global setting consoleproxy.session.timeout from the configuration and set sessionTimeoutMillis accordingly, with logging and validation.
  - Pass the timeout information to ConsoleProxyGCThread (via the shared ConsoleProxy.sessionTimeoutMillis value).

- services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
  - Replace the hard-coded MAX_SESSION_IDLE_SECONDS with DEFAULT_MAX_SESSION_IDLE_SECONDS.
  - Add getMaxSessionIdleSeconds() to derive the idle timeout from ConsoleProxy.sessionTimeoutMillis (falling back to the default when the setting is disabled or invalid).
  - Use getMaxSessionIdleSeconds() when deciding whether to close idle sessions.

- services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
  - Set the Jetty WebSocket Session idle timeout from ConsoleProxy.sessionTimeoutMillis.
  - Improve error logging in onError() to include the exception only when the viewer is available, and add a separate log message for errors before viewer initialization.