### PR TITLE
UI: Fix select search icon orientation in dropdown menu

### DIFF
--- a/ui/src/style/ant-overwrite/ant-form.less
+++ b/ui/src/style/ant-overwrite/ant-form.less
@@ -23,6 +23,6 @@
   transition: transform .3s, -webkit-transform .3s;
 }
 
-.ant-select-open .ant-select-arrow .ant-select-suffix svg {
+.ant-select-open .ant-select-arrow .ant-select-suffix:not(.anticon-search) svg {
   transform: rotateZ(-180deg);
 }


### PR DESCRIPTION
### Description

The small search (magnifying glass) icon that appears inside searchable dropdowns was showing up upside down whenever the dropdown was opened. This affected every searchable dropdown across the UI.

<!-- Fixes: # -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots:

### Before: 
<img width="595" height="229" alt="image" src="https://github.com/user-attachments/assets/ba52bd62-ee11-4ad9-9d30-63b72104ee64" />

### After: 

<img width="540" height="207" alt="image" src="https://github.com/user-attachments/assets/25ba4477-1188-47bf-b299-eb574363fba5" />


### How Has This Been Tested?

Opened searchable dropdowns (e.g. the Domain field in "Add new Affinity Group") and confirmed the search icon now appears right-side up. Verified the chevron arrow on regular dropdowns still flips when opened.