### PR TITLE
Fix NPE on `findHostsForMigration` when no suitable hosts are found

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1707,16 +1707,15 @@ public class ManagementServerImpl extends MutualExclusiveIdsManagerBase implemen
 
         if (CollectionUtils.isEmpty(suitableHosts)) {
             logger.warn("No suitable hosts found.");
-        } else {
-            logger.debug("Hosts having capacity and are suitable for migration: {}", suitableHosts);
+            return suitableHosts;
         }
 
+        logger.debug("Hosts having capacity and are suitable for migration: {}", suitableHosts);
+
         // Only list hosts of the same architecture as the source Host in a multi-arch zone
-        if (!suitableHosts.isEmpty()) {
-            List<CPU.CPUArch> clusterArchs = ApiDBUtils.listZoneClustersArchs(vm.getDataCenterId());
-            if (CollectionUtils.isNotEmpty(clusterArchs) && clusterArchs.size() > 1) {
-                suitableHosts = suitableHosts.stream().filter(h -> h.getArch() == srcHost.getArch()).collect(Collectors.toList());
-            }
+        List<CPU.CPUArch> clusterArchs = ApiDBUtils.listZoneClustersArchs(vm.getDataCenterId());
+        if (CollectionUtils.isNotEmpty(clusterArchs) && clusterArchs.size() > 1) {
+            suitableHosts = suitableHosts.stream().filter(h -> h.getArch() == srcHost.getArch()).collect(Collectors.toList());
         }
 
         return suitableHosts;

--- a/server/src/test/java/com/cloud/server/ManagementServerImplTest.java
+++ b/server/src/test/java/com/cloud/server/ManagementServerImplTest.java
@@ -23,6 +23,10 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.cloud.deploy.DataCenterDeployment;
+import com.cloud.deploy.DeploymentPlanner;
+import com.cloud.deploy.DeploymentPlanningManager;
+import com.cloud.vm.VirtualMachineProfile;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -180,6 +184,24 @@ public class ManagementServerImplTest {
 
     @Mock
     HostAllocator hostAllocator;
+
+    @Mock
+    VirtualMachine virtualMachineMock;
+
+    @Mock
+    VirtualMachineProfile virtualMachineProfileMock;
+
+    @Mock
+    DataCenterDeployment dataCenterDeploymentMock;
+
+    @Mock
+    DeploymentPlanner.ExcludeList excludeListMock;
+
+    @Mock
+    Host hostMock;
+
+    @Mock
+    DeploymentPlanningManager deploymentPlanningManagerMock;
 
     private AutoCloseable closeable;
     private MockedStatic<ApiDBUtils> apiDBUtilsMock;
@@ -1053,10 +1075,19 @@ public class ManagementServerImplTest {
 
     @Test
     public void testGetExternalVmConsole() {
-        VirtualMachine virtualMachine = Mockito.mock(VirtualMachine.class);
         Host host = Mockito.mock(Host.class);
-        Mockito.when(extensionManager.getInstanceConsole(virtualMachine, host)).thenReturn(Mockito.mock(com.cloud.agent.api.Answer.class));
-        Assert.assertNotNull(spy.getExternalVmConsole(virtualMachine, host));
-        Mockito.verify(extensionManager).getInstanceConsole(virtualMachine, host);
+        Mockito.when(extensionManager.getInstanceConsole(virtualMachineMock, host)).thenReturn(Mockito.mock(com.cloud.agent.api.Answer.class));
+        Assert.assertNotNull(spy.getExternalVmConsole(virtualMachineMock, host));
+        Mockito.verify(extensionManager).getInstanceConsole(virtualMachineMock, host);
+    }
+
+    @Test
+    public void getCapableSuitableHostsTestHostArchIsNotFilteredWhenNoSuitableHostsAreFound() {
+        List<Host> compatibleHosts = List.of(hostMock);
+        Mockito.doReturn(null).when(hostAllocator).allocateTo(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyList(), Mockito.anyInt(), Mockito.anyBoolean());
+
+        spy.getCapableSuitableHosts(virtualMachineMock, virtualMachineProfileMock, dataCenterDeploymentMock, compatibleHosts, excludeListMock, hostMock);
+
+        apiDBUtilsMock.verify(() -> ApiDBUtils.listZoneClustersArchs(Mockito.anyLong()), Mockito.never());
     }
 }


### PR DESCRIPTION
### Description

This patch fixes a NPE `findHostsForMigration` introduced in #9074 that occurs when no suitable hosts are found (`suitableHosts` is null) due to a missing return statement.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?

In a test environment with two hosts, `host-1` and `host-2`:

1. I deployed a VM in `host-1`.
2. I disabled `host-2`.
3. I attempted to open the VM migration wizard.

Before the patch, I would get a NPE in step 3. Now, I do not receive the NPE anymore.