### PR TITLE
Fix NPE with ApiKeyPair during listApis call (from cmk)

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -3202,7 +3202,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         ApiKeyPair keyPair;
         if (accessingApiKey != null) {
             ApiKeyPair accessingKeyPair = apiKeyPairService.findByApiKey(accessingApiKey);
-            if (userId == accessingKeyPair.getUserId()) {
+            if (accessingKeyPair != null && userId == accessingKeyPair.getUserId()) {
                 keyPair = apiKeyPairService.findByApiKey(accessingApiKey);
             } else {
                 keyPair = _accountService.getLatestUserKeyPair(userId);
@@ -3320,6 +3320,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             return Boolean.TRUE;
         }
         ApiKeyPair accessingKeyPair = apiKeyPairService.findByApiKey(apiKey);
+        if (accessingKeyPair == null) {
+            logger.warn("Unable to find API key pair for the accessing API key: {}", apiKey);
+            return Boolean.TRUE;
+        }
         return isApiKeySupersetOfPermission(new ArrayList<>(getAllKeypairPermissions(accessingKeyPair.getApiKey())), new ArrayList<>(getAllKeypairPermissions(accessedKeyPair.getApiKey())));
     }
 
@@ -3335,7 +3339,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 return accessingApiKey;
             }
         } catch (NullPointerException e) {
-            logger.info("Accessing API through session.");
+            logger.info("Accessing API through session.", e);
         }
         return null;
     }
@@ -3582,6 +3586,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             throw new InvalidParameterValueException("API key not present in the request's URL and, thus, unable to fetch API key rules.");
         }
         ApiKeyPair apiKeyPair = keyPairManager.findByApiKey(apiKey);
+        if (apiKeyPair == null) {
+            logger.warn("Unable to find API key pair by API key: {}", apiKey);
+            return new ArrayList<>();
+        }
         Account account = _accountDao.findById(apiKeyPair.getAccountId());
         List<ApiKeyPairPermission> keyPairPermissions = keyPairManager.findAllPermissionsByKeyPairId(apiKeyPair.getId(), account.getRoleId());
         return new ArrayList<>(keyPairPermissions);
@@ -3848,12 +3856,11 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     @Override
     public UserAccount getUserByApiKey(String apiKey) {
         ApiKeyPairVO keyPair = apiKeyPairDao.findByApiKey(apiKey);
-
-        if (keyPair == null) {
-            return null;
+        if (keyPair != null) {
+            return userAccountDao.findById(keyPair.getUserId());
         }
 
-        return userAccountDao.findById(keyPair.getUserId());
+        return null;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -3321,7 +3321,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         }
         ApiKeyPair accessingKeyPair = apiKeyPairService.findByApiKey(apiKey);
         if (accessingKeyPair == null) {
-            logger.warn("Unable to find API key pair for the accessing API key: {}", apiKey);
+            logger.warn("Unable to find API key pair for the accessing API key.");
             return Boolean.FALSE;
         }
         return isApiKeySupersetOfPermission(new ArrayList<>(getAllKeypairPermissions(accessingKeyPair.getApiKey())), new ArrayList<>(getAllKeypairPermissions(accessedKeyPair.getApiKey())));
@@ -3338,8 +3338,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             if (accessedByApiKey) {
                 return accessingApiKey;
             }
-        } catch (NullPointerException e) {
-            logger.info("Accessing API through session.", e);
+        } catch (Exception e) {
+            logger.info("Error accessing API through session.", e);
         }
         return null;
     }
@@ -3587,7 +3587,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         }
         ApiKeyPair apiKeyPair = keyPairManager.findByApiKey(apiKey);
         if (apiKeyPair == null) {
-            logger.warn("Unable to find API key pair by API key: {}", apiKey);
+            logger.warn("Unable to find API key pair by API key.");
             return new ArrayList<>();
         }
         Account account = _accountDao.findById(apiKeyPair.getAccountId());

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -3322,7 +3322,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         ApiKeyPair accessingKeyPair = apiKeyPairService.findByApiKey(apiKey);
         if (accessingKeyPair == null) {
             logger.warn("Unable to find API key pair for the accessing API key: {}", apiKey);
-            return Boolean.TRUE;
+            return Boolean.FALSE;
         }
         return isApiKeySupersetOfPermission(new ArrayList<>(getAllKeypairPermissions(accessingKeyPair.getApiKey())), new ArrayList<>(getAllKeypairPermissions(accessedKeyPair.getApiKey())));
     }


