### PR TITLE
server: make HikariCP leak detection configurable

### DIFF
--- a/client/conf/db.properties.in
+++ b/client/conf/db.properties.in
@@ -41,6 +41,11 @@ db.cloud.maxWait=600000
 db.cloud.minIdleConnections=5
 db.cloud.connectionTimeout=30000
 db.cloud.keepAliveTime=600000
+# HikariCP leak detection threshold in milliseconds. A value of 0 (or unset) disables leak detection.
+# Useful for debugging borrowed DB connections that are not returned to the pool. HikariCP ignores values below 2000.
+# db.cloud.leakDetectionThreshold=0
+# Enable HikariCP JMX MBeans for observing pool counters. Disabled by default.
+# db.cloud.registerMbeans=false
 db.cloud.validationQuery=/* ping */ SELECT 1
 db.cloud.testOnBorrow=true
 db.cloud.testWhileIdle=true

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -38,6 +38,7 @@ import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnection;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.pool2.ObjectPool;
@@ -1065,6 +1066,8 @@ public class TransactionLegacy implements Closeable {
             final Integer cloudMinIdleConnections = parseNumber(dbProps.getProperty("db.cloud.minIdleConnections"), Integer.class);
             final Long cloudConnectionTimeout = parseNumber(dbProps.getProperty("db.cloud.connectionTimeout"), Long.class);
             final Long cloudKeepAliveTimeout = parseNumber(dbProps.getProperty("db.cloud.keepAliveTime"), Long.class);
+            final Long cloudLeakDetectionThreshold = parseNumber(dbProps.getProperty("db.cloud.leakDetectionThreshold"), Long.class);
+            final Boolean cloudRegisterMbeans = BooleanUtils.toBooleanObject(dbProps.getProperty("db.cloud.registerMbeans"));
             final String cloudUsername = dbProps.getProperty("db.cloud.username");
             final String cloudPassword = dbProps.getProperty("db.cloud.password");
             final String cloudValidationQuery = dbProps.getProperty("db.cloud.validationQuery");
@@ -1107,7 +1110,7 @@ public class TransactionLegacy implements Closeable {
                     cloudUsername, cloudPassword, cloudMaxActive, cloudMaxIdle, cloudMaxWait,
                     cloudTimeBtwEvictionRunsMillis, cloudMinEvcitableIdleTimeMillis, cloudTestWhileIdle,
                     cloudTestOnBorrow, cloudValidationQuery, cloudMinIdleConnections, cloudConnectionTimeout,
-                    cloudKeepAliveTimeout, isolationLevel, "cloud");
+                    cloudKeepAliveTimeout, cloudLeakDetectionThreshold, cloudRegisterMbeans, isolationLevel, "cloud");
 
             // Configure the usage db
             final Integer usageMaxActive = parseNumber(dbProps.getProperty("db.usage.maxActive"), Integer.class);
