### PR TITLE
Allow preserving duplicate MACs during VM import

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -250,6 +250,7 @@ public class ApiConstants {
     public static final String FILESYSTEM = "filesystem";
     public static final String FIRSTNAME = "firstname";
     public static final String FORCED = "forced";
+    public static final String ALLOW_DUPLICATE_MAC_ADDRESSES = "allowduplicatemacaddresses";
     public static final String FORCED_DESTROY_LOCAL_STORAGE = "forcedestroylocalstorage";
     public static final String FORCE_CONVERT_TO_POOL = "forceconverttopool";
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
@@ -152,8 +152,14 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
 
     @Parameter(name = ApiConstants.FORCED,
             type = CommandType.BOOLEAN,
-            description = "Instance is imported despite some of its NIC's MAC addresses are already present, in case the MAC address exists then a new MAC address is generated")
+            description = "Instance is imported even if some NIC MAC addresses already exist. If a MAC address exists, a new MAC address is generated")
     private Boolean forced;
+
+    @Parameter(name = ApiConstants.ALLOW_DUPLICATE_MAC_ADDRESSES,
+            type = CommandType.BOOLEAN,
+            since = "4.23.0",
+            description = "Preserve imported NIC MAC addresses even when they already exist on the target network. Intended for migration cutover workflows where the source and imported VMs are not active on the same L2 network at the same time")
+    private Boolean allowDuplicateMacAddresses;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -276,6 +282,10 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
 
     public boolean isForced() {
         return BooleanUtils.isTrue(forced);
+    }
+
+    public boolean isAllowDuplicateMacAddresses() {
+        return BooleanUtils.isTrue(allowDuplicateMacAddresses);
     }
 
     /////////////////////////////////////////////////////

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -372,7 +372,7 @@ public interface NetworkOrchestrationService {
      */
     void cleanupNicDhcpDnsEntry(Network network, VirtualMachineProfile vmProfile, NicProfile nicProfile);
 
-    Pair<NicProfile, Integer> importNic(final String macAddress, int deviceId, final Network network, final Boolean isDefaultNic, final VirtualMachine vm, final Network.IpAddresses ipAddresses, final DataCenter datacenter, boolean forced) throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException;
+    Pair<NicProfile, Integer> importNic(final String macAddress, int deviceId, final Network network, final Boolean isDefaultNic, final VirtualMachine vm, final Network.IpAddresses ipAddresses, final DataCenter datacenter, boolean forced, boolean allowDuplicateMacAddress) throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException;
 
     void unmanageNics(VirtualMachineProfile vm);
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -4770,7 +4770,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
     @DB
     @Override
-    public Pair<NicProfile, Integer> importNic(final String macAddress, int deviceId, final Network network, final Boolean isDefaultNic, final VirtualMachine vm, final Network.IpAddresses ipAddresses, final DataCenter dataCenter, final boolean forced)
+    public Pair<NicProfile, Integer> importNic(final String macAddress, int deviceId, final Network network, final Boolean isDefaultNic, final VirtualMachine vm, final Network.IpAddresses ipAddresses, final DataCenter dataCenter, final boolean forced, final boolean allowDuplicateMacAddress)
             throws ConcurrentOperationException, InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException {
         logger.debug("Allocating NIC for Instance {} in Network {} during import", vm, network);
         String selectedIp = null;
@@ -4796,7 +4796,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     throw new CloudRuntimeException("Invalid mac address: " + macAddressToPersist);
                 }
                 NicVO existingNic = _nicDao.findByNetworkIdAndMacAddress(network.getId(), macAddressToPersist);
-                if (existingNic != null) {
+                if (existingNic != null && !allowDuplicateMacAddress) {
                     macAddressToPersist = generateNewMacAddressIfForced(network, macAddressToPersist, forced);
                 }
                 NicVO vo = new NicVO(network.getGuruName(), vm.getId(), network.getId(), vm.getType());

--- a/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
+++ b/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
@@ -913,7 +913,7 @@ public class NetworkOrchestratorTest extends TestCase {
         Mockito.when(testOrchestrator._networkModel.listNetworkOfferingServices(networkOfferingId)).thenReturn(Arrays.asList(Service.Dns, Service.Dhcp));
         String macAddress = "02:01:01:82:00:01";
         int deviceId = 0;
-        testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false);
+        testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false, false);
     }
 
     @Test(expected = InsufficientVirtualNetworkCapacityException.class)
