### PR TITLE
systemvm: emit IPv6 prefix block for redundant VPC VRs in radvd.conf

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsVpcGuestNetwork.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsVpcGuestNetwork.py
@@ -107,12 +107,11 @@ class CsVpcGuestNetwork(CsDataBag):
             self.conf.append("    AdvSendAdvert on;")
             self.conf.append("    MinRtrAdvInterval 5;")
             self.conf.append("    MaxRtrAdvInterval 15;")
-            if entry['router_guest_ip6'] == entry['router_guest_ip6_gateway']:
-                self.conf.append("    prefix %s" % full_addr)
-                self.conf.append("    {")
-                self.conf.append("        AdvOnLink on;")
-                self.conf.append("        AdvAutonomous on;")
-                self.conf.append("    };")
+            self.conf.append("    prefix %s" % full_addr)
+            self.conf.append("    {")
+            self.conf.append("        AdvOnLink on;")
+            self.conf.append("        AdvAutonomous on;")
+            self.conf.append("    };")
             if 'dns6' in list(entry.keys()) and entry['dns6']:
                 for dns in entry['dns6'].split(","):
                     self.conf.append("    RDNSS %s" % dns)

--- a/systemvm/debian/opt/cloud/bin/cs/CsVpcGuestNetwork.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsVpcGuestNetwork.py
@@ -107,11 +107,12 @@ class CsVpcGuestNetwork(CsDataBag):
             self.conf.append("    AdvSendAdvert on;")
             self.conf.append("    MinRtrAdvInterval 5;")
             self.conf.append("    MaxRtrAdvInterval 15;")
-            self.conf.append("    prefix %s" % full_addr)
-            self.conf.append("    {")
-            self.conf.append("        AdvOnLink on;")
-            self.conf.append("        AdvAutonomous on;")
-            self.conf.append("    };")
+            if entry['router_guest_ip6'] == entry['router_guest_ip6_gateway'] or self.cl.is_redundant():
+                self.conf.append("    prefix %s" % full_addr)
+                self.conf.append("    {")
+                self.conf.append("        AdvOnLink on;")
+                self.conf.append("        AdvAutonomous on;")
+                self.conf.append("    };")
             if 'dns6' in list(entry.keys()) and entry['dns6']:
                 for dns in entry['dns6'].split(","):
                     self.conf.append("    RDNSS %s" % dns)


### PR DESCRIPTION
### Description

Fixes #13121 — IPv6 SLAAC broken on Redundant VPC Virtual Router due to a missing                                                                 
  Prefix Information Option (PIO) in `radvd.conf`.                                                                                                  
                                                                                                                                                    
  In `CsVpcGuestNetwork.add_radvd_conf()`, the `prefix { ... }` block was emitted                                                                   
  only when `router_guest_ip6 == router_guest_ip6_gateway`. That condition is true                                                                  
  for non-redundant VRs (where the router itself is the gateway), but never for                                                                     
  redundant VRs:                                                                                                                                    
                                                                                                                                                    
                                                                                                                                                    
  As a result, on a redundant VPC tier the radvd daemon was started but advertised                                                                  
  RAs without a Prefix Information Option, so guest VMs could only configure                                                                        
  link-local `fe80::` addresses and never obtained a global IPv6 via SLAAC.                                                                         
                                                                                                                                                    
  The fix removes the conditional and always emits the prefix block when radvd is                                                                   
  configured for the tier. This aligns the VPC path with the non-VPC path                                                                           
  (`systemvm/debian/opt/cloud/bin/setup/common.sh` + `radvd.conf.tmpl`), which                                                                      
  already emits the prefix block unconditionally.                                                                                                   
                                                                                                                                                    
  ## Types of changes                                                                                                                               
                                                                                                                                                    
  - [x] Bug fix (non-breaking change which fixes an issue)                                                                                          
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Enhancement (improves an existing feature and functionality)                                                                                
  - [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
  - [ ] build/CI                                                                                                                                    
  - [ ] test (unit or integration test code)                                                                                                        
                                                                                                                                                    
  ## Feature/Enhancement Scale or Bug Severity                                                                                                      
                  
  ### Bug Severity                                                                                                                                  
                  
  - [ ] BLOCKER                                                                                                                                     
  - [] Critical  
  - [x] Major
  - [ ] Minor                                                                                                                                       
  - [ ] Trivial
                                                                                                                                                    
  ## Screenshots (if appropriate):                                                                                                                  
   
  N/A — config file change.                                                                                                                         
                  
  ## How Has This Been Tested?

  Tested on a VPC with IPv6 enabled and Redundant VR enabled, SystemVM template                                                                     
  based on Debian, SLAAC only (no DHCPv6).
                                                                                                                                                    
  Before the fix:                                                                                                                                   
  - `cat /etc/radvd.conf` on the primary VR showed the `interface ethX { ... }`                                                                     
    block but no `prefix` section.                                                                                                                  
  - `tcpdump -i ethX -vv 'icmp6 and ip6[40] = 134'` showed Router Advertisements
    without a Prefix Information Option.                                                                                                            
  - Guest VMs only configured a link-local `fe80::` address.
                                                                                                                                                    
  After the fix:  
  - `/etc/radvd.conf` contains the expected                                                                                                         
    `prefix <gateway>/64 { AdvOnLink on; AdvAutonomous on; };` block.
  - `tcpdump` confirms RAs include the Prefix Information Option.                                                                                   
  - Guest VMs auto-configure global IPv6 addresses via SLAAC.                                                                                       
  - Failover from primary to backup still works: backup VR keeps radvd disabled                                                                     
    via `CsRedundant._disable_radvd`, so no duplicate RAs are emitted; on                                                                           
    promotion, radvd is started with the correct configuration.                                                                                     
                                                                                                                                                    
  Non-redundant VPC VRs are unchanged (`router_guest_ip6 == router_guest_ip6_gateway`                                                               
  in that case, which already produced the same output as the unconditional path).
                                                                                                                                                    
   