@@ -1116,6 +1119,8 @@ public class TransactionLegacy implements Closeable {
             final Integer usageMinIdleConnections = parseNumber(dbProps.getProperty("db.usage.minIdleConnections"), Integer.class);
             final Long usageConnectionTimeout = parseNumber(dbProps.getProperty("db.usage.connectionTimeout"), Long.class);
             final Long usageKeepAliveTimeout = parseNumber(dbProps.getProperty("db.usage.keepAliveTime"), Long.class);
+            final Long usageLeakDetectionThreshold = parseNumber(dbProps.getProperty("db.usage.leakDetectionThreshold"), Long.class);
+            final Boolean usageRegisterMbeans = BooleanUtils.toBooleanObject(dbProps.getProperty("db.usage.registerMbeans"));
             final String usageUsername = dbProps.getProperty("db.usage.username");
             final String usagePassword = dbProps.getProperty("db.usage.password");
 
@@ -1127,7 +1132,8 @@ public class TransactionLegacy implements Closeable {
             s_usageDS = createDataSource(dbProps.getProperty("db.usage.connectionPoolLib"), usageUriAndDriver.first(),
                     usageUsername, usagePassword, usageMaxActive, usageMaxIdle, usageMaxWait, null,
                     null, null, null, null,
-                    usageMinIdleConnections, usageConnectionTimeout, usageKeepAliveTimeout, isolationLevel, "usage");
+                    usageMinIdleConnections, usageConnectionTimeout, usageKeepAliveTimeout, usageLeakDetectionThreshold,
+                    usageRegisterMbeans, isolationLevel, "usage");
 
             try {
                 // Configure the simulator db
@@ -1137,6 +1143,8 @@ public class TransactionLegacy implements Closeable {
                 final Integer simulatorMinIdleConnections = parseNumber(dbProps.getProperty("db.simulator.minIdleConnections"), Integer.class);
                 final Long simulatorConnectionTimeout = parseNumber(dbProps.getProperty("db.simulator.connectionTimeout"), Long.class);
                 final Long simulatorKeepAliveTimeout = parseNumber(dbProps.getProperty("db.simulator.keepAliveTime"), Long.class);
+                final Long simulatorLeakDetectionThreshold = parseNumber(dbProps.getProperty("db.simulator.leakDetectionThreshold"), Long.class);
+                final Boolean simulatorRegisterMbeans = BooleanUtils.toBooleanObject(dbProps.getProperty("db.simulator.registerMbeans"));
                 final String simulatorUsername = dbProps.getProperty("db.simulator.username");
                 final String simulatorPassword = dbProps.getProperty("db.simulator.password");
 
@@ -1167,7 +1175,8 @@ public class TransactionLegacy implements Closeable {
                         simulatorConnectionUri, simulatorUsername, simulatorPassword, simulatorMaxActive,
                         simulatorMaxIdle, simulatorMaxWait, null, null, null, null,
                         cloudValidationQuery, simulatorMinIdleConnections, simulatorConnectionTimeout,
-                        simulatorKeepAliveTimeout, isolationLevel, "simulator");
+                        simulatorKeepAliveTimeout, simulatorLeakDetectionThreshold, simulatorRegisterMbeans,
+                        isolationLevel, "simulator");
             } catch (Exception e) {
                 LOGGER.debug("Simulator DB properties are not available. Not initializing simulator DS");
             }
@@ -1269,7 +1278,8 @@ public class TransactionLegacy implements Closeable {
     private static DataSource createDataSource(String connectionPoolLib, String uri, String username, String password,
                Integer maxActive, Integer maxIdle, Long maxWait, Long timeBtwnEvictionRuns, Long minEvictableIdleTime,
                Boolean testWhileIdle, Boolean testOnBorrow, String validationQuery, Integer minIdleConnections,
-               Long connectionTimeout, Long keepAliveTime, Integer isolationLevel, String dsName) {
+               Long connectionTimeout, Long keepAliveTime, Long leakDetectionThreshold, Boolean registerMbeans,
+               Integer isolationLevel, String dsName) {
         LOGGER.debug("Creating datasource for database: {} with connection pool lib: {}", dsName,
                 connectionPoolLib);
         if (CONNECTION_POOL_LIB_DBCP.equals(connectionPoolLib)) {
@@ -1277,12 +1287,13 @@ public class TransactionLegacy implements Closeable {
                     minEvictableIdleTime, testWhileIdle, testOnBorrow, validationQuery, isolationLevel);
         }
         return createHikaricpDataSource(uri, username, password, maxActive, maxIdle, maxWait, minIdleConnections,
-                connectionTimeout, keepAliveTime, isolationLevel, dsName);
+                connectionTimeout, keepAliveTime, leakDetectionThreshold, registerMbeans, isolationLevel, dsName);
     }
 
     private static DataSource createHikaricpDataSource(String uri, String username, String password,
                                                Integer maxActive, Integer maxIdle, Long maxWait,
                                                Integer minIdleConnections, Long connectionTimeout, Long keepAliveTime,
+                                               Long leakDetectionThreshold, Boolean registerMbeans,
                                                Integer isolationLevel, String dsName) {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(uri);
@@ -1298,6 +1309,8 @@ public class TransactionLegacy implements Closeable {
         config.setMinimumIdle(ObjectUtils.defaultIfNull(minIdleConnections, 5));
         config.setConnectionTimeout(ObjectUtils.defaultIfNull(connectionTimeout, 30000L));
         config.setKeepaliveTime(ObjectUtils.defaultIfNull(keepAliveTime, 600000L));
+
+        applyHikariDebugSettings(config, leakDetectionThreshold, registerMbeans, dsName);
 
         String isolationLevelString = "TRANSACTION_READ_COMMITTED";
         if (isolationLevel == Connection.TRANSACTION_SERIALIZABLE) {
@@ -1324,6 +1337,21 @@ public class TransactionLegacy implements Closeable {
 
         HikariDataSource dataSource = new HikariDataSource(config);
         return dataSource;
+    }
+
+    /**
+     * Applies optional HikariCP debugging aids (leak detection and JMX MBeans). Both are disabled by
+     * default; leakDetectionThreshold is only applied when set to a positive value (HikariCP treats 0
+     * as disabled and ignores values below 2000ms). Package-private for unit testing.
+     */
+    static void applyHikariDebugSettings(HikariConfig config, Long leakDetectionThreshold, Boolean registerMbeans, String dsName) {
+        if (leakDetectionThreshold != null && leakDetectionThreshold > 0) {
+            config.setLeakDetectionThreshold(leakDetectionThreshold);
+        }
+        config.setRegisterMbeans(ObjectUtils.defaultIfNull(registerMbeans, false));
+        LOGGER.debug("HikariCP pool {}: leakDetectionThreshold={} ms, registerMbeans={}", dsName,
+                ObjectUtils.defaultIfNull(leakDetectionThreshold, 0L),
+                ObjectUtils.defaultIfNull(registerMbeans, false));
     }
 
     private static DataSource createDbcpDataSource(String uri, String username, String password,

--- a/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
+++ b/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
@@ -17,6 +17,7 @@
 package com.cloud.utils.db;
 
 import com.cloud.utils.Pair;
+import com.zaxxer.hikari.HikariConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -113,5 +114,45 @@ public class TransactionLegacyTest {
         String result = TransactionLegacy.buildConnectionUri(null, "driver", true, "host", null, 5555, "cloud", false, null, null);
 
         Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false&useSSL=true", result);
+    }
+
+    @Test
+    public void applyHikariDebugSettingsDisabledByDefault() {
+        HikariConfig config = new HikariConfig();
+
+        TransactionLegacy.applyHikariDebugSettings(config, null, null, "cloud");
+
+        Assert.assertEquals(0L, config.getLeakDetectionThreshold());
+        Assert.assertFalse(config.isRegisterMbeans());
+    }
+
+    @Test
+    public void applyHikariDebugSettingsZeroThresholdKeepsLeakDetectionDisabled() {
+        HikariConfig config = new HikariConfig();
+
+        TransactionLegacy.applyHikariDebugSettings(config, 0L, false, "cloud");
+
+        Assert.assertEquals(0L, config.getLeakDetectionThreshold());
+        Assert.assertFalse(config.isRegisterMbeans());
+    }
+
+    @Test
+    public void applyHikariDebugSettingsEnablesLeakDetection() {
+        HikariConfig config = new HikariConfig();
+
+        TransactionLegacy.applyHikariDebugSettings(config, 60000L, null, "cloud");
+
+        Assert.assertEquals(60000L, config.getLeakDetectionThreshold());
+        Assert.assertFalse(config.isRegisterMbeans());
+    }
+
+    @Test
+    public void applyHikariDebugSettingsEnablesRegisterMbeans() {
+        HikariConfig config = new HikariConfig();
+
+        TransactionLegacy.applyHikariDebugSettings(config, null, true, "cloud");
+
+        Assert.assertEquals(0L, config.getLeakDetectionThreshold());
+        Assert.assertTrue(config.isRegisterMbeans());
     }
 }


### PR DESCRIPTION
### Description

This PR makes the HikariCP **leak-detection threshold** and **JMX MBean registration** configurable per database pool via `db.properties`, instead of relying on HikariCP defaults that cannot be changed without a code change.

CloudStack already maps a subset of `db.properties` values onto `HikariConfig` in `framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java` (e.g. `maxActive`, `maxIdle`, `maxWait`, `minIdleConnections`, `connectionTimeout`, `keepAliveTime`). This PR adds two more, following the exact same parsing/threading pattern:

| Property | Maps to | Default |
|---|---|---|
| `db.<pool>.leakDetectionThreshold` | `HikariConfig#setLeakDetectionThreshold(long)` | `0` (disabled) |
| `db.<pool>.registerMbeans` | `HikariConfig#setRegisterMbeans(boolean)` | `false` (disabled) |

Supported for all three pools that use the shared datasource factory: `cloud`, `usage`, `simulator`.

**Behaviour:**
- `leakDetectionThreshold` absent or `0` → leak detection disabled (unchanged default behaviour). Only applied when set to a value `> 0`. *(HikariCP itself ignores values below 2000 ms with a warning.)*
- `registerMbeans` absent or `false` → MBeans disabled (unchanged default). `true` → Hikari JMX MBeans registered for live pool-counter observation.
- Settings are applied **only on the HikariCP path**; the DBCP datasource path is unaffected.
- A debug-level log line reports the effective values per pool (no credentials or sensitive data).

**Motivation / context:** in production we saw the management server become unstable — and eventually crash — on clusters exercising Host-HA. Watching MySQL with `SHOW PROCESSLIST` during the incident showed the number of sessions owned by the `cloud` DB user climbing steadily over a couple of hours, **all of them in the `Sleep` state**, until the HikariCP pool (`db.cloud.maxActive`, default `250`) was exhausted and the server could no longer borrow a connection. That signature — monotonically growing, never-reaped, all idle, all owned by the `cloud` user — is a classic DB connection leak in a periodic code path (suspected Host-HA host checks) that borrows a pooled connection and never returns it.

The problem is these symptoms tell you *that* connections leak, not *where*. HikariCP already has the exact tool for that — `leakDetectionThreshold` — but CloudStack hard-wires it off with no way to turn it on. This PR exposes it (and `registerMbeans`) through `db.properties` so an operator can enable leak detection on a live server; HikariCP then logs an `Apparent connection leak detected` stack trace identifying the precise code path that borrowed the connection and failed to return it, and the MBeans give live pool-counter visibility. The actual leak fix is a separate change; this PR is the diagnostic enabler.

Everything is **disabled by default**, so there is no behavioural change for existing deployments that don't set the new properties.

<!-- Fixes: # -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

**Build:** compiled the affected module and its dependencies off tag `4.22.1.0`:

```
mvn -pl framework/db -am -DskipTests compile
```
Result: **BUILD SUCCESS** (checkstyle passed). The change is confined to property parsing and threading through the existing `createDataSource` → `createHikaricpDataSource` chain, reusing the existing `parseNumber(...)` helper.

**Unit tests:** the apply-logic is factored into a package-private `applyHikariDebugSettings(HikariConfig, Long, Boolean, String)` and covered by 4 new `TransactionLegacyTest` cases — defaults-disabled, `0`-keeps-disabled, leak-detection-enabled (`60000`), and register-MBeans-enabled:

```
mvn -pl framework/db test -Dtest='TransactionLegacyTest#applyHikariDebugSettings*'
```
Result: **Tests run: 4, Failures: 0, Errors: 0** — BUILD SUCCESS.

**Runtime validation plan (on a patched management server):**

1. In `/etc/cloudstack/management/db.properties`:
   ```
   db.cloud.leakDetectionThreshold=60000
   db.cloud.registerMbeans=true
   ```
2. `systemctl restart cloudstack-management`
3. Reproduce the Host-HA scenario and watch:
   ```
   grep -iE "leak detection|Apparent connection leak|ProxyLeakTask|Hikari" \
     /var/log/cloudstack/management/management-server.log
   ```
   Expected: `java.lang.Exception: Apparent connection leak detected` with a stack trace through `com.zaxxer.hikari.HikariDataSource.getConnection(...)` → `com.cloud.utils.db.TransactionLegacy...` identifying the borrowing path.
4. With `registerMbeans=true`, the `com.zaxxer.hikari:type=Pool (cloud)` MBean is visible via JMX for live pool counters.

#### How did you try to break this feature and the system with this change?

Edge cases considered:
- Property **absent** → null → leak detection disabled, `registerMbeans=false` (existing behaviour preserved).
- `leakDetectionThreshold=0` → not applied (disabled).
- `leakDetectionThreshold` between 1–1999 ms → passed to Hikari, which warns and ignores it (documented Hikari behaviour; noted in the code comment and the sample config).
- `registerMbeans=false` explicitly → MBeans off.
- DBCP connection-pool path → new values are not forwarded, so behaviour is unchanged.
- Default datasource fallback path (`getDefaultHikaricpDataSource`) → untouched.

These cases (defaults, `0`, enabled threshold, enabled MBeans) are locked down by the new `applyHikariDebugSettings` unit tests.
