### PR TITLE
fix(linstor): surface ambiguous template fallbacks and legacy orphan cleanup

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -508,9 +508,20 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
             // if there is only one template-for property left for templates, the template isn't needed anymore
             // or if it isn't a template anyway, it will not have this Aux property
             // _cs-template-for- properties work like a ref-count.
-            if (rd.getProps().keySet().stream()
+            long remainingTemplateRefs = rd.getProps().keySet().stream()
                     .filter(key -> key.startsWith("Aux/" + LinstorUtil.CS_TEMPLATE_FOR_PREFIX))
-                    .count() == expectedProps) {
+                    .count();
+            if (remainingTemplateRefs == expectedProps) {
+                // Surface the case where a resource that LOOKS like a template (resource name
+                // starts with the requested prefix) has zero `_cs-template-for-` aux properties
+                // even though we never decremented one — that's a legacy template predating the
+                // ref-count convention. Logging it before deletion lets operators audit how
+                // many such orphans existed at upgrade time.
+                if (expectedProps == 0 && rd.getName().toLowerCase().startsWith(rscName.toLowerCase())) {
+                    logger.info("Linstor: deleting resource {} which has no _cs-template-for- aux properties " +
+                                    "(legacy template predating the ref-count convention, or a stale orphan). " +
+                                    "Resource group context: {}", rd.getName(), rscGrpName);
+                }
                 ApiCallRcList answers = api.resourceDefinitionDelete(rd.getName());
                 checkLinstorAnswersThrow(answers);
                 deleted = true;

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -512,12 +512,11 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
                     .filter(key -> key.startsWith("Aux/" + LinstorUtil.CS_TEMPLATE_FOR_PREFIX))
                     .count();
             if (remainingTemplateRefs == expectedProps) {
-                // Surface the case where a resource that LOOKS like a template (resource name
-                // starts with the requested prefix) has zero `_cs-template-for-` aux properties
-                // even though we never decremented one — that's a legacy template predating the
-                // ref-count convention. Logging it before deletion lets operators audit how
-                // many such orphans existed at upgrade time.
-                if (expectedProps == 0 && rd.getName().toLowerCase().startsWith(rscName.toLowerCase())) {
+                // Surface the legacy case where a resource has zero `_cs-template-for-` aux
+                // properties even though we never decremented one — that's a template predating
+                // the ref-count convention, or a stale orphan. Logging before deletion lets
+                // operators audit how many such orphans existed at upgrade time.
+                if (expectedProps == 0) {
                     logger.info("Linstor: deleting resource {} which has no _cs-template-for- aux properties " +
                                     "(legacy template predating the ref-count convention, or a stale orphan). " +
                                     "Resource group context: {}", rd.getName(), rscGrpName);

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -491,7 +491,26 @@ public class LinstorUtil {
                 .filter(rscDfn -> rscDfn.getProps().containsKey(LinstorUtil.getTemplateForAuxPropKey(rscGrpName)))
                 .findFirst();
 
-        return rd.orElseGet(() -> rdsStartingWith.get(0));
+        if (rd.isPresent()) {
+            return rd.get();
+        }
+        // Fallback: no resource has the exact "_cs-template-for-<rscGrpName>" property.
+        // This happens when (a) the matched resource is a legacy template created before that
+        // convention was introduced, or (b) the template was cached by a different resource
+        // group and the operator hopes to share it. Log so the ambiguity is visible — silent
+        // first-match selection has previously routed clones to the wrong template when
+        // multiple resource groups coexisted on the same controller.
+        ResourceDefinition fallback = rdsStartingWith.get(0);
+        LOGGER.warn("LINSTOR findResourceDefinition: no resource for '{}' has the expected " +
+                        "Aux property '{}' for resource group '{}'; falling back to first match '{}' " +
+                        "(present aux properties: {}). If this is wrong, set the property explicitly " +
+                        "or remove the unrelated resource definition.",
+                rscName, getTemplateForAuxPropKey(rscGrpName), rscGrpName,
+                fallback.getName(),
+                fallback.getProps().keySet().stream()
+                        .filter(k -> k.startsWith("Aux/" + CS_TEMPLATE_FOR_PREFIX))
+                        .collect(Collectors.toList()));
+        return fallback;
     }
 
     public static boolean isRscDiskless(ResourceWithVolumes rsc) {

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -498,7 +498,7 @@ public class LinstorUtil {
         // This happens when (a) the matched resource is a legacy template created before that
         // convention was introduced, or (b) the template was cached by a different resource
         // group and the operator hopes to share it. Log so the ambiguity is visible — silent
-        // first-match selection has previously routed clones to the wrong template when
+        // first-match fallback has previously routed clones to the wrong template when
         // multiple resource groups coexisted on the same controller.
         ResourceDefinition fallback = rdsStartingWith.get(0);
         LOGGER.warn("LINSTOR findResourceDefinition: no resource for '{}' has the expected " +


### PR DESCRIPTION
## Summary

Two small visibility improvements to the LINSTOR template-handling path. Both preserve existing behaviour and only add log output that surfaces conditions operators have currently no easy way to detect.

## 1. \`LinstorUtil.findResourceDefinition\` — log on ambiguous fallback

When clone-from-template runs, the method scans for a resource whose name starts with the template prefix AND whose aux properties include \`_cs-template-for-<rscGrpName>\`. If no exact-property match exists, the method falls back to the *first* matching resource by name and returns it silently.

In setups with multiple resource groups on the same controller (or with legacy templates cached before the ref-count convention was added), this fallback can return a template that belongs to the wrong resource group, and the clone produces an unexpected result.

This change keeps the fallback behaviour but logs a WARN naming:
- the requested resource name and resource group
- the fallback resource that was chosen
- the actual \`_cs-template-for-*\` aux properties present on the fallback (so operators can see what RGs *do* claim it)

## 2. \`LinstorStorageAdaptor.deRefOrDeleteResource\` — log on legacy-template orphan cleanup

The ref-count branch already deletes resources that have zero remaining \`_cs-template-for-\` aux properties. Two conditions reach this branch:
- a normal resource (no template-for properties expected) — already commented in code
- a *legacy template* with no template-for properties (predates the ref-count convention)

Currently both look identical in the logs. Operators upgrading from older versions can't tell how many orphan legacy templates were cleaned up.

This change logs an INFO line in the second case, identifying the resource as a legacy template and naming the resource group context. Behaviour unchanged.

## Test plan

- [ ] CI build + unit tests
- [ ] Manual: deploy a VM from template in a single-RG setup — no new logs
- [ ] Manual: deploy a VM from template in a multi-RG setup where the template lacks the exact aux property — observe the new WARN
- [ ] Manual: evict a legacy template (no aux properties) — observe the new INFO line during cleanup

## Why three small PRs

Per the suggestion from earlier review, splitting LINSTOR plugin improvements into focused PRs:

- This PR (template hygiene)
- #13076 (delete-verification — addresses stuck DELETING accumulation)
- #13077 (live-migration pre-flight — catches not-a-LINSTOR-satellite up-front)

All three target the LINSTOR primary-storage plugin and can be reviewed independently.