### PR TITLE
API rule regex optimization

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/acl/Rule.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/Rule.java
@@ -36,7 +36,7 @@ public final class Rule {
 
     public boolean matches(final String commandName) {
         return StringUtils.isNotEmpty(commandName)
-                && compiledPattern.matcher(commandName.toLowerCase()).matches();
+                && compiledPattern.matcher(commandName).matches();
     }
 
     public String getRuleString() {

--- a/api/src/main/java/org/apache/cloudstack/acl/Rule.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/Rule.java
@@ -25,16 +25,18 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class Rule {
     private final String rule;
+    private final Pattern compiledPattern;
     private final static Pattern ALLOWED_PATTERN = Pattern.compile("^[a-zA-Z0-9*]+$");
 
     public Rule(final String rule) {
         validate(rule);
         this.rule = rule;
+        this.compiledPattern = Pattern.compile(rule.toLowerCase().replace("*", "\\w*"));
     }
 
     public boolean matches(final String commandName) {
         return StringUtils.isNotEmpty(commandName)
-                && commandName.toLowerCase().matches(rule.toLowerCase().replace("*", "\\w*"));
+                && compiledPattern.matcher(commandName.toLowerCase()).matches();
     }
 
     public String getRuleString() {

--- a/api/src/main/java/org/apache/cloudstack/acl/Rule.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/Rule.java
@@ -31,7 +31,7 @@ public final class Rule {
     public Rule(final String rule) {
         validate(rule);
         this.rule = rule;
-        this.compiledPattern = Pattern.compile(rule.toLowerCase().replace("*", "\\w*"));
+        this.compiledPattern = Pattern.compile(rule.replace("*", "\\w*"), Pattern.CASE_INSENSITIVE);
     }
 
     public boolean matches(final String commandName) {


### PR DESCRIPTION
### Description

This PR optimizes the API rule regex, to compile the pattern once in the constructor and store it in a compiledPattern field, instead of recompiling via String.matches() on every matches() call.

 With ~879 APIs checked per getApisAllowedToAccount, that's ~879 pattern compilations per invocation. Pre-compiling the pattern in the constructor would eliminate this.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
