### PR TITLE
Additional metrics for virtual machine orchestration

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -418,7 +418,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         try {
             JmxReporter.forRegistry(METRIC_REGISTRY).inDomain("vm-extra").build().start();
         } catch (Exception e) {
-            LOGGER.warn("Failed to start JMX reporter for METRIC_REGISTRY; CloudOS metrics will not be visible via JMX", e);
+            logger.warn("Failed to start JMX reporter for METRIC_REGISTRY, metrics will not be visible via JMX", e);
         }
         return true;
     }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -418,7 +418,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         try {
             JmxReporter.forRegistry(METRIC_REGISTRY).inDomain("vm-extra").build().start();
         } catch (Exception e) {
-            LOGGER.warn("Failed to start JMX reporter for METRIC_REGISTRY; CloudOS metrics will not be visible via JMX: " + e.getMessage());
+            LOGGER.warn("Failed to start JMX reporter for METRIC_REGISTRY; CloudOS metrics will not be visible via JMX", e);
         }
         return true;
     }

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -166,6 +166,7 @@ import com.codahale.metrics.JvmAttributeGaugeSet;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.jvm.BufferPoolMetricSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
@@ -387,7 +388,11 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     private boolean _dailyOrHourly = false;
     protected long managementServerNodeId = ManagementServerNode.getManagementServerId();
     protected long msId = managementServerNodeId;
-    final static MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+    public static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+
+    public static void registerMetric(String name, Metric metric) {
+        METRIC_REGISTRY.register(name, metric);
+    }
 
     public static StatsCollector getInstance() {
         return s_instance;
@@ -410,6 +415,11 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         registerAll("memory", new MemoryUsageGaugeSet(), METRIC_REGISTRY);
         registerAll("threads", new ThreadStatesGaugeSet(), METRIC_REGISTRY);
         registerAll("jvm", new JvmAttributeGaugeSet(), METRIC_REGISTRY);
+        try {
+            JmxReporter.forRegistry(METRIC_REGISTRY).inDomain("vm-extra").build().start();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to start JMX reporter for METRIC_REGISTRY; CloudOS metrics will not be visible via JMX: " + e.getMessage());
+        }
         return true;
     }
     @Override


### PR DESCRIPTION
### Description

This PR adds support for additional metrics for virtual machine orchestration.

- Adds additional VM metrics to StatsCollector for enhanced observability.
- Makes METRIC_REGISTRY public and adds a registerMetric() static helper for external metric registration.
- Starts a JMX reporter under the vm-extra domain so metrics are visible via JMX.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
