### PR TITLE
Prefill custom compute offering values for VMware import

### DIFF
--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -279,6 +279,7 @@
                   @select-compute-item="($event) => updateComputeOffering($event)"
                   @handle-search-filter="($event) => fetchComputeOfferings($event)" />
                 <compute-selection
+                  :key="computeSelectionKey"
                   class="row-element"
                   v-if="computeOffering && (computeOffering.iscustomized || computeOffering.iscustomizediops)"
                   :isCustomized="computeOffering.iscustomized"
@@ -287,7 +288,7 @@
                   :cpuSpeedInputDecorator="cpuSpeedKey"
                   :memoryInputDecorator="memoryKey"
                   :computeOfferingId="computeOffering.id"
-                  :preFillContent="resource"
+                  :preFillContent="computeOfferingPreFillContent"
                   :isConstrained="'serviceofferingdetails' in computeOffering"
                   :minCpu="getMinCpu()"
                   :maxCpu="getMaxCpu()"
@@ -765,6 +766,23 @@ export default {
         }
       }
       return nics
+    },
+    computeOfferingPreFillContent () {
+      return {
+        ...this.resource,
+        cpunumber: this.getCustomCpuNumberDefault(),
+        cpuspeed: this.getCPUSpeed(),
+        memory: this.getCustomMemoryDefault()
+      }
+    },
+    computeSelectionKey () {
+      const preFill = this.computeOfferingPreFillContent
+      return [
+        this.computeOffering?.id || 'offering',
+        preFill.cpunumber || 'cpu',
+        preFill.cpuspeed || 'speed',
+        preFill.memory || 'memory'
+      ].join('-')
     }
   },
   watch: {
@@ -865,14 +883,26 @@ export default {
       }
       return 'serviceofferingdetails' in this.computeOffering ? this.computeOffering.serviceofferingdetails.maxmemory * 1 : Number.MAX_SAFE_INTEGER
     },
+    clampCustomValue (value, min, max) {
+      if (value === undefined || value === null || isNaN(value)) {
+        return min
+      }
+      return Math.min(Math.max(value * 1, min), max)
+    },
+    getCustomCpuNumberDefault () {
+      return this.clampCustomValue(this.resource?.cpunumber, this.getMinCpu(), this.getMaxCpu())
+    },
+    getCustomMemoryDefault () {
+      return this.clampCustomValue(this.resource?.memory, this.getMinMemory(), this.getMaxMemory())
+    },
     getCPUSpeed () {
       if (!this.computeOffering) {
-        return 0
+        return 2000
       }
       if (this.computeOffering.cpuspeed) {
         return this.computeOffering.cpuspeed * 1
       }
-      return this.resource.cpuspeed * 1 || 0
+      return this.resource.cpuspeed * 1 || 2000
     },
     fetchOptions (param, name, exclude) {
       if (exclude && exclude.length > 0) {


### PR DESCRIPTION
## Summary
- **Fix unconstrained custom offering defaults** during VMware import.
- **Keep constrained custom offering behavior intact**, while making it explicit and consistent.
- **Default unknown CPU speed to 2000 MHz** instead of showing/importing `0 MHz`.

## Problem
When importing a VMware VM and selecting a **custom unconstrained compute offering**, the UI could prefill the custom fields with generic fallback values instead of the discovered source VM sizing:

- **CPU cores:** `1`
- **CPU speed:** `0 MHz`
- **Memory:** `32 MB`

This happened even when the source VM details already showed useful sizing information, for example `3 CPU` and `4096 MB` memory.

## Existing Behavior
- **Custom constrained offerings already behave correctly** because the UI receives `serviceofferingdetails` with min/max CPU and memory bounds.
- With those bounds present, the custom input component can initialize CPU and memory from values inside the allowed range.
<img width="1635" height="987" alt="image" src="https://github.com/user-attachments/assets/6ae8b5bb-272e-481d-b3de-e412c6ab712e" />


- **Custom unconstrained offerings do not have those min/max bounds**, so the UI falls back to generic defaults: `1 CPU`, `0 MHz`, and `32 MB`.

<img width="1666" height="1001" alt="image" src="https://github.com/user-attachments/assets/48d05c14-ea7e-45c0-a009-ba79c5d61491" />

## New Behavior
- **Custom constrained offerings:** continue to prefill from the discovered source VM sizing, clamped to the configured min/max range.
- **Custom unconstrained offerings:** now also prefill from the discovered source VM sizing instead of using the generic fallback values.
- **Unknown source CPU speed:** if VMware reports CPU speed as `0` or unknown, the UI now defaults the custom CPU speed field to `2000 MHz`.
- **Selection refresh:** the custom compute input row is recreated when the selected offering or discovered sizing values change, so stale custom values are not retained.
<img width="1624" height="976" alt="image" src="https://github.com/user-attachments/assets/5218844d-a21e-468d-9b6f-6874063f91b2" />




## Testing
- Ran `git diff --check`.
- Verified the pull request diff only changes `ui/src/views/tools/ImportUnmanagedInstance.vue`.