### PR TITLE
Convert command's timeout for snapshots commands

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -2061,7 +2061,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         QemuImgFile destFile = new QemuImgFile(snapshotPath);
         destFile.setFormat(PhysicalDiskFormat.QCOW2);
 
-        QemuImg q = new QemuImg(wait * 1000);
+        QemuImg q = new QemuImg(wait * 1000L);
         q.convert(srcFile, destFile, options, qemuObjects, qemuImageOpts, null, true);
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -2061,7 +2061,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         QemuImgFile destFile = new QemuImgFile(snapshotPath);
         destFile.setFormat(PhysicalDiskFormat.QCOW2);
 
-        QemuImg q = new QemuImg(wait);
+        QemuImg q = new QemuImg(wait * 1000);
         q.convert(srcFile, destFile, options, qemuObjects, qemuImageOpts, null, true);
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -55,7 +55,7 @@ public class QemuImg {
     /* The qemu-img binary. We expect this to be in $PATH */
     public String _qemuImgPath = "qemu-img";
     private String cloudQemuImgPath = "cloud-qemu-img";
-    private int timeout;
+    private long timeout;
     private boolean skipZero = false;
     private boolean noCache = false;
     private long version;
@@ -118,7 +118,7 @@ public class QemuImg {
      * @param skipZeroIfSupported Don't write zeroes to target device during convert, if supported by qemu-img
      * @param noCache Ensure we flush writes to target disk (useful for block device targets)
      */
-    public QemuImg(final int timeout, final boolean skipZeroIfSupported, final boolean noCache) throws LibvirtException {
+    public QemuImg(final long timeout, final boolean skipZeroIfSupported, final boolean noCache) throws LibvirtException {
         if (skipZeroIfSupported) {
             final Script s = new Script(_qemuImgPath, timeout);
             s.add("--help");
@@ -148,7 +148,7 @@ public class QemuImg {
      * @param timeout
      *            The timeout of scripts executed by this QemuImg object.
      */
-    public QemuImg(final int timeout) throws LibvirtException, QemuImgException {
+    public QemuImg(final long timeout) throws LibvirtException, QemuImgException {
         this(timeout, false, false);
     }
 


### PR DESCRIPTION
### Description

The #9659 PR introduced the `commands.timeout` global configuration for granular command timeout definition. If a operator wishes to increase snapshot related timeouts, he could increase the `CreateObjectCommand` timeout in the `commands.timeout` configuration. The defined timeouts are set in seconds. 

However, normal and incremental snapshots creation flows use `qemu-img` script to execute some of the necessary operations. These scripts accept timeouts as milliseconds, but receive them as seconds from the `CreateObjectCommand`. This leads to incorrect timeouts.

Therefore, this PR converts the `CreateObjectCommand` seconds to milliseconds before passing them to `qemu-img` scripts.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

First, I set `commands.timeout` configuration value to `CreateObjectCommand=300`. This defines this command timeout to 5 minutes. Then, I tried to create a full volume snapshot. The process failed due to a timeout.

<details><summary>Command timeout log</summary>

```
2026-05-21 15:04:44,122 DEBUG [c.c.a.m.ClusteredAgentManagerImpl] (Work-Job-Executor-13:[ctx-fe95241a, job-77/job-78, ctx-11fcb589]) (logid:d462b71a) Wait time setting on org.apache.cloudstack.storage.command.CreateObjectCommand is 300 seconds
```

</details>

<details><summary>Failure log</summary>

```
2026-05-21 15:04:56,776 DEBUG [utils.script.Script] (AgentRequest-Handler-1:[]) (logid:d462b71a) Executing command [qemu-img convert -O qcow2 -U --image-opts driver=qcow2,file.filename=/mnt/4244ccc6-8f06-3f9c-87bc-a7ba8c1caae9/5331f95a-ec63-4a79-a28f-7642ed095875 /mnt/507fca2c-a424-3ffc-b5f6-f7fe9e7c17e7/snapshots/2/4/2ad278b7-e1fa-4331-ae36-4ba67db4097b ].
2026-05-21 15:04:57,080 WARN  [utils.script.Script] (AgentRequest-Handler-1:[]) (logid:d462b71a) Process [14516] for command [qemu-img convert -O qcow2 -U --image-opts driver=qcow2,file.filename=/mnt/4244ccc6-8f06-3f9c-87bc-a7ba8c1caae9/5331f95a-ec63-4a79-a28f-7642ed095875 /mnt/507fca2c-a424-3ffc-b5f6-f7fe9e7c17e7/snapshots/2/4/2ad278b7-e1fa-4331-ae36-4ba67db4097b ] timed out. Output is [].
```

</details>

I installed the packages with the timeout conversion to my local environment, then tried to create another snapshot. Using a debug breakpoint, I validated that the `qemu-img` script instance had the converted timeout. The new snapshot was created successfully,

---

When trying to create a incremental snapshot, the same error occurred. Then, I installed the packages with the necessary changes and tried to create another incremental snapshot. This process also used debug breakpoints to validate the scripts timeout.