### PR TITLE
Fix: Don't set management server ID if cookie isn't set.

### DIFF
--- a/ui/src/permission.js
+++ b/ui/src/permission.js
@@ -93,7 +93,10 @@ router.beforeEach((to, from, next) => {
           return
         }
         store.commit('SET_LOGIN_FLAG', true)
-        store.commit('SET_MS_ID', Cookies.get('managementserverid'))
+        const MS_ID = Cookies.get('managementserverid')
+        if (MS_ID) {
+          store.commit('SET_MS_ID', MS_ID)
+        }
       }
       if (Object.keys(store.getters.apis).length === 0) {
         const cachedApis = vueProps.$localStorage.get(APIS, {})


### PR DESCRIPTION
### Description

This PR prevents the frontend from setting MS_ID if the "managementserverid" cookie isn't set. 

We upgraded to 4.22.1.0 yesterday and non-root-admins couldn't log in with SAML, they were presented with a blank white page and some errors in the javascript console. After a little time in the debugger, I chased it down to [this change](https://github.com/apache/cloudstack/commit/d6c39772b2177c9fde87780611f33a52902d4395#diff-54d65f8d5d3306bece6cb1a2f67106114a6a73fe342d3a3ec47649f7a7563c0fR96) setting MS_ID in localstorage to "undefined", causing downstream issues in `store/modules/user.js`. 

Fixes: #13277 
 

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?
Rebuilt the UI and swapped it in place live on our management server. 

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