@@ -932,7 +932,7 @@ public class NetworkOrchestratorTest extends TestCase {
         Mockito.when(testOrchestrator._networkModel.listNetworkOfferingServices(networkOfferingId)).thenReturn(Arrays.asList(Service.Dns, Service.Dhcp));
         String macAddress = "02:01:01:82:00:01";
         int deviceId = 0;
-        testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false);
+        testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false, false);
     }
 
     @Test
@@ -959,7 +959,7 @@ public class NetworkOrchestratorTest extends TestCase {
         Mockito.when(testOrchestrator._networkModel.getNetworkTag(hypervisorType, network)).thenReturn("testtag");
         try (MockedStatic<Transaction> transactionMocked = Mockito.mockStatic(Transaction.class)) {
             transactionMocked.when(() -> Transaction.execute(any(TransactionCallback.class))).thenReturn(nic);
-            Pair<NicProfile, Integer> nicProfileIntegerPair = testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false);
+            Pair<NicProfile, Integer> nicProfileIntegerPair = testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false, false);
             verify(testOrchestrator._networkModel, times(1)).getNetworkRate(networkId, vmId);
             verify(testOrchestrator._networkModel, times(1)).isSecurityGroupSupportedInNetwork(network);
             verify(testOrchestrator._networkModel, times(1)).getNetworkTag(Hypervisor.HypervisorType.KVM, network);
@@ -997,7 +997,7 @@ public class NetworkOrchestratorTest extends TestCase {
         Mockito.when(testOrchestrator._networkModel.getNetworkTag(hypervisorType, network)).thenReturn("testtag");
         try (MockedStatic<Transaction> transactionMocked = Mockito.mockStatic(Transaction.class)) {
             transactionMocked.when(() -> Transaction.execute(any(TransactionCallback.class))).thenReturn(nic);
-            Pair<NicProfile, Integer> nicProfileIntegerPair = testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false);
+            Pair<NicProfile, Integer> nicProfileIntegerPair = testOrchestrator.importNic(macAddress, deviceId, network, true, vm, ipAddresses, dataCenter, false, false);
             verify(testOrchestrator, times(1)).getSelectedIpForNicImport(network, dataCenter, ipAddresses);
             verify(testOrchestrator._networkModel, times(1)).getNetworkRate(networkId, vmId);
             verify(testOrchestrator._networkModel, times(1)).isSecurityGroupSupportedInNetwork(network);

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -847,9 +847,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         return new Pair<DiskProfile, StoragePool>(profile, storagePool);
     }
 
-    private NicProfile importNic(UnmanagedInstanceTO.Nic nic, VirtualMachine vm, Network network, Network.IpAddresses ipAddresses, int deviceId, boolean isDefaultNic, boolean forced) throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException {
+    private NicProfile importNic(UnmanagedInstanceTO.Nic nic, VirtualMachine vm, Network network, Network.IpAddresses ipAddresses, int deviceId, boolean isDefaultNic,
+                                 boolean forced, boolean allowDuplicateMacAddress) throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException {
         DataCenterVO dataCenterVO = dataCenterDao.findById(network.getDataCenterId());
-        Pair<NicProfile, Integer> result = networkOrchestrationService.importNic(nic.getMacAddress(), deviceId, network, isDefaultNic, vm, ipAddresses, dataCenterVO, forced);
+        Pair<NicProfile, Integer> result = networkOrchestrationService.importNic(nic.getMacAddress(), deviceId, network, isDefaultNic, vm, ipAddresses, dataCenterVO, forced, allowDuplicateMacAddress);
         if (result == null) {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("NIC ID: %s import failed", nic.getNicId()));
         }
@@ -1056,7 +1057,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                 final VirtualMachineTemplate template, final String displayName, final String hostName, final Account caller, final Account owner, final Long userId,
                                                 final ServiceOfferingVO serviceOffering, final Map<String, Long> dataDiskOfferingMap,
                                                 final Map<String, Long> nicNetworkMap, final Map<String, Network.IpAddresses> callerNicIpAddressMap, final Long guestOsId,
-                                                final Map<String, String> details, final boolean migrateAllowed, final boolean forced, final boolean isImportUnmanagedFromSameHypervisor) {
+                                                final Map<String, String> details, final boolean migrateAllowed, final boolean forced, final boolean allowDuplicateMacAddress,
+                                                final boolean isImportUnmanagedFromSameHypervisor) {
         logger.debug(LogUtils.logGsonWithoutException("Trying to import VM [%s] with name [%s], in zone [%s], cluster [%s], and host [%s], using template [%s], service offering [%s], disks map [%s], NICs map [%s] and details [%s].",
                 unmanagedInstance, displayName, zone, cluster, host, template, serviceOffering, dataDiskOfferingMap, nicNetworkMap, details));
         UserVm userVm = null;
@@ -1186,7 +1188,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 for (UnmanagedInstanceTO.Nic nic : unmanagedInstance.getNics()) {
                     Network network = networkDao.findById(allNicNetworkMap.get(nic.getNicId()));
                     Network.IpAddresses ipAddresses = nicIpAddressMap.get(nic.getNicId());
-                    importNic(nic, userVm, network, ipAddresses, nicIndex, nicIndex == 0, forced);
+                    importNic(nic, userVm, network, ipAddresses, nicIndex, nicIndex == 0, forced, allowDuplicateMacAddress);
                     nicIndex++;
                 }
             } catch (Exception e) {
@@ -1319,6 +1321,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         final Map<String, Long> dataDiskOfferingMap = cmd.getDataDiskToDiskOfferingList();
         final Map<String, String> details = cmd.getDetails();
         final boolean forced = cmd.isForced();
+        final boolean allowDuplicateMacAddress = cmd.isAllowDuplicateMacAddresses();
+        if (forced && allowDuplicateMacAddress) {
+            throw new InvalidParameterValueException(String.format("%s and %s are mutually exclusive", ApiConstants.FORCED, ApiConstants.ALLOW_DUPLICATE_MAC_ADDRESSES));
+        }
         List<HostVO> hosts = resourceManager.listHostsInClusterByStatus(clusterId, Status.Up);
         UserVm userVm = null;
         List<String> additionalNameFilters = getAdditionalNameFilters(cluster);
@@ -1342,7 +1348,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                             template, instanceName, displayName, hostName, caller, owner, userId,
                             serviceOffering, dataDiskOfferingMap,
                             nicNetworkMap, nicIpAddressMap,
-                            details, importVmCmd, forced);
+                            details, importVmCmd, forced, allowDuplicateMacAddress);
                 }
             } else {
                 if (List.of(Hypervisor.HypervisorType.VMware, Hypervisor.HypervisorType.KVM).contains(cluster.getHypervisorType())) {
@@ -1350,7 +1356,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                             template, instanceName, displayName, hostName, caller, owner, userId,
                             serviceOffering, dataDiskOfferingMap,
                             nicNetworkMap, nicIpAddressMap,
-                            details, cmd.getMigrateAllowed(), managedVms, forced);
+                            details, cmd.getMigrateAllowed(), managedVms, forced, allowDuplicateMacAddress);
                 }
             }
 
@@ -1497,7 +1503,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                          String hostName, Account caller, Account owner, long userId,
                                                          ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap,
                                                          Map<String, Long> nicNetworkMap, Map<String, Network.IpAddresses> nicIpAddressMap,
