### PR TITLE
KVM HA: Fix CheckOnHostAnswer success flag when there is no heartbeat

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckOnHostCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckOnHostCommandWrapper.java
@@ -55,7 +55,7 @@ public final class LibvirtCheckOnHostCommandWrapper extends CommandWrapper<Check
             if (hasHeartBeat) {
                 return new CheckOnHostAnswer(command, true, "Heart is beating");
             } else {
-                return new CheckOnHostAnswer(command, "Heart is not beating");
+                return new CheckOnHostAnswer(command, false, "Heart is not beating");
             }
         } catch (final InterruptedException e) {
             return new CheckOnHostAnswer(command, "CheckOnHostCommand: can't get status of host: InterruptedException");

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHostActivityChecker.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHostActivityChecker.java
@@ -109,6 +109,7 @@ public class KVMHostActivityChecker extends AdapterBase implements ActivityCheck
         }
 
         Status hostStatusFromNeighbour = checkHostStatusWithNeighbourHosts(host);
+        logger.debug("{} status reported from itself: {} and neighbor: {}", host.toString(), hostStatusFromItself, hostStatusFromNeighbour);
         Status hostStatus = hostStatusFromItself;
         if (hostStatusFromNeighbour == Status.Up && (hostStatusFromItself == Status.Disconnected || hostStatusFromItself == Status.Down)) {
             hostStatus = Status.Disconnected;

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -61,6 +61,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import com.cloud.agent.api.CheckOnHostAnswer;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -3130,7 +3131,9 @@ public class LibvirtComputingResourceTest {
         assertNotNull(wrapper);
 
         final Answer answer = wrapper.execute(command, libvirtComputingResourceMock);
-        assertFalse(answer.getResult());
+        assertTrue(answer.getResult());
+        assertTrue(answer instanceof CheckOnHostAnswer);
+        assertFalse(((CheckOnHostAnswer)answer).isAlive());
 
         verify(libvirtComputingResourceMock, times(1)).getMonitor();
     }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5807,7 +5807,7 @@ public class VmwareResource extends ServerResourceBase implements StoragePoolRes
     }
 
     protected Answer execute(CheckOnHostCommand cmd) {
-        return new CheckOnHostAnswer(cmd, null, "Not Implmeneted");
+        return new CheckOnHostAnswer(cmd, null, "Not Implemented");
     }
 
     protected Answer execute(ModifySshKeysCommand cmd) {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCheckOnHostCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCheckOnHostCommandWrapper.java
@@ -31,6 +31,6 @@ public final class CitrixCheckOnHostCommandWrapper extends CommandWrapper<CheckO
 
     @Override
     public Answer execute(final CheckOnHostCommand command, final CitrixResourceBase citrixResourceBase) {
-        return new CheckOnHostAnswer(command, "Not Implmeneted");
+        return new CheckOnHostAnswer(command, "Not Implemented");
     }
 }


### PR DESCRIPTION
### Description

This PR fixes the CheckOnHostAnswer success flag when there is no heartbeat, for KVM HA.

Fixes #13371 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
