### PR TITLE
KVM: allow importVm to adopt an existing RBD (Ceph) root volume

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -1165,6 +1165,19 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
         }
     }
 
+    /**
+     * Returns the image format for a volume taking the underlying storage pool type into account.
+     * On KVM the default cluster format is QCOW2, but block-based pools such as RBD (Ceph) store
+     * volumes as RAW images. This is relevant when importing/adopting an existing volume so the
+     * recorded format matches what is actually on the pool.
+     */
+    protected ImageFormat getSupportedImageFormatForCluster(HypervisorType hyperType, Storage.StoragePoolType poolType) {
+        if (hyperType == HypervisorType.KVM && poolType == Storage.StoragePoolType.RBD) {
+            return ImageFormat.RAW;
+        }
+        return getSupportedImageFormatForCluster(hyperType);
+    }
+
     private boolean isSupportedImageFormatForCluster(VolumeInfo volume, HypervisorType rootDiskHyperType) {
         ImageFormat volumeFormat = volume.getFormat();
         if (rootDiskHyperType == HypervisorType.Hyperv) {
@@ -2367,7 +2380,7 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
             vol.setDisplayVolume(userVm.isDisplayVm());
         }
 
-        vol.setFormat(getSupportedImageFormatForCluster(hypervisorType));
+        vol.setFormat(getSupportedImageFormatForCluster(hypervisorType, poolType));
         vol.setPoolId(poolId);
         vol.setPoolType(poolType);
         vol.setPath(path);
@@ -2411,7 +2424,7 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
             vol.setDisplayVolume(userVm.isDisplayVm());
         }
 
-        vol.setFormat(getSupportedImageFormatForCluster(vm.getHypervisorType()));
+        vol.setFormat(getSupportedImageFormatForCluster(vm.getHypervisorType(), poolType));
         vol.setPoolId(poolId);
         vol.setPoolType(poolType);
         vol.setPath(path);

--- a/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestratorTest.java
+++ b/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestratorTest.java
@@ -174,6 +174,28 @@ public class VolumeOrchestratorTest {
     }
 
     @Test