### PR DESCRIPTION
### Description

This PR fixes NPE issue with ApiKeyPair during listApis call (from cmk).


```
(localcloud) 🐱 > sync
[debug] ExecLine line:sync
[debug] ExecCmd args: sync
[debug] NewAPIRequest API request URL:http://10.0.33.254:8080/client/api?apiKey=LIN6rqXuaJwMPfGYFh13qDwYz5VNNz1J2J6qIOWcd3oLQOq0WtD4CwRundBL6rzXToa3lQOC_vKjI3nkHtiD8Q&command=listApis&expires=2026-05-12T10%3A52%3A21Z&listall=true&response=json&signatureversion=3
[debug] Using HTTP POST for the request: http://10.0.33.254:8080/client/api
⣷ 😸 discovering APIs, please wait...[debug] NewAPIRequest response status code:401
[debug] Login POST URL:http://10.0.33.254:8080/client/apimap[command:[login] domain:[/] password:[password] response:[json] username:[admin]]
[debug] Login POST response status code:200
[debug] Login response body:{"loginresponse":{"username":"admin","userid":"0058d371-493c-11f1-8b72-1e00f0000291","domainid":"a728ab4b-493b-11f1-8b72-1e00f0000291","timeout":1800,"account":"admin","firstname":"admin","lastname":"cloud","type":"1","timezone":"UTC","timezoneoffset":"0.0","registered":"false","sessionkey":"WjoANDlHyxTdO9Aa_LXOa4rei34","is2faenabled":"false","is2faverified":"true","issuerfor2fa":"CloudStack","managementserverid":"c5a6dd86-fead-4397-8cf5-55250df33c24"}}
[debug] Login sessionkey:WjoANDlHyxTdO9Aa_LXOa4rei34
[debug] Checking if 2FA is enabled and verified for the user map[account:admin domainid:a728ab4b-493b-11f1-8b72-1e00f0000291 firstname:admin is2faenabled:false is2faverified:true issuerfor2fa:CloudStack lastname:cloud managementserverid:c5a6dd86-fead-4397-8cf5-55250df33c24 registered:false sessionkey:WjoANDlHyxTdO9Aa_LXOa4rei34 timeout:1800 timezone:UTC timezoneoffset:0.0 type:1 userid:0058d371-493c-11f1-8b72-1e00f0000291 username:admin]
[debug] 2FA is not enabled for the user, skipping 2FA validation
[debug] NewAPIRequest API request URL:http://10.0.33.254:8080/client/api?apiKey=LIN6rqXuaJwMPfGYFh13qDwYz5VNNz1J2J6qIOWcd3oLQOq0WtD4CwRundBL6rzXToa3lQOC_vKjI3nkHtiD8Q&command=listApis&expires=2026-05-12T10%3A52%3A21Z&listall=true&response=json&sessionkey=WjoANDlHyxTdO9Aa_LXOa4rei34&signature=9kJbbP3gtVaU2N6XZzKPmYRDYFE%3D&signatureversion=3
[debug] Using HTTP POST for the request: http://10.0.33.254:8080/client/api
[debug] NewAPIRequest response body:{"listapisresponse":{"uuidList":[],"errorcode":530,"cserrorcode":9999,"errortext":"Cannot invoke \"org.apache.cloudstack.acl.apikeypair.ApiKeyPair.getAccountId()\" because \"apiKeyPair\" is null"}}
🙈 Error: (HTTP 530, error code 9999) Cannot invoke "org.apache.cloudstack.acl.apikeypair.ApiKeyPair.getAccountId()" because "apiKeyPair" is null
(localcloud) 🐱 > 
```

