### PR TITLE
Fix in the calculation of a volume's physical size

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeDef.java
@@ -83,6 +83,10 @@ public class LibvirtStorageVolumeDef {
         return this._volFormat;
     }
 
+    public Long getVolSize() {
+        return _volSize;
+    }
+
     @Override
     public String toString() {
         StringBuilder storageVolBuilder = new StringBuilder();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.cloud.utils.StringUtils;
 import org.apache.cloudstack.utils.security.ParserUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -50,7 +51,7 @@ public class LibvirtStorageVolumeXMLParser {
                 NodeList pathNodes = backingStore.getElementsByTagName("path");
                 if (pathNodes.getLength() > 0) {
                     String path = pathNodes.item(0).getTextContent();
-                    if (path == null || path.trim().isEmpty()) {
+                    if (StringUtils.isEmpty(path)) {
                         return null;
                     }
                     path = path.trim();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
@@ -44,10 +44,19 @@ public class LibvirtStorageVolumeXMLParser {
             Document doc = builder.parse(is);
 
             Element rootElement = doc.getDocumentElement();
-            Element backingStore = (Element)rootElement.getElementsByTagName("backingStore").item(0);
-            if (backingStore != null) {
-                String[] paths = getTagValue("path", backingStore).split("/");
-                return paths[paths.length-1];
+            NodeList backingStores = rootElement.getElementsByTagName("backingStore");
+            if (backingStores.getLength() > 0) {
+                Element backingStore = (Element) backingStores.item(0);
+                NodeList pathNodes = backingStore.getElementsByTagName("path");
+                if (pathNodes.getLength() > 0) {
+                    String path = pathNodes.item(0).getTextContent();
+                    if (path == null || path.trim().isEmpty()) {
+                        return null;
+                    }
+                    path = path.trim();
+                    int lastSlash = path.lastIndexOf('/');
+                    return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+                }
             }
         } catch (ParserConfigurationException | SAXException | IOException e) {
             logger.error(e.toString(), e);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
@@ -35,6 +35,26 @@ import org.xml.sax.SAXException;
 public class LibvirtStorageVolumeXMLParser {
     protected Logger logger = LogManager.getLogger(getClass());
 
+    public String getBackingFileNameIfExists(String volXML) {
+        try {
+            DocumentBuilder builder = ParserUtils.getSaferDocumentBuilderFactory().newDocumentBuilder();
+
+            InputSource is = new InputSource();
+            is.setCharacterStream(new StringReader(volXML));
+            Document doc = builder.parse(is);
+
+            Element rootElement = doc.getDocumentElement();
+            Element backingStore = (Element)rootElement.getElementsByTagName("backingStore").item(0);
+            if (backingStore != null) {
+                String[] paths = getTagValue("path", backingStore).split("/");
+                return paths[paths.length-1];
+            }
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            logger.error(e.toString(), e);
+        }
+        return null;
+    }
+
     public LibvirtStorageVolumeDef parseStorageVolumeXML(String volXML) {
         DocumentBuilder builder;
         try {
@@ -50,6 +70,7 @@ public class LibvirtStorageVolumeXMLParser {
             Element target = (Element)rootElement.getElementsByTagName("target").item(0);
             String format = getAttrValue("type", "format", target);
             Long capacity = Long.parseLong(getTagValue("capacity", rootElement));
+
             return new LibvirtStorageVolumeDef(VolName, capacity, LibvirtStorageVolumeDef.VolumeFormat.getFormat(format), null, null);
         } catch (ParserConfigurationException e) {
             logger.debug(e.toString());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
@@ -51,7 +51,7 @@ public class LibvirtStorageVolumeXMLParser {
                 NodeList pathNodes = backingStore.getElementsByTagName("path");
                 if (pathNodes.getLength() > 0) {
                     String path = pathNodes.item(0).getTextContent();
-                    if (StringUtils.isEmpty(path)) {
+                    if (StringUtils.isBlank(path)) {
                         return null;
                     }
                     path = path.trim();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtStorageVolumeXMLParser.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.cloud.utils.StringUtils;
 import org.apache.cloudstack.utils.security.ParserUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -34,6 +35,35 @@ import org.xml.sax.SAXException;
 
 public class LibvirtStorageVolumeXMLParser {
     protected Logger logger = LogManager.getLogger(getClass());
+
+    public String getBackingFileNameIfExists(String volXML) {
+        try {
+            DocumentBuilder builder = ParserUtils.getSaferDocumentBuilderFactory().newDocumentBuilder();
+
+            InputSource is = new InputSource();
+            is.setCharacterStream(new StringReader(volXML));
+            Document doc = builder.parse(is);
+
+            Element rootElement = doc.getDocumentElement();
+            NodeList backingStores = rootElement.getElementsByTagName("backingStore");
+            if (backingStores.getLength() > 0) {
+                Element backingStore = (Element) backingStores.item(0);
+                NodeList pathNodes = backingStore.getElementsByTagName("path");
+                if (pathNodes.getLength() > 0) {
+                    String path = pathNodes.item(0).getTextContent();
+                    if (StringUtils.isBlank(path)) {
+                        return null;
+                    }
+                    path = path.trim();
+                    int lastSlash = path.lastIndexOf('/');
+                    return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+                }
+            }
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            logger.error(e.toString(), e);
+        }
+        return null;
+    }
 
     public LibvirtStorageVolumeDef parseStorageVolumeXML(String volXML) {
         DocumentBuilder builder;
@@ -50,6 +80,7 @@ public class LibvirtStorageVolumeXMLParser {
             Element target = (Element)rootElement.getElementsByTagName("target").item(0);
             String format = getAttrValue("type", "format", target);
             Long capacity = Long.parseLong(getTagValue("capacity", rootElement));
+
             return new LibvirtStorageVolumeDef(VolName, capacity, LibvirtStorageVolumeDef.VolumeFormat.getFormat(format), null, null);
         } catch (ParserConfigurationException e) {
             logger.debug(e.toString());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -507,6 +507,12 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         return parser.parseStoragePoolXML(poolDefXML);
     }
 
+    public String getBackingFileOfVolumeIfExists(StorageVol vol) throws LibvirtException {
+        String volDefXML = vol.getXMLDesc(0);
+        LibvirtStorageVolumeXMLParser parser = new LibvirtStorageVolumeXMLParser();
+        return parser.getBackingFileNameIfExists(volDefXML);
+    }
+
     public LibvirtStorageVolumeDef getStorageVolumeDef(Connect conn, StorageVol vol) throws LibvirtException {
         String volDefXML = vol.getXMLDesc(0);
         LibvirtStorageVolumeXMLParser parser = new LibvirtStorageVolumeXMLParser();
@@ -657,6 +663,16 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         }
     }
 
+    public Long getBackingFileSizes(StoragePool pool, StorageVol vol) throws LibvirtException {
+        long size = vol.getInfo().allocation;
+        String backingFileOfVolumeIfExists = getBackingFileOfVolumeIfExists(vol);
+        if (backingFileOfVolumeIfExists != null) {
+            StorageVol backingFile = getVolume(pool, backingFileOfVolumeIfExists);
+            size += getBackingFileSizes(pool, backingFile);
+        }
+        return size;
+    }
+
     @Override
     public KVMPhysicalDisk getPhysicalDisk(String volumeUuid, KVMStoragePool pool) {
         LibvirtStoragePool libvirtPool = (LibvirtStoragePool)pool;
@@ -665,8 +681,9 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
             StorageVol vol = getVolume(libvirtPool.getPool(), volumeUuid);
             KVMPhysicalDisk disk;
             LibvirtStorageVolumeDef voldef = getStorageVolumeDef(libvirtPool.getPool().getConnect(), vol);
+            Long allSizes = getBackingFileSizes(libvirtPool.getPool(), vol);
             disk = new KVMPhysicalDisk(vol.getPath(), vol.getName(), pool);
-            disk.setSize(vol.getInfo().allocation);
+            disk.setSize(allSizes);
             disk.setVirtualSize(vol.getInfo().capacity);
 
             /**

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -507,7 +507,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         return parser.parseStoragePoolXML(poolDefXML);
     }
 
-    public String getBackingFileOfVolumeIfExists(StorageVol vol) throws LibvirtException {
+    private String getBackingFileOfVolumeIfExists(StorageVol vol) throws LibvirtException {
         String volDefXML = vol.getXMLDesc(0);
         LibvirtStorageVolumeXMLParser parser = new LibvirtStorageVolumeXMLParser();
         return parser.getBackingFileNameIfExists(volDefXML);
@@ -663,7 +663,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         }
     }
 
-    public Long getBackingFileSizes(StoragePool pool, StorageVol vol) throws LibvirtException {
+    private Long getBackingFileSizes(StoragePool pool, StorageVol vol) throws LibvirtException {
         long size = vol.getInfo().allocation;
         String backingFileOfVolumeIfExists = getBackingFileOfVolumeIfExists(vol);
         if (backingFileOfVolumeIfExists != null) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -664,13 +664,25 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
     }
 
     private Long getBackingFileSizes(StoragePool pool, StorageVol vol) throws LibvirtException {
-        long size = vol.getInfo().allocation;
-        String backingFileOfVolumeIfExists = getBackingFileOfVolumeIfExists(vol);
-        if (backingFileOfVolumeIfExists != null) {
-            StorageVol backingFile = getVolume(pool, backingFileOfVolumeIfExists);
-            size += getBackingFileSizes(pool, backingFile);
+        long total = 0L;
+        Set<String> visited = new HashSet<>();
+        StorageVol current = vol;
+
+        while (current != null) {
+            total += current.getInfo().allocation;
+            String backingName = getBackingFileOfVolumeIfExists(current);
+            if (StringUtils.isBlank(backingName) || !visited.add(backingName)) {
+                break;
+            }
+            try {
+                current = getVolume(pool, backingName);
+            } catch (CloudRuntimeException e) {
+                logger.debug("Unable to resolve backing volume {} in pool {}: {}", backingName, pool.getName(), e.getMessage());
+                break;
+            }
         }
-        return size;
+
+        return total;
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -505,6 +505,12 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         return parser.parseStoragePoolXML(poolDefXML);
     }
 
+    private String getBackingFileOfVolumeIfExists(StorageVol vol) throws LibvirtException {
+        String volDefXML = vol.getXMLDesc(0);
+        LibvirtStorageVolumeXMLParser parser = new LibvirtStorageVolumeXMLParser();
+        return parser.getBackingFileNameIfExists(volDefXML);
+    }
+
     public LibvirtStorageVolumeDef getStorageVolumeDef(Connect conn, StorageVol vol) throws LibvirtException {
         String volDefXML = vol.getXMLDesc(0);
         LibvirtStorageVolumeXMLParser parser = new LibvirtStorageVolumeXMLParser();
@@ -655,6 +661,28 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         }
     }
 
+    private Long getBackingFileSizes(StoragePool pool, StorageVol vol) throws LibvirtException {
+        long total = 0L;
+        Set<String> visited = new HashSet<>();
+        StorageVol current = vol;
+
+        while (current != null) {
+            total += current.getInfo().allocation;
+            String backingName = getBackingFileOfVolumeIfExists(current);
+            if (StringUtils.isBlank(backingName) || !visited.add(backingName)) {
+                break;
+            }
+            try {
+                current = getVolume(pool, backingName);
+            } catch (CloudRuntimeException e) {
+                logger.error("Unable to resolve backing volume {} in pool {}: {}", backingName, pool.getName(), e.getMessage());
+                break;
+            }
+        }
+
+        return total;
+    }
+
     @Override
     public KVMPhysicalDisk getPhysicalDisk(String volumeUuid, KVMStoragePool pool) {
         LibvirtStoragePool libvirtPool = (LibvirtStoragePool)pool;
@@ -663,8 +691,9 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
             StorageVol vol = getVolume(libvirtPool.getPool(), volumeUuid);
             KVMPhysicalDisk disk;
             LibvirtStorageVolumeDef voldef = getStorageVolumeDef(libvirtPool.getPool().getConnect(), vol);
+            Long allSizes = getBackingFileSizes(libvirtPool.getPool(), vol);
             disk = new KVMPhysicalDisk(vol.getPath(), vol.getName(), pool);
-            disk.setSize(vol.getInfo().allocation);
+            disk.setSize(allSizes);
             disk.setVirtualSize(vol.getInfo().capacity);
 
             /**

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -677,7 +677,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
             try {
                 current = getVolume(pool, backingName);
             } catch (CloudRuntimeException e) {
-                logger.debug("Unable to resolve backing volume {} in pool {}: {}", backingName, pool.getName(), e.getMessage());
+                logger.error("Unable to resolve backing volume {} in pool {}: {}", backingName, pool.getName(), e.getMessage());
                 break;
             }
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;


### PR DESCRIPTION
<!-- title: Fix in the calculation of a volume's physical size -->

### Description

Currently, when using the KVM hypervisor, the calculation of a volume's physical size ignores the backing files (if they exist) as part of the volume's physical size in storage, which can cause confusion for users. This behavior has been changed in this PR so that the backing files are now taken into account for the volume's physical size.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial


### Screenshots (if appropriate):

### How Has This Been Tested?

To perform the tests, I created a new VM with a backing file, and after that I took a few backups of this VM. Then, when checking the volume of this VM, it was observed that the physical size is proportional to the physical size in the storage.
