### PR TITLE
flasharray: authenticate via REST 2.x api-token and discover API version

### DIFF
--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -593,10 +593,10 @@ public class FlashArrayAdapter implements ProviderAdapter {
 
         apiVersion = connectionDetails.get(FlashArrayAdapter.API_VERSION);
         boolean apiVersionExplicit = apiVersion != null;
-        if (apiVersion == null) {
+        if (!apiVersionExplicit) {
             apiVersion = queryParms.get(FlashArrayAdapter.API_VERSION);
             apiVersionExplicit = apiVersion != null;
-            if (apiVersion == null) {
+            if (!apiVersionExplicit) {
                 apiVersion = API_VERSION_DEFAULT;
             }
         }
@@ -702,7 +702,11 @@ public class FlashArrayAdapter implements ProviderAdapter {
                             + "/api_version, falling back to default " + API_VERSION_DEFAULT, e);
                 } finally {
                     if (vResp != null) {
-                        vResp.close();
+                        try {
+                            vResp.close();
+                        } catch (IOException e) {
+                            logger.debug("Error closing /api/api_version response from FlashArray [" + url + "]", e);
+                        }
                     }
                 }
             }
@@ -736,7 +740,11 @@ public class FlashArrayAdapter implements ProviderAdapter {
                             "Unexpected HTTP response code from FlashArray [" + url + "] - [" + statusCode
                                     + "] - " + response.getStatusLine().getReasonPhrase());
                 }
-                response.close();
+                try {
+                    response.close();
+                } catch (IOException e) {
+                    logger.debug("Error closing legacy auth/apitoken response from FlashArray [" + url + "]", e);
+                }
                 response = null;
             }
 

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -61,6 +61,7 @@ import org.apache.http.ssl.SSLContextBuilder;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -591,8 +592,10 @@ public class FlashArrayAdapter implements ProviderAdapter {
         }
 
         apiVersion = connectionDetails.get(FlashArrayAdapter.API_VERSION);
