### PR TITLE
Fix for usage server getting stuck due to duplicate VM events

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import com.cloud.upgrade.dao.Upgrade42020to42030;
 import com.cloud.utils.FileUtil;
 import org.apache.cloudstack.utils.CloudStackVersion;
 import org.apache.commons.lang3.StringUtils;
@@ -90,6 +89,8 @@ import com.cloud.upgrade.dao.Upgrade41810to41900;
 import com.cloud.upgrade.dao.Upgrade41900to41910;
 import com.cloud.upgrade.dao.Upgrade41910to42000;
 import com.cloud.upgrade.dao.Upgrade42000to42010;
+import com.cloud.upgrade.dao.Upgrade42020to42030;
+import com.cloud.upgrade.dao.Upgrade42030to42040;
 import com.cloud.upgrade.dao.Upgrade420to421;
 import com.cloud.upgrade.dao.Upgrade421to430;
 import com.cloud.upgrade.dao.Upgrade430to440;
@@ -238,6 +239,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.19.1.0", new Upgrade41910to42000())
                 .next("4.20.0.0", new Upgrade42000to42010())
                 .next("4.20.2.0", new Upgrade42020to42030())
+                .next("4.20.3.0", new Upgrade42030to42040())
                 .build();
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42030to42040.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42030to42040.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade.dao;
+
+import java.io.InputStream;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.cloud.utils.exception.CloudRuntimeException;
+
+public class Upgrade42030to42040 extends DbUpgradeAbstractImpl implements DbUpgrade, DbUpgradeSystemVmTemplate {
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[]{"4.20.3.0", "4.20.4.0"};
+    }
+
+    @Override
+    public String getUpgradedVersion() {
+        return "4.20.4.0";
+    }
+
+    @Override
+    public boolean supportsRollingUpgrade() {
+        return false;
+    }
+
+    @Override
+    public InputStream[] getPrepareScripts() {
+        return null;
+    }
+
+    @Override
+    public void performDataMigration(Connection conn) {
+        final List<String> indexList = new ArrayList<String>();
+        logger.debug("Dropping index vm_instance_id from usage_vm_instance table if it exists");
+        indexList.add("vm_instance_id");
+        DbUpgradeUtils.dropKeysIfExist(conn, "cloud_usage.usage_vm_instance", indexList, false);
+    }
+
+    @Override
+    public InputStream[] getCleanupScripts() {
+        return null;
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42030to42040.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42030to42040.java
@@ -21,8 +21,6 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.cloud.utils.exception.CloudRuntimeException;
-
 public class Upgrade42030to42040 extends DbUpgradeAbstractImpl implements DbUpgrade, DbUpgradeSystemVmTemplate {
 
     @Override

--- a/setup/db/create-schema-premium.sql
+++ b/setup/db/create-schema-premium.sql
@@ -70,7 +70,8 @@ CREATE TABLE  `cloud_usage`.`usage_vm_instance` (
   `template_id` bigint unsigned NOT NULL,
   `hypervisor_type` varchar(255),
   `start_date` DATETIME NOT NULL,
-  `end_date` DATETIME NULL
+  `end_date` DATETIME NULL,
+  UNIQUE KEY (`vm_instance_id`, `usage_type`, `start_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `cloud_usage`.`usage_vm_instance` ADD INDEX `i_usage_vm_instance__account_id`(`account_id`);

--- a/setup/db/create-schema-premium.sql
+++ b/setup/db/create-schema-premium.sql
@@ -70,8 +70,7 @@ CREATE TABLE  `cloud_usage`.`usage_vm_instance` (
   `template_id` bigint unsigned NOT NULL,
   `hypervisor_type` varchar(255),
   `start_date` DATETIME NOT NULL,
-  `end_date` DATETIME NULL,
-  UNIQUE KEY (`vm_instance_id`, `usage_type`, `start_date`)
+  `end_date` DATETIME NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `cloud_usage`.`usage_vm_instance` ADD INDEX `i_usage_vm_instance__account_id`(`account_id`);


### PR DESCRIPTION
### Description

This PR fixes #12590 

Fix is to remove the unique key constraint from the `usage_vm_instance` table.
The constraint is not required, and can cause issues with usage processing.
The other helper tables either don't have a constraint or duplicate events cannot happen as the event is generated only at create.
In case of VM instance the event is generated at every Start which makes it susceptible to duplicate events.

Added change in the upgrade path as well as in `create-schema-premium.sql`

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

To test, I added 2 VM.START events to the usage_event table with the same `created` time **(id 18 and 20)** and set the `usage.stats.job.aggregation.range` to 5 (minutes)
<img width="3684" height="990" alt="image" src="https://github.com/user-attachments/assets/d0f35f7e-17cd-4257-a013-b896fb36eba5" />

Without the fix the usage server was stuck processing that interval
<img width="1791" height="457" alt="Screenshot 2026-04-14 at 10 44 21 AM" src="https://github.com/user-attachments/assets/18d52dcc-0fdd-4768-b9d3-48c56191d6b8" />

After removing the unique constraint, usage server finished successfully and generated the correct usage.
<img width="1796" height="808" alt="Screenshot 2026-04-14 at 10 52 26 AM" src="https://github.com/user-attachments/assets/416d0be0-2969-4f03-a75c-0608f8b7e1e9" />


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
