### PR TITLE
Allow selecting guest OS for KVM imports

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
@@ -122,7 +122,7 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.OS_ID,
             type = CommandType.UUID,
             entityType = GuestOSResponse.class,
-            since = "4.22.1",
+            since = "4.23.0",
             description = "optional - the ID of the guest OS for the imported Instance.")
     private Long guestOsId;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceCmd.java
@@ -32,6 +32,7 @@ import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.api.response.GuestOSResponse;
 import org.apache.cloudstack.api.response.ProjectResponse;
 import org.apache.cloudstack.api.response.ServiceOfferingResponse;
 import org.apache.cloudstack.api.response.TemplateResponse;
@@ -118,6 +119,13 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
             description = "The ID of the Template for the Instance")
     private Long templateId;
 
+    @Parameter(name = ApiConstants.OS_ID,
+            type = CommandType.UUID,
+            entityType = GuestOSResponse.class,
+            since = "4.22.1",
+            description = "optional - the ID of the guest OS for the imported Instance.")
+    private Long guestOsId;
+
     @Parameter(name = ApiConstants.SERVICE_OFFERING_ID,
             type = CommandType.UUID,
             entityType = ServiceOfferingResponse.class,
@@ -185,6 +193,10 @@ public class ImportUnmanagedInstanceCmd extends BaseAsyncCmd {
 
     public Long getTemplateId() {
         return templateId;
+    }
+
+    public Long getGuestOsId() {
+        return guestOsId;
     }
 
     public Long getProjectId() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportVmCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportVmCmd.java
@@ -30,7 +30,6 @@ import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.ServerApiException;
-import org.apache.cloudstack.api.response.GuestOSResponse;
 import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.NetworkResponse;
 import org.apache.cloudstack.api.response.StoragePoolResponse;
@@ -107,6 +106,18 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
             description = "the network ID")
     private Long networkId;
 
+    @Parameter(name = ApiConstants.MAC_ADDRESS,
+            type = CommandType.STRING,
+            since = "4.22.1",
+            description = "(only for importing VMs from KVM local/shared storage) optional - the MAC address for the imported VM NIC. If omitted, a new MAC address is generated.")
+    private String macAddress;
+
+    @Parameter(name = ApiConstants.IP_ADDRESS,
+            type = CommandType.STRING,
+            since = "4.22.1",
+            description = "(only for importing VMs from KVM local/shared storage) optional - the IPv4 address for the imported VM NIC. If omitted, IPv4 assignment remains automatic.")
+    private String ipAddress;
+
     @Parameter(name = ApiConstants.HOST_ID, type = CommandType.UUID, entityType = HostResponse.class, description = "Host where local disk is located")
     private Long hostId;
 
@@ -171,13 +182,6 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
             since = "4.22",
             description = "(only for importing VMs from VMware to KVM) optional - if true, forces virt-v2v conversions to write directly on the provided storage pool (avoid using temporary conversion pool).")
     private Boolean forceConvertToPool;
