### PR TITLE
Correction of the user responsible for the `RESOURCE.UPDATE.LIMIT` event 

### DIFF
--- a/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -1037,7 +1037,8 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
         ResourceLimitVO limit = _resourceLimitDao.findByOwnerIdAndTypeAndTag(ownerId, ownerType, resourceType, tag);
 
-        ActionEventUtils.onActionEvent(caller.getId(), caller.getAccountId(),
+        Long callingUserId = CallContext.current().getCallingUserId();
+        ActionEventUtils.onActionEvent(callingUserId, caller.getAccountId(),
                 caller.getDomainId(), EventTypes.EVENT_RESOURCE_LIMIT_UPDATE,
                 "Resource limit updated. Resource Type: " + resourceType + ", New Value: " + max,
                 ownerResourceId, ownerResourceType.toString());


### PR DESCRIPTION
### Description

Currently, events of the `RESOURCE.UPDATE.LIMIT` type do not register the user responsible for the performed action. Instead of that, the considered responsible user for the event is the account itself. Changes were made to consider the user responsible for the event as the one that actually performed the event's corresponding action.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

The tests were performed on version 4.22.1.0. In the graphical interface, I updated the resources of an account, and when navigating to the events tab, I was able to verify that the user responsible for the action was properly assigned.

