### PR TITLE
Support for migration of system VMs with volumes in the GUI

### DIFF
--- a/ui/src/components/view/InstanceVolumesStoragePoolSelectListView.vue
+++ b/ui/src/components/view/InstanceVolumesStoragePoolSelectListView.vue
@@ -170,7 +170,8 @@ export default {
       this.volumes = []
       getAPI('listVolumes', {
         listAll: true,
-        virtualmachineid: this.resource.id
+        virtualmachineid: this.resource.id,
+        listsystemvms: true
       }).then(response => {
         var volumes = response.listvolumesresponse.volume
         if (volumes && volumes.length > 0) {

--- a/ui/src/views/compute/MigrateWizard.vue
+++ b/ui/src/views/compute/MigrateWizard.vue
@@ -97,7 +97,7 @@
     </a-pagination>
 
     <a-form-item
-      v-if="isUserVm && hasVolumes"
+      v-if="hasVolumes"
       class="top-spaced">
       <template #label>
         <tooltip-label :title="$t('label.migrate.with.storage')" :tooltip="$t('message.migrate.with.storage')"/>
@@ -307,7 +307,8 @@ export default {
       this.volumes = []
       getAPI('listVolumes', {
         listAll: true,
-        virtualmachineid: this.resource.id
+        virtualmachineid: this.resource.id,
+        listsystemvms: !this.isUserVm
       }).then(response => {
         this.volumes = response?.listvolumesresponse?.volume || []
       }).finally(() => {

--- a/ui/src/views/compute/MigrateWizard.vue
+++ b/ui/src/views/compute/MigrateWizard.vue
@@ -338,11 +338,11 @@ export default {
     submitForm () {
       if (this.loading) return
       this.loading = true
-      const migrateApi = this.isUserVm
-        ? this.requiresStorageMigration()
-          ? 'migrateVirtualMachineWithVolume'
-          : 'migrateVirtualMachine'
-        : 'migrateSystemVm'
+      const migrateApi = !this.requiresStorageMigration()
+        ? this.isUserVm
+          ? 'migrateVirtualMachine'
+          : 'migrateSystemVm'
+        : 'migrateVirtualMachineWithVolume'
       var params = this.selectedHost.id === -1
         ? { autoselect: true, virtualmachineid: this.resource.id }
         : { hostid: this.selectedHost.id, virtualmachineid: this.resource.id }


### PR DESCRIPTION
### Description

Currently, Apache CloudStack's graphical interface does not allow migrating system VMs alongside their volumes.

This PR adds graphical interface support for this operation.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details><summary></summary>

<img width="1833" height="1799" alt="image" src="https://github.com/user-attachments/assets/f6615049-a2e9-406b-bfcb-1bcdd8b664b5" />

</details>




### How Has This Been Tested?

I went to the system VMs page and migrated a system VM with its volume to another host and primary storage. Through the browser's developer tools, I observed that the `migrateVirtualMachineWithVolume` API was correctly called, and that the migration operation succeeded without any errors.
