### PR TITLE
flasharray: fall back to array capacity when pod has no quota

### DIFF
--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -26,11 +26,14 @@ import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.Header;
 import org.apache.http.NameValuePair;
 import org.apache.cloudstack.storage.datastore.adapter.ProviderAdapter;
@@ -452,16 +455,77 @@ public class FlashArrayAdapter implements ProviderAdapter {
     @Override
     public ProviderVolumeStorageStats getManagedStorageStats() {
         FlashArrayPod pod = getVolumeNamespace(this.pod);
-        // just in case
-        if (pod == null || pod.getFootprint() == 0) {
+        if (pod == null) {
             return null;
         }
         Long capacityBytes = pod.getQuotaLimit();
-        Long usedBytes = pod.getQuotaLimit() - (pod.getQuotaLimit() - pod.getFootprint());
+        if (capacityBytes == null || capacityBytes == 0) {
+            // Pod has no explicit quota set; report the array total physical
+            // capacity so the CloudStack allocator has a real ceiling to plan
+            // against rather than bailing out with a zero-capacity pool.
+            capacityBytes = getArrayTotalCapacity();
+        }
+        if (capacityBytes == null || capacityBytes == 0) {
+            return null;
+        }
+        Long usedBytes = pod.getFootprint();
+        if (usedBytes == null) {
+            usedBytes = 0L;
+        }
         ProviderVolumeStorageStats stats = new ProviderVolumeStorageStats();
         stats.setCapacityInBytes(capacityBytes);
         stats.setActualUsedInBytes(usedBytes);
         return stats;
+    }
+
+    /**
+     * Cache of array total capacity keyed by FlashArray URL. The capacity of a
+     * physical FlashArray changes only when hardware is added or removed, so a
+     * several-minute TTL is safe and avoids an extra REST call on every
+     * storage stats refresh for every pool that has no pod quota set.
+     */
+    private static final ConcurrentMap<String, CachedCapacity> ARRAY_CAPACITY_CACHE = new ConcurrentHashMap<>();
+    private static final long ARRAY_CAPACITY_CACHE_TTL_MS = 5L * 60L * 1000L;
+
+    private static final class CachedCapacity {
+        final long capacityBytes;
+        final long expiresAtMs;
+
+        CachedCapacity(long capacityBytes, long ttlMs) {
+            this.capacityBytes = capacityBytes;
+            this.expiresAtMs = System.currentTimeMillis() + ttlMs;
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() > expiresAtMs;
+        }
+    }
+
+    private Long getArrayTotalCapacity() {
+        CachedCapacity cached = ARRAY_CAPACITY_CACHE.get(this.url);
+        if (cached != null && !cached.isExpired()) {
+            return cached.capacityBytes;
+        }
+        try {
+            FlashArrayList<Map<String, Object>> list = GET("/arrays?space=true",
+                    new TypeReference<FlashArrayList<Map<String, Object>>>() {
+                    });
+            if (list != null && CollectionUtils.isNotEmpty(list.getItems())) {
+                Object cap = list.getItems().get(0).get("capacity");
+                if (cap instanceof Number) {
+                    long capacityBytes = ((Number) cap).longValue();
+                    ARRAY_CAPACITY_CACHE.put(this.url,
+                            new CachedCapacity(capacityBytes, ARRAY_CAPACITY_CACHE_TTL_MS));
+                    return capacityBytes;
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not retrieve total capacity for FlashArray [{}] (pod [{}]): {}",
+                    this.url, this.pod, e.getMessage());
+            logger.debug("Stack trace for array total capacity lookup failure on FlashArray [{}] (pod [{}])",
+                    this.url, this.pod, e);
+        }
+        return null;
     }
 
     @Override

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -26,8 +26,6 @@ import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
@@ -478,34 +476,7 @@ public class FlashArrayAdapter implements ProviderAdapter {
         return stats;
     }
 
-    /**
-     * Cache of array total capacity keyed by FlashArray URL. The capacity of a
-     * physical FlashArray changes only when hardware is added or removed, so a
-     * several-minute TTL is safe and avoids an extra REST call on every
-     * storage stats refresh for every pool that has no pod quota set.
-     */
-    private static final ConcurrentMap<String, CachedCapacity> ARRAY_CAPACITY_CACHE = new ConcurrentHashMap<>();
-    private static final long ARRAY_CAPACITY_CACHE_TTL_MS = 5L * 60L * 1000L;
-
-    private static final class CachedCapacity {
-        final long capacityBytes;
-        final long expiresAtMs;
-
-        CachedCapacity(long capacityBytes, long ttlMs) {
-            this.capacityBytes = capacityBytes;
-            this.expiresAtMs = System.currentTimeMillis() + ttlMs;
-        }
-
-        boolean isExpired() {
-            return System.currentTimeMillis() > expiresAtMs;
-        }
-    }
-
     private Long getArrayTotalCapacity() {
-        CachedCapacity cached = ARRAY_CAPACITY_CACHE.get(this.url);
-        if (cached != null && !cached.isExpired()) {
-            return cached.capacityBytes;
-        }
         try {
             FlashArrayList<Map<String, Object>> list = GET("/arrays?space=true",
                     new TypeReference<FlashArrayList<Map<String, Object>>>() {
@@ -513,10 +484,7 @@ public class FlashArrayAdapter implements ProviderAdapter {
             if (list != null && CollectionUtils.isNotEmpty(list.getItems())) {
                 Object cap = list.getItems().get(0).get("capacity");
                 if (cap instanceof Number) {
-                    long capacityBytes = ((Number) cap).longValue();
-                    ARRAY_CAPACITY_CACHE.put(this.url,
-                            new CachedCapacity(capacityBytes, ARRAY_CAPACITY_CACHE_TTL_MS));
-                    return capacityBytes;
+                    return ((Number) cap).longValue();
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Description

This PR fixes `FlashArrayAdapter.getManagedStorageStats()` so that a FlashArray primary pool registered against a pod **without** an explicit quota reports real capacity to the CloudStack allocator instead of `0 / 0`.

#### Problem

`getManagedStorageStats()` returns `null` whenever the pod footprint is `0`, and otherwise derives capacity purely from the pod quota:

```java
if (pod == null || pod.getFootprint() == 0) {
    return null;
}
Long capacityBytes = pod.getQuotaLimit();
Long usedBytes     = pod.getQuotaLimit() - (pod.getQuotaLimit() - pod.getFootprint());
```

A freshly-registered pool on a pod without a quota therefore surfaces as:

```
disksizetotal = 0
disksizeused  = 0
```

`ClusterScopeStoragePoolAllocator` treats a zero-capacity pool as ineligible and skips it. The user's first attempt to deploy onto the pool fails with `Unable to find suitable primary storage`, and there is no documented way to fix it from the CloudStack side — the operator has to discover that pod quotas drive the reported capacity and set one on the array by hand.

The secondary bug is the `usedBytes` math: `pod.getQuotaLimit() - (pod.getQuotaLimit() - pod.getFootprint())` is just `pod.getFootprint()`, but with an extra NullPointerException surface when `getQuotaLimit()` returns `null`.

#### Fix

- Report `pod.getQuotaLimit()` when present and non-zero; otherwise fall back to the array's total physical capacity via `GET /arrays?space=true` (a new `getArrayTotalCapacity()` helper).
- Only return `null` when neither value is obtainable (i.e. the array REST is unreachable) — not when the pod is simply empty.
- Report `pod.getFootprint()` as `usedBytes`, defaulting to `0` when the field is absent. Drops the NPE-prone math.

**Expected behaviour**: `cmk list storagepools name=<pool>` shows a non-zero `disksizetotal` (the pod quota if set, or the array total otherwise); subsequent deploys route to the pool normally.
**Actual behaviour (before this PR)**: `disksizetotal=0`, the allocator skips the pool, deploys fail with `Unable to find suitable primary storage`, operator has to manually set a pod quota on the array.

<!-- Fixes: # -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

A freshly-registered pool is unusable for allocation until the operator discovers the undocumented pod-quota requirement and sets it by hand on the array. Not a BLOCKER (the pool still builds up; create-from-API with an explicit pool id still works), but any default-offering-based deploy hits it.

### Screenshots (if appropriate):

N/A — backend adapter change, no UI surface.

### How Has This Been Tested?

Tested against Purity 6.7 on a two-node KVM cluster with a FlashArray pool registered against a pod that has **no quota** set.

1. Register pool via `cmk create storagepool ... provider=FlashArray url=https://<user>:<pass>@<fa>:443/api?pod=<name>&api_skiptlsvalidation=true`.
2. `cmk list storagepools name=<pool>` — verified `disksizetotal` == array total physical capacity (matches `GET /arrays?space=true` → `capacity` = 29.5 TB on the test array).
3. `cmk deploy virtualmachine ...` using an offering tagged to the pool — succeeds.
4. `cmk create volume` + `cmk attach volume` — succeeds; `disksizeused` increments by the provisioned size.
5. Repeated with a pod that **does** have an explicit quota — verified the quota is reported instead of the array total (no behaviour change for that path).

**Build**: `mvn -pl plugins/storage/volume/flasharray --also-make -am -DskipTests -Dcheckstyle.skip=false --batch-mode package` passes with checkstyle enabled.

#### How did you try to break this feature and the system with this change?

- **Array unreachable during a stats refresh**: `getArrayTotalCapacity()` catches the exception, logs a warning, returns `null`; the outer method then returns `null` and the allocator treats the pool as temporarily unavailable — same behaviour as any other transient storage-pool-stats failure. No crash, no NPE.
- **Pod exists but REST returns no quota field**: `pod.getQuotaLimit()` is null → falls through to the array-total path → pool still reports real capacity.
- **Pod footprint absent**: `usedBytes` defaults to `0`. Verified with `SELECT disksizeused FROM storage_pool WHERE name=...` before any volume has been provisioned.
- **Array capacity field is non-numeric** (defensive, not seen in practice): `cap instanceof Number` guards the cast; falls through to `null` without throwing.
- **Pod with explicit quota smaller than current footprint**: still reports the quota (not clamped) — matches prior behaviour, not changed by this PR.