-                                                         Map<String, String> details, Boolean migrateAllowed, List<String> managedVms, boolean forced) throws ResourceAllocationException {
+                                                         Map<String, String> details, Boolean migrateAllowed, List<String> managedVms, boolean forced,
+                                                         boolean allowDuplicateMacAddress) throws ResourceAllocationException {
         UserVm userVm = null;
         for (HostVO host : hosts) {
             HashMap<String, UnmanagedInstanceTO> unmanagedInstances = getUnmanagedInstancesForHost(host, instanceName, managedVms);
@@ -1549,7 +1556,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                             template, displayName, hostName, CallContext.current().getCallingAccount(), owner, userId,
                             serviceOffering, dataDiskOfferingMap,
                             nicNetworkMap, nicIpAddressMap, null,
-                            details, migrateAllowed, forced, true);
+                            details, migrateAllowed, forced, allowDuplicateMacAddress, true);
                 } finally {
                     ReservationHelper.closeAll(reservations);
                 }
@@ -1648,7 +1655,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                           Account caller, Account owner, long userId,
                                                           ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap,
                                                           Map<String, Long> nicNetworkMap, Map<String, Network.IpAddresses> nicIpAddressMap,
-                                                          Map<String, String> details, ImportVmCmd cmd, boolean forced) throws ResourceAllocationException {
+                                                          Map<String, String> details, ImportVmCmd cmd, boolean forced, boolean allowDuplicateMacAddress) throws ResourceAllocationException {
         Long existingVcenterId = cmd.getExistingVcenterId();
         String vcenter = cmd.getVcenter();
         String datacenterName = cmd.getDatacenterName();
@@ -1741,7 +1748,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 checkConversionSupportOnHost(convertHost, sourceVMName, true, useVddk, details);
             }
 
-            checkNetworkingBeforeConvertingVmwareInstance(zone, owner, displayName, hostName, sourceVMwareInstance, nicNetworkMap, nicIpAddressMap, forced);
+            checkNetworkingBeforeConvertingVmwareInstance(zone, owner, displayName, hostName, sourceVMwareInstance, nicNetworkMap, nicIpAddressMap, forced, allowDuplicateMacAddress);
             UnmanagedInstanceTO convertedInstance;
             if (!useVddk && (forceMsToImportVmFiles || !isOvfExportSupported)) {
                 // Uses MS for OVF export to temporary conversion location
@@ -1769,7 +1776,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                     template, displayName, hostName, caller, owner, userId,
                     serviceOffering, dataDiskOfferingMap,
                     nicNetworkMap, nicIpAddressMap, guestOsId,
-                    details, false, forced, false);
+                    details, false, forced, allowDuplicateMacAddress, false);
             long timeElapsedInSecs = (System.currentTimeMillis() - importStartTime) / 1000;
             logger.debug(String.format("VMware VM %s imported successfully to CloudStack instance %s (%s), Time taken: %d secs, OVF files imported from %s, Source VMware VM details - OS: %s, PowerState: %s, Disks: %s, NICs: %s",
                     sourceVMName, displayName, displayName, timeElapsedInSecs, (ovfTemplateOnConvertLocation != null)? "MS" : "KVM Host", sourceVMwareInstance.getOperatingSystem(), sourceVMwareInstance.getPowerState(), sourceVMwareInstance.getDisks(), sourceVMwareInstance.getNics()));
@@ -1859,7 +1866,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                                String hostName, UnmanagedInstanceTO sourceVMwareInstance,
                                                                Map<String, Long> nicNetworkMap,
                                                                Map<String, Network.IpAddresses> nicIpAddressMap,
-                                                               boolean forced) {
+                                                               boolean forced, boolean allowDuplicateMacAddress) {
         List<UnmanagedInstanceTO.Nic> nics = sourceVMwareInstance.getNics();
         List<Long> networkIds = new ArrayList<>(nicNetworkMap.values());
         if (nics.size() != networkIds.size()) {
@@ -1882,18 +1889,19 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 ipAddresses = nicIpAddressMap.get(nic.getNicId());
             }
             boolean autoImport = ipAddresses != null && ipAddresses.getIp4Address() != null && ipAddresses.getIp4Address().equalsIgnoreCase("auto");
-            checkUnmanagedNicAndNetworkMacAddressForImport(network, nic, forced);
+            checkUnmanagedNicAndNetworkMacAddressForImport(network, nic, forced, allowDuplicateMacAddress);
             checkUnmanagedNicAndNetworkForImport(displayName, nic, network, zone, owner, autoImport, Hypervisor.HypervisorType.KVM);
             checkUnmanagedNicAndNetworkHostnameForImport(displayName, nic, network, hostName);
             checkUnmanagedNicIpAndNetworkForImport(displayName, nic, network, ipAddresses);
         }
     }
 
