### PR TITLE
Linstor: fix create volume from snapshot on primary storage

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -153,7 +153,8 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         // CAN_CREATE_VOLUME_FROM_SNAPSHOT see note from CAN_CREATE_VOLUME_FROM_VOLUME
         mapCapabilities.put(DataStoreCapabilities.CAN_CREATE_VOLUME_FROM_SNAPSHOT.toString(), Boolean.TRUE.toString());
         mapCapabilities.put(DataStoreCapabilities.CAN_REVERT_VOLUME_TO_SNAPSHOT.toString(), Boolean.TRUE.toString());
-        mapCapabilities.put(DataStoreCapabilities.CAN_CREATE_TEMPLATE_FROM_SNAPSHOT.toString(), Boolean.TRUE.toString());
+        mapCapabilities.put(DataStoreCapabilities.CAN_CREATE_TEMPLATE_FROM_SNAPSHOT.toString(),
+            Boolean.toString(system_snapshot));
 
         return mapCapabilities;
     }

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -778,24 +778,15 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
     }
 
     private CopyCommandResult copySnapshotToVolume(SnapshotInfo snapshotInfo, VolumeInfo volumeInfo) {
-        String errMsg = null;
-        CopyCmdAnswer answer = null;
-        try {
-            StoragePoolVO storagePoolVO = _storagePoolDao.findById(snapshotInfo.getDataStore().getId());
-            String rscName = LinstorUtil.RSC_PREFIX + volumeInfo.getUuid();
-            createResourceFromSnapshot(snapshotInfo.getId(), rscName, storagePoolVO);
+        StoragePoolVO storagePoolVO = _storagePoolDao.findById(snapshotInfo.getDataStore().getId());
+        String rscName = LinstorUtil.RSC_PREFIX + volumeInfo.getUuid();
+        createResourceFromSnapshot(snapshotInfo.getId(), rscName, storagePoolVO);
 
-            VolumeObjectTO volumeTO = (VolumeObjectTO) volumeInfo.getTO();
-            volumeTO.setPath(volumeInfo.getUuid());
-            volumeTO.setSize(volumeInfo.getSize());
-            answer = new CopyCmdAnswer(volumeTO);
-        } catch (Exception e) {
-            errMsg = "Failed to create volume from snapshot: " + e.getMessage();
-            logger.error(errMsg, e);
-        }
-        CopyCommandResult result = new CopyCommandResult(null, answer);
-        result.setResult(errMsg);
-        return result;
+        VolumeObjectTO volumeTO = (VolumeObjectTO) volumeInfo.getTO();
+        volumeTO.setPath(volumeInfo.getUuid());
+        volumeTO.setSize(volumeInfo.getSize());
+
+        return new CopyCommandResult(null, new CopyCmdAnswer(volumeTO));
     }
 
     @Override

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -153,6 +153,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         // CAN_CREATE_VOLUME_FROM_SNAPSHOT see note from CAN_CREATE_VOLUME_FROM_VOLUME
         mapCapabilities.put(DataStoreCapabilities.CAN_CREATE_VOLUME_FROM_SNAPSHOT.toString(), Boolean.TRUE.toString());
         mapCapabilities.put(DataStoreCapabilities.CAN_REVERT_VOLUME_TO_SNAPSHOT.toString(), Boolean.TRUE.toString());
+        mapCapabilities.put(DataStoreCapabilities.CAN_CREATE_TEMPLATE_FROM_SNAPSHOT.toString(), Boolean.TRUE.toString());
 
         return mapCapabilities;
     }
@@ -720,6 +721,13 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         }
     }
 
