### PR TITLE
fix(linstor): verify resource deletion completes; warn if stuck in DELETING

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -514,6 +514,17 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
                 ApiCallRcList answers = api.resourceDefinitionDelete(rd.getName());
                 checkLinstorAnswersThrow(answers);
                 deleted = true;
+
+                // LINSTOR can return success here while the resource lingers in DELETING state
+                // on the controller (down peer, lost quorum, etc.). Confirm it's actually gone
+                // — if not, log a WARN so operators can clear it manually. Don't throw: the
+                // CloudStack-side accounting has already moved on.
+                if (!LinstorUtil.waitForResourceDefinitionDeleted(api, rd.getName(),
+                        LinstorUtil.DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS)) {
+                    logger.warn("Linstor: resource {} still present {}ms after delete returned success — " +
+                            "may be stuck in DELETING. Check the LINSTOR controller (linstor resource list).",
+                            rd.getName(), LinstorUtil.DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS);
+                }
             }
         }
         return deleted;

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -230,6 +230,20 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                 throw new CloudRuntimeException("Linstor: Unable to delete resource definition: " + rscDefName);
             }
             logger.info("Linstor: Deleted resource {}", rscDefName);
+
+            // LINSTOR can return success on the delete API call while the resource lingers in
+            // DELETING state (peer issues, lost quorum, satellite down). Verify the resource is
+            // actually gone — if not, log a WARN so operators see it. We deliberately do NOT
+            // throw here: the volume is already considered gone on the CloudStack side, and
+            // throwing would leave the CS DB and LINSTOR in different states.
+            if (!LinstorUtil.waitForResourceDefinitionDeleted(linstorApi, rscDefName,
+                    LinstorUtil.DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS))
+            {
+                logger.warn("Linstor: resource {} still present {}ms after delete returned success — " +
+                        "may be stuck in DELETING. Check the LINSTOR controller (linstor resource list) " +
+                        "and clear manually if the resource has no live peers.",
+                        rscDefName, LinstorUtil.DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS);
+            }
         } catch (ApiException apiEx)
         {
             logger.error("Linstor: ApiEx - " + apiEx.getMessage());

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -402,6 +402,57 @@ public class LinstorUtil {
     }
 
     /**
+     * Default per-call timeout for {@link #waitForResourceDefinitionDeleted}. Long enough for a
+     * healthy LINSTOR controller to finish a normal delete; short enough not to block the calling
+     * agent thread for too long if the delete is genuinely stuck.
+     */
+    public static final long DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS = 30_000L;
+
+    /**
+     * Returns {@code true} if the named resource definition is no longer present on the LINSTOR
+     * controller. Used after a {@code resourceDefinitionDelete} to verify the delete actually
+     * completed (LINSTOR can return success on the API call while the resource lingers in
+     * DELETING state due to peer issues, lost quorum, or down satellites).
+     */
+    public static boolean isResourceDefinitionGone(DevelopersApi api, String rscName) throws ApiException {
+        List<ResourceDefinition> all = api.resourceDefinitionList(null, false, null, null, null);
+        if (all == null) {
+            return true;
+        }
+        return all.stream().noneMatch(rd -> rscName.equalsIgnoreCase(rd.getName()));
+    }
+
+    /**
+     * Polls the controller until the named resource definition is gone or the timeout elapses.
+     * Returns {@code true} if the resource was confirmed gone, {@code false} if it was still
+     * present (or the controller kept erroring) at the deadline. Callers should NOT throw on a
+     * {@code false} return — the upstream API call already reported success and the operator
+     * may need to investigate manually. Log a WARN with the resource name instead.
+     */
+    public static boolean waitForResourceDefinitionDeleted(DevelopersApi api, String rscName, long timeoutMillis) {
+        final long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (true) {
+            try {
+                if (isResourceDefinitionGone(api, rscName)) {
+                    return true;
+                }
+            } catch (ApiException e) {
+                LOGGER.debug("LINSTOR delete-verify poll failed for {}: {}", rscName, e.getMessage());
+                // Keep polling — controller may be transiently unavailable.
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                return false;
+            }
+            try {
+                Thread.sleep(1_000L);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    /**
      * Returns a pair list of resource-definitions with ther 1:1 mapped resource-group objects that start with the
      * resource name `startWith`
      * @param api

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -404,7 +404,8 @@ public class LinstorUtil {
     /**
      * Default per-call timeout for {@link #waitForResourceDefinitionDeleted}. Long enough for a
      * healthy LINSTOR controller to finish a normal delete; short enough not to block the calling
-     * agent thread for too long if the delete is genuinely stuck.
+     * thread for too long if the delete is genuinely stuck. Used both from the management server
+     * (e.g. {@code LinstorPrimaryDataStoreDriverImpl}) and from KVM agent paths.
      */
     public static final long DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS = 30_000L;
 
@@ -412,14 +413,14 @@ public class LinstorUtil {
      * Returns {@code true} if the named resource definition is no longer present on the LINSTOR
      * controller. Used after a {@code resourceDefinitionDelete} to verify the delete actually
      * completed (LINSTOR can return success on the API call while the resource lingers in
-     * DELETING state due to peer issues, lost quorum, or down satellites).
+     * DELETING state due to peer issues, lost quorum, or down satellites). Uses the
+     * controller-side name filter rather than scanning every RD on the cluster (cheap even
+     * when polled once per second from {@link #waitForResourceDefinitionDeleted}).
      */
     public static boolean isResourceDefinitionGone(DevelopersApi api, String rscName) throws ApiException {
-        List<ResourceDefinition> all = api.resourceDefinitionList(null, false, null, null, null);
-        if (all == null) {
-            return true;
-        }
-        return all.stream().noneMatch(rd -> rscName.equalsIgnoreCase(rd.getName()));
+        List<ResourceDefinition> matching =
+                api.resourceDefinitionList(Collections.singletonList(rscName), false, null, null, null);
+        return matching == null || matching.isEmpty();
     }
 
     /**


### PR DESCRIPTION
## Summary

The LINSTOR plugin treats a successful HTTP response from `resourceDefinitionDelete` as proof the resource is gone and immediately drops the volume from CloudStack's accounting. In practice LINSTOR can return success while the resource lingers in DELETING state — for example when a DRBD peer is unreachable, quorum was lost, or a satellite is down. The plugin has no retry, no verification, and no sweeper. We've found hundreds of stuck DELETING resources accumulated over weeks because nothing surfaces the divergence between the CS view and the LINSTOR view.

## What this PR does

Adds two helpers to `LinstorUtil`:

- `isResourceDefinitionGone(api, rscName)` — existence check via `resourceDefinitionList`
- `waitForResourceDefinitionDeleted(api, rscName, timeoutMillis)` — polls every 1s until the resource is gone OR timeout elapses; returns `true` on confirmed-gone, `false` on timeout

Calls `waitForResourceDefinitionDeleted` from both delete paths:

- `LinstorPrimaryDataStoreDriverImpl.deleteResourceDefinition` (driver / management-server side)
- `LinstorStorageAdaptor.deRefOrDeleteResource` (host / KVM agent side)

Default timeout 30 seconds (`DEFAULT_RD_DELETE_VERIFY_TIMEOUT_MILLIS`).

## Behaviour

- **Resource deletes within 30s** (the normal case) — no log change, no behaviour change.
- **Resource still in DELETING after 30s** — emits a WARN naming the resource and pointing the operator at `linstor resource list`. Returns success to the caller (the CS-side accounting has already moved on; throwing here would create a different inconsistency).
- **Controller transiently unreachable during poll** — debug-logs each failed poll, keeps trying until deadline.

## What this does NOT do (deferred)

- Tier-2 sweeper that periodically re-attempts delete on long-stuck resources is not in this PR. The Tier-1 surface here is the minimum needed to make the problem visible in operator logs. A sweeper can land separately if maintainers want it.

## Test plan

- [ ] CI build + unit tests pass (no public API changes; only behaviour additions in private methods)
- [ ] Manual: delete a volume on a healthy LINSTOR cluster — no new logs, ~30s shorter than `wait` would otherwise be (immediate return after first poll confirms gone)
- [ ] Manual: delete a volume on a cluster with a downed satellite — observe the new WARN line in the agent log and confirm the resource is still in `linstor resource list` until manually cleared