### PR TITLE
Fix KVM live volume migration command payload

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -545,7 +545,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
         VolumeInfo volume = (VolumeInfo)srcData;
         StoragePool srcPool = (StoragePool)dataStoreMgr.getDataStore(srcData.getDataStore().getId(), DataStoreRole.Primary);
         StoragePool destPool = (StoragePool)dataStoreMgr.getDataStore(destData.getDataStore().getId(), DataStoreRole.Primary);
-        MigrateVolumeCommand command = new MigrateVolumeCommand(volume.getId(), volume.getPath(), destPool, volume.getAttachedVmName(), volume.getVolumeType(), waitInterval, volume.getChainInfo());
+        MigrateVolumeCommand command = new MigrateVolumeCommand(srcData.getTO(), destData.getTO(), null, null, waitInterval);
         if (srcPool.getParent() != 0) {
             command.setContextParam(DiskTO.PROTOCOL_TYPE, Storage.StoragePoolType.DatastoreCluster.toString());
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateVolumeCommandWrapper.java
@@ -75,6 +75,11 @@ public class LibvirtMigrateVolumeCommandWrapper extends CommandWrapper<MigrateVo
     @Override
     public Answer execute(final MigrateVolumeCommand command, final LibvirtComputingResource libvirtComputingResource) {
         VolumeObjectTO srcVolumeObjectTO = (VolumeObjectTO)command.getSrcData();
+
+        if (srcVolumeObjectTO == null) {
+            return migrateRegularVolume(command, libvirtComputingResource);
+        }
+
         PrimaryDataStoreTO srcPrimaryDataStore = (PrimaryDataStoreTO)srcVolumeObjectTO.getDataStore();
 
         MigrateVolumeAnswer answer;

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3531,9 +3531,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     StoragePoolVO destinationStoragePoolVo = _storagePoolDao.findById(storagePoolId);
 
                     if (isSourceOrDestNotOnStorPool(srcStoragePoolVO, destinationStoragePoolVo)) {
-                        throw new InvalidParameterValueException("KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. " +
-                                "Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. " +
-                                "Use 'migrateVirtualMachineWithVolumes' instead.");
+                        logger.debug("Allowing KVM live volume migration between different storage pools. VM [{}], volume [{}], source pool [{}], destination pool [{}].",
+                                vm, vol, srcStoragePoolVO, destinationStoragePoolVo);
                     }
                     srcAndDestOnStorPool = isSourceAndDestOnStorPool(srcStoragePoolVO, destinationStoragePoolVo);
                 }


### PR DESCRIPTION
### Description

This PR fixes KVM live volume migration for storage pools where storage motion is supported.

<img width="1280" height="687" alt="1failed" src="https://github.com/user-attachments/assets/8489eb48-198f-4a44-baad-be40b245649f" />

<img width="1280" height="697" alt="2failed" src="https://github.com/user-attachments/assets/b1595eb7-00bf-46de-b0a3-ab1d20805fc3" />

<img width="1280" height="689" alt="3oke" src="https://github.com/user-attachments/assets/3a15bb18-0b6d-45d1-b553-9c05eb9397a4" />

Test evidence: failure before the fix and successful live migration after applying the code changes.

### Environment tested

- Apache CloudStack: 4.20.0.0
- Management server OS: Ubuntu 22.04
- KVM host OS: Ubuntu 22.04
- Hypervisor: KVM
- VM state: Running
- Source primary storage: NetworkFilesystem
- Destination primary storage: RBD / Ceph
- API: `migrateVolume` with `livemigrate=true`

### Problem

Currently, KVM live volume migration is rejected early in `VolumeApiServiceImpl` for non-PowerFlex pools with the following error:

`KVM does not support volume live migration due to the limited possibility to refresh VM XML domain. Therefore, to live migrate a volume between storage pools, one must migrate the VM to a different host as well to force the VM XML domain update. Use 'migrateVirtualMachineWithVolumes' instead.`

When this early guard is bypassed, `AncientDataMotionStrategy` still creates `MigrateVolumeCommand` using the legacy constructor. That constructor does not populate `srcData` and `destData`.

As a result, the KVM agent receives a `MigrateVolumeCommand` with `srcData == null`, and `LibvirtMigrateVolumeCommandWrapper` fails with a `NullPointerException` while accessing `srcVolumeObjectTO.getDataStore()`.

### Functional change

This PR changes the migration flow to pass the source and destination data objects to the KVM agent and adds defensive null handling in the KVM wrapper.

Changes included:

- Allows the KVM live volume migration flow to continue instead of rejecting it early for non-PowerFlex pools.
- Uses the `srcData` / `destData` aware `MigrateVolumeCommand` constructor in `AncientDataMotionStrategy`.
- Adds defensive null handling in `LibvirtMigrateVolumeCommandWrapper.execute()` to avoid an NPE if a legacy command path still sends a command without `srcData`.

<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

Screenshots were added above showing the failure before the fix and successful live migration after applying the code changes.

### How Has This Been Tested?

Tested manually on Apache CloudStack 4.20.0.0 with Ubuntu 22.04 management and KVM hosts.

Test scenario:

- VM was running on KVM.
- Source primary storage was NetworkFilesystem.
- Destination primary storage was RBD / Ceph.
- Live volume migration was triggered using `migrateVolume` with `livemigrate=true`.

Before this change:

1. `migrateVolume` with `livemigrate=true` failed at the API layer with the KVM live volume migration restriction.
2. After bypassing the API guard, the KVM agent failed with a `NullPointerException` because `srcVolumeObjectTO` was null.

After this change:

1. `MigrateVolumeCommand` is created with `srcData` and `destData`.
2. The KVM agent receives the source and destination volume objects.
3. `LibvirtMigrateVolumeCommandWrapper` no longer throws a `NullPointerException`.
4. Live volume migration from NetworkFilesystem to RBD completed successfully for a running VM.

I also verified the bytecode before and after the change:

- Before: `AncientDataMotionStrategy` called the legacy `MigrateVolumeCommand(long, String, StoragePool, String, Volume.Type, int, String)` constructor.
- After: `AncientDataMotionStrategy` calls the `MigrateVolumeCommand(DataTO, DataTO, Map, Map, int)` constructor.

#### How did you try to break this feature and the system with this change?

I tested the failure path and the fixed path by rolling the staging environment back to the original behavior and then applying the fix again step by step.

Validation performed:

- Confirmed the original API-level KVM restriction returned before applying the fix.
- Confirmed the original KVM agent wrapper dereferenced `srcData` directly and could fail with `srcVolumeObjectTO == null`.
- Applied the changes and retested the same live volume migration operation.
- Verified that the command sent to the agent included source and destination data.
- Verified that the migration completed successfully.
- Verified that the fallback null guard in the KVM wrapper prevents a `NullPointerException` if a legacy command path is still used.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->