### PR TITLE
framework/spring: throw RuntimeException when fail to start or load a module

### DIFF
--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -73,8 +73,8 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
                 try {
                     lifecycle.start();
                 } catch (Exception e) {
-                    logger.error("Error on starting bean {} - {}", lifecycle.getName(), e.getMessage(), e);
-                    throw new CloudRuntimeException("Failed to start bean [" + lifecycle.getName() + "]", e);
+                    logger.error("Error on starting bean [{}] due to: {}", lifecycle.getName(), e);
+                    throw new CloudRuntimeException("Failed to start bean [" + lifecycle.getName() + "]");
                 }
 
                 if (lifecycle instanceof ManagementBean) {

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -74,6 +74,7 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
                     lifecycle.start();
                 } catch (Exception e) {
                     logger.error("Error on starting bean {} - {}", lifecycle.getName(), e.getMessage(), e);
+                    throw new CloudRuntimeException("Failed to start bean [" + lifecycle.getName() + "]", e);
                 }
 
                 if (lifecycle instanceof ManagementBean) {

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
@@ -112,11 +112,8 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
                             logger.debug(String.format("Could not get module [%s] context bean.", moduleDefinitionName));
                         }
                     } catch (BeansException e) {
-                        logger.warn(String.format("Failed to start module [%s] due to: [%s].", moduleDefinitionName, e.getMessage()));
-                        if (logger.isDebugEnabled()) {
-                            logger.debug(String.format("module start failure of module [%s] was due to: ", moduleDefinitionName), e);
-                        }
-                        throw new RuntimeException(String.format("Failed to start module [%s]", moduleDefinitionName), e);
+                        logger.error("Failed to start module [{}] due to: {}", def.getName(), e);
+                        throw new RuntimeException(String.format("Failed to start module [%s]", def.getName()));
                     }
                 } catch (EmptyStackException e) {
                     logger.warn(String.format("Failed to obtain module context due to [%s]. Using root context instead.", e.getMessage()));
@@ -148,11 +145,8 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
                         logger.debug("Failed to obtain module context: ", e);
                     }
                 } catch (BeansException e) {
-                    logger.warn(String.format("Failed to load module [%s] due to: [%s].", def.getName(), e.getMessage()));
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(String.format("module load failure of module [%s] was due to: ", def.getName()), e);
-                    }
-                    throw new RuntimeException(String.format("Failed to load module [%s]", def.getName()), e);
+                    logger.error("Failed to load module [{}] due to: {}", def.getName(), e);
+                    throw new RuntimeException(String.format("Failed to load module [%s]", def.getName()));
                 }
             }
         });

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
@@ -116,6 +116,7 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
                         if (logger.isDebugEnabled()) {
                             logger.debug(String.format("module start failure of module [%s] was due to: ", moduleDefinitionName), e);
                         }
+                        throw new RuntimeException(String.format("Failed to start module [%s]", moduleDefinitionName), e);
                     }
                 } catch (EmptyStackException e) {
                     logger.warn(String.format("Failed to obtain module context due to [%s]. Using root context instead.", e.getMessage()));
@@ -147,10 +148,11 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
                         logger.debug("Failed to obtain module context: ", e);
                     }
                 } catch (BeansException e) {
-                    logger.warn(String.format("Failed to start module [%s] due to: [%s].", def.getName(), e.getMessage()));
+                    logger.warn(String.format("Failed to load module [%s] due to: [%s].", def.getName(), e.getMessage()));
                     if (logger.isDebugEnabled()) {
-                        logger.debug(String.format("module start failure of module [%s] was due to: ", def.getName()), e);
+                        logger.debug(String.format("module load failure of module [%s] was due to: ", def.getName()), e);
                     }
+                    throw new RuntimeException(String.format("Failed to load module [%s]", def.getName()), e);
                 }
             }
         });


### PR DESCRIPTION
### Description

This PR fixes the issue that when fail to start cloudstack-management service, there are huge amount of logs which are misleading and difficult to address the root cause.

Steps to reproduce the issue

- use a wrong db username in `/etc/cloudstack/management/db.properties`, for example
```
db.cloud.username=wronguser
```
- restart cloudstack-management service

Prior, there are hundreds of errors like `No bean named 'DefaultConfigResources' available`

```
# grep "No bean named 'DefaultConfigResources' available" /var/log/cloudstack/management/management-server.log |wc -l
372
```

With this change, these errors do not appear. only get few errors like
```
2026-05-19 06:49:17,187 DEBUG [c.c.u.d.T.Transaction] (main:[]) (logid:) Creating default datasource for database: cloud with connection pool lib: hikaricp
2026-05-19 06:49:17,191 DEBUG [c.c.u.d.T.Transaction] (main:[]) (logid:) Creating default datasource for database: cloud_usage with connection pool lib: hikaricp
2026-05-19 06:49:17,194 DEBUG [c.c.u.d.T.Transaction] (main:[]) (logid:) Creating default datasource for database: simulator with connection pool lib: hikaricp
2026-05-19 06:49:17,196 WARN  [c.c.u.d.T.Transaction] (main:[]) (logid:) Unable to load db configuration, using defaults with 5 connections. Falling back on assumed datasource on localhost:3306 using username:password=cloud:cloud. Please check your configuration com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: Could not create connection to database server. Attempted reconnect 3 times. Giving up.
...
```


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
