### PR TITLE
Skip stale destroyed volumes in local storage checks

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -44,6 +44,8 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> findByInstance(long id);
 
+    List<VolumeVO> findByInstanceAndNotDestroyed(long id);
+
     List<VolumeVO> findByInstanceAndType(long id, Volume.Type vType);
 
     List<VolumeVO> findIncludingRemovedByInstanceAndType(long id, Volume.Type vType);

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -129,6 +129,14 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     }
 
     @Override
+    public List<VolumeVO> findByInstanceAndNotDestroyed(long id) {
+        SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
+        sc.setParameters("instanceId", id);
+        sc.setParameters("notDestroyed", Volume.State.Destroy, Volume.State.Expunged);
+        return listBy(sc);
+    }
+
+    @Override
     public List<VolumeVO> findByInstanceAndDeviceId(long instanceId, long deviceId) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("instanceId", instanceId);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -7660,11 +7660,27 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     protected boolean isAnyVmVolumeUsingLocalStorage(final List<VolumeVO> volumes) {
         for (VolumeVO vol : volumes) {
+            if (vol == null || vol.getRemoved() != null ||
+                    Volume.State.Destroy.equals(vol.getState()) ||
+                    Volume.State.Expunged.equals(vol.getState())) {
+                logger.debug("Skipping non-active volume while checking local storage usage: {}", vol);
+                continue;
+            }
             DiskOfferingVO diskOffering = _diskOfferingDao.findById(vol.getDiskOfferingId());
-            if (diskOffering.isUseLocalStorage()) {
+            if (diskOffering != null && diskOffering.isUseLocalStorage()) {
                 return true;
             }
-            StoragePoolVO storagePool = _storagePoolDao.findById(vol.getPoolId());
+            Long poolId = vol.getPoolId();
+            if (poolId == null) {
+                logger.debug("Skipping volume without storage pool while checking local storage usage: {}", vol);
+                continue;
+            }
+            StoragePoolVO storagePool = _storagePoolDao.findById(poolId);
+            if (storagePool == null || storagePool.getRemoved() != null) {
+                throw new CloudRuntimeException(String.format(
+                        "Cannot determine local storage usage for active volume %s because storage pool ID %s is missing or removed",
+                        vol, poolId));
+            }
             if (storagePool.isLocal()) {
                 return true;
             }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -7225,7 +7225,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     }
 
     public boolean isVMUsingLocalStorage(VMInstanceVO vm) {
-        List<VolumeVO> volumes = _volsDao.findByInstance(vm.getId());
+        List<VolumeVO> volumes = _volsDao.findByInstanceAndNotDestroyed(vm.getId());
         return isAnyVmVolumeUsingLocalStorage(volumes);
     }
 
@@ -7660,12 +7660,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     protected boolean isAnyVmVolumeUsingLocalStorage(final List<VolumeVO> volumes) {
         for (VolumeVO vol : volumes) {
-            if (vol == null || vol.getRemoved() != null ||
-                    Volume.State.Destroy.equals(vol.getState()) ||
-                    Volume.State.Expunged.equals(vol.getState())) {
-                logger.debug("Skipping non-active volume while checking local storage usage: {}", vol);
-                continue;
-            }
             DiskOfferingVO diskOffering = _diskOfferingDao.findById(vol.getDiskOfferingId());
             if (diskOffering != null && diskOffering.isUseLocalStorage()) {
                 return true;

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -1265,27 +1265,8 @@ public class UserVmManagerImplTest {
     }
 
     @Test
-    public void testIsAnyVmVolumeUsingLocalStorageSkipsDestroyedVolumeWithMissingPool() {
-        VolumeVO volume = Mockito.mock(VolumeVO.class);
-        Mockito.when(volume.getState()).thenReturn(Volume.State.Destroy);
-
-        Assert.assertFalse(userVmManagerImpl.isAnyVmVolumeUsingLocalStorage(Collections.singletonList(volume)));
-        Mockito.verify(primaryDataStoreDao, never()).findById(anyLong());
-    }
-
-    @Test
-    public void testIsAnyVmVolumeUsingLocalStorageSkipsRemovedVolume() {
-        VolumeVO volume = Mockito.mock(VolumeVO.class);
-        Mockito.when(volume.getRemoved()).thenReturn(new Date());
-
-        Assert.assertFalse(userVmManagerImpl.isAnyVmVolumeUsingLocalStorage(Collections.singletonList(volume)));
-        Mockito.verify(primaryDataStoreDao, never()).findById(anyLong());
-    }
-
-    @Test
     public void testIsAnyVmVolumeUsingLocalStorageFailsForActiveVolumeWithMissingPool() {
         VolumeVO volume = Mockito.mock(VolumeVO.class);
-        Mockito.when(volume.getState()).thenReturn(Volume.State.Ready);
         Mockito.when(volume.getDiskOfferingId()).thenReturn(1L);
         Mockito.when(volume.getPoolId()).thenReturn(2L);
         DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
@@ -1301,7 +1282,6 @@ public class UserVmManagerImplTest {
     @Test
     public void testIsAnyVmVolumeUsingLocalStorageFailsForActiveVolumeWithRemovedPool() {
         VolumeVO volume = Mockito.mock(VolumeVO.class);
-        Mockito.when(volume.getState()).thenReturn(Volume.State.Ready);
         Mockito.when(volume.getDiskOfferingId()).thenReturn(1L);
         Mockito.when(volume.getPoolId()).thenReturn(2L);
         DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -1264,6 +1264,58 @@ public class UserVmManagerImplTest {
         }
     }
 
+    @Test
+    public void testIsAnyVmVolumeUsingLocalStorageSkipsDestroyedVolumeWithMissingPool() {
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        Mockito.when(volume.getState()).thenReturn(Volume.State.Destroy);
+
+        Assert.assertFalse(userVmManagerImpl.isAnyVmVolumeUsingLocalStorage(Collections.singletonList(volume)));
+        Mockito.verify(primaryDataStoreDao, never()).findById(anyLong());
+    }
+
+    @Test
+    public void testIsAnyVmVolumeUsingLocalStorageSkipsRemovedVolume() {
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        Mockito.when(volume.getRemoved()).thenReturn(new Date());
+
+        Assert.assertFalse(userVmManagerImpl.isAnyVmVolumeUsingLocalStorage(Collections.singletonList(volume)));
+        Mockito.verify(primaryDataStoreDao, never()).findById(anyLong());
+    }
+
+    @Test
+    public void testIsAnyVmVolumeUsingLocalStorageFailsForActiveVolumeWithMissingPool() {
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        Mockito.when(volume.getState()).thenReturn(Volume.State.Ready);
+        Mockito.when(volume.getDiskOfferingId()).thenReturn(1L);
+        Mockito.when(volume.getPoolId()).thenReturn(2L);
+        DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
+        Mockito.when(diskOfferingDao.findById(1L)).thenReturn(diskOffering);
+        Mockito.when(diskOffering.isUseLocalStorage()).thenReturn(false);
+        Mockito.when(primaryDataStoreDao.findById(2L)).thenReturn(null);
+
+        CloudRuntimeException exception = assertThrows(CloudRuntimeException.class, () ->
+                userVmManagerImpl.isAnyVmVolumeUsingLocalStorage(Collections.singletonList(volume)));
+        Assert.assertTrue(exception.getMessage().contains("storage pool ID 2 is missing or removed"));
+    }
+
+    @Test
+    public void testIsAnyVmVolumeUsingLocalStorageFailsForActiveVolumeWithRemovedPool() {
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        Mockito.when(volume.getState()).thenReturn(Volume.State.Ready);
+        Mockito.when(volume.getDiskOfferingId()).thenReturn(1L);
+        Mockito.when(volume.getPoolId()).thenReturn(2L);
+        DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
+        Mockito.when(diskOfferingDao.findById(1L)).thenReturn(diskOffering);
+        Mockito.when(diskOffering.isUseLocalStorage()).thenReturn(false);
+        StoragePoolVO storagePool = Mockito.mock(StoragePoolVO.class);
+        Mockito.when(storagePool.getRemoved()).thenReturn(new Date());
+        Mockito.when(primaryDataStoreDao.findById(2L)).thenReturn(storagePool);
+
+        CloudRuntimeException exception = assertThrows(CloudRuntimeException.class, () ->
+                userVmManagerImpl.isAnyVmVolumeUsingLocalStorage(Collections.singletonList(volume)));
+        Assert.assertTrue(exception.getMessage().contains("storage pool ID 2 is missing or removed"));
+    }
+
     private List<VolumeVO> mockVolumesForIsAllVmVolumesOnZoneWideStore(int nullPoolIdVolumes, int nullPoolVolumes, int zoneVolumes, int nonZoneVolumes) {
         List<VolumeVO> volumes = new ArrayList<>();
         for (int i=0; i< nullPoolIdVolumes + nullPoolVolumes + zoneVolumes + nonZoneVolumes; ++i) {


### PR DESCRIPTION
﻿### Description

During VM migration and host maintenance flows, `UserVmManagerImpl.isAnyVmVolumeUsingLocalStorage` checks VM volumes to decide whether the VM uses local storage. If a stale destroyed volume row still references a storage pool that has since been removed, the method can dereference a null `StoragePoolVO` and fail with an NPE.

This change skips non-active volume rows while evaluating local-storage usage:

- null volume entries
- volumes with `removed` set
- volumes in `Destroy` state
- volumes in `Expunged` state

For active volumes, the method now fails with a clear `CloudRuntimeException` if the referenced storage pool is missing or removed instead of throwing a null-pointer exception. This keeps stale destroyed metadata from blocking unrelated VM/host operations while still surfacing real active-volume inconsistency.

Fixes #13124

### Tests

Added unit coverage in `UserVmManagerImplTest` for:

- skipping destroyed volumes with missing pools
- skipping removed volumes
- failing clearly for active volumes with missing pools
- failing clearly for active volumes with removed pools

<br>
<br>
<br>
<br>

##########################################################
Generated by AI - **do you REALLY think I became a Java developer overnight**?
So, **REVIEW PROPERLY** and feel free to decline the PR if it's bunch of junk !
#########################################################

