### PR TITLE
Fix/flasharray delete rename destroy patch conflict

### DIFF
--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -200,9 +200,30 @@ public class FlashArrayAdapter implements ProviderAdapter {
 
     @Override
     public void delete(ProviderAdapterContext context, ProviderAdapterDataObject dataObject) {
+        String fullName = normalizeName(pod, dataObject.getExternalName());
+
+        // Snapshots live under /volume-snapshots and have the reserved form
+        // <volume>.<suffix>: the FlashArray rejects renames to any name that
+        // includes '.' or is not pure alphanumeric+'_'+'-', so we cannot
+        // tag them with a timestamp on the way out. Just mark them destroyed.
+        if (dataObject.getType() == ProviderAdapterDataObject.Type.SNAPSHOT) {
+            try {
+                FlashArrayVolume destroy = new FlashArrayVolume();
+                destroy.setDestroyed(true);
+                PATCH("/volume-snapshots?names=" + fullName, destroy, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
+                });
+            } catch (CloudRuntimeException e) {
+                if (e.toString().contains("No such volume or snapshot")
+                        || e.toString().contains("Volume does not exist")) {
+                    return;
+                }
+                throw e;
+            }
+            return;
+        }
+
         // first make sure we are disconnected
         removeVlunsAll(context, pod, dataObject.getExternalName());
-        String fullName = normalizeName(pod, dataObject.getExternalName());
 
         // Rename then destroy: FlashArray keeps destroyed volumes in a recycle
         // bin (default 24h) from which they can be recovered. Renaming with a

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -204,21 +204,25 @@ public class FlashArrayAdapter implements ProviderAdapter {
         removeVlunsAll(context, pod, dataObject.getExternalName());
         String fullName = normalizeName(pod, dataObject.getExternalName());
 
-        FlashArrayVolume volume = new FlashArrayVolume();
-
-        // rename as we delete so it doesn't conflict if the template or volume is ever recreated
-        // pure keeps the volume(s) around in a Destroyed bucket for a period of time post delete
+        // Rename then destroy: FlashArray keeps destroyed volumes in a recycle
+        // bin (default 24h) from which they can be recovered. Renaming with a
+        // deletion timestamp gives operators a forensic trail when browsing the
+        // array - they can see when each destroyed copy was deleted on the
+        // CloudStack side. FlashArray rejects a single PATCH that combines
+        // {name, destroyed}, so the rename and the destroy must be issued as
+        // two separate requests each carrying only its own field.
         String timestamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new java.util.Date());
-        volume.setExternalName(fullName + "-" + timestamp);
+        String renamedName = fullName + "-" + timestamp;
 
         try {
-            PATCH("/volumes?names=" + fullName, volume, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
+            FlashArrayVolume rename = new FlashArrayVolume();
+            rename.setExternalName(renamedName);
+            PATCH("/volumes?names=" + fullName, rename, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
             });
 
-            // now delete it with new name
-            volume.setDestroyed(true);
-
-            PATCH("/volumes?names=" + fullName + "-" + timestamp, volume, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
+            FlashArrayVolume destroy = new FlashArrayVolume();
+            destroy.setDestroyed(true);
+            PATCH("/volumes?names=" + renamedName, destroy, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
             });
         } catch (CloudRuntimeException e) {
             if (e.toString().contains("Volume does not exist")) {

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -206,14 +206,14 @@ public class FlashArrayAdapter implements ProviderAdapter {
     public void delete(ProviderAdapterContext context, ProviderAdapterDataObject dataObject) {
         String fullName = normalizeName(pod, dataObject.getExternalName());
 
-        // Snapshots live under /volume-snapshots and already use the
-        // reserved form <volume>.<suffix>. FlashArray volume/snapshot names
-        // must match [A-Za-z0-9_-] and start/end with an alphanumeric, so
-        // appending our usual deletion-timestamp suffix to a snapshot name
-        // would produce a target like "<vol>.<n>-<ts>" - the embedded "."
-        // is rejected by the array. We therefore skip the rename for
-        // snapshots and only mark them destroyed; the array's own ".N"
-        // suffix already disambiguates them in the recycle bin.
+        // Snapshots live under /volume-snapshots and already use the array's
+        // reserved form <volume>.<suffix>, which legitimately contains ".".
+        // The stricter [A-Za-z0-9_-] naming rule applies to regular volume
+        // names and free-form rename targets, not to these reserved snapshot
+        // names. Since FlashArray snapshot names are system-defined rather
+        // than arbitrary rename targets, we skip the usual timestamped rename
+        // and only mark snapshots destroyed; the array's own ".N" suffix
+        // already disambiguates them in the recycle bin.
         if (dataObject.getType() == ProviderAdapterDataObject.Type.SNAPSHOT) {
             try {
                 FlashArrayVolume destroy = new FlashArrayVolume();

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -23,7 +23,8 @@ import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -88,6 +89,9 @@ public class FlashArrayAdapter implements ProviderAdapter {
     static final ObjectMapper mapper = new ObjectMapper();
     public String pod = null;
     public String hostgroup = null;
+    private static final DateTimeFormatter DELETION_TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneOffset.UTC);
+
     private String username;
     private String password;
     private String accessToken;
@@ -202,11 +206,14 @@ public class FlashArrayAdapter implements ProviderAdapter {
     public void delete(ProviderAdapterContext context, ProviderAdapterDataObject dataObject) {
         String fullName = normalizeName(pod, dataObject.getExternalName());
 
-        // Snapshots live under /volume-snapshots and already use the reserved
-        // form <volume>.<suffix>. FlashArray snapshot rename constraints do
-        // not let us rename them to an arbitrary timestamp-suffixed name
-        // before deletion, so unlike volumes we skip rename and only mark
-        // them destroyed.
+        // Snapshots live under /volume-snapshots and already use the
+        // reserved form <volume>.<suffix>. FlashArray volume/snapshot names
+        // must match [A-Za-z0-9_-] and start/end with an alphanumeric, so
+        // appending our usual deletion-timestamp suffix to a snapshot name
+        // would produce a target like "<vol>.<n>-<ts>" - the embedded "."
+        // is rejected by the array. We therefore skip the rename for
+        // snapshots and only mark them destroyed; the array's own ".N"
+        // suffix already disambiguates them in the recycle bin.
         if (dataObject.getType() == ProviderAdapterDataObject.Type.SNAPSHOT) {
             try {
                 FlashArrayVolume destroy = new FlashArrayVolume();
@@ -214,8 +221,9 @@ public class FlashArrayAdapter implements ProviderAdapter {
                 PATCH("/volume-snapshots?names=" + fullName, destroy, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
                 });
             } catch (CloudRuntimeException e) {
-                if (e.toString().contains("No such volume or snapshot")
-                        || e.toString().contains("Volume does not exist")) {
+                String msg = e.getMessage();
+                if (msg != null && (msg.contains("No such volume or snapshot")
+                        || msg.contains("Volume does not exist"))) {
                     return;
                 }
                 throw e;
@@ -233,7 +241,11 @@ public class FlashArrayAdapter implements ProviderAdapter {
         // CloudStack side. FlashArray rejects a single PATCH that combines
         // {name, destroyed}, so the rename and the destroy must be issued as
         // two separate requests each carrying only its own field.
-        String timestamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new java.util.Date());
+        // Use UTC so the rename suffix is stable regardless of the management
+        // server's local timezone or DST changes - operators correlating the
+        // CloudStack delete event with the array's audit log get a consistent
+        // wall-clock value.
+        String timestamp = DELETION_TIMESTAMP_FORMAT.format(java.time.Instant.now());
         String renamedName = fullName + "-" + timestamp;
 
         try {
@@ -247,7 +259,8 @@ public class FlashArrayAdapter implements ProviderAdapter {
             PATCH("/volumes?names=" + renamedName, destroy, new TypeReference<FlashArrayList<FlashArrayVolume>>() {
             });
         } catch (CloudRuntimeException e) {
-            if (e.toString().contains("Volume does not exist")) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("Volume does not exist")) {
                 return;
             } else {
                 throw e;

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -202,10 +202,11 @@ public class FlashArrayAdapter implements ProviderAdapter {
     public void delete(ProviderAdapterContext context, ProviderAdapterDataObject dataObject) {
         String fullName = normalizeName(pod, dataObject.getExternalName());
 
-        // Snapshots live under /volume-snapshots and have the reserved form
-        // <volume>.<suffix>: the FlashArray rejects renames to any name that
-        // includes '.' or is not pure alphanumeric+'_'+'-', so we cannot
-        // tag them with a timestamp on the way out. Just mark them destroyed.
+        // Snapshots live under /volume-snapshots and already use the reserved
+        // form <volume>.<suffix>. FlashArray snapshot rename constraints do
+        // not let us rename them to an arbitrary timestamp-suffixed name
+        // before deletion, so unlike volumes we skip rename and only mark
+        // them destroyed.
         if (dataObject.getType() == ProviderAdapterDataObject.Type.SNAPSHOT) {
             try {
                 FlashArrayVolume destroy = new FlashArrayVolume();


### PR DESCRIPTION
### Description

This PR fixes two independent bugs in `FlashArrayAdapter.delete()`, the adapter method the adaptive storage driver calls whenever CloudStack deletes a volume or a snapshot on a Pure Storage FlashArray primary pool. On Purity 6.x both paths currently fail, leaving objects leaked on the array and CloudStack DB rows stuck in `Destroy` state with no clean recovery via the UI.

#### Bug 1 — Volume delete: `{name, destroyed}` PATCH rejected

The current code builds a single `FlashArrayVolume` object, then issues two PATCH requests against it: first to rename the volume with a timestamp suffix (so an operator browsing the array's 24 h recycle bin can see when each copy was deleted), then to mark it `destroyed: true`. The second PATCH reuses the same object, which still has the new name set, so the request body carries **both** `name` and `destroyed`. Purity rejects the combined body:

```
400 Bad Request
Invalid combination of parameters specified.
```

The first PATCH succeeds (volume renamed), the second fails. Net result: the volume leaks on the array (never reaches the destroyed bucket) and the CloudStack `volumes` row stays in `Destroy` forever.

**Expected behaviour**: `cmk delete volume id=<id>` returns success; the array shows the volume with `destroyed=true`, `time_remaining≈24h`; the CloudStack row is `Expunged`.
**Actual behaviour (before this PR)**: the async job fails with `Invalid combination of parameters specified`; the array shows the volume renamed with a `-<timestamp>` suffix but `destroyed=false`; the CloudStack row stays in `Destroy` and `removed` is never set.

**Fix**: keep the rename (it's an operator-visible forensic trail that is genuinely useful when recovering from accidental deletes), but issue the two operations as two separate PATCH requests, each body carrying only its own field. No behaviour change from the user's point of view on a successful delete.

**Repro**: on a cluster with a FlashArray adaptive primary pool, `cmk delete volume id=<id>` on any volume that has been provisioned on the array.

#### Bug 2 — Snapshot delete: wrong endpoint and invalid rename

The same `delete()` method is called by the snapshot service (`SnapshotServiceImpl.deleteSnapshot` → `AdaptiveDataStoreDriverImpl.deleteAsync` → `api.delete(context, inData)`), but the adapter has no special handling when `dataObject.getType()` is `SNAPSHOT`. Two problems compound:

- FlashArray snapshots live at `/volume-snapshots`, not `/volumes`. The PATCH hits the wrong endpoint.
- The rename computes `<snapshot_name>-<timestamp>`. FlashArray snapshot names have the reserved form `<volume>.<suffix>`, so the new name becomes e.g. `cloudstack::vol-2-1-2-192.1-20260420214120` — which contains a literal `.`. The array rejects the rename:

  > Volume name must be between 1 and 63 characters (alphanumeric, `_` and `-`), begin and end with a letter or number, and include at least one letter, `_`, or `-`.

**Expected behaviour**: `cmk delete snapshot id=<id>` returns success; the array shows the snapshot `destroyed=true` with a 24 h recycle window; the CloudStack row is `Destroyed`.
**Actual behaviour (before this PR)**: the async job fails with a 400 from the array; the snapshot leaks on both sides.

**Fix**: branch early in `delete()` when the data object is a `SNAPSHOT`. Issue a single PATCH to `/volume-snapshots?names=<name>` with body `{ destroyed: true }` on the original name. No rename — Pure assigns the `.<suffix>` portion itself and rejects any freely-appended text. Recovery via `purevol recover` still works within the 24 h window.

<!-- Fixes: # -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

Deletes of every array-backed volume and snapshot on the FlashArray plugin fail, silently leaking space on the array and leaving stuck CloudStack DB rows. The pool otherwise works (create/attach/detach/snapshot/revert all succeed), so the bug is not a BLOCKER, but it fully breaks the lifecycle end state of any object that goes through the plugin.

### Screenshots (if appropriate):

N/A — backend adapter changes, no UI surface.

### How Has This Been Tested?

Tested manually against a two-node KVM cluster on CloudStack 4.22 with a Pure Storage FlashArray (Purity 6.7) primary pool registered via the adaptive/flasharray plugin. The plugin was patched in-place with the classes built from this branch and the management server restarted before each test.

**Commit 1 — volume delete**
1. `cmk create volume name=<n> diskofferingid=<pool-tagged>`
2. `cmk attach volume id=<v> virtualmachineid=<vm>` — forces provisioning on the array
3. `cmk detach volume id=<v>`
4. `cmk delete volume id=<v>`

Verified: delete returns `success: true`; the array shows `cloudstack::vol-2-1-2-N-<timestamp>` with `destroyed=true`, `time_remaining=86400000`; CloudStack `volumes.state=Expunged` with `removed` set.

**Commit 2 — snapshot delete**
1. `cmk create snapshot volumeid=<v> name=<s>`
2. `cmk delete snapshot id=<s>`

Verified: delete returns `success: true`; the array shows `cloudstack::vol-2-1-2-N.1` with `destroyed=true`, `time_remaining=86400000`; CloudStack `snapshots.status=Destroyed`.

**Regression coverage on adjacent paths**: create, attach, snapshot, revert, detach, re-attach, re-delete all continue to work end-to-end. Full attach/detach cycle across both commits: disk formatted as XFS, file written, volume detached, re-attached, filesystem UUID and contents preserved.

**Build**: `mvn -pl plugins/storage/volume/flasharray --also-make -am -DskipTests -Dcheckstyle.skip=false --batch-mode package` passes with checkstyle enabled.

No unit tests exist for `FlashArrayAdapter`; the class is built entirely around the Purity REST API and would require substantial HTTP-level mocking to cover meaningfully. Happy to add integration-style tests in a follow-up if the reviewers want them.

#### How did you try to break this feature and the system with this change?

- **Delete a volume that is still attached to a VM**: CloudStack refuses the request before `delete()` is reached, as expected.
- **Delete a volume twice**: first call succeeds; second call sees `Volume does not exist` from the array, caught by the existing exception handler, no error surfaced. Verified both commits preserve this behaviour.
- **Delete a snapshot whose parent volume has already been destroyed**: snapshot delete still succeeds via `/volume-snapshots` — the snapshot is an independent object in Purity until the retention window expires.
- **Delete a snapshot twice**: first call succeeds; second call returns `No such volume or snapshot`, caught by the new exception handler in the snapshot branch, no error surfaced.
- **Delete during maintenance / while the CS pool is in maintenance mode**: CloudStack gates the API call at a higher layer; the adapter is never reached. Not affected by this change.
- **Race with revert**: snapshot revert holds a reference to the snapshot on the array; the revert operation completes first, and the subsequent delete then operates on a non-live snapshot. Verified with `cmk revert snapshot` immediately followed by `cmk delete snapshot`.
- **Build with checkstyle enabled**: passes. No new warnings introduced.

