### PR TITLE
docs: note MariaDB support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Unrestricted (TSU) exception (see the BIS Export Administration Regulations, Sec
 The following provides more details on the included cryptographic software:
 
 * CloudStack makes use of JaSypt cryptographic libraries.
-* CloudStack has a system requirement of MySQL, and uses native database encryption functionality.
+* CloudStack requires a MySQL-compatible database (MariaDB or MySQL). The Docker development setup in `tools/docker/docker-compose.yml` uses MariaDB, and uses native database encryption functionality.
 * CloudStack makes use of the Bouncy Castle general-purpose encryption library.
 * CloudStack can optionally interact with and control OpenSwan-based VPNs.
 * CloudStack has a dependency on and makes use of JSch - a java SSH2 implementation.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Unrestricted (TSU) exception (see the BIS Export Administration Regulations, Sec
 The following provides more details on the included cryptographic software:
 
 * CloudStack makes use of JaSypt cryptographic libraries.
-* CloudStack requires a MySQL-compatible database (MariaDB or MySQL). The Docker development setup in `tools/docker/docker-compose.yml` uses MariaDB, and uses native database encryption functionality.
+* CloudStack requires a MySQL-compatible database (MariaDB or MySQL), and uses native database encryption functionality.
 * CloudStack makes use of the Bouncy Castle general-purpose encryption library.
 * CloudStack can optionally interact with and control OpenSwan-based VPNs.
 * CloudStack has a dependency on and makes use of JSch - a java SSH2 implementation.


### PR DESCRIPTION
## Summary

Documents that CloudStack uses a MySQL-compatible database. The Docker development setup in `tools/docker/docker-compose.yml` uses MariaDB (`mariadb:10.0`); the README only mentioned MySQL in the cryptographic software notice.

Documentation only; no code or deployment changes.

## Test plan

- [x] README only