-    private void checkUnmanagedNicAndNetworkMacAddressForImport(NetworkVO network, UnmanagedInstanceTO.Nic nic, boolean forced) {
+    private void checkUnmanagedNicAndNetworkMacAddressForImport(NetworkVO network, UnmanagedInstanceTO.Nic nic, boolean forced, boolean allowDuplicateMacAddress) {
         NicVO existingNic = nicDao.findByNetworkIdAndMacAddress(network.getId(), nic.getMacAddress());
-        if (existingNic != null && !forced) {
-            String err = String.format("NIC %s with MAC address %s already exists on network %s and forced flag is disabled. " +
-                    "Retry with forced flag enabled if a new MAC address to be generated.", nic, nic.getMacAddress(), network);
+        if (existingNic != null && !forced && !allowDuplicateMacAddress) {
+            String err = String.format("NIC %s with MAC address %s already exists on network %s. " +
+                    "Retry with %s=true to generate a new MAC address or %s=true to preserve the duplicate MAC address.",
+                    nic, nic.getMacAddress(), network, ApiConstants.FORCED, ApiConstants.ALLOW_DUPLICATE_MAC_ADDRESSES);
             logger.error(err);
             throw new CloudRuntimeException(err);
         }
@@ -2809,7 +2817,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 for (UnmanagedInstanceTO.Nic nic : unmanagedInstance.getNics()) {
                     Network network = networkDao.findById(allNicNetworkMap.get(nic.getNicId()));
                     Network.IpAddresses ipAddresses = nicIpAddressMap.get(nic.getNicId());
-                    importNic(nic, userVm, network, ipAddresses, nicIndex, nicIndex==0, true);
+                    importNic(nic, userVm, network, ipAddresses, nicIndex, nicIndex==0, true, false);
                     nicIndex++;
                 }
             } catch (Exception e) {
@@ -2980,7 +2988,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 cleanupFailedImportVM(userVm);
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to import volumes while importing vm: %s. %s", instanceName, StringUtils.defaultString(e.getMessage())));
             }
-            networkOrchestrationService.importNic(macAddress, 0, network, true, userVm, requestedIpPair, zone, true);
+            networkOrchestrationService.importNic(macAddress, 0, network, true, userVm, requestedIpPair, zone, true, false);
             publishVMUsageUpdateResourceCount(userVm, dummyOffering, template);
             return userVm;
 

--- a/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -1071,7 +1071,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     }
 
     @Override
-    public Pair<NicProfile, Integer> importNic(String macAddress, int deviceId, Network network, Boolean isDefaultNic, VirtualMachine vm, IpAddresses ipAddresses, DataCenter dataCenter, boolean forced) {
+    public Pair<NicProfile, Integer> importNic(String macAddress, int deviceId, Network network, Boolean isDefaultNic, VirtualMachine vm, IpAddresses ipAddresses, DataCenter dataCenter, boolean forced, boolean allowDuplicateMacAddress) {
         return null;
     }
 

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -388,7 +388,7 @@ public class UnmanagedVMsManagerImplTest {
         NicProfile profile = Mockito.mock(NicProfile.class);
         Integer deviceId = 100;
         Pair<NicProfile, Integer> pair = new Pair<>(profile, deviceId);
-        when(networkOrchestrationService.importNic(nullable(String.class), nullable(Integer.class), nullable(Network.class), nullable(Boolean.class), nullable(VirtualMachine.class), nullable(Network.IpAddresses.class), nullable(DataCenter.class), Mockito.anyBoolean())).thenReturn(pair);
+        when(networkOrchestrationService.importNic(nullable(String.class), nullable(Integer.class), nullable(Network.class), nullable(Boolean.class), nullable(VirtualMachine.class), nullable(Network.IpAddresses.class), nullable(DataCenter.class), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(pair);
         when(volumeDao.findByInstance(Mockito.anyLong())).thenReturn(volumes);
         List<UserVmResponse> userVmResponses = new ArrayList<>();
         UserVmResponse userVmResponse = new UserVmResponse();

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1133,6 +1133,7 @@
 "label.forcks": "For CKS",
 "label.forbidden": "Forbidden",
 "label.forced": "Force",
+"label.generate.new.mac.if.required": "Generate new MAC if required",
 "label.force.convert.to.pool": "Force converting to storage pool directly (not using temporary storage for conversion)",
 "label.force.ms.to.import.vm.files": "Enable to force OVF Download via Management Server. Disable to use KVM Host ovftool (if installed)",
 "label.force.update.os.type": "Force update OS type",

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -352,15 +352,25 @@
                   </template>
                   <span>{{ $t('message.ip.address.changes.effect.after.vm.restart') }}</span>
                 </a-form-item>
-                <a-row v-if="selectedVmwareVcenter" :gutter="12" justify="end">
+                <a-row v-if="selectedVmwareVcenter && showMacConflictOptions" :gutter="12" justify="end">
                   <a-col style="text-align: right">
                     <a-form-item name="forced" ref="forced">
                       <template #label>
                         <tooltip-label
-                          :title="$t('label.allow.duplicate.macaddresses')"
+                          :title="$t('label.generate.new.mac.if.required')"
                           :tooltip="apiParams.forced.description"/>
                       </template>
-                      <a-switch v-model:checked="form.forced" @change="val => { switches.forced = val }" />
+                      <a-switch v-model:checked="form.forced" @change="onForcedMacConflictChange" />
+                    </a-form-item>
+                  </a-col>
+                  <a-col style="text-align: right" v-if="showAllowDuplicateMacAddresses">
+                    <a-form-item name="allowduplicatemacaddresses" ref="allowduplicatemacaddresses">
+                      <template #label>
+                        <tooltip-label
+                          :title="$t('label.allow.duplicate.macaddresses')"
+                          :tooltip="apiParams.allowduplicatemacaddresses.description"/>
+                      </template>
+                      <a-switch v-model:checked="form.allowduplicatemacaddresses" @change="onAllowDuplicateMacAddressesChange" />
                     </a-form-item>
                   </a-col>
                 </a-row>
@@ -414,14 +424,24 @@
                     <a-switch v-model:checked="form.migrateallowed" @change="val => { switches.migrateAllowed = val }" />
                   </a-form-item>
                 </a-col>
-                <a-col>
+                <a-col v-if="showMacConflictOptions">
                   <a-form-item name="forced" ref="forced">
                     <template #label>
                       <tooltip-label
-                        :title="$t('label.forced')"
+                        :title="$t('label.generate.new.mac.if.required')"
                         :tooltip="apiParams.forced.description"/>
                     </template>
-                    <a-switch v-model:checked="form.forced" @change="val => { switches.forced = val }" />
+                    <a-switch v-model:checked="form.forced" @change="onForcedMacConflictChange" />
+                  </a-form-item>
+                </a-col>
+                <a-col v-if="showAllowDuplicateMacAddresses">
+                  <a-form-item name="allowduplicatemacaddresses" ref="allowduplicatemacaddresses">
+                    <template #label>
+                      <tooltip-label
+                        :title="$t('label.allow.duplicate.macaddresses')"
+                        :tooltip="apiParams.allowduplicatemacaddresses.description"/>
+                    </template>
+                    <a-switch v-model:checked="form.allowduplicatemacaddresses" @change="onAllowDuplicateMacAddressesChange" />
                   </a-form-item>
                 </a-col>
               </a-row>
@@ -673,6 +693,15 @@ export default {
     isKVMUnmanage () {
       return this.hypervisor && this.hypervisor === 'kvm' && (this.importsource === 'unmanaged' || this.importsource === 'external')
     },
+    hasSourceNicMacAddresses () {
+      return !this.isDiskImport && this.resource?.nic?.some(nic => nic.macaddress || nic.mac)
+    },
+    showMacConflictOptions () {
+      return this.hasSourceNicMacAddresses
+    },
+    showAllowDuplicateMacAddresses () {
+      return this.showMacConflictOptions && this.apiParams.allowduplicatemacaddresses
+    },
     domainSelectOptions () {
       var domains = this.options.domains.map((domain) => {
         return {
@@ -789,6 +818,7 @@ export default {
         usevddk: false,
         migrateallowed: this.switches.migrateAllowed,
         forced: this.switches.forced,
+        allowduplicatemacaddresses: this.switches.allowDuplicateMacAddresses,
         forcemstoimportvmfiles: this.switches.forceMsToImportVmFiles,
         forceconverttopool: this.switches.forceConvertToPool,
         domainid: null,
@@ -1163,6 +1193,22 @@ export default {
       this.showStoragePoolsForConversion = false
       this.resetStorageOptionsForConversion()
     },
+    onForcedMacConflictChange (val) {
+      this.switches.forced = val
+      this.form.forced = val
+      if (val) {
+        this.switches.allowDuplicateMacAddresses = false
+        this.form.allowduplicatemacaddresses = false
+      }
+    },
+    onAllowDuplicateMacAddressesChange (val) {
+      this.switches.allowDuplicateMacAddresses = val
+      this.form.allowduplicatemacaddresses = val
+      if (val) {
+        this.switches.forced = false
+        this.form.forced = false
+      }
+    },
     onUseVddkChange (val, isUserChange = true) {
       if (isUserChange) {
         this.userModifiedVddkSetting = true
@@ -1317,7 +1363,13 @@ export default {
             params.forceconverttopool = values.forceconverttopool
           }
         }
-        var keys = ['hostname', 'domainid', 'projectid', 'account', 'migrateallowed', 'forced', 'osid']
+        var keys = ['hostname', 'domainid', 'projectid', 'account', 'migrateallowed', 'osid']
+        if (this.showMacConflictOptions) {
+          keys.push('forced')
+        }
+        if (this.showAllowDuplicateMacAddresses) {
+          keys.push('allowduplicatemacaddresses')
+        }
         if (this.templateType !== 'auto') {
           keys.push('templateid')
         }
@@ -1434,6 +1486,8 @@ export default {
       this.form.usevddk = false
       this.form.forceconverttopool = false
       this.form.forcemstoimportvmfiles = false
+      this.form.forced = false
+      this.form.allowduplicatemacaddresses = false
       this.userModifiedVddkSetting = false
       this.resetStorageOptionsForConversion()
     },


### PR DESCRIPTION
﻿### Description
This change adds an explicit import option to preserve duplicate NIC MAC addresses during VM import workflows.

The existing `forced` option continues to mean: if the imported VM has a NIC MAC address that already exists on the selected CloudStack network, continue the import by generating a new MAC address. 

A new `allowduplicatemacaddresses` API parameter allows the opposite behavior: preserve the imported VM's MAC address even if that same MAC is already present on the selected network. The two options are mutually exclusive.

This is useful for migration cutover workflows where a VMware-sourced VM is imported to KVM while the original VM still exists in CloudStack, but the operator wants the imported instance to keep the same MAC address for guest/network continuity.

The UI import form now labels `forced` as "Generate new MAC if required" and exposes a separate "Allow duplicate MAC addresses" switch. 
These MAC conflicting) options are shown for **VM migration/import flows where an existing source VM has NICs to preserve**. 
They are hidden when **creating a brand-new VM from existing QCOW2 files on local/shared storage**, because that path creates a new CloudStack NIC instead of importing a source NIC from another VM.

In other words, the MAC options are available when CloudStack has to decide what to do with a MAC address from a source VM: either keep it, generate a replacement, or fail on conflict. They are not shown for QCOW2 disk import, where there is no source VM NIC to preserve.

### Types of changes
- [x] New feature
- [x] UI change
- [x] API change

### Testing
- `mvn -pl api -am -DskipTests install`
- `mvn -pl server -am -DskipTests compile`
- `npm run lint -- --no-fix src/views/tools/ImportUnmanagedInstance.vue`
- Parsed `ui/public/locales/en.json`
- `git diff --check`

<br>
<br>
<br>
<br>

https://github.com/user-attachments/assets/08962bf2-3914-4275-b7a9-bd8953f7e3f3