+        boolean apiVersionExplicit = apiVersion != null;
         if (apiVersion == null) {
             apiVersion = queryParms.get(FlashArrayAdapter.API_VERSION);
+            apiVersionExplicit = apiVersion != null;
             if (apiVersion == null) {
                 apiVersion = API_VERSION_DEFAULT;
             }
@@ -660,72 +663,117 @@ public class FlashArrayAdapter implements ProviderAdapter {
             skipTlsValidation = true;
         }
 
+        // Resolve the long-lived API token. Prefer a pre-minted api_token (Purity REST 2.x flow);
+        // fall back to legacy username/password auth via Purity REST 1.x for backward compatibility.
+        String apiToken = connectionDetails.get(ProviderAdapter.API_TOKEN_KEY);
+        if (apiToken != null && apiToken.isEmpty()) {
+            apiToken = null;
+        }
+        boolean usingLegacyUserPass = apiToken == null;
+        if (usingLegacyUserPass && (username == null || password == null)) {
+            throw new CloudRuntimeException("FlashArray adapter requires either " + ProviderAdapter.API_TOKEN_KEY
+                    + " (preferred) or both " + ProviderAdapter.API_USERNAME_KEY + " and "
+                    + ProviderAdapter.API_PASSWORD_KEY + " in the connection details");
+        }
+
+        CloseableHttpClient client = getClient();
         CloseableHttpResponse response = null;
         try {
-            HttpPost request = new HttpPost(url + "/" + apiLoginVersion + "/auth/apitoken");
-            // request.addHeader("Content-Type", "application/json");
-            // request.addHeader("Accept", "application/json");
-            ArrayList<NameValuePair> postParms = new ArrayList<NameValuePair>();
-            postParms.add(new BasicNameValuePair("username", username));
-            postParms.add(new BasicNameValuePair("password", password));
-            request.setEntity(new UrlEncodedFormEntity(postParms, "UTF-8"));
-            CloseableHttpClient client = getClient();
-            response = (CloseableHttpResponse) client.execute(request);
-
-            int statusCode = response.getStatusLine().getStatusCode();
-            FlashArrayApiToken apitoken = null;
-            if (statusCode == 200 | statusCode == 201) {
-                apitoken = mapper.readValue(response.getEntity().getContent(), FlashArrayApiToken.class);
-                if (apitoken == null) {
-                    throw new CloudRuntimeException(
-                            "Authentication responded successfully but no api token was returned");
+            // Discover the latest supported API version from the array unless one was explicitly configured.
+            // GET /api/api_version is unauthenticated and returns {"version":["1.0",...,"2.36"]}.
+            if (!apiVersionExplicit) {
+                HttpGet vReq = new HttpGet(url + "/api_version");
+                CloseableHttpResponse vResp = null;
+                try {
+                    vResp = (CloseableHttpResponse) client.execute(vReq);
+                    if (vResp.getStatusLine().getStatusCode() == 200) {
+                        JsonNode root = mapper.readTree(vResp.getEntity().getContent());
+                        JsonNode versions = root.get("version");
+                        if (versions != null && versions.isArray() && versions.size() > 0) {
+                            apiVersion = versions.get(versions.size() - 1).asText();
+                        }
+                    } else {
+                        logger.warn("Unexpected HTTP " + vResp.getStatusLine().getStatusCode()
+                                + " from FlashArray [" + url + "] /api_version, falling back to default "
+                                + API_VERSION_DEFAULT);
+                    }
+                } catch (Exception e) {
+                    logger.warn("Failed to discover Purity REST API version from " + url
+                            + "/api_version, falling back to default " + API_VERSION_DEFAULT, e);
+                } finally {
+                    if (vResp != null) {
+                        vResp.close();
+                    }
                 }
-            } else if (statusCode == 401 || statusCode == 403) {
-                throw new CloudRuntimeException(
-                        "Authentication or Authorization to FlashArray [" + url + "] with user [" + username
-                                + "] failed, unable to retrieve session token");
-            } else {
-                throw new CloudRuntimeException(
-                        "Unexpected HTTP response code from FlashArray [" + url + "] - [" + statusCode
-                                + "] - " + response.getStatusLine().getReasonPhrase());
             }
 
-            // now we need to get the access token
-            request = new HttpPost(url + "/" + apiVersion + "/login");
-            request.addHeader("api-token", apitoken.getApiToken());
-            response = (CloseableHttpResponse) client.execute(request);
+            if (usingLegacyUserPass) {
+                logger.warn("FlashArray adapter at [" + url + "] is using deprecated username/password "
+                        + "login against Purity REST 1.x. Replace with a pre-minted "
+                        + ProviderAdapter.API_TOKEN_KEY + " detail; the username/password code path will be "
+                        + "removed in a future release.");
+                HttpPost request = new HttpPost(url + "/" + apiLoginVersion + "/auth/apitoken");
+                ArrayList<NameValuePair> postParms = new ArrayList<NameValuePair>();
+                postParms.add(new BasicNameValuePair("username", username));
+                postParms.add(new BasicNameValuePair("password", password));
+                request.setEntity(new UrlEncodedFormEntity(postParms, "UTF-8"));
+                response = (CloseableHttpResponse) client.execute(request);
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 200 || statusCode == 201) {
+                    FlashArrayApiToken legacyToken = mapper.readValue(response.getEntity().getContent(),
+                            FlashArrayApiToken.class);
+                    if (legacyToken == null || legacyToken.getApiToken() == null) {
+                        throw new CloudRuntimeException(
+                                "Authentication responded successfully but no api token was returned");
+                    }
+                    apiToken = legacyToken.getApiToken();
+                } else if (statusCode == 401 || statusCode == 403) {
+                    throw new CloudRuntimeException(
+                            "Authentication or Authorization to FlashArray [" + url + "] with user [" + username
+                                    + "] failed, unable to retrieve session token");
+                } else {
+                    throw new CloudRuntimeException(
+                            "Unexpected HTTP response code from FlashArray [" + url + "] - [" + statusCode
+                                    + "] - " + response.getStatusLine().getReasonPhrase());
+                }
+                response.close();
+                response = null;
+            }
 
-            statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode == 200 | statusCode == 201) {
+            // Exchange the long-lived api-token for a short-lived x-auth-token (REST 2.x).
+            HttpPost request = new HttpPost(url + "/" + apiVersion + "/login");
+            request.addHeader("api-token", apiToken);
+            response = (CloseableHttpResponse) client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode == 200 || statusCode == 201) {
                 Header[] headers = response.getHeaders("x-auth-token");
                 if (headers == null || headers.length == 0) {
                     throw new CloudRuntimeException(
-                            "Getting access token responded successfully but access token was not available");
+                            "FlashArray /login responded successfully but no x-auth-token header was returned");
                 }
                 accessToken = headers[0].getValue();
             } else if (statusCode == 401 || statusCode == 403) {
                 throw new CloudRuntimeException(
-                        "Authentication or Authorization to FlashArray [" + url + "] with user [" + username
-                                + "] failed, unable to retrieve session token");
+                        "FlashArray [" + url + "] rejected the api-token at /" + apiVersion + "/login");
             } else {
                 throw new CloudRuntimeException(
-                        "Unexpected HTTP response code from FlashArray [" + url + "] - [" + statusCode
-                                + "] - " + response.getStatusLine().getReasonPhrase());
+                        "Unexpected HTTP response code from FlashArray [" + url + "] /" + apiVersion
+                                + "/login - [" + statusCode + "] - "
+                                + response.getStatusLine().getReasonPhrase());
             }
-
         } catch (UnsupportedEncodingException e) {
-            throw new CloudRuntimeException("Error creating input for login, check username/password encoding");
+            throw new CloudRuntimeException("Error encoding login form for FlashArray [" + url + "]", e);
         } catch (UnsupportedOperationException e) {
             throw new CloudRuntimeException("Error processing login response from FlashArray [" + url + "]", e);
         } catch (IOException e) {
             throw new CloudRuntimeException("Error sending login request to FlashArray [" + url + "]", e);
         } finally {
-            try {
-                if (response != null) {
+            if (response != null) {
+                try {
                     response.close();
+                } catch (IOException e) {
+                    logger.debug("Error closing response from login attempt to FlashArray", e);
                 }
-            } catch (IOException e) {
-                logger.debug("Error closing response from login attempt to FlashArray", e);
             }
         }
     }

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -705,7 +705,7 @@ public class FlashArrayAdapter implements ProviderAdapter {
                         try {
                             vResp.close();
                         } catch (IOException e) {
-                            logger.debug("Error closing /api/api_version response from FlashArray [" + url + "]", e);
+                            logger.debug("Error closing /api_version response from FlashArray [" + url + "]", e);
                         }
                     }
                 }

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -27,6 +27,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -85,6 +87,10 @@ public class FlashArrayAdapter implements ProviderAdapter {
     private static final long POST_COPY_WAIT_MS_DEFAULT = 5000;
     private static final String API_LOGIN_VERSION_DEFAULT = "1.19";
     private static final String API_VERSION_DEFAULT = "2.23";
+
+    // URLs for which the legacy-auth deprecation WARN has already been emitted,
+    // so we don't spam the logs once per refresh per pool while it's still configured.
+    private static final Set<String> WARNED_LEGACY_URLS = ConcurrentHashMap.newKeySet();
 
     static final ObjectMapper mapper = new ObjectMapper();
     public String pod = null;
@@ -712,10 +718,12 @@ public class FlashArrayAdapter implements ProviderAdapter {
             }
 
             if (usingLegacyUserPass) {
-                logger.warn("FlashArray adapter at [" + url + "] is using deprecated username/password "
-                        + "login against Purity REST 1.x. Replace with a pre-minted "
-                        + ProviderAdapter.API_TOKEN_KEY + " detail; the username/password code path will be "
-                        + "removed in a future release.");
+                if (WARNED_LEGACY_URLS.add(url)) {
+                    logger.warn("FlashArray adapter at [" + url + "] is using deprecated username/password "
+                            + "login against Purity REST 1.x. Replace with a pre-minted "
+                            + ProviderAdapter.API_TOKEN_KEY + " detail; the username/password code path will be "
+                            + "removed in a future release.");
+                }
                 HttpPost request = new HttpPost(url + "/" + apiLoginVersion + "/auth/apitoken");
                 ArrayList<NameValuePair> postParms = new ArrayList<NameValuePair>();
                 postParms.add(new BasicNameValuePair("username", username));

--- a/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
+++ b/plugins/storage/volume/flasharray/src/main/java/org/apache/cloudstack/storage/datastore/adapter/flasharray/FlashArrayAdapter.java
@@ -524,6 +524,91 @@ public class FlashArrayAdapter implements ProviderAdapter {
         return accessToken;
     }
 
+    /**
+     * Discover the latest supported Purity REST API version by hitting the unauthenticated
+     * {@code /api/api_version} endpoint (returns {@code {"version":["1.0",...,"2.36"]}}).
+     * The discovered version is stored on {@link #apiVersion}; on failure the caller-configured
+     * default remains in place.
+     */
+    private void fetchApiVersionFromPurity(CloseableHttpClient client) {
+        HttpGet vReq = new HttpGet(url + "/api_version");
+        CloseableHttpResponse vResp = null;
+        try {
+            vResp = client.execute(vReq);
+            if (vResp.getStatusLine().getStatusCode() == 200) {
+                JsonNode root = mapper.readTree(vResp.getEntity().getContent());
+                JsonNode versions = root.get("version");
+                if (versions != null && versions.isArray() && versions.size() > 0) {
+                    apiVersion = versions.get(versions.size() - 1).asText();
+                }
+            } else {
+                logger.warn("Unexpected HTTP " + vResp.getStatusLine().getStatusCode()
+                        + " from FlashArray [" + url + "] /api_version, falling back to default "
+                        + API_VERSION_DEFAULT);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to discover Purity REST API version from " + url
+                    + "/api_version, falling back to default " + API_VERSION_DEFAULT, e);
+        } finally {
+            if (vResp != null) {
+                try {
+                    vResp.close();
+                } catch (IOException e) {
+                    logger.debug("Error closing /api_version response from FlashArray [" + url + "]", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Exchange the operator-configured username/password for a long-lived Purity api-token
+     * via REST 1.x {@code /auth/apitoken}. Emits the once-per-URL deprecation WARN.
+     * @return the api-token to feed into the REST 2.x /login exchange.
+     */
+    private String getApiTokenUsingUserPass(CloseableHttpClient client) throws IOException {
+        if (WARNED_LEGACY_URLS.add(url)) {
+            logger.warn("FlashArray adapter at [" + url + "] is using deprecated username/password "
+                    + "login against Purity REST 1.x. Replace with a pre-minted "
+                    + ProviderAdapter.API_TOKEN_KEY + " detail; the username/password code path will be "
+                    + "removed in a future release.");
+        }
+        HttpPost request = new HttpPost(url + "/" + apiLoginVersion + "/auth/apitoken");
+        ArrayList<NameValuePair> postParms = new ArrayList<NameValuePair>();
+        postParms.add(new BasicNameValuePair("username", username));
+        postParms.add(new BasicNameValuePair("password", password));
+        request.setEntity(new UrlEncodedFormEntity(postParms, "UTF-8"));
+        CloseableHttpResponse response = null;
+        try {
+            response = client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode == 200 || statusCode == 201) {
+                FlashArrayApiToken legacyToken = mapper.readValue(response.getEntity().getContent(),
+                        FlashArrayApiToken.class);
+                if (legacyToken == null || legacyToken.getApiToken() == null) {
+                    throw new CloudRuntimeException(
+                            "Authentication responded successfully but no api token was returned");
+                }
+                return legacyToken.getApiToken();
+            } else if (statusCode == 401 || statusCode == 403) {
+                throw new CloudRuntimeException(
+                        "Authentication or Authorization to FlashArray [" + url + "] with user [" + username
+                                + "] failed, unable to retrieve session token");
+            } else {
+                throw new CloudRuntimeException(
+                        "Unexpected HTTP response code from FlashArray [" + url + "] - [" + statusCode
+                                + "] - " + response.getStatusLine().getReasonPhrase());
+            }
+        } finally {
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (IOException e) {
+                    logger.debug("Error closing legacy auth/apitoken response from FlashArray [" + url + "]", e);
+                }
+            }
+        }
+    }
+
     private synchronized void refreshSession(boolean force) {
         try {
             if (force || keyExpiration < System.currentTimeMillis()) {
@@ -688,78 +773,17 @@ public class FlashArrayAdapter implements ProviderAdapter {
             // Discover the latest supported API version from the array unless one was explicitly configured.
             // GET /api/api_version is unauthenticated and returns {"version":["1.0",...,"2.36"]}.
             if (!apiVersionExplicit) {
-                HttpGet vReq = new HttpGet(url + "/api_version");
-                CloseableHttpResponse vResp = null;
-                try {
-                    vResp = (CloseableHttpResponse) client.execute(vReq);
-                    if (vResp.getStatusLine().getStatusCode() == 200) {
-                        JsonNode root = mapper.readTree(vResp.getEntity().getContent());
-                        JsonNode versions = root.get("version");
-                        if (versions != null && versions.isArray() && versions.size() > 0) {
-                            apiVersion = versions.get(versions.size() - 1).asText();
-                        }
-                    } else {
-                        logger.warn("Unexpected HTTP " + vResp.getStatusLine().getStatusCode()
-                                + " from FlashArray [" + url + "] /api_version, falling back to default "
-                                + API_VERSION_DEFAULT);
-                    }
-                } catch (Exception e) {
-                    logger.warn("Failed to discover Purity REST API version from " + url
-                            + "/api_version, falling back to default " + API_VERSION_DEFAULT, e);
-                } finally {
-                    if (vResp != null) {
-                        try {
-                            vResp.close();
-                        } catch (IOException e) {
-                            logger.debug("Error closing /api_version response from FlashArray [" + url + "]", e);
-                        }
-                    }
-                }
+                fetchApiVersionFromPurity(client);
             }
 
             if (usingLegacyUserPass) {
-                if (WARNED_LEGACY_URLS.add(url)) {
-                    logger.warn("FlashArray adapter at [" + url + "] is using deprecated username/password "
-                            + "login against Purity REST 1.x. Replace with a pre-minted "
-                            + ProviderAdapter.API_TOKEN_KEY + " detail; the username/password code path will be "
-                            + "removed in a future release.");
-                }
-                HttpPost request = new HttpPost(url + "/" + apiLoginVersion + "/auth/apitoken");
-                ArrayList<NameValuePair> postParms = new ArrayList<NameValuePair>();
-                postParms.add(new BasicNameValuePair("username", username));
-                postParms.add(new BasicNameValuePair("password", password));
-                request.setEntity(new UrlEncodedFormEntity(postParms, "UTF-8"));
-                response = (CloseableHttpResponse) client.execute(request);
-                int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == 200 || statusCode == 201) {
-                    FlashArrayApiToken legacyToken = mapper.readValue(response.getEntity().getContent(),
-                            FlashArrayApiToken.class);
-                    if (legacyToken == null || legacyToken.getApiToken() == null) {
-                        throw new CloudRuntimeException(
-                                "Authentication responded successfully but no api token was returned");
-                    }
-                    apiToken = legacyToken.getApiToken();
-                } else if (statusCode == 401 || statusCode == 403) {
-                    throw new CloudRuntimeException(
-                            "Authentication or Authorization to FlashArray [" + url + "] with user [" + username
-                                    + "] failed, unable to retrieve session token");
-                } else {
-                    throw new CloudRuntimeException(
-                            "Unexpected HTTP response code from FlashArray [" + url + "] - [" + statusCode
-                                    + "] - " + response.getStatusLine().getReasonPhrase());
-                }
-                try {
-                    response.close();
-                } catch (IOException e) {
-                    logger.debug("Error closing legacy auth/apitoken response from FlashArray [" + url + "]", e);
-                }
-                response = null;
+                apiToken = getApiTokenUsingUserPass(client);
             }
 
             // Exchange the long-lived api-token for a short-lived x-auth-token (REST 2.x).
             HttpPost request = new HttpPost(url + "/" + apiVersion + "/login");
             request.addHeader("api-token", apiToken);
-            response = (CloseableHttpResponse) client.execute(request);
+            response = client.execute(request);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200 || statusCode == 201) {
                 Header[] headers = response.getHeaders("x-auth-token");
@@ -957,7 +981,7 @@ public class FlashArrayAdapter implements ProviderAdapter {
             request.setEntity(new StringEntity(data));
 
             CloseableHttpClient client = getClient();
-            response = (CloseableHttpResponse) client.execute(request);
+            response = client.execute(request);
 
             final int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200 || statusCode == 201) {
@@ -1012,7 +1036,7 @@ public class FlashArrayAdapter implements ProviderAdapter {
             request.addHeader("X-auth-token", getAccessToken());
 
             CloseableHttpClient client = getClient();
-            response = (CloseableHttpResponse) client.execute(request);
+            response = client.execute(request);
             final int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200) {
                 try {
@@ -1054,7 +1078,7 @@ public class FlashArrayAdapter implements ProviderAdapter {
             request.addHeader("X-auth-token", getAccessToken());
 
             CloseableHttpClient client = getClient();
-            response = (CloseableHttpResponse) client.execute(request);
+            response = client.execute(request);
             final int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200 || statusCode == 404 || statusCode == 400) {
                 // this means the volume was deleted successfully, or doesn't exist (effective


### PR DESCRIPTION
The FlashArray adapter previously always made an initial call to the deprecated Purity REST 1.x session endpoint using a username and password to obtain a long-lived api_token, then exchanged that token for the REST 2.x x-auth-token session key. Purity 1.x is being removed from the array, so this path has an expiration date, and storing the username and password as pool details is not what the Purity documentation recommends.

Accept a pre-minted api_token in the pool details (ProviderAdapter.API_TOKEN_KEY, already reserved in the base interface) and go straight to the REST 2.x /login endpoint. The api_token is long-lived and is created on the array via the Purity GUI (Users -> API Tokens) or CLI (pureadmin create --api-token).

If api_token is not set, fall back to the legacy username/password flow and emit a deprecation warning so existing deployments keep working during the transition. The fallback path will be removed in a later release.

While here, resolve the API version dynamically by calling the unauthenticated GET /api/api_version endpoint the first time a login happens on a pool, unless the operator pinned a specific version via API_VERSION. This makes the adapter pick up newer Purity releases automatically instead of being stuck on the hard-coded 2.23 default.

### Description

The FlashArray adapter currently performs two calls to log in: a POST to the deprecated Purity **REST 1.x** `auth/apitoken` endpoint with username/password to obtain a long-lived `api_token`, then a POST to `/api/<ver>/login` with `api-token:` header to get the session `x-auth-token`. Pure Storage is phasing out REST 1.x, and storing username/password as pool details is not the recommended pattern.

This PR:

- Accepts a pre-minted long-lived `api_token` as a pool detail (`ProviderAdapter.API_TOKEN_KEY`, already reserved in the base interface). When present, the adapter skips the 1.x call entirely and goes straight to `POST /api/<ver>/login` with `api-token:` header.
- Falls back to the legacy username/password flow when `api_token` is not set, logging a deprecation warning. No existing deployments break; removal of the fallback can happen in a later release.
- Discovers the latest supported REST API version by calling the unauthenticated `GET /api/api_version` on first login (unless an explicit `api_version` pool detail pins it). Replaces the hardcoded `2.23` default, so the adapter tracks newer Purity releases automatically.

### Types of changes

- [x] Enhancement (non-breaking change which adds functionality)

### How Has This Been Tested?

Validated on a 4.23-SNAPSHOT lab against a Purity 6.7.7 FlashArray:

- Added `details[api_token]=<long-lived-token>` to an existing pool and restarted mgmt → adapter resumes without the deprecation warning, capacity polling and volume create continue working.
- Removed the api_token detail → adapter logs the deprecation warning and falls back to u/p against `/api/1.19/auth/apitoken`, still working.
- `/api/api_version` discovery resolves to `2.36` on Purity 6.7.7 without manual configuration.

### How to Get an API Token on the Array

Purity GUI: *Settings → Users → &lt;user&gt; → API Tokens → Create API Token*. CLI: `ssh pureuser@<array>; pureadmin create --api-token <user>`.