### PR TITLE
Fix ISO tagging tests: wait for ISO download before tagging operations

### DIFF
--- a/test/integration/component/test_tags.py
+++ b/test/integration/component/test_tags.py
@@ -3049,10 +3049,11 @@ class TestResourceTags(cloudstackTestCase):
         self.cleanup.append(iso)
         self.debug("ISO created with ID: %s" % iso.id)
 
-        list_iso_response = Iso.list(self.apiclient,
-                                     id=iso.id)
-
-        if not isinstance(list_iso_response, list):
-            raise unittest.SkipTest("Registered ISO can not be found/listed for tagging")
+        try:
+            iso.download(self.apiclient)
+        except Exception as e:
+            raise unittest.SkipTest(
+                "ISO download failed: %s" % e
+            )
 
         return iso


### PR DESCRIPTION
🤖

### Description

The `create_iso()` helper in `test/integration/component/test_tags.py` calls `Iso.create()` and immediately returns, but the ISO may still be downloading when tagging tests proceed. This causes tests 7, 16, and 17 to fail intermittently when the ISO upload hasn't completed.

This PR adds a call to `iso.download()` after creation. The `download()` method (on the `Iso` class in marvin) already has a built-in retry loop (300 retries × 5s interval) that waits for the ISO to reach `Successfully Installed` and `isready` state.

If the download fails after the retry period, the test is skipped with a clear message rather than failing with an opaque upload error.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Fixes

Fixes #7041

### Affected tests

- `test_07_iso_tag`
- `test_16_query_tags_other_account`
- `test_17_query_tags_admin_account`