### PR TITLE
ui: do not show deploy instance button for not ready images

### DIFF
--- a/ui/src/components/view/ImageDeployInstanceButton.vue
+++ b/ui/src/components/view/ImageDeployInstanceButton.vue
@@ -84,7 +84,7 @@ export default {
     allowed () {
       return (this.$route.meta.name === 'template' ||
         (this.$route.meta.name === 'iso' && this.resource?.bootable)) &&
-        this.resource?.state === 'Ready'
+        this.resource.isready
     }
   },
   methods: {
@@ -92,7 +92,7 @@ export default {
       this.fetchResourceData()
     },
     fetchResourceData () {
-      if (!this.resource || !this.resource.id || this.resource.state !== 'Ready') {
+      if (!this.resource || !this.resource.id || !this.resource.isready) {
         return
       }
       const params = {

--- a/ui/src/components/view/ImageDeployInstanceButton.vue
+++ b/ui/src/components/view/ImageDeployInstanceButton.vue
@@ -83,7 +83,8 @@ export default {
   computed: {
     allowed () {
       return (this.$route.meta.name === 'template' ||
-        (this.$route.meta.name === 'iso' && this.resource.bootable))
+        (this.$route.meta.name === 'iso' && this.resource?.bootable)) &&
+        this.resource?.state === 'Ready'
     }
   },
   methods: {
@@ -91,7 +92,7 @@ export default {
       this.fetchResourceData()
     },
     fetchResourceData () {
-      if (!this.resource || !this.resource.id) {
+      if (!this.resource || !this.resource.id || this.resource.state !== 'Ready') {
         return
       }
       const params = {

--- a/ui/src/components/view/ImageDeployInstanceButton.vue
+++ b/ui/src/components/view/ImageDeployInstanceButton.vue
@@ -84,7 +84,7 @@ export default {
     allowed () {
       return (this.$route.meta.name === 'template' ||
         (this.$route.meta.name === 'iso' && this.resource?.bootable)) &&
-        this.resource.isready
+        !!this.resource?.isready
     }
   },
   methods: {


### PR DESCRIPTION

### Description

Currently, InfoCard for a not ready template shows deploy instance button which is incorrect.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
