### PR TITLE
Optimize UsageJobDaoImpl.updateJobSuccess to use direct UPDATE instead of row-level lock

### DIFF
--- a/engine/schema/src/main/java/com/cloud/usage/dao/UsageJobDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/usage/dao/UsageJobDaoImpl.java
@@ -61,9 +61,6 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
     public void updateJobSuccess(Long jobId, long startMillis, long endMillis, long execTime, boolean success) {
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
         try {
-            txn.start();
-
-            UsageJobVO job = lockRow(jobId, Boolean.TRUE);
             UsageJobVO jobForUpdate = createForUpdate();
             jobForUpdate.setStartMillis(startMillis);
             jobForUpdate.setEndMillis(endMillis);
@@ -71,11 +68,8 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
             jobForUpdate.setStartDate(new Date(startMillis));
             jobForUpdate.setEndDate(new Date(endMillis));
             jobForUpdate.setSuccess(success);
-            update(job.getId(), jobForUpdate);
-
-            txn.commit();
+            update(jobId, jobForUpdate);
         } catch (Exception ex) {
-            txn.rollback();
             logger.error("error updating job success date", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {


### PR DESCRIPTION
### Description

Replace lockRow + explicit transaction with a single update(jobId, jobForUpdate) call. All field values are parameters passed by the caller — nothing is read from the locked row.

The TransactionLegacy.open(USAGE_DB) is kept since this method explicitly targets the usage database. The txn.start/commit/rollback are removed since the single update() call is autocommit.

The lock was redundant because the usage server model is single-owner: one server processes one job at a time.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [X] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
#### Compilation and static analysis:
 - mvn -pl engine/schema -am compile -DskipTests — compiles clean
 - mvn -pl engine/schema checkstyle:check — passes
 - mvn -pl engine/schema test — all tests pass

#### Code-level verification:
 - The update(jobId, jobForUpdate) call generates a single UPDATE usage_job SET start_millis=?, end_millis=?, exec_time=?, start_date=?, end_date=?, success=? WHERE id=? — all columns written atomically in one statement
 - TransactionLegacy.open(USAGE_DB) is kept since this method explicitly targets the usage database connection. The txn.start()/txn.commit()/txn.rollback() are removed since the single update() call is autocommit
 - Confirmed lockRow no longer appears in the method
 - The original code read job.getId() from the locked row to pass to update() — but job.getId() always equals jobId (the parameter), since lockRow(jobId) fetches the row by that same ID. The new code uses jobId directly, eliminating the unnecessary indirection

#### Behavioral equivalence:
 - All six field values (startMillis, endMillis, execTime, startDate, endDate, success) are parameters passed by the caller — nothing is read from the locked row that feeds into the write
 - The usage server model is single-owner: one server processes one job at a time. Concurrent updates to the same job row do not occur by design, so the lock was defense-in-depth rather than a correctness requirement