### PR TITLE
Infer single conversion storage pool for VMware import

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1679,6 +1679,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                             ApiConstants.FORCE_MS_TO_IMPORT_VM_FILES, ApiConstants.USE_VDDK));
         }
 
+        convertStoragePoolId = resolveImplicitConversionStoragePoolId(destinationCluster, convertStoragePoolId, forceConvertToPool);
         checkConversionStoragePool(convertStoragePoolId, forceConvertToPool);
         validateSelectedConversionStoragePoolForVddk(useVddk, convertStoragePoolId, serviceOffering, dataDiskOfferingMap);
 
@@ -1814,6 +1815,45 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                         "as its type %s", selectedStoragePool.getName(), selectedStoragePool.getPoolType().name()));
             }
         }
+    }
+
+    protected Long resolveImplicitConversionStoragePoolId(Cluster destinationCluster, Long convertStoragePoolId,
+                                                          boolean forceConvertToPool) {
+        if (!forceConvertToPool || convertStoragePoolId != null) {
+            return convertStoragePoolId;
+        }
+
+        List<StoragePoolVO> candidatePools = getImplicitForceConvertToPoolStoragePools(destinationCluster);
+        if (candidatePools.isEmpty()) {
+            logFailureAndThrowException(String.format("The parameter forceconverttopool is set to true, but no suitable primary storage pool was found in cluster %s",
+                    destinationCluster.getName()));
+        }
+        if (candidatePools.size() > 1) {
+            logFailureAndThrowException(String.format("The parameter forceconverttopool is set to true, but multiple suitable primary storage pools were found in cluster %s. Please provide convertinstancepoolid.",
+                    destinationCluster.getName()));
+        }
+
+        StoragePoolVO implicitPool = candidatePools.get(0);
+        logger.debug("The parameter forceconverttopool is set to true and no conversion storage pool was provided; using the only suitable primary storage pool [{}].",
+                implicitPool.getName());
+        return implicitPool.getId();
+    }
+
+    private List<StoragePoolVO> getImplicitForceConvertToPoolStoragePools(Cluster destinationCluster) {
+        Set<StoragePoolVO> pools = new HashSet<>();
+        for (Storage.StoragePoolType poolType : forceConvertToPoolAllowedTypes) {
+            List<StoragePoolVO> clusterPools = primaryDataStoreDao.findClusterWideStoragePoolsByHypervisorAndPoolType(destinationCluster.getId(),
+                    Hypervisor.HypervisorType.KVM, poolType);
+            if (clusterPools != null) {
+                pools.addAll(clusterPools);
+            }
+            List<StoragePoolVO> zonePools = primaryDataStoreDao.findZoneWideStoragePoolsByHypervisorAndPoolType(destinationCluster.getDataCenterId(),
+                    Hypervisor.HypervisorType.KVM, poolType);
+            if (zonePools != null) {
+                pools.addAll(zonePools);
+            }
+        }
+        return new ArrayList<>(pools);
     }
 
     protected void validateSelectedConversionStoragePoolForVddk(boolean useVddk, Long convertStoragePoolId,

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -1406,6 +1406,46 @@ public class UnmanagedVMsManagerImplTest {
     }
 
     @Test
+    public void testResolveImplicitConversionStoragePoolIdUsesSingleSuitablePoolWhenForceConvertToPool() {
+        ClusterVO cluster = getClusterForTests();
+        StoragePoolVO storagePool = mock(StoragePoolVO.class);
+        when(storagePool.getId()).thenReturn(42L);
+        when(primaryDataStoreDao.findClusterWideStoragePoolsByHypervisorAndPoolType(cluster.getId(),
+                Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.NetworkFilesystem))
+                .thenReturn(List.of(storagePool));
+
+        Long storagePoolId = unmanagedVMsManager.resolveImplicitConversionStoragePoolId(cluster, null, true);
+
+        Assert.assertEquals(Long.valueOf(42L), storagePoolId);
+    }
+
+    @Test
+    public void testResolveImplicitConversionStoragePoolIdKeepsExplicitPoolWhenForceConvertToPool() {
+        ClusterVO cluster = getClusterForTests();
+
+        Long storagePoolId = unmanagedVMsManager.resolveImplicitConversionStoragePoolId(cluster, 42L, true);
+
+        Assert.assertEquals(Long.valueOf(42L), storagePoolId);
+        Mockito.verifyNoInteractions(primaryDataStoreDao);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testResolveImplicitConversionStoragePoolIdFailsWhenMultiplePoolsFound() {
+        ClusterVO cluster = getClusterForTests();
+        when(cluster.getName()).thenReturn("cluster-1");
+        StoragePoolVO firstStoragePool = mock(StoragePoolVO.class);
+        StoragePoolVO secondStoragePool = mock(StoragePoolVO.class);
+        when(primaryDataStoreDao.findClusterWideStoragePoolsByHypervisorAndPoolType(cluster.getId(),
+                Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.NetworkFilesystem))
+                .thenReturn(List.of(firstStoragePool));
+        when(primaryDataStoreDao.findZoneWideStoragePoolsByHypervisorAndPoolType(cluster.getDataCenterId(),
+                Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.NetworkFilesystem))
+                .thenReturn(List.of(secondStoragePool));
+
+        unmanagedVMsManager.resolveImplicitConversionStoragePoolId(cluster, null, true);
+    }
+
+    @Test
     public void testCheckConversionStoragePoolPrimaryStagingPool() {
         StoragePoolVO destPool = mock(StoragePoolVO.class);
         long destPoolId = 1L;

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -1085,11 +1085,7 @@ export default {
         }
         getAPI('listStoragePools', params).then(json => {
           this.storagePoolsForConversion = json.liststoragepoolsresponse.storagepool || []
-          // Keep selected pool state aligned when the value is auto-populated by v-model.
-          if (this.form.convertstoragepoolid) {
-            const poolExists = this.storagePoolsForConversion.some(pool => pool.id === this.form.convertstoragepoolid)
-            this.selectedStoragePoolForConversion = poolExists ? this.form.convertstoragepoolid : null
-          }
+          this.syncSelectedStoragePoolForConversion()
         })
       } else if (this.selectedStorageOptionForConversion === 'local') {
         const kvmHost = this.kvmHostsForConversion.filter(x => x.id === this.selectedKvmHostForConversion)[0]
@@ -1099,11 +1095,23 @@ export default {
           status: 'Up'
         }).then(json => {
           this.storagePoolsForConversion = json.liststoragepoolsresponse.storagepool || []
-          if (this.form.convertstoragepoolid) {
-            const poolExists = this.storagePoolsForConversion.some(pool => pool.id === this.form.convertstoragepoolid)
-            this.selectedStoragePoolForConversion = poolExists ? this.form.convertstoragepoolid : null
-          }
+          this.syncSelectedStoragePoolForConversion()
         })
+      }
+    },
+    syncSelectedStoragePoolForConversion () {
+      if (this.form.convertstoragepoolid) {
+        const poolExists = this.storagePoolsForConversion.some(pool => pool.id === this.form.convertstoragepoolid)
+        if (poolExists) {
+          this.selectedStoragePoolForConversion = this.form.convertstoragepoolid
+          return
+        }
+        this.form.convertstoragepoolid = null
+        this.selectedStoragePoolForConversion = null
+      }
+      if (this.storagePoolsForConversion.length === 1) {
+        this.form.convertstoragepoolid = this.storagePoolsForConversion[0].id
+        this.selectedStoragePoolForConversion = this.form.convertstoragepoolid
       }
     },
     updateSelectedKvmHostForImporting (clusterid, checked, value) {
@@ -1162,6 +1170,9 @@ export default {
       this.selectedStoragePoolForConversion = null
       this.showStoragePoolsForConversion = false
       this.resetStorageOptionsForConversion()
+      if (val) {
+        this.selectPrimaryStorageForForcedConversion()
+      }
     },
     onUseVddkChange (val, isUserChange = true) {
       if (isUserChange) {
@@ -1186,6 +1197,14 @@ export default {
         this.fetchKvmHostsForConversion()
       }
       this.resetStorageOptionsForConversion()
+      if (val) {
+        this.selectPrimaryStorageForForcedConversion()
+      }
+    },
+    selectPrimaryStorageForForcedConversion () {
+      this.selectedStorageOptionForConversion = 'primary'
+      this.showStoragePoolsForConversion = true
+      this.fetchStoragePoolsForConversion()
     },
     updateSelectedRootDisk () {
       var rootDisk = this.resource.disk[this.selectedRootDiskIndex]


### PR DESCRIPTION
## Description

This improves the VMware import workflow when `forceconverttopool=true` and the caller does not provide `convertinstancepoolid`.

Previously, the API always failed in that case, even when the destination environment had exactly one suitable primary storage pool. With this change, CloudStack infers that single suitable pool and proceeds. If no suitable pool exists, or if multiple suitable pools exist, the API still fails with a clear message so the caller can provide `convertinstancepoolid` explicitly.

No API parameters are added or removed.

## API behavior

When `forceconverttopool=true`:

- If `convertinstancepoolid` is supplied, the selected pool is used and validated as before.
- If `convertinstancepoolid` is omitted and exactly one suitable KVM primary storage pool exists for the destination cluster or zone, that pool is used automatically.
- If no suitable pool exists, the request fails with a clear error.
- If multiple suitable pools exist, the request fails and asks the caller to provide `convertinstancepoolid`.

## UI behavior

- Direct conversion opens the primary storage selection path.
- If the returned storage-pool list contains exactly one pool, the UI selects it automatically.
- If multiple pools are available, the operator still chooses the intended pool.

## Testing

- `mvn -pl server -am -Dtest=UnmanagedVMsManagerImplTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`