### PR TITLE
UI: Fix VNF NIC mapping network select always disabled

### DIFF
--- a/ui/src/views/compute/wizard/VnfNicsSelection.vue
+++ b/ui/src/views/compute/wizard/VnfNicsSelection.vue
@@ -50,7 +50,6 @@
       <template #network="{ record }">
         <a-form-item style="display: block" :name="'nic-' + record.deviceid">
           <a-select
-            disabled="templateNics && templateNics.length > 0"
             @change="updateNicNetworkValue($event, record.deviceid)"
             optionFilterProp="label"
             :filterOption="(input, option) => {


### PR DESCRIPTION
### Description
Fixes VNF NIC mapping network select dropdown which was permanently disabled in the UI.

**Root cause:**
In `ui/src/views/compute/wizard/VnfNicsSelection.vue` the `disabled` attribute
was written as a plain HTML string instead of a Vue reactive binding (missing `:` prefix).
In Vue/Ant Design, any non-empty string is treated as truthy, making the select
always disabled regardless of state.

**Steps to reproduce:**
1. Create an Isolated network (WAN) and L2 network (LAN)
2. Go to Network → VNF Appliances → Add VNF Appliance
3. Select a VNF template with NIC definitions
4. Add networks on the Networks step
5. Proceed to VNF NIC Mappings step — all dropdowns are disabled

**Expected:** Network dropdowns are enabled and selectable
**Actual:** All dropdowns permanently disabled, VNF cannot be deployed via UI

**Tested on:** CloudStack 4.22.1.0, KVM hypervisor

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity
- [x] Minor