+    private static boolean canCopySnapshotToVolumeCond(DataObject srcData, DataObject dstData) {
+        return srcData.getType() == DataObjectType.SNAPSHOT && dstData.getType() == DataObjectType.VOLUME
+            && srcData.getDataStore().getRole() == DataStoreRole.Primary
+            && dstData.getDataStore().getRole() == DataStoreRole.Primary
+            && srcData.getDataStore().getId() == dstData.getDataStore().getId();
+    }
+
     private static boolean canCopySnapshotCond(DataObject srcData, DataObject dstData) {
         return srcData.getType() == DataObjectType.SNAPSHOT && dstData.getType() == DataObjectType.SNAPSHOT
             && (dstData.getDataStore().getRole() == DataStoreRole.Image
@@ -747,7 +755,10 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
     {
         logger.debug("LinstorPrimaryDataStoreDriverImpl.canCopy: " + srcData.getType() + " -> " + dstData.getType());
 
-        if (canCopySnapshotCond(srcData, dstData)) {
+        if (canCopySnapshotToVolumeCond(srcData, dstData)) {
+            StoragePoolVO storagePool = _storagePoolDao.findById(srcData.getDataStore().getId());
+            return storagePool.getStorageProviderName().equals(LinstorUtil.PROVIDER_NAME);
+        } else if (canCopySnapshotCond(srcData, dstData)) {
             SnapshotInfo sinfo = (SnapshotInfo) srcData;
             VolumeInfo volume = sinfo.getBaseVolume();
             StoragePoolVO storagePool = _storagePoolDao.findById(volume.getPoolId());
@@ -766,6 +777,27 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         return false;
     }
 
+    private CopyCommandResult copySnapshotToVolume(SnapshotInfo snapshotInfo, VolumeInfo volumeInfo) {
+        String errMsg = null;
+        CopyCmdAnswer answer = null;
+        try {
+            StoragePoolVO storagePoolVO = _storagePoolDao.findById(snapshotInfo.getDataStore().getId());
+            String rscName = LinstorUtil.RSC_PREFIX + volumeInfo.getUuid();
+            createResourceFromSnapshot(snapshotInfo.getId(), rscName, storagePoolVO);
+
+            VolumeObjectTO volumeTO = (VolumeObjectTO) volumeInfo.getTO();
+            volumeTO.setPath(volumeInfo.getUuid());
+            volumeTO.setSize(volumeInfo.getSize());
+            answer = new CopyCmdAnswer(volumeTO);
+        } catch (Exception e) {
+            errMsg = "Failed to create volume from snapshot: " + e.getMessage();
+            logger.error(errMsg, e);
+        }
+        CopyCommandResult result = new CopyCommandResult(null, answer);
+        result.setResult(errMsg);
+        return result;
+    }
+
     @Override
     public void copyAsync(DataObject srcData, DataObject dstData, AsyncCompletionCallback<CopyCommandResult> callback)
     {
@@ -773,7 +805,9 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             + srcData.getType() + " -> " + dstData.getType());
 
         final CopyCommandResult res;
-        if (canCopySnapshotCond(srcData, dstData)) {
+        if (canCopySnapshotToVolumeCond(srcData, dstData)) {
+            res = copySnapshotToVolume((SnapshotInfo) srcData, (VolumeInfo) dstData);
+        } else if (canCopySnapshotCond(srcData, dstData)) {
             String errMsg = null;
             Answer answer = copySnapshot(srcData, dstData);
             if (answer != null && !answer.getResult()) {

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImplTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImplTest.java
@@ -25,13 +25,24 @@ import com.linbit.linstor.api.model.ResourceGroup;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import com.cloud.agent.api.to.DataObjectType;
+import com.cloud.storage.DataStoreRole;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreCapabilities;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.datastore.util.LinstorUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.mock;
@@ -41,6 +52,9 @@ import static org.mockito.Mockito.when;
 public class LinstorPrimaryDataStoreDriverImplTest {
 
     private DevelopersApi api;
+
+    @Mock
+    private PrimaryDataStoreDao _storagePoolDao;
 
     @InjectMocks
     private LinstorPrimaryDataStoreDriverImpl linstorPrimaryDataStoreDriver;
@@ -84,5 +98,99 @@ public class LinstorPrimaryDataStoreDriverImplTest {
 
         layers = LinstorUtil.getEncryptedLayerList(api, "EncryptedGrp");
         Assert.assertEquals(Arrays.asList(LayerType.DRBD, LayerType.LUKS, LayerType.STORAGE), layers);
+    }
+
+    @Test
+    public void testGetCapabilitiesIncludesCreateTemplateFromSnapshot() {
+        Map<String, String> caps = linstorPrimaryDataStoreDriver.getCapabilities();
+
+        Assert.assertTrue("Linstor should advertise CAN_CREATE_TEMPLATE_FROM_SNAPSHOT",
+                Boolean.parseBoolean(caps.get(DataStoreCapabilities.CAN_CREATE_TEMPLATE_FROM_SNAPSHOT.toString())));
+    }
+
+    @Test
+    public void testCanCopySnapshotToVolumeOnSamePrimary() {
+        DataStore primaryStore = mock(DataStore.class);
+        when(primaryStore.getRole()).thenReturn(DataStoreRole.Primary);
+        when(primaryStore.getId()).thenReturn(1L);
+
+        SnapshotInfo snapshot = mock(SnapshotInfo.class);
+        when(snapshot.getType()).thenReturn(DataObjectType.SNAPSHOT);
+        when(snapshot.getDataStore()).thenReturn(primaryStore);
+
+        VolumeInfo volume = mock(VolumeInfo.class);
+        when(volume.getType()).thenReturn(DataObjectType.VOLUME);
+        when(volume.getDataStore()).thenReturn(primaryStore);
+
+        StoragePoolVO pool = mock(StoragePoolVO.class);
+        when(pool.getStorageProviderName()).thenReturn(LinstorUtil.PROVIDER_NAME);
+        when(_storagePoolDao.findById(1L)).thenReturn(pool);
+
+        Assert.assertTrue("canCopy should return true for SNAPSHOT -> VOLUME on same Linstor primary",
+                linstorPrimaryDataStoreDriver.canCopy(snapshot, volume));
+    }
+
+    @Test
+    public void testCanCopySnapshotToVolumeRejectsNonLinstor() {
+        DataStore primaryStore = mock(DataStore.class);
+        when(primaryStore.getRole()).thenReturn(DataStoreRole.Primary);
+        when(primaryStore.getId()).thenReturn(1L);
+
+        SnapshotInfo snapshot = mock(SnapshotInfo.class);
+        when(snapshot.getType()).thenReturn(DataObjectType.SNAPSHOT);
+        when(snapshot.getDataStore()).thenReturn(primaryStore);
+
+        VolumeInfo volume = mock(VolumeInfo.class);
+        when(volume.getType()).thenReturn(DataObjectType.VOLUME);
+        when(volume.getDataStore()).thenReturn(primaryStore);
+
+        StoragePoolVO pool = mock(StoragePoolVO.class);
+        when(pool.getStorageProviderName()).thenReturn("SomeOtherProvider");
+        when(_storagePoolDao.findById(1L)).thenReturn(pool);
+
+        Assert.assertFalse("canCopy should return false for non-Linstor storage",
+                linstorPrimaryDataStoreDriver.canCopy(snapshot, volume));
+    }
+
+    @Test
+    public void testCanCopySnapshotToVolumeRejectsCrossPrimary() {
+        DataStore srcStore = mock(DataStore.class);
+        when(srcStore.getRole()).thenReturn(DataStoreRole.Primary);
+        when(srcStore.getId()).thenReturn(1L);
+
+        DataStore destStore = mock(DataStore.class);
+        when(destStore.getRole()).thenReturn(DataStoreRole.Primary);
+        when(destStore.getId()).thenReturn(2L);
+
+        SnapshotInfo snapshot = mock(SnapshotInfo.class);
+        when(snapshot.getType()).thenReturn(DataObjectType.SNAPSHOT);
+        when(snapshot.getDataStore()).thenReturn(srcStore);
+
+        VolumeInfo volume = mock(VolumeInfo.class);
+        when(volume.getType()).thenReturn(DataObjectType.VOLUME);
+        when(volume.getDataStore()).thenReturn(destStore);
+
+        Assert.assertFalse("canCopy should return false for SNAPSHOT -> VOLUME across different primary stores",
+                linstorPrimaryDataStoreDriver.canCopy(snapshot, volume));
+    }
+
+    @Test
+    public void testCanCopySnapshotToVolumeRejectsImageDest() {
+        DataStore primaryStore = mock(DataStore.class);
+        when(primaryStore.getRole()).thenReturn(DataStoreRole.Primary);
+
+        DataStore imageStore = mock(DataStore.class);
+        when(imageStore.getRole()).thenReturn(DataStoreRole.Image);
+
+        SnapshotInfo snapshot = mock(SnapshotInfo.class);
+        when(snapshot.getType()).thenReturn(DataObjectType.SNAPSHOT);
+        when(snapshot.getDataStore()).thenReturn(primaryStore);
+
+        VolumeInfo volume = mock(VolumeInfo.class);
+        when(volume.getType()).thenReturn(DataObjectType.VOLUME);
+        when(volume.getDataStore()).thenReturn(imageStore);
+
+        Assert.assertFalse("canCopy should return false when destination is Image store",
+                linstorPrimaryDataStoreDriver.canCopy(snapshot, volume));
     }
 }

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImplTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImplTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 import com.cloud.agent.api.to.DataObjectType;
 import com.cloud.storage.DataStoreRole;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreCapabilities;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
@@ -101,11 +100,13 @@ public class LinstorPrimaryDataStoreDriverImplTest {
     }
 
     @Test
-    public void testGetCapabilitiesIncludesCreateTemplateFromSnapshot() {
+    public void testGetCapabilitiesIncludesCreateTemplateFromSnapshotMatchesSystemSnapshot() {
         Map<String, String> caps = linstorPrimaryDataStoreDriver.getCapabilities();
 
-        Assert.assertTrue("Linstor should advertise CAN_CREATE_TEMPLATE_FROM_SNAPSHOT",
-                Boolean.parseBoolean(caps.get(DataStoreCapabilities.CAN_CREATE_TEMPLATE_FROM_SNAPSHOT.toString())));
+        Assert.assertEquals(
+                "CAN_CREATE_TEMPLATE_FROM_SNAPSHOT should match STORAGE_SYSTEM_SNAPSHOT",
+                caps.get(DataStoreCapabilities.STORAGE_SYSTEM_SNAPSHOT.toString()),
+                caps.get(DataStoreCapabilities.CAN_CREATE_TEMPLATE_FROM_SNAPSHOT.toString()));
     }
 
     @Test


### PR DESCRIPTION
### Context

I run a private cloud using 4.22 CloudStack, with Linstor primary storage, Kubernetes, CloudStack CSI driver with additional `registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1` sidecar and `snapshot-controller`. 

I wanted to duplicate PVC from kubectl, by creating a snapshot and restoring another PVC from the snapshot. The main problem is that the snapshot wanted to be copied to SecondaryStorage, which is not what I wanted. Secondary storage is slow and outside of the network, so transferring 1TB volume is long and silly. I got a chain of errors, identified those, and prepared a patch that solved my issues. I built and pushed only `cloud-plugin-storage-volume-linstor-4.22.0.0.jar` to my servers, and after restarting both management / agent services, the PVC copy via snapshots worked fine. Also I modified the following cloudstack settings:

| Setting | Value   | Was     | Purpose                       |
|--------------------------------|---------|---------|----------------------------------------------------------|
| kvm.snapshot.enabled           | true    | false   | Allow snapshots on running KVM VMs                       |
| snapshot.backup.to.secondary   | false   | true    | Skip secondary storage backup for  snapshots              |
| lin.backup.snapshots           | false   | false   | Linstor-specific: keep snapshots on  primary storage only |


### Description

When creating a volume from a snapshot on Linstor primary storage (with `lin.backup.snapshots=false`), the operation fails with:

> Only the following image types are currently supported: VHD, OVA, QCOW2, RAW (for PowerFlex and FiberChannel)

**Root cause:** The Linstor driver does not handle SNAPSHOT → VOLUME in its `canCopy()`/`copyAsync()` methods. This causes `DataMotionServiceImpl` to fall through to `StorageSystemDataMotionStrategy` (selected because Linstor advertises `STORAGE_SYSTEM_SNAPSHOT=true`). That strategy's `verifyFormatWithPoolType()` rejects RAW format for Linstor pools, since RAW is only allowed for PowerFlex and FiberChannel.

Additionally, `VolumeOrchestrator.createVolumeFromSnapshot()` attempts to back up the snapshot to secondary storage when the storage plugin does not advertise `CAN_CREATE_TEMPLATE_FROM_SNAPSHOT`. This backup fails because the snapshot only exists on Linstor primary storage.

**Fix:**

- Add `CAN_CREATE_TEMPLATE_FROM_SNAPSHOT` capability so the orchestrator skips the backup-to-secondary path
- Add `canCopySnapshotToVolumeCond()` to match SNAPSHOT → VOLUME when both are on the same Linstor primary store
- Wire it into `canCopy()` to intercept at `DataMotionServiceImpl` before strategy selection, bypassing `StorageSystemDataMotionStrategy` entirely
- Implement `copySnapshotToVolume()` which delegates to the existing `createResourceFromSnapshot()` for native Linstor snapshot restore

This follows the same pattern used by the StorPool plugin, which handles SNAPSHOT → VOLUME directly in its driver rather than going through `StorageSystemDataMotionStrategy`.

Fixes: #11451

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

**Unit tests:** 5 new tests added to `LinstorPrimaryDataStoreDriverImplTest`:
- `testGetCapabilitiesIncludesCreateTemplateFromSnapshot` — verifies the capability is advertised
- `testCanCopySnapshotToVolumeOnSamePrimary` — verifies `canCopy()` returns true for SNAPSHOT → VOLUME on same Linstor primary
- `testCanCopySnapshotToVolumeRejectsNonLinstor` — verifies `canCopy()` returns false for non-Linstor storage
- `testCanCopySnapshotToVolumeRejectsCrossPrimary` — verifies `canCopy()` returns false across different primary stores
- `testCanCopySnapshotToVolumeRejectsImageDest` — verifies `canCopy()` returns false when destination is Image store

**Integration test:** Tested on CloudStack 4.22 with Linstor LVM_THIN storage (DRBD-replicated across 3 nodes), creating a volume from a 1TB CNPG Postgres database snapshot via `createVolume` API:
- Volume creates successfully with state=Ready and correct UUID path
- Volume deletes cleanly (both CloudStack DB and Linstor resource)
- Linstor resource is properly created via native snapshot restore (`resourceSnapshotRestore` API)

#### How did you try to break this feature and the system with this change?

- Verified that the existing `canCopy()` paths (SNAPSHOT→SNAPSHOT to Image, TEMPLATE→TEMPLATE, VOLUME→VOLUME/TEMPLATE) are not affected by the new condition being checked first
- Verified cross-primary-store and non-Linstor scenarios are rejected
- Verified volume path is stored as UUID (not device path) to ensure delete operations work correctly
- The change is confined to the Linstor plugin — no modifications to shared CloudStack code