+    public void testGetSupportedImageFormatForClusterKvmRbdIsRaw() {
+        Assert.assertEquals(Storage.ImageFormat.RAW,
+                volumeOrchestrator.getSupportedImageFormatForCluster(Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.RBD));
+    }
+
+    @Test
+    public void testGetSupportedImageFormatForClusterKvmNonRbdIsQcow2() {
+        Assert.assertEquals(Storage.ImageFormat.QCOW2,
+                volumeOrchestrator.getSupportedImageFormatForCluster(Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.NetworkFilesystem));
+        Assert.assertEquals(Storage.ImageFormat.QCOW2,
+                volumeOrchestrator.getSupportedImageFormatForCluster(Hypervisor.HypervisorType.KVM, Storage.StoragePoolType.Filesystem));
+    }
+
+    @Test
+    public void testGetSupportedImageFormatForClusterNonKvmIgnoresPoolType() {
+        Assert.assertEquals(Storage.ImageFormat.VHD,
+                volumeOrchestrator.getSupportedImageFormatForCluster(Hypervisor.HypervisorType.XenServer, Storage.StoragePoolType.RBD));
+        Assert.assertEquals(Storage.ImageFormat.OVA,
+                volumeOrchestrator.getSupportedImageFormatForCluster(Hypervisor.HypervisorType.VMware, Storage.StoragePoolType.RBD));
+    }
+
+    @Test
     public void testGrantVolumeAccessToHostIfNeededDriverNoNeed() {
         PrimaryDataStore store = Mockito.mock(PrimaryDataStore.class);
         PrimaryDataStoreDriver driver = Mockito.mock(PrimaryDataStoreDriver.class);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVolumeCommandWrapper.java
@@ -50,7 +50,8 @@ public final class LibvirtCheckVolumeCommandWrapper extends CommandWrapper<Check
     private static final List<Storage.StoragePoolType> STORAGE_POOL_TYPES_SUPPORTED = Arrays.asList(
             Storage.StoragePoolType.Filesystem,
             Storage.StoragePoolType.NetworkFilesystem,
-            Storage.StoragePoolType.SharedMountPoint);
+            Storage.StoragePoolType.SharedMountPoint,
+            Storage.StoragePoolType.RBD);
 
     @Override
     public Answer execute(final CheckVolumeCommand command, final LibvirtComputingResource libvirtComputingResource) {
@@ -63,6 +64,9 @@ public final class LibvirtCheckVolumeCommandWrapper extends CommandWrapper<Check
         try {
             if (STORAGE_POOL_TYPES_SUPPORTED.contains(storageFilerTO.getType())) {
                 final KVMPhysicalDisk vol = pool.getPhysicalDisk(srcFile);
+                if (Storage.StoragePoolType.RBD.equals(storageFilerTO.getType())) {
+                    return checkRbdVolume(command, pool, vol);
+                }
                 final String path = vol.getPath();
                 try {
                     KVMPhysicalDisk.checkQcow2File(path);
@@ -79,6 +83,21 @@ public final class LibvirtCheckVolumeCommandWrapper extends CommandWrapper<Check
             logger.error("Error while checking the disk: {}", e.getMessage());
             return new Answer(command, false, result);
         }
+    }
+
+    /**
+     * RBD (Ceph) volumes are raw images that cannot be inspected through direct file reads
+     * (checkQcow2File / getVirtualSizeFromFile operate on a local path). Instead the volume is
+     * inspected through the RBD URI via qemu-img (see {@link #getDiskFileInfo}). The virtual size
+     * is taken from the disk reported by the storage pool, and the encrypted/backing-file/locked
+     * details are still collected so the management server can apply its import validations.
+     */
+    private Answer checkRbdVolume(final CheckVolumeCommand command, final KVMStoragePool pool, final KVMPhysicalDisk disk) {
+        Map<VolumeOnStorageTO.Detail, String> volumeDetails = getVolumeDetails(pool, disk);
+        if (volumeDetails == null) {
+            return new CheckVolumeAnswer(command, false, "", 0, null);
+        }
+        return new CheckVolumeAnswer(command, true, "", disk.getVirtualSize(), volumeDetails);
     }
 
     private Map<VolumeOnStorageTO.Detail, String> getVolumeDetails(KVMStoragePool pool, KVMPhysicalDisk disk) {
@@ -122,6 +141,10 @@ public final class LibvirtCheckVolumeCommandWrapper extends CommandWrapper<Check
         try {
             QemuImg qemu = new QemuImg(0);
             QemuImgFile qemuFile = new QemuImgFile(disk.getPath(), disk.getFormat());
+            if (Storage.StoragePoolType.RBD.equals(pool.getType())) {
+                String rbdDestFile = KVMPhysicalDisk.RBDStringBuilder(pool, disk.getPath());
+                qemuFile = new QemuImgFile(rbdDestFile, disk.getFormat());
+            }
             return qemu.info(qemuFile, secure);
         } catch (QemuImgException | LibvirtException ex) {
             logger.error("Failed to get info of disk file: " + ex.getMessage());

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVolumeCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVolumeCommandWrapperTest.java
@@ -1,0 +1,189 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CheckVolumeAnswer;
+import com.cloud.agent.api.CheckVolumeCommand;
+import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.hypervisor.kvm.storage.KVMPhysicalDisk;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
+import com.cloud.storage.Storage;
+import org.apache.cloudstack.storage.volume.VolumeOnStorageTO;
+import org.apache.cloudstack.utils.qemu.QemuImg;
+import org.apache.cloudstack.utils.qemu.QemuImgFile;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LibvirtCheckVolumeCommandWrapperTest {
+
+    @Mock
+    LibvirtComputingResource libvirtComputingResource;
+    @Mock
+    KVMStoragePoolManager storagePoolMgr;
+    @Mock
+    KVMStoragePool storagePool;
+    @Mock
+    StorageFilerTO storageFilerTO;
+    @Mock
+    KVMPhysicalDisk disk;
+
+    @Spy
+    LibvirtCheckVolumeCommandWrapper wrapper = new LibvirtCheckVolumeCommandWrapper();
+
+    MockedConstruction<QemuImg> qemuImg;
+
+    private final String poolUuid = "pool-uuid";
+    private final String srcFile = "rbd-volume-uuid";
+    private final long virtualSize = 21474836480L; // 20 GiB
+
+    private Map<String, String> qemuInfo;
+
+    @Before
+    public void setUp() {
+        qemuInfo = new HashMap<>();
+        qemuInfo.put(QemuImg.FILE_FORMAT, "raw");
+        Mockito.when(libvirtComputingResource.getStoragePoolMgr()).thenReturn(storagePoolMgr);
+    }
+
+    @After
+    public void tearDown() {
+        if (qemuImg != null) {
+            qemuImg.close();
+        }
+    }
+
+    private void mockRbdPool() {
+        Mockito.when(storageFilerTO.getType()).thenReturn(Storage.StoragePoolType.RBD);
+        Mockito.when(storageFilerTO.getUuid()).thenReturn(poolUuid);
+        Mockito.when(storagePoolMgr.getStoragePool(Storage.StoragePoolType.RBD, poolUuid)).thenReturn(storagePool);
+        Mockito.when(storagePool.getType()).thenReturn(Storage.StoragePoolType.RBD);
+        Mockito.when(storagePool.getPhysicalDisk(srcFile)).thenReturn(disk);
+        Mockito.when(disk.getPath()).thenReturn(srcFile);
+        Mockito.when(disk.getFormat()).thenReturn(QemuImg.PhysicalDiskFormat.RAW);
+        // values consumed by KVMPhysicalDisk.RBDStringBuilder when building the RBD URI
+        Mockito.when(storagePool.getSourceHost()).thenReturn("10.0.0.10");
+        Mockito.when(storagePool.getSourcePort()).thenReturn(6789);
+        Mockito.when(storagePool.getAuthUserName()).thenReturn(null);
+        Mockito.when(storagePool.getDetails()).thenReturn(null);
+    }
+
+    private CheckVolumeCommand buildCommand() {
+        CheckVolumeCommand command = new CheckVolumeCommand();
+        command.setSrcFile(srcFile);
+        command.setStorageFilerTO(storageFilerTO);
+        return command;
+    }
+
+    @Test
+    public void testRbdVolumeReturnsSuccessWithVirtualSizeAndDetails() {
+        mockRbdPool();
+        Mockito.when(disk.getVirtualSize()).thenReturn(virtualSize);
+        qemuImg = Mockito.mockConstruction(QemuImg.class, (mock, context) ->
+                Mockito.when(mock.info(Mockito.any(QemuImgFile.class), Mockito.anyBoolean())).thenReturn(qemuInfo));
+
+        Answer answer = wrapper.execute(buildCommand(), libvirtComputingResource);
+
+        Assert.assertTrue(answer instanceof CheckVolumeAnswer);
+        Assert.assertTrue(answer.getResult());
+        CheckVolumeAnswer checkVolumeAnswer = (CheckVolumeAnswer) answer;
+        Assert.assertEquals(virtualSize, checkVolumeAnswer.getSize());
+        Map<VolumeOnStorageTO.Detail, String> details = checkVolumeAnswer.getVolumeDetails();
+        Assert.assertNotNull(details);
+        Assert.assertEquals("raw", details.get(VolumeOnStorageTO.Detail.FILE_FORMAT));
+        Assert.assertEquals("false", details.get(VolumeOnStorageTO.Detail.IS_LOCKED));
+    }
+
+    @Test
+    public void testRbdVolumeInspectedThroughRbdUri() throws Exception {
+        mockRbdPool();
+        Mockito.when(disk.getVirtualSize()).thenReturn(virtualSize);
+        qemuImg = Mockito.mockConstruction(QemuImg.class, (mock, context) ->
+                Mockito.when(mock.info(Mockito.any(QemuImgFile.class), Mockito.anyBoolean())).thenReturn(qemuInfo));
+
+        wrapper.execute(buildCommand(), libvirtComputingResource);
+
+        ArgumentCaptor<QemuImgFile> fileCaptor = ArgumentCaptor.forClass(QemuImgFile.class);
+        Mockito.verify(qemuImg.constructed().get(0), Mockito.atLeastOnce())
+                .info(fileCaptor.capture(), Mockito.anyBoolean());
+        Assert.assertTrue("qemu-img should be pointed at the RBD URI",
+                fileCaptor.getValue().getFileName().startsWith("rbd:" + srcFile));
+    }
+
+    @Test
+    public void testRbdVolumeReportsLockedWhenInfoProbeFails() {
+        mockRbdPool();
+        Mockito.when(disk.getVirtualSize()).thenReturn(virtualSize);
+        qemuImg = Mockito.mockConstruction(QemuImg.class, (mock, context) -> {
+            // secure=true uses force-share and succeeds; secure=false is the lock probe
+            Mockito.when(mock.info(Mockito.any(QemuImgFile.class), Mockito.eq(true))).thenReturn(qemuInfo);
+            Mockito.when(mock.info(Mockito.any(QemuImgFile.class), Mockito.eq(false))).thenReturn(null);
+        });
+
+        Answer answer = wrapper.execute(buildCommand(), libvirtComputingResource);
+
+        Assert.assertTrue(answer instanceof CheckVolumeAnswer);
+        Assert.assertTrue(answer.getResult());
+        Map<VolumeOnStorageTO.Detail, String> details = ((CheckVolumeAnswer) answer).getVolumeDetails();
+        Assert.assertEquals("true", details.get(VolumeOnStorageTO.Detail.IS_LOCKED));
+    }
+
+    @Test
+    public void testRbdVolumeWithoutInfoReturnsInvalid() {
+        mockRbdPool();
+        qemuImg = Mockito.mockConstruction(QemuImg.class, (mock, context) ->
+                Mockito.when(mock.info(Mockito.any(QemuImgFile.class), Mockito.anyBoolean())).thenReturn(null));
+
+        Answer answer = wrapper.execute(buildCommand(), libvirtComputingResource);
+
+        Assert.assertTrue(answer instanceof CheckVolumeAnswer);
+        Assert.assertFalse(answer.getResult());
+        CheckVolumeAnswer checkVolumeAnswer = (CheckVolumeAnswer) answer;
+        Assert.assertEquals(0, checkVolumeAnswer.getSize());
+        Assert.assertNull(checkVolumeAnswer.getVolumeDetails());
+    }
+
+    @Test
+    public void testUnsupportedStoragePoolReturnsPlainAnswer() {
+        Mockito.when(storageFilerTO.getType()).thenReturn(Storage.StoragePoolType.PowerFlex);
+        Mockito.when(storageFilerTO.getUuid()).thenReturn(poolUuid);
+
+        Answer answer = wrapper.execute(buildCommand(), libvirtComputingResource);
+
+        Assert.assertFalse(answer instanceof CheckVolumeAnswer);
+        Assert.assertFalse(answer.getResult());
+        Assert.assertEquals("Unsupported Storage Pool", answer.getDetails());
+    }
+}

--- a/server/src/test/java/org/apache/cloudstack/storage/volume/VolumeImportUnmanageManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/volume/VolumeImportUnmanageManagerImplTest.java
@@ -291,6 +291,55 @@ public class VolumeImportUnmanageManagerImplTest {
     }
 
     @Test
+    public void testImportVolumeForwardsRbdPoolTypeToOrchestrator() throws ResourceAllocationException {
+        ImportVolumeCmd cmd = mock(ImportVolumeCmd.class);
+        when(cmd.getPath()).thenReturn(path);
+        when(cmd.getStorageId()).thenReturn(poolId);
+        when(cmd.getDiskOfferingId()).thenReturn(diskOfferingId);
+        when(volumeDao.findByPoolIdAndPath(poolId, path)).thenReturn(null);
+        when(templatePoolDao.findByPoolPath(poolId, path)).thenReturn(null);
+
+        // Import a KVM volume residing on an RBD (Ceph) pool
+        when(storagePoolVO.getPoolType()).thenReturn(Storage.StoragePoolType.RBD);
+
+        VolumeOnStorageTO volumeOnStorageTO = new VolumeOnStorageTO(Hypervisor.HypervisorType.KVM, path, name, fullPath,
+                "raw", size, virtualSize);
+        List<VolumeOnStorageTO> volumesOnStorageTO = new ArrayList<>();
+        volumesOnStorageTO.add(volumeOnStorageTO);
+        doReturn(volumesOnStorageTO).when(volumeImportUnmanageManager).listVolumesForImportInternal(storagePoolVO, path, null);
+
+        doNothing().when(volumeImportUnmanageManager).checkIfVolumeIsLocked(volumeOnStorageTO);
+        doNothing().when(volumeImportUnmanageManager).checkIfVolumeIsEncrypted(volumeOnStorageTO);
+        doNothing().when(volumeImportUnmanageManager).checkIfVolumeHasBackingFile(volumeOnStorageTO);
+
+        DiskOfferingVO diskOffering = mock(DiskOfferingVO.class);
+        when(diskOffering.isCustomized()).thenReturn(true);
+        doReturn(diskOffering).when(volumeImportUnmanageManager).getOrCreateDiskOffering(account, diskOfferingId, zoneId, isLocal);
+        doNothing().when(volumeApiService).validateCustomDiskOfferingSizeRange(anyLong());
+        doReturn(true).when(volumeApiService).doesStoragePoolSupportDiskOffering(any(), any());
+        doReturn(diskProfile).when(volumeManager).importVolume(any(), anyString(), any(), eq(virtualSize), isNull(), isNull(), anyLong(),
+                any(), isNull(), isNull(), any(), isNull(), anyLong(), any(), anyString(), isNull());
+        when(diskProfile.getVolumeId()).thenReturn(volumeId);
+        when(volumeDao.findById(volumeId)).thenReturn(volumeVO);
+
+        doNothing().when(resourceLimitService).incrementResourceCount(accountId, Resource.ResourceType.volume);
+        doNothing().when(resourceLimitService).incrementResourceCount(accountId, Resource.ResourceType.primary_storage, virtualSize);
+
+        VolumeResponse response = mock(VolumeResponse.class);
+        doReturn(response).when(responseGenerator).createVolumeResponse(ResponseObject.ResponseView.Full, volumeVO);
+        try (MockedStatic<UsageEventUtils> ignored = Mockito.mockStatic(UsageEventUtils.class);
+             MockedStatic<ActionEventUtils> ignoredtoo = Mockito.mockStatic(ActionEventUtils.class)) {
+            volumeImportUnmanageManager.importVolume(cmd);
+        }
+
+        // The RBD pool type and KVM hypervisor are forwarded to the orchestrator, which is what makes the
+        // imported volume be recorded with RAW format (see VolumeOrchestrator.getSupportedImageFormatForCluster).
+        verify(volumeManager).importVolume(eq(Volume.Type.DATADISK), anyString(), any(), eq(virtualSize), isNull(), isNull(),
+                anyLong(), eq(Hypervisor.HypervisorType.KVM), isNull(), isNull(), any(), isNull(), anyLong(),
+                eq(Storage.StoragePoolType.RBD), anyString(), isNull());
+    }
+
+    @Test
     public void testListVolumesForImportInternal() {
         Pair<HostVO, String> hostAndLocalPath = mock(Pair.class);
         doReturn(hostAndLocalPath).when(volumeImportUnmanageManager).findHostAndLocalPathForVolumeImport(storagePoolVO);


### PR DESCRIPTION
### Description

This PR allows KVM volume import on **RBD (Ceph)** primary storage to correctly adopt and record existing volumes. It covers two related flows that share the same code paths:

**A) `importVm` (`importsource=shared`, KVM) adopting an existing ROOT volume on RBD** — previously failed with `Disk not found or is invalid` (jobresultcode 530).

**B) `importVolume` (managing a previously-unmanaged volume) on RBD** — previously succeeded but recorded the wrong volume format (`QCOW2` instead of `RAW`).

Two things were responsible:

1. **Agent side (flow A)** — `LibvirtCheckVolumeCommandWrapper` (which backs the `CheckVolumeCommand` issued during import) only whitelisted file-based pools (`Filesystem`, `NetworkFilesystem`, `SharedMountPoint`) and inspected the volume with direct file reads (`checkQcow2File` / `getVirtualSizeFromFile`). Those do not work on RBD, so the command returned `Unsupported Storage Pool`, the server-side `instanceof CheckVolumeAnswer` cast failed, and the import was rolled back with `Disk not found or is invalid`.

   RBD is now supported by inspecting the volume through the RBD URI via `qemu-img` — the same approach already used by `LibvirtGetVolumesOnStorageCommandWrapper`, which backs `listVolumesForImport` and already works on RBD. For raw RBD images the QCOW2 validation is skipped, the virtual size comes from the pool-reported disk, and the encrypted / backing-file / locked details are still collected so the existing server-side import validations keep working.

2. **Server / engine side (flows A and B)** — `VolumeOrchestrator.importVolume()` and `updateImportedVolume()` hardcoded the KVM volume format to `QCOW2`. RBD-backed volumes are `RAW`. The format is now derived from the storage pool type (RBD → RAW) via a single shared helper, applied at both import call sites. Because the standalone `importVolume` API (`VolumeImportUnmanageManagerImpl` → `volumeManager.importVolume(...)`) goes through the same method, managing a previously-unmanaged RBD volume now also records it as `RAW`.

No new server-side guardrails were required: `importKVMSharedDisk` is already pool-type agnostic and passes the pool type through.

#### Upgrading existing (already-imported) volumes

This is a fix at import time; it does not retroactively rewrite volumes that were imported/managed before the fix and recorded as `QCOW2`. RBD/Ceph stores raw block images, so any volume on an RBD pool recorded as `QCOW2` is a metadata error and can be corrected with:

```sql
UPDATE `cloud`.`volumes` v
JOIN `cloud`.`storage_pool` sp ON v.pool_id = sp.id
SET v.format = 'RAW'
WHERE sp.pool_type = 'RBD'
  AND v.format = 'QCOW2'
  AND v.removed IS NULL;
```

This is provided as an operator step rather than an automatic DB migration, because the 4.22 branch does not yet have a `4.22.1.0 → 4.22.2.0` schema-upgrade path scaffolded (the chain currently runs a no-op for that step). It can be promoted to an automatic migration if preferred.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Unit tests (new + extended), all passing locally on the `4.22` branch (JDK 17, Maven 3.9.9):

- `LibvirtCheckVolumeCommandWrapperTest` (new, 5 tests) — RBD success path (virtual size + collected details), verification that `qemu-img` is pointed at the RBD URI, locked-volume detail propagation, invalid/missing volume, and unsupported pool type.
- `VolumeOrchestratorTest` (3 added) — KVM+RBD → RAW, KVM+non-RBD → QCOW2, non-KVM ignores the pool type.
- `VolumeImportUnmanageManagerImplTest` (1 added) — the `importVolume` (manage-volume) flow forwards the RBD pool type and KVM hypervisor to the orchestrator (i.e. flow B is wired to the RAW-format fix).

```
mvn -pl plugins/hypervisors/kvm test -Dtest='LibvirtCheckVolumeCommandWrapperTest'
mvn -pl engine/orchestration test -Dtest='VolumeOrchestratorTest'
mvn -pl server test -Dtest='VolumeImportUnmanageManagerImplTest'
```

To be verified on a KVM + Ceph/RBD environment: (A) `importVm` with `importsource=shared` adopting an existing ROOT volume on an RBD pool now succeeds and the resulting volume is recorded with format `RAW`; (B) `importVolume` of an unmanaged RBD volume records it as `RAW`.

#### How did you try to break this feature and the system with this change?

- Non-RBD pools (Filesystem / NetworkFilesystem / SharedMountPoint) keep their existing behaviour (QCOW2 validation and QCOW2 format unchanged).
- Unsupported pool types still return `Unsupported Storage Pool`.
- Locked / encrypted / volumes with a backing file on RBD are still rejected by the existing server-side `checkVolume` validations (details are collected via the force-share `qemu-img -U` probe).
- Non-KVM hypervisors are unaffected: the format helper only maps RBD → RAW for KVM, otherwise it delegates to the existing per-hypervisor mapping.
