### PR TITLE
Add xenserver.create.full.clone global setting

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
+++ b/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
@@ -195,6 +195,14 @@ public interface StorageManager extends StorageService {
             true,
             ConfigKey.Scope.StoragePool,
             null);
+    ConfigKey<Boolean> XenserverCreateCloneFull = new ConfigKey<>(Boolean.class,
+            "xenserver.create.full.clone",
+            "Storage",
+            "false",
+            "If set to true, creates VMs as full clones on XenServer hypervisor (uses VDI.copy instead of VDI.clone, removing the linked-clone parent relationship).",
+            true,
+            ConfigKey.Scope.StoragePool,
+            null);
     ConfigKey<Boolean> VmwareAllowParallelExecution = new ConfigKey<>(Boolean.class,
             "vmware.allow.parallel.command.execution",
             "Advanced",

--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -284,14 +284,14 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
         if (dataTO == null) {
             return dataTO;
         }
-        switch (dataTO.getHypervisorType()) {
-            case VMware:
-                return addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(dataTO);
-            case XenServer:
-                return addFullCloneAndDiskprovisiongStrictnessFlagOnXenServerDest(dataTO);
-            default:
-                return dataTO;
+        Hypervisor.HypervisorType hypervisorType = dataTO.getHypervisorType();
+        if (Hypervisor.HypervisorType.VMware.equals(hypervisorType)) {
+            return addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(dataTO);
         }
+        if (Hypervisor.HypervisorType.XenServer.equals(hypervisorType)) {
+            return addFullCloneAndDiskprovisiongStrictnessFlagOnXenServerDest(dataTO);
+        }
+        return dataTO;
     }
 
     protected Answer copyObject(DataObject srcData, DataObject destData) {

--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -191,7 +191,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                 srcForCopy = cacheData = cacheMgr.createCacheObject(srcData, destScope);
             }
 
-            CopyCommand cmd = new CopyCommand(srcForCopy.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(destData.getTO()), primaryStorageDownloadWait,
+            CopyCommand cmd = new CopyCommand(srcForCopy.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnDest(destData.getTO()), primaryStorageDownloadWait,
                     VirtualMachineManager.ExecuteInSequence.value());
             EndPoint ep = destHost != null ? RemoteHostEndPoint.getHypervisorHostEndPoint(destHost) : selector.select(srcForCopy, destData);
             if (ep == null) {
@@ -257,6 +257,43 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
         return dataTO;
     }
 
+    /**
+     * Adds {@code 'xenserver.create.full.clone'} value for a given primary storage, whose HV is XenServer, on datastore's {@code fullCloneFlag} field
+     * @param dataTO Dest data store TO
+     * @return dataTO including fullCloneFlag, if provided
+     */
+    protected DataTO addFullCloneAndDiskprovisiongStrictnessFlagOnXenServerDest(DataTO dataTO) {
+        if (dataTO != null && dataTO.getHypervisorType().equals(Hypervisor.HypervisorType.XenServer)){
+            DataStoreTO dataStoreTO = dataTO.getDataStore();
+            if (dataStoreTO != null && dataStoreTO instanceof PrimaryDataStoreTO){
+                PrimaryDataStoreTO primaryDataStoreTO = (PrimaryDataStoreTO) dataStoreTO;
+                primaryDataStoreTO.setFullCloneFlag(StorageManager.XenserverCreateCloneFull.valueIn(primaryDataStoreTO.getId()));
+            }
+        }
+        return dataTO;
+    }
+
+    /**
+     * Dispatches to the per-hypervisor {@code addFullCloneAndDiskprovisiongStrictnessFlagOn*Dest} helper
+     * based on {@code dataTO.getHypervisorType()}. Returns {@code dataTO} unchanged for hypervisors
+     * that do not have a full-clone toggle.
+     * @param dataTO Dest data store TO
+     * @return dataTO including fullCloneFlag, if provided
+     */
+    protected DataTO addFullCloneAndDiskprovisiongStrictnessFlagOnDest(DataTO dataTO) {
+        if (dataTO == null) {
+            return dataTO;
+        }
+        switch (dataTO.getHypervisorType()) {
+            case VMware:
+                return addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(dataTO);
+            case XenServer:
+                return addFullCloneAndDiskprovisiongStrictnessFlagOnXenServerDest(dataTO);
+            default:
+                return dataTO;
+        }
+    }
+
     protected Answer copyObject(DataObject srcData, DataObject destData) {
         return copyObject(srcData, destData, null);
     }
@@ -315,7 +352,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
 
             updateLockHostForVolume(ep, volObj);
 
-            CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(volObj.getTO()), _createVolumeFromSnapshotWait, VirtualMachineManager.ExecuteInSequence.value());
+            CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnDest(volObj.getTO()), _createVolumeFromSnapshotWait, VirtualMachineManager.ExecuteInSequence.value());
 
             Answer answer = null;
             if (ep == null) {
@@ -361,7 +398,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
     }
 
     protected Answer cloneVolume(DataObject template, DataObject volume) {
-        CopyCommand cmd = new CopyCommand(template.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(volume.getTO()), 0, VirtualMachineManager.ExecuteInSequence.value());
+        CopyCommand cmd = new CopyCommand(template.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnDest(volume.getTO()), 0, VirtualMachineManager.ExecuteInSequence.value());
         try {
             EndPoint ep = selector.select(volume, anyVolumeRequiresEncryption(volume));
             Answer answer = null;
@@ -445,7 +482,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
 
                 objOnImageStore.processEvent(Event.CopyingRequested);
 
-                CopyCommand cmd = new CopyCommand(objOnImageStore.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(destData.getTO()), _copyvolumewait, VirtualMachineManager.ExecuteInSequence.value());
+                CopyCommand cmd = new CopyCommand(objOnImageStore.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnDest(destData.getTO()), _copyvolumewait, VirtualMachineManager.ExecuteInSequence.value());
                 EndPoint ep = selector.select(objOnImageStore, destData, encryptionRequired);
                 if (ep == null) {
                     String errMsg = String.format(NO_REMOTE_ENDPOINT_WITH_ENCRYPTION, encryptionRequired);
@@ -692,7 +729,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
             ep = selector.select(srcData, destData);
         }
 
-        CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(destData.getTO()), _createprivatetemplatefromsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
+        CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnDest(destData.getTO()), _createprivatetemplatefromsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
         Answer answer = null;
         if (ep == null) {
             logger.error(NO_REMOTE_ENDPOINT_SSVM);
@@ -730,7 +767,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                 Scope selectedScope = pickCacheScopeForCopy(srcData, destData);
                 cacheData = cacheMgr.getCacheObject(srcData, selectedScope);
 
-                CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(destData.getTO()), _backupsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
+                CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneAndDiskprovisiongStrictnessFlagOnDest(destData.getTO()), _backupsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
                 cmd.setCacheTO(cacheData.getTO());
                 cmd.setOptions(options);
                 EndPoint ep = selector.select(srcData, destData, encryptionRequired);
@@ -741,7 +778,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                     answer = ep.sendMessage(cmd);
                 }
             } else {
-                addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest(destData.getTO());
+                addFullCloneAndDiskprovisiongStrictnessFlagOnDest(destData.getTO());
                 CopyCommand cmd = new CopyCommand(srcData.getTO(), destData.getTO(), _backupsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
                 cmd.setOptions(options);
                 EndPoint ep = selector.select(srcData, destData, StorageAction.BACKUPSNAPSHOT, encryptionRequired);

--- a/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategyTest.java
+++ b/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategyTest.java
@@ -114,6 +114,14 @@ public class AncientDataMotionStrategyTest {
     }
 
     @Test
+    public void testAddFullCloneFlagOnXenServerDest() throws IllegalAccessException, NoSuchFieldException {
+        overrideDefaultConfigValue(StorageManager.XenserverCreateCloneFull, String.valueOf(FULL_CLONE_FLAG));
+        when(dataTO.getHypervisorType()).thenReturn(HypervisorType.XenServer);
+        strategy.addFullCloneAndDiskprovisiongStrictnessFlagOnXenServerDest(dataTO);
+        verify(dataStoreTO).setFullCloneFlag(FULL_CLONE_FLAG);
+    }
+
+    @Test
     public void testAddFullCloneFlagOnNotVmwareDest(){
         verify(dataStoreTO, never()).setFullCloneFlag(any(Boolean.class));
     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -859,12 +859,19 @@ public class XenServerStorageProcessor implements StorageProcessor {
         final DataTO srcData = cmd.getSrcTO();
         final DataTO destData = cmd.getDestTO();
         final VolumeObjectTO volume = (VolumeObjectTO) destData;
+        final DataStoreTO destStore = volume.getDataStore();
+        final boolean fullClone = destStore instanceof PrimaryDataStoreTO
+                && Boolean.TRUE.equals(((PrimaryDataStoreTO) destStore).isFullCloneFlag());
         VDI vdi = null;
         try {
             VDI tmpltvdi = null;
 
             tmpltvdi = getVDIbyUuid(conn, srcData.getPath());
-            vdi = tmpltvdi.createClone(conn, new HashMap<String, String>());
+            if (fullClone) {
+                vdi = tmpltvdi.copy(conn, tmpltvdi.getSR(conn));
+            } else {
+                vdi = tmpltvdi.createClone(conn, new HashMap<String, String>());
+            }
             Long virtualSize  = vdi.getVirtualSize(conn);
             if (volume.getSize() > virtualSize) {
                 logger.debug("Overriding provided Template's size with new size " + toHumanReadableSize(volume.getSize()) + " for volume: " + volume.getName());

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -4621,6 +4621,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 SecStorageVMAutoScaleDown,
                 MountDisabledStoragePool,
                 VmwareCreateCloneFull,
+                XenserverCreateCloneFull,
                 VmwareAllowParallelExecution,
                 DataStoreDownloadFollowRedirects,
                 AllowVolumeReSizeBeyondAllocation,


### PR DESCRIPTION
### Description

This PR adds a new global setting **`xenserver.create.full.clone`** that mirrors the existing `vmware.create.full.clone` behaviour for the XenServer/XCP-ng hypervisor.

Until now, XenServer-backed VMs created from a template have always been provisioned as **linked clones** (`VDI.clone()`), which on file-backed SRs (NFS/EXT/XFS) produces a copy-on-write disk that depends on the cached template VDI. This has two practical drawbacks:

1. The cached template VDI cannot be removed while any linked-clone child still exists (XenServer enforces a VHD parent ref-count), so template cleanup is blocked.
2. There is a hard ceiling of ~30 linked clones per VHD chain in XenServer.

When the new setting is enabled (per-pool or globally), the XenServer storage processor instead issues `VDI.copy(conn, sr)` for the template→volume operation, producing a fully-independent VDI with no parent VHD relationship. Deleting the template afterwards is harmless to existing VMs, and the per-chain clone ceiling no longer applies.

**Default value is `false`**, so existing deployments are unaffected unless an operator opts in.

How it's wired up:

- New `ConfigKey<Boolean> XenserverCreateCloneFull` in `StorageManager` (StoragePool scope, dynamic, default `"false"`), registered via `StorageManagerImpl.getConfigKeys()`.
- `AncientDataMotionStrategy` keeps `addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest` byte-for-byte unchanged. A new sibling helper `addFullCloneAndDiskprovisiongStrictnessFlagOnXenServerDest` writes the per-pool XenServer value onto `PrimaryDataStoreTO.fullCloneFlag`, and a new dispatcher `addFullCloneAndDiskprovisiongStrictnessFlagOnDest` switches on `dataTO.getHypervisorType()` to call the right per-hypervisor helper. All seven existing call sites that used to call the VMware helper now call the dispatcher instead — VMware behaviour is preserved exactly.
- `PrimaryDataStoreTO.fullCloneFlag` already exists and is hypervisor-agnostic; no TO change required.
- On the agent, `XenServerStorageProcessor.cloneVolumeFromBaseTemplate` reads `((PrimaryDataStoreTO) destStore).isFullCloneFlag()` and, when true, calls `tmpltvdi.copy(conn, tmpltvdi.getSR(conn))` instead of `tmpltvdi.createClone(conn, new HashMap<>())`. `Xenserver625StorageProcessor` does not override the method, so all XenServer versions are covered with a single edit.

The legacy `CitrixCreateCommandWrapper.CreateCommand` path is intentionally left untouched — `new CreateCommand(...)` is only constructed by test code in this repository, so the wrapper is unreachable in production today.

<!-- Fixes: # -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

_Global Settings UI showing the new `xenserver.create.full.clone` key — TODO: attach screenshot._

### How Has This Been Tested?

**Unit tests**

- Added `AncientDataMotionStrategyTest.testAddFullCloneFlagOnXenServerDest`, mirroring the existing VMware test, which overrides the `XenserverCreateCloneFull` default, sets `dataTO.getHypervisorType()` to `HypervisorType.XenServer`, calls the new XenServer helper, and verifies that `setFullCloneFlag(true)` is invoked on the destination `PrimaryDataStoreTO`.
- Existing `testAddFullCloneFlagOnVMwareDest` and `testAddFullCloneFlagOnNotVmwareDest` continue to pass — the VMware helper was not modified.

**Manual test environment** _(fill in)_

- CloudStack version: `<version>`
- XenServer / XCP-ng version: `<version>`
- Primary storage type tested: `<NFS / EXT / LVM / iSCSI>`
- Template format / size: `<format / size>`

**Manual scenarios** _(fill in results)_

1. With `xenserver.create.full.clone=false` (default), deploy a VM from a template and run on the XenServer host:
   ```
   xe vdi-list params=uuid,sm-config name-label=ROOT-<vmid>
   ```
   Expect `sm-config:vhd-parent` to be present (linked clone, today's behaviour). _Result: ☐_

2. Set `xenserver.create.full.clone=true` on the pool (Infrastructure → Primary Storage → Settings) and deploy another VM from the same template. Re-run the command above and expect `sm-config:vhd-parent` to be **absent**, and `physical-utilisation` to be on the same order of magnitude as `virtual-size`. _Result: ☐_

3. Delete the cached template VDI on the primary storage. The full-clone-backed VM keeps running normally; a linked-clone-backed VM would lose data. Restore the template afterwards. _Result: ☐_

4. Repeat (1)–(3) on a VMware pool to confirm the `vmware.create.full.clone` path is unaffected by the helper refactor. _Result: ☐_

#### How did you try to break this feature and the system with this change?

- **Mixed hypervisors:** verified the dispatch's `switch` only triggers when `dataTO.getHypervisorType()` is `XenServer`; pools with `KVM`, `Hyperv`, etc. fall through and `fullCloneFlag` is left untouched (linked-clone behaviour preserved).
- **No hypervisor type:** if `Volume.getHypervisorType()` returns `HypervisorType.None` (storage pool not bound to a cluster with a known hypervisor), the dispatch falls through to the default branch and the volume is linked-cloned — safe default, no regression.
- **VMware regression:** the original `addFullCloneAndDiskprovisiongStrictnessFlagOnVMwareDest` is byte-for-byte unchanged; the seven call sites that previously called it now go through the dispatcher, which routes VMware traffic back into the same method.
- **Managed storage path (out of scope, documented):** flows that route through `StorageSystemDataMotionStrategy` (e.g. SolidFire) bypass the dispatcher — same VMware-side limitation today, behaviour preserved.
- **Legacy `CreateCommand` path (out of scope, documented):** `CitrixCreateCommandWrapper.execute(CreateCommand)` still always linked-clones, but `new CreateCommand(...)` has no production callers in this repository (only test code).
- **Default value:** `false`, so the change is a no-op on upgrade until an operator opts in.
