### PR TITLE
Fix the validation of CPVMs states in multiple zones

### DIFF
--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -1525,9 +1525,9 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
             return false;
         }
 
-        List<ConsoleProxyVO> l = consoleProxyDao.getProxyListInStates(dataCenterId, State.Starting, State.Stopping);
-        if (!l.isEmpty()) {
-            logger.debug("Zone {} has {} console proxy VM(s) in transition state.", zone, l.size());
+        List<ConsoleProxyVO> consoleProxiesInTransitionStates = consoleProxyDao.getProxyListInStates(dataCenterId, State.Starting, State.Stopping);
+        if (!consoleProxiesInTransitionStates.isEmpty()) {
+            logger.debug("Zone {} has {} console proxy VM(s) in transition state.", zone, consoleProxiesInTransitionStates.size());
             return false;
         }
 

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -1525,12 +1525,9 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
             return false;
         }
 
-        List<ConsoleProxyVO> l = consoleProxyDao.getProxyListInStates(State.Starting, State.Stopping);
-        if (l.size() > 0) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Zone {} has {} console proxy VM(s) in transition state", zone, l.size());
-            }
-
+        List<ConsoleProxyVO> l = consoleProxyDao.getProxyListInStates(dataCenterId, State.Starting, State.Stopping);
+        if (!l.isEmpty()) {
+            logger.debug("Zone {} has {} console proxy VM(s) in transition state.", zone, l.size());
             return false;
         }
 


### PR DESCRIPTION
### Description

Currently, during the deployment of CPVMs, CloudStack validates whether there are already CPVMs in the `Starting` or `Stopping` state in the environment, in order to avoid duplicate provisioning. However, this operation does not filter for zones. Therefore, if there is more than one zone in the environment, and in one of these zones there is a CPVM in one of these states, the CPVMs of other zones will not be created.

Changes were made to consider only the zone in which the CPVM will be created.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

In an environment with two configured zones, `zn-01` and `zn-02`, I started the `zn-01` and waited for its system VMs to start while zone `zn-02` was deactivated. After the system VMs in zone `zn-01` were in the `Running` state, I changed their states to `Starting` in the database and activated zone `zn-02`. I went to the system VMs tab and observed that the system VMs in `zn-02` were being created while those in zone `zn-01` were in the `Starting` state.
