### PR TITLE
Prevent downloading templates to secondary storages that are in `read-only`

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreManager.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreManager.java
@@ -60,4 +60,6 @@ public interface DataStoreManager {
     DataStore getImageStoreByUuid(String uuid);
 
     Long getStoreZoneId(long storeId, DataStoreRole role);
+
+    boolean isRemovedOrReadonly(DataStore store);
 }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -299,7 +299,7 @@ public class TemplateServiceImpl implements TemplateService {
 
     protected boolean shouldDownloadTemplateToStore(VMTemplateVO template, DataStore store) {
         if (dataStoreDao.findById(store.getId()).isReadonly()) {
-            logger.debug("Template [{}] will not be download to image store [{}] because this store is marked as read-only.", template.getUniqueName(),
+            logger.debug("Template [{}] will not be downloaded to image store [{}] because this store is marked as read-only.", template.getUniqueName(),
                     store.getName());
             return false;
         }
@@ -307,7 +307,7 @@ public class TemplateServiceImpl implements TemplateService {
         Long zoneId = store.getScope().getScopeId();
         DataStore directedStore = _tmpltMgr.verifyHeuristicRulesForZone(template, zoneId);
         if (directedStore != null && store.getId() != directedStore.getId()) {
-            logger.info("Template [{}] will not be download to image store [{}], as a heuristic rule is directing it to another store.",
+            logger.info("Template [{}] will not be downloaded to image store [{}], as a heuristic rule is directing it to another store.",
                     template.getUniqueName(), store.getName());
             return false;
         }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -64,6 +64,7 @@ import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.cloudstack.storage.command.DeleteCommand;
 import org.apache.cloudstack.storage.datastore.DataObjectManager;
 import org.apache.cloudstack.storage.datastore.ObjectInDataStoreManager;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
 import org.apache.cloudstack.storage.image.datastore.ImageStoreEntity;
@@ -163,6 +164,8 @@ public class TemplateServiceImpl implements TemplateService {
     TemplateDataFactory imageFactory;
     @Inject
     StorageOrchestrationService storageOrchestrator;
+    @Inject
+    ImageStoreDao dataStoreDao;
 
     class TemplateOpContext<T> extends AsyncRpcContext<T> {
         final TemplateObject template;
@@ -295,6 +298,12 @@ public class TemplateServiceImpl implements TemplateService {
     }
 
     protected boolean shouldDownloadTemplateToStore(VMTemplateVO template, DataStore store) {
+        if (dataStoreDao.findById(store.getId()).isReadonly()) {
+            logger.debug("Template [{}] will not be download to image store [{}] because this store is marked as read-only.", template.getUniqueName(),
+                    store.getName());
+            return false;
+        }
+
         Long zoneId = store.getScope().getScopeId();
         DataStore directedStore = _tmpltMgr.verifyHeuristicRulesForZone(template, zoneId);
         if (directedStore != null && store.getId() != directedStore.getId()) {

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -165,7 +165,7 @@ public class TemplateServiceImpl implements TemplateService {
     @Inject
     StorageOrchestrationService storageOrchestrator;
     @Inject
-    ImageStoreDao dataStoreDao;
+    ImageStoreDao imageStoreDao;
 
     class TemplateOpContext<T> extends AsyncRpcContext<T> {
         final TemplateObject template;
@@ -298,9 +298,7 @@ public class TemplateServiceImpl implements TemplateService {
     }
 
     protected boolean shouldDownloadTemplateToStore(VMTemplateVO template, DataStore store) {
-        if (dataStoreDao.findById(store.getId()).isReadonly()) {
-            logger.debug("Template [{}] will not be downloaded to image store [{}] because this store is marked as read-only.", template.getUniqueName(),
-                    store.getName());
+        if (_storeMgr.isRemovedOrReadonly(store)) {
             return false;
         }
 

--- a/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
+++ b/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
@@ -32,6 +32,8 @@ import org.apache.cloudstack.engine.orchestration.service.StorageOrchestrationSe
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.Scope;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
 import org.apache.cloudstack.storage.image.store.TemplateObject;
@@ -104,6 +106,12 @@ public class TemplateServiceImplTest {
     @Mock
     DataCenterDao _dcDao;
 
+    @Mock
+    ImageStoreDao imageStore;
+
+    @Mock
+    ImageStoreVO imageMock;
+
     Map<String, TemplateProp> templatesInSourceStore = new HashMap<>();
 
     @Before
@@ -119,11 +127,13 @@ public class TemplateServiceImplTest {
         Mockito.doReturn(templateInfoMock).when(templateDataFactoryMock).getTemplate(2L, sourceStoreMock);
         Mockito.doReturn(3L).when(dataStoreMock).getId();
         Mockito.doReturn(zoneScopeMock).when(dataStoreMock).getScope();
+        Mockito.when(imageStore.findById(3L)).thenReturn(imageMock);
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsTemplateDirectedToAnotherStorage() {
         DataStore destinedStore = Mockito.mock(DataStore.class);
+        Mockito.when(imageMock.isReadonly()).thenReturn(false);
         Mockito.doReturn(dataStoreMock.getId() + 1L).when(destinedStore).getId();
         Mockito.when(templateManagerMock.verifyHeuristicRulesForZone(tmpltMock, zoneScopeMock.getScopeId())).thenReturn(destinedStore);
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
@@ -131,31 +141,43 @@ public class TemplateServiceImplTest {
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsPublicTemplate() {
+        Mockito.when(imageMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.isPublicTemplate()).thenReturn(true);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsFeaturedTemplate() {
+        Mockito.when(imageMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.isFeatured()).thenReturn(true);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsSystemTemplate() {
+        Mockito.when(imageMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.getTemplateType()).thenReturn(Storage.TemplateType.SYSTEM);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsPrivateNoRefTemplate() {
+        Mockito.when(imageMock.isReadonly()).thenReturn(false);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsPrivateExistingTemplate() {
+        Mockito.when(imageMock.isReadonly()).thenReturn(false);
         Mockito.when(templateDataStoreDao.findByTemplateZone(tmpltMock.getId(), zoneScopeMock.getScopeId(), DataStoreRole.Image)).thenReturn(Mockito.mock(TemplateDataStoreVO.class));
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
+    }
+
+    @Test
+    public void shouldDownloadTemplateToStoreTestSkipsWhenStorageIsReadOnly() {
+        Mockito.when(imageMock.isReadonly()).thenReturn(true);
+        Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
+
     }
 
     @Test

--- a/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
+++ b/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
@@ -127,13 +127,11 @@ public class TemplateServiceImplTest {
         Mockito.doReturn(templateInfoMock).when(templateDataFactoryMock).getTemplate(2L, sourceStoreMock);
         Mockito.doReturn(3L).when(dataStoreMock).getId();
         Mockito.doReturn(zoneScopeMock).when(dataStoreMock).getScope();
-        Mockito.when(imageStoreDao.findById(3L)).thenReturn(imageStoreMock);
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsTemplateDirectedToAnotherStorage() {
         DataStore destinedStore = Mockito.mock(DataStore.class);
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.doReturn(dataStoreMock.getId() + 1L).when(destinedStore).getId();
         Mockito.when(templateManagerMock.verifyHeuristicRulesForZone(tmpltMock, zoneScopeMock.getScopeId())).thenReturn(destinedStore);
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
@@ -141,41 +139,36 @@ public class TemplateServiceImplTest {
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsPublicTemplate() {
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.isPublicTemplate()).thenReturn(true);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsFeaturedTemplate() {
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.isFeatured()).thenReturn(true);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsSystemTemplate() {
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.getTemplateType()).thenReturn(Storage.TemplateType.SYSTEM);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsPrivateNoRefTemplate() {
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsPrivateExistingTemplate() {
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(templateDataStoreDao.findByTemplateZone(tmpltMock.getId(), zoneScopeMock.getScopeId(), DataStoreRole.Image)).thenReturn(Mockito.mock(TemplateDataStoreVO.class));
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsWhenStorageIsReadOnly() {
-        Mockito.when(imageStoreMock.isReadonly()).thenReturn(true);
+        Mockito.when(dataStoreManagerMock.isRemovedOrReadonly(Mockito.any())).thenReturn(true);
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
 
     }

--- a/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
+++ b/engine/storage/image/src/test/java/org/apache/cloudstack/storage/image/TemplateServiceImplTest.java
@@ -107,10 +107,10 @@ public class TemplateServiceImplTest {
     DataCenterDao _dcDao;
 
     @Mock
-    ImageStoreDao imageStore;
+    ImageStoreDao imageStoreDao;
 
     @Mock
-    ImageStoreVO imageMock;
+    ImageStoreVO imageStoreMock;
 
     Map<String, TemplateProp> templatesInSourceStore = new HashMap<>();
 
@@ -127,13 +127,13 @@ public class TemplateServiceImplTest {
         Mockito.doReturn(templateInfoMock).when(templateDataFactoryMock).getTemplate(2L, sourceStoreMock);
         Mockito.doReturn(3L).when(dataStoreMock).getId();
         Mockito.doReturn(zoneScopeMock).when(dataStoreMock).getScope();
-        Mockito.when(imageStore.findById(3L)).thenReturn(imageMock);
+        Mockito.when(imageStoreDao.findById(3L)).thenReturn(imageStoreMock);
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsTemplateDirectedToAnotherStorage() {
         DataStore destinedStore = Mockito.mock(DataStore.class);
-        Mockito.when(imageMock.isReadonly()).thenReturn(false);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.doReturn(dataStoreMock.getId() + 1L).when(destinedStore).getId();
         Mockito.when(templateManagerMock.verifyHeuristicRulesForZone(tmpltMock, zoneScopeMock.getScopeId())).thenReturn(destinedStore);
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
@@ -141,41 +141,41 @@ public class TemplateServiceImplTest {
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsPublicTemplate() {
-        Mockito.when(imageMock.isReadonly()).thenReturn(false);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.isPublicTemplate()).thenReturn(true);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsFeaturedTemplate() {
-        Mockito.when(imageMock.isReadonly()).thenReturn(false);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.isFeatured()).thenReturn(true);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsSystemTemplate() {
-        Mockito.when(imageMock.isReadonly()).thenReturn(false);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(tmpltMock.getTemplateType()).thenReturn(Storage.TemplateType.SYSTEM);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestDownloadsPrivateNoRefTemplate() {
-        Mockito.when(imageMock.isReadonly()).thenReturn(false);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Assert.assertTrue(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsPrivateExistingTemplate() {
-        Mockito.when(imageMock.isReadonly()).thenReturn(false);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(false);
         Mockito.when(templateDataStoreDao.findByTemplateZone(tmpltMock.getId(), zoneScopeMock.getScopeId(), DataStoreRole.Image)).thenReturn(Mockito.mock(TemplateDataStoreVO.class));
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
     }
 
     @Test
     public void shouldDownloadTemplateToStoreTestSkipsWhenStorageIsReadOnly() {
-        Mockito.when(imageMock.isReadonly()).thenReturn(true);
+        Mockito.when(imageStoreMock.isReadonly()).thenReturn(true);
         Assert.assertFalse(templateService.shouldDownloadTemplateToStore(tmpltMock, dataStoreMock));
 
     }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/datastore/DataStoreManagerImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/datastore/DataStoreManagerImpl.java
@@ -26,7 +26,11 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
 import org.apache.cloudstack.engine.subsystem.api.storage.Scope;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.object.datastore.ObjectStoreProviderManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.storage.image.datastore.ImageStoreProviderManager;
@@ -37,12 +41,16 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
 public class DataStoreManagerImpl implements DataStoreManager {
+    protected Logger logger = LogManager.getLogger(DataStoreManagerImpl.class);
+
     @Inject
     PrimaryDataStoreProviderManager primaryStoreMgr;
     @Inject
     ImageStoreProviderManager imageDataStoreMgr;
     @Inject
     ObjectStoreProviderManager objectStoreProviderMgr;
+    @Inject
+    ImageStoreDao imageStoreDao;
 
     @Override
     public DataStore getDataStore(long storeId, DataStoreRole role) {
@@ -198,5 +206,19 @@ public class DataStoreManagerImpl implements DataStoreManager {
             }
         } catch (CloudRuntimeException ignored) {}
         return null;
+    }
+
+    @Override
+    public boolean isRemovedOrReadonly(DataStore store) {
+        ImageStoreVO storeVO = imageStoreDao.findById(store.getId());
+        if (storeVO  == null) {
+            logger.debug("Could not find image store with id [{}], skipping it.", store.getId());
+            return true;
+        }
+        if (storeVO.isReadonly()) {
+            logger.debug("Image store [{}] is read-only, skipping it.", storeVO);
+            return true;
+        }
+        return false;
     }
 }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -44,6 +44,7 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.command.CommandResult;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.DeleteCommand;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
@@ -126,6 +127,8 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
     AgentManager agentMgr;
     @Inject
     DataStoreManager dataStoreManager;
+    @Inject
+    ImageStoreDao dataStoreDao;
 
     protected String _proxy = null;
 
@@ -175,10 +178,13 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         AsyncCallbackDispatcher<BaseImageStoreDriverImpl, DownloadAnswer> caller = AsyncCallbackDispatcher.create(this);
         caller.setContext(context);
         if (data.getType() == DataObjectType.TEMPLATE) {
-            caller.setCallback(caller.getTarget().createTemplateAsyncCallback(null, null));
-            if (logger.isDebugEnabled()) {
-                logger.debug("Downloading template to data store {}", dataStore);
+            if (dataStoreDao.findById(dataStore.getId()).isReadonly()) {
+                logger.debug("Template [{}] will not be download to image store [{}] because this store is marked as read-only.", data.getName(),
+                        dataStore.getName());
+                return;
             }
+            caller.setCallback(caller.getTarget().createTemplateAsyncCallback(null, null));
+            logger.debug("Downloading template [{}] to data store [{}].", data.getName(), dataStore.getName());
             _downloadMonitor.downloadTemplateToStorage(data, caller);
         } else if (data.getType() == DataObjectType.VOLUME) {
             caller.setCallback(caller.getTarget().createVolumeAsyncCallback(null, null));

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -179,7 +179,7 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         caller.setContext(context);
         if (data.getType() == DataObjectType.TEMPLATE) {
             if (dataStoreDao.findById(dataStore.getId()).isReadonly()) {
-                logger.debug("Template [{}] will not be download to image store [{}] because this store is marked as read-only.", data.getName(),
+                logger.debug("Template [{}] will not be downloaded to image store [{}] because this store is marked as read-only.", data.getName(),
                         dataStore.getName());
                 return;
             }

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -44,7 +44,6 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.command.CommandResult;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.DeleteCommand;
-import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
@@ -127,8 +126,6 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
     AgentManager agentMgr;
     @Inject
     DataStoreManager dataStoreManager;
-    @Inject
-    ImageStoreDao imageStoreDao;
 
     protected String _proxy = null;
 
@@ -178,13 +175,10 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         AsyncCallbackDispatcher<BaseImageStoreDriverImpl, DownloadAnswer> caller = AsyncCallbackDispatcher.create(this);
         caller.setContext(context);
         if (data.getType() == DataObjectType.TEMPLATE) {
-            if (dataStoreManager.isRemovedOrReadonly(dataStore)) {
-                DownloadAnswer ans = new DownloadAnswer("Data store is removed or in read-only mode", VMTemplateStorageResourceAssoc.Status.UNKNOWN);
-                caller.complete(ans);
-                return;
-            }
             caller.setCallback(caller.getTarget().createTemplateAsyncCallback(null, null));
-            logger.debug("Downloading template [{}] to data store [{}].", data.getName(), dataStore.getName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Downloading template to data store {}", dataStore);
+            }
             _downloadMonitor.downloadTemplateToStorage(data, caller);
         } else if (data.getType() == DataObjectType.VOLUME) {
             caller.setCallback(caller.getTarget().createVolumeAsyncCallback(null, null));

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -128,7 +128,7 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
     @Inject
     DataStoreManager dataStoreManager;
     @Inject
-    ImageStoreDao dataStoreDao;
+    ImageStoreDao imageStoreDao;
 
     protected String _proxy = null;
 
@@ -178,9 +178,9 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         AsyncCallbackDispatcher<BaseImageStoreDriverImpl, DownloadAnswer> caller = AsyncCallbackDispatcher.create(this);
         caller.setContext(context);
         if (data.getType() == DataObjectType.TEMPLATE) {
-            if (dataStoreDao.findById(dataStore.getId()).isReadonly()) {
-                logger.debug("Template [{}] will not be downloaded to image store [{}] because this store is marked as read-only.", data.getName(),
-                        dataStore.getName());
+            if (dataStoreManager.isRemovedOrReadonly(dataStore)) {
+                DownloadAnswer ans = new DownloadAnswer("Data store is removed or in read-only mode", VMTemplateStorageResourceAssoc.Status.UNKNOWN);
+                caller.complete(ans);
                 return;
             }
             caller.setCallback(caller.getTarget().createTemplateAsyncCallback(null, null));

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -338,6 +338,11 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
             return false;
         }
 
+        if (_imgStoreDao.findById(imageStore.getId()).isReadonly()) {
+            logger.info("Image store [{}] is marked as read-only. Skip downloading template to this image store.", imageStore);
+            return false;
+        }
+
         if (!_statsCollector.imageStoreHasEnoughCapacity(imageStore)) {
             logger.info("Image store doesn't have enough capacity. Skip downloading template to this image store [{}].", imageStore);
             return false;

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -338,7 +338,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
             return false;
         }
 
-        if (_imgStoreDao.findById(imageStore.getId()).isReadonly()) {
+        if (storeMgr.isRemovedOrReadonly(imageStore)) {
             logger.info("Image store [{}] is marked as read-only. Skip downloading template to this image store.", imageStore);
             return false;
         }

--- a/server/src/main/java/org/apache/cloudstack/storage/heuristics/HeuristicRuleHelper.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/heuristics/HeuristicRuleHelper.java
@@ -272,6 +272,10 @@ public class HeuristicRuleHelper {
                         "returning a valid UUID.", scriptReturn, rule));
             }
 
+            if (dataStoreManager.isRemovedOrReadonly(dataStore)) {
+                throw new CloudRuntimeException(String.format("DataStore [{}] returned by heuristic rule is marked as read-only.", dataStore));
+            }
+
             return dataStore;
         } catch (IOException ex) {
             String message = String.format("Error while executing script [%s].", rule);

--- a/server/src/test/java/com/cloud/template/HypervisorTemplateAdapterTest.java
+++ b/server/src/test/java/com/cloud/template/HypervisorTemplateAdapterTest.java
@@ -49,6 +49,8 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.events.Event;
 import org.apache.cloudstack.framework.events.EventDistributor;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
 import org.apache.cloudstack.storage.heuristics.HeuristicRuleHelper;
@@ -136,6 +138,9 @@ public class HypervisorTemplateAdapterTest {
 
     @Mock
     StatsCollector statsCollectorMock;
+
+    @Mock
+    ImageStoreDao _imgStoreDao;
 
     @Mock
     Logger loggerMock;
@@ -458,11 +463,13 @@ public class HypervisorTemplateAdapterTest {
     @Test
     public void isZoneAndImageStoreAvailableTestImageStoreDoesNotHaveEnoughCapacityShouldReturnFalse() {
         DataStore dataStoreMock = Mockito.mock(DataStore.class);
+        ImageStoreVO ImageStoreVOMock = Mockito.mock(ImageStoreVO.class);
         Long zoneId = 1L;
         Set<Long> zoneSet = null;
         boolean isTemplatePrivate = false;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
 
+        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(ImageStoreVOMock);
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(false);
@@ -477,11 +484,13 @@ public class HypervisorTemplateAdapterTest {
     @Test
     public void isZoneAndImageStoreAvailableTestImageStoreHasEnoughCapacityAndZoneSetIsNullShouldReturnTrue() {
         DataStore dataStoreMock = Mockito.mock(DataStore.class);
+        ImageStoreVO ImageStoreVOMock = Mockito.mock(ImageStoreVO.class);
         Long zoneId = 1L;
         Set<Long> zoneSet = null;
         boolean isTemplatePrivate = false;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
 
+        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(ImageStoreVOMock);
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);
@@ -496,11 +505,13 @@ public class HypervisorTemplateAdapterTest {
     @Test
     public void isZoneAndImageStoreAvailableTestTemplateIsPrivateAndItIsAlreadyAllocatedToTheSameZoneShouldReturnFalse() {
         DataStore dataStoreMock = Mockito.mock(DataStore.class);
+        ImageStoreVO ImageStoreVOMock = Mockito.mock(ImageStoreVO.class);
         Long zoneId = 1L;
         Set<Long> zoneSet = Set.of(1L);
         boolean isTemplatePrivate = true;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
 
+        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(ImageStoreVOMock);
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);
@@ -515,11 +526,13 @@ public class HypervisorTemplateAdapterTest {
     @Test
     public void isZoneAndImageStoreAvailableTestTemplateIsPrivateAndItIsNotAlreadyAllocatedToTheSameZoneShouldReturnTrue() {
         DataStore dataStoreMock = Mockito.mock(DataStore.class);
+        ImageStoreVO ImageStoreVOMock = Mockito.mock(ImageStoreVO.class);
         Long zoneId = 1L;
         Set<Long> zoneSet = new HashSet<>();
         boolean isTemplatePrivate = true;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
 
+        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(ImageStoreVOMock);
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);

--- a/server/src/test/java/com/cloud/template/HypervisorTemplateAdapterTest.java
+++ b/server/src/test/java/com/cloud/template/HypervisorTemplateAdapterTest.java
@@ -526,13 +526,13 @@ public class HypervisorTemplateAdapterTest {
     @Test
     public void isZoneAndImageStoreAvailableTestTemplateIsPrivateAndItIsNotAlreadyAllocatedToTheSameZoneShouldReturnTrue() {
         DataStore dataStoreMock = Mockito.mock(DataStore.class);
-        ImageStoreVO ImageStoreVOMock = Mockito.mock(ImageStoreVO.class);
+        ImageStoreVO imageStoreVoMock = Mockito.mock(ImageStoreVO.class);
         Long zoneId = 1L;
         Set<Long> zoneSet = new HashSet<>();
         boolean isTemplatePrivate = true;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
 
-        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(ImageStoreVOMock);
+        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(imageStoreVoMock);
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);


### PR DESCRIPTION
### Description

When a Secondary Storage is marked as read-only, download of new templates is still performed in it. This behavior has been fixed, making it so that read-only storages are ignored during the template download process.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I put a secondary in the zone in the read-only state and verified that it no longer would be selected for the download.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
