### PR TITLE
Update in `force.ha` value configuration value obtention

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -4936,8 +4936,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     EventTypes.EVENT_VM_STOP, "Out of band VM power off", vm.getId(), getApiCommandResourceTypeForVm(vm).toString());
         case Migrating:
             logger.info("VM {} is at {} and we received a {} report while there is no pending jobs on it"
-                            , vm, vm.getState(), vm.getPowerState());
-            if((HighAvailabilityManager.ForceHA.value() || vm.isHaEnabled()) && vm.getState() == State.Running
+                            , vm.getInstanceName(), vm.getState(), vm.getPowerState());
+            Pair<Long, Long> clusterHostPair = findClusterAndHostIdForVm(vm, false);
+            if ((HighAvailabilityManager.ForceHA.valueIn(clusterHostPair.first()) || vm.isHaEnabled()) && vm.getState() == State.Running
                     && HaVmRestartHostUp.value()
                     && vm.getHypervisorType() != HypervisorType.VMware
                     && vm.getHypervisorType() != HypervisorType.Hyperv) {

--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.utils.Pair;
 import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
@@ -479,7 +480,9 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
                 alertType = AlertManager.AlertType.ALERT_TYPE_SSVM;
             }
 
-            if (!(ForceHA.value() || vm.isHaEnabled())) {
+
+            Pair<Long, Long> clusterHostPair = _itMgr.findClusterAndHostIdForVm(vm, false);
+            if (!(ForceHA.valueIn(clusterHostPair.first()) || vm.isHaEnabled())) {
                 String hostDesc = "id:" + vm.getHostId() + ", availability zone id:" + vm.getDataCenterId() + ", pod id:" + vm.getPodIdToDeployIn();
                 _alertMgr.sendAlert(alertType, vm.getDataCenterId(), vm.getPodIdToDeployIn(), "VM (name: " + vm.getHostName() + ", id: " + vm.getId() +
                     ") stopped unexpectedly on host " + hostDesc, "Virtual Machine " + vm.getHostName() + " (id: " + vm.getId() + ") running on host [" + vm.getHostId() +
@@ -722,7 +725,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
 
         vm = _itMgr.findById(vm.getId());
 
-        if (!ForceHA.value() && !vm.isHaEnabled()) {
+        if (!ForceHA.valueIn(host.getClusterId()) && !vm.isHaEnabled()) {
             if (logger.isDebugEnabled()) {
                 logger.debug("VM is not HA enabled so we're done.");
             }

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -2851,7 +2851,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         logger.debug("Cannot transmit host {} to Disabled state", host, e);
                     }
                     for (final VMInstanceVO vm : vms) {
-                        if ((! HighAvailabilityManager.ForceHA.valueIn(host.getClusterId()) && !vm.isHaEnabled()) || vm.getState() == State.Stopping) {
+                        if ((!HighAvailabilityManager.ForceHA.valueIn(host.getClusterId()) && !vm.isHaEnabled()) || vm.getState() == State.Stopping) {
                             logger.debug(String.format("Stopping %s as a part of hostDelete for %s",vm, host));
                             try {
                                 _haMgr.scheduleStop(vm, host.getId(), WorkType.Stop);

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -946,7 +946,6 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
                 host.setGuid(null);
                 final Long clusterId = host.getClusterId();
-                host.setClusterId(null);
                 _hostDao.update(host.getId(), host);
 
                 Host hostRemoved = _hostDao.findById(hostId);
@@ -2852,7 +2851,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         logger.debug("Cannot transmit host {} to Disabled state", host, e);
                     }
                     for (final VMInstanceVO vm : vms) {
-                        if ((!HighAvailabilityManager.ForceHA.value() && !vm.isHaEnabled()) || vm.getState() == State.Stopping) {
+                        if ((! HighAvailabilityManager.ForceHA.valueIn(host.getClusterId()) && !vm.isHaEnabled()) || vm.getState() == State.Stopping) {
                             logger.debug(String.format("Stopping %s as a part of hostDelete for %s",vm, host));
                             try {
                                 _haMgr.scheduleStop(vm, host.getId(), WorkType.Stop);
@@ -2861,7 +2860,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                                 logger.debug(errorMsg, e);
                                 throw new UnableDeleteHostException(errorMsg + "," + e.getMessage());
                             }
-                        } else if ((HighAvailabilityManager.ForceHA.value() || vm.isHaEnabled()) && (vm.getState() == State.Running || vm.getState() == State.Starting)) {
+                        } else if ((HighAvailabilityManager.ForceHA.valueIn(host.getClusterId()) || vm.isHaEnabled()) && (vm.getState() == State.Running || vm.getState() == State.Starting)) {
                             logger.debug(String.format("Scheduling restart for %s, state: %s on host: %s.", vm, vm.getState(), host));
                             _haMgr.scheduleRestart(vm, false);
                         }


### PR DESCRIPTION
### Description

Currently, workflows that use the `force.ha` configuration value only consider the global value of the configuration, even though it has a `Cluster` scope. To fix this, changes were made to consider the configuration's cluster scope value. If it is not configured at cluster level, the global value is used.

Sometimes, the cluster ID was not available at the method for the configuration value obtention, and the host could be `null`. Thus, the `findClusterAndHostIdForVM` was used, as it searches for the VM's host/last host and the returned host's cluster. If they (host and cluster) are both null, the cluster ID is obtained from the storage where the VM volume is allocated is returned.

This PR also removes the host's cluster cleanup that was executed during host's removal. It was observed that there was no impact in removing the host' cluster ID, and processes that could be affected by it already contained validations to prevent errors.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

First, I validated that without the changes, VMs without HA enabled in their offerings were not restarted, even though the `force.ha` configuration was enabled at cluster scope. After installing the packages with the new changes, I made the following tests. All the tests were executed one time with the configuration enabled globally, and one time with it enabled at cluster scope:

| Test | Result |
| ---- | ------ |
| Kill the VM's process with `kill -9 <pid>` | The VM was identified as shutdown, and restarted automatically. |
| Hard power off the VM's host | The host was identified as `Disconnected`, and the VM was restarted in another environment node. | 
| Host's forced removal | ACS identified that that were VMs running in the host, and restarted them automatically in another node. |

---

Regarding the cluster ID cleanup removal, the following tests were conducted to check whether keeping it would cause inconsistencies:

| Test | Result |
| ---- | ------ |
| Host removal | The host was removed, and its cluster ID was kept. |
| Host removal with running VMs | The host was removed, the cluster ID was kept, and the VMs were restarted on another node. |
| Host reintroduction | The host was reintroduced with success. |
| Cluster and host creation | No issue was found during the creation of both resources. No issue was found during the removal of both resources. |
| Removing host from Cluster 1, deleting Cluster 1, and adding host to Cluster 2 | The host was added with success. |  

Before the cluster ID cleanup removal, during the host's forced removal, HA restart jobs are created for the workers (`ha.workers` configuration) to process. However, if there aren't enough workers available to process the jobs and the `force.ha` configuration is enabled only at cluster scope, it is possible that the host's removal flow finishes before processing all HA jobs, leading to inconsistent VMs. 

In order to validate if this was fixed after the cleanup removal, in a environment with 2 hosts, I provisioned 35 VMs in one host and set the `ha.workers` amount to `1`. Then, I forcefully removed the host where the VMs were provisioned, and validated that all the VMs were stopped, and restarted on the other host.