### PR TITLE
Backport: Honour consoleproxy.session.timeout for noVNC console sessions

### DIFF
--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -36,15 +36,14 @@ import java.util.concurrent.Executor;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.jetty.websocket.api.Session;
 
 import com.cloud.utils.PropertiesUtil;
 import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpServer;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  *
@@ -82,7 +81,7 @@ public class ConsoleProxy {
     static boolean standaloneStart = false;
 
     static String encryptorPassword = "Dummy";
-    static final String[] skipProperties = new String[]{"certificate", "cacertificate", "keystore_password", "privatekey"};
+    static final String[] skipProperties = new String[] {"certificate", "cacertificate", "keystore_password", "privatekey"};
 
     static Set<String> allowedSessions = new HashSet<>();
 
@@ -93,11 +92,13 @@ public class ConsoleProxy {
     private static void configLog4j() {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         URL configUrl = loader.getResource("/conf/log4j-cloud.xml");
-        if (configUrl == null)
+        if (configUrl == null) {
             configUrl = ClassLoader.getSystemResource("log4j-cloud.xml");
+        }
 
-        if (configUrl == null)
+        if (configUrl == null) {
             configUrl = ClassLoader.getSystemResource("conf/log4j-cloud.xml");
+        }
 
         if (configUrl != null) {
             try {
@@ -114,7 +115,6 @@ public class ConsoleProxy {
             } catch (URISyntaxException e) {
                 System.out.println("Unable to convert log4j configuration Url to URI");
             }
-            // DOMConfigurator.configure(configUrl);
         } else {
             System.out.println("Configure log4j with default properties");
         }
@@ -122,20 +122,21 @@ public class ConsoleProxy {
 
     private static void configProxy(Properties conf) {
         LOGGER.info("Configure console proxy...");
-        for (Object key : conf.keySet()) {
-            LOGGER.info("Property " + (String)key + ": " + conf.getProperty((String)key));
-            if (!ArrayUtils.contains(skipProperties, key)) {
-                LOGGER.info("Property " + (String)key + ": " + conf.getProperty((String)key));
+        if (conf != null) {
+            for (Object key : conf.keySet()) {
+                if (!ArrayUtils.contains(skipProperties, key)) {
+                    LOGGER.info("Property " + (String) key + ": " + conf.getProperty((String) key));
+                }
             }
         }
 
-        String s = conf.getProperty("consoleproxy.httpListenPort");
+        String s = conf != null ? conf.getProperty("consoleproxy.httpListenPort") : null;
         if (s != null) {
             httpListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpListenPort=" + s);
         }
 
-        s = conf.getProperty("premium");
+        s = conf != null ? conf.getProperty("premium") : null;
         if (s != null && s.equalsIgnoreCase("true")) {
             LOGGER.info("Premium setting will override settings from consoleproxy.properties, listen at port 443");
             httpListenPort = 443;
@@ -144,25 +145,25 @@ public class ConsoleProxy {
             factoryClzName = ConsoleProxyBaseServerFactoryImpl.class.getName();
         }
 
-        s = conf.getProperty("consoleproxy.httpCmdListenPort");
+        s = conf != null ? conf.getProperty("consoleproxy.httpCmdListenPort") : null;
         if (s != null) {
             httpCmdListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpCmdListenPort=" + s);
         }
 
-        s = conf.getProperty("consoleproxy.reconnectMaxRetry");
+        s = conf != null ? conf.getProperty("consoleproxy.reconnectMaxRetry") : null;
         if (s != null) {
             reconnectMaxRetry = Integer.parseInt(s);
             LOGGER.info("Setting reconnectMaxRetry=" + reconnectMaxRetry);
         }
 
-        s = conf.getProperty("consoleproxy.readTimeoutSeconds");
+        s = conf != null ? conf.getProperty("consoleproxy.readTimeoutSeconds") : null;
         if (s != null) {
             readTimeoutSeconds = Integer.parseInt(s);
             LOGGER.info("Setting readTimeoutSeconds=" + readTimeoutSeconds);
         }
 
-        s = conf.getProperty("consoleproxy.defaultBufferSize");
+        s = conf != null ? conf.getProperty("consoleproxy.defaultBufferSize") : null;
         if (s != null) {
             defaultBufferSize = Integer.parseInt(s);
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
@@ -173,7 +174,7 @@ public class ConsoleProxy {
         try {
             Class<?> clz = Class.forName(factoryClzName);
             try {
-                ConsoleProxyServerFactory factory = (ConsoleProxyServerFactory)clz.newInstance();
+                ConsoleProxyServerFactory factory = (ConsoleProxyServerFactory) clz.newInstance();
                 factory.init(ConsoleProxy.ksBits, ConsoleProxy.ksPassword);
                 return factory;
             } catch (InstantiationException e) {
@@ -197,11 +198,11 @@ public class ConsoleProxy {
         authResult.setHost(param.getClientHostAddress());
         authResult.setPort(param.getClientHostPort());
 
-        if (org.apache.commons.lang3.StringUtils.isNotBlank(param.getExtraSecurityToken())) {
+        if (StringUtils.isNotBlank(param.getExtraSecurityToken())) {
             String extraToken = param.getExtraSecurityToken();
             String clientProvidedToken = param.getClientProvidedExtraSecurityToken();
-            LOGGER.debug(String.format("Extra security validation for the console access, provided %s " +
-                    "to validate against %s", clientProvidedToken, extraToken));
+            LOGGER.debug(String.format("Extra security validation for the console access, provided %s to validate against %s",
+                    clientProvidedToken, extraToken));
 
             if (!extraToken.equals(clientProvidedToken)) {
                 LOGGER.error("The provided extra token does not match the expected value for this console endpoint");
@@ -233,20 +234,21 @@ public class ConsoleProxy {
             Object result;
             try {
                 result =
-                        authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()), param.getClientTag(),
-                                param.getClientHostPassword(), param.getTicket(), reauthentication, param.getSessionUuid());
+                        authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()),
+                                param.getClientTag(), param.getClientHostPassword(), param.getTicket(), reauthentication,
+                                param.getSessionUuid(), param.getClientIp());
             } catch (IllegalAccessException e) {
-                LOGGER.error("Unable to invoke authenticateConsoleAccess due to IllegalAccessException" + " for vm: " + param.getClientTag(), e);
+                LOGGER.error("Unable to invoke authenticateConsoleAccess due to IllegalAccessException for vm: " + param.getClientTag(), e);
                 authResult.setSuccess(false);
                 return authResult;
             } catch (InvocationTargetException e) {
-                LOGGER.error("Unable to invoke authenticateConsoleAccess due to InvocationTargetException " + " for vm: " + param.getClientTag(), e);
+                LOGGER.error("Unable to invoke authenticateConsoleAccess due to InvocationTargetException for vm: " + param.getClientTag(), e);
                 authResult.setSuccess(false);
                 return authResult;
             }
 
             if (result != null && result instanceof String) {
-                authResult = new Gson().fromJson((String)result, ConsoleProxyAuthenticationResult.class);
+                authResult = new Gson().fromJson((String) result, ConsoleProxyAuthenticationResult.class);
             } else {
                 LOGGER.error("Invalid authentication return object " + result + " for vm: " + param.getClientTag() + ", decline the access");
                 authResult.setSuccess(false);
@@ -286,7 +288,8 @@ public class ConsoleProxy {
         }
     }
 
-    public static void startWithContext(Properties conf, Object context, byte[] ksBits, String ksPassword, String password, Boolean isSourceIpCheckEnabled) {
+    public static void startWithContext(Properties conf, Object context, byte[] ksBits, String ksPassword,
+                                        String password, Boolean isSourceIpCheckEnabled) {
         setEncryptorPassword(password);
         configLog4j();
         LOGGER.info("Start console proxy with context");
@@ -308,7 +311,7 @@ public class ConsoleProxy {
             final ClassLoader loader = Thread.currentThread().getContextClassLoader();
             Class<?> contextClazz = loader.loadClass("com.cloud.agent.resource.consoleproxy.ConsoleProxyResource");
             authMethod = contextClazz.getDeclaredMethod("authenticateConsoleAccess", String.class, String.class,
-                    String.class, String.class, String.class, Boolean.class, String.class);
+                    String.class, String.class, String.class, Boolean.class, String.class, String.class);
             reportMethod = contextClazz.getDeclaredMethod("reportLoadInfo", String.class);
             ensureRouteMethod = contextClazz.getDeclaredMethod("ensureRoute", String.class);
         } catch (SecurityException e) {
@@ -326,33 +329,39 @@ public class ConsoleProxy {
         Properties props = new Properties();
         if (confs == null) {
             final File file = PropertiesUtil.findConfigFile("consoleproxy.properties");
-            if (file == null)
+            if (file == null) {
                 LOGGER.info("Can't load consoleproxy.properties from classpath, will use default configuration");
-            else
+            } else {
                 try {
                     confs = new FileInputStream(file);
                 } catch (FileNotFoundException e) {
                     LOGGER.info("Ignoring file not found exception and using defaults");
                 }
+            }
         }
         if (confs != null) {
             try {
                 props.load(confs);
 
+                if (conf == null) {
+                    conf = new Properties();
+                }
                 for (Object key : props.keySet()) {
                     // give properties passed via context high priority, treat properties from consoleproxy.properties
                     // as default values
-                    if (conf.get(key) == null)
+                    if (conf.get(key) == null) {
                         conf.put(key, props.get(key));
+                    }
                 }
             } catch (Exception e) {
                 LOGGER.error(e.toString(), e);
+            } finally {
+                try {
+                    confs.close();
+                } catch (IOException e) {
+                    LOGGER.error("Failed to close consoleproxy.properties : " + e.toString(), e);
+                }
             }
-        }
-        try {
-            confs.close();
-        } catch (IOException e) {
-            LOGGER.error("Failed to close consolepropxy.properties : " + e.toString(), e);
         }
 
         start(conf);
@@ -474,8 +483,8 @@ public class ConsoleProxy {
                 LOGGER.info("The rfb thread died, reinitializing the viewer " + viewer);
                 viewer.initClient(param);
             } else if (!param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
-                LOGGER.warn("Bad sid detected(VNC port may be reused). sid in session: " + viewer.getClientHostPassword() + ", sid in request: " +
-                        param.getClientHostPassword());
+                LOGGER.warn("Bad sid detected(VNC port may be reused). sid in session: " + viewer.getClientHostPassword() +
+                        ", sid in request: " + param.getClientHostPassword());
                 viewer.initClient(param);
             }
         }
@@ -484,8 +493,9 @@ public class ConsoleProxy {
             ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
             String loadInfo = statsCollector.getStatsReport();
             reportLoadInfo(loadInfo);
-            if (LOGGER.isDebugEnabled())
+            if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Report load change : " + loadInfo);
+            }
         }
 
         return viewer;
@@ -509,13 +519,15 @@ public class ConsoleProxy {
                 // protected against malicious attack by modifying URL content
                 if (ajaxSession != null) {
                     long ajaxSessionIdFromUrl = Long.parseLong(ajaxSession);
-                    if (ajaxSessionIdFromUrl != viewer.getAjaxSessionId())
+                    if (ajaxSessionIdFromUrl != viewer.getAjaxSessionId()) {
                         throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": modified AJAX session id");
+                    }
                 }
 
-                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty() ||
-                        !param.getClientHostPassword().equals(viewer.getClientHostPassword()))
+                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
+                        || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
+                }
 
                 if (!viewer.isFrontEndAlive()) {
 
@@ -529,8 +541,9 @@ public class ConsoleProxy {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
                 String loadInfo = statsCollector.getStatsReport();
                 reportLoadInfo(loadInfo);
-                if (LOGGER.isDebugEnabled())
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Report load change : " + loadInfo);
+                }
             }
             return viewer;
         }
@@ -566,9 +579,11 @@ public class ConsoleProxy {
         ConsoleProxyAuthenticationResult authResult = authenticateConsoleAccess(param, false);
 
         if (authResult == null || !authResult.isSuccess()) {
-            LOGGER.warn("External authenticator failed authentication request for vm " + param.getClientTag() + " with sid " + param.getClientHostPassword());
+            LOGGER.warn("External authenticator failed authentication request for vm " + param.getClientTag()
+                    + " with sid " + param.getClientHostPassword());
 
-            throw new AuthenticationException("External authenticator failed request for vm " + param.getClientTag() + " with sid " + param.getClientHostPassword());
+            throw new AuthenticationException("External authenticator failed request for vm " + param.getClientTag()
+                    + " with sid " + param.getClientHostPassword());
         }
     }
 
@@ -596,50 +611,55 @@ public class ConsoleProxy {
     }
 
     public static ConsoleProxyNoVncClient getNoVncViewer(ConsoleProxyClientParam param, String ajaxSession,
-            Session session) throws AuthenticationException {
+                                                         Session session) throws AuthenticationException {
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
-        synchronized (connectionMap) {
-            ConsoleProxyClient viewer = connectionMap.get(clientKey);
-            if (viewer == null || viewer.getClass() != ConsoleProxyNoVncClient.class) {
-                authenticationExternally(param);
-                viewer = new ConsoleProxyNoVncClient(session);
-                viewer.initClient(param);
+        LOGGER.debug("Getting NoVNC viewer for {}. Client tag: {}. session UUID: {}",
+        clientKey, param.getClientTag(), param.getSessionUuid());
+synchronized (connectionMap) {
+    ConsoleProxyClient viewer = connectionMap.get(clientKey);
+    if (viewer == null || viewer.getClass() != ConsoleProxyNoVncClient.class) {
+        authenticationExternally(param);
+        viewer = new ConsoleProxyNoVncClient(session);
+        viewer.initClient(param);
 
-                connectionMap.put(clientKey, viewer);
-                reportLoadChange = true;
-            } else {
-                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty() ||
-                        !param.getClientHostPassword().equals(viewer.getClientHostPassword()))
-                    throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
+        connectionMap.put(clientKey, viewer);
+        reportLoadChange = true;
+    } else {
+        if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
+                || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
+            throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
+        }
 
-                try {
-                    authenticationExternally(param);
-                } catch (Exception e) {
-                    LOGGER.error("Authentication failed for param: " + param);
-                    return null;
-                }
-                LOGGER.info("Initializing new novnc client and disconnecting existing session");
-                try {
-                    ((ConsoleProxyNoVncClient)viewer).getSession().disconnect();
-                } catch (IOException e) {
-                    LOGGER.error("Exception while disconnect session of novnc viewer object: " + viewer, e);
-                }
-                removeViewer(viewer);
-                viewer = new ConsoleProxyNoVncClient(session);
-                viewer.initClient(param);
-                connectionMap.put(clientKey, viewer);
-                reportLoadChange = true;
-            }
+        try {
+            authenticationExternally(param);
+        } catch (Exception e) {
+            LOGGER.error("Authentication failed for param: " + param);
+            return null;
+        }
+        LOGGER.info("Initializing new novnc client and disconnecting existing session");
+        try {
+            ((ConsoleProxyNoVncClient) viewer).getSession().disconnect();
+        } catch (IOException e) {
+            LOGGER.error("Exception while disconnect session of novnc viewer object: " + viewer, e);
+        }
+        removeViewer(viewer);
+        viewer = new ConsoleProxyNoVncClient(session);
+        viewer.initClient(param);
+        connectionMap.put(clientKey, viewer);
+        reportLoadChange = true;
+    }
+
 
             if (reportLoadChange) {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
                 String loadInfo = statsCollector.getStatsReport();
                 reportLoadInfo(loadInfo);
-                if (LOGGER.isDebugEnabled())
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Report load change : " + loadInfo);
+                }
             }
-            return (ConsoleProxyNoVncClient)viewer;
+            return (ConsoleProxyNoVncClient) viewer;
         }
     }
 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.consoleproxy;
 
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -34,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -41,9 +43,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.jetty.websocket.api.Session;
 
+
 import com.cloud.utils.PropertiesUtil;
 import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpServer;
+
 
 /**
  *
@@ -52,12 +56,20 @@ import com.sun.net.httpserver.HttpServer;
 public class ConsoleProxy {
     protected static Logger LOGGER = LogManager.getLogger(ConsoleProxy.class);
 
+
     public static final int KEYBOARD_RAW = 0;
     public static final int KEYBOARD_COOKED = 1;
 
+
     public static final int VIEWER_LINGER_SECONDS = 180;
 
+    // New: default and effective session timeout (milliseconds) honoured from consoleproxy.session.timeout
+    public static final int DEFAULT_SESSION_TIMEOUT_MILLIS = 300000;
+    public static volatile int sessionTimeoutMillis = DEFAULT_SESSION_TIMEOUT_MILLIS;
+
+
     public static Object context;
+
 
     // this has become more ugly, to store keystore info passed from management server (we now use management server managed keystore to support
     // dynamically changing to customer supplied certificate)
@@ -65,9 +77,11 @@ public class ConsoleProxy {
     public static String ksPassword;
     public static Boolean isSourceIpCheckEnabled;
 
+
     public static Method authMethod;
     public static Method reportMethod;
     public static Method ensureRouteMethod;
+
 
     static Hashtable<String, ConsoleProxyClient> connectionMap = new Hashtable<String, ConsoleProxyClient>();
     static Set<String> removedSessionsSet = ConcurrentHashMap.newKeySet();
@@ -80,14 +94,18 @@ public class ConsoleProxy {
     static String factoryClzName;
     static boolean standaloneStart = false;
 
+
     static String encryptorPassword = "Dummy";
     static final String[] skipProperties = new String[] {"certificate", "cacertificate", "keystore_password", "privatekey"};
 
+
     static Set<String> allowedSessions = new HashSet<>();
+
 
     public static void addAllowedSession(String sessionUuid) {
         allowedSessions.add(sessionUuid);
     }
+
 
     private static void configLog4j() {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -96,9 +114,11 @@ public class ConsoleProxy {
             configUrl = ClassLoader.getSystemResource("log4j-cloud.xml");
         }
 
+
         if (configUrl == null) {
             configUrl = ClassLoader.getSystemResource("conf/log4j-cloud.xml");
         }
+
 
         if (configUrl != null) {
             try {
@@ -107,8 +127,10 @@ public class ConsoleProxy {
                 e1.printStackTrace();
             }
 
+
             try {
                 File file = new File(configUrl.toURI());
+
 
                 System.out.println("Log4j configuration from : " + file.getAbsolutePath());
                 Configurator.initialize(null, file.getAbsolutePath());
@@ -120,6 +142,7 @@ public class ConsoleProxy {
         }
     }
 
+
     private static void configProxy(Properties conf) {
         LOGGER.info("Configure console proxy...");
         if (conf != null) {
@@ -130,11 +153,13 @@ public class ConsoleProxy {
             }
         }
 
+
         String s = conf != null ? conf.getProperty("consoleproxy.httpListenPort") : null;
         if (s != null) {
             httpListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpListenPort=" + s);
         }
+
 
         s = conf != null ? conf.getProperty("premium") : null;
         if (s != null && s.equalsIgnoreCase("true")) {
@@ -145,11 +170,13 @@ public class ConsoleProxy {
             factoryClzName = ConsoleProxyBaseServerFactoryImpl.class.getName();
         }
 
+
         s = conf != null ? conf.getProperty("consoleproxy.httpCmdListenPort") : null;
         if (s != null) {
             httpCmdListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpCmdListenPort=" + s);
         }
+
 
         s = conf != null ? conf.getProperty("consoleproxy.reconnectMaxRetry") : null;
         if (s != null) {
@@ -157,18 +184,41 @@ public class ConsoleProxy {
             LOGGER.info("Setting reconnectMaxRetry=" + reconnectMaxRetry);
         }
 
+
         s = conf != null ? conf.getProperty("consoleproxy.readTimeoutSeconds") : null;
         if (s != null) {
             readTimeoutSeconds = Integer.parseInt(s);
             LOGGER.info("Setting readTimeoutSeconds=" + readTimeoutSeconds);
         }
 
+
         s = conf != null ? conf.getProperty("consoleproxy.defaultBufferSize") : null;
         if (s != null) {
             defaultBufferSize = Integer.parseInt(s);
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
         }
+
+        // New: read consoleproxy.session.timeout (milliseconds)
+        s = conf != null ? conf.getProperty("consoleproxy.session.timeout") : null;
+        if (s != null) {
+            try {
+                int value = Integer.parseInt(s);
+                if (value <= 0) {
+                    LOGGER.warn("consoleproxy.session.timeout={} is <= 0, using default {} ms",
+                            value, DEFAULT_SESSION_TIMEOUT_MILLIS);
+                    sessionTimeoutMillis = DEFAULT_SESSION_TIMEOUT_MILLIS;
+                } else {
+                    sessionTimeoutMillis = value;
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid value for consoleproxy.session.timeout: {}, using default {} ms",
+                        s, DEFAULT_SESSION_TIMEOUT_MILLIS, e);
+                sessionTimeoutMillis = DEFAULT_SESSION_TIMEOUT_MILLIS;
+            }
+        }
+        LOGGER.info("Effective consoleproxy.session.timeout={} ms", sessionTimeoutMillis);
     }
+
 
     public static ConsoleProxyServerFactory getHttpServerFactory() {
         try {
@@ -190,7 +240,9 @@ public class ConsoleProxy {
         }
     }
 
+
     public static ConsoleProxyAuthenticationResult authenticateConsoleAccess(ConsoleProxyClientParam param, boolean reauthentication) {
+
 
         ConsoleProxyAuthenticationResult authResult = new ConsoleProxyAuthenticationResult();
         authResult.setSuccess(true);
@@ -198,11 +250,13 @@ public class ConsoleProxy {
         authResult.setHost(param.getClientHostAddress());
         authResult.setPort(param.getClientHostPort());
 
+
         if (StringUtils.isNotBlank(param.getExtraSecurityToken())) {
             String extraToken = param.getExtraSecurityToken();
             String clientProvidedToken = param.getClientProvidedExtraSecurityToken();
             LOGGER.debug(String.format("Extra security validation for the console access, provided %s to validate against %s",
                     clientProvidedToken, extraToken));
+
 
             if (!extraToken.equals(clientProvidedToken)) {
                 LOGGER.error("The provided extra token does not match the expected value for this console endpoint");
@@ -210,6 +264,7 @@ public class ConsoleProxy {
                 return authResult;
             }
         }
+
 
         String sessionUuid = param.getSessionUuid();
         if (allowedSessions.contains(sessionUuid)) {
@@ -221,22 +276,26 @@ public class ConsoleProxy {
             return authResult;
         }
 
+
         String websocketUrl = param.getWebsocketUrl();
         if (StringUtils.isNotBlank(websocketUrl)) {
             return authResult;
         }
 
+
         if (standaloneStart) {
             return authResult;
         }
 
+
         if (authMethod != null) {
             Object result;
             try {
+                // 4.20: authenticateConsoleAccess(host, port, vmId, sid, ticket, isReauthentication, sessionToken)
                 result =
                         authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()),
                                 param.getClientTag(), param.getClientHostPassword(), param.getTicket(), reauthentication,
-                                param.getSessionUuid(), param.getClientIp());
+                                param.getSessionUuid());
             } catch (IllegalAccessException e) {
                 LOGGER.error("Unable to invoke authenticateConsoleAccess due to IllegalAccessException for vm: " + param.getClientTag(), e);
                 authResult.setSuccess(false);
@@ -246,6 +305,7 @@ public class ConsoleProxy {
                 authResult.setSuccess(false);
                 return authResult;
             }
+
 
             if (result != null && result instanceof String) {
                 authResult = new Gson().fromJson((String) result, ConsoleProxyAuthenticationResult.class);
@@ -257,8 +317,10 @@ public class ConsoleProxy {
             LOGGER.warn("Private channel towards management server is not setup. Switch to offline mode and allow access to vm: " + param.getClientTag());
         }
 
+
         return authResult;
     }
+
 
     public static void reportLoadInfo(String gsonLoadInfo) {
         if (reportMethod != null) {
@@ -274,6 +336,7 @@ public class ConsoleProxy {
         }
     }
 
+
     public static void ensureRoute(String address) {
         if (ensureRouteMethod != null) {
             try {
@@ -288,11 +351,13 @@ public class ConsoleProxy {
         }
     }
 
+
     public static void startWithContext(Properties conf, Object context, byte[] ksBits, String ksPassword,
                                         String password, Boolean isSourceIpCheckEnabled) {
         setEncryptorPassword(password);
         configLog4j();
         LOGGER.info("Start console proxy with context");
+
 
         if (conf != null) {
             for (Object key : conf.keySet()) {
@@ -302,6 +367,7 @@ public class ConsoleProxy {
             }
         }
 
+
         // Using reflection to setup private/secure communication channel towards management server
         ConsoleProxy.context = context;
         ConsoleProxy.ksBits = ksBits;
@@ -310,8 +376,9 @@ public class ConsoleProxy {
         try {
             final ClassLoader loader = Thread.currentThread().getContextClassLoader();
             Class<?> contextClazz = loader.loadClass("com.cloud.agent.resource.consoleproxy.ConsoleProxyResource");
+            // 4.20 signature: 7 parameters
             authMethod = contextClazz.getDeclaredMethod("authenticateConsoleAccess", String.class, String.class,
-                    String.class, String.class, String.class, Boolean.class, String.class, String.class);
+                    String.class, String.class, String.class, Boolean.class, String.class);
             reportMethod = contextClazz.getDeclaredMethod("reportLoadInfo", String.class);
             ensureRouteMethod = contextClazz.getDeclaredMethod("ensureRoute", String.class);
         } catch (SecurityException e) {
@@ -323,6 +390,7 @@ public class ConsoleProxy {
         } catch (ClassNotFoundException e) {
             LOGGER.error("Unable to setup private channel due to ClassNotFoundException", e);
         }
+
 
         // merge properties from conf file
         InputStream confs = ConsoleProxy.class.getResourceAsStream("/conf/consoleproxy.properties");
@@ -342,6 +410,7 @@ public class ConsoleProxy {
         if (confs != null) {
             try {
                 props.load(confs);
+
 
                 if (conf == null) {
                     conf = new Properties();
@@ -364,19 +433,24 @@ public class ConsoleProxy {
             }
         }
 
+
         start(conf);
     }
+
 
     public static void start(Properties conf) {
         System.setProperty("java.awt.headless", "true");
 
+
         configProxy(conf);
+
 
         ConsoleProxyServerFactory factory = getHttpServerFactory();
         if (factory == null) {
             LOGGER.error("Unable to load console proxy server factory");
             System.exit(1);
         }
+
 
         if (httpListenPort != 0) {
             startupHttpMain();
@@ -385,16 +459,19 @@ public class ConsoleProxy {
             System.exit(1);
         }
 
+
         if (httpCmdListenPort > 0) {
             startupHttpCmdPort();
         } else {
             LOGGER.info("HTTP command port is disabled");
         }
 
+
         ConsoleProxyGCThread cthread = new ConsoleProxyGCThread(connectionMap, removedSessionsSet);
         cthread.setName("Console Proxy GC Thread");
         cthread.start();
     }
+
 
     private static void startupHttpMain() {
         try {
@@ -404,6 +481,7 @@ public class ConsoleProxy {
                 System.exit(1);
             }
 
+
             HttpServer server = factory.createHttpServerInstance(httpListenPort);
             server.createContext("/getscreen", new ConsoleProxyThumbnailHandler());
             server.createContext("/resource/", new ConsoleProxyResourceHandler());
@@ -412,8 +490,10 @@ public class ConsoleProxy {
             server.setExecutor(new ThreadExecutor()); // creates a default executor
             server.start();
 
+
             ConsoleProxyNoVNCServer noVNCServer = getNoVNCServer();
             noVNCServer.start();
+
 
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
@@ -421,12 +501,14 @@ public class ConsoleProxy {
         }
     }
 
+
     private static ConsoleProxyNoVNCServer getNoVNCServer() {
         int vncPort = ConsoleProxyNoVNCServer.getVNCPort();
         return vncPort == ConsoleProxyNoVNCServer.WSS_PORT ?
                 new ConsoleProxyNoVNCServer(ksBits, ksPassword) :
                 new ConsoleProxyNoVNCServer();
     }
+
 
     private static void startupHttpCmdPort() {
         try {
@@ -441,9 +523,11 @@ public class ConsoleProxy {
         }
     }
 
+
     public static void main(String[] argv) {
         standaloneStart = true;
         configLog4j();
+
 
         InputStream confs = ConsoleProxy.class.getResourceAsStream("/conf/consoleproxy.properties");
         Properties conf = new Properties();
@@ -465,8 +549,10 @@ public class ConsoleProxy {
         start(conf);
     }
 
+
     public static ConsoleProxyClient getVncViewer(ConsoleProxyClientParam param) throws Exception {
         ConsoleProxyClient viewer = null;
+
 
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
@@ -477,6 +563,7 @@ public class ConsoleProxy {
                 viewer.initClient(param);
                 connectionMap.put(clientKey, viewer);
                 LOGGER.info("Added viewer object " + viewer);
+
 
                 reportLoadChange = true;
             } else if (!viewer.isFrontEndAlive()) {
@@ -489,6 +576,7 @@ public class ConsoleProxy {
             }
         }
 
+
         if (reportLoadChange) {
             ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
             String loadInfo = statsCollector.getStatsReport();
@@ -498,10 +586,13 @@ public class ConsoleProxy {
             }
         }
 
+
         return viewer;
     }
 
+
     public static ConsoleProxyClient getAjaxVncViewer(ConsoleProxyClientParam param, String ajaxSession) throws Exception {
+
 
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
@@ -511,6 +602,7 @@ public class ConsoleProxy {
                 authenticationExternally(param);
                 viewer = getClient(param);
                 viewer.initClient(param);
+
 
                 connectionMap.put(clientKey, viewer);
                 LOGGER.info("Added viewer object " + viewer);
@@ -524,18 +616,22 @@ public class ConsoleProxy {
                     }
                 }
 
+
                 if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
                         || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
                 }
 
+
                 if (!viewer.isFrontEndAlive()) {
+
 
                     authenticationExternally(param);
                     viewer.initClient(param);
                     reportLoadChange = true;
                 }
             }
+
 
             if (reportLoadChange) {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
@@ -549,6 +645,7 @@ public class ConsoleProxy {
         }
     }
 
+
     private static ConsoleProxyClient getClient(ConsoleProxyClientParam param) {
         if (param.getHypervHost() != null) {
             return new ConsoleProxyRdpClient();
@@ -556,6 +653,7 @@ public class ConsoleProxy {
             return new ConsoleProxyVncClient();
         }
     }
+
 
     public static void removeViewer(ConsoleProxyClient viewer) {
         synchronized (connectionMap) {
@@ -569,39 +667,48 @@ public class ConsoleProxy {
         }
     }
 
+
     public static ConsoleProxyClientStatsCollector getStatsCollector() {
         synchronized (connectionMap) {
             return new ConsoleProxyClientStatsCollector(connectionMap);
         }
     }
 
+
     public static void authenticationExternally(ConsoleProxyClientParam param) throws AuthenticationException {
         ConsoleProxyAuthenticationResult authResult = authenticateConsoleAccess(param, false);
+
 
         if (authResult == null || !authResult.isSuccess()) {
             LOGGER.warn("External authenticator failed authentication request for vm " + param.getClientTag()
                     + " with sid " + param.getClientHostPassword());
+
 
             throw new AuthenticationException("External authenticator failed request for vm " + param.getClientTag()
                     + " with sid " + param.getClientHostPassword());
         }
     }
 
+
     public static ConsoleProxyAuthenticationResult reAuthenticationExternally(ConsoleProxyClientParam param) {
         return authenticateConsoleAccess(param, true);
     }
+
 
     public static String getEncryptorPassword() {
         return encryptorPassword;
     }
 
+
     public static void setEncryptorPassword(String password) {
         encryptorPassword = password;
     }
 
+
     public static void setIsSourceIpCheckEnabled(Boolean isEnabled) {
         isSourceIpCheckEnabled = isEnabled;
     }
+
 
     static class ThreadExecutor implements Executor {
         @Override
@@ -610,45 +717,48 @@ public class ConsoleProxy {
         }
     }
 
+
     public static ConsoleProxyNoVncClient getNoVncViewer(ConsoleProxyClientParam param, String ajaxSession,
                                                          Session session) throws AuthenticationException {
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
         LOGGER.debug("Getting NoVNC viewer for {}. Client tag: {}. session UUID: {}",
-        clientKey, param.getClientTag(), param.getSessionUuid());
-synchronized (connectionMap) {
-    ConsoleProxyClient viewer = connectionMap.get(clientKey);
-    if (viewer == null || viewer.getClass() != ConsoleProxyNoVncClient.class) {
-        authenticationExternally(param);
-        viewer = new ConsoleProxyNoVncClient(session);
-        viewer.initClient(param);
+                clientKey, param.getClientTag(), param.getSessionUuid());
+        synchronized (connectionMap) {
+            ConsoleProxyClient viewer = connectionMap.get(clientKey);
+            if (viewer == null || viewer.getClass() != ConsoleProxyNoVncClient.class) {
+                authenticationExternally(param);
+                viewer = new ConsoleProxyNoVncClient(session);
+                viewer.initClient(param);
 
-        connectionMap.put(clientKey, viewer);
-        reportLoadChange = true;
-    } else {
-        if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
-                || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
-            throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
-        }
 
-        try {
-            authenticationExternally(param);
-        } catch (Exception e) {
-            LOGGER.error("Authentication failed for param: " + param);
-            return null;
-        }
-        LOGGER.info("Initializing new novnc client and disconnecting existing session");
-        try {
-            ((ConsoleProxyNoVncClient) viewer).getSession().disconnect();
-        } catch (IOException e) {
-            LOGGER.error("Exception while disconnect session of novnc viewer object: " + viewer, e);
-        }
-        removeViewer(viewer);
-        viewer = new ConsoleProxyNoVncClient(session);
-        viewer.initClient(param);
-        connectionMap.put(clientKey, viewer);
-        reportLoadChange = true;
-    }
+                connectionMap.put(clientKey, viewer);
+                reportLoadChange = true;
+            } else {
+                if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
+                        || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
+                    throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
+                }
+
+
+                try {
+                    authenticationExternally(param);
+                } catch (Exception e) {
+                    LOGGER.error("Authentication failed for param: {}", param, e);
+                    return null;
+                }
+                LOGGER.info("Initializing new novnc client and disconnecting existing session");
+                try {
+                    ((ConsoleProxyNoVncClient) viewer).getSession().disconnect();
+                } catch (IOException e) {
+                    LOGGER.error("Exception while disconnect session of novnc viewer object: " + viewer, e);
+                }
+                removeViewer(viewer);
+                viewer = new ConsoleProxyNoVncClient(session);
+                viewer.initClient(param);
+                connectionMap.put(clientKey, viewer);
+                reportLoadChange = true;
+            }
 
 
             if (reportLoadChange) {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -64,8 +64,8 @@ public class ConsoleProxy {
     public static final int VIEWER_LINGER_SECONDS = 180;
 
     // New: default and effective session timeout (milliseconds) honoured from consoleproxy.session.timeout
-    public static final int DEFAULT_SESSION_TIMEOUT_MILLIS = 300000;
-    public static volatile int sessionTimeoutMillis = DEFAULT_SESSION_TIMEOUT_MILLIS;
+    public static final long DEFAULT_SESSION_TIMEOUT_MILLIS = 300000;
+    public static volatile long sessionTimeoutMillis = DEFAULT_SESSION_TIMEOUT_MILLIS;
 
 
     public static Object context;
@@ -202,7 +202,7 @@ public class ConsoleProxy {
         s = conf != null ? conf.getProperty("consoleproxy.session.timeout") : null;
         if (s != null) {
             try {
-                int value = Integer.parseInt(s);
+                long value = Long.parseLong(s);
                 if (value <= 0) {
                     LOGGER.warn("consoleproxy.session.timeout={} is <= 0, using default {} ms",
                             value, DEFAULT_SESSION_TIMEOUT_MILLIS);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.consoleproxy;
 
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -35,14 +34,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.jetty.websocket.api.Session;
-
 
 import com.cloud.utils.PropertiesUtil;
 import com.google.gson.Gson;
@@ -56,10 +53,8 @@ import com.sun.net.httpserver.HttpServer;
 public class ConsoleProxy {
     protected static Logger LOGGER = LogManager.getLogger(ConsoleProxy.class);
 
-
     public static final int KEYBOARD_RAW = 0;
     public static final int KEYBOARD_COOKED = 1;
-
 
     public static final int VIEWER_LINGER_SECONDS = 180;
 
@@ -70,18 +65,15 @@ public class ConsoleProxy {
 
     public static Object context;
 
-
     // this has become more ugly, to store keystore info passed from management server (we now use management server managed keystore to support
     // dynamically changing to customer supplied certificate)
     public static byte[] ksBits;
     public static String ksPassword;
     public static Boolean isSourceIpCheckEnabled;
 
-
     public static Method authMethod;
     public static Method reportMethod;
     public static Method ensureRouteMethod;
-
 
     static Hashtable<String, ConsoleProxyClient> connectionMap = new Hashtable<String, ConsoleProxyClient>();
     static Set<String> removedSessionsSet = ConcurrentHashMap.newKeySet();
@@ -94,18 +86,15 @@ public class ConsoleProxy {
     static String factoryClzName;
     static boolean standaloneStart = false;
 
-
     static String encryptorPassword = "Dummy";
     static final String[] skipProperties = new String[] {"certificate", "cacertificate", "keystore_password", "privatekey"};
 
 
     static Set<String> allowedSessions = new HashSet<>();
 
-
     public static void addAllowedSession(String sessionUuid) {
         allowedSessions.add(sessionUuid);
     }
-
 
     private static void configLog4j() {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -114,11 +103,9 @@ public class ConsoleProxy {
             configUrl = ClassLoader.getSystemResource("log4j-cloud.xml");
         }
 
-
         if (configUrl == null) {
             configUrl = ClassLoader.getSystemResource("conf/log4j-cloud.xml");
         }
-
 
         if (configUrl != null) {
             try {
@@ -126,7 +113,6 @@ public class ConsoleProxy {
             } catch (URISyntaxException e1) {
                 e1.printStackTrace();
             }
-
 
             try {
                 File file = new File(configUrl.toURI());
@@ -142,7 +128,6 @@ public class ConsoleProxy {
         }
     }
 
-
     private static void configProxy(Properties conf) {
         LOGGER.info("Configure console proxy...");
         if (conf != null) {
@@ -153,13 +138,11 @@ public class ConsoleProxy {
             }
         }
 
-
         String s = conf != null ? conf.getProperty("consoleproxy.httpListenPort") : null;
         if (s != null) {
             httpListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpListenPort=" + s);
         }
-
 
         s = conf != null ? conf.getProperty("premium") : null;
         if (s != null && s.equalsIgnoreCase("true")) {
@@ -170,13 +153,11 @@ public class ConsoleProxy {
             factoryClzName = ConsoleProxyBaseServerFactoryImpl.class.getName();
         }
 
-
         s = conf != null ? conf.getProperty("consoleproxy.httpCmdListenPort") : null;
         if (s != null) {
             httpCmdListenPort = Integer.parseInt(s);
             LOGGER.info("Setting httpCmdListenPort=" + s);
         }
-
 
         s = conf != null ? conf.getProperty("consoleproxy.reconnectMaxRetry") : null;
         if (s != null) {
@@ -184,13 +165,11 @@ public class ConsoleProxy {
             LOGGER.info("Setting reconnectMaxRetry=" + reconnectMaxRetry);
         }
 
-
         s = conf != null ? conf.getProperty("consoleproxy.readTimeoutSeconds") : null;
         if (s != null) {
             readTimeoutSeconds = Integer.parseInt(s);
             LOGGER.info("Setting readTimeoutSeconds=" + readTimeoutSeconds);
         }
-
 
         s = conf != null ? conf.getProperty("consoleproxy.defaultBufferSize") : null;
         if (s != null) {
@@ -198,7 +177,6 @@ public class ConsoleProxy {
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
         }
 
-        // New: read consoleproxy.session.timeout (milliseconds)
         s = conf != null ? conf.getProperty("consoleproxy.session.timeout") : null;
         if (s != null) {
             try {
@@ -218,7 +196,6 @@ public class ConsoleProxy {
         }
         LOGGER.info("Effective consoleproxy.session.timeout={} ms", sessionTimeoutMillis);
     }
-
 
     public static ConsoleProxyServerFactory getHttpServerFactory() {
         try {
@@ -240,9 +217,7 @@ public class ConsoleProxy {
         }
     }
 
-
     public static ConsoleProxyAuthenticationResult authenticateConsoleAccess(ConsoleProxyClientParam param, boolean reauthentication) {
-
 
         ConsoleProxyAuthenticationResult authResult = new ConsoleProxyAuthenticationResult();
         authResult.setSuccess(true);
@@ -250,13 +225,11 @@ public class ConsoleProxy {
         authResult.setHost(param.getClientHostAddress());
         authResult.setPort(param.getClientHostPort());
 
-
         if (StringUtils.isNotBlank(param.getExtraSecurityToken())) {
             String extraToken = param.getExtraSecurityToken();
             String clientProvidedToken = param.getClientProvidedExtraSecurityToken();
             LOGGER.debug(String.format("Extra security validation for the console access, provided %s to validate against %s",
                     clientProvidedToken, extraToken));
-
 
             if (!extraToken.equals(clientProvidedToken)) {
                 LOGGER.error("The provided extra token does not match the expected value for this console endpoint");
@@ -264,7 +237,6 @@ public class ConsoleProxy {
                 return authResult;
             }
         }
-
 
         String sessionUuid = param.getSessionUuid();
         if (allowedSessions.contains(sessionUuid)) {
@@ -276,22 +248,18 @@ public class ConsoleProxy {
             return authResult;
         }
 
-
         String websocketUrl = param.getWebsocketUrl();
         if (StringUtils.isNotBlank(websocketUrl)) {
             return authResult;
         }
 
-
         if (standaloneStart) {
             return authResult;
         }
 
-
         if (authMethod != null) {
             Object result;
             try {
-                // 4.20: authenticateConsoleAccess(host, port, vmId, sid, ticket, isReauthentication, sessionToken)
                 result =
                         authMethod.invoke(ConsoleProxy.context, param.getClientHostAddress(), String.valueOf(param.getClientHostPort()),
                                 param.getClientTag(), param.getClientHostPassword(), param.getTicket(), reauthentication,
@@ -306,7 +274,6 @@ public class ConsoleProxy {
                 return authResult;
             }
 
-
             if (result != null && result instanceof String) {
                 authResult = new Gson().fromJson((String) result, ConsoleProxyAuthenticationResult.class);
             } else {
@@ -317,10 +284,8 @@ public class ConsoleProxy {
             LOGGER.warn("Private channel towards management server is not setup. Switch to offline mode and allow access to vm: " + param.getClientTag());
         }
 
-
         return authResult;
     }
-
 
     public static void reportLoadInfo(String gsonLoadInfo) {
         if (reportMethod != null) {
@@ -336,7 +301,6 @@ public class ConsoleProxy {
         }
     }
 
-
     public static void ensureRoute(String address) {
         if (ensureRouteMethod != null) {
             try {
@@ -351,13 +315,11 @@ public class ConsoleProxy {
         }
     }
 
-
     public static void startWithContext(Properties conf, Object context, byte[] ksBits, String ksPassword,
                                         String password, Boolean isSourceIpCheckEnabled) {
         setEncryptorPassword(password);
         configLog4j();
         LOGGER.info("Start console proxy with context");
-
 
         if (conf != null) {
             for (Object key : conf.keySet()) {
@@ -367,7 +329,6 @@ public class ConsoleProxy {
             }
         }
 
-
         // Using reflection to setup private/secure communication channel towards management server
         ConsoleProxy.context = context;
         ConsoleProxy.ksBits = ksBits;
@@ -376,7 +337,6 @@ public class ConsoleProxy {
         try {
             final ClassLoader loader = Thread.currentThread().getContextClassLoader();
             Class<?> contextClazz = loader.loadClass("com.cloud.agent.resource.consoleproxy.ConsoleProxyResource");
-            // 4.20 signature: 7 parameters
             authMethod = contextClazz.getDeclaredMethod("authenticateConsoleAccess", String.class, String.class,
                     String.class, String.class, String.class, Boolean.class, String.class);
             reportMethod = contextClazz.getDeclaredMethod("reportLoadInfo", String.class);
@@ -390,7 +350,6 @@ public class ConsoleProxy {
         } catch (ClassNotFoundException e) {
             LOGGER.error("Unable to setup private channel due to ClassNotFoundException", e);
         }
-
 
         // merge properties from conf file
         InputStream confs = ConsoleProxy.class.getResourceAsStream("/conf/consoleproxy.properties");
@@ -410,7 +369,6 @@ public class ConsoleProxy {
         if (confs != null) {
             try {
                 props.load(confs);
-
 
                 if (conf == null) {
                     conf = new Properties();
@@ -433,24 +391,19 @@ public class ConsoleProxy {
             }
         }
 
-
         start(conf);
     }
-
 
     public static void start(Properties conf) {
         System.setProperty("java.awt.headless", "true");
 
-
         configProxy(conf);
-
 
         ConsoleProxyServerFactory factory = getHttpServerFactory();
         if (factory == null) {
             LOGGER.error("Unable to load console proxy server factory");
             System.exit(1);
         }
-
 
         if (httpListenPort != 0) {
             startupHttpMain();
@@ -459,19 +412,16 @@ public class ConsoleProxy {
             System.exit(1);
         }
 
-
         if (httpCmdListenPort > 0) {
             startupHttpCmdPort();
         } else {
             LOGGER.info("HTTP command port is disabled");
         }
 
-
         ConsoleProxyGCThread cthread = new ConsoleProxyGCThread(connectionMap, removedSessionsSet);
         cthread.setName("Console Proxy GC Thread");
         cthread.start();
     }
-
 
     private static void startupHttpMain() {
         try {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -459,7 +459,6 @@ public class ConsoleProxy {
                 new ConsoleProxyNoVNCServer();
     }
 
-
     private static void startupHttpCmdPort() {
         try {
             LOGGER.info("Listening for HTTP CMDs on port " + httpCmdListenPort);
@@ -473,11 +472,9 @@ public class ConsoleProxy {
         }
     }
 
-
     public static void main(String[] argv) {
         standaloneStart = true;
         configLog4j();
-
 
         InputStream confs = ConsoleProxy.class.getResourceAsStream("/conf/consoleproxy.properties");
         Properties conf = new Properties();
@@ -499,10 +496,8 @@ public class ConsoleProxy {
         start(conf);
     }
 
-
     public static ConsoleProxyClient getVncViewer(ConsoleProxyClientParam param) throws Exception {
         ConsoleProxyClient viewer = null;
-
 
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
@@ -513,7 +508,6 @@ public class ConsoleProxy {
                 viewer.initClient(param);
                 connectionMap.put(clientKey, viewer);
                 LOGGER.info("Added viewer object " + viewer);
-
 
                 reportLoadChange = true;
             } else if (!viewer.isFrontEndAlive()) {
@@ -526,7 +520,6 @@ public class ConsoleProxy {
             }
         }
 
-
         if (reportLoadChange) {
             ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
             String loadInfo = statsCollector.getStatsReport();
@@ -536,13 +529,10 @@ public class ConsoleProxy {
             }
         }
 
-
         return viewer;
     }
 
-
     public static ConsoleProxyClient getAjaxVncViewer(ConsoleProxyClientParam param, String ajaxSession) throws Exception {
-
 
         boolean reportLoadChange = false;
         String clientKey = param.getClientMapKey();
@@ -552,7 +542,6 @@ public class ConsoleProxy {
                 authenticationExternally(param);
                 viewer = getClient(param);
                 viewer.initClient(param);
-
 
                 connectionMap.put(clientKey, viewer);
                 LOGGER.info("Added viewer object " + viewer);
@@ -566,22 +555,18 @@ public class ConsoleProxy {
                     }
                 }
 
-
                 if (param.getClientHostPassword() == null || param.getClientHostPassword().isEmpty()
                         || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
                 }
 
-
                 if (!viewer.isFrontEndAlive()) {
-
 
                     authenticationExternally(param);
                     viewer.initClient(param);
                     reportLoadChange = true;
                 }
             }
-
 
             if (reportLoadChange) {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();
@@ -595,7 +580,6 @@ public class ConsoleProxy {
         }
     }
 
-
     private static ConsoleProxyClient getClient(ConsoleProxyClientParam param) {
         if (param.getHypervHost() != null) {
             return new ConsoleProxyRdpClient();
@@ -603,7 +587,6 @@ public class ConsoleProxy {
             return new ConsoleProxyVncClient();
         }
     }
-
 
     public static void removeViewer(ConsoleProxyClient viewer) {
         synchronized (connectionMap) {
@@ -617,48 +600,39 @@ public class ConsoleProxy {
         }
     }
 
-
     public static ConsoleProxyClientStatsCollector getStatsCollector() {
         synchronized (connectionMap) {
             return new ConsoleProxyClientStatsCollector(connectionMap);
         }
     }
 
-
     public static void authenticationExternally(ConsoleProxyClientParam param) throws AuthenticationException {
         ConsoleProxyAuthenticationResult authResult = authenticateConsoleAccess(param, false);
-
 
         if (authResult == null || !authResult.isSuccess()) {
             LOGGER.warn("External authenticator failed authentication request for vm " + param.getClientTag()
                     + " with sid " + param.getClientHostPassword());
-
 
             throw new AuthenticationException("External authenticator failed request for vm " + param.getClientTag()
                     + " with sid " + param.getClientHostPassword());
         }
     }
 
-
     public static ConsoleProxyAuthenticationResult reAuthenticationExternally(ConsoleProxyClientParam param) {
         return authenticateConsoleAccess(param, true);
     }
-
 
     public static String getEncryptorPassword() {
         return encryptorPassword;
     }
 
-
     public static void setEncryptorPassword(String password) {
         encryptorPassword = password;
     }
 
-
     public static void setIsSourceIpCheckEnabled(Boolean isEnabled) {
         isSourceIpCheckEnabled = isEnabled;
     }
-
 
     static class ThreadExecutor implements Executor {
         @Override
@@ -666,7 +640,6 @@ public class ConsoleProxy {
             new Thread(r).start();
         }
     }
-
 
     public static ConsoleProxyNoVncClient getNoVncViewer(ConsoleProxyClientParam param, String ajaxSession,
                                                          Session session) throws AuthenticationException {
@@ -681,7 +654,6 @@ public class ConsoleProxy {
                 viewer = new ConsoleProxyNoVncClient(session);
                 viewer.initClient(param);
 
-
                 connectionMap.put(clientKey, viewer);
                 reportLoadChange = true;
             } else {
@@ -689,7 +661,6 @@ public class ConsoleProxy {
                         || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
                 }
-
 
                 try {
                     authenticationExternally(param);
@@ -709,7 +680,6 @@ public class ConsoleProxy {
                 connectionMap.put(clientKey, viewer);
                 reportLoadChange = true;
             }
-
 
             if (reportLoadChange) {
                 ConsoleProxyClientStatsCollector statsCollector = getStatsCollector();

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -117,7 +117,6 @@ public class ConsoleProxy {
             try {
                 File file = new File(configUrl.toURI());
 
-
                 System.out.println("Log4j configuration from : " + file.getAbsolutePath());
                 Configurator.initialize(null, file.getAbsolutePath());
             } catch (URISyntaxException e) {
@@ -230,7 +229,6 @@ public class ConsoleProxy {
             String clientProvidedToken = param.getClientProvidedExtraSecurityToken();
             LOGGER.debug(String.format("Extra security validation for the console access, provided %s to validate against %s",
                     clientProvidedToken, extraToken));
-
             if (!extraToken.equals(clientProvidedToken)) {
                 LOGGER.error("The provided extra token does not match the expected value for this console endpoint");
                 authResult.setSuccess(false);
@@ -390,7 +388,6 @@ public class ConsoleProxy {
                 }
             }
         }
-
         start(conf);
     }
 

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -431,7 +431,6 @@ public class ConsoleProxy {
                 System.exit(1);
             }
 
-
             HttpServer server = factory.createHttpServerInstance(httpListenPort);
             server.createContext("/getscreen", new ConsoleProxyThumbnailHandler());
             server.createContext("/resource/", new ConsoleProxyResourceHandler());
@@ -440,17 +439,14 @@ public class ConsoleProxy {
             server.setExecutor(new ThreadExecutor()); // creates a default executor
             server.start();
 
-
             ConsoleProxyNoVNCServer noVNCServer = getNoVNCServer();
             noVNCServer.start();
-
 
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             System.exit(1);
         }
     }
-
 
     private static ConsoleProxyNoVNCServer getNoVNCServer() {
         int vncPort = ConsoleProxyNoVNCServer.getVNCPort();
@@ -661,7 +657,6 @@ public class ConsoleProxy {
                         || !param.getClientHostPassword().equals(viewer.getClientHostPassword())) {
                     throw new AuthenticationException("Cannot use the existing viewer " + viewer + ": bad sid");
                 }
-
                 try {
                     authenticationExternally(param);
                 } catch (Exception e) {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -32,9 +32,13 @@ import org.apache.logging.log4j.LogManager;
  * management software
  */
 public class ConsoleProxyGCThread extends Thread {
-    protected Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
+    private static final Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
 
-    private final static int MAX_SESSION_IDLE_SECONDS = 180;
+    /**
+     * Maximum time (in seconds) a console session is allowed to be idle before it is closed.
+     * This value should be kept in sync with ConsoleProxy.VIEWER_LINGER_SECONDS.
+     */
+    private static final int MAX_SESSION_IDLE_SECONDS = 180;
 
     private final Map<String, ConsoleProxyClient> connMap;
     private final Set<String> removedSessionsSet;
@@ -46,21 +50,21 @@ public class ConsoleProxyGCThread extends Thread {
     }
 
     private void cleanupLogging() {
-        if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000)
+        if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000) {
             return;
+        }
 
         lastLogScan = System.currentTimeMillis();
 
         File logDir = new File("./logs");
-        File files[] = logDir.listFiles();
+        File[] files = logDir.listFiles();
         if (files != null) {
             for (File file : files) {
                 if (System.currentTimeMillis() - file.lastModified() >= 86400000L) {
                     try {
                         file.delete();
                     } catch (Throwable e) {
-                        logger.info("[ignored]"
-                                + "failed to delete file: " + e.getLocalizedMessage());
+                        logger.info("[ignored] failed to delete file: " + e.getLocalizedMessage());
                     }
                 }
             }
@@ -78,10 +82,10 @@ public class ConsoleProxyGCThread extends Thread {
             bReportLoad = false;
 
             if (logger.isDebugEnabled()) {
-                logger.debug(String.format("connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
+                logger.debug(String.format("ConsoleProxyGCThread loop: connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
             }
-            Set<String> e = connMap.keySet();
-            Iterator<String> iterator = e.iterator();
+            Set<String> keys = connMap.keySet();
+            Iterator<String> iterator = keys.iterator();
             while (iterator.hasNext()) {
                 String key;
                 ConsoleProxyClient client;
@@ -91,8 +95,12 @@ public class ConsoleProxyGCThread extends Thread {
                     client = connMap.get(key);
                 }
 
-                long seconds_unused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
-                if (seconds_unused < MAX_SESSION_IDLE_SECONDS) {
+                if (client == null) {
+                    continue;
+                }
+
+                long secondsUnused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
+                if (secondsUnused < MAX_SESSION_IDLE_SECONDS) {
                     continue;
                 }
 
@@ -102,12 +110,12 @@ public class ConsoleProxyGCThread extends Thread {
                 }
 
                 // close the server connection
-                logger.info("Dropping " + client + " which has not been used for " + seconds_unused + " seconds");
+                logger.info("Dropping " + client + " which has not been used for " + secondsUnused + " seconds");
                 client.closeClient();
             }
 
             if (bReportLoad || System.currentTimeMillis() - lastReportTick > 5000) {
-                // report load changes
+                // report load changes, including removed sessions since last report
                 ConsoleProxyClientStatsCollector collector = new ConsoleProxyClientStatsCollector(connMap);
                 collector.setRemovedSessions(new ArrayList<>(removedSessionsSet));
                 String loadInfo = collector.getStatsReport();
@@ -125,7 +133,7 @@ public class ConsoleProxyGCThread extends Thread {
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException ex) {
-                logger.debug("[ignored] Console proxy was interrupted during GC.");
+                logger.debug("[ignored] Console proxy GC thread interrupted.", ex);
             }
         }
     }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -16,14 +16,17 @@
 // under the License.
 package com.cloud.consoleproxy;
 
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+
 
 /**
  *
@@ -34,27 +37,26 @@ import org.apache.logging.log4j.LogManager;
 public class ConsoleProxyGCThread extends Thread {
     private static final Logger logger = LogManager.getLogger(ConsoleProxyGCThread.class);
 
-    /**
-     * Maximum time (in seconds) a console session is allowed to be idle before it is closed.
-     * This value should be kept in sync with ConsoleProxy.VIEWER_LINGER_SECONDS.
-     */
-    private static final int MAX_SESSION_IDLE_SECONDS = 180;
 
     private final Map<String, ConsoleProxyClient> connMap;
     private final Set<String> removedSessionsSet;
     private long lastLogScan = 0;
+
 
     public ConsoleProxyGCThread(Map<String, ConsoleProxyClient> connMap, Set<String> removedSet) {
         this.connMap = connMap;
         this.removedSessionsSet = removedSet;
     }
 
+
     private void cleanupLogging() {
         if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000) {
             return;
         }
 
+
         lastLogScan = System.currentTimeMillis();
+
 
         File logDir = new File("./logs");
         File[] files = logDir.listFiles();
@@ -71,15 +73,19 @@ public class ConsoleProxyGCThread extends Thread {
         }
     }
 
+
     @Override
     public void run() {
+
 
         boolean bReportLoad = false;
         long lastReportTick = System.currentTimeMillis();
 
+
         while (true) {
             cleanupLogging();
             bReportLoad = false;
+
 
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("ConsoleProxyGCThread loop: connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
@@ -90,29 +96,36 @@ public class ConsoleProxyGCThread extends Thread {
                 String key;
                 ConsoleProxyClient client;
 
+
                 synchronized (connMap) {
                     key = iterator.next();
                     client = connMap.get(key);
                 }
 
+
                 if (client == null) {
                     continue;
                 }
 
-                long secondsUnused = (System.currentTimeMillis() - client.getClientLastFrontEndActivityTime()) / 1000;
-                if (secondsUnused < MAX_SESSION_IDLE_SECONDS) {
+
+                long millisecondsUnused = System.currentTimeMillis() - client.getClientLastFrontEndActivityTime();
+                if (millisecondsUnused < ConsoleProxy.sessionTimeoutMillis) {
                     continue;
                 }
+
 
                 synchronized (connMap) {
                     connMap.remove(key);
                     bReportLoad = true;
                 }
 
+
                 // close the server connection
-                logger.info("Dropping " + client + " which has not been used for " + secondsUnused + " seconds");
+                logger.info("Dropping " + client + " which has not been used for " + millisecondsUnused
+                        + " ms (configured timeout: " + ConsoleProxy.sessionTimeoutMillis + " ms)");
                 client.closeClient();
             }
+
 
             if (bReportLoad || System.currentTimeMillis() - lastReportTick > 5000) {
                 // report load changes, including removed sessions since last report
@@ -125,10 +138,12 @@ public class ConsoleProxyGCThread extends Thread {
                     removedSessionsSet.clear();
                 }
 
+
                 if (logger.isDebugEnabled()) {
                     logger.debug("Report load change : " + loadInfo);
                 }
             }
+
 
             try {
                 Thread.sleep(5000);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -48,7 +48,6 @@ public class ConsoleProxyGCThread extends Thread {
         if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000) {
             return;
         }
-
         lastLogScan = System.currentTimeMillis();
 
         File logDir = new File("./logs");

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -95,7 +95,6 @@ public class ConsoleProxyGCThread extends Thread {
                  keys = new ArrayList<>(connMap.keySet());
              }
              for (String key : keys) {
-                String key;
                 ConsoleProxyClient client;
 
 

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -16,17 +16,14 @@
 // under the License.
 package com.cloud.consoleproxy;
 
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
 
 /**
  *
@@ -42,21 +39,17 @@ public class ConsoleProxyGCThread extends Thread {
     private final Set<String> removedSessionsSet;
     private long lastLogScan = 0;
 
-
     public ConsoleProxyGCThread(Map<String, ConsoleProxyClient> connMap, Set<String> removedSet) {
         this.connMap = connMap;
         this.removedSessionsSet = removedSet;
     }
-
 
     private void cleanupLogging() {
         if (lastLogScan != 0 && System.currentTimeMillis() - lastLogScan < 3600000) {
             return;
         }
 
-
         lastLogScan = System.currentTimeMillis();
-
 
         File logDir = new File("./logs");
         File[] files = logDir.listFiles();
@@ -73,19 +66,15 @@ public class ConsoleProxyGCThread extends Thread {
         }
     }
 
-
     @Override
     public void run() {
-
 
         boolean bReportLoad = false;
         long lastReportTick = System.currentTimeMillis();
 
-
         while (true) {
             cleanupLogging();
             bReportLoad = false;
-
 
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("ConsoleProxyGCThread loop: connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
@@ -97,35 +86,29 @@ public class ConsoleProxyGCThread extends Thread {
              for (String key : keys) {
                 ConsoleProxyClient client;
 
-
                 synchronized (connMap) {
                     client = connMap.get(key);
                 }
 
-
                 if (client == null) {
                     continue;
                 }
-
 
                 long millisecondsUnused = System.currentTimeMillis() - client.getClientLastFrontEndActivityTime();
                 if (millisecondsUnused < ConsoleProxy.sessionTimeoutMillis) {
                     continue;
                 }
 
-
                 synchronized (connMap) {
                     connMap.remove(key);
                     bReportLoad = true;
                 }
-
 
                 // close the server connection
                 logger.info("Dropping " + client + " which has not been used for " + millisecondsUnused
                         + " ms (configured timeout: " + ConsoleProxy.sessionTimeoutMillis + " ms)");
                 client.closeClient();
             }
-
 
             if (bReportLoad || System.currentTimeMillis() - lastReportTick > 5000) {
                 // report load changes, including removed sessions since last report
@@ -138,12 +121,10 @@ public class ConsoleProxyGCThread extends Thread {
                     removedSessionsSet.clear();
                 }
 
-
                 if (logger.isDebugEnabled()) {
                     logger.debug("Report load change : " + loadInfo);
                 }
             }
-
 
             try {
                 Thread.sleep(5000);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -19,7 +19,7 @@ package com.cloud.consoleproxy;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -90,15 +90,16 @@ public class ConsoleProxyGCThread extends Thread {
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("ConsoleProxyGCThread loop: connMap=%s, removedSessions=%s", connMap, removedSessionsSet));
             }
-            Set<String> keys = connMap.keySet();
-            Iterator<String> iterator = keys.iterator();
-            while (iterator.hasNext()) {
+            List<String> keys;
+            synchronized (connMap) {
+                 keys = new ArrayList<>(connMap.keySet());
+             }
+             for (String key : keys) {
                 String key;
                 ConsoleProxyClient client;
 
 
                 synchronized (connMap) {
-                    key = iterator.next();
                     client = connMap.get(key);
                 }
 

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -40,8 +40,9 @@ import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 @WebSocket
 public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
+    private static final Logger logger = LogManager.getLogger(ConsoleProxyNoVNCHandler.class);
+
     private ConsoleProxyNoVncClient viewer = null;
-    protected Logger logger = LogManager.getLogger(getClass());
 
     public ConsoleProxyNoVNCHandler() {
         super();
@@ -93,15 +94,16 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         String websocketUrl = queryMap.get("websocketUrl");
         String sessionUuid = queryMap.get("sessionUuid");
         String clientIp = session.getRemoteAddress().getAddress().getHostAddress();
+        boolean sessionRequiresNewViewer = Boolean.parseBoolean(queryMap.get("sessionRequiresNewViewer"));
 
-        if (tag == null)
+        if (tag == null) {
             tag = "";
+        }
 
-        long ajaxSessionId = 0;
         int port;
-
-        if (host == null || portStr == null || sid == null)
-            throw new IllegalArgumentException();
+        if (host == null || portStr == null || sid == null) {
+            throw new IllegalArgumentException("Missing required console connection parameters");
+        }
 
         try {
             port = Integer.parseInt(portStr);
@@ -112,7 +114,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
         if (ajaxSessionIdStr != null) {
             try {
-                ajaxSessionId = Long.parseLong(ajaxSessionIdStr);
+                Long.parseLong(ajaxSessionIdStr);
             } catch (NumberFormatException e) {
                 logger.error("Invalid ajaxSessionId (sess) value in query string: {}. Expected a number.", ajaxSessionIdStr, e);
                 throw new IllegalArgumentException(e);
@@ -148,10 +150,11 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             if (queryMap.containsKey("extra")) {
                 param.setClientProvidedExtraSecurityToken(queryMap.get("extra"));
             }
+
             viewer = ConsoleProxy.getNoVncViewer(param, ajaxSessionIdStr, session);
             logger.info("Viewer has been created successfully [session UUID: {}, client IP: {}].", sessionUuid, clientIp);
         } catch (Exception e) {
-            logger.error("Failed to create viewer [session UUID: {}, client IP: {}] due to {}.", sessionUuid, clientIp, e.getMessage(), e);
+            logger.error("Failed to create viewer [session UUID: {}, client IP: {}].", sessionUuid, clientIp, e);
             return;
         } finally {
             if (viewer == null) {
@@ -160,7 +163,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         }
     }
 
-    private boolean checkSessionSourceIp(final Session session, final String sourceIP, String sessionSourceIP) throws IOException {
+    private boolean checkSessionSourceIp(final Session session, final String sourceIP, final String sessionSourceIP) throws IOException {
         logger.info("Verifying session source IP {} from WebSocket connection request.", sessionSourceIP);
         if (ConsoleProxy.isSourceIpCheckEnabled && (sessionSourceIP == null || !sessionSourceIP.equals(sourceIP))) {
             logger.warn("Failed to access console as the source IP to request the console is {}.", sourceIP);
@@ -174,7 +177,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
     @OnWebSocketClose
     public void onClose(Session session, int statusCode, String reason) throws IOException, InterruptedException {
         String sessionSourceIp = session.getRemoteAddress().getAddress().getHostAddress();
-        logger.debug("Closing WebSocket session [source IP: {}, status code: {}].", sessionSourceIp, statusCode);
+        logger.debug("Closing WebSocket session [source IP: {}, status code: {}, reason: {}].", sessionSourceIp, statusCode, reason);
         if (viewer != null) {
             ConsoleProxy.removeViewer(viewer);
         }
@@ -183,12 +186,20 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
     @OnWebSocketFrame
     public void onFrame(Frame f) throws IOException {
+        if (viewer == null) {
+            logger.debug("Ignoring WebSocket frame because viewer is not initialized yet.");
+            return;
+        }
         logger.trace("Sending client [ID: {}] frame of {} bytes.", viewer.getClientId(), f.getPayloadLength());
         viewer.sendClientFrame(f);
     }
 
     @OnWebSocketError
     public void onError(Throwable cause) {
-        logger.error("Error on WebSocket [client ID: {}, session UUID: {}].", cause, viewer.getClientId(), viewer.getSessionUuid());
+        if (viewer != null) {
+            logger.error("Error on WebSocket [client ID: {}, session UUID: {}].", viewer.getClientId(), viewer.getSessionUuid(), cause);
+        } else {
+            logger.error("Error on WebSocket before viewer initialization.", cause);
+        }
     }
 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -74,7 +74,6 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
     @OnWebSocketConnect
     public void onConnect(final Session session) throws IOException, InterruptedException {
-    public void onConnect(final Session session) throws IOException, InterruptedException {
         session.setIdleTimeout(ConsoleProxy.sessionTimeoutMillis);
         logger.debug("Set WebSocket idle timeout to {} ms for session from {}.",
                 ConsoleProxy.sessionTimeoutMillis, session.getRemoteAddress());

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -153,7 +153,6 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             if (queryMap.containsKey("extra")) {
                 param.setClientProvidedExtraSecurityToken(queryMap.get("extra"));
             }
-
             viewer = ConsoleProxy.getNoVncViewer(param, ajaxSessionIdStr, session);
             logger.info("Viewer has been created successfully [session UUID: {}, client IP: {}].", sessionUuid, clientIp);
         } catch (Exception e) {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -98,7 +98,6 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
         String websocketUrl = queryMap.get("websocketUrl");
         String sessionUuid = queryMap.get("sessionUuid");
         String clientIp = session.getRemoteAddress().getAddress().getHostAddress();
-        boolean sessionRequiresNewViewer = Boolean.parseBoolean(queryMap.get("sessionRequiresNewViewer"));
 
         if (tag == null) {
             tag = "";
@@ -195,6 +194,7 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
             return;
         }
         logger.trace("Sending client [ID: {}] frame of {} bytes.", viewer.getClientId(), f.getPayloadLength());
+        viewer.updateFrontEndActivityTime();
         viewer.sendClientFrame(f);
     }
 

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -74,6 +74,11 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
     @OnWebSocketConnect
     public void onConnect(final Session session) throws IOException, InterruptedException {
+    public void onConnect(final Session session) throws IOException, InterruptedException {
+        session.setIdleTimeout(ConsoleProxy.sessionTimeoutMillis);
+        logger.debug("Set WebSocket idle timeout to {} ms for session from {}.",
+                ConsoleProxy.sessionTimeoutMillis, session.getRemoteAddress());
+
         String queries = session.getUpgradeRequest().getQueryString();
         Map<String, String> queryMap = ConsoleProxyHttpHandlerHelper.getQueryMap(queries);
 


### PR DESCRIPTION
### Description

This PR backports the console proxy/noVNC timeout fix to the 4.20 branch.

It ensures that `consoleproxy.session.timeout` is honoured for noVNC console
sessions, so idle sessions are cleaned up correctly and do not linger
indefinitely.

Key points:
- Wire `consoleproxy.session.timeout` through the console proxy server for
  noVNC-based console sessions.
- Apply the timeout in the WebSocket handler and GC thread so idle sessions
  are closed after the configured period.
- Keep the change minimal and compatible with 4.20: do not introduce the
  newer `sessionRequiresNewViewer` API on `ConsoleProxyClientParam`, only
  remove the references that exist in later branches.

### Related work

- Backport of the console proxy timeout fix from the main branch.
- Intended to address the same behaviour as the upstream change that fixed
  idle noVNC sessions not respecting `consoleproxy.session.timeout`.

### Testing

- Compiled the console proxy server module successfully:

  ```bash
  mvn -pl services/console-proxy/server -am -DskipTests compile
  ```

- Verified that the code builds cleanly with checkstyle on the 4.20 branch.
Fix #12810 