### PR TITLE
add VR health checks to prometheus output

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -59,7 +59,11 @@ import com.cloud.host.HostVO;
 import com.cloud.host.Status;
 import com.cloud.host.dao.HostDao;
 import com.cloud.host.dao.HostTagsDao;
+import com.cloud.network.VirtualNetworkApplianceService;
 import com.cloud.network.dao.IPAddressDao;
+import com.cloud.network.dao.RouterHealthCheckResultDao;
+import com.cloud.network.dao.RouterHealthCheckResultVO;
+import com.cloud.network.router.VirtualRouter;
 import com.cloud.storage.ImageStore;
 import com.cloud.storage.StorageStats;
 import com.cloud.storage.Volume;
@@ -70,7 +74,9 @@ import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.component.Manager;
 import com.cloud.utils.component.ManagerBase;
+import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.VirtualMachine.State;
+import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
@@ -137,6 +143,10 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     private HostTagsDao _hostTagsDao;
     @Inject
     private CAManager caManager;
+    @Inject
+    private DomainRouterDao domainRouterDao;
+    @Inject
+    private RouterHealthCheckResultDao routerHealthCheckResultDao;
 
     public PrometheusExporterImpl() {
         super();
@@ -501,6 +511,35 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         }
     }
 
+    private void addVirtualRouterHealthCheckMetrics(final List<Item> metricsList, final long dcId, final String zoneName, final String zoneUuid) {
+        List<DomainRouterVO> routers = domainRouterDao.listByDataCenter(dcId);
+        if (routers == null) {
+            return;
+        }
+        for (DomainRouterVO router : routers) {
+            if (router.getRole() != VirtualRouter.Role.VIRTUAL_ROUTER) {
+                continue;
+            }
+            List<RouterHealthCheckResultVO> checks = routerHealthCheckResultDao.getHealthCheckResults(router.getId());
+            if (checks == null || checks.isEmpty()) {
+                continue;
+            }
+            for (RouterHealthCheckResultVO check : checks) {
+                int resultValue = (check.getCheckResult() ==
+                        VirtualNetworkApplianceService.RouterHealthStatus.SUCCESS) ? 1 : 0;
+                metricsList.add(new ItemVRHealthCheckResult(
+                        zoneName, router.getInstanceName(),
+                        check.getCheckName(), check.getCheckType(), resultValue));
+                if (check.getLastUpdateTime() != null) {
+                    long epochSeconds = check.getLastUpdateTime().getTime() / 1000L;
+                    metricsList.add(new ItemVRHealthCheckLastCheck(
+                            zoneName, router.getInstanceName(),
+                            check.getCheckName(), check.getCheckType(), epochSeconds));
+                }
+            }
+        }
+    }
+
     @Override
     public void updateMetrics() {
         final List<Item> latestMetricsItems = new ArrayList<Item>();
@@ -518,6 +557,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
                 addDomainMetrics(latestMetricsItems, zoneName, zoneUuid);
                 addAccountMetrics(latestMetricsItems, dc.getId(), zoneName, zoneUuid);
                 addVMsBySizeMetrics(latestMetricsItems, dc.getId(), zoneName, zoneUuid);
+                addVirtualRouterHealthCheckMetrics(latestMetricsItems, dc.getId(), zoneName, zoneUuid);
             }
             addDomainLimits(latestMetricsItems);
             addDomainResourceCount(latestMetricsItems);
@@ -1178,6 +1218,58 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         @Override
         public String toMetricsString() {
             return String.format("%s{zone=\"%s\",hostname=\"%s\",ip=\"%s\"} %d", name, zoneName, hostName, hostIp, expiryTimestamp);
+        }
+    }
+
+    class ItemVRHealthCheckResult extends Item {
+        String zoneName;
+        String routerName;
+        String checkName;
+        String checkType;
+        int result;
+
+        public ItemVRHealthCheckResult(String zn, String rn, String cn, String ct, int res) {
+            super("cloudstack_virtualrouter_healthcheck_result",
+                    "Virtual Router Health Check result (1=success, 0=failure/unknown)",
+                    "gauge");
+            zoneName = zn;
+            routerName = rn;
+            checkName = cn;
+            checkType = ct;
+            result = res;
+        }
+
+        @Override
+        public String toMetricsString() {
+            return String.format(
+                    "%s{checkname=\"%s\",checktype=\"%s\",zone=\"%s\",virtualrouter=\"%s\"} %d",
+                    name, checkName, checkType, zoneName, routerName, result);
+        }
+    }
+
+    class ItemVRHealthCheckLastCheck extends Item {
+        String zoneName;
+        String routerName;
+        String checkName;
+        String checkType;
+        long lastCheckEpochSeconds;
+
+        public ItemVRHealthCheckLastCheck(String zn, String rn, String cn, String ct, long ts) {
+            super("cloudstack_virtualrouter_healthcheck_lastcheck",
+                    "Virtual Router Health Check last check timestamp (Unix seconds)",
+                    "gauge");
+            zoneName = zn;
+            routerName = rn;
+            checkName = cn;
+            checkType = ct;
+            lastCheckEpochSeconds = ts;
+        }
+
+        @Override
+        public String toMetricsString() {
+            return String.format(
+                    "%s{checkname=\"%s\",checktype=\"%s\",zone=\"%s\",virtualrouter=\"%s\"} %d",
+                    name, checkName, checkType, zoneName, routerName, lastCheckEpochSeconds);
         }
     }
 }


### PR DESCRIPTION
### Description

This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #6212

aided by AI

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document —>
output should look something like 
```
# HELP cloudstack_virtualrouter_healthcheck_result Virtual Router Health Check result (1=success, 0=failure/unknown)
# TYPE cloudstack_virtualrouter_healthcheck_result gauge
cloudstack_virtualrouter_healthcheck_result{checkname="connectivity.test",checktype="basic",zone="zone1",virtualrouter="r-123-VM"} 1

# HELP cloudstack_virtualrouter_healthcheck_lastcheck Virtual Router Health Check last check timestamp (Unix seconds)
# TYPE cloudstack_virtualrouter_healthcheck_lastcheck gauge
cloudstack_virtualrouter_healthcheck_lastcheck{checkname="connectivity.test",checktype="basic",zone="zone1",virtualrouter="r-123-VM"} 1649228157
```