### PR TITLE
Soft delete port forwarding, load balancing and firewall rules

### DIFF
--- a/engine/schema/src/main/java/com/cloud/network/LBHealthCheckPolicyVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/LBHealthCheckPolicyVO.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.network;
 
+import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -25,8 +26,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import com.cloud.network.rules.HealthCheckPolicy;
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 @Entity
@@ -67,6 +71,10 @@ public class LBHealthCheckPolicyVO implements HealthCheckPolicy {
 
     @Column(name = "display", updatable = true, nullable = false)
     protected boolean display = true;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed;
 
     protected LBHealthCheckPolicyVO() {
         this.uuid = UUID.randomUUID().toString();

--- a/engine/schema/src/main/java/com/cloud/network/dao/FirewallRulesDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/FirewallRulesDaoImpl.java
@@ -94,6 +94,7 @@ public class FirewallRulesDaoImpl extends GenericDaoBase<FirewallRuleVO, Long> i
         ReleaseSearch.and("ipId", ReleaseSearch.entity().getSourceIpAddressId(), Op.EQ);
         ReleaseSearch.and("purpose", ReleaseSearch.entity().getPurpose(), Op.EQ);
         ReleaseSearch.and("ports", ReleaseSearch.entity().getSourcePortStart(), Op.IN);
+        ReleaseSearch.and("removed", ReleaseSearch.entity().getRemoved(), Op.NULL);
         ReleaseSearch.done();
 
         SystemRuleSearch = createSearchBuilder();

--- a/engine/schema/src/main/java/com/cloud/network/dao/LBHealthCheckPolicyDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LBHealthCheckPolicyDaoImpl.java
@@ -32,8 +32,9 @@ public class LBHealthCheckPolicyDaoImpl extends GenericDaoBase<LBHealthCheckPoli
     public void remove(long loadBalancerId) {
         SearchCriteria<LBHealthCheckPolicyVO> sc = createSearchCriteria();
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
 
-        expunge(sc);
+        remove(sc);
     }
 
     @Override
@@ -41,8 +42,9 @@ public class LBHealthCheckPolicyDaoImpl extends GenericDaoBase<LBHealthCheckPoli
         SearchCriteria<LBHealthCheckPolicyVO> sc = createSearchCriteria();
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
         sc.addAnd("revoke", SearchCriteria.Op.EQ, revoke);
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
 
-        expunge(sc);
+        remove(sc);
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/network/dao/LBStickinessPolicyDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LBStickinessPolicyDao.java
@@ -28,4 +28,6 @@ public interface LBStickinessPolicyDao extends GenericDao<LBStickinessPolicyVO, 
     List<LBStickinessPolicyVO> listByLoadBalancerIdAndDisplayFlag(long loadBalancerId, boolean forDisplay);
 
     List<LBStickinessPolicyVO> listByLoadBalancerId(long loadBalancerId, boolean revoke);
+
+    List<LBStickinessPolicyVO> listByLoadBalancerId(long loadBalancerId);
 }

--- a/engine/schema/src/main/java/com/cloud/network/dao/LBStickinessPolicyDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LBStickinessPolicyDaoImpl.java
@@ -31,8 +31,9 @@ public class LBStickinessPolicyDaoImpl extends GenericDaoBase<LBStickinessPolicy
     public void remove(long loadBalancerId) {
         SearchCriteria<LBStickinessPolicyVO> sc = createSearchCriteria();
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
 
-        expunge(sc);
+        remove(sc);
     }
 
     @Override
@@ -40,8 +41,9 @@ public class LBStickinessPolicyDaoImpl extends GenericDaoBase<LBStickinessPolicy
         SearchCriteria<LBStickinessPolicyVO> sc = createSearchCriteria();
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
         sc.addAnd("revoke", SearchCriteria.Op.EQ, revoke);
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
 
-        expunge(sc);
+        remove(sc);
     }
 
     @Override
@@ -62,4 +64,10 @@ public class LBStickinessPolicyDaoImpl extends GenericDaoBase<LBStickinessPolicy
         return listBy(sc);
     }
 
