### PR TITLE
Enable dynamic scaling of Kubernetes cluster offerings for KVM

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterScaleWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterScaleWorker.java
@@ -44,7 +44,6 @@ import com.cloud.exception.ManagementServerException;
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.VirtualMachineMigrationException;
-import com.cloud.hypervisor.Hypervisor;
 import com.cloud.kubernetes.cluster.KubernetesCluster;
 import com.cloud.kubernetes.cluster.KubernetesClusterManagerImpl;
 import com.cloud.kubernetes.cluster.KubernetesClusterService;
@@ -61,8 +60,6 @@ import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.ssh.SshHelper;
 import com.cloud.vm.UserVmVO;
-import com.cloud.vm.VMInstanceVO;
-import com.cloud.vm.VirtualMachine;
 import org.apache.logging.log4j.Level;
 
 import static com.cloud.kubernetes.cluster.KubernetesServiceHelper.KubernetesClusterNodeType.CONTROL;
@@ -310,18 +307,8 @@ public class KubernetesClusterScaleWorker extends KubernetesClusterResourceModif
         }
         final long originalNodeCount = kubernetesCluster.getTotalNodeCount();
         List<KubernetesClusterVmMapVO> vmList = kubernetesClusterVmMapDao.listByClusterId(kubernetesCluster.getId());
-        if (vmList == null || vmList.isEmpty() || vmList.size() < originalNodeCount) {
+        if (CollectionUtils.isEmpty(vmList) || vmList.size() < originalNodeCount) {
             logTransitStateToFailedIfNeededAndThrow(Level.WARN, String.format("Scaling Kubernetes cluster : %s failed, it is in unstable state as not enough existing VM instances found!", kubernetesCluster.getName()));
-        } else {
-            for (KubernetesClusterVmMapVO vmMapVO : vmList) {
-                VMInstanceVO vmInstance = vmInstanceDao.findById(vmMapVO.getVmId());
-                if (vmInstance != null && vmInstance.getState().equals(VirtualMachine.State.Running) &&
-                        vmInstance.getHypervisorType() != Hypervisor.HypervisorType.XenServer &&
-                        vmInstance.getHypervisorType() != Hypervisor.HypervisorType.VMware &&
-                        vmInstance.getHypervisorType() != Hypervisor.HypervisorType.Simulator) {
-                    logTransitStateToFailedIfNeededAndThrow(Level.WARN, String.format("Scaling Kubernetes cluster : %s failed, scaling Kubernetes cluster with running VMs on hypervisor %s is not supported!", kubernetesCluster.getName(), vmInstance.getHypervisorType()));
-                }
-            }
         }
     }
 


### PR DESCRIPTION
### Description

PR #12975 introduced support for live scaling VMs with fixed service offerings on KVM. However, it did not remove a constraint in the Kubernetes cluster scaling workflow that prevented changing cluster compute offerings while the clusters were running.

This PR removes this leftover constraint, enabling dynamic scaling of Kubernetes cluster offerings.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?

- Created a k8s cluster with a compute offering of 2 vCPUs and 4096 MiB of memory (without CPU cap):

    <details>

    <summary>k8s cluster details</summary>

    <img width="604" height="763" alt="image" src="https://github.com/user-attachments/assets/8fb8daa8-c192-40ea-bf3b-da2ec56cb565" />

    </details>

- Scaled the k8s cluster and upgraded its offering to 2 vCPUs and 4096 MiB of memory (with CPU cap):

    <details>

    <summary>k8s cluster control plane VM XML</summary>

    ```xml
    <maxMemory slots='16' unit='KiB'>15327232</maxMemory>
    <memory unit='KiB'>4194304</memory>
    <currentMemory unit='KiB'>4194304</currentMemory>
    <vcpu placement='static' current='2'>8</vcpu>
    <cputune>
        <shares>835</shares>
        <period>10000</period>
        <quota>3300</quota>
    </cputune>
    ```

    </details>

- Scaled the worker nodes compute offering to 3 vCPUs and 4096 MiB of memory (with CPU cap):

    <details>

    <summary>k8s cluster details</summary>

    <img width="646" height="1054" alt="image" src="https://github.com/user-attachments/assets/b4179554-0730-40f7-babc-adf8d60122ba" />

    </details>

    <details>

    <summary>k8s cluster worker plane VM XML</summary>

    ```xml
    <maxMemory slots='16' unit='KiB'>15327232</maxMemory>
    <memory unit='KiB'>4194304</memory>
    <currentMemory unit='KiB'>4194304</currentMemory>
    <vcpu placement='static' current='3'>8</vcpu>
    <vcpus>
        <vcpu id='0' enabled='yes' hotpluggable='no' order='1'/>
        <vcpu id='1' enabled='yes' hotpluggable='no' order='2'/>
        <vcpu id='2' enabled='yes' hotpluggable='yes' order='3'/>
        <vcpu id='3' enabled='no' hotpluggable='yes'/>
        <vcpu id='4' enabled='no' hotpluggable='yes'/>
        <vcpu id='5' enabled='no' hotpluggable='yes'/>
        <vcpu id='6' enabled='no' hotpluggable='yes'/>
        <vcpu id='7' enabled='no' hotpluggable='yes'/>
    </vcpus>
    ```

    </details>