### PR TITLE
 Don't call delete volume on store if volume doesn't exist on it

### DIFF
--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -395,9 +395,9 @@ public class VolumeServiceImpl implements VolumeService {
         }
 
         // Find out if the volume is at state of download_in_progress on secondary storage
-        VolumeDataStoreVO volumeStore = _volumeStoreDao.findByVolume(volume.getId());
-        if (volumeStore != null) {
-            if (volumeStore.getDownloadState() == VMTemplateStorageResourceAssoc.Status.DOWNLOAD_IN_PROGRESS) {
+        VolumeDataStoreVO volumeOnImageStore = _volumeStoreDao.findByVolume(volume.getId());
+        if (volumeOnImageStore != null) {
+            if (volumeOnImageStore.getDownloadState() == VMTemplateStorageResourceAssoc.Status.DOWNLOAD_IN_PROGRESS) {
                 String msg = String.format("Volume: %s is currently being uploaded; can't delete it.", volume);
                 logger.debug(msg);
                 result.setSuccess(false);
@@ -416,10 +416,10 @@ public class VolumeServiceImpl implements VolumeService {
 
         if (!volumeExistsOnPrimary(vol)) {
             // not created on primary store
-            if (volumeStore == null) {
+            if (volumeOnImageStore == null) {
                 // also not created on secondary store
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Marking volume that was never created as destroyed: " + vol);
+                    logger.debug("Marking volume that was never created as destroyed: {}", vol);
                 }
                 VMTemplateVO template = templateDao.findById(vol.getTemplateId());
                 if (template != null && !template.isDeployAsIs()) {
@@ -435,11 +435,21 @@ public class VolumeServiceImpl implements VolumeService {
         if (volume.getDataStore().getRole() == DataStoreRole.Image) {
             // no need to change state in volumes table
             volume.processEventOnly(Event.DestroyRequested);
+            if (volumeOnImageStore == null) {
+                logger.debug("Volume {} doesn't exist on image store, no need to delete", vol);
+                future.complete(result);
+                return future;
+            }
         } else if (volume.getDataStore().getRole() == DataStoreRole.Primary) {
             if (vol.getState() == Volume.State.Expunging) {
                 logger.info("Volume {} is already in Expunging, retrying", volume);
             }
             volume.processEvent(Event.ExpungeRequested);
+            if (!volumeExistsOnPrimary(vol)) {
+                logger.debug("Volume {} doesn't exist on primary storage, no need to delete", vol);
+                future.complete(result);
+                return future;
+            }
         }
 
         DeleteVolumeContext<VolumeApiResult> context = new DeleteVolumeContext<>(null, vo, future);
@@ -460,13 +470,11 @@ public class VolumeServiceImpl implements VolumeService {
 
     private boolean volumeExistsOnPrimary(VolumeVO vol) {
         Long poolId = vol.getPoolId();
-
         if (poolId == null) {
             return false;
         }
 
         PrimaryDataStore primaryStore = dataStoreMgr.getPrimaryDataStore(poolId);
-
         if (primaryStore == null) {
             return false;
         }
@@ -476,8 +484,7 @@ public class VolumeServiceImpl implements VolumeService {
         }
 
         String volumePath = vol.getPath();
-
-        if (volumePath == null || volumePath.trim().isEmpty()) {
+        if (StringUtils.isBlank(volumePath)) {
             return false;
         }
 


### PR DESCRIPTION
### Description

This PR updates changes to not call delete volume on store if volume doesn't exist on it.

Noticed this issue in the failed xenserver test 'test_02_list_snapshots_with_removed_data_store' in test_snapshots.py.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Successfully deleted volume not created on the primary storage.

BEFORE:

Delete volume fails with error " The uuid you supplied was invalid.", and also doesn't allow to remove the storage pool as non-destroyed volumes exists.

```
2026-05-06 20:03:00,121 INFO  [c.c.s.VolumeApiServiceImpl] (qtp2038105753-24:[ctx-0c63e636, ctx-6a458984]) (logid:0a3bbd32) Expunging volume Volume {"id":630,"instanceId":null,"name":"Test Volume-JE9STT","uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK"} from Primary data store
2026-05-06 20:03:00,124 DEBUG [o.a.c.s.v.VolumeServiceImpl] (qtp2038105753-24:[ctx-0c63e636, ctx-6a458984]) (logid:0a3bbd32) Marking volume that was never created as destroyed: Volume {"id":630,"instanceId":null,"name":"Test Volume-JE9STT","uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK"}

2026-05-06 20:03:00,141 DEBUG [c.c.a.m.ClusteredAgentManagerImpl] (qtp2038105753-24:[ctx-0c63e636, ctx-6a458984]) (logid:0a3bbd32) Wait time setting on org.apache.cloudstack.storage.command.DeleteCommand is 1800 seconds
2026-05-06 20:03:00,142 DEBUG [c.c.a.m.ClusteredDirectAgentAttache] (qtp2038105753-24:[ctx-0c63e636, ctx-6a458984]) (logid:0a3bbd32) Seq 12-5679602080067635204: Routed from 32988301624164
2026-05-06 20:03:00,142 DEBUG [c.c.a.t.Request] (qtp2038105753-24:[ctx-0c63e636, ctx-6a458984]) (logid:0a3bbd32) Seq 1-5679602080067635204: Sending  { Cmd , MgmtId: 32988301624164, via: 1(pr12001-t16006-xcpng83-xs1), Ver: v1, Flags: 100011, [{"org.apache.cloudstack.storage.command.DeleteCommand":{"data":{"org.apache.cloudstack.storage.to.VolumeObjectTO":{"uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"4a7792fb-c135-3ca2-a5c8-bc7e080d76ba","name":"Test nfs2 primary","id":"9","poolType":"NetworkFilesystem","host":"10.0.32.4","path":"/acs/primary/pr12001-t16006-xcpng83/nfs2","port":"2049","url":"NetworkFilesystem://10.0.32.4/acs/primary/pr12001-t16006-xcpng83/nfs2/?ROLE=Primary&STOREUUID=4a7792fb-c135-3ca2-a5c8-bc7e080d76ba","isManaged":"false"}},"name":"Test Volume-JE9STT","size":"(1.00 GB) 1073741824","volumeId":"630","accountId":"317","format":"VHD","provisioningType":"THIN","poolId":"9","id":"630","hypervisorType":"XenServer","directDownload":"false","deployAsIs":"false","checkpointPaths":[],"checkpointImageStoreUrls":[],"followRedirects":"false"}},"wait":"0","bypassHostMaintenance":"false"}}] }
2026-05-06 20:03:00,143 DEBUG [c.c.a.t.Request] (qtp2038105753-24:[ctx-0c63e636, ctx-6a458984]) (logid:0a3bbd32) Seq 1-5679602080067635204: Executing:  { Cmd , MgmtId: 32988301624164, via: 1(pr12001-t16006-xcpng83-xs1), Ver: v1, Flags: 100011, [{"org.apache.cloudstack.storage.command.DeleteCommand":{"data":{"org.apache.cloudstack.storage.to.VolumeObjectTO":{"uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"4a7792fb-c135-3ca2-a5c8-bc7e080d76ba","name":"Test nfs2 primary","id":"9","poolType":"NetworkFilesystem","host":"10.0.32.4","path":"/acs/primary/pr12001-t16006-xcpng83/nfs2","port":"2049","url":"NetworkFilesystem://10.0.32.4/acs/primary/pr12001-t16006-xcpng83/nfs2/?ROLE=Primary&STOREUUID=4a7792fb-c135-3ca2-a5c8-bc7e080d76ba","isManaged":"false"}},"name":"Test Volume-JE9STT","size":"(1.00 GB) 1073741824","volumeId":"630","accountId":"317","format":"VHD","provisioningType":"THIN","poolId":"9","id":"630","hypervisorType":"XenServer","directDownload":"false","deployAsIs":"false","checkpointPaths":[],"checkpointImageStoreUrls":[],"followRedirects":"false"}},"wait":"0","bypassHostMaintenance":"false"}}] }
2026-05-06 20:03:00,143 DEBUG [c.c.a.m.D.Task] (DirectAgent-267:[ctx-eb1ace39]) (logid:f7c80038) Seq 12-5679602080067635204: Executing request
2026-05-06 20:03:00,143 DEBUG [c.c.s.r.StorageSubsystemCommandHandlerBase] (DirectAgent-267:[ctx-eb1ace39]) (logid:0a3bbd32) Executing command DeleteCommand: [{"data":{"org.apache.cloudstack.storage.to.VolumeObjectTO":{"uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK","dataStore":{"org.apache.cloudstack.storage.to.PrimaryDataStoreTO":{"uuid":"4a7792fb-c135-3ca2-a5c8-bc7e080d76ba","name":"Test nfs2 primary","id":9,"poolType":"NetworkFilesystem","host":"10.0.32.4","path":"/acs/primary/pr12001-t16006-xcpng83/nfs2","port":2049,"url":"NetworkFilesystem://10.0.32.4/acs/primary/pr12001-t16006-xcpng83/nfs2/?ROLE=Primary&STOREUUID=4a7792fb-c135-3ca2-a5c8-bc7e080d76ba","isManaged":false}},"name":"Test Volume-JE9STT","size":1073741824,"volumeId":630,"accountId":317,"format":"VHD","provisioningType":"THIN","poolId":9,"id":630,"hypervisorType":"XenServer","directDownload":false,"deployAsIs":false,"checkpointPaths":[],"checkpointImageStoreUrls":[],"followRedirects":false}},"wait":0,"bypassHostMaintenance":false}].
2026-05-06 20:03:00,151 DEBUG [c.c.h.x.r.Xenserver625StorageProcessor] (DirectAgent-267:[ctx-eb1ace39]) (logid:0a3bbd32) Failed to delete volume The uuid you supplied was invalid.
	at com.xensource.xenapi.Types.checkResponse(Types.java:2352)
	at com.xensource.xenapi.ConnectionNew.dispatch(ConnectionNew.java:318)
	at com.cloud.hypervisor.xenserver.resource.XenServerConnectionPool$XenServerConnection.dispatch(XenServerConnectionPool.java:459)
	at com.xensource.xenapi.VDI.getByUuid(VDI.java:355)
	at com.cloud.hypervisor.xenserver.resource.XenServerStorageProcessor.deleteVolume(XenServerStorageProcessor.java:587)
...
2026-05-06 20:03:37,729 DEBUG [c.c.s.StorageManagerImpl] (qtp2038105753-24:[ctx-2dd11af0, ctx-d6bc8eab]) (logid:5ea94ed6) Cannot delete storage pool StoragePool {"id":9,"name":"Test nfs2 primary","poolType":"NetworkFilesystem","uuid":"4a7792fb-c135-3ca2-a5c8-bc7e080d76ba"} as the following non-destroyed volumes are on it: [].
2026-05-06 20:03:37,730 ERROR [c.c.a.ApiServer] (qtp2038105753-24:[ctx-2dd11af0, ctx-d6bc8eab]) (logid:5ea94ed6) unhandled exception executing api command: [Ljava.lang.String;@716b52cd com.cloud.utils.exception.CloudRuntimeException: Cannot delete pool StoragePool {"id":9,"name":"Test nfs2 primary","poolType":"NetworkFilesystem","uuid":"4a7792fb-c135-3ca2-a5c8-bc7e080d76ba"} as there are non-destroyed volumes associated to this pool.
	at com.cloud.storage.StorageManagerImpl.deleteDataStoreInternal(StorageManagerImpl.java:1783)
	at com.cloud.storage.StorageManagerImpl.deletePool(StorageManagerImpl.java:1706)
```

AFTER:

```
2026-05-06 20:45:23,762 INFO  [c.c.s.VolumeApiServiceImpl] (qtp2038105753-23:[ctx-631e2bf2, ctx-04adee99]) (logid:62cd1e87) Expunging volume Volume {"id":630,"instanceId":null,"name":"Test Volume-JE9STT","uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK"} from Primary data store
2026-05-06 20:45:23,766 DEBUG [o.a.c.s.v.VolumeServiceImpl] (qtp2038105753-23:[ctx-631e2bf2, ctx-04adee99]) (logid:62cd1e87) Marking volume that was never created as destroyed: Volume {"id":630,"instanceId":null,"name":"Test Volume-JE9STT","uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK"}
2026-05-06 20:45:23,784 DEBUG [o.a.c.s.v.VolumeServiceImpl] (qtp2038105753-23:[ctx-631e2bf2, ctx-04adee99]) (logid:62cd1e87) Volume Volume {"id":630,"instanceId":null,"name":"Test Volume-JE9STT","uuid":"6c5a4d4a-c12c-449e-9074-65ac240e5fe8","volumeType":"DATADISK"} doesn't exist on primary storage, no need to delete
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
