### PR TITLE
 Correction in the public IP ranges addition form for the Public traffic type

### DIFF
--- a/ui/src/views/infra/network/IpRangesTabPublic.vue
+++ b/ui/src/views/infra/network/IpRangesTabPublic.vue
@@ -590,6 +590,10 @@ export default {
     handleShowAccountFields () {
       if (this.showAccountFields) {
         this.fetchDomains()
+      } else {
+        this.form.account = null
+        this.form.domain = null
+        this.form.forsystemvms = false
       }
     },
     handleOpenAddIpRangeModal () {


### PR DESCRIPTION
### Description

The ACS UI currently has an inconsistency in the public IP ranges addition form for the Public traffic type of zones. When the `Set reservation` switch is toggled on and off and the form is submitted, the Domain and Account fields are not reset to their initial values. Therefore, modifications have been applied to fix this inconsistency.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots (if appropriate):

Before:

![](https://github.com/user-attachments/assets/082ed9e0-5f66-40c6-8d03-3fb86ac4a37d)

![](https://github.com/user-attachments/assets/ef7016c8-3bce-4cf8-b31d-8bb82ab618bb)

![](https://github.com/user-attachments/assets/d0f88728-c0c2-428c-972b-7042300fa967)

After:

![](https://github.com/user-attachments/assets/023cdd9c-ee33-4a37-ae89-b97f2bcf8296)

![](https://github.com/user-attachments/assets/f72054c4-1e5b-44f0-8401-9414d9fc0220)

![](https://github.com/user-attachments/assets/f877ac4e-bafc-4c6b-9e75-174a26816e06)

### How Has This Been Tested?

First, I created a domain. Next, I added a public IP range with the `Set reservation` switch selected and its fields filled with a domain and/or account. Before submitting the form, I disabled the toggle. After, I verified that the account and domain are reset to their initial values.