```
2026-05-12 10:37:22,051 DEBUG [c.c.a.ApiServlet] (qtp253011924-24:[ctx-313ce9a0]) (logid:d4f7907a) ===START===  10.0.33.254 -- POST  
apiKey=LIN6rqXuaJwMPfGYFh13qDwYz5VNNz1J2J6qIOWcd3oLQOq0WtD4CwRundBL6rzXToa3lQOC_vKjI3nkHtiD8Q 
command=listApis 
expires=2026-05-12T10:52:21Z 
listall=true 
response=json 
sessionkey=WjoANDlHyxTdO9Aa_LXOa4rei34 
signature=9kJbbP3gtVaU2N6XZzKPmYRDYFE= 
signatureversion=3 

2026-05-12 10:37:22,054 DEBUG [c.c.a.ApiServer] (qtp253011924-24:[ctx-313ce9a0, ctx-e535ff0f]) (logid:d4f7907a) CIDRs from which account 'Account [{"accountName":"admin","id":2,"uuid":"00583461-493c-11f1-8b72-1e00f0000291"}]' is allowed to perform API calls: 0.0.0.0/0,::/0
2026-05-12 10:37:22,055 INFO  [o.a.c.a.DynamicRoleBasedAPIAccessChecker] (qtp253011924-24:[ctx-313ce9a0, ctx-e535ff0f]) (logid:d4f7907a) Account [Account [{"accountName":"admin","id":2,"uuid":"00583461-493c-11f1-8b72-1e00f0000291"}]] is Root Admin and there aren't any API key pair permissions involved, thus, all APIs are allowed.
2026-05-12 10:37:22,055 DEBUG [o.a.c.a.StaticRoleBasedAPIAccessChecker] (qtp253011924-24:[ctx-313ce9a0, ctx-e535ff0f]) (logid:d4f7907a) RoleService is enabled. We will use it instead of StaticRoleBasedAPIAccessChecker.
2026-05-12 10:37:22,055 DEBUG [o.a.c.r.ApiRateLimitServiceImpl] (qtp253011924-24:[ctx-313ce9a0, ctx-e535ff0f]) (logid:d4f7907a) API rate limiting is disabled. We will not use ApiRateLimitService.
2026-05-12 10:37:22,056 WARN  [c.c.a.d.ParamGenericValidationWorker] (qtp253011924-24:[ctx-313ce9a0, ctx-e535ff0f]) (logid:d4f7907a) Received unknown parameters for command listApis. Unknown parameters : listall
2026-05-12 10:37:22,059 ERROR [c.c.a.ApiServer] (qtp253011924-24:[ctx-313ce9a0, ctx-e535ff0f]) (logid:d4f7907a) unhandled exception executing api command: [Ljava.lang.String;@1e71e72d java.lang.NullPointerException: Cannot invoke "org.apache.cloudstack.acl.apikeypair.ApiKeyPair.getAccountId()" because "apiKeyPair" is null
	at com.cloud.user.AccountManagerImpl.getAllKeypairPermissions(AccountManagerImpl.java:3585)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at jdk.proxy3/jdk.proxy3.$Proxy104.getAllKeypairPermissions(Unknown Source)
	at org.apache.cloudstack.discovery.ApiDiscoveryServiceImpl.listApisForKeyPair(ApiDiscoveryServiceImpl.java:357)
	at org.apache.cloudstack.discovery.ApiDiscoveryServiceImpl.listApis(ApiDiscoveryServiceImpl.java:283)
	at org.apache.cloudstack.api.command.user.discovery.ListApisCmd.execute(ListApisCmd.java:55)
	at com.cloud.api.ApiDispatcher.dispatch(ApiDispatcher.java:173)
	at com.cloud.api.ApiServer.queueCommand(ApiServer.java:883)
	at com.cloud.api.ApiServer.handleRequest(ApiServer.java:697)
	at com.cloud.api.ApiServlet.processRequestInContext(ApiServlet.java:414)
	at com.cloud.api.ApiServlet$1.run(ApiServlet.java:191)
```

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
