### PR TITLE
Support VDDK imports into RBD storage

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -39,3 +39,11 @@ example.ver.1 > example.ver.2:
     which can now be attached to Instances. This is to prevent the Secondary
     Storage to grow to enormous sizes as Linux Distributions keep growing in
     size while a stripped down Linux should fit on a 2.88MB floppy.
+
+4.23.0.0:
+  * VMware-to-KVM import using VDDK can import powered-off VMware VMs directly
+    into Ceph RBD primary storage when forceconverttopool is enabled and the
+    selected KVM conversion host supports qemu RBD access and in-place virt-v2v
+    finalization. Hosts without in-place finalization support can still use the
+    staged VDDK flow, converting to temporary qcow2 storage before copying the
+    finalized disks into RBD.

--- a/api/src/main/java/com/cloud/agent/api/to/RemoteInstanceTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/RemoteInstanceTO.java
@@ -38,6 +38,7 @@ public class RemoteInstanceTO implements Serializable {
     private String datacenterName;
     private String clusterName;
     private String hostName;
+    private String vmwareMoref;
 
     public RemoteInstanceTO() {
     }
@@ -99,5 +100,13 @@ public class RemoteInstanceTO implements Serializable {
 
     public String getHostName() {
         return hostName;
+    }
+
+    public String getVmwareMoref() {
+        return vmwareMoref;
+    }
+
+    public void setVmwareMoref(String vmwareMoref) {
+        this.vmwareMoref = vmwareMoref;
     }
 }

--- a/api/src/main/java/com/cloud/agent/api/to/VmwareVddkSourceDiskTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/VmwareVddkSourceDiskTO.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.agent.api.to;
+
+import java.io.Serializable;
+
+public class VmwareVddkSourceDiskTO implements Serializable {
+
+    private String diskId;
+    private String sourceDiskPath;
+    private long capacityBytes;
+    private Integer position;
+
+    public VmwareVddkSourceDiskTO() {
+    }
+
+    public VmwareVddkSourceDiskTO(String diskId, String sourceDiskPath, long capacityBytes, Integer position) {
+        this.diskId = diskId;
+        this.sourceDiskPath = sourceDiskPath;
+        this.capacityBytes = capacityBytes;
+        this.position = position;
+    }
+
+    public String getDiskId() {
+        return diskId;
+    }
+
+    public String getSourceDiskPath() {
+        return sourceDiskPath;
+    }
+
+    public long getCapacityBytes() {
+        return capacityBytes;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+}

--- a/api/src/main/java/com/cloud/host/Host.java
+++ b/api/src/main/java/com/cloud/host/Host.java
@@ -62,6 +62,10 @@ public interface Host extends StateObject<Status>, Identity, Partition, HAResour
     String HOST_VDDK_VERSION = "host.vddk.version";
     String HOST_OVFTOOL_VERSION = "host.ovftool.version";
     String HOST_VIRTV2V_VERSION = "host.virtv2v.version";
+    String HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT = "host.vddk.rbd.direct.import.support";
+    String HOST_VIRTV2V_INPLACE_SUPPORT = "host.virt.v2v.inplace.support";
+    String HOST_QEMU_IMG_RBD_SUPPORT = "host.qemu.img.rbd.support";
+    String HOST_RBD_QEMU_COPY_SUPPORT = "host.rbd.qemu.copy.support";
     String HOST_SSH_PORT = "host.ssh.port";
 
     int DEFAULT_SSH_PORT = 22;

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportVmCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportVmCmd.java
@@ -153,7 +153,8 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
     private Long importInstanceHostId;
 
     @Parameter(name = ApiConstants.CONVERT_INSTANCE_STORAGE_POOL_ID, type = CommandType.UUID, entityType = StoragePoolResponse.class,
-            description = "(only for importing VMs from VMware to KVM) optional - the temporary storage pool to perform the virt-v2v migration from VMware to KVM.")
+            description = "(only for importing VMs from VMware to KVM) optional - the temporary storage pool to perform the virt-v2v migration from VMware to KVM. " +
+                    "When " + ApiConstants.USE_VDDK + " and " + ApiConstants.FORCE_CONVERT_TO_POOL + " are true, this can be an RBD primary storage pool for direct RBD import.")
     private Long convertStoragePoolId;
 
     @Parameter(name = ApiConstants.FORCE_MS_TO_IMPORT_VM_FILES, type = CommandType.BOOLEAN,
@@ -183,7 +184,9 @@ public class ImportVmCmd extends ImportUnmanagedInstanceCmd {
             type = CommandType.BOOLEAN,
             since = "4.22.1",
             description = "(only for importing VMs from VMware to KVM) optional - if true, uses VDDK on the KVM conversion host for converting the VM. " +
-                    "This parameter is mutually exclusive with " + ApiConstants.FORCE_MS_TO_IMPORT_VM_FILES + ".")
+                    "This parameter is mutually exclusive with " + ApiConstants.FORCE_MS_TO_IMPORT_VM_FILES + ". " +
+                    "With " + ApiConstants.FORCE_CONVERT_TO_POOL + "=true and an RBD conversion pool, the source VMware VM must be powered off and " +
+                    "the conversion host must support qemu RBD access and in-place virt-v2v finalization.")
     private Boolean useVddk;
 
 

--- a/api/src/main/java/org/apache/cloudstack/vm/UnmanagedInstanceTO.java
+++ b/api/src/main/java/org/apache/cloudstack/vm/UnmanagedInstanceTO.java
@@ -66,6 +66,7 @@ public class UnmanagedInstanceTO {
 
     private String bootType;
     private String bootMode;
+    private String vmwareMoref;
 
     public String getName() {
         return name;
@@ -232,6 +233,14 @@ public class UnmanagedInstanceTO {
 
     public void setBootMode(String bootMode) {
         this.bootMode = bootMode;
+    }
+
+    public String getVmwareMoref() {
+        return vmwareMoref;
+    }
+
+    public void setVmwareMoref(String vmwareMoref) {
+        this.vmwareMoref = vmwareMoref;
     }
 
     public static class Disk {

--- a/core/src/main/java/com/cloud/agent/api/CheckConvertInstanceCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/CheckConvertInstanceCommand.java
@@ -19,6 +19,7 @@ package com.cloud.agent.api;
 public class CheckConvertInstanceCommand extends Command {
     boolean checkWindowsGuestConversionSupport = false;
     boolean useVddk = false;
+    boolean checkVddkRbdDirectImportSupport = false;
     String vddkLibDir;
 
     public CheckConvertInstanceCommand() {
@@ -48,6 +49,14 @@ public class CheckConvertInstanceCommand extends Command {
 
     public void setUseVddk(boolean useVddk) {
         this.useVddk = useVddk;
+    }
+
+    public boolean isCheckVddkRbdDirectImportSupport() {
+        return checkVddkRbdDirectImportSupport;
+    }
+
+    public void setCheckVddkRbdDirectImportSupport(boolean checkVddkRbdDirectImportSupport) {
+        this.checkVddkRbdDirectImportSupport = checkVddkRbdDirectImportSupport;
     }
 
     public String getVddkLibDir() {

--- a/core/src/main/java/com/cloud/agent/api/ConvertInstanceCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/ConvertInstanceCommand.java
@@ -18,7 +18,10 @@ package com.cloud.agent.api;
 
 import com.cloud.agent.api.to.DataStoreTO;
 import com.cloud.agent.api.to.RemoteInstanceTO;
+import com.cloud.agent.api.to.VmwareVddkSourceDiskTO;
 import com.cloud.hypervisor.Hypervisor;
+
+import java.util.List;
 
 public class ConvertInstanceCommand extends Command {
 
@@ -35,6 +38,7 @@ public class ConvertInstanceCommand extends Command {
     private String vddkLibDir;
     private String vddkTransports;
     private String vddkThumbprint;
+    private List<VmwareVddkSourceDiskTO> vmwareVddkSourceDisks;
 
     public ConvertInstanceCommand() {
     }
@@ -124,6 +128,14 @@ public class ConvertInstanceCommand extends Command {
 
     public void setVddkThumbprint(String vddkThumbprint) {
         this.vddkThumbprint = vddkThumbprint;
+    }
+
+    public List<VmwareVddkSourceDiskTO> getVmwareVddkSourceDisks() {
+        return vmwareVddkSourceDisks;
+    }
+
+    public void setVmwareVddkSourceDisks(List<VmwareVddkSourceDiskTO> vmwareVddkSourceDisks) {
+        this.vmwareVddkSourceDisks = vmwareVddkSourceDisks;
     }
 
     @Override

--- a/core/src/main/java/com/cloud/agent/api/ImportConvertedInstanceCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/ImportConvertedInstanceCommand.java
@@ -18,6 +18,7 @@ package com.cloud.agent.api;
 
 import com.cloud.agent.api.to.DataStoreTO;
 import com.cloud.agent.api.to.RemoteInstanceTO;
+import com.cloud.storage.Storage;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ public class ImportConvertedInstanceCommand extends Command {
 
     private RemoteInstanceTO sourceInstance;
     private List<String> destinationStoragePools;
+    private List<Storage.StoragePoolType> destinationStoragePoolTypes;
     private DataStoreTO conversionTemporaryLocation;
     private String temporaryConvertUuid;
     private boolean forceConvertToPool;
@@ -34,13 +36,22 @@ public class ImportConvertedInstanceCommand extends Command {
 
     public ImportConvertedInstanceCommand(RemoteInstanceTO sourceInstance,
                                           List<String> destinationStoragePools,
+                                          List<Storage.StoragePoolType> destinationStoragePoolTypes,
                                           DataStoreTO conversionTemporaryLocation, String temporaryConvertUuid,
                                           boolean forceConvertToPool) {
         this.sourceInstance = sourceInstance;
         this.destinationStoragePools = destinationStoragePools;
+        this.destinationStoragePoolTypes = destinationStoragePoolTypes;
         this.conversionTemporaryLocation = conversionTemporaryLocation;
         this.temporaryConvertUuid = temporaryConvertUuid;
         this.forceConvertToPool = forceConvertToPool;
+    }
+
+    public ImportConvertedInstanceCommand(RemoteInstanceTO sourceInstance,
+                                          List<String> destinationStoragePools,
+                                          DataStoreTO conversionTemporaryLocation, String temporaryConvertUuid,
+                                          boolean forceConvertToPool) {
+        this(sourceInstance, destinationStoragePools, null, conversionTemporaryLocation, temporaryConvertUuid, forceConvertToPool);
     }
 
     public RemoteInstanceTO getSourceInstance() {
@@ -49,6 +60,10 @@ public class ImportConvertedInstanceCommand extends Command {
 
     public List<String> getDestinationStoragePools() {
         return destinationStoragePools;
+    }
+
+    public List<Storage.StoragePoolType> getDestinationStoragePoolTypes() {
+        return destinationStoragePoolTypes;
     }
 
     public DataStoreTO getConversionTemporaryLocation() {

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -808,8 +808,13 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 String vddkSupport = detailsMap.get(Host.HOST_VDDK_SUPPORT);
                 String vddkLibDir = detailsMap.get(Host.HOST_VDDK_LIB_DIR);
                 String vddkVersion = detailsMap.get(Host.HOST_VDDK_VERSION);
+                String virtv2vInPlaceSupport = detailsMap.get(Host.HOST_VIRTV2V_INPLACE_SUPPORT);
+                String qemuImgRbdSupport = detailsMap.get(Host.HOST_QEMU_IMG_RBD_SUPPORT);
+                String rbdQemuCopySupport = detailsMap.get(Host.HOST_RBD_QEMU_COPY_SUPPORT);
+                String vddkRbdDirectImportSupport = detailsMap.get(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT);
                 logger.debug("Got HOST_UEFI_ENABLE [{}] for host [{}]:", uefiEnabled, host);
-                if (ObjectUtils.anyNotNull(uefiEnabled, virtv2vVersion, ovftoolVersion, vddkSupport, vddkLibDir, vddkVersion)) {
+                if (ObjectUtils.anyNotNull(uefiEnabled, virtv2vVersion, ovftoolVersion, vddkSupport, vddkLibDir, vddkVersion,
+                        virtv2vInPlaceSupport, qemuImgRbdSupport, rbdQemuCopySupport, vddkRbdDirectImportSupport)) {
                     _hostDao.loadDetails(host);
                     boolean updateNeeded = false;
                     if (StringUtils.isNotBlank(uefiEnabled) && !uefiEnabled.equals(host.getDetails().get(Host.HOST_UEFI_ENABLE))) {
@@ -842,6 +847,22 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                         } else {
                             host.getDetails().put(Host.HOST_VDDK_VERSION, vddkVersion);
                         }
+                        updateNeeded = true;
+                    }
+                    if (StringUtils.isNotBlank(virtv2vInPlaceSupport) && !virtv2vInPlaceSupport.equals(host.getDetails().get(Host.HOST_VIRTV2V_INPLACE_SUPPORT))) {
+                        host.getDetails().put(Host.HOST_VIRTV2V_INPLACE_SUPPORT, virtv2vInPlaceSupport);
+                        updateNeeded = true;
+                    }
+                    if (StringUtils.isNotBlank(qemuImgRbdSupport) && !qemuImgRbdSupport.equals(host.getDetails().get(Host.HOST_QEMU_IMG_RBD_SUPPORT))) {
+                        host.getDetails().put(Host.HOST_QEMU_IMG_RBD_SUPPORT, qemuImgRbdSupport);
+                        updateNeeded = true;
+                    }
+                    if (StringUtils.isNotBlank(rbdQemuCopySupport) && !rbdQemuCopySupport.equals(host.getDetails().get(Host.HOST_RBD_QEMU_COPY_SUPPORT))) {
+                        host.getDetails().put(Host.HOST_RBD_QEMU_COPY_SUPPORT, rbdQemuCopySupport);
+                        updateNeeded = true;
+                    }
+                    if (StringUtils.isNotBlank(vddkRbdDirectImportSupport) && !vddkRbdDirectImportSupport.equals(host.getDetails().get(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT))) {
+                        host.getDetails().put(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT, vddkRbdDirectImportSupport);
                         updateNeeded = true;
                     }
                     if (updateNeeded) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -18,9 +18,13 @@ package com.cloud.hypervisor.kvm.resource;
 
 import static com.cloud.host.Host.HOST_INSTANCE_CONVERSION;
 import static com.cloud.host.Host.HOST_OVFTOOL_VERSION;
+import static com.cloud.host.Host.HOST_QEMU_IMG_RBD_SUPPORT;
+import static com.cloud.host.Host.HOST_RBD_QEMU_COPY_SUPPORT;
+import static com.cloud.host.Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT;
 import static com.cloud.host.Host.HOST_VDDK_LIB_DIR;
 import static com.cloud.host.Host.HOST_VDDK_SUPPORT;
 import static com.cloud.host.Host.HOST_VDDK_VERSION;
+import static com.cloud.host.Host.HOST_VIRTV2V_INPLACE_SUPPORT;
 import static com.cloud.host.Host.HOST_VIRTV2V_VERSION;
 import static com.cloud.host.Host.HOST_VOLUME_ENCRYPTION;
 import static org.apache.cloudstack.utils.linux.KVMHostInfo.isHostS390x;
@@ -358,6 +362,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     public static final String TUNGSTEN_PATH = "scripts/vm/network/tungsten";
 
     public static final String INSTANCE_CONVERSION_SUPPORTED_CHECK_CMD = "virt-v2v --version";
+    public static final String INSTANCE_CONVERSION_IN_PLACE_BINARY_SUPPORTED_CHECK_CMD = "virt-v2v-in-place --version";
+    public static final String INSTANCE_CONVERSION_IN_PLACE_OPTION_SUPPORTED_CHECK_CMD = "virt-v2v --help 2>&1 | grep -q -- '--in-place'";
+    public static final String QEMU_IMG_RBD_SUPPORTED_CHECK_CMD = "qemu-img --help 2>&1 | grep -Eq '(^|[[:space:]])rbd([[:space:]]|$)'";
     // virt-v2v --version => sample output: virt-v2v 1.42.0rhel=8,release=22.module+el8.10.0+1590+a67ab969
     public static final String OVF_EXPORT_SUPPORTED_CHECK_CMD = "ovftool --version";
     // ovftool --version => sample output: VMware ovftool 4.6.0 (build-21452615)
@@ -4274,6 +4281,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         boolean instanceConversionSupported = hostSupportsInstanceConversion();
         cmd.getHostDetails().put(HOST_INSTANCE_CONVERSION, String.valueOf(instanceConversionSupported));
         cmd.getHostDetails().put(HOST_VDDK_SUPPORT, String.valueOf(hostSupportsVddk()));
+        cmd.getHostDetails().put(HOST_VIRTV2V_INPLACE_SUPPORT, String.valueOf(hostSupportsVirtV2vInPlace()));
+        cmd.getHostDetails().put(HOST_QEMU_IMG_RBD_SUPPORT, String.valueOf(hostSupportsQemuImgRbd()));
+        cmd.getHostDetails().put(HOST_RBD_QEMU_COPY_SUPPORT, String.valueOf(hostSupportsRbdQemuCopy()));
+        cmd.getHostDetails().put(HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT, String.valueOf(hostSupportsVddkRbdDirectImport()));
         if (StringUtils.isNotBlank(vddkLibDir)) {
             cmd.getHostDetails().put(HOST_VDDK_LIB_DIR, vddkLibDir);
         }
@@ -6008,6 +6019,34 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             effectiveVddkLibDir = detectVddkLibDir();
         }
         return hostSupportsInstanceConversion() && isVddkLibDirValid(effectiveVddkLibDir) && StringUtils.isNotBlank(detectVddkVersion());
+    }
+
+    public boolean hostSupportsVirtV2vInPlace() {
+        return hostSupportsVirtV2vInPlaceBinary() || hostSupportsVirtV2vInPlaceOption();
+    }
+
+    public boolean hostSupportsVirtV2vInPlaceBinary() {
+        return Script.runSimpleBashScriptForExitValue(INSTANCE_CONVERSION_IN_PLACE_BINARY_SUPPORTED_CHECK_CMD) == 0;
+    }
+
+    public boolean hostSupportsVirtV2vInPlaceOption() {
+        return Script.runSimpleBashScriptForExitValue(INSTANCE_CONVERSION_IN_PLACE_OPTION_SUPPORTED_CHECK_CMD) == 0;
+    }
+
+    public boolean hostSupportsQemuImgRbd() {
+        return Script.runSimpleBashScriptForExitValue(QEMU_IMG_RBD_SUPPORTED_CHECK_CMD) == 0;
+    }
+
+    public boolean hostSupportsRbdQemuCopy() {
+        return hostSupportsQemuImgRbd();
+    }
+
+    public boolean hostSupportsVddkRbdDirectImport() {
+        return hostSupportsVddkRbdDirectImport(null);
+    }
+
+    public boolean hostSupportsVddkRbdDirectImport(String overriddenVddkLibDir) {
+        return hostSupportsVddk(overriddenVddkLibDir) && hostSupportsQemuImgRbd() && hostSupportsVirtV2vInPlace();
     }
 
     protected boolean isVddkLibDirValid(String path) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckConvertInstanceCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckConvertInstanceCommandWrapper.java
@@ -31,6 +31,13 @@ public class LibvirtCheckConvertInstanceCommandWrapper extends CommandWrapper<Ch
     @Override
     public Answer execute(CheckConvertInstanceCommand cmd, LibvirtComputingResource serverResource) {
         if (cmd.isUseVddk()) {
+            if (cmd.isCheckVddkRbdDirectImportSupport() && !serverResource.hostSupportsVddkRbdDirectImport(cmd.getVddkLibDir())) {
+                String msg = String.format("Cannot directly import VMware disks to RBD on host %s. Direct RBD VDDK import requires VDDK, qemu-img RBD support, and in-place virt-v2v support. " +
+                                "Use staged import with temporary conversion storage on this host, or select an EL9/Ubuntu 24.04-like conversion host with virt-v2v-in-place support.",
+                        serverResource.getPrivateIp());
+                logger.info(msg);
+                return new CheckConvertInstanceAnswer(cmd, false, msg);
+            }
             if (!serverResource.hostSupportsVddk(cmd.getVddkLibDir())) {
                 String msg = String.format("Cannot convert the instance from VMware using VDDK on host %s. " +
                                 "Please make sure virt-v2v%s, nbdkit-vddk and a valid VDDK library directory are available on the host.",

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapper.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Arrays;
 import java.util.List;
@@ -42,14 +43,18 @@ import com.cloud.agent.api.ConvertInstanceCommand;
 import com.cloud.agent.api.to.DataStoreTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.RemoteInstanceTO;
+import com.cloud.agent.api.to.VmwareVddkSourceDiskTO;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef;
+import com.cloud.hypervisor.kvm.storage.KVMPhysicalDisk;
 import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
 import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
+import com.cloud.storage.Storage;
 import com.cloud.utils.FileUtil;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.Script;
 
@@ -89,6 +94,7 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
 
         final KVMStoragePoolManager storagePoolMgr = serverResource.getStoragePoolMgr();
         KVMStoragePool temporaryStoragePool = getTemporaryStoragePool(conversionTemporaryLocation, storagePoolMgr);
+        boolean directRbdVddkImport = isDirectRbdVddkImport(cmd);
 
         logger.info(String.format("(%s) Attempting to convert the instance %s from %s to KVM",
                 originalVMName, sourceInstanceName, sourceHypervisorType));
@@ -114,9 +120,21 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
                 String vddkTransports = resolveVddkSetting(cmd.getVddkTransports(), serverResource.getVddkTransports());
                 String configuredVddkThumbprint = resolveVddkSetting(cmd.getVddkThumbprint(), serverResource.getVddkThumbprint());
                 String passwordOption = serverResource.getDetectedPasswordFileOption();
-                result = performInstanceConversionUsingVddk(sourceInstance, originalVMName, temporaryConvertPath,
-                        vddkLibDir, serverResource.getLibguestfsBackend(), vddkTransports, configuredVddkThumbprint,
-                        timeout, verboseModeEnabled, extraParams, temporaryConvertUuid, passwordOption);
+                if (directRbdVddkImport) {
+                    if (!serverResource.hostSupportsVddkRbdDirectImport(cmd.getVddkLibDir())) {
+                        String err = String.format("Direct RBD VDDK import requires VDDK, qemu-img RBD support, and virt-v2v in-place support on host %s. " +
+                                "Use staged import with temporary conversion storage or select a newer conversion host.", serverResource.getPrivateIp());
+                        logger.error("({}) {}", originalVMName, err);
+                        return new Answer(cmd, false, err);
+                    }
+                    result = performInstanceConversionUsingVddkDirectToRbd(cmd, temporaryStoragePool, originalVMName,
+                            vddkLibDir, serverResource.getLibguestfsBackend(), vddkTransports, configuredVddkThumbprint,
+                            timeout, verboseModeEnabled, temporaryConvertUuid, serverResource);
+                } else {
+                    result = performInstanceConversionUsingVddk(sourceInstance, originalVMName, temporaryConvertPath,
+                            vddkLibDir, serverResource.getLibguestfsBackend(), vddkTransports, configuredVddkThumbprint,
+                            timeout, verboseModeEnabled, extraParams, temporaryConvertUuid, passwordOption);
+                }
             } else {
                 logger.info("({}) Using OVF-based conversion (export + local convert)", originalVMName);
                 String sourceOVFDirPath;
@@ -175,6 +193,12 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
                 storagePoolMgr.deleteStoragePool(temporaryStoragePool.getType(), temporaryStoragePool.getUuid());
             }
         }
+    }
+
+    private boolean isDirectRbdVddkImport(ConvertInstanceCommand cmd) {
+        DataStoreTO conversionTemporaryLocation = cmd.getConversionTemporaryLocation();
+        return cmd.isUseVddk() && conversionTemporaryLocation instanceof PrimaryDataStoreTO &&
+                ((PrimaryDataStoreTO) conversionTemporaryLocation).getPoolType() == Storage.StoragePoolType.RBD;
     }
 
     protected KVMStoragePool getTemporaryStoragePool(DataStoreTO conversionTemporaryLocation, KVMStoragePoolManager storagePoolMgr) {
@@ -397,6 +421,249 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
                 logger.warn("({}) Failed to delete password file {}: {}", originalVMName, passwordFilePath, e.getMessage());
             }
         }
+    }
+
+    protected boolean performInstanceConversionUsingVddkDirectToRbd(ConvertInstanceCommand cmd,
+                                                                    KVMStoragePool targetPool,
+                                                                    String originalVMName,
+                                                                    String vddkLibDir,
+                                                                    String libguestfsBackend,
+                                                                    String vddkTransports,
+                                                                    String configuredVddkThumbprint,
+                                                                    long timeout,
+                                                                    boolean verboseModeEnabled,
+                                                                    String temporaryConvertUuid,
+                                                                    LibvirtComputingResource serverResource) {
+        RemoteInstanceTO vmwareInstance = cmd.getSourceInstance();
+        List<VmwareVddkSourceDiskTO> sourceDisks = cmd.getVmwareVddkSourceDisks();
+        if (sourceDisks == null || sourceDisks.isEmpty()) {
+            logger.error("({}) Direct RBD VDDK import requires VMware source disk metadata", originalVMName);
+            return false;
+        }
+
+        probeRbdQemuAccess(targetPool, temporaryConvertUuid);
+
+        String vcenterPassword = vmwareInstance.getVcenterPassword();
+        if (StringUtils.isBlank(vcenterPassword)) {
+            logger.error("({}) Could not determine vCenter password for {}", originalVMName, vmwareInstance.getVcenterHost());
+            return false;
+        }
+
+        String vddkThumbprint = StringUtils.trimToNull(configuredVddkThumbprint);
+        if (StringUtils.isBlank(vddkThumbprint)) {
+            vddkThumbprint = getVcenterThumbprint(vmwareInstance.getVcenterHost(), timeout, originalVMName);
+        }
+        if (StringUtils.isBlank(vddkThumbprint)) {
+            logger.error("({}) Could not determine vCenter thumbprint for {}", originalVMName, vmwareInstance.getVcenterHost());
+            return false;
+        }
+
+        String passwordFilePath = String.format("/tmp/v2v.rbd.pass.cloud.%s.%s",
+                StringUtils.defaultIfBlank(vmwareInstance.getVcenterHost(), "unknown"),
+                UUID.randomUUID());
+        List<String> createdImages = new ArrayList<>();
+        try {
+            Files.writeString(Path.of(passwordFilePath), vcenterPassword);
+            Files.setPosixFilePermissions(Path.of(passwordFilePath), Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+
+            for (int i = 0; i < sourceDisks.size(); i++) {
+                VmwareVddkSourceDiskTO sourceDisk = sourceDisks.get(i);
+                String imageName = buildRbdImageName(temporaryConvertUuid, i);
+                createdImages.add(imageName);
+                copyVddkSourceDiskToRbd(vmwareInstance, sourceDisk, targetPool, imageName, passwordFilePath,
+                        vddkLibDir, vddkTransports, vddkThumbprint, timeout, originalVMName);
+            }
+
+            Path inputXml = Files.createTempFile("cloudstack-vddk-rbd-" + temporaryConvertUuid, ".xml");
+            Path outputXml = Files.createTempFile("cloudstack-vddk-rbd-" + temporaryConvertUuid + "-out", ".xml");
+            Files.writeString(inputXml, buildDirectRbdLibvirtXml(temporaryConvertUuid, targetPool, createdImages));
+
+            boolean finalized = runInPlaceFinalization(inputXml, outputXml, libguestfsBackend, timeout, verboseModeEnabled, originalVMName, serverResource);
+            if (!finalized) {
+                cleanupRbdImages(targetPool, createdImages, originalVMName);
+            }
+            Files.deleteIfExists(inputXml);
+            Files.deleteIfExists(outputXml);
+            return finalized;
+        } catch (Exception e) {
+            logger.error("({}) Direct RBD VDDK import failed: {}", originalVMName, e.getMessage(), e);
+            cleanupRbdImages(targetPool, createdImages, originalVMName);
+            return false;
+        } finally {
+            try {
+                Files.deleteIfExists(Path.of(passwordFilePath));
+            } catch (Exception e) {
+                logger.warn("({}) Failed to delete password file {}: {}", originalVMName, passwordFilePath, e.getMessage());
+            }
+        }
+    }
+
+    private void copyVddkSourceDiskToRbd(RemoteInstanceTO vmwareInstance, VmwareVddkSourceDiskTO sourceDisk,
+                                         KVMStoragePool targetPool, String imageName, String passwordFilePath,
+                                         String vddkLibDir, String vddkTransports, String vddkThumbprint,
+                                         long timeout, String originalVMName) {
+        if (StringUtils.isBlank(sourceDisk.getSourceDiskPath())) {
+            throw new CloudRuntimeException(String.format("VMware source disk %s does not have a VMDK path", sourceDisk.getDiskId()));
+        }
+        String rbdImagePath = targetPool.getSourceDir() + "/" + imageName;
+        String qemuRbdTarget = KVMPhysicalDisk.RBDStringBuilder(targetPool, rbdImagePath);
+        StringBuilder command = new StringBuilder();
+        command.append("nbdkit -r -U - vddk ");
+        command.append("file=").append(shellQuote(sourceDisk.getSourceDiskPath())).append(" ");
+        command.append("server=").append(shellQuote(vmwareInstance.getVcenterHost())).append(" ");
+        command.append("user=").append(shellQuote(vmwareInstance.getVcenterUsername())).append(" ");
+        command.append("password=+").append(shellQuote(passwordFilePath)).append(" ");
+        if (StringUtils.isNotBlank(vmwareInstance.getVmwareMoref())) {
+            command.append("vm=").append(shellQuote("moref=" + vmwareInstance.getVmwareMoref())).append(" ");
+        } else {
+            command.append("vm=").append(shellQuote(vmwareInstance.getInstanceName())).append(" ");
+        }
+        command.append("libdir=").append(shellQuote(vddkLibDir)).append(" ");
+        command.append("thumbprint=").append(shellQuote(vddkThumbprint)).append(" ");
+        if (StringUtils.isNotBlank(vddkTransports)) {
+            command.append("transports=").append(shellQuote(vddkTransports)).append(" ");
+        }
+        String runCommand = "qemu-img convert -f raw -O raw \"$uri\" " + shellQuote(qemuRbdTarget);
+        command.append("--run ").append(shellQuote(runCommand));
+
+        Script script = new Script("/bin/bash", timeout, logger);
+        script.add("-c");
+        script.add(command.toString());
+        String logPrefix = String.format("(%s) vddk to rbd disk %s", originalVMName, sourceDisk.getDiskId());
+        OutputInterpreter.LineByLineOutputLogger outputLogger = new OutputInterpreter.LineByLineOutputLogger(logger, logPrefix);
+        logger.info("({}) Copying VMware disk {} to RBD image {}", originalVMName, sourceDisk.getSourceDiskPath(), rbdImagePath);
+        script.execute(outputLogger);
+        if (script.getExitValue() != 0) {
+            throw new CloudRuntimeException(String.format("Failed to copy VMware disk %s to RBD image %s", sourceDisk.getSourceDiskPath(), rbdImagePath));
+        }
+    }
+
+    private boolean runInPlaceFinalization(Path inputXml, Path outputXml, String libguestfsBackend, long timeout,
+                                           boolean verboseModeEnabled, String originalVMName,
+                                           LibvirtComputingResource serverResource) {
+        StringBuilder command = new StringBuilder();
+        command.append("export LIBGUESTFS_BACKEND=").append(shellQuote(libguestfsBackend)).append(" && ");
+        if (serverResource.hostSupportsVirtV2vInPlaceBinary()) {
+            command.append("virt-v2v-in-place --root first -i libvirtxml ")
+                    .append(shellQuote(inputXml.toString())).append(" -O ")
+                    .append(shellQuote(outputXml.toString())).append(" ");
+        } else if (serverResource.hostSupportsVirtV2vInPlaceOption()) {
+            command.append("virt-v2v --root first -i libvirtxml ")
+                    .append(shellQuote(inputXml.toString())).append(" --in-place ");
+        } else {
+            logger.error("({}) No virt-v2v in-place finalization method is available", originalVMName);
+            return false;
+        }
+        if (verboseModeEnabled) {
+            command.append("-v ");
+        }
+
+        Script script = new Script("/bin/bash", timeout, logger);
+        script.add("-c");
+        script.add(command.toString());
+        OutputInterpreter.LineByLineOutputLogger outputLogger = new OutputInterpreter.LineByLineOutputLogger(logger,
+                String.format("(%s) virt-v2v rbd in-place", originalVMName));
+        script.execute(outputLogger);
+        return script.getExitValue() == 0;
+    }
+
+    private String buildDirectRbdLibvirtXml(String temporaryConvertUuid, KVMStoragePool targetPool, List<String> imageNames) {
+        StringBuilder xml = new StringBuilder();
+        xml.append("<domain type='kvm'>\n");
+        xml.append("  <name>").append(xmlEscape("cloudstack-vddk-rbd-" + temporaryConvertUuid)).append("</name>\n");
+        xml.append("  <memory unit='KiB'>1048576</memory>\n");
+        xml.append("  <vcpu>1</vcpu>\n");
+        xml.append("  <os><type>hvm</type><boot dev='hd'/></os>\n");
+        xml.append("  <devices>\n");
+        for (int i = 0; i < imageNames.size(); i++) {
+            String imageName = imageNames.get(i);
+            xml.append("    <disk type='network' device='disk'>\n");
+            xml.append("      <driver name='qemu' type='raw'/>\n");
+            xml.append("      <source protocol='rbd' name='").append(xmlEscape(targetPool.getSourceDir() + "/" + imageName)).append("'>\n");
+            for (String sourceHost : StringUtils.split(StringUtils.defaultString(targetPool.getSourceHost()), ",")) {
+                xml.append("        <host name='").append(xmlEscape(sourceHost.replace("[", "").replace("]", ""))).append("'");
+                if (targetPool.getSourcePort() != 0) {
+                    xml.append(" port='").append(targetPool.getSourcePort()).append("'");
+                }
+                xml.append("/>\n");
+            }
+            xml.append("      </source>\n");
+            if (StringUtils.isNotBlank(targetPool.getAuthUserName())) {
+                xml.append("      <auth username='").append(xmlEscape(targetPool.getAuthUserName())).append("'>\n");
+                xml.append("        <secret type='ceph' uuid='").append(xmlEscape(targetPool.getUuid())).append("'/>\n");
+                xml.append("      </auth>\n");
+            }
+            xml.append("      <target dev='").append(diskTargetName(i)).append("' bus='scsi'/>\n");
+            xml.append("    </disk>\n");
+        }
+        xml.append("  </devices>\n");
+        xml.append("</domain>\n");
+        return xml.toString();
+    }
+
+    private String buildRbdImageName(String temporaryConvertUuid, int position) {
+        return String.format("%s-disk-%03d", temporaryConvertUuid, position);
+    }
+
+    private String diskTargetName(int index) {
+        StringBuilder target = new StringBuilder("sd");
+        int value = index;
+        do {
+            target.insert(2, (char) ('a' + (value % 26)));
+            value = value / 26 - 1;
+        } while (value >= 0);
+        return target.toString();
+    }
+
+    private void probeRbdQemuAccess(KVMStoragePool pool, String temporaryConvertUuid) {
+        String probeName = temporaryConvertUuid + "-probe-" + UUID.randomUUID();
+        String rbdImagePath = pool.getSourceDir() + "/" + probeName;
+        String qemuRbdPath = KVMPhysicalDisk.RBDStringBuilder(pool, rbdImagePath);
+        try {
+            Script qemuImg = new Script("qemu-img", 120000, logger);
+            qemuImg.add("create", "-f", "raw", qemuRbdPath, "4194304");
+            qemuImg.execute();
+            if (qemuImg.getExitValue() != 0) {
+                throw new CloudRuntimeException(String.format("qemu-img could not create RBD probe image %s", rbdImagePath));
+            }
+
+            Script qemuIo = new Script("qemu-io", 120000, logger);
+            qemuIo.add("-f", "raw", "-c", "write -P 0x5a 0 4k", "-c", "read -P 0x5a 0 4k", qemuRbdPath);
+            qemuIo.execute();
+            if (qemuIo.getExitValue() != 0) {
+                throw new CloudRuntimeException(String.format("qemu-io could not verify RBD probe image %s", rbdImagePath));
+            }
+        } finally {
+            try {
+                pool.deletePhysicalDisk(probeName, Storage.ImageFormat.RAW);
+            } catch (Exception e) {
+                logger.warn("Failed to delete RBD probe image {} from pool {}: {}", probeName, pool.getUuid(), e.getMessage());
+            }
+        }
+    }
+
+    private void cleanupRbdImages(KVMStoragePool pool, List<String> imageNames, String originalVMName) {
+        for (String imageName : imageNames) {
+            try {
+                logger.info("({}) Cleaning up RBD image {} after failed direct import", originalVMName, imageName);
+                pool.deletePhysicalDisk(imageName, Storage.ImageFormat.RAW);
+            } catch (Exception e) {
+                logger.warn("({}) Failed to delete RBD image {} from pool {}: {}", originalVMName, imageName, pool.getUuid(), e.getMessage());
+            }
+        }
+    }
+
+    private String shellQuote(String value) {
+        return "'" + StringUtils.defaultString(value).replace("'", "'\"'\"'") + "'";
+    }
+
+    private String xmlEscape(String value) {
+        return StringUtils.defaultString(value)
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
     protected String getVcenterThumbprint(String vcenterHost, long timeout, String originalVMName) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtImportConvertedInstanceCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtImportConvertedInstanceCommandWrapper.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -65,6 +66,7 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
         Hypervisor.HypervisorType sourceHypervisorType = sourceInstance.getHypervisorType();
         String sourceInstanceName = sourceInstance.getInstanceName();
         List<String> destinationStoragePools = cmd.getDestinationStoragePools();
+        List<Storage.StoragePoolType> destinationStoragePoolTypes = cmd.getDestinationStoragePoolTypes();
         DataStoreTO conversionTemporaryLocation = cmd.getConversionTemporaryLocation();
         final String temporaryConvertUuid = cmd.getTemporaryConvertUuid();
         final boolean forceConvertToPool = cmd.isForceConvertToPool();
@@ -74,6 +76,12 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
         final String temporaryConvertPath = temporaryStoragePool.getLocalPath();
 
         try {
+            if (isForcedRbdConversion(conversionTemporaryLocation, forceConvertToPool)) {
+                List<KVMPhysicalDisk> disks = getTemporaryDisksWithPrefixFromTemporaryPool(temporaryStoragePool, temporaryConvertPath, temporaryConvertUuid);
+                UnmanagedInstanceTO convertedInstanceTO = getConvertedUnmanagedInstance(temporaryConvertUuid, disks, null);
+                return new ImportConvertedInstanceAnswer(cmd, convertedInstanceTO);
+            }
+
             String convertedBasePath = String.format("%s/%s", temporaryConvertPath, temporaryConvertUuid);
             LibvirtDomainXMLParser xmlParser = parseMigratedVMXmlDomain(convertedBasePath);
 
@@ -87,7 +95,7 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
                 disks = temporaryDisks;
             } else {
                 disks = moveTemporaryDisksToDestination(temporaryDisks,
-                        destinationStoragePools, storagePoolMgr);
+                        destinationStoragePools, destinationStoragePoolTypes, storagePoolMgr);
                 cleanupDisksAndDomainFromTemporaryLocation(temporaryDisks, temporaryStoragePool, temporaryConvertUuid);
             }
 
@@ -105,6 +113,11 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
                 storagePoolMgr.deleteStoragePool(temporaryStoragePool.getType(), temporaryStoragePool.getUuid());
             }
         }
+    }
+
+    private boolean isForcedRbdConversion(DataStoreTO conversionTemporaryLocation, boolean forceConvertToPool) {
+        return forceConvertToPool && conversionTemporaryLocation instanceof PrimaryDataStoreTO &&
+                ((PrimaryDataStoreTO) conversionTemporaryLocation).getPoolType() == Storage.StoragePoolType.RBD;
     }
 
     protected KVMStoragePool getTemporaryStoragePool(DataStoreTO conversionTemporaryLocation, KVMStoragePoolManager storagePoolMgr) {
@@ -146,6 +159,7 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
         List<KVMPhysicalDisk> disksWithPrefix = pool.listPhysicalDisks()
                 .stream()
                 .filter(x -> x.getName().startsWith(prefix) && !x.getName().endsWith(".xml"))
+                .sorted(Comparator.comparing(KVMPhysicalDisk::getName))
                 .collect(Collectors.toList());
         if (CollectionUtils.isEmpty(disksWithPrefix)) {
             msg = String.format("Could not find any converted disk with prefix %s on temporary location %s", prefix, path);
@@ -177,6 +191,13 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
     protected List<KVMPhysicalDisk> moveTemporaryDisksToDestination(List<KVMPhysicalDisk> temporaryDisks,
                                                                     List<String> destinationStoragePools,
                                                                     KVMStoragePoolManager storagePoolMgr) {
+        return moveTemporaryDisksToDestination(temporaryDisks, destinationStoragePools, null, storagePoolMgr);
+    }
+
+    protected List<KVMPhysicalDisk> moveTemporaryDisksToDestination(List<KVMPhysicalDisk> temporaryDisks,
+                                                                    List<String> destinationStoragePools,
+                                                                    List<Storage.StoragePoolType> destinationStoragePoolTypes,
+                                                                    KVMStoragePoolManager storagePoolMgr) {
         List<KVMPhysicalDisk> targetDisks = new ArrayList<>();
         if (temporaryDisks.size() != destinationStoragePools.size()) {
             String warn = String.format("Discrepancy between the converted instance disks (%s) " +
@@ -185,16 +206,12 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
         }
         for (int i = 0; i < temporaryDisks.size(); i++) {
             String poolPath = destinationStoragePools.get(i);
-            KVMStoragePool destinationPool = storagePoolMgr.getStoragePool(Storage.StoragePoolType.NetworkFilesystem, poolPath);
+            Storage.StoragePoolType poolType = getDestinationStoragePoolType(destinationStoragePoolTypes, i);
+            KVMStoragePool destinationPool = storagePoolMgr.getStoragePool(poolType, poolPath);
             if (destinationPool == null) {
                 String err = String.format("Could not find a storage pool by URI: %s", poolPath);
                 logger.error(err);
-                continue;
-            }
-            if (destinationPool.getType() != Storage.StoragePoolType.NetworkFilesystem) {
-                String err = String.format("Storage pool by URI: %s is not an NFS storage", poolPath);
-                logger.error(err);
-                continue;
+                throw new CloudRuntimeException(err);
             }
             KVMPhysicalDisk sourceDisk = temporaryDisks.get(i);
             if (logger.isDebugEnabled()) {
@@ -204,11 +221,48 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
             }
 
             String destinationName = UUID.randomUUID().toString();
+            if (destinationPool.getType() == Storage.StoragePoolType.RBD) {
+                probeRbdQemuAccess(destinationPool, destinationName);
+            }
 
             KVMPhysicalDisk destinationDisk = storagePoolMgr.copyPhysicalDisk(sourceDisk, destinationName, destinationPool, 7200 * 1000);
             targetDisks.add(destinationDisk);
         }
         return targetDisks;
+    }
+
+    private Storage.StoragePoolType getDestinationStoragePoolType(List<Storage.StoragePoolType> destinationStoragePoolTypes, int index) {
+        if (CollectionUtils.isEmpty(destinationStoragePoolTypes) || destinationStoragePoolTypes.size() <= index || destinationStoragePoolTypes.get(index) == null) {
+            return Storage.StoragePoolType.NetworkFilesystem;
+        }
+        return destinationStoragePoolTypes.get(index);
+    }
+
+    private void probeRbdQemuAccess(KVMStoragePool pool, String destinationName) {
+        String probeName = destinationName + "-probe";
+        String rbdImagePath = pool.getSourceDir() + "/" + probeName;
+        String qemuRbdPath = KVMPhysicalDisk.RBDStringBuilder(pool, rbdImagePath);
+        try {
+            Script qemuImg = new Script("qemu-img", 120000, logger);
+            qemuImg.add("create", "-f", "raw", qemuRbdPath, "4194304");
+            qemuImg.execute();
+            if (qemuImg.getExitValue() != 0) {
+                throw new CloudRuntimeException(String.format("qemu-img could not create RBD probe image %s", rbdImagePath));
+            }
+
+            Script qemuIo = new Script("qemu-io", 120000, logger);
+            qemuIo.add("-f", "raw", "-c", "write -P 0x5a 0 4k", "-c", "read -P 0x5a 0 4k", qemuRbdPath);
+            qemuIo.execute();
+            if (qemuIo.getExitValue() != 0) {
+                throw new CloudRuntimeException(String.format("qemu-io could not verify RBD probe image %s", rbdImagePath));
+            }
+        } finally {
+            try {
+                pool.deletePhysicalDisk(probeName, Storage.ImageFormat.RAW);
+            } catch (Exception e) {
+                logger.warn("Failed to delete RBD probe image {} from pool {}: {}", probeName, pool.getUuid(), e.getMessage());
+            }
+        }
     }
 
     private UnmanagedInstanceTO getConvertedUnmanagedInstance(String baseName,
@@ -244,9 +298,15 @@ public class LibvirtImportConvertedInstanceCommandWrapper extends CommandWrapper
             KVMStoragePool storagePool = physicalDisk.getPool();
             UnmanagedInstanceTO.Disk disk = new UnmanagedInstanceTO.Disk();
             disk.setPosition(i);
-            Pair<String, String> storagePoolHostAndPath = getNfsStoragePoolHostAndPath(storagePool);
-            disk.setDatastoreHost(storagePoolHostAndPath.first());
-            disk.setDatastorePath(storagePoolHostAndPath.second());
+            if (storagePool.getType() == Storage.StoragePoolType.RBD) {
+                disk.setDatastoreHost(storagePool.getSourceHost());
+                disk.setDatastorePath(storagePool.getSourceDir());
+                disk.setImagePath(physicalDisk.getName());
+            } else {
+                Pair<String, String> storagePoolHostAndPath = getNfsStoragePoolHostAndPath(storagePool);
+                disk.setDatastoreHost(storagePoolHostAndPath.first());
+                disk.setDatastorePath(storagePoolHostAndPath.second());
+            }
             disk.setDatastoreName(storagePool.getUuid());
             disk.setDatastoreType(storagePool.getType().name());
             disk.setCapacity(physicalDisk.getVirtualSize());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -54,6 +54,10 @@ public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyComman
         hostDetails.put(Host.HOST_VDDK_SUPPORT, Boolean.toString(libvirtComputingResource.hostSupportsVddk()));
         hostDetails.put(Host.HOST_VDDK_LIB_DIR, StringUtils.defaultString(libvirtComputingResource.getVddkLibDir()));
         hostDetails.put(Host.HOST_VDDK_VERSION, StringUtils.defaultString(libvirtComputingResource.getVddkVersion()));
+        hostDetails.put(Host.HOST_VIRTV2V_INPLACE_SUPPORT, Boolean.toString(libvirtComputingResource.hostSupportsVirtV2vInPlace()));
+        hostDetails.put(Host.HOST_QEMU_IMG_RBD_SUPPORT, Boolean.toString(libvirtComputingResource.hostSupportsQemuImgRbd()));
+        hostDetails.put(Host.HOST_RBD_QEMU_COPY_SUPPORT, Boolean.toString(libvirtComputingResource.hostSupportsRbdQemuCopy()));
+        hostDetails.put(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT, Boolean.toString(libvirtComputingResource.hostSupportsVddkRbdDirectImport()));
 
         if (libvirtComputingResource.hostSupportsOvfExport()) {
             hostDetails.put(Host.HOST_OVFTOOL_VERSION, libvirtComputingResource.getHostOvfToolVersion());

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckConvertInstanceCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckConvertInstanceCommandWrapperTest.java
@@ -79,6 +79,32 @@ public class LibvirtCheckConvertInstanceCommandWrapperTest {
     }
 
     @Test
+    public void testCheckInstanceCommand_vddkDirectRbdSuccess() {
+        Mockito.when(checkConvertInstanceCommandMock.isUseVddk()).thenReturn(true);
+        Mockito.when(checkConvertInstanceCommandMock.isCheckVddkRbdDirectImportSupport()).thenReturn(true);
+        Mockito.when(checkConvertInstanceCommandMock.getVddkLibDir()).thenReturn("/opt/vmware-vddk/vmware-vix-disklib-distrib");
+        Mockito.when(libvirtComputingResourceMock.hostSupportsVddkRbdDirectImport("/opt/vmware-vddk/vmware-vix-disklib-distrib")).thenReturn(true);
+        Mockito.when(libvirtComputingResourceMock.hostSupportsVddk("/opt/vmware-vddk/vmware-vix-disklib-distrib")).thenReturn(true);
+
+        Answer answer = checkConvertInstanceCommandWrapper.execute(checkConvertInstanceCommandMock, libvirtComputingResourceMock);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testCheckInstanceCommand_vddkDirectRbdFailure() {
+        Mockito.when(checkConvertInstanceCommandMock.isUseVddk()).thenReturn(true);
+        Mockito.when(checkConvertInstanceCommandMock.isCheckVddkRbdDirectImportSupport()).thenReturn(true);
+        Mockito.when(checkConvertInstanceCommandMock.getVddkLibDir()).thenReturn("/opt/vmware-vddk/vmware-vix-disklib-distrib");
+        Mockito.when(libvirtComputingResourceMock.hostSupportsVddkRbdDirectImport("/opt/vmware-vddk/vmware-vix-disklib-distrib")).thenReturn(false);
+
+        Answer answer = checkConvertInstanceCommandWrapper.execute(checkConvertInstanceCommandMock, libvirtComputingResourceMock);
+
+        assertFalse(answer.getResult());
+        assertTrue(StringUtils.isNotBlank(answer.getDetails()));
+    }
+
+    @Test
     public void testCheckInstanceCommand_vddkFailure() {
         Mockito.when(checkConvertInstanceCommandMock.isUseVddk()).thenReturn(true);
         Mockito.when(checkConvertInstanceCommandMock.getVddkLibDir()).thenReturn("/opt/vmware-vddk/vmware-vix-disklib-distrib");

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapperTest.java
@@ -44,6 +44,7 @@ import com.cloud.hypervisor.kvm.resource.LibvirtVMDef;
 import com.cloud.hypervisor.kvm.storage.KVMPhysicalDisk;
 import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
 import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
+import com.cloud.storage.Storage;
 import com.cloud.utils.script.Script;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -149,6 +150,26 @@ public class LibvirtConvertInstanceCommandWrapperTest {
         ConvertInstanceCommand cmd = getConvertInstanceCommand(remoteInstanceTO, Hypervisor.HypervisorType.KVM, true);
         Answer answer = convertInstanceCommandWrapper.execute(cmd, libvirtComputingResourceMock);
         Assert.assertFalse(answer.getResult());
+    }
+
+    @Test
+    public void testExecuteDirectRbdVddkFailsWhenHostLacksDirectRbdSupport() {
+        RemoteInstanceTO remoteInstanceTO = getRemoteInstanceTO(Hypervisor.HypervisorType.VMware);
+        ConvertInstanceCommand cmd = getConvertInstanceCommand(remoteInstanceTO, Hypervisor.HypervisorType.KVM, false);
+        Mockito.when(cmd.isUseVddk()).thenReturn(true);
+        Mockito.when(cmd.getVddkLibDir()).thenReturn("/opt/vddk");
+        Mockito.when(cmd.getConversionTemporaryLocation()).thenReturn(primaryDataStore);
+        Mockito.when(primaryDataStore.getPoolType()).thenReturn(Storage.StoragePoolType.RBD);
+        Mockito.when(primaryDataStore.getUuid()).thenReturn("rbd-pool-uuid");
+        Mockito.when(storagePoolManager.getStoragePool(Storage.StoragePoolType.RBD, "rbd-pool-uuid")).thenReturn(destinationPool);
+        Mockito.when(destinationPool.getLocalPath()).thenReturn("/rbd");
+        Mockito.when(libvirtComputingResourceMock.getVddkLibDir()).thenReturn("/opt/vddk");
+        Mockito.when(libvirtComputingResourceMock.hostSupportsVddkRbdDirectImport("/opt/vddk")).thenReturn(false);
+
+        Answer answer = convertInstanceCommandWrapper.execute(cmd, libvirtComputingResourceMock);
+
+        Assert.assertFalse(answer.getResult());
+        Assert.assertTrue(answer.getDetails().contains("Direct RBD VDDK import requires"));
     }
 
     @Test

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtImportConvertedInstanceCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtImportConvertedInstanceCommandWrapperTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Spy;
@@ -168,6 +169,40 @@ public class LibvirtImportConvertedInstanceCommandWrapperTest {
     }
 
     @Test
+    public void testMoveTemporaryDisksToRbdDestinationUsesDestinationPoolType() {
+        KVMPhysicalDisk sourceDisk = Mockito.mock(KVMPhysicalDisk.class);
+        Mockito.lenient().when(sourceDisk.getPool()).thenReturn(temporaryPool);
+        List<KVMPhysicalDisk> disks = List.of(sourceDisk);
+        String destinationPoolUuid = UUID.randomUUID().toString();
+        List<String> destinationPools = List.of(destinationPoolUuid);
+        List<Storage.StoragePoolType> destinationPoolTypes = List.of(Storage.StoragePoolType.RBD);
+
+        KVMPhysicalDisk destDisk = Mockito.mock(KVMPhysicalDisk.class);
+        Mockito.when(destDisk.getPath()).thenReturn("rbd/image");
+        Mockito.when(storagePoolManager.getStoragePool(Storage.StoragePoolType.RBD, destinationPoolUuid))
+                .thenReturn(destinationPool);
+        Mockito.when(destinationPool.getType()).thenReturn(Storage.StoragePoolType.RBD);
+        Mockito.when(destinationPool.getSourceDir()).thenReturn("cloudstack");
+        Mockito.when(destinationPool.getSourceHost()).thenReturn("10.0.0.1,10.0.0.2");
+        Mockito.when(destinationPool.getSourcePort()).thenReturn(6789);
+        Mockito.when(storagePoolManager.copyPhysicalDisk(Mockito.eq(sourceDisk), Mockito.anyString(), Mockito.eq(destinationPool), Mockito.anyInt()))
+                .thenReturn(destDisk);
+
+        try (MockedConstruction<Script> ignored = Mockito.mockConstruction(Script.class, (mock, context) -> {
+            Mockito.when(mock.execute()).thenReturn("");
+            Mockito.when(mock.getExitValue()).thenReturn(0);
+        })) {
+            List<KVMPhysicalDisk> movedDisks = importInstanceCommandWrapper.moveTemporaryDisksToDestination(disks,
+                    destinationPools, destinationPoolTypes, storagePoolManager);
+
+            Assert.assertEquals(1, movedDisks.size());
+            Assert.assertEquals("rbd/image", movedDisks.get(0).getPath());
+            Mockito.verify(storagePoolManager).getStoragePool(Storage.StoragePoolType.RBD, destinationPoolUuid);
+            Mockito.verify(destinationPool).deletePhysicalDisk(Mockito.endsWith("-probe"), Mockito.eq(Storage.ImageFormat.RAW));
+        }
+    }
+
+    @Test
     public void testGetUnmanagedInstanceDisks() {
         try (MockedStatic<Script> ignored = Mockito.mockStatic(Script.class)) {
             String relativePath = UUID.randomUUID().toString();
@@ -194,6 +229,31 @@ public class LibvirtImportConvertedInstanceCommandWrapperTest {
             UnmanagedInstanceTO.Disk disk = unmanagedInstanceDisks.get(0);
             Assert.assertEquals(LibvirtVMDef.DiskDef.DiskBus.IDE.toString(), disk.getController());
         }
+    }
+
+    @Test
+    public void testGetUnmanagedInstanceDisksForRbdDoesNotParseNfsMount() {
+        KVMPhysicalDisk sourceDisk = Mockito.mock(KVMPhysicalDisk.class);
+        Mockito.when(sourceDisk.getName()).thenReturn("rbd-image");
+        Mockito.when(sourceDisk.getVirtualSize()).thenReturn(5242880L);
+        Mockito.when(sourceDisk.getPool()).thenReturn(destinationPool);
+        Mockito.when(destinationPool.getType()).thenReturn(Storage.StoragePoolType.RBD);
+        Mockito.when(destinationPool.getUuid()).thenReturn("rbd-pool-uuid");
+        Mockito.when(destinationPool.getSourceHost()).thenReturn("10.0.0.1,10.0.0.2");
+        Mockito.when(destinationPool.getSourceDir()).thenReturn("cloudstack");
+
+        List<UnmanagedInstanceTO.Disk> unmanagedInstanceDisks = importInstanceCommandWrapper.getUnmanagedInstanceDisks(List.of(sourceDisk), null);
+
+        Assert.assertEquals(1, unmanagedInstanceDisks.size());
+        UnmanagedInstanceTO.Disk disk = unmanagedInstanceDisks.get(0);
+        Assert.assertEquals("rbd-image", disk.getFileBaseName());
+        Assert.assertEquals("rbd-image", disk.getImagePath());
+        Assert.assertEquals("rbd-pool-uuid", disk.getDatastoreName());
+        Assert.assertEquals(Storage.StoragePoolType.RBD.name(), disk.getDatastoreType());
+        Assert.assertEquals("10.0.0.1,10.0.0.2", disk.getDatastoreHost());
+        Assert.assertEquals("cloudstack", disk.getDatastorePath());
+        Assert.assertEquals(LibvirtVMDef.DiskDef.DiskBus.VIRTIO.toString(), disk.getController());
+        Mockito.verify(importInstanceCommandWrapper, Mockito.never()).getNfsStoragePoolHostAndPath(destinationPool);
     }
 
     @Test

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -1788,7 +1788,9 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             return userVm;
         } catch (CloudRuntimeException e) {
             logger.error(String.format("Error importing VM: %s", e.getMessage()), e);
-            importVmTasksManager.updateImportVMTaskErrorState(importVMTask, ImportVmTask.TaskState.Failed, e.getMessage());
+            if (importVMTask != null) {
+                importVmTasksManager.updateImportVMTaskErrorState(importVMTask, ImportVmTask.TaskState.Failed, e.getMessage());
+            }
             ActionEventUtils.onCompletedActionEvent(userId, owner.getId(), EventVO.LEVEL_ERROR, EventTypes.EVENT_VM_IMPORT,
                     cmd.getEventDescription(), null, null, 0);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -38,6 +38,7 @@ import com.cloud.agent.api.PrepareUnmanageVMInstanceCommand;
 import com.cloud.agent.api.to.DataStoreTO;
 import com.cloud.agent.api.to.RemoteInstanceTO;
 import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.agent.api.to.VmwareVddkSourceDiskTO;
 import com.cloud.configuration.Config;
 import com.cloud.configuration.Resource;
 import com.cloud.dc.DataCenter;
@@ -212,6 +213,11 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     private static final List<Storage.StoragePoolType> forceConvertToPoolAllowedTypes =
             Arrays.asList(Storage.StoragePoolType.NetworkFilesystem, Storage.StoragePoolType.Filesystem,
                     Storage.StoragePoolType.SharedMountPoint);
+    private static final List<Storage.StoragePoolType> vddkDirectConvertToPoolAllowedTypes =
+            Arrays.asList(Storage.StoragePoolType.NetworkFilesystem, Storage.StoragePoolType.Filesystem,
+                    Storage.StoragePoolType.SharedMountPoint, Storage.StoragePoolType.RBD);
+    private static final List<Storage.StoragePoolType> stagedConversionDestinationPoolTypes =
+            Arrays.asList(Storage.StoragePoolType.NetworkFilesystem, Storage.StoragePoolType.RBD);
     private static final String DETAIL_VDDK_TRANSPORTS = "vddk.transports";
     private static final String DETAIL_VDDK_THUMBPRINT = "vddk.thumbprint";
 
@@ -1679,8 +1685,12 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                             ApiConstants.FORCE_MS_TO_IMPORT_VM_FILES, ApiConstants.USE_VDDK));
         }
 
-        checkConversionStoragePool(convertStoragePoolId, forceConvertToPool);
-        validateSelectedConversionStoragePoolForVddk(useVddk, convertStoragePoolId, serviceOffering, dataDiskOfferingMap);
+        StoragePoolVO selectedConversionStoragePool = convertStoragePoolId == null ? null : primaryDataStoreDao.findById(convertStoragePoolId);
+        boolean directRbdVddkImport = useVddk && forceConvertToPool && selectedConversionStoragePool != null &&
+                selectedConversionStoragePool.getPoolType() == Storage.StoragePoolType.RBD;
+
+        checkConversionStoragePool(convertStoragePoolId, forceConvertToPool, useVddk);
+        validateSelectedConversionStoragePoolForVddk(useVddk, forceConvertToPool, convertStoragePoolId, serviceOffering, dataDiskOfferingMap);
 
         checkExtraParamsAllowed(extraParams);
 
@@ -1704,13 +1714,13 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         ImportVmTask importVMTask = null;
         List<Reserver> reservations = new ArrayList<>();
         try {
-            HostVO convertHost = selectKVMHostForConversionInCluster(destinationCluster, convertInstanceHostId, useVddk);
+            HostVO convertHost = selectKVMHostForConversionInCluster(destinationCluster, convertInstanceHostId, useVddk, directRbdVddkImport);
             HostVO importHost = (useVddk && importInstanceHostId == null)
                     ? convertHost
                     : selectKVMHostForImportingInCluster(destinationCluster, importInstanceHostId);
 
             boolean isOvfExportSupported = false;
-            CheckConvertInstanceAnswer conversionSupportAnswer = checkConversionSupportOnHost(convertHost, sourceVMName, false, useVddk, details);
+            CheckConvertInstanceAnswer conversionSupportAnswer = checkConversionSupportOnHost(convertHost, sourceVMName, false, useVddk, details, directRbdVddkImport);
             if (!useVddk) {
                 isOvfExportSupported = conversionSupportAnswer.isOvfExportSupported();
             }
@@ -1732,13 +1742,14 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             Pair<UnmanagedInstanceTO, Boolean> sourceInstanceDetails = getSourceVmwareUnmanagedInstance(vcenter, datacenterName, username, password, clusterName, sourceHostName, sourceVMName, serviceOffering);
             sourceVMwareInstance = sourceInstanceDetails.first();
             isClonedInstance = sourceInstanceDetails.second();
+            validateDirectRbdVddkSourceVm(directRbdVddkImport, sourceVMName, sourceVMwareInstance, isClonedInstance);
 
             // Ensure that the configured resource limits will not be exceeded before beginning the conversion process
             checkVmResourceLimitsForUnmanagedInstanceImport(owner, sourceVMwareInstance, serviceOffering, template, reservations);
 
             boolean isWindowsVm = sourceVMwareInstance.getOperatingSystem().toLowerCase().contains("windows");
             if (isWindowsVm) {
-                checkConversionSupportOnHost(convertHost, sourceVMName, true, useVddk, details);
+                checkConversionSupportOnHost(convertHost, sourceVMName, true, useVddk, details, directRbdVddkImport);
             }
 
             checkNetworkingBeforeConvertingVmwareInstance(zone, owner, displayName, hostName, sourceVMwareInstance, nicNetworkMap, nicIpAddressMap, forced);
@@ -1800,6 +1811,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
      * @throws CloudRuntimeException in case these requirements are not met
      */
     protected void checkConversionStoragePool(Long convertStoragePoolId, boolean forceConvertToPool) {
+        checkConversionStoragePool(convertStoragePoolId, forceConvertToPool, false);
+    }
+
+    protected void checkConversionStoragePool(Long convertStoragePoolId, boolean forceConvertToPool, boolean useVddk) {
         if (forceConvertToPool && convertStoragePoolId == null) {
             String msg = "The parameter forceconverttopool is set to true, but a primary storage pool has not been provided for conversion";
             logFailureAndThrowException(msg);
@@ -1809,16 +1824,26 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             if (selectedStoragePool == null) {
                 logFailureAndThrowException(String.format("Cannot find a storage pool with ID %s", convertStoragePoolId));
             }
-            if (forceConvertToPool && !forceConvertToPoolAllowedTypes.contains(selectedStoragePool.getPoolType())) {
+            List<Storage.StoragePoolType> allowedTypes = useVddk ? vddkDirectConvertToPoolAllowedTypes : forceConvertToPoolAllowedTypes;
+            if (forceConvertToPool && !allowedTypes.contains(selectedStoragePool.getPoolType())) {
                 logFailureAndThrowException(String.format("The selected storage pool %s does not support direct conversion " +
                         "as its type %s", selectedStoragePool.getName(), selectedStoragePool.getPoolType().name()));
+            }
+            if (forceConvertToPool && selectedStoragePool.getPoolType() == Storage.StoragePoolType.RBD && !useVddk) {
+                logFailureAndThrowException(String.format("The selected RBD storage pool %s can be used for direct conversion only with %s=true",
+                        selectedStoragePool.getName(), ApiConstants.USE_VDDK));
             }
         }
     }
 
     protected void validateSelectedConversionStoragePoolForVddk(boolean useVddk, Long convertStoragePoolId,
                                                                 ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap) {
-        if (!useVddk || convertStoragePoolId == null) {
+        validateSelectedConversionStoragePoolForVddk(useVddk, true, convertStoragePoolId, serviceOffering, dataDiskOfferingMap);
+    }
+
+    protected void validateSelectedConversionStoragePoolForVddk(boolean useVddk, boolean forceConvertToPool, Long convertStoragePoolId,
+                                                                ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap) {
+        if (!useVddk || !forceConvertToPool || convertStoragePoolId == null) {
             return;
         }
 
@@ -2018,6 +2043,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
     }
 
     HostVO selectKVMHostForConversionInCluster(Cluster destinationCluster, Long convertInstanceHostId, boolean useVddk) {
+        return selectKVMHostForConversionInCluster(destinationCluster, convertInstanceHostId, useVddk, false);
+    }
+
+    HostVO selectKVMHostForConversionInCluster(Cluster destinationCluster, Long convertInstanceHostId, boolean useVddk, boolean requireVddkRbdDirectImportSupport) {
         if (convertInstanceHostId != null) {
             HostVO selectedHost = hostDao.findById(convertInstanceHostId);
             String err = null;
@@ -2057,6 +2086,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                     hosts = vddkHosts;
                 }
             }
+            if (requireVddkRbdDirectImportSupport) {
+                List<HostVO> directRbdHosts = filterHostsWithVddkRbdDirectImportSupport(hosts);
+                hosts = directRbdHosts;
+            }
             if (CollectionUtils.isNotEmpty(hosts)) {
                 return hosts.get(new Random().nextInt(hosts.size()));
             }
@@ -2071,12 +2104,19 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                     hosts = vddkHosts;
                 }
             }
+            if (requireVddkRbdDirectImportSupport) {
+                List<HostVO> directRbdHosts = filterHostsWithVddkRbdDirectImportSupport(hosts);
+                hosts = directRbdHosts;
+            }
             if (CollectionUtils.isNotEmpty(hosts)) {
                 return hosts.get(new Random().nextInt(hosts.size()));
             }
         }
 
-        String err = useVddk
+        String err = requireVddkRbdDirectImportSupport
+                ? String.format("Could not find any suitable %s host in cluster %s with '%s' configured to perform direct RBD VDDK import",
+                        destinationCluster.getHypervisorType(), destinationCluster, Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT)
+                : useVddk
                 ? String.format("Could not find any suitable %s host in cluster %s with '%s' configured to perform the VDDK-based instance conversion",
                         destinationCluster.getHypervisorType(), destinationCluster, Host.HOST_VDDK_SUPPORT)
                 : String.format("Could not find any suitable %s host in cluster %s to perform the instance conversion",
@@ -2092,14 +2132,29 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }).collect(Collectors.toList());
     }
 
+    private List<HostVO> filterHostsWithVddkRbdDirectImportSupport(List<HostVO> hosts) {
+        return hosts.stream().filter(h -> {
+            hostDao.loadDetails(h);
+            return Boolean.parseBoolean(h.getDetail(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT));
+        }).collect(Collectors.toList());
+    }
+
     private CheckConvertInstanceAnswer checkConversionSupportOnHost(HostVO convertHost, String sourceVM,
                                                                     boolean checkWindowsGuestConversionSupport,
                                                                     boolean useVddk, Map<String, String> details) {
+        return checkConversionSupportOnHost(convertHost, sourceVM, checkWindowsGuestConversionSupport, useVddk, details, false);
+    }
+
+    private CheckConvertInstanceAnswer checkConversionSupportOnHost(HostVO convertHost, String sourceVM,
+                                                                    boolean checkWindowsGuestConversionSupport,
+                                                                    boolean useVddk, Map<String, String> details,
+                                                                    boolean checkVddkRbdDirectImportSupport) {
         logger.debug(String.format("Checking the %s%s conversion support on the host %s",
                 useVddk ? "VDDK " : "",
                 checkWindowsGuestConversionSupport ? "windows guest " : "",
                 convertHost));
         CheckConvertInstanceCommand cmd = new CheckConvertInstanceCommand(checkWindowsGuestConversionSupport, useVddk);
+        cmd.setCheckVddkRbdDirectImportSupport(checkVddkRbdDirectImportSupport);
         if (MapUtils.isNotEmpty(details)) {
             cmd.setVddkLibDir(StringUtils.trimToNull(details.get(Host.HOST_VDDK_LIB_DIR)));
         }
@@ -2137,7 +2192,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 sourceVM, convertHost, ovfTemplateDirConvertLocation);
 
         RemoteInstanceTO remoteInstanceTO = new RemoteInstanceTO(sourceVM, sourceVMwareInstance.getClusterName(), sourceVMwareInstance.getHostName());
-        List<String> destinationStoragePools = selectInstanceConversionStoragePools(convertStoragePools, sourceVMwareInstance.getDisks(), serviceOffering, dataDiskOfferingMap);
+        List<StoragePoolVO> destinationStoragePools = selectInstanceConversionDestinationStoragePools(convertStoragePools, sourceVMwareInstance.getDisks(), serviceOffering, dataDiskOfferingMap);
+        validateStagedRbdImportHostSupport(forceConvertToPool, destinationStoragePools, importHost);
         ConvertInstanceCommand cmd = new ConvertInstanceCommand(remoteInstanceTO,
                 Hypervisor.HypervisorType.KVM, temporaryConvertLocation,
                 ovfTemplateDirConvertLocation, false, false, sourceVM);
@@ -2148,7 +2204,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         cmd.setWait(timeoutSeconds);
 
         return convertAndImportToKVM(cmd, convertHost, importHost, sourceVM,
-                remoteInstanceTO, destinationStoragePools, temporaryConvertLocation, forceConvertToPool);
+                remoteInstanceTO, getStoragePoolUuids(destinationStoragePools), getStoragePoolTypes(destinationStoragePools),
+                temporaryConvertLocation, forceConvertToPool);
     }
 
     private UnmanagedInstanceTO convertVmwareInstanceToKVMUsingVDDKOrAfterExportingOVFToConvertLocation(
@@ -2161,7 +2218,9 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         logger.debug("Delegating the conversion of instance {} from VMware to KVM to the host {} after OVF export through ovftool", sourceVM, convertHost);
 
         RemoteInstanceTO remoteInstanceTO = new RemoteInstanceTO(sourceVMwareInstance.getName(), sourceVMwareInstance.getPath(), vcenterHost, vcenterUsername, vcenterPassword, datacenterName, sourceVMwareInstance.getClusterName(), sourceVMwareInstance.getHostName());
-        List<String> destinationStoragePools = selectInstanceConversionStoragePools(convertStoragePools, sourceVMwareInstance.getDisks(), serviceOffering, dataDiskOfferingMap);
+        remoteInstanceTO.setVmwareMoref(sourceVMwareInstance.getVmwareMoref());
+        List<StoragePoolVO> destinationStoragePools = selectInstanceConversionDestinationStoragePools(convertStoragePools, sourceVMwareInstance.getDisks(), serviceOffering, dataDiskOfferingMap);
+        validateStagedRbdImportHostSupport(forceConvertToPool, destinationStoragePools, importHost);
         ConvertInstanceCommand cmd = new ConvertInstanceCommand(remoteInstanceTO,
                 Hypervisor.HypervisorType.KVM, temporaryConvertLocation, null, false, true, sourceVM);
         int timeoutSeconds = UnmanagedVMsManager.ConvertVmwareInstanceToKvmTimeout.value() * 60 * 60;
@@ -2176,9 +2235,26 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             cmd.setExtraParams(extraParams);
         }
         cmd.setUseVddk(useVddk);
+        if (useVddk) {
+            cmd.setVmwareVddkSourceDisks(toVmwareVddkSourceDisks(sourceVMwareInstance.getDisks()));
+        }
         applyVddkOverridesFromDetails(cmd, details);
         return convertAndImportToKVM(cmd, convertHost, importHost, sourceVM,
-                remoteInstanceTO, destinationStoragePools, temporaryConvertLocation, forceConvertToPool);
+                remoteInstanceTO, getStoragePoolUuids(destinationStoragePools), getStoragePoolTypes(destinationStoragePools),
+                temporaryConvertLocation, forceConvertToPool);
+    }
+
+    private List<VmwareVddkSourceDiskTO> toVmwareVddkSourceDisks(List<UnmanagedInstanceTO.Disk> disks) {
+        if (CollectionUtils.isEmpty(disks)) {
+            return Collections.emptyList();
+        }
+        List<VmwareVddkSourceDiskTO> sourceDisks = new ArrayList<>(disks.size());
+        for (int i = 0; i < disks.size(); i++) {
+            UnmanagedInstanceTO.Disk disk = disks.get(i);
+            sourceDisks.add(new VmwareVddkSourceDiskTO(disk.getDiskId(), disk.getImagePath(),
+                    disk.getCapacity() == null ? 0L : disk.getCapacity(), i));
+        }
+        return sourceDisks;
     }
 
     private void applyVddkOverridesFromDetails(ConvertInstanceCommand cmd, Map<String, String> details) {
@@ -2191,10 +2267,35 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         cmd.setVddkThumbprint(StringUtils.trimToNull(details.get(DETAIL_VDDK_THUMBPRINT)));
     }
 
+    private void validateDirectRbdVddkSourceVm(boolean directRbdVddkImport, String sourceVM,
+                                               UnmanagedInstanceTO sourceVMwareInstance, boolean isClonedInstance) {
+        if (!directRbdVddkImport) {
+            return;
+        }
+        if (isClonedInstance || sourceVMwareInstance == null || sourceVMwareInstance.getPowerState() != UnmanagedInstanceTO.PowerState.PowerOff) {
+            throw new CloudRuntimeException(String.format("Direct RBD VDDK import is supported only for powered-off VMware VMs. " +
+                    "Please power off VM %s, or disable %s and use staged import with temporary conversion storage.",
+                    sourceVM, ApiConstants.FORCE_CONVERT_TO_POOL));
+        }
+    }
+
+    private void validateStagedRbdImportHostSupport(boolean forceConvertToPool, List<StoragePoolVO> destinationStoragePools, HostVO importHost) {
+        if (forceConvertToPool || destinationStoragePools.stream().noneMatch(pool -> pool.getPoolType() == Storage.StoragePoolType.RBD)) {
+            return;
+        }
+        hostDao.loadDetails(importHost);
+        if (!Boolean.parseBoolean(importHost.getDetail(Host.HOST_RBD_QEMU_COPY_SUPPORT))) {
+            throw new CloudRuntimeException(String.format("Import host %s cannot copy converted qcow2 disks to RBD. " +
+                    "Please select an import host with %s=true, or use a non-RBD destination pool.",
+                    importHost.getName(), Host.HOST_RBD_QEMU_COPY_SUPPORT));
+        }
+    }
+
     private UnmanagedInstanceTO convertAndImportToKVM(ConvertInstanceCommand convertInstanceCommand, HostVO convertHost, HostVO importHost,
                                                       String sourceVM,
                                                       RemoteInstanceTO remoteInstanceTO,
                                                       List<String> destinationStoragePools,
+                                                      List<Storage.StoragePoolType> destinationStoragePoolTypes,
                                                       DataStoreTO temporaryConvertLocation,
                                                       boolean forceConvertToPool) {
         Answer convertAnswer;
@@ -2217,7 +2318,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         Answer importAnswer;
         try {
             ImportConvertedInstanceCommand importCmd = new ImportConvertedInstanceCommand(
-                    remoteInstanceTO, destinationStoragePools, temporaryConvertLocation,
+                    remoteInstanceTO, destinationStoragePools, destinationStoragePoolTypes, temporaryConvertLocation,
                     ((ConvertInstanceAnswer)convertAnswer).getTemporaryConvertUuid(), forceConvertToPool);
             importAnswer = agentManager.send(importHost.getId(), importCmd);
         } catch (AgentUnavailableException | OperationTimedoutException e) {
@@ -2245,8 +2346,12 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             DataStoreTO temporaryConvertLocation, boolean forceConvertToPool) {
         List<StoragePoolVO> poolsList;
         if (!forceConvertToPool) {
-            Set<StoragePoolVO> pools = new HashSet<>(primaryDataStoreDao.findClusterWideStoragePoolsByHypervisorAndPoolType(destinationCluster.getId(), Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.NetworkFilesystem));
-            pools.addAll(primaryDataStoreDao.findZoneWideStoragePoolsByHypervisorAndPoolType(destinationCluster.getDataCenterId(), Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.NetworkFilesystem));
+            List<StoragePoolVO> pools = new ArrayList<>();
+            for (Storage.StoragePoolType poolType : stagedConversionDestinationPoolTypes) {
+                Set<StoragePoolVO> poolsForType = new HashSet<>(primaryDataStoreDao.findClusterWideStoragePoolsByHypervisorAndPoolType(destinationCluster.getId(), Hypervisor.HypervisorType.KVM, poolType));
+                poolsForType.addAll(primaryDataStoreDao.findZoneWideStoragePoolsByHypervisorAndPoolType(destinationCluster.getDataCenterId(), Hypervisor.HypervisorType.KVM, poolType));
+                pools.addAll(poolsForType);
+            }
             if (pools.isEmpty()) {
                 String msg = String.format("Cannot find suitable storage pools in the cluster %s for the conversion", destinationCluster.getName());
                 logger.error(msg);
@@ -2304,7 +2409,14 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             List<StoragePoolVO> pools, List<UnmanagedInstanceTO.Disk> disks,
             ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap
     ) {
-        List<String> storagePools = new ArrayList<>(disks.size());
+        return getStoragePoolUuids(selectInstanceConversionDestinationStoragePools(pools, disks, serviceOffering, dataDiskOfferingMap));
+    }
+
+    private List<StoragePoolVO> selectInstanceConversionDestinationStoragePools(
+            List<StoragePoolVO> pools, List<UnmanagedInstanceTO.Disk> disks,
+            ServiceOfferingVO serviceOffering, Map<String, Long> dataDiskOfferingMap
+    ) {
+        List<StoragePoolVO> storagePools = new ArrayList<>(disks.size());
         Set<String> dataDiskIds = dataDiskOfferingMap.keySet();
         for (UnmanagedInstanceTO.Disk disk : disks) {
             Long diskOfferingId = null;
@@ -2316,14 +2428,22 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
 
             //TODO: Choose pools by capacity
             if (diskOfferingId == null) {
-                storagePools.add(pools.get(0).getUuid());
+                storagePools.add(pools.get(0));
             } else {
                 DiskOfferingVO diskOffering = diskOfferingDao.findById(diskOfferingId);
                 StoragePoolVO pool = getStoragePoolWithTags(pools, diskOffering.getTags());
-                storagePools.add(pool.getUuid());
+                storagePools.add(pool);
             }
         }
         return storagePools;
+    }
+
+    private List<String> getStoragePoolUuids(List<StoragePoolVO> pools) {
+        return pools.stream().map(StoragePoolVO::getUuid).collect(Collectors.toList());
+    }
+
+    private List<Storage.StoragePoolType> getStoragePoolTypes(List<StoragePoolVO> pools) {
+        return pools.stream().map(StoragePoolVO::getPoolType).collect(Collectors.toList());
     }
 
     private void logFailureAndThrowException(String msg) {

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -2374,8 +2374,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 throw new CloudRuntimeException(msg);
             }
             if (getStoragePoolWithTags(poolsList, diskOffering.getTags()) == null) {
-                String msg = String.format("Cannot find an Up destination primary storage pool matching storage tags '%s' required by root disk offering %s used by service offering %s",
-                        diskOffering.getTags(), diskOffering.getName(), serviceOffering.getName());
+                String msg = String.format("Cannot find an Up destination primary storage pool matching storage tags '%s' required by service offering %s",
+                        diskOffering.getTags(), serviceOffering.getName());
                 logger.error(msg);
                 throw new CloudRuntimeException(msg);
             }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -2374,7 +2374,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 throw new CloudRuntimeException(msg);
             }
             if (getStoragePoolWithTags(poolsList, diskOffering.getTags()) == null) {
-                String msg = String.format("Cannot find suitable storage pool for disk offering %s that belongs to the service offering %s", diskOffering.getName(), serviceOffering.getName());
+                String msg = String.format("Cannot find an Up destination primary storage pool matching storage tags '%s' required by root disk offering %s used by service offering %s",
+                        diskOffering.getTags(), diskOffering.getName(), serviceOffering.getName());
                 logger.error(msg);
                 throw new CloudRuntimeException(msg);
             }
@@ -2387,7 +2388,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                 throw new CloudRuntimeException(msg);
             }
             if (getStoragePoolWithTags(poolsList, diskOffering.getTags()) == null) {
-                String msg = String.format("Cannot find suitable storage pool for disk offering %s", diskOffering.getName());
+                String msg = String.format("Cannot find an Up destination primary storage pool matching storage tags '%s' required by data disk offering %s",
+                        diskOffering.getTags(), diskOffering.getName());
                 logger.error(msg);
                 throw new CloudRuntimeException(msg);
             }

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -2116,7 +2116,8 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }
 
         String err = requireVddkRbdDirectImportSupport
-                ? String.format("Could not find any suitable %s host in cluster %s with '%s' configured to perform direct RBD VDDK import",
+                ? String.format("Could not find any suitable %s host in cluster %s with '%s' enabled, which is required to perform direct RBD VDDK import. " +
+                        "This usually means the host is missing VDDK, qemu-img RBD support, or in-place virt-v2v support through the virt-v2v-in-place binary or virt-v2v --in-place option.",
                         destinationCluster.getHypervisorType(), destinationCluster, Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT)
                 : useVddk
                 ? String.format("Could not find any suitable %s host in cluster %s with '%s' configured to perform the VDDK-based instance conversion",

--- a/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImplTest.java
@@ -1075,6 +1075,19 @@ public class UnmanagedVMsManagerImplTest {
                 serviceOffering, Map.of("1000-2", 32L));
     }
 
+    @Test
+    public void testValidateSelectedConversionStoragePoolForVddkSkipsTemporaryPoolForStagedImport() {
+        long poolId = 12L;
+        ServiceOfferingVO serviceOffering = mock(ServiceOfferingVO.class);
+
+        Mockito.reset(primaryDataStoreDao, diskOfferingDao, volumeApiService);
+
+        unmanagedVMsManager.validateSelectedConversionStoragePoolForVddk(true, false, poolId,
+                serviceOffering, Map.of("1000-2", 32L));
+
+        Mockito.verifyNoInteractions(primaryDataStoreDao, diskOfferingDao, volumeApiService);
+    }
+
     private ClusterVO getClusterForTests() {
         ClusterVO cluster = mock(ClusterVO.class);
         when(cluster.getId()).thenReturn(1L);
@@ -1395,6 +1408,40 @@ public class UnmanagedVMsManagerImplTest {
     }
 
     @Test
+    public void testSelectKVMHostForConversionInClusterDirectRbdAutoSelectsHostWithDirectSupport() {
+        ClusterVO cluster = getClusterForTests();
+        HostVO hostWithVddkOnly = Mockito.mock(HostVO.class);
+        HostVO hostWithDirectRbd = Mockito.mock(HostVO.class);
+        when(hostWithVddkOnly.getDetail(Host.HOST_VDDK_SUPPORT)).thenReturn("true");
+        when(hostWithVddkOnly.getDetail(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT)).thenReturn(null);
+        when(hostWithDirectRbd.getDetail(Host.HOST_VDDK_SUPPORT)).thenReturn("true");
+        when(hostWithDirectRbd.getDetail(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT)).thenReturn("true");
+
+        when(hostDao.listByClusterHypervisorTypeAndHostCapability(cluster.getId(),
+                cluster.getHypervisorType(), Host.HOST_INSTANCE_CONVERSION))
+                .thenReturn(List.of(hostWithVddkOnly, hostWithDirectRbd));
+
+        HostVO returnedHost = unmanagedVMsManager.selectKVMHostForConversionInCluster(cluster, null, true, true);
+        Assert.assertEquals(hostWithDirectRbd, returnedHost);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testSelectKVMHostForConversionInClusterDirectRbdFailsWithoutDirectSupport() {
+        ClusterVO cluster = getClusterForTests();
+        HostVO hostWithVddkOnly = Mockito.mock(HostVO.class);
+        when(hostWithVddkOnly.getDetail(Host.HOST_VDDK_SUPPORT)).thenReturn("true");
+        when(hostWithVddkOnly.getDetail(Host.HOST_VDDK_RBD_DIRECT_IMPORT_SUPPORT)).thenReturn(null);
+
+        when(hostDao.listByClusterHypervisorTypeAndHostCapability(cluster.getId(),
+                cluster.getHypervisorType(), Host.HOST_INSTANCE_CONVERSION))
+                .thenReturn(List.of(hostWithVddkOnly));
+        when(hostDao.listByClusterAndHypervisorType(cluster.getId(), cluster.getHypervisorType()))
+                .thenReturn(List.of(hostWithVddkOnly));
+
+        unmanagedVMsManager.selectKVMHostForConversionInCluster(cluster, null, true, true);
+    }
+
+    @Test
     public void testCheckConversionStoragePoolSecondaryStorageStaging() {
         unmanagedVMsManager.checkConversionStoragePool(null, false);
         Mockito.verifyNoInteractions(primaryDataStoreDao);
@@ -1420,6 +1467,15 @@ public class UnmanagedVMsManagerImplTest {
         long destPoolId = 1L;
         Mockito.when(primaryDataStoreDao.findById(destPoolId)).thenReturn(destPool);
         unmanagedVMsManager.checkConversionStoragePool(destPoolId, true);
+    }
+
+    @Test
+    public void testCheckConversionStoragePoolRbdAllowedForVddkForceConvertToPool() {
+        StoragePoolVO destPool = mock(StoragePoolVO.class);
+        Mockito.when(destPool.getPoolType()).thenReturn(Storage.StoragePoolType.RBD);
+        long destPoolId = 1L;
+        Mockito.when(primaryDataStoreDao.findById(destPoolId)).thenReturn(destPool);
+        unmanagedVMsManager.checkConversionStoragePool(destPoolId, true, true);
     }
 
     @Test(expected = CloudRuntimeException.class)

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -806,6 +806,7 @@ public class VmwareHelper {
             instance.setName(vmMo.getVmName());
             instance.setInternalCSName(vmMo.getInternalCSName());
             instance.setPath((vmMo.getPath()));
+            instance.setVmwareMoref(vmMo.getMor().getValue());
             instance.setCpuCoresPerSocket(vmMo.getCoresPerSocket());
             instance.setOperatingSystemId(vmMo.getVmGuestInfo().getGuestId());
             VirtualMachineConfigSummary configSummary = vmMo.getConfigSummary();


### PR DESCRIPTION
Companion main/4.23 PR: #13270

This PR is intended to keep the 4.22 and main branches aligned for the VDDK-to-RBD import feature.

### Description

This PR extends the existing VMware-to-KVM VDDK import flow with Ceph RBD support, while preserving the current VDDK/QCOW2 behaviour.

The existing VDDK/QCOW2 writer remains supported in both existing modes:

- With `forceconverttopool=true`, CloudStack continues to let `virt-v2v` write QCOW2 output directly into the selected supported primary storage pool using `-o local -os <pool-path> -of qcow2`.
- With `forceconverttopool=false`, CloudStack continues to use the staged flow: `virt-v2v` writes finalized QCOW2 disks to temporary conversion storage, and the import step then moves/copies those disks to the final destination pool.

This change adds a destination-aware writer model for VDDK imports. The current file/QCOW2 writer path remains, and a new Ceph RBD/raw writer path is added. This gives the VDDK import flow a cleaner foundation for adding more destination-specific writers later.

For Ceph RBD, two modes are supported:

1. Direct RBD mode

   When `usevddk=true`, `forceconverttopool=true`, and `convertinstancepoolid` points to an RBD primary storage pool, CloudStack can write the VMware disk data directly into raw RBD images.

   This path does not use the normal `virt-v2v -o local -of qcow2` writer, because RBD is not a local filesystem target. Instead, the conversion host:

   - exposes the VMware source disks through VDDK/`nbdkit`
   - writes the data directly into raw RBD images using `qemu-img convert`
   - runs guest finalization in place on the newly-created RBD images using `virt-v2v-in-place`, or `virt-v2v --in-place` when supported

   The in-place finalization happens only on the destination RBD images. The VMware source disks are not modified.

2. Staged RBD mode

   When `usevddk=true` and `forceconverttopool=false`, RBD can still be used as the final destination through the existing staged model.

   In this mode:

   - regular VDDK/`virt-v2v` creates finalized QCOW2 disks on temporary conversion storage
   - the import step then converts/copies those QCOW2 disks into raw RBD images

   This mode does not require in-place `virt-v2v`, because regular `virt-v2v` has already finalized the guest while creating the temporary QCOW2 disks.

Direct RBD mode requires newer conversion-host tooling. The practical recommended baseline is EL9-family KVM hosts, such as Oracle Linux 9, Rocky Linux 9, AlmaLinux 9, or RHEL 9, and Ubuntu 24.04-style hosts where `virt-v2v-in-place` or `virt-v2v --in-place` is available. EL8 and Ubuntu 22.04-style hosts should use staged RBD import unless compatible in-place tooling has been explicitly installed and detected by CloudStack.

The implementation adds KVM host capability detection for:

- VDDK RBD direct import support
- in-place `virt-v2v` support
- `qemu-img` RBD support
- qemu-based RBD copy support

Direct RBD mode is rejected early when the selected conversion host does not support the required in-place finalization path. Staged RBD remains available in that case.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Focused compile and unit test coverage was run for the changed API/core/server/KVM paths, including:

```text
git diff --check
mvn -pl api,core -am -DskipTests -Dcheckstyle.skip=true compile
mvn -pl engine/orchestration -am -DskipTests -Dcheckstyle.skip=true compile
mvn -pl plugins/hypervisors/kvm -am -DskipTests -Dcheckstyle.skip=true compile
mvn -pl plugins/hypervisors/kvm -am -Dtest=LibvirtCheckConvertInstanceCommandWrapperTest,LibvirtConvertInstanceCommandWrapperTest,LibvirtImportConvertedInstanceCommandWrapperTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
mvn -pl server -am -Dtest=UnmanagedVMsManagerImplTest#testValidateSelectedConversionStoragePoolForVddkSkipsTemporaryPoolForStagedImport+testSelectKVMHostForConversionInClusterDirectRbdAutoSelectsHostWithDirectSupport+testSelectKVMHostForConversionInClusterDirectRbdFailsWithoutDirectSupport+testCheckConversionStoragePoolRbdAllowedForVddkForceConvertToPool -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
```

The tests cover direct RBD host capability checks, rejection when direct RBD support is missing, staged RBD destination handling, RBD destination pool type propagation, RBD disk metadata, and server-side validation for RBD storage pools.

#### How did you try to break this feature and the system with this change?

Negative tests were added for hosts without direct VDDK/RBD support, and staged RBD import is validated separately so that lack of in-place `virt-v2v` blocks only direct RBD mode, not RBD import as a whole. Existing VDDK/QCOW2 direct and staged flows are kept on the existing writer path unless the selected forced conversion pool is RBD.