-
-    @Parameter(name = ApiConstants.OS_ID,
-            type = CommandType.UUID,
-            entityType = GuestOSResponse.class,
-            since = "4.22.1",
-            description = "(only for importing VMs from VMware to KVM) optional - the ID of the guest OS for the imported VM.")
-    private Long guestOsId;
 
     @Parameter(name = ApiConstants.USE_VDDK,
             type = CommandType.BOOLEAN,
@@ -275,6 +279,14 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
         return networkId;
     }
 
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
     @Override
     public String getEventType() {
         return EventTypes.EVENT_VM_IMPORT;
@@ -286,10 +298,6 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
 
     public boolean getForceConvertToPool() {
         return BooleanUtils.toBooleanDefaultIfNull(forceConvertToPool, false);
-    }
-
-    public Long getGuestOsId() {
-        return guestOsId;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportVmCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportVmCmd.java
@@ -108,7 +108,7 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
 
     @Parameter(name = ApiConstants.MAC_ADDRESS,
             type = CommandType.STRING,
-            since = "4.22.1",
+            since = "4.23.0",
             description = "(only for importing VMs from KVM local/shared storage) optional - the MAC address for the imported VM NIC. If omitted, a new MAC address is generated.")
     private String macAddress;
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParser.java
@@ -61,6 +61,7 @@ public class LibvirtDomainXMLParser {
     private Integer vncPort;
     private  String vncPasswd;
     private String desc;
+    private String osInfoId;
     private LibvirtVMDef.CpuTuneDef cpuTuneDef;
     private LibvirtVMDef.CpuModeDef cpuModeDef;
     private String name;
@@ -79,6 +80,7 @@ public class LibvirtDomainXMLParser {
             Element rootElement = doc.getDocumentElement();
 
             desc = getTagValue("description", rootElement);
+            osInfoId = getOsInfoId(rootElement);
             name = getTagValue("name", rootElement);
 
             Element devices = (Element)rootElement.getElementsByTagName("devices").item(0);
@@ -455,6 +457,27 @@ public class LibvirtDomainXMLParser {
         return node.getAttribute(attr);
     }
 
+    private static String getOsInfoId(Element rootElement) {
+        if (rootElement == null) {
+            return null;
+        }
+
+        NodeList nodes = rootElement.getElementsByTagName("*");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            String nodeName = node.getNodeName();
+            String namespace = node.getNamespaceURI();
+            if ("libosinfo:os".equals(nodeName) || ("os".equals(node.getLocalName()) && StringUtils.contains(namespace, "libosinfo"))) {
+                Element element = (Element)node;
+                String id = element.getAttribute("id");
+                if (StringUtils.isNotBlank(id)) {
+                    return id;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Parse the disk block part of the libvirt XML.
      * @param def
@@ -508,6 +531,10 @@ public class LibvirtDomainXMLParser {
 
     public String getDescription() {
         return desc;
+    }
+
+    public String getOsInfoId() {
+        return osInfoId;
     }
 
     public String getName() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetRemoteVmsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetRemoteVmsCommandWrapper.java
@@ -98,6 +98,8 @@ public final class LibvirtGetRemoteVmsCommandWrapper extends CommandWrapper<GetR
             if (parser.getCpuTuneDef() !=null) {
                 instance.setCpuSpeed(parser.getCpuTuneDef().getShares());
             }
+            instance.setOperatingSystemId(parser.getOsInfoId());
+            instance.setOperatingSystem(parser.getDescription());
             instance.setHypervisorType(Hypervisor.HypervisorType.KVM.name());
             instance.setPowerState(getPowerState(libvirtComputingResource.getVmState(conn,domain.getName())));
             instance.setNics(getUnmanagedInstanceNics(parser.getInterfaces()));

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetUnmanagedInstancesCommandWrapper.java
@@ -131,6 +131,8 @@ public final class LibvirtGetUnmanagedInstancesCommandWrapper extends CommandWra
             if (parser.getCpuModeDef() != null) {
                 instance.setCpuCoresPerSocket(parser.getCpuModeDef().getCoresPerSocket());
             }
+            instance.setOperatingSystemId(parser.getOsInfoId());
+            instance.setOperatingSystem(parser.getDescription());
             instance.setHypervisorType(Hypervisor.HypervisorType.KVM.name());
             instance.setPowerState(getPowerState(libvirtComputingResource.getVmState(conn,domain.getName())));
             instance.setMemory((int) LibvirtComputingResource.getDomainMemory(domain) / 1024);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
@@ -73,10 +73,17 @@ public class LibvirtDomainXMLParserTest extends TestCase {
         String diskPath2 = "/var/lib/libvirt/images/my-test-image2.qcow2";
         String secretUuid = "5644d664-a238-3a9b-811c-961f609d29f4";
 
-        String xml = "<domain type='kvm' id='10'>" +
+        String osInfoId = "http://ubuntu.com/ubuntu/24.04";
+
+        String xml = "<domain type='kvm' id='10' xmlns:libosinfo='http://libosinfo.org/xmlns/libvirt/domain/1.0'>" +
                      "<name>s-2970-VM</name>" +
                      "<uuid>4d2c1526-865d-4fc9-a1ac-dbd1801a22d0</uuid>" +
                      "<description>Debian GNU/Linux 6(64-bit)</description>" +
+                     "<metadata>" +
+                     "<libosinfo:libosinfo>" +
+                     "<libosinfo:os id='" + osInfoId + "'/>" +
+                     "</libosinfo:libosinfo>" +
+                     "</metadata>" +
                      "<memory unit='KiB'>262144</memory>" +
                      "<currentMemory unit='KiB'>262144</currentMemory>" +
                      "<vcpu placement='static'>1</vcpu>" +
@@ -220,6 +227,7 @@ public class LibvirtDomainXMLParserTest extends TestCase {
         parser.parseDomainXML(xml);
 
         assertEquals(vncPort - 5900, (int)parser.getVncPort());
+        assertEquals(osInfoId, parser.getOsInfoId());
 
         List<DiskDef> disks = parser.getDisks();
         /* Disk 0 is the first disk, the QCOW2 file backed virto disk */

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1319,6 +1319,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         final Map<String, Long> dataDiskOfferingMap = cmd.getDataDiskToDiskOfferingList();
         final Map<String, String> details = cmd.getDetails();
         final boolean forced = cmd.isForced();
+        Long guestOsId = cmd.getGuestOsId();
         List<HostVO> hosts = resourceManager.listHostsInClusterByStatus(clusterId, Status.Up);
         UserVm userVm = null;
         List<String> additionalNameFilters = getAdditionalNameFilters(cluster);
@@ -1350,7 +1351,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                             template, instanceName, displayName, hostName, caller, owner, userId,
                             serviceOffering, dataDiskOfferingMap,
                             nicNetworkMap, nicIpAddressMap,
-                            details, cmd.getMigrateAllowed(), managedVms, forced);
+                            details, cmd.getMigrateAllowed(), managedVms, forced, guestOsId);
                 }
             }
 
@@ -1497,7 +1498,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                          String hostName, Account caller, Account owner, long userId,
                                                          ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap,
                                                          Map<String, Long> nicNetworkMap, Map<String, Network.IpAddresses> nicIpAddressMap,
-                                                         Map<String, String> details, Boolean migrateAllowed, List<String> managedVms, boolean forced) throws ResourceAllocationException {
+                                                         Map<String, String> details, Boolean migrateAllowed, List<String> managedVms, boolean forced, Long guestOsId) throws ResourceAllocationException {
         UserVm userVm = null;
         for (HostVO host : hosts) {
             HashMap<String, UnmanagedInstanceTO> unmanagedInstances = getUnmanagedInstancesForHost(host, instanceName, managedVms);
@@ -1548,7 +1549,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                     userVm = importVirtualMachineInternal(unmanagedInstance, instanceName, zone, cluster, host,
                             template, displayName, hostName, CallContext.current().getCallingAccount(), owner, userId,
                             serviceOffering, dataDiskOfferingMap,
-                            nicNetworkMap, nicIpAddressMap, null,
+                            nicNetworkMap, nicIpAddressMap, guestOsId,
                             details, migrateAllowed, forced, true);
                 } finally {
                     ReservationHelper.closeAll(reservations);
@@ -2611,6 +2612,9 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         Long hostId = cmd.getHostId();
         Long poolId = cmd.getStoragePoolId();
         Long networkId = cmd.getNetworkId();
+        Long guestOsId = cmd.getGuestOsId();
+        String macAddress = cmd.getMacAddress();
+        String ipAddress = cmd.getIpAddress();
 
         UnmanagedInstanceTO unmanagedInstanceTO = null;
         if (ImportSource.EXTERNAL == importSource) {
@@ -2679,12 +2683,12 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 userVm = importExternalKvmVirtualMachine(unmanagedInstanceTO, instanceName, zone,
                         template, displayName, hostName, caller, owner, userId,
                         serviceOffering, dataDiskOfferingMap,
-                        nicNetworkMap, nicIpAddressMap, remoteUrl, username, password, tmpPath, details);
+                        nicNetworkMap, nicIpAddressMap, guestOsId, remoteUrl, username, password, tmpPath, details);
             } else if (ImportSource.SHARED == importSource || ImportSource.LOCAL == importSource) {
                 try {
                     userVm = importKvmVirtualMachineFromDisk(importSource, instanceName, zone,
                             template, displayName, hostName, caller, owner, userId,
-                            serviceOffering, dataDiskOfferingMap, networkId, hostId, poolId, diskPath,
+                            serviceOffering, dataDiskOfferingMap, networkId, macAddress, ipAddress, guestOsId, hostId, poolId, diskPath,
                             details);
                 } catch (InsufficientCapacityException e) {
                     throw new RuntimeException(e);
@@ -2711,7 +2715,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                 final VirtualMachineTemplate template, final String displayName, final String hostName, final Account caller, final Account owner, final Long userId,
                                                 final ServiceOfferingVO serviceOffering, final Map<String, Long> dataDiskOfferingMap,
                                                 final Map<String, Long> nicNetworkMap, final Map<String, Network.IpAddresses> callerNicIpAddressMap,
-                                                final String remoteUrl, String username, String password, String tmpPath, final Map<String, String> details) throws ResourceAllocationException {
+                                                final Long guestOsId, final String remoteUrl, String username, String password, String tmpPath, final Map<String, String> details) throws ResourceAllocationException {
         UserVm userVm = null;
 
         Map<String, String> allDetails = new HashMap<>(details);
@@ -2747,7 +2751,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         try {
             userVm = userVmManager.importVM(zone, null, template, null, displayName, owner,
                     null, caller, true, null, owner.getAccountId(), userId,
-                    serviceOffering, null, null, hostName,
+                    serviceOffering, null, guestOsId, hostName,
                     Hypervisor.HypervisorType.KVM, allDetails, powerState, null);
         } catch (InsufficientCapacityException ice) {
             logger.error(String.format("Failed to import vm name: %s", instanceName), ice);
@@ -2848,6 +2852,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     private UserVm importKvmVirtualMachineFromDisk(final ImportSource importSource, final String instanceName, final DataCenter zone,
                                                    final VirtualMachineTemplate template, final String displayName, final String hostName, final Account caller, final Account owner, final Long userId,
                                                    final ServiceOfferingVO serviceOffering, final Map<String, Long> dataDiskOfferingMap, final Long networkId,
+                                                   final String requestedMacAddress, final String requestedIpAddress, final Long guestOsId,
                                                    final Long hostId, final Long poolId, final String diskPath, final Map<String, String> details) throws InsufficientCapacityException, ResourceAllocationException {
 
         UserVm userVm = null;
@@ -2878,9 +2883,15 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             }
         }
 
-        String macAddress = networkModel.getNextAvailableMacAddressInNetwork(networkId);
+        String macAddress = StringUtils.defaultIfBlank(requestedMacAddress, networkModel.getNextAvailableMacAddressInNetwork(networkId));
+        if (!NetUtils.isValidMac(macAddress)) {
+            throw new InvalidParameterValueException("MAC address is invalid: " + macAddress);
+        }
 
-        String ipAddress = network.getGuestType() != Network.GuestType.L2 ? "auto" : null;
+        String ipAddress = StringUtils.defaultIfBlank(requestedIpAddress, network.getGuestType() != Network.GuestType.L2 ? "auto" : null);
+        if (StringUtils.isNotBlank(ipAddress) && !"auto".equals(ipAddress) && !NetUtils.isValidIp4(ipAddress)) {
+            throw new InvalidParameterValueException("IP address is invalid: " + ipAddress);
+        }
 
         Network.IpAddresses requestedIpPair = new Network.IpAddresses(ipAddress, null, macAddress);
 
@@ -2903,7 +2914,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             checkVmResourceLimitsForExternalKvmVmImport(owner, serviceOffering, (VMTemplateVO) template, details, reservations);
             userVm = userVmManager.importVM(zone, null, template, null, displayName, owner,
                     null, caller, true, null, owner.getAccountId(), userId,
-                    serviceOffering, null, null, hostName,
+                    serviceOffering, null, guestOsId, hostName,
                     Hypervisor.HypervisorType.KVM, allDetails, powerState, networkNicMap);
 
             if (userVm == null) {

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -107,7 +107,6 @@ import com.cloud.deploy.DeploymentPlanningManager;
 import com.cloud.event.ActionEventUtils;
 import com.cloud.event.UsageEventUtils;
 import com.cloud.exception.AgentUnavailableException;
-import com.cloud.exception.InsufficientServerCapacityException;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.exception.ResourceAllocationException;
@@ -385,6 +384,7 @@ public class UnmanagedVMsManagerImplTest {
         networks.add(networkVO);
         when(networkDao.listByZone(anyLong())).thenReturn(networks);
         doNothing().when(networkModel).checkNetworkPermissions(any(Account.class), any(Network.class));
+        when(networkModel.getNextAvailableMacAddressInNetwork(anyLong())).thenReturn("02:00:00:00:00:01");
         NicProfile profile = Mockito.mock(NicProfile.class);
         Integer deviceId = 100;
         Pair<NicProfile, Integer> pair = new Pair<>(profile, deviceId);
@@ -653,7 +653,7 @@ public class UnmanagedVMsManagerImplTest {
         unmanagedVMsManager.listVmsForImport(cmd);
     }
     @Test
-    public void testImportFromExternalTest() throws InsufficientServerCapacityException {
+    public void testImportFromExternalTest() throws Exception {
         String vmname = "TestInstance";
         ImportVmCmd cmd = Mockito.mock(ImportVmCmd.class);
         when(cmd.getHypervisor()).thenReturn(Hypervisor.HypervisorType.KVM.toString());
@@ -662,6 +662,7 @@ public class UnmanagedVMsManagerImplTest {
         when(cmd.getPassword()).thenReturn("pass");
         when(cmd.getImportSource()).thenReturn("external");
         when(cmd.getDomainId()).thenReturn(null);
+        when(cmd.getGuestOsId()).thenReturn(99L);
         HostVO host = Mockito.mock(HostVO.class);
         DeployDestination mockDest = Mockito.mock(DeployDestination.class);
         when(deploymentPlanningManager.planDeployment(any(), any(), any(), any())).thenReturn(mockDest);
@@ -682,6 +683,10 @@ public class UnmanagedVMsManagerImplTest {
              MockedConstruction<CheckedReservation> mockCheckedReservation = Mockito.mockConstruction(CheckedReservation.class)) {
             unmanagedVMsManager.importVm(cmd);
         }
+        verify(userVmManager).importVM(nullable(DataCenter.class), nullable(Host.class), nullable(VirtualMachineTemplate.class), nullable(String.class), nullable(String.class),
+                nullable(Account.class), nullable(String.class), nullable(Account.class), nullable(Boolean.class), nullable(String.class),
+                nullable(Long.class), nullable(Long.class), nullable(ServiceOffering.class), nullable(String.class), Mockito.eq(99L),
+                nullable(String.class), nullable(Hypervisor.HypervisorType.class), nullable(Map.class), nullable(VirtualMachine.PowerState.class), nullable(LinkedHashMap.class));
     }
 
     private void baseBasicParametersCheckForImportInstance(String name, Long domainId, String accountName) {
@@ -943,16 +948,16 @@ public class UnmanagedVMsManagerImplTest {
     }
 
     @Test
-    public void importFromLocalDisk() throws InsufficientServerCapacityException {
+    public void importFromLocalDisk() throws Exception {
         importFromDisk("local");
     }
 
     @Test
-    public void importFromsharedStorage() throws InsufficientServerCapacityException {
+    public void importFromsharedStorage() throws Exception {
         importFromDisk("shared");
     }
 
-    private void importFromDisk(String source) throws InsufficientServerCapacityException {
+    private void importFromDisk(String source) throws Exception {
         String vmname = "testVm";
         ImportVmCmd cmd = Mockito.mock(ImportVmCmd.class);
         when(cmd.getHypervisor()).thenReturn(Hypervisor.HypervisorType.KVM.toString());
@@ -960,6 +965,9 @@ public class UnmanagedVMsManagerImplTest {
         when(cmd.getImportSource()).thenReturn(source);
         when(cmd.getDiskPath()).thenReturn("/var/lib/libvirt/images/test.qcow2");
         when(cmd.getDomainId()).thenReturn(null);
+        when(cmd.getMacAddress()).thenReturn("02:00:00:00:00:05");
+        when(cmd.getIpAddress()).thenReturn("192.0.2.10");
+        when(cmd.getGuestOsId()).thenReturn(99L);
         HostVO host = Mockito.mock(HostVO.class);
         when(hostDao.findById(anyLong())).thenReturn(host);
         NetworkOffering netOffering = Mockito.mock(NetworkOffering.class);
@@ -990,6 +998,9 @@ public class UnmanagedVMsManagerImplTest {
              MockedConstruction<CheckedReservation> mockCheckedReservation = Mockito.mockConstruction(CheckedReservation.class)) {
                 unmanagedVMsManager.importVm(cmd);
         }
+        verify(networkOrchestrationService).importNic(Mockito.eq("02:00:00:00:00:05"), Mockito.eq(0), any(Network.class), Mockito.eq(true), any(VirtualMachine.class),
+                Mockito.argThat(ipAddresses -> "192.0.2.10".equals(ipAddresses.getIp4Address()) && "02:00:00:00:00:05".equals(ipAddresses.getMacAddress())),
+                any(DataCenter.class), Mockito.eq(true));
     }
 
     @Test

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -264,7 +264,7 @@
               </a-form-item>
               <a-form-item name="osid" ref="osid" v-if="showOsTypeSelection">
                 <template #label>
-                  <tooltip-label :title="$t('label.guest.os')" :tooltip="$t('label.select.guest.os.type')"/>
+                  <tooltip-label :title="$t('label.guest.os')" :tooltip="apiParams.osid.description"/>
                 </template>
                 <a-select
                   v-model:value="form.osid"

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -262,6 +262,24 @@
                   <a-span v-else>{{ $t('label.no.matching.guest.os.vmware.import') }}</a-span>
                 </template>
               </a-form-item>
+              <a-form-item name="osid" ref="osid" v-if="showOsTypeSelection">
+                <template #label>
+                  <tooltip-label :title="$t('label.guest.os')" :tooltip="$t('label.select.guest.os.type')"/>
+                </template>
+                <a-select
+                  v-model:value="form.osid"
+                  showSearch
+                  allowClear
+                  optionFilterProp="label"
+                  :filterOption="(input, option) => {
+                    return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
+                  }"
+                  :loading="osTypesLoading">
+                  <a-select-option v-for="ostype in osTypeSelectOptions" :key="ostype.value" :label="ostype.label">
+                    {{ ostype.label }}
+                  </a-select-option>
+                </a-select>
+              </a-form-item>
               <a-form-item name="serviceofferingid" ref="serviceofferingid">
                 <template #label>
                   <tooltip-label :title="$t('label.serviceofferingid')" :tooltip="apiParams.serviceofferingid.description"/>
@@ -403,6 +421,22 @@
                       </span>
                     </a-select-option>
                   </a-select>
+                </a-form-item>
+                <a-form-item name="macaddress" ref="macaddress" v-if="apiParams.macaddress">
+                  <template #label>
+                    <tooltip-label :title="$t('label.macaddress')" :tooltip="apiParams.macaddress.description"/>
+                  </template>
+                  <a-input
+                    v-model:value="form.macaddress"
+                    :placeholder="$t('label.macaddress.example')" />
+                </a-form-item>
+                <a-form-item name="ipaddress" ref="ipaddress" v-if="apiParams.ipaddress">
+                  <template #label>
+                    <tooltip-label :title="$t('label.ipaddress')" :tooltip="apiParams.ipaddress.description"/>
+                  </template>
+                  <a-input
+                    v-model:value="form.ipaddress"
+                    :placeholder="$t('label.ipaddress')" />
                 </a-form-item>
               </div>
               <a-row v-if="!selectedVmwareVcenter" :gutter="12">
@@ -546,6 +580,8 @@ export default {
       selectedDomainId: null,
       templates: [],
       templateLoading: false,
+      osTypes: [],
+      osTypesLoading: false,
       templateType: this.defaultTemplateType(),
       totalComputeOfferings: 0,
       computeOfferings: [],
@@ -670,6 +706,12 @@ export default {
       }
       return false
     },
+    showOsTypeSelection () {
+      return (this.isDiskImport || this.isExternalImport || this.isKVMUnmanagedImport) && this.apiParams.osid
+    },
+    isKVMUnmanagedImport () {
+      return this.hypervisor && this.hypervisor === 'kvm' && this.importsource === 'unmanaged'
+    },
     isKVMUnmanage () {
       return this.hypervisor && this.hypervisor === 'kvm' && (this.importsource === 'unmanaged' || this.importsource === 'external')
     },
@@ -724,6 +766,32 @@ export default {
           ostypename: template.ostypename
         }
       })
+    },
+    osTypeSelectOptions () {
+      const options = this.osTypes.map((ostype) => {
+        return {
+          label: ostype.description,
+          value: ostype.id
+        }
+      })
+      const filter = this.getGuestOsFilter()
+      if (!filter.familyTerms.length) {
+        return options
+      }
+
+      const familyMatches = options.filter(option => this.matchesGuestOsFamily(option.label, filter.familyTerms))
+      if (!familyMatches.length) {
+        return options
+      }
+
+      if (filter.version) {
+        const versionMatches = familyMatches.filter(option => this.matchesGuestOsVersion(option.label, filter.version))
+        if (versionMatches.length) {
+          return versionMatches
+        }
+      }
+
+      return familyMatches
     },
     dataDisks () {
       var disks = []
@@ -793,7 +861,9 @@ export default {
         forceconverttopool: this.switches.forceConvertToPool,
         domainid: null,
         account: null,
-        osid: null
+        osid: null,
+        macaddress: null,
+        ipaddress: null
       })
       this.rules = reactive({
         displayname: [{ required: true, message: this.$t('message.error.input.value') }],
@@ -814,10 +884,69 @@ export default {
       })
       this.fetchKvmHostsForConversion()
       this.fetchKvmHostsForImporting()
+      if (this.showOsTypeSelection) {
+        this.fetchOsTypes()
+      }
       if (this.resource?.disk?.length > 1) {
         this.updateSelectedRootDisk()
       }
       this.fetchVmwareToKVMExtraConfigsSetting()
+    },
+    fetchOsTypes () {
+      if (!('listOsTypes' in this.$store.getters.apis)) {
+        return
+      }
+      this.osTypesLoading = true
+      getAPI('listOsTypes').then(json => {
+        this.osTypes = json.listostypesresponse.ostype || []
+        this.selectMatchedOsType()
+      }).finally(() => {
+        this.osTypesLoading = false
+      })
+    },
+    getGuestOsFilter () {
+      const source = [
+        this.resource?.operatingSystemId,
+        this.resource?.operatingSystem
+      ].filter(Boolean).join(' ').toLowerCase()
+      const families = [
+        { aliases: ['ubuntu'], terms: ['ubuntu'] },
+        { aliases: ['debian'], terms: ['debian'] },
+        { aliases: ['redhat', 'red hat', 'rhel'], terms: ['red hat', 'rhel'] },
+        { aliases: ['centos'], terms: ['centos'] },
+        { aliases: ['rocky'], terms: ['rocky'] },
+        { aliases: ['alma'], terms: ['alma'] },
+        { aliases: ['oracle'], terms: ['oracle'] },
+        { aliases: ['suse', 'opensuse'], terms: ['suse'] },
+        { aliases: ['fedora'], terms: ['fedora'] },
+        { aliases: ['windows'], terms: ['windows'] },
+        { aliases: ['freebsd'], terms: ['freebsd'] }
+      ]
+      const matchedFamilies = families.filter(family => family.aliases.some(alias => source.includes(alias)))
+      const versionMatch = source.match(/\b\d+(?:[._-]\d+)?\b/)
+      return {
+        familyTerms: matchedFamilies.flatMap(family => family.terms),
+        version: versionMatch ? versionMatch[0].replace(/[_-]/g, '.') : null
+      }
+    },
+    matchesGuestOsFamily (label, familyTerms) {
+      const normalizedLabel = label.toLowerCase()
+      return familyTerms.some(term => normalizedLabel.includes(term))
+    },
+    matchesGuestOsVersion (label, version) {
+      const normalizedLabel = label.toLowerCase()
+      const normalizedVersion = version.toLowerCase()
+      const majorVersion = normalizedVersion.split('.')[0]
+      return normalizedLabel.includes(normalizedVersion) || normalizedLabel.includes(majorVersion)
+    },
+    selectMatchedOsType () {
+      if (this.form.osid || !this.osTypes.length) {
+        return
+      }
+      const options = this.osTypeSelectOptions
+      if (options.length > 0 && options.length < this.osTypes.length) {
+        this.form.osid = options[0].value
+      }
     },
     fetchVmwareToKVMExtraConfigsSetting () {
       const params = {
@@ -1228,6 +1357,12 @@ export default {
             }
             params.name = values.displayname
             params.networkid = values.networkid
+            if (values.macaddress) {
+              params.macaddress = values.macaddress
+            }
+            if (values.ipaddress) {
+              params.ipaddress = values.ipaddress
+            }
           }
         }
         if (!this.computeOffering || !this.computeOffering.id) {


### PR DESCRIPTION
### Description

This PR improves the KVM VM import flows by allowing operators to select the guest OS type instead of relying only on the default import template guest OS - it's an extension of https://github.com/apache/cloudstack/pull/12802 by @nvazquez 

The change covers:

- Import Instance from Remote KVM host (`importsource=external`)
- KVM unmanaged instance imports through `importUnmanagedInstance`
- KVM local/shared storage QCOW2 imports through `importVm`

For remote and unmanaged KVM VM imports, CloudStack now parses libvirt metadata when available and exposes the detected source OS information to the UI. The UI uses this information to filter and preselect the Guest OS list where possible:

- Prefer `libosinfo:os id`, for example `http://ubuntu.com/ubuntu/24.04` or `http://redhat.com/rhel/8.0`
- Fall back to the libvirt domain description, for example `Debian GNU/Linux 12 (64-bit)` (typical for CloudStack KVM VMs)
- Show the full Guest OS list when no useful match is found

For QCOW2 imports from local/shared storage there is no source VM metadata, so the UI shows the full Guest OS list.

This PR also allows optional `macaddress` and `ipaddress` parameters for KVM local/shared storage imports, so a caller can explicitly request the NIC MAC and IPv4 address when creating the imported VM from an existing disk. to make this import UI a bit closer to the UI of creating a brand new VM Instance.

### Testing

- `mvn -pl api,server -am -DskipTests compile`
- `mvn -pl server -am -Dtest=UnmanagedVMsManagerImplTest#importFromLocalDisk+importFromsharedStorage+testImportFromExternalTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl plugins/hypervisors/kvm -am -Dtest=LibvirtDomainXMLParserTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`