### PR TITLE
Fix VM migration with attached ISO

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -279,8 +279,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
 
     private void checkNetfsStoragePoolMounted(String uuid) {
         String targetPath = _mountPoint + File.separator + uuid;
-        int mountpointResult = Script.runSimpleBashScriptForExitValue("mountpoint -q " + targetPath);
-        if (mountpointResult != 0) {
+        if (!isStoragePoolMounted(targetPath)) {
             String errMsg = String.format("libvirt failed to mount storage pool %s at %s", uuid, targetPath);
             logger.error(errMsg);
             throw new CloudRuntimeException(errMsg);
@@ -295,9 +294,8 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         try {
             logger.debug(spd.toString());
             // check whether the pool is already mounted
-            int mountpointResult = Script.runSimpleBashScriptForExitValue("mountpoint -q " + targetPath);
             // if the pool is mounted, try to unmount it
-            if(mountpointResult == 0) {
+            if (isStoragePoolMounted(targetPath)) {
                 logger.info("Attempting to unmount old mount at " + targetPath);
                 String result = Script.runSimpleBashScript("umount -l " + targetPath);
                 if (result == null) {
@@ -830,6 +828,12 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
             } else if (type == StoragePoolType.CLVM) {
                 sp = createCLVMStoragePool(conn, name, host, path);
             }
+        } else {
+            String targetPath = _mountPoint + File.separator + name;
+            if (type == StoragePoolType.NetworkFilesystem && !isPrimaryStorage && !isStoragePoolMounted(targetPath)) {
+                String storageMountPoint = host + ":" + path;
+                mountNfsStoragePool(storageMountPoint, targetPath, nfsMountOpts);
+            }
         }
 
         if (sp == null) {
@@ -864,6 +868,16 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                 throw new CloudRuntimeException(error);
             }
         }
+    }
+
+    private boolean isStoragePoolMounted(String path) {
+        return Script.runSimpleBashScriptForExitValue("mountpoint -q " + path) == 0;
+    }
+
+    private void mountNfsStoragePool(String storageMountPoint, String targetPath, List<String> nfsMountOptions) {
+        String mountOptions = CollectionUtils.isNotEmpty(nfsMountOptions) ? String.format("-o %s", String.join(",", nfsMountOptions)) : "";
+        logger.debug("Attempting to mount NFS storage [{}] at [{}] with options [{}].", storageMountPoint, targetPath, mountOptions);
+        Script.runSimpleBashScript(String.format("mount -t nfs %s %s %s", mountOptions, storageMountPoint, targetPath));
     }
 
     private boolean destroyStoragePool(Connect conn, String uuid) throws LibvirtException {


### PR DESCRIPTION
### Description

Using KVM, if a VM with an attached ISO is migrated to a host that does not have the path of that ISO mounted, but already has the libvirt storage pool corresponding to that ISO created, an exception is thrown. Therefore, it is not possible to migrate this VM.

Based on this, changes were made to ensure that the path of the ISO attached to the VM will be mounted during the migration.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

1. I deployed a VM on host `A` and attached an ISO to it;
2. I migrated this VM to host `B`;
3. I unmounted the ISO directory on host `A`;
4. I attempted to migrate the VM to host `A`.

**Without the changes:** an error occurred stating that it was not possible to mount the ISO's storage pool and the migration failed.

**With the changes:** the storage pool was mounted and the migration finished successfully.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
