### PR TITLE
kvm: Add a configuration setting to switch between multicast and evpn VXLAN modes

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -364,6 +364,14 @@ iscsi.session.cleanup.enabled=false
 # to the directory "/usr/share/cloudstack-common/".
 #network.scripts.dir=scripts/vm/network/vnet
 
+# Sets the VXLAN networking mode used, either 'multicast' (default) or 'evpn'.
+# The different modes lead to different scripts being executed by the Agent.
+# multicast: modifyvxlan.sh
+# evpn: modifyvxlan-evpn.sh
+# Existing environments using VXLAN can safely switch to the 'evpn' mode as this
+# will not break existing functionality.
+#network.vxlan.mode=multicast
+
 # Defines the location for storage scripts.
 # The path defined in this property is relative.
 # To locate the script, ACS first tries to concatenate

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -305,6 +305,15 @@ public class AgentProperties{
     public static final Property<String> NETWORK_BRIDGE_TYPE = new Property<>("network.bridge.type", "native");
 
     /**
+     * Sets the VXLAN networking mode used by the BridgeVifDriver.<br>
+     * Possible values: multicast | evpn <br>
+     * When set to <code>evpn</code>, the driver will use modifyvxlan-evpn.sh instead of modifyvxlan.sh.<br>
+     * Data type: String.<br>
+     * Default value: <code>multicast</code>
+     */
+    public static final Property<String> NETWORK_VXLAN_MODE = new Property<>("network.vxlan.mode", "multicast");
+
+    /**
      * Sets the driver used to plug and unplug NICs from the bridges.<br>
      * A sensible default value will be selected based on the network.bridge.type but can be overridden here.<br>
      * Value for native = com.cloud.hypervisor.kvm.resource.BridgeVifDriver<br>

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -76,9 +76,11 @@ public class BridgeVifDriver extends VifDriverBase {
         if (_modifyVlanPath == null) {
             throw new ConfigurationException("Unable to find modifyvlan.sh");
         }
-        _modifyVxlanPath = Script.findScript(networkScriptsDir, "modifyvxlan.sh");
+        String vxlanMode = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.NETWORK_VXLAN_MODE);
+        String vxlanScript = "evpn".equalsIgnoreCase(vxlanMode) ? "modifyvxlan-evpn.sh" : "modifyvxlan.sh";
+        _modifyVxlanPath = Script.findScript(networkScriptsDir, vxlanScript);
         if (_modifyVxlanPath == null) {
-            throw new ConfigurationException("Unable to find modifyvxlan.sh");
+            throw new ConfigurationException("Unable to find " + vxlanScript);
         }
 
         libvirtVersion = (Long) params.get("libvirtVersion");


### PR DESCRIPTION
### Description
Using the 'network.vxlan.mode' setting you can switch between the multicast (default) and evpn VXLAN modes on a KVM Agent.

When nothing is configured CloudStack will default to multicast by using the modifyvxlan.sh script in the background. If this setting is set to 'evpn' the KVM Agent will execute the 'modifyvxlan-evpn.sh' script which will configure the VXLAN devices for EVPN (usually with FRRouting with BGP) mode.

This removes the need to manually replace a shell script on the hypervisor to switch modes.

Existing environments are not touched by this and it is safe to add this setting a an environment already using EVPN for the VXLAN deployment.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor
