### PR TITLE
kvm: fix direct-download live storage migration

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -1964,7 +1964,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         Storage.StoragePoolType srcPoolType = srcPool.getPoolType();
         Long srcPoolClusterId = srcPool.getClusterId();
         VMTemplateStoragePoolVO ref = templatePoolDao.findByPoolTemplate(destVolumeInfo.getPoolId(), srcVolumeInfo.getTemplateId(), null);
-        boolean updateBackingFileReference = ref == null;
+        boolean updateBackingFileReference = ref == null || !StringUtils.equals(ref.getInstallPath(), srcVolumeBackingFile);
         String backingFile = !updateBackingFileReference ? ref.getInstallPath() : srcVolumeBackingFile;
         ScopeType scopeType = srcVolumeInfo.getDataStore().getScope().getScopeType();
         return new MigrationOptions(srcPoolUuid, srcPoolType, backingFile, updateBackingFileReference, scopeType, srcPoolClusterId);
@@ -2010,6 +2010,34 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
     }
 
     /**
+     * KVM/libvirt selects linked-clone or full-clone storage migration for the whole VM migration request.
+     * If any disk is backed by a direct-download template, force the request to full clone so libvirt does
+     * not use incremental shared-backing semantics for a disk whose backing chain is not guaranteed on the destination.
+     */
+    protected boolean shouldForceFullCloneMigration(Map<VolumeInfo, DataStore> volumeDataStoreMap, Host destHost) {
+        for (Map.Entry<VolumeInfo, DataStore> entry : volumeDataStoreMap.entrySet()) {
+            VolumeInfo srcVolumeInfo = entry.getKey();
+            DataStore destDataStore = entry.getValue();
+            StoragePoolVO sourceStoragePool = _storagePoolDao.findById(srcVolumeInfo.getPoolId());
+            StoragePoolVO destStoragePool = _storagePoolDao.findById(destDataStore.getId());
+
+            if (shouldSkipVolumeMigration(sourceStoragePool, destHost, destStoragePool)) {
+                continue;
+            }
+
+            if (srcVolumeInfo.isDirectDownload()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean shouldSkipVolumeMigration(StoragePoolVO sourceStoragePool, Host destHost, StoragePoolVO destStoragePool) {
+        return (sourceStoragePool.getId() == destStoragePool.getId() && sourceStoragePool.getPoolType() == Storage.StoragePoolType.PowerFlex) ||
+                !shouldMigrateVolume(sourceStoragePool, destHost, destStoragePool);
+    }
+
+    /**
      * For each disk to migrate:
      * <ul>
      *  <li>Create a volume on the target storage system.</li>
@@ -2036,6 +2064,10 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             List<MigrateDiskInfo> migrateDiskInfoList = new ArrayList<MigrateDiskInfo>();
 
             Map<String, MigrateCommand.MigrateDiskInfo> migrateStorage = new HashMap<>();
+            boolean forceFullCloneMigration = shouldForceFullCloneMigration(volumeDataStoreMap, destHost);
+            if (forceFullCloneMigration) {
+                logger.info("Using full clone live storage migration for VM [{}] because one or more migrated volumes are backed by direct-download templates.", vmTO);
+            }
 
             boolean managedStorageDestination = false;
             boolean migrateNonSharedInc = false;
@@ -2047,16 +2079,12 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 StoragePoolVO destStoragePool = _storagePoolDao.findById(destDataStore.getId());
                 StoragePoolVO sourceStoragePool = _storagePoolDao.findById(srcVolumeInfo.getPoolId());
 
-                // do not initiate migration for the same PowerFlex/ScaleIO pool
-                if (sourceStoragePool.getId() == destStoragePool.getId() && sourceStoragePool.getPoolType() == Storage.StoragePoolType.PowerFlex) {
+                if (shouldSkipVolumeMigration(sourceStoragePool, destHost, destStoragePool)) {
                     continue;
                 }
 
-                if (!shouldMigrateVolume(sourceStoragePool, destHost, destStoragePool)) {
-                    continue;
-                }
-
-                MigrationOptions.Type migrationType = decideMigrationTypeAndCopyTemplateIfNeeded(destHost, vmInstance, srcVolumeInfo, sourceStoragePool, destStoragePool, destDataStore);
+                MigrationOptions.Type migrationType = decideMigrationTypeAndCopyTemplateIfNeeded(destHost, vmInstance, srcVolumeInfo, sourceStoragePool, destStoragePool,
+                        destDataStore, forceFullCloneMigration);
                 migrateNonSharedInc = migrateNonSharedInc || MigrationOptions.Type.LinkedClone.equals(migrationType);
 
                 VolumeVO destVolume = duplicateVolumeOnAnotherStorage(srcVolume, destStoragePool);
@@ -2068,6 +2096,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 destVolumeInfo.processEvent(Event.MigrationCopySucceeded);
                 // move the volume from Ready to Migrating
                 destVolumeInfo.processEvent(Event.MigrationRequested);
+                srcVolumeInfoToDestVolumeInfo.put(srcVolumeInfo, destVolumeInfo);
 
                 setVolumeMigrationOptions(srcVolumeInfo, destVolumeInfo, vmTO, srcHost, destStoragePool, migrationType);
 
@@ -2112,8 +2141,6 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 prepareDiskWithSecretConsumerDetail(vmTO, srcVolumeInfo, destVolumeInfo.getPath());
 
                 migrateStorage.put(srcVolumeInfo.getPath(), migrateDiskInfo);
-
-                srcVolumeInfoToDestVolumeInfo.put(srcVolumeInfo, destVolumeInfo);
             }
 
             PrepareForMigrationCommand pfmc = new PrepareForMigrationCommand(vmTO);
@@ -2211,7 +2238,13 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         }
     }
 
-    private MigrationOptions.Type decideMigrationTypeAndCopyTemplateIfNeeded(Host destHost, VMInstanceVO vmInstance, VolumeInfo srcVolumeInfo, StoragePoolVO sourceStoragePool, StoragePoolVO destStoragePool, DataStore destDataStore) {
+    protected MigrationOptions.Type decideMigrationTypeAndCopyTemplateIfNeeded(Host destHost, VMInstanceVO vmInstance, VolumeInfo srcVolumeInfo, StoragePoolVO sourceStoragePool,
+            StoragePoolVO destStoragePool, DataStore destDataStore, boolean forceFullCloneMigration) {
+        if (forceFullCloneMigration) {
+            logger.debug("Skipping linked clone migration for volume [{}] because the migration request includes a direct-download backed volume.", srcVolumeInfo.getId());
+            return MigrationOptions.Type.FullClone;
+        }
+
         VMTemplateVO vmTemplate = _vmTemplateDao.findById(vmInstance.getTemplateId());
         String srcVolumeBackingFile = getVolumeBackingFile(srcVolumeInfo);
         if (StringUtils.isNotBlank(srcVolumeBackingFile) && supportStoragePoolType(destStoragePool.getPoolType(), StoragePoolType.Filesystem) &&
@@ -2449,7 +2482,11 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
     protected String connectHostToVolume(Host host, long storagePoolId, String iqn) {
         ModifyTargetsCommand modifyTargetsCommand = getModifyTargetsCommand(storagePoolId, iqn, true);
 
-        return sendModifyTargetsCommand(modifyTargetsCommand, host.getId()).get(0);
+        List<String> connectedPaths = sendModifyTargetsCommand(modifyTargetsCommand, host.getId());
+        if (CollectionUtils.isEmpty(connectedPaths)) {
+            throw new CloudRuntimeException(String.format("Unable to modify targets on the following host: %s because no connected path was returned for target [%s].", host.getId(), iqn));
+        }
+        return connectedPaths.get(0);
     }
 
     private void disconnectHostFromVolume(Host host, long storagePoolId, String iqn) {
@@ -2484,14 +2521,25 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
     }
 
     private List<String> sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {
-        ModifyTargetsAnswer modifyTargetsAnswer = (ModifyTargetsAnswer)agentManager.easySend(hostId, cmd);
+        Answer answer = agentManager.easySend(hostId, cmd);
 
-        if (modifyTargetsAnswer == null) {
+        if (answer == null) {
             throw new CloudRuntimeException("Unable to get an answer to the modify targets command");
         }
 
+        if (!(answer instanceof ModifyTargetsAnswer)) {
+            String details = StringUtils.defaultIfBlank(answer.getDetails(),
+                    String.format("Unexpected answer type returned: %s", answer.getClass().getName()));
+            throw new CloudRuntimeException(String.format("Unable to modify targets on the following host: %s due to [%s]", hostId, details));
+        }
+
+        ModifyTargetsAnswer modifyTargetsAnswer = (ModifyTargetsAnswer)answer;
+
         if (!modifyTargetsAnswer.getResult()) {
             String msg = "Unable to modify targets on the following host: " + hostId;
+            if (StringUtils.isNotBlank(modifyTargetsAnswer.getDetails())) {
+                msg = String.format("%s due to [%s]", msg, modifyTargetsAnswer.getDetails());
+            }
 
             throw new CloudRuntimeException(msg);
         }
@@ -2504,14 +2552,25 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
      */
     protected void updateCopiedTemplateReference(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo) {
         VMTemplateStoragePoolVO ref = templatePoolDao.findByPoolTemplate(srcVolumeInfo.getPoolId(), srcVolumeInfo.getTemplateId(), null);
-        VMTemplateStoragePoolVO newRef = new VMTemplateStoragePoolVO(destVolumeInfo.getPoolId(), ref.getTemplateId(), null);
-        newRef.setDownloadPercent(100);
-        newRef.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOADED);
-        newRef.setState(ObjectInDataStoreStateMachine.State.Ready);
-        newRef.setTemplateSize(ref.getTemplateSize());
-        newRef.setLocalDownloadPath(ref.getLocalDownloadPath());
-        newRef.setInstallPath(ref.getInstallPath());
-        templatePoolDao.persist(newRef);
+        if (ref == null) {
+            throw new CloudRuntimeException(String.format("Unable to update copied template reference because source template reference was not found for pool [%s] and template [%s].",
+                    srcVolumeInfo.getPoolId(), srcVolumeInfo.getTemplateId()));
+        }
+        VMTemplateStoragePoolVO destRef = templatePoolDao.findByPoolTemplate(destVolumeInfo.getPoolId(), ref.getTemplateId(), null);
+        if (destRef == null) {
+            destRef = new VMTemplateStoragePoolVO(destVolumeInfo.getPoolId(), ref.getTemplateId(), null);
+        }
+        destRef.setDownloadPercent(100);
+        destRef.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOADED);
+        destRef.setState(ObjectInDataStoreStateMachine.State.Ready);
+        destRef.setTemplateSize(ref.getTemplateSize());
+        destRef.setLocalDownloadPath(ref.getLocalDownloadPath());
+        destRef.setInstallPath(ref.getInstallPath());
+        if (destRef.getId() == 0) {
+            templatePoolDao.persist(destRef);
+        } else {
+            templatePoolDao.update(destRef.getId(), destRef);
+        }
     }
 
     /**

--- a/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/KvmNonManagedStorageSystemDataMotionTest.java
+++ b/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/KvmNonManagedStorageSystemDataMotionTest.java
@@ -338,6 +338,29 @@ public class KvmNonManagedStorageSystemDataMotionTest {
     }
 
     @Test
+    public void copyTemplateToTargetStorageIfNeededTestDirectDownloadTemplateAlreadyStaged() {
+        DataStore destDataStore = Mockito.mock(DataStore.class);
+        Host destHost = Mockito.mock(Host.class);
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        StoragePool srcStoragePool = Mockito.mock(StoragePool.class);
+        StoragePool destStoragePool = Mockito.mock(StoragePool.class);
+        TemplateInfo directDownloadTemplateInfo = Mockito.mock(TemplateInfo.class);
+
+        Mockito.when(destDataStore.getId()).thenReturn(11L);
+        Mockito.when(destHost.getId()).thenReturn(12L);
+        Mockito.when(srcVolumeInfo.getTemplateId()).thenReturn(13L);
+        Mockito.when(srcVolumeInfo.getVolumeType()).thenReturn(Volume.Type.ROOT);
+        Mockito.when(templateDataFactory.getReadyBypassedTemplateOnPrimaryStore(13L, 11L, 12L)).thenReturn(directDownloadTemplateInfo);
+
+        kvmNonManagedStorageDataMotionStrategy.copyTemplateToTargetFilesystemStorageIfNeeded(srcVolumeInfo, srcStoragePool, destDataStore, destStoragePool, destHost);
+
+        Mockito.verify(templateDataFactory).getReadyBypassedTemplateOnPrimaryStore(13L, 11L, 12L);
+        Mockito.verify(vmTemplatePoolDao, Mockito.never()).findByPoolTemplate(Mockito.anyLong(), Mockito.anyLong(), nullable(String.class));
+        Mockito.verify(dataStoreManagerImpl, Mockito.never()).getRandomImageStore(Mockito.anyLong());
+        Mockito.verify(kvmNonManagedStorageDataMotionStrategy, Mockito.never()).sendCopyCommand(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
     public void migrateTemplateToTargetStorageIfNeededTestNonDesiredStoragePoolType() throws AgentUnavailableException, OperationTimedoutException {
         StoragePoolType[] storagePoolTypeArray = StoragePoolType.values();
         for (int i = 0; i < storagePoolTypeArray.length; i++) {

--- a/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategyTest.java
+++ b/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategyTest.java
@@ -25,12 +25,20 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.Scope;
 import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.storage.datastore.PrimaryDataStoreImpl;
@@ -42,26 +50,35 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.MigrateCommand;
+import com.cloud.agent.api.ModifyTargetsAnswer;
+import com.cloud.agent.api.ModifyTargetsCommand;
+import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.ImageStore;
+import com.cloud.storage.MigrationOptions;
 import com.cloud.storage.ScopeType;
 import com.cloud.storage.Storage;
 import com.cloud.storage.Storage.StoragePoolType;
+import com.cloud.storage.VMTemplateStoragePoolVO;
+import com.cloud.storage.VMTemplateStorageResourceAssoc;
+import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import com.cloud.storage.dao.VMTemplateDao;
+import com.cloud.storage.dao.VMTemplatePoolDao;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VMInstanceVO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StorageSystemDataMotionStrategyTest {
@@ -80,6 +97,12 @@ public class StorageSystemDataMotionStrategyTest {
     private ImageStore destinationStore;
     @Mock
     private PrimaryDataStoreDao primaryDataStoreDao;
+    @Mock
+    private AgentManager agentManager;
+    @Mock
+    private VMTemplatePoolDao templatePoolDao;
+    @Mock
+    private VMTemplateDao vmTemplateDao;
 
     @Mock
     StoragePoolVO sourceStoragePoolVoMock, destinationStoragePoolVoMock;
@@ -186,6 +209,53 @@ public class StorageSystemDataMotionStrategyTest {
     }
 
     @Test
+    public void connectHostToVolumeSurfacesOriginalAgentErrorWhenAnswerTypeIsGeneric() {
+        Host host = mock(Host.class);
+        StoragePoolVO storagePool = mock(StoragePoolVO.class);
+        Answer answer = new Answer(mock(ModifyTargetsCommand.class), false, "Can't find volume:volume-1");
+
+        Mockito.when(host.getId()).thenReturn(42L);
+        Mockito.doReturn(storagePool).when(primaryDataStoreDao).findById(0L);
+        Mockito.when(storagePool.getPoolType()).thenReturn(StoragePoolType.NetworkFilesystem);
+        Mockito.when(storagePool.getUuid()).thenReturn("pool-uuid");
+        Mockito.when(storagePool.getHostAddress()).thenReturn("10.0.0.10");
+        Mockito.when(storagePool.getPort()).thenReturn(2049);
+        Mockito.doReturn(answer).when(agentManager).easySend(Mockito.eq(42L), Mockito.any(ModifyTargetsCommand.class));
+
+        try {
+            strategy.connectHostToVolume(host, 0L, "volume-1");
+            Assert.fail("Expected CloudRuntimeException to be thrown");
+        } catch (CloudRuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("Can't find volume:volume-1"));
+            Assert.assertFalse(e.getMessage().contains("ClassCastException"));
+        }
+    }
+
+    @Test
+    public void connectHostToVolumeThrowsWhenConnectedPathIsMissing() {
+        Host host = mock(Host.class);
+        StoragePoolVO storagePool = mock(StoragePoolVO.class);
+        ModifyTargetsAnswer answer = new ModifyTargetsAnswer();
+        answer.setConnectedPaths(Collections.emptyList());
+
+        Mockito.when(host.getId()).thenReturn(42L);
+        Mockito.doReturn(storagePool).when(primaryDataStoreDao).findById(0L);
+        Mockito.when(storagePool.getPoolType()).thenReturn(StoragePoolType.NetworkFilesystem);
+        Mockito.when(storagePool.getUuid()).thenReturn("pool-uuid");
+        Mockito.when(storagePool.getHostAddress()).thenReturn("10.0.0.10");
+        Mockito.when(storagePool.getPort()).thenReturn(2049);
+        Mockito.doReturn(answer).when(agentManager).easySend(Mockito.eq(42L), Mockito.any(ModifyTargetsCommand.class));
+
+        try {
+            strategy.connectHostToVolume(host, 0L, "volume-1");
+            Assert.fail("Expected CloudRuntimeException to be thrown");
+        } catch (CloudRuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("no connected path was returned"));
+            Assert.assertTrue(e.getMessage().contains("volume-1"));
+        }
+    }
+
+    @Test
     public void configureMigrateDiskInfoTest() {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
         Mockito.doReturn("volume path").when(srcVolumeInfo).getPath();
@@ -208,6 +278,223 @@ public class StorageSystemDataMotionStrategyTest {
         Assert.assertEquals("destPath", migrateDiskInfo.getSourceText());
         Assert.assertEquals("volume path", migrateDiskInfo.getSerialNumber());
         Assert.assertEquals("backingPath", migrateDiskInfo.getBackingStoreText());
+    }
+
+    @Test
+    public void createLinkedCloneMigrationOptionsUsesSourceBackingFileWhenDestinationReferencePathDiffers() {
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        VolumeInfo destVolumeInfo = Mockito.mock(VolumeInfo.class);
+        StoragePoolVO srcPool = Mockito.mock(StoragePoolVO.class);
+        DataStore srcDataStore = Mockito.mock(DataStore.class);
+        Scope scope = Mockito.mock(Scope.class);
+        VMTemplateStoragePoolVO ref = Mockito.mock(VMTemplateStoragePoolVO.class);
+
+        Mockito.when(srcPool.getUuid()).thenReturn("src-pool");
+        Mockito.when(srcPool.getPoolType()).thenReturn(StoragePoolType.NetworkFilesystem);
+        Mockito.when(srcPool.getClusterId()).thenReturn(1L);
+        Mockito.when(srcVolumeInfo.getTemplateId()).thenReturn(13L);
+        Mockito.when(srcVolumeInfo.getDataStore()).thenReturn(srcDataStore);
+        Mockito.when(srcDataStore.getScope()).thenReturn(scope);
+        Mockito.when(scope.getScopeType()).thenReturn(ScopeType.CLUSTER);
+        Mockito.when(destVolumeInfo.getPoolId()).thenReturn(4L);
+        Mockito.when(templatePoolDao.findByPoolTemplate(4L, 13L, null)).thenReturn(ref);
+        Mockito.when(ref.getInstallPath()).thenReturn("target-backing.qcow2");
+
+        MigrationOptions options = strategy.createLinkedCloneMigrationOptions(srcVolumeInfo, destVolumeInfo, "source-backing.qcow2", srcPool);
+
+        Assert.assertTrue(options.isCopySrcTemplate());
+        Assert.assertEquals("source-backing.qcow2", options.getSrcBackingFilePath());
+    }
+
+    @Test
+    public void updateCopiedTemplateReferenceUpdatesExistingDestinationReference() {
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        VolumeInfo destVolumeInfo = Mockito.mock(VolumeInfo.class);
+        VMTemplateStoragePoolVO srcRef = Mockito.mock(VMTemplateStoragePoolVO.class);
+        VMTemplateStoragePoolVO destRef = Mockito.mock(VMTemplateStoragePoolVO.class);
+
+        Mockito.when(srcVolumeInfo.getPoolId()).thenReturn(5L);
+        Mockito.when(srcVolumeInfo.getTemplateId()).thenReturn(13L);
+        Mockito.when(destVolumeInfo.getPoolId()).thenReturn(4L);
+        Mockito.when(srcRef.getTemplateId()).thenReturn(13L);
+        Mockito.when(srcRef.getTemplateSize()).thenReturn(1851129856L);
+        Mockito.when(srcRef.getLocalDownloadPath()).thenReturn("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7");
+        Mockito.when(srcRef.getInstallPath()).thenReturn("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7");
+        Mockito.when(destRef.getId()).thenReturn(19L);
+        Mockito.when(templatePoolDao.findByPoolTemplate(5L, 13L, null)).thenReturn(srcRef);
+        Mockito.when(templatePoolDao.findByPoolTemplate(4L, 13L, null)).thenReturn(destRef);
+
+        strategy.updateCopiedTemplateReference(srcVolumeInfo, destVolumeInfo);
+
+        Mockito.verify(destRef).setDownloadPercent(100);
+        Mockito.verify(destRef).setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOADED);
+        Mockito.verify(destRef).setState(ObjectInDataStoreStateMachine.State.Ready);
+        Mockito.verify(destRef).setTemplateSize(1851129856L);
+        Mockito.verify(destRef).setLocalDownloadPath("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7");
+        Mockito.verify(destRef).setInstallPath("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7");
+        Mockito.verify(templatePoolDao).update(19L, destRef);
+        Mockito.verify(templatePoolDao, Mockito.never()).persist(Mockito.any(VMTemplateStoragePoolVO.class));
+    }
+
+    @Test
+    public void updateCopiedTemplateReferencePersistsDestinationReferenceWhenMissing() {
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        VolumeInfo destVolumeInfo = Mockito.mock(VolumeInfo.class);
+        VMTemplateStoragePoolVO srcRef = Mockito.mock(VMTemplateStoragePoolVO.class);
+        ArgumentCaptor<VMTemplateStoragePoolVO> captor = ArgumentCaptor.forClass(VMTemplateStoragePoolVO.class);
+
+        Mockito.when(srcVolumeInfo.getPoolId()).thenReturn(5L);
+        Mockito.when(srcVolumeInfo.getTemplateId()).thenReturn(13L);
+        Mockito.when(destVolumeInfo.getPoolId()).thenReturn(4L);
+        Mockito.when(srcRef.getTemplateId()).thenReturn(13L);
+        Mockito.when(srcRef.getTemplateSize()).thenReturn(1851129856L);
+        Mockito.when(srcRef.getLocalDownloadPath()).thenReturn("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7");
+        Mockito.when(srcRef.getInstallPath()).thenReturn("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7");
+        Mockito.when(templatePoolDao.findByPoolTemplate(5L, 13L, null)).thenReturn(srcRef);
+        Mockito.when(templatePoolDao.findByPoolTemplate(4L, 13L, null)).thenReturn(null);
+
+        strategy.updateCopiedTemplateReference(srcVolumeInfo, destVolumeInfo);
+
+        Mockito.verify(templatePoolDao).persist(captor.capture());
+        VMTemplateStoragePoolVO persistedRef = captor.getValue();
+        Assert.assertEquals(4L, persistedRef.getPoolId());
+        Assert.assertEquals(13L, persistedRef.getTemplateId());
+        Assert.assertEquals(100, persistedRef.getDownloadPercent());
+        Assert.assertEquals(VMTemplateStorageResourceAssoc.Status.DOWNLOADED, persistedRef.getDownloadState());
+        Assert.assertEquals(ObjectInDataStoreStateMachine.State.Ready, persistedRef.getState());
+        Assert.assertEquals(1851129856L, persistedRef.getTemplateSize());
+        Assert.assertEquals("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7", persistedRef.getLocalDownloadPath());
+        Assert.assertEquals("d06b4640-d7d3-45d7-92c1-8cd3c8eb1eb7", persistedRef.getInstallPath());
+        Mockito.verify(templatePoolDao, Mockito.never()).update(Mockito.anyLong(), Mockito.any(VMTemplateStoragePoolVO.class));
+    }
+
+    @Test
+    public void updateCopiedTemplateReferenceThrowsWhenSourceReferenceMissing() {
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        VolumeInfo destVolumeInfo = Mockito.mock(VolumeInfo.class);
+
+        Mockito.when(srcVolumeInfo.getPoolId()).thenReturn(5L);
+        Mockito.when(srcVolumeInfo.getTemplateId()).thenReturn(13L);
+        Mockito.when(templatePoolDao.findByPoolTemplate(5L, 13L, null)).thenReturn(null);
+
+        try {
+            strategy.updateCopiedTemplateReference(srcVolumeInfo, destVolumeInfo);
+            Assert.fail("Expected CloudRuntimeException to be thrown");
+        } catch (CloudRuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("source template reference was not found"));
+            Assert.assertTrue(e.getMessage().contains("pool [5]"));
+            Assert.assertTrue(e.getMessage().contains("template [13]"));
+        }
+    }
+
+    @Test
+    public void shouldForceFullCloneMigrationReturnsTrueForMixedDirectDownloadVolumes() {
+        VolumeInfo directDownloadVolume = Mockito.mock(VolumeInfo.class);
+        VolumeInfo regularVolume = Mockito.mock(VolumeInfo.class);
+        DataStore destPrimary = Mockito.mock(DataStore.class);
+        DataStore otherDestPrimary = Mockito.mock(DataStore.class);
+        Host destHost = Mockito.mock(Host.class);
+        Map<VolumeInfo, DataStore> volumeMap = new HashMap<>();
+
+        configurePoolLookup(directDownloadVolume, destPrimary, 1L, 2L, StoragePoolType.NetworkFilesystem, StoragePoolType.NetworkFilesystem);
+        configurePoolLookup(regularVolume, otherDestPrimary, 3L, 4L, StoragePoolType.NetworkFilesystem, StoragePoolType.NetworkFilesystem);
+        Mockito.when(directDownloadVolume.isDirectDownload()).thenReturn(true);
+        Mockito.when(regularVolume.isDirectDownload()).thenReturn(false);
+
+        volumeMap.put(directDownloadVolume, destPrimary);
+        volumeMap.put(regularVolume, otherDestPrimary);
+
+        Assert.assertTrue(strategy.shouldForceFullCloneMigration(volumeMap, destHost));
+    }
+
+    @Test
+    public void shouldForceFullCloneMigrationIgnoresSkippedDirectDownloadVolumes() {
+        VolumeInfo skippedDirectDownloadVolume = Mockito.mock(VolumeInfo.class);
+        VolumeInfo regularVolume = Mockito.mock(VolumeInfo.class);
+        DataStore samePowerFlexStore = Mockito.mock(DataStore.class);
+        DataStore destPrimary = Mockito.mock(DataStore.class);
+        Host destHost = Mockito.mock(Host.class);
+        Map<VolumeInfo, DataStore> volumeMap = new HashMap<>();
+
+        configurePoolLookup(skippedDirectDownloadVolume, samePowerFlexStore, 1L, 1L, StoragePoolType.PowerFlex, StoragePoolType.PowerFlex);
+        configurePoolLookup(regularVolume, destPrimary, 3L, 4L, StoragePoolType.NetworkFilesystem, StoragePoolType.NetworkFilesystem);
+        Mockito.when(regularVolume.isDirectDownload()).thenReturn(false);
+
+        volumeMap.put(skippedDirectDownloadVolume, samePowerFlexStore);
+        volumeMap.put(regularVolume, destPrimary);
+
+        Assert.assertFalse(strategy.shouldForceFullCloneMigration(volumeMap, destHost));
+    }
+
+    @Test
+    public void shouldForceFullCloneMigrationReturnsFalseWhenNoVolumeIsDirectDownload() {
+        VolumeInfo regularVolume = Mockito.mock(VolumeInfo.class);
+        DataStore destPrimary = Mockito.mock(DataStore.class);
+        Host destHost = Mockito.mock(Host.class);
+        Map<VolumeInfo, DataStore> volumeMap = new HashMap<>();
+
+        configurePoolLookup(regularVolume, destPrimary, 3L, 4L, StoragePoolType.NetworkFilesystem, StoragePoolType.NetworkFilesystem);
+        Mockito.when(regularVolume.isDirectDownload()).thenReturn(false);
+        volumeMap.put(regularVolume, destPrimary);
+
+        Assert.assertFalse(strategy.shouldForceFullCloneMigration(volumeMap, destHost));
+    }
+
+    private void configurePoolLookup(VolumeInfo volume, DataStore destStore, long sourcePoolId, long destPoolId, StoragePoolType sourcePoolType, StoragePoolType destPoolType) {
+        StoragePoolVO sourcePool = Mockito.mock(StoragePoolVO.class);
+        StoragePoolVO destPool = sourcePoolId == destPoolId ? sourcePool : Mockito.mock(StoragePoolVO.class);
+
+        Mockito.when(volume.getPoolId()).thenReturn(sourcePoolId);
+        Mockito.when(destStore.getId()).thenReturn(destPoolId);
+        Mockito.when(sourcePool.getId()).thenReturn(sourcePoolId);
+        Mockito.lenient().when(destPool.getId()).thenReturn(destPoolId);
+        Mockito.when(sourcePool.getPoolType()).thenReturn(sourcePoolType);
+        Mockito.lenient().when(destPool.getPoolType()).thenReturn(destPoolType);
+        Mockito.when(primaryDataStoreDao.findById(sourcePoolId)).thenReturn(sourcePool);
+        Mockito.when(primaryDataStoreDao.findById(destPoolId)).thenReturn(destPool);
+    }
+
+    @Test
+    public void decideMigrationTypeAndCopyTemplateIfNeededUsesFullCloneWhenForced() {
+        Host destHost = Mockito.mock(Host.class);
+        VMInstanceVO vmInstance = Mockito.mock(VMInstanceVO.class);
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        StoragePoolVO sourceStoragePool = Mockito.mock(StoragePoolVO.class);
+        StoragePoolVO destStoragePool = Mockito.mock(StoragePoolVO.class);
+        DataStore destDataStore = Mockito.mock(DataStore.class);
+
+        Mockito.when(srcVolumeInfo.getId()).thenReturn(61L);
+
+        MigrationOptions.Type migrationType = strategy.decideMigrationTypeAndCopyTemplateIfNeeded(destHost, vmInstance, srcVolumeInfo, sourceStoragePool,
+                destStoragePool, destDataStore, true);
+
+        Assert.assertEquals(MigrationOptions.Type.FullClone, migrationType);
+        Mockito.verify(strategy, Mockito.never()).copyTemplateToTargetFilesystemStorageIfNeeded(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void decideMigrationTypeAndCopyTemplateIfNeededUsesLinkedCloneWhenForcedFlagIsFalse() {
+        Host destHost = Mockito.mock(Host.class);
+        VMInstanceVO vmInstance = Mockito.mock(VMInstanceVO.class);
+        VolumeInfo srcVolumeInfo = Mockito.mock(VolumeInfo.class);
+        StoragePoolVO sourceStoragePool = Mockito.mock(StoragePoolVO.class);
+        StoragePoolVO destStoragePool = Mockito.mock(StoragePoolVO.class);
+        DataStore destDataStore = Mockito.mock(DataStore.class);
+        VMTemplateVO vmTemplate = Mockito.mock(VMTemplateVO.class);
+
+        Mockito.when(vmInstance.getTemplateId()).thenReturn(101L);
+        Mockito.when(vmTemplateDao.findById(101L)).thenReturn(vmTemplate);
+        Mockito.when(vmTemplate.getName()).thenReturn("rocky-template");
+        Mockito.when(srcVolumeInfo.getId()).thenReturn(61L);
+        Mockito.when(srcVolumeInfo.getTemplateId()).thenReturn(13L);
+        Mockito.when(destStoragePool.getPoolType()).thenReturn(StoragePoolType.Filesystem);
+        Mockito.doReturn("source-backing.qcow2").when(strategy).getVolumeBackingFile(srcVolumeInfo);
+
+        MigrationOptions.Type migrationType = strategy.decideMigrationTypeAndCopyTemplateIfNeeded(destHost, vmInstance, srcVolumeInfo, sourceStoragePool,
+                destStoragePool, destDataStore, false);
+
+        Assert.assertEquals(MigrationOptions.Type.LinkedClone, migrationType);
+        Mockito.verify(strategy).copyTemplateToTargetFilesystemStorageIfNeeded(srcVolumeInfo, sourceStoragePool, destDataStore, destStoragePool, destHost);
     }
 
     @Test

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeDataFactoryImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeDataFactoryImpl.java
@@ -56,6 +56,7 @@ public class VolumeDataFactoryImpl implements VolumeDataFactory {
         VolumeVO volumeVO = volumeDao.findById(volumeId);
 
         VolumeObject vol = VolumeObject.getVolumeObject(store, volumeVO);
+        setDirectDownloadFlagIfNeeded(vol);
 
         return vol;
     }
@@ -77,6 +78,7 @@ public class VolumeDataFactoryImpl implements VolumeDataFactory {
                 vol = VolumeObject.getVolumeObject(store, volumeVO);
             }
         }
+        setDirectDownloadFlagIfNeeded(vol);
         return vol;
     }
 
@@ -102,12 +104,7 @@ public class VolumeDataFactoryImpl implements VolumeDataFactory {
             }
             vol = VolumeObject.getVolumeObject(store, volumeVO);
         }
-        if (vol.getTemplateId() != null) {
-            VMTemplateVO template = templateDao.findById(vol.getTemplateId());
-            if (template != null) {
-                vol.setDirectDownload(template.isDirectDownload());
-            }
-        }
+        setDirectDownloadFlagIfNeeded(vol);
         return vol;
     }
 
@@ -116,6 +113,16 @@ public class VolumeDataFactoryImpl implements VolumeDataFactory {
         VolumeInfo vol = getVolume(volume.getId(), store);
         vol.addPayload(((VolumeInfo)volume).getpayload());
         return vol;
+    }
+
+    private void setDirectDownloadFlagIfNeeded(VolumeObject vol) {
+        if (vol == null || vol.getTemplateId() == null) {
+            return;
+        }
+        VMTemplateVO template = templateDao.findByIdIncludingRemoved(vol.getTemplateId());
+        if (template != null) {
+            vol.setDirectDownload(template.isDirectDownload());
+        }
     }
 
     @Override

--- a/engine/storage/volume/src/test/java/org/apache/cloudstack/storage/volume/VolumeDataFactoryImplTest.java
+++ b/engine/storage/volume/src/test/java/org/apache/cloudstack/storage/volume/VolumeDataFactoryImplTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.storage.volume;
+
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreVO;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.VMTemplateVO;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VMTemplateDao;
+import com.cloud.storage.dao.VolumeDao;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VolumeDataFactoryImplTest {
+
+    private VolumeDataFactoryImpl volumeDataFactory;
+
+    @Mock
+    private VolumeDao volumeDao;
+    @Mock
+    private VolumeDataStoreDao volumeStoreDao;
+    @Mock
+    private DataStoreManager storeMgr;
+    @Mock
+    private VMTemplateDao templateDao;
+    @Mock
+    private VolumeVO volumeVO;
+    @Mock
+    private VolumeObject volumeObject;
+    @Mock
+    private VolumeDataStoreVO volumeDataStoreVO;
+    @Mock
+    private DataStore dataStore;
+    @Mock
+    private VMTemplateVO templateVO;
+
+    @Before
+    public void setUp() {
+        volumeDataFactory = new VolumeDataFactoryImpl();
+        volumeDataFactory.volumeDao = volumeDao;
+        volumeDataFactory.volumeStoreDao = volumeStoreDao;
+        volumeDataFactory.storeMgr = storeMgr;
+        volumeDataFactory.templateDao = templateDao;
+    }
+
+    @Test
+    public void getVolumeByExplicitStoreSetsDirectDownloadFlag() {
+        Mockito.when(volumeDao.findById(42L)).thenReturn(volumeVO);
+        Mockito.when(volumeObject.getTemplateId()).thenReturn(9L);
+        Mockito.when(templateDao.findByIdIncludingRemoved(9L)).thenReturn(templateVO);
+        Mockito.when(templateVO.isDirectDownload()).thenReturn(true);
+
+        try (MockedStatic<VolumeObject> mockedStatic = Mockito.mockStatic(VolumeObject.class)) {
+            mockedStatic.when(() -> VolumeObject.getVolumeObject(dataStore, volumeVO)).thenReturn(volumeObject);
+
+            Assert.assertSame(volumeObject, volumeDataFactory.getVolume(42L, dataStore));
+        }
+
+        Mockito.verify(volumeObject).setDirectDownload(true);
+    }
+
+    @Test
+    public void getVolumeByPrimaryStoreRoleSetsDirectDownloadFlag() {
+        Mockito.when(volumeDao.findById(42L)).thenReturn(volumeVO);
+        Mockito.when(volumeVO.getPoolId()).thenReturn(7L);
+        Mockito.when(storeMgr.getDataStore(7L, DataStoreRole.Primary)).thenReturn(dataStore);
+        Mockito.when(volumeObject.getTemplateId()).thenReturn(9L);
+        Mockito.when(templateDao.findByIdIncludingRemoved(9L)).thenReturn(templateVO);
+        Mockito.when(templateVO.isDirectDownload()).thenReturn(true);
+
+        try (MockedStatic<VolumeObject> mockedStatic = Mockito.mockStatic(VolumeObject.class)) {
+            mockedStatic.when(() -> VolumeObject.getVolumeObject(dataStore, volumeVO)).thenReturn(volumeObject);
+
+            Assert.assertSame(volumeObject, volumeDataFactory.getVolume(42L, DataStoreRole.Primary));
+        }
+
+        Mockito.verify(volumeObject).setDirectDownload(true);
+    }
+
+    @Test
+    public void getVolumeByImageStoreRoleSetsDirectDownloadFlag() {
+        Mockito.when(volumeDao.findById(42L)).thenReturn(volumeVO);
+        Mockito.when(volumeStoreDao.findByVolume(42L)).thenReturn(volumeDataStoreVO);
+        Mockito.when(volumeDataStoreVO.getDataStoreId()).thenReturn(11L);
+        Mockito.when(storeMgr.getDataStore(11L, DataStoreRole.Image)).thenReturn(dataStore);
+        Mockito.when(volumeObject.getTemplateId()).thenReturn(9L);
+        Mockito.when(templateDao.findByIdIncludingRemoved(9L)).thenReturn(templateVO);
+        Mockito.when(templateVO.isDirectDownload()).thenReturn(true);
+
+        try (MockedStatic<VolumeObject> mockedStatic = Mockito.mockStatic(VolumeObject.class)) {
+            mockedStatic.when(() -> VolumeObject.getVolumeObject(dataStore, volumeVO)).thenReturn(volumeObject);
+
+            Assert.assertSame(volumeObject, volumeDataFactory.getVolume(42L, DataStoreRole.Image));
+        }
+
+        Mockito.verify(volumeObject).setDirectDownload(true);
+    }
+
+    @Test
+    public void getVolumeByExplicitStoreSkipsTemplateLookupWhenVolumeHasNoTemplate() {
+        Mockito.when(volumeDao.findById(42L)).thenReturn(volumeVO);
+        Mockito.when(volumeObject.getTemplateId()).thenReturn(null);
+
+        try (MockedStatic<VolumeObject> mockedStatic = Mockito.mockStatic(VolumeObject.class)) {
+            mockedStatic.when(() -> VolumeObject.getVolumeObject(dataStore, volumeVO)).thenReturn(volumeObject);
+
+            Assert.assertSame(volumeObject, volumeDataFactory.getVolume(42L, dataStore));
+        }
+
+        Mockito.verifyNoInteractions(templateDao);
+        Mockito.verify(volumeObject, Mockito.never()).setDirectDownload(Mockito.anyBoolean());
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes live storage migration for KVM instances whose migrated volumes are backed by direct-download templates.

The problematic path is linked-clone live storage migration. For that mode, libvirt expects the rest of the backing chain to already exist on the destination and to match the source. That assumption is not safe for direct-download backed volumes, where the template may have been bypassed or staged directly on primary storage. When such a volume is part of the actual migration set, this PR forces the KVM migration request to use full-clone storage migration instead.

A few related edge cases are handled in the same path:

- the full-clone decision ignores volumes that are skipped from the migration request, such as same-pool PowerFlex volumes or volumes rejected by `shouldMigrateVolume`
- `VolumeDataFactoryImpl` now carries the template `directDownload` flag consistently across its `getVolume(...)` variants, including volumes whose template was removed later
- copied template references are updated instead of blindly persisted, and missing source references now fail with a useful error instead of a later NPE
- `ModifyTargetsCommand` failures preserve the agent error details and empty connected-path answers fail with a clearer exception

This keeps the change scoped to the KVM storage migration bug. It does not try to mix linked-clone and full-clone per disk, since the current KVM/libvirt migration command chooses the storage migration mode for the VM migration request as a whole.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A. This is a backend KVM storage migration fix.

### How Has This Been Tested?

Targeted unit tests:

```bash
mvn -pl engine/storage/datamotion,engine/storage/volume -am \
  -Dtest=StorageSystemDataMotionStrategyTest,KvmNonManagedStorageSystemDataMotionTest,VolumeDataFactoryImplTest \
  -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 63 tests run, 0 failures, build success.

Manual verification was also done in a two-host KVM 4.22 test environment:

- registered a direct-download Rocky Linux template
- deployed an instance from that template
- live migrated the instance with storage from host A to host B
- live migrated it back from host B to host A
- confirmed the VM stayed running after each migration
- confirmed management logs showed the expected full-clone fallback for the direct-download backed volume

#### How did you try to break this feature and the system with this change?

Covered the boundary cases that are most likely to regress this path:

- mixed migration requests with a direct-download volume and a normal volume
- direct-download volumes that are skipped and should not force the rest of the request to full clone
- existing and missing copied template references
- destination template references whose backing path differs from the source backing path
- `ModifyTargetsCommand` returning a generic failed `Answer`
- `ModifyTargetsAnswer` returning no connected paths
- volumes with no template ID, to avoid unnecessary template lookups
