### PR TITLE
UI support for the scaleSystemVm API

### DIFF
--- a/ui/src/config/section/infra/systemVms.js
+++ b/ui/src/config/section/infra/systemVms.js
@@ -100,14 +100,15 @@ export default {
       label: 'label.change.service.offering',
       message: 'message.confirm.scale.up.system.vm',
       dataView: true,
-      show: (record) => { return record.state === 'Running' && record.hypervisor === 'VMware' || record.state === 'Stopped' },
+      show: (record) => { return record.state === 'Running' && (record.hypervisor === 'VMware' || record.hypervisor === 'KVM') || record.state === 'Stopped' },
       args: ['serviceofferingid'],
       mapping: {
         serviceofferingid: {
           api: 'listServiceOfferings',
           params: (record) => { return { virtualmachineid: record.id, issystem: true, systemvmtype: record.systemvmtype } }
         }
-      }
+      },
+      popup: true
     },
     {
       api: 'migrateSystemVm',


### PR DESCRIPTION
### Description

ACS has the `scaleSystemVm` API that allows scaling system VMs. However, currently the API is not accessible through the graphical interface for KVM. Thus, the graphical interface has been extended to allow the execution of this API.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### Screenshots (if appropriate):

![](https://github.com/user-attachments/assets/6d2a366d-5471-47fa-9400-4f8809e9f69c)

### How Has This Been Tested?

The global setting `enable.dynamic.scale.vm` was set to True, then the system VM template's `Dynamically scalable` option was also set to True. Finally, new system offerings were registered to verify the form's listing behavior, showing only offers greater than or equal to the current offer. Lastly, the service offering change was performed both for running and stopped VMs.

Before:
```
virsh dumpxml 4 | grep "memory unit" -A 2
  <memory unit='KiB'>524288</memory>
  <currentMemory unit='KiB'>524288</currentMemory>
  <vcpu placement='static' current='1'>4</vcpu>
```

After:
```
virsh dumpxml 5 | grep "memory unit" -A 2
  <memory unit='KiB'>2097152</memory>
  <currentMemory unit='KiB'>2097152</currentMemory>
  <vcpu placement='static' current='2'>4</vcpu>
```
