### PR TITLE
fix(linstor): pre-flight check destination is a LINSTOR satellite before live migration

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/motion/LinstorDataMotionStrategy.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/motion/LinstorDataMotionStrategy.java
@@ -314,6 +314,58 @@ public class LinstorDataMotionStrategy implements DataMotionStrategy {
         return true;
     }
 
+    /**
+     * Verify that the destination KVM host is a registered LINSTOR satellite on the controller
+     * backing every destination pool involved in this migration. Throws CloudRuntimeException
+     * with a clear message when it isn't, instead of letting the resource creation later fail
+     * obscurely inside auto-placement.
+     *
+     * Best-effort: a transient controller error during this check does not block the migration
+     * — we log a warning and let the downstream resource-create surface the real issue. Only a
+     * confirmed "host not in node list" outcome aborts the migration up-front.
+     */
+    private void verifyDestinationIsLinstorSatellite(Map<VolumeInfo, DataStore> volumeDataStoreMap, Host destHost) {
+        if (destHost == null || destHost.getName() == null) {
+            // Without a destination host name to match, the only sensible thing is to let the
+            // existing flow run and report whatever it would have reported.
+            return;
+        }
+        for (Map.Entry<VolumeInfo, DataStore> entry : volumeDataStoreMap.entrySet()) {
+            DataStore destDataStore = entry.getValue();
+            StoragePoolVO destStoragePool = _storagePool.findById(destDataStore.getId());
+            if (destStoragePool == null
+                    || destStoragePool.getPoolType() != Storage.StoragePoolType.Linstor) {
+                continue;
+            }
+            DevelopersApi api = LinstorUtil.getLinstorAPI(destStoragePool.getHostAddress());
+            try {
+                List<String> nodes = LinstorUtil.getLinstorNodeNames(api);
+                if (nodes == null) {
+                    logger.warn("LINSTOR controller {} returned null node list; skipping pre-flight",
+                            destStoragePool.getHostAddress());
+                    return;
+                }
+                if (!nodes.contains(destHost.getName())) {
+                    throw new CloudRuntimeException(String.format(
+                            "Cannot migrate to host '%s': it is not a registered LINSTOR satellite on " +
+                                    "controller %s (pool '%s'). Known satellites: %s. Either register the " +
+                                    "host with `linstor node create` or pick a different destination.",
+                            destHost.getName(),
+                            destStoragePool.getHostAddress(),
+                            destStoragePool.getName(),
+                            nodes));
+                }
+            } catch (ApiException apiEx) {
+                // Don't block migration on a transient controller hiccup — log and let the
+                // downstream resource creation handle the real failure.
+                logger.warn("LINSTOR pre-flight check could not contact controller {}: {}; " +
+                                "letting downstream resource creation proceed",
+                        destStoragePool.getHostAddress(), apiEx.getBestMessage());
+                return;
+            }
+        }
+    }
+
     @Override
     public void copyAsync(Map<VolumeInfo, DataStore> volumeDataStoreMap, VirtualMachineTO vmTO, Host srcHost,
             Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
@@ -322,6 +374,15 @@ public class LinstorDataMotionStrategy implements DataMotionStrategy {
             throw new CloudRuntimeException(
                     String.format("Invalid hypervisor type [%s]. Only KVM supported", srcHost.getHypervisorType()));
         }
+
+        // Pre-flight: verify the destination KVM host is registered as a satellite on the
+        // LINSTOR controller backing each destination pool. Without this check, resource
+        // creation falls through to the resource-group's auto-placement filters and may
+        // either silently place the resource on the wrong node or fail with an opaque
+        // auto-place error from the LINSTOR API. Failing fast here gives operators a clear
+        // actionable message instead of having to correlate the live-migration failure with
+        // an unrelated LINSTOR controller log entry.
+        verifyDestinationIsLinstorSatellite(volumeDataStoreMap, destHost);
 
         String errMsg = null;
         VMInstanceVO vmInstance = _vmDao.findById(vmTO.getId());


### PR DESCRIPTION
## Summary

`LinstorDataMotionStrategy.copyAsync` (added in #12830 / Jan 29 2026) calls `LinstorUtil.createResource` on the destination pool's controller without first verifying the destination KVM host is registered as a LINSTOR satellite there. Two failure modes follow:

1. **Wrong-node placement.** The resource group's auto-placement filter picks a *different* registered satellite that is NOT the migration destination. The resource silently lands on the wrong node. The subsequent migrate then fails because the destination KVM host has no DRBD device for the resource.
2. **Opaque auto-place failure.** The auto-placement filter has no candidates and the LINSTOR API returns a generic error. Operator has to correlate the migration failure with an unrelated controller log entry to understand what went wrong.

We've hit (1) on host-5 → host-6 migrations where host-6 was not registered as a LINSTOR satellite. The migration logs were unhelpful.

## Change

Adds `verifyDestinationIsLinstorSatellite()` called at the top of `copyAsync`. For each LINSTOR-typed pool in `volumeDataStoreMap`:

- Fetches the controller's node list via `LinstorUtil.getLinstorNodeNames`
- If `destHost.getName()` is missing from the list, throws `CloudRuntimeException` with a clear actionable message that lists the known satellites and tells the operator to either `linstor node create` or pick a different destination
- Silently skips on transient controller errors (so a controller hiccup doesn't block an otherwise valid migration — the existing flow surfaces the real failure downstream)

Non-LINSTOR destination pools are skipped (mixed-storage migrations are unaffected).

## Test plan

- [ ] CI build + unit tests
- [ ] Manual: migrate a VM to a host that IS a LINSTOR satellite — works as before, no behaviour change
- [ ] Manual: migrate a VM to a host that is NOT a LINSTOR satellite — fails fast with the new error message naming the host and listing known satellites