### PR TITLE
Remove UUID parse from param processing workflow

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/BaseCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/BaseCmd.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
@@ -504,12 +503,6 @@ public abstract class BaseCmd {
     }
 
     public String getResourceUuid(String parameterName) {
-        UUID resourceUuid = CallContext.current().getApiResourceUuid(parameterName);
-
-        if (resourceUuid != null) {
-            return resourceUuid.toString();
-        }
-
-        return null;
+        return CallContext.current().getApiResourceUuid(parameterName);
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/context/CallContext.java
+++ b/api/src/main/java/org/apache/cloudstack/context/CallContext.java
@@ -63,7 +63,7 @@ public class CallContext {
     private User user;
     private long userId;
     private final Map<Object, Object> context = new HashMap<Object, Object>();
-    private final Map<String, UUID> apiResourcesUuids = new HashMap<>();
+    private final Map<String, String> apiResourcesUuids = new HashMap<>();
     private Project project;
     private String apiName;
 
@@ -389,11 +389,11 @@ public class CallContext {
         isEventDisplayEnabled = eventDisplayEnabled;
     }
 
-    public UUID getApiResourceUuid(String paramName) {
+    public String getApiResourceUuid(String paramName) {
         return apiResourcesUuids.get(paramName);
     }
 
-    public void putApiResourceUuid(String paramName, UUID uuid) {
+    public void putApiResourceUuid(String paramName, String uuid) {
         apiResourcesUuids.put(paramName, uuid);
     }
 

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/CreateIpv4SubnetForGuestNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/CreateIpv4SubnetForGuestNetworkCmdTest.java
@@ -40,7 +40,7 @@ public class CreateIpv4SubnetForGuestNetworkCmdTest {
     @Test
     public void testCreateIpv4SubnetForGuestNetworkCmd() {
         Long parentId = 1L;
-        UUID parentUuid = UUID.randomUUID();
+        String parentUuid = UUID.randomUUID().toString();
         String subnet = "192.168.1.0/24";
         Integer cidrSize = 26;
 

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/CreateIpv4SubnetForZoneCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/CreateIpv4SubnetForZoneCmdTest.java
@@ -40,7 +40,7 @@ public class CreateIpv4SubnetForZoneCmdTest {
     @Test
     public void testCreateIpv4SubnetForZoneCmd() {
         Long zoneId = 1L;
-        UUID zoneUuid = UUID.randomUUID();
+        String zoneUuid = UUID.randomUUID().toString();
         String subnet = "192.168.1.0/24";
         String accountName = "user";
         Long projectId = 10L;

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/DedicateIpv4SubnetForZoneCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/DedicateIpv4SubnetForZoneCmdTest.java
@@ -39,7 +39,7 @@ public class DedicateIpv4SubnetForZoneCmdTest {
     @Test
     public void testDedicateIpv4SubnetForZoneCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         String accountName = "user";
         Long projectId = 10L;
         Long domainId = 11L;

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/DeleteIpv4SubnetForGuestNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/DeleteIpv4SubnetForGuestNetworkCmdTest.java
@@ -39,7 +39,7 @@ public class DeleteIpv4SubnetForGuestNetworkCmdTest {
     @Test
     public void testDeleteIpv4SubnetForGuestNetworkCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
 
         DeleteIpv4SubnetForGuestNetworkCmd cmd = new DeleteIpv4SubnetForGuestNetworkCmd();
         ReflectionTestUtils.setField(cmd, "id", id);

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/DeleteIpv4SubnetForZoneCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/DeleteIpv4SubnetForZoneCmdTest.java
@@ -39,7 +39,7 @@ public class DeleteIpv4SubnetForZoneCmdTest {
     @Test
     public void testDeleteIpv4SubnetForZoneCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
 
         DeleteIpv4SubnetForZoneCmd cmd = new DeleteIpv4SubnetForZoneCmd();
         ReflectionTestUtils.setField(cmd, "id", id);

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/ReleaseDedicatedIpv4SubnetForZoneCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/ReleaseDedicatedIpv4SubnetForZoneCmdTest.java
@@ -39,7 +39,7 @@ public class ReleaseDedicatedIpv4SubnetForZoneCmdTest {
     @Test
     public void testReleaseDedicatedIpv4SubnetForZoneCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
 
         ReleaseDedicatedIpv4SubnetForZoneCmd cmd = new ReleaseDedicatedIpv4SubnetForZoneCmd();
         ReflectionTestUtils.setField(cmd, "id", id);

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/UpdateIpv4SubnetForZoneCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/UpdateIpv4SubnetForZoneCmdTest.java
@@ -40,7 +40,7 @@ public class UpdateIpv4SubnetForZoneCmdTest {
     @Test
     public void testUpdateIpv4SubnetForZoneCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         String subnet = "192.168.1.0/24";
 
         UpdateIpv4SubnetForZoneCmd cmd = new UpdateIpv4SubnetForZoneCmd();

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/ChangeBgpPeersForNetworkCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/ChangeBgpPeersForNetworkCmdTest.java
@@ -46,7 +46,7 @@ public class ChangeBgpPeersForNetworkCmdTest {
     @Test
     public void testChangeBgpPeersForNetworkCmd() {
         Long networkId = 10L;
-        UUID networkUuid = UUID.randomUUID();
+        String networkUuid = UUID.randomUUID().toString();
         List<Long> bgpPeerIds = Arrays.asList(20L, 21L);
 
         ChangeBgpPeersForNetworkCmd cmd = new ChangeBgpPeersForNetworkCmd();

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/ChangeBgpPeersForVpcCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/ChangeBgpPeersForVpcCmdTest.java
@@ -46,7 +46,7 @@ public class ChangeBgpPeersForVpcCmdTest {
     @Test
     public void testChangeBgpPeersForVpcCmd() {
         Long VpcId = 10L;
-        UUID vpcUuid = UUID.randomUUID();
+        String vpcUuid = UUID.randomUUID().toString();
         List<Long> bgpPeerIds = Arrays.asList(20L, 21L);
 
         ChangeBgpPeersForVpcCmd cmd = new ChangeBgpPeersForVpcCmd();

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/CreateBgpPeerCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/CreateBgpPeerCmdTest.java
@@ -40,7 +40,7 @@ public class CreateBgpPeerCmdTest {
     @Test
     public void testCreateBgpPeerCmd() {
         Long zoneId = 1L;
-        UUID zoneUuid = UUID.randomUUID();
+        String zoneUuid = UUID.randomUUID().toString();
         String accountName = "user";
         Long projectId = 10L;
         Long domainId = 11L;

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/DedicateBgpPeerCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/DedicateBgpPeerCmdTest.java
@@ -39,7 +39,7 @@ public class DedicateBgpPeerCmdTest {
     @Test
     public void testDedicateBgpPeerCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         String accountName = "user";
         Long projectId = 10L;
         Long domainId = 11L;

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/DeleteBgpPeerCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/DeleteBgpPeerCmdTest.java
@@ -39,7 +39,7 @@ public class DeleteBgpPeerCmdTest {
     @Test
     public void testDeleteBgpPeerCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
 
         DeleteBgpPeerCmd cmd = new DeleteBgpPeerCmd();
         ReflectionTestUtils.setField(cmd, "id", id);

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/ReleaseDedicatedBgpPeerCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/ReleaseDedicatedBgpPeerCmdTest.java
@@ -39,7 +39,7 @@ public class ReleaseDedicatedBgpPeerCmdTest {
     @Test
     public void testReleaseDedicatedBgpPeerCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
 
         ReleaseDedicatedBgpPeerCmd cmd = new ReleaseDedicatedBgpPeerCmd();
         ReflectionTestUtils.setField(cmd, "id", id);

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/UpdateBgpPeerCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/bgp/UpdateBgpPeerCmdTest.java
@@ -40,7 +40,7 @@ public class UpdateBgpPeerCmdTest {
     @Test
     public void testUpdateBgpPeerCmd() {
         Long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         String ip4Address = "ip4-address";
         String ip6Address = "ip6-address";
         Long peerAsNumber = 15000L;

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/storage/DownloadImageStoreObjectCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/storage/DownloadImageStoreObjectCmdTest.java
@@ -97,7 +97,7 @@ public class DownloadImageStoreObjectCmdTest {
 
     @Test
     public void testGetEventDescription() {
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
 
         ReflectionTestUtils.setField(cmd, "storeId", 1L);
         ReflectionTestUtils.setField(cmd, "path", "path/to/object");

--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/volume/UnmanageVolumeCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/volume/UnmanageVolumeCmdTest.java
@@ -44,7 +44,7 @@ public class UnmanageVolumeCmdTest {
     public void testUnmanageVolumeCmd() {
         long accountId = 2L;
         Long volumeId = 3L;
-        UUID volumeUuid = UUID.randomUUID();
+        String volumeUuid = UUID.randomUUID().toString();
         Volume volume = Mockito.mock(Volume.class);
 
         Mockito.when(responseGenerator.findVolumeById(volumeId)).thenReturn(volume);

--- a/api/src/test/java/org/apache/cloudstack/api/command/test/CreateSnapshotCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/test/CreateSnapshotCmdTest.java
@@ -118,7 +118,7 @@ public class CreateSnapshotCmdTest extends TestCase {
         AccountService accountService = Mockito.mock(AccountService.class);
         Account account = Mockito.mock(Account.class);
         Mockito.when(accountService.getAccount(anyLong())).thenReturn(account);
-        UUID volumeUuid = UUID.randomUUID();
+        String volumeUuid = UUID.randomUUID().toString();
 
         CallContext.current().putApiResourceUuid("volumeid", volumeUuid);
 

--- a/api/src/test/java/org/apache/cloudstack/api/command/test/UpdateConditionCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/test/UpdateConditionCmdTest.java
@@ -56,7 +56,7 @@ public class UpdateConditionCmdTest {
     private static final Long threshold = 100L;
 
     private static final long accountId = 5L;
-    private static final UUID conditionUuid = UUID.randomUUID();
+    private static final String conditionUuid = UUID.randomUUID().toString();
 
     @Before
     public void setUp() {

--- a/api/src/test/java/org/apache/cloudstack/api/command/user/network/routing/DeleteRoutingFirewallRuleCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/user/network/routing/DeleteRoutingFirewallRuleCmdTest.java
@@ -49,7 +49,7 @@ public class DeleteRoutingFirewallRuleCmdTest {
         ReflectionTestUtils.setField(cmd, "_firewallService", _firewallService);
 
         long id = 1L;
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         long accountId = 2L;
         long networkId = 3L;
 

--- a/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/main/java/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.UUID;
 import java.util.regex.Matcher;
 
 import javax.inject.Inject;
@@ -526,7 +525,7 @@ public class ParamProcessWorker implements DispatchWorker {
                         continue;
                     }
                     String entityUuid = ((Identity) objVO).getUuid();
-                    CallContext.current().putApiResourceUuid(annotation.name(), UUID.fromString(entityUuid));
+                    CallContext.current().putApiResourceUuid(annotation.name(), entityUuid);
                 }
                 validateNaturalNumber(internalId, annotation.name());
                 return internalId;
@@ -551,7 +550,7 @@ public class ParamProcessWorker implements DispatchWorker {
             }
             // Return on first non-null Id for the uuid entity
             if (internalId != null){
-                CallContext.current().putApiResourceUuid(annotation.name(), UUID.fromString(uuid));
+                CallContext.current().putApiResourceUuid(annotation.name(), uuid);
                 CallContext.current().putContextParameter(entity, uuid);
                 break;
             }


### PR DESCRIPTION
### Description

PR #12502 introduced a generic method to retrieve untranslated UUIDs received as command parameters, without having to query the database during the command processing workflow. A validation using `UUID.parseString` was included before storing them in the context to ensure that they were valid UUIDs. However, it was previously possible to set the UUID of some entities to values that are not valid UUIDs, which got broken by this validation.

This PR removes the validation in order to support back the usage of arbitrary values as resource UUIDs.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

After changing the code, I built it with Maven and validated that no error occurred during the build. The unit tests were not skipped for the build process.

After installing the packages with the changes to my environment, I created a account with `nonuuidvalue` as its UUID. Then, I listed the registered accounts with the `listAccounts` API. With this, I validated that the error from parsing the `id` attribute value was fixed.

<details><summary><code>listAccounts</code> API result</summary>

```
(all-in-one) 🐋 > list accounts id=nonuuidvalue details=min
{
  "account": [
    {
      "accounttype": 0,
      "apikeyaccess": "INHERIT",
      "created": "2026-04-23T14:37:52+0000",
      "domain": "ROOT",
      "domainid": "ee564f54-13df-11f1-9489-464a3dd4490d",
      "domainpath": "ROOT",
      "groups": [],
      "id": "nonuuidvalue",
      "isdefault": false,
      "name": "b",
      "roleid": "fe5eecbe-13e1-11f1-9dfe-464a3dd4490d",
      "rolename": "User",
      "roletype": "User",
      "secondarystoragetotal": 0,
      "state": "disabled",
      "user": [
        {
          "account": "b",
          "accountid": "nonuuidvalue",
          "accounttype": 0,
          "created": "2026-04-23T14:37:55+0000",
          "domain": "ROOT",
          "domainid": "ee564f54-13df-11f1-9489-464a3dd4490d",
          "email": "b",
          "firstname": "b",
          "id": "b164a13c-0dcd-4604-b06e-954ec1ca452a",
          "is2faenabled": false,
          "is2famandated": false,
          "iscallerchilddomain": false,
          "isdefault": false,
          "lastname": "b",
          "roleid": "fe5eecbe-13e1-11f1-9dfe-464a3dd4490d",
          "rolename": "User",
          "roletype": "User",
          "state": "enabled",
          "username": "b",
          "usersource": "native"
        }
      ]
    }
  ],
  "count": 1
}
```

</details>

I also validated that the UUID obtention for events description was not affected by the changes. In order to test this, I disabled two different accounts: the one with the `nonuuidvalue` value as UUID, and an account that I created for this test. After inspecting the events, it was possible to validate that the resources' UUIDs were still being displayed correctly.

<details><summary>Events description</summary>

```
MariaDB [cloud]> select type, state, description, account_id from event where type = "ACCOUNT.DISABLE" and state = "Scheduled";
+-----------------+-----------+-----------------------------------------------------------------+------------+
| type            | state     | description                                                     | account_id |
+-----------------+-----------+-----------------------------------------------------------------+------------+
| ACCOUNT.DISABLE | Scheduled | Disabling Account with ID: a4ae3004-19b6-4152-9a1a-4d18f24410da |          6 |
| ACCOUNT.DISABLE | Scheduled | Disabling Account with ID: nonuuidvalue                         |          5 |
+-----------------+-----------+-----------------------------------------------------------------+------------+
```

</details>