### PR TITLE
NPE correction when informing removed project in the `listProjectRoles`

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/ListProjectRolesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/acl/project/ListProjectRolesCmd.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.cloud.exception.InvalidParameterValueException;
 import org.apache.cloudstack.acl.ProjectRole;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
@@ -55,7 +56,6 @@ public class ListProjectRolesCmd extends BaseListCmd {
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
-
     public Long getProjectRoleId() { return projectRoleId; }
 
     public Long getProjectId() {
@@ -72,7 +72,10 @@ public class ListProjectRolesCmd extends BaseListCmd {
 
     @Override
     public void execute() {
-        List<ProjectRole> projectRoles = new ArrayList<>();
+        if (getProjectId() != null && _projectService.getProject(getProjectId()) == null) {
+            throw new InvalidParameterValueException("Failed to find project by ID.");
+        }
+        List<ProjectRole> projectRoles;
         if (getProjectId() != null && getProjectRoleId() != null) {
             projectRoles = Collections.singletonList(projRoleService.findProjectRole(getProjectRoleId(), getProjectId()));
         } else if (StringUtils.isNotBlank(getRoleName())) {

--- a/server/src/main/java/org/apache/cloudstack/acl/ProjectRoleManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/acl/ProjectRoleManagerImpl.java
@@ -168,9 +168,9 @@ public class ProjectRoleManagerImpl extends ManagerBase implements ProjectRoleSe
 
     @Override
     public List<ProjectRole> findProjectRoles(Long projectId, String keyword) {
-        if (projectId == null || projectId < 1L || projectDao.findById(projectId) == null) {
-            logger.warn("Invalid project ID provided");
-            return null;
+        if (projectId == null) {
+            logger.warn("Invalid project ID provided; thus, an empty list is being returned.");
+            return Collections.emptyList();
         }
         return ListUtils.toListOfInterface(projRoleDao.findAllRoles(projectId, keyword));
     }

--- a/server/src/main/java/org/apache/cloudstack/acl/ProjectRoleManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/acl/ProjectRoleManagerImpl.java
@@ -168,7 +168,7 @@ public class ProjectRoleManagerImpl extends ManagerBase implements ProjectRoleSe
 
     @Override
     public List<ProjectRole> findProjectRoles(Long projectId, String keyword) {
-        if (projectId == null) {
+        if (projectId == null || projectId < 1L || projectDao.findById(projectId) == null) {
             logger.warn("Invalid project ID provided; thus, an empty list is being returned.");
             return Collections.emptyList();
         }


### PR DESCRIPTION
### Description

Currently, when using the `listProjectRoles` API, passing the `projectid` parameter of a removed project results in an NPE. This PR changes this behavior to return the message `Failed to find project by ID` instead.


### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial

### Screenshots (if appropriate):

<details><summary>Before the changes</summary>

<img width="2228" height="152" alt="image" src="https://github.com/user-attachments/assets/4dca6fca-62e5-45ae-9282-d2b80e2be9d2" />

</details>

<details><summary>After the changes</summary>

<img width="1716" height="119" alt="image" src="https://github.com/user-attachments/assets/007a5c30-ef02-4a00-876e-1d25c3c3f8be" />

</details>

### How Has This Been Tested?

To perform the tests, a test project was created along with a project role. The project was deleted and the `listProjectRoles` API was called passing the ID of the project role. This showed the new message.