+    @Override
+    public List<LBStickinessPolicyVO> listByLoadBalancerId(long loadBalancerId) {
+        SearchCriteria<LBStickinessPolicyVO> sc = createSearchCriteria();
+        sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
+        return listBy(sc);
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/network/dao/LBStickinessPolicyVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LBStickinessPolicyVO.java
@@ -17,6 +17,7 @@
 package com.cloud.network.dao;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -30,9 +31,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import com.cloud.network.rules.StickinessPolicy;
 import com.cloud.utils.Pair;
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 @Entity
@@ -67,6 +71,10 @@ public class LBStickinessPolicyVO implements StickinessPolicy {
 
     @Column(name = "display", updatable = true, nullable = false)
     protected boolean display = true;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed;
 
     protected LBStickinessPolicyVO() {
         this.uuid = UUID.randomUUID().toString();

--- a/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerCertMapVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerCertMapVO.java
@@ -16,13 +16,17 @@
 // under the License.
 package com.cloud.network.dao;
 
+import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.api.InternalIdentity;
 
 @Entity
@@ -44,6 +48,10 @@ public class LoadBalancerCertMapVO implements InternalIdentity {
 
     @Column(name = "revoke")
     private boolean revoke = false;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed;
 
     public LoadBalancerCertMapVO() {
         this.uuid = UUID.randomUUID().toString();

--- a/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVMMapDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVMMapDaoImpl.java
@@ -34,8 +34,9 @@ public class LoadBalancerVMMapDaoImpl extends GenericDaoBase<LoadBalancerVMMapVO
     public void remove(long loadBalancerId) {
         SearchCriteria<LoadBalancerVMMapVO> sc = createSearchCriteria();
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
 
-        expunge(sc);
+        remove(sc);
     }
 
     @Override
@@ -43,11 +44,12 @@ public class LoadBalancerVMMapDaoImpl extends GenericDaoBase<LoadBalancerVMMapVO
         SearchCriteria<LoadBalancerVMMapVO> sc = createSearchCriteria();
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
         sc.addAnd("instanceId", SearchCriteria.Op.IN, instanceIds.toArray());
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
         if (revoke != null) {
             sc.addAnd("revoke", SearchCriteria.Op.EQ, revoke);
         }
 
-        expunge(sc);
+        remove(sc);
     }
 
     @Override
@@ -56,12 +58,13 @@ public class LoadBalancerVMMapDaoImpl extends GenericDaoBase<LoadBalancerVMMapVO
         sc.addAnd("loadBalancerId", SearchCriteria.Op.EQ, loadBalancerId);
         sc.addAnd("instanceId", SearchCriteria.Op.IN, instanceId);
         sc.addAnd("instanceIp", SearchCriteria.Op.EQ, instanceIp);
+        sc.addAnd("removed", SearchCriteria.Op.NULL);
 
         if (revoke != null) {
             sc.addAnd("revoke", SearchCriteria.Op.EQ, revoke);
         }
 
-        expunge(sc);
+        remove(sc);
     }
 
 

--- a/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVMMapVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVMMapVO.java
@@ -22,8 +22,13 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.api.InternalIdentity;
+
+import java.util.Date;
 
 @Entity
 @Table(name = "load_balancer_vm_map")
@@ -47,6 +52,10 @@ public class LoadBalancerVMMapVO implements InternalIdentity {
 
     @Column(name = "state")
     private String state;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed = null;
 
     public LoadBalancerVMMapVO() {
     }

--- a/engine/schema/src/main/java/com/cloud/network/rules/FirewallRuleVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/rules/FirewallRuleVO.java
@@ -32,6 +32,8 @@ import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
 import com.cloud.utils.db.GenericDao;
@@ -81,6 +83,10 @@ public class FirewallRuleVO implements FirewallRule {
 
     @Column(name = GenericDao.CREATED_COLUMN)
     Date created;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed;
 
     @Column(name = "network_id")
     Long networkId;
@@ -201,6 +207,10 @@ public class FirewallRuleVO implements FirewallRule {
 
     public Date getCreated() {
         return created;
+    }
+
+    public Date getRemoved() {
+        return removed;
     }
 
     protected FirewallRuleVO() {

--- a/engine/schema/src/main/java/org/apache/cloudstack/region/gslb/GlobalLoadBalancerRuleVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/region/gslb/GlobalLoadBalancerRuleVO.java
@@ -17,6 +17,7 @@
 
 package org.apache.cloudstack.region.gslb;
 
+import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -27,8 +28,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import com.cloud.region.ha.GlobalLoadBalancerRule;
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.utils.reflectiontostringbuilderutils.ReflectionToStringBuilderUtils;
 
 @Entity
@@ -73,6 +77,10 @@ public class GlobalLoadBalancerRuleVO implements GlobalLoadBalancerRule {
     @Enumerated(value = EnumType.STRING)
     @Column(name = "state")
     GlobalLoadBalancerRule.State state;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed;
 
     public GlobalLoadBalancerRuleVO() {
         uuid = UUID.randomUUID().toString();

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42300.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42300.sql
@@ -221,6 +221,7 @@ CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.load_balancer_stickiness_policies', 
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.global_load_balancer_lb_rule_map', 'removed', 'datetime DEFAULT NULL');
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.elastic_lb_vm_map', 'removed', 'datetime DEFAULT NULL');
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.tungsten_lb_health_monitor', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.global_load_balancing_rules', 'removed', 'datetime DEFAULT NULL');
 
 ALTER TABLE `cloud`.`load_balancer_vm_map`
 DROP KEY `load_balancer_id`,

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42300.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42300.sql
@@ -211,3 +211,21 @@ WHERE rule = 'quotaStatement' AND NOT EXISTS(SELECT 1 FROM cloud.role_permission
 
 -- Add description for secondary IP addresses
 CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.nic_secondary_ips', 'description', 'VARCHAR(2048) DEFAULT NULL');
+
+-- Soft delete port forwarding, load balancing and firewall rules
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.firewall_rules', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.load_balancer_vm_map', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.load_balancer_cert_map', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.load_balancer_healthcheck_policies', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.load_balancer_stickiness_policies', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.global_load_balancer_lb_rule_map', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.elastic_lb_vm_map', 'removed', 'datetime DEFAULT NULL');
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.tungsten_lb_health_monitor', 'removed', 'datetime DEFAULT NULL');
+
+ALTER TABLE `cloud`.`load_balancer_vm_map`
+DROP KEY `load_balancer_id`,
+ADD UNIQUE KEY `load_balancer_id` (`load_balancer_id`, `instance_id`, `instance_ip`, `removed`);
+
+ALTER TABLE `cloud`.`global_load_balancer_lb_rule_map`
+DROP KEY `gslb_rule_id`,
+ADD UNIQUE KEY `gslb_rule_id` (`gslb_rule_id`, `lb_rule_id`, `removed`);

--- a/plugins/network-elements/elastic-loadbalancer/src/main/java/com/cloud/network/ElasticLbVmMapVO.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/main/java/com/cloud/network/ElasticLbVmMapVO.java
@@ -27,10 +27,15 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.SecondaryTable;
 import javax.persistence.SecondaryTables;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.api.InternalIdentity;
 
 import com.cloud.utils.net.Ip;
+
+import java.util.Date;
 
 @Entity
 @Table(name = "elastic_lb_vm_map")
@@ -56,6 +61,10 @@ public class ElasticLbVmMapVO implements InternalIdentity {
     @Column(name = "public_ip_address", table = "user_ip_address", insertable = false, updatable = false)
     @Enumerated(value = EnumType.STRING)
     private Ip address = null;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed;
 
     public ElasticLbVmMapVO() {
     }

--- a/plugins/network-elements/tungsten/src/main/java/org/apache/cloudstack/network/tungsten/dao/TungstenFabricLBHealthMonitorVO.java
+++ b/plugins/network-elements/tungsten/src/main/java/org/apache/cloudstack/network/tungsten/dao/TungstenFabricLBHealthMonitorVO.java
@@ -16,9 +16,11 @@
 // under the License.
 package org.apache.cloudstack.network.tungsten.dao;
 
+import com.cloud.utils.db.GenericDao;
 import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
 
+import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -28,6 +30,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 @Entity
 @Table(name = "tungsten_lb_health_monitor")
@@ -65,6 +69,10 @@ public class TungstenFabricLBHealthMonitorVO implements InternalIdentity, Identi
 
     @Column(name = "url_path")
     private String urlPath;
+
+    @Column(name = GenericDao.REMOVED_COLUMN)
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date removed = null;
 
     public TungstenFabricLBHealthMonitorVO() {
         this.uuid = UUID.randomUUID().toString();

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -862,7 +862,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 success = false;
             }
         } else {
-            _lb2stickinesspoliciesDao.expunge(stickinessPolicyId);
+            _lb2stickinesspoliciesDao.remove(stickinessPolicyId);
         }
         return success;
     }
@@ -1662,6 +1662,12 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 for (LBHealthCheckPolicyVO lbHealthCheck : hcPolicies) {
                     lbHealthCheck.setRevoke(true);
                     _lb2healthcheckDao.persist(lbHealthCheck);
+                }
+
+                List<LBStickinessPolicyVO> stickinessPolicies = _lb2stickinesspoliciesDao.listByLoadBalancerId(loadBalancerId);
+                for (LBStickinessPolicyVO stickinessPolicy : stickinessPolicies) {
+                    stickinessPolicy.setRevoke(true);
+                    _lb2stickinesspoliciesDao.persist(stickinessPolicy);
                 }
 
                 if (generateUsageEvent) {

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -2684,7 +2684,12 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
     @Override
     public void removeLBRule(LoadBalancer rule) {
-        // remove the rule
+        FirewallRule relatedFirewallRule = _firewallDao.findByRelatedId(rule.getId());
+        if (relatedFirewallRule != null) {
+            logger.debug("Load balancer [{}] has a related firewall rule [{}]. Removing it.", rule.getUuid(), relatedFirewallRule.getUuid());
+            _firewallDao.remove(relatedFirewallRule.getId());
+        }
+
         _lbDao.remove(rule.getId());
     }
 

--- a/test/integration/component/test_vpc_network_lbrules.py
+++ b/test/integration/component/test_vpc_network_lbrules.py
@@ -939,10 +939,6 @@ class TestVPCNetworkLBRules(cloudstackTestCase):
         lb_rule = self.create_LB_Rule(public_ip_1, network_1, [vm_2, vm_1])
         public_ip_1.delete(self.apiclient)
         self.cleanup.remove(public_ip_1)
-
-        with self.assertRaises(Exception):
-            lb_rules = LoadBalancerRule.list(self.apiclient,
-                                        id=lb_rule.id,
-                                        listall=True
-                                        )
+        lb_rule_after_deletion = LoadBalancerRule.list(self.apiclient, id=lb_rule.id, listall=True)
+        self.assertEqual(lb_rule_after_deletion, None, 'Load balancer rule should be deleted.')
         return

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -470,10 +470,8 @@ class TestPortForwarding(cloudstackTestCase):
         except Exception as e:
             self.fail("NAT Rule Deletion Failed: %s" % e)
 
-        # NAT rule listing should fail as the nat rule does not exist
-        with self.assertRaises(Exception):
-            list_nat_rules(self.apiclient,
-                           id=nat_rule.id)
+        nat_rules_after_deletion = list_nat_rules(self.apiclient, id=nat_rule.id)
+        self.assertEqual(nat_rules_after_deletion, None, "Check that the port forwarding rule has been deleted.")
 
         # Check if the Public SSH port is inaccessible
         with self.assertRaises(Exception):
@@ -585,13 +583,8 @@ class TestPortForwarding(cloudstackTestCase):
 
         nat_rule.delete(self.apiclient)
 
-        try:
-            list_nat_rule_response = list_nat_rules(
-                self.apiclient,
-                id=nat_rule.id
-            )
-        except CloudstackAPIException:
-            logger.debug("Nat Rule is deleted")
+        nat_rules_after_deletion = list_nat_rules(self.apiclient, id=nat_rule.id)
+        self.assertEqual(nat_rules_after_deletion, None, "Check that the port forwarding rule has been deleted.")
 
         # Check if the Public SSH port is inaccessible
         with self.assertRaises(Exception):


### PR DESCRIPTION
### Description

Currently, when port forwarding, load balancing and firewall rules are removed, their records are permanently deleted from the database. This makes it impossible to track and audit previously applied rules after their removal.

Therefore, this PR proposes to, instead of deleting the records associated with such network rules, only marking them as removed. To achieve that, a `removed` column has been added to the tables that store the rules metadata, allowing to track the exact date and time when a rule was removed.

Maintaining these records is essential for auditing and traceability purposes. It ensures that historical network configurations remain accessible for cloud administrators/operators, enabling proper investigation, compliance verification and analysis of past behavior, even after rules are no longer active.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

#### Egress rules (ER)

1. I added an ER and verified that connectivity to the outside world was successfully established.
2. I deleted and reintroduced the same ER and verified that connectivity to the outside world was successfully established.
3. I added an ER allowing outbound TCP traffic for a specific port range and CIDR, and verified that connectivity to the outside world was successfully established.
4. I restarted the guest network with clean up and verified that the ER continued to be applied successfully.
5. I performed a live patch on the VR and verified that the ER continued to be applied successfully.
6. I deleted the network and verified that all egress rules were marked as deleted in the DB.

<details>

<summary>Records persisted in the database after the tests</summary>

```
MariaDB [cloud]> SELECT * FROM firewall_rules fw LEFT JOIN firewall_rules_cidrs fw_cidr ON fw.id = fw_cidr.firewall_rule_id LEFT JOIN firewall_rules_dcidrs fw_d_cidr ON fw.id = fw_d_cidr.firewall_rule_id\G
*************************** 1. row ***************************
              id: 1
            uuid: 969cd29e-ca98-46bb-ac43-633283cc9b58
   ip_address_id: NULL
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: tcp
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: 25bde535-5550-457c-98c1-f8e283c6c84e
         created: 2026-04-13 19:11:14
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Egress
         display: 1
         removed: 2026-04-13 19:12:54
              id: 1
firewall_rule_id: 1
     source_cidr: 10.1.1.0/24
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 2. row ***************************
              id: 2
            uuid: 03448b4d-4e79-40f6-b8ef-d95cb879ec7e
   ip_address_id: 6
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: tcp
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: 2402345a-df09-4885-b6ba-79996f8c5c70
         created: 2026-04-13 19:12:12
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Ingress
         display: 1
         removed: 2026-04-13 19:16:54
              id: 2
firewall_rule_id: 2
     source_cidr: 0.0.0.0/0
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 3. row ***************************
              id: 3
            uuid: 06a589af-1b76-4f55-9e7a-aeb3e4edad88
   ip_address_id: NULL
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: all
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: 23ec2ac4-73ef-4b73-a02b-a836b0221a87
         created: 2026-04-13 19:12:58
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Egress
         display: 1
         removed: 2026-04-13 19:13:05
              id: 3
firewall_rule_id: 3
     source_cidr: 10.1.1.0/24
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 4. row ***************************
              id: 4
            uuid: 8ef1e486-1a0a-4862-80d1-eb766f75cfeb
   ip_address_id: NULL
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: all
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: d164f1d8-c5d2-4aa1-84a6-ec9f20ae6687
         created: 2026-04-13 19:13:25
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Egress
         display: 1
         removed: 2026-04-13 19:13:49
              id: 4
firewall_rule_id: 4
     source_cidr: 10.1.1.0/24
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 5. row ***************************
              id: 5
            uuid: 37826bb2-b845-4208-a86f-2c0098e82570
   ip_address_id: NULL
      start_port: 22
        end_port: 22
           state: Revoke
        protocol: tcp
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: bd2ee1c8-5c88-4170-bc6c-e7903ae7a170
         created: 2026-04-13 19:14:03
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Egress
         display: 1
         removed: 2026-04-13 19:14:25
              id: NULL
firewall_rule_id: NULL
     source_cidr: NULL
              id: 1
firewall_rule_id: 5
destination_cidr: 192.168.122.0/24
*************************** 6. row ***************************
              id: 6
            uuid: a8ce6b28-5d3d-4b61-9e60-ba21c916df1e
   ip_address_id: NULL
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: all
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: ecdd0ffd-71a2-4c10-b2cc-a7f2b53261df
         created: 2026-04-13 19:15:09
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Egress
         display: 1
         removed: 2026-04-13 19:17:15
              id: 5
firewall_rule_id: 6
     source_cidr: 10.1.1.0/24
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
6 rows in set (0.000 sec)
```

</details>

#### Firewall (FW)

1. I added an FW rule allowing inbound TCP traffic from any source and verified its behavior.
2. I deleted and reintroduced the same FW rule and verified its behavior.
3. I deleted the previous rule and introduced a new one with a specific source CIDR and port range, and validated its behavior.
4. I restarted the guest network with clean up and verified that the FW rule behavior remained consistent.
5. I performed a live patch on the VR and verified that the FW rule behavior remained consistent.
6. I deleted the network and verified that all egress rules were marked as deleted in the DB.

<details>

<summary>Records persisted in the database after the tests</summary>

```
MariaDB [cloud]> SELECT * FROM firewall_rules fw LEFT JOIN firewall_rules_cidrs fw_cidr     ON fw.id = fw_cidr.firewall_rule_id LEFT JOIN firewall_rules_dcidrs fw_d_cidr ON fw.id = fw_d_cidr.firewall_rule_id WHERE fw.purpose = 'Firewall' AND fw.traffic_type = 'Ingress'\G
*************************** 1. row ***************************
              id: 2
            uuid: 03448b4d-4e79-40f6-b8ef-d95cb879ec7e
   ip_address_id: 6
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: tcp
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 205
             xid: 2402345a-df09-4885-b6ba-79996f8c5c70
         created: 2026-04-13 19:12:12
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Ingress
         display: 1
         removed: 2026-04-13 19:16:54
              id: 2
firewall_rule_id: 2
     source_cidr: 0.0.0.0/0
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 2. row ***************************
              id: 7
            uuid: 424797c4-5931-4bc1-8ae6-cf7140f84098
   ip_address_id: 3
      start_port: NULL
        end_port: NULL
           state: Revoke
        protocol: tcp
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 206
             xid: e9037cad-4dd1-4733-94c4-ff990cbaebc5
         created: 2026-04-13 19:20:10
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Ingress
         display: 1
         removed: 2026-04-13 19:20:55
              id: 6
firewall_rule_id: 7
     source_cidr: 0.0.0.0/0
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 3. row ***************************
              id: 9
            uuid: 4623d80d-9562-4fea-8330-5bfaed436cc5
   ip_address_id: 3
      start_port: 22
        end_port: 22
           state: Revoke
        protocol: tcp
         purpose: Firewall
      account_id: 2
       domain_id: 1
      network_id: 206
             xid: 04a471f3-04d4-48e3-9d62-e380eee41f31
         created: 2026-04-13 19:21:10
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: Ingress
         display: 1
         removed: 2026-04-13 19:34:53
              id: 7
firewall_rule_id: 9
     source_cidr: 0.0.0.0/0
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
3 rows in set (0.001 sec)
```

</details>

#### Port forwarding (PF)

1. I added PF rules and validated their behavior.
2. I deleted and reintroduced the rules and validated their behavior.
3. I restarted the guest network with clean up and validated that the PF rules continued to work correctly.
4. I performed a live patch on the VR and validated that the PF rules continued to work correctly.
5. I verified that conflicting PF rules were properly validated.
6. I deleted the network and verified that all egress rules were marked as deleted in the DB.

<details>

<summary>Records persisted in the database after the tests</summary>

```
MariaDB [cloud]> SELECT *     FROM firewall_rules fw     JOIN port_forwarding_rules pf         ON fw.id = pf.id     LEFT JOIN
firewall_rules_cidrs fw_cidr         ON fw.id = fw_cidr.firewall_rule_id     LEFT JOIN firewall_rules_dcidrs fw_d_cidr
 ON fw.id = fw_d_cidr.firewall_rule_id\G
*************************** 1. row ***************************
              id: 8
            uuid: df083b12-3936-41a3-8a26-eeb7dfb76b73
   ip_address_id: 3
      start_port: 22
        end_port: 22
           state: Revoke
        protocol: tcp
         purpose: PortForwarding
      account_id: 2
       domain_id: 1
      network_id: 206
             xid: b40c4908-e850-4ece-86f9-b2279a2d4fd9
         created: 2026-04-13 19:20:34
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: NULL
         display: 1
         removed: 2026-04-13 19:34:36
              id: 8
     instance_id: 34
 dest_ip_address: 10.1.1.201
 dest_port_start: 22
   dest_port_end: 22
              id: NULL
firewall_rule_id: NULL
     source_cidr: NULL
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 2. row ***************************
              id: 12
            uuid: fd063651-9b8e-4ff3-b9b8-20506757ea5f
   ip_address_id: 3
      start_port: 22
        end_port: 22
           state: Revoke
        protocol: tcp
         purpose: PortForwarding
      account_id: 2
       domain_id: 1
      network_id: 207
             xid: 9e5a3b48-78fe-4f19-8b79-299edbe160bd
         created: 2026-04-13 19:36:55
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: NULL
         display: 1
         removed: 2026-04-13 19:40:47
              id: 12
     instance_id: 36
 dest_ip_address: 10.1.1.243
 dest_port_start: 22
   dest_port_end: 22
              id: NULL
firewall_rule_id: NULL
     source_cidr: NULL
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 3. row ***************************
              id: 13
            uuid: 32b54eee-7b4c-40cf-8afa-771d1b0c0579
   ip_address_id: 3
      start_port: 2222
        end_port: 2222
           state: Revoke
        protocol: tcp
         purpose: PortForwarding
      account_id: 2
       domain_id: 1
      network_id: 207
             xid: 79359742-80a3-4b4f-858b-73a38f30f70d
         created: 2026-04-13 19:38:18
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: NULL
         display: 1
         removed: 2026-04-13 19:38:48
              id: 13
     instance_id: 36
 dest_ip_address: 10.1.1.243
 dest_port_start: 22
   dest_port_end: 22
              id: NULL
firewall_rule_id: NULL
     source_cidr: NULL
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
*************************** 4. row ***************************
              id: 14
            uuid: 00ab94f5-a3b6-46d9-9f4d-809ba0fe1316
   ip_address_id: 3
      start_port: 2222
        end_port: 2222
           state: Revoke
        protocol: tcp
         purpose: PortForwarding
      account_id: 2
       domain_id: 1
      network_id: 207
             xid: d8d3ddd6-1af9-4fd7-98bb-638fb64c05d7
         created: 2026-04-13 19:38:58
       icmp_code: NULL
       icmp_type: NULL
         related: NULL
            type: User
          vpc_id: NULL
    traffic_type: NULL
         display: 1
         removed: 2026-04-13 19:41:18
              id: 14
     instance_id: 36
 dest_ip_address: 10.1.1.243
 dest_port_start: 22
   dest_port_end: 22
              id: NULL
firewall_rule_id: NULL
     source_cidr: NULL
              id: NULL
firewall_rule_id: NULL
destination_cidr: NULL
4 rows in set (0.001 sec)
```

</details>

#### Public Load balancing (LB)

1. I created a public LB rule and validated its behavior.
2. I added a stickiness method.
3. I removed a VM from the LB and validated its behavior.
4. I reintroduced the VM into the LB and validated its behavior.
5. I removed the VM again and validated its behavior.
6. I deleted and reintroduced the stickiness method.
7. I deleted the LB rule and verified that the VM mappings and stickiness methods were successfully removed.

<details>

<summary>Records persisted in the database after the tests</summary>

```
MariaDB [cloud]> SELECT *
    -> FROM firewall_rules fw
    -> JOIN load_balancing_rules lb
    ->     ON fw.id = lb.id
    -> LEFT JOIN firewall_rules_cidrs fw_cidr
    ->     ON fw.id = fw_cidr.firewall_rule_id
    -> LEFT JOIN firewall_rules_dcidrs fw_d_cidr
    ->     ON fw.id = fw_d_cidr.firewall_rule_id
    -> LEFT JOIN load_balancer_vm_map lb_vm_map
    ->     ON fw.id = lb_vm_map.load_balancer_id
    -> LEFT JOIN load_balancer_stickiness_policies lb_stickiness_map
    ->     ON fw.id = lb_stickiness_map.load_balancer_id
    -> \G
*************************** 1. row ***************************
                          id: 15
                        uuid: 8d950836-cada-4ce9-9643-eff0adeaeaaa
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 208
                         xid: 0a6aaf01-daa7-4b9d-b566-2741ec06e2c8
                     created: 2026-04-13 19:44:27
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:16:09
                          id: 15
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 2
            load_balancer_id: 15
                 instance_id: 40
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.202
                     removed: 2026-04-13 20:16:09
                          id: 1
                        uuid: ebf6d3aa-32ea-4914-bc23-ec1c0aa8ca6f
            load_balancer_id: 15
                        name: name
                 description: NULL
                 method_name: LbCookie
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 19:51:25
*************************** 2. row ***************************
                          id: 15
                        uuid: 8d950836-cada-4ce9-9643-eff0adeaeaaa
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 208
                         xid: 0a6aaf01-daa7-4b9d-b566-2741ec06e2c8
                     created: 2026-04-13 19:44:27
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:16:09
                          id: 15
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 3
            load_balancer_id: 15
                 instance_id: 38
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.145
                     removed: 2026-04-13 20:16:09
                          id: 1
                        uuid: ebf6d3aa-32ea-4914-bc23-ec1c0aa8ca6f
            load_balancer_id: 15
                        name: name
                 description: NULL
                 method_name: LbCookie
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 19:51:25
*************************** 3. row ***************************
                          id: 18
                        uuid: d781daff-75e2-46c7-ad95-3fbfb012f27b
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 209
                         xid: 9ca1c4c7-6304-4647-bae4-b2eabf9036f9
                     created: 2026-04-13 20:20:19
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:23:53
                          id: 18
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 4
            load_balancer_id: 18
                 instance_id: 43
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.128
                     removed: 2026-04-13 20:22:10
                          id: 2
                        uuid: 90e03462-6674-4833-9256-85d8d31fd3de
            load_balancer_id: 18
                        name: sourcebased
                 description: NULL
                 method_name: SourceBased
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 20:22:55
*************************** 4. row ***************************
                          id: 18
                        uuid: d781daff-75e2-46c7-ad95-3fbfb012f27b
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 209
                         xid: 9ca1c4c7-6304-4647-bae4-b2eabf9036f9
                     created: 2026-04-13 20:20:19
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:23:53
                          id: 18
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 5
            load_balancer_id: 18
                 instance_id: 41
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.125
                     removed: 2026-04-13 20:23:53
                          id: 2
                        uuid: 90e03462-6674-4833-9256-85d8d31fd3de
            load_balancer_id: 18
                        name: sourcebased
                 description: NULL
                 method_name: SourceBased
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 20:22:55
*************************** 5. row ***************************
                          id: 18
                        uuid: d781daff-75e2-46c7-ad95-3fbfb012f27b
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 209
                         xid: 9ca1c4c7-6304-4647-bae4-b2eabf9036f9
                     created: 2026-04-13 20:20:19
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:23:53
                          id: 18
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 6
            load_balancer_id: 18
                 instance_id: 43
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.128
                     removed: 2026-04-13 20:22:28
                          id: 2
                        uuid: 90e03462-6674-4833-9256-85d8d31fd3de
            load_balancer_id: 18
                        name: sourcebased
                 description: NULL
                 method_name: SourceBased
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 20:22:55
*************************** 6. row ***************************
                          id: 18
                        uuid: d781daff-75e2-46c7-ad95-3fbfb012f27b
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 209
                         xid: 9ca1c4c7-6304-4647-bae4-b2eabf9036f9
                     created: 2026-04-13 20:20:19
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:23:53
                          id: 18
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 4
            load_balancer_id: 18
                 instance_id: 43
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.128
                     removed: 2026-04-13 20:22:10
                          id: 3
                        uuid: ebfc3019-e0b3-4663-b203-aee760e63853
            load_balancer_id: 18
                        name: sourcebased
                 description: NULL
                 method_name: SourceBased
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 20:23:53
*************************** 7. row ***************************
                          id: 18
                        uuid: d781daff-75e2-46c7-ad95-3fbfb012f27b
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 209
                         xid: 9ca1c4c7-6304-4647-bae4-b2eabf9036f9
                     created: 2026-04-13 20:20:19
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:23:53
                          id: 18
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 5
            load_balancer_id: 18
                 instance_id: 41
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.125
                     removed: 2026-04-13 20:23:53
                          id: 3
                        uuid: ebfc3019-e0b3-4663-b203-aee760e63853
            load_balancer_id: 18
                        name: sourcebased
                 description: NULL
                 method_name: SourceBased
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 20:23:53
*************************** 8. row ***************************
                          id: 18
                        uuid: d781daff-75e2-46c7-ad95-3fbfb012f27b
               ip_address_id: 3
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 209
                         xid: 9ca1c4c7-6304-4647-bae4-b2eabf9036f9
                     created: 2026-04-13 20:20:19
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:23:53
                          id: 18
                        name: lb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: roundrobin
           source_ip_address: NULL
source_ip_address_network_id: NULL
                      scheme: Public
                 lb_protocol: tcp
                   cidr_list: 
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 6
            load_balancer_id: 18
                 instance_id: 43
                      revoke: 1
                       state: NULL
                 instance_ip: 10.1.1.128
                     removed: 2026-04-13 20:22:28
                          id: 3
                        uuid: ebfc3019-e0b3-4663-b203-aee760e63853
            load_balancer_id: 18
                        name: sourcebased
                 description: NULL
                 method_name: SourceBased
                      params: 
                      revoke: 1
                     display: 1
                     removed: 2026-04-13 20:23:53
8 rows in set (0.001 sec)
```

</details>

#### Internal Load balancing (LB)

1. I created an internal LB rule and verified its behavior.
2. I deleted the internal LB rule and verified that the database records were marked as removed.
3. I reintroduced the internal LB rule and verified its behavior.
4. I deleted the VM participating in the internal LB and reintroduced it, and verified its behavior.
5. I deleted the user VMs that were part of the tier, deleted the tier, and verified that the database records were marked as removed, as expected.

<details>

<summary>Records persisted in the database after the tests</summary>

```
SELECT * FROM firewall_rules fw JOIN load_balancing_rules lb     ON fw.id = lb.id LEFT JOIN firewall_rules_cidrs fw_cidr     ON fw.id = fw_cidr.firewall_rule_id LEFT JOIN firewall_rules_dcidrs fw_d_cidr     ON fw.id = fw_d_cidr.firewall_rule_id LEFT JOIN load_balancer_vm_map lb_vm_map     ON fw.id = lb_vm_map.load_balancer_id LEFT JOIN load_balancer_stickiness_policies lb_stickiness_map     ON fw.id = lb_stickiness_map.load_balancer_id WHERE lb.scheme = "Internal"\G
*************************** 1. row ***************************
                          id: 19
                        uuid: 021e13ff-379e-416d-8412-b205a5921a43
               ip_address_id: NULL
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 210
                         xid: eb83f294-5cf9-4403-a104-aac6f23bc9c3
                     created: 2026-04-13 20:30:45
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:32:48
                          id: 19
                        name: internallb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: Source
           source_ip_address: 10.0.0.240
source_ip_address_network_id: 210
                      scheme: Internal
                 lb_protocol: NULL
                   cidr_list: NULL
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 7
            load_balancer_id: 19
                 instance_id: 45
                      revoke: 1
                       state: NULL
                 instance_ip: 10.0.0.157
                     removed: 2026-04-13 20:32:48
                          id: NULL
                        uuid: NULL
            load_balancer_id: NULL
                        name: NULL
                 description: NULL
                 method_name: NULL
                      params: NULL
                      revoke: NULL
                     display: NULL
                     removed: NULL
*************************** 2. row ***************************
                          id: 20
                        uuid: f88dcded-aa42-43ae-9457-1c6c645f7d61
               ip_address_id: NULL
                  start_port: 22
                    end_port: 22
                       state: Add
                    protocol: tcp
                     purpose: LoadBalancing
                  account_id: 2
                   domain_id: 1
                  network_id: 210
                         xid: 733ff32d-9b19-40a9-9e7c-72649d584838
                     created: 2026-04-13 20:34:29
                   icmp_code: NULL
                   icmp_type: NULL
                     related: NULL
                        type: User
                      vpc_id: NULL
                traffic_type: NULL
                     display: 1
                     removed: 2026-04-13 20:38:42
                          id: 20
                        name: internallb
                 description: NULL
          default_port_start: 22
            default_port_end: 22
                   algorithm: Source
           source_ip_address: 10.0.0.115
source_ip_address_network_id: 210
                      scheme: Internal
                 lb_protocol: NULL
                   cidr_list: NULL
                          id: NULL
            firewall_rule_id: NULL
                 source_cidr: NULL
                          id: NULL
            firewall_rule_id: NULL
            destination_cidr: NULL
                          id: 8
            load_balancer_id: 20
                 instance_id: 45
                      revoke: 1
                       state: NULL
                 instance_ip: 10.0.0.157
                     removed: 2026-04-13 20:38:29
                          id: NULL
                        uuid: NULL
            load_balancer_id: NULL
                        name: NULL
                 description: NULL
                 method_name: NULL
                      params: NULL
                      revoke: NULL
                     display: NULL
                     removed: NULL
2 rows in set (0.001 sec)
```

</details>
