### PR TITLE
Snapshot state normalization for failure due to malformed secondary s…

### DIFF
--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -1633,11 +1633,17 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         boolean backupSnapToSecondary = isBackupSnapshotToSecondaryForZone(volume.getDataCenterId());
 
         if (isKvmAndFileBasedStorage && backupSnapToSecondary) {
-            DataStore imageStore = snapshotSrv.findSnapshotImageStore(snapshot);
-            if (imageStore == null) {
-                throw new CloudRuntimeException(String.format("Could not find any secondary storage to allocate snapshot [%s].", snapshot));
+            try {
+                DataStore imageStore = snapshotSrv.findSnapshotImageStore(snapshot);
+                if (imageStore == null) {
+                    throw new CloudRuntimeException(String.format("Could not find any secondary storage to allocate snapshot [%s].", snapshot));
+                }
+                snapshot.setImageStore(imageStore);
+            } catch (CloudRuntimeException ex) {
+                logger.error("There was an error while selecting image store for snapshot: {}", ex.getMessage());
+                handleErrorInUncreatedSnapshot(snapshotId);
+                throw new CloudRuntimeException(ex.getMessage());
             }
-            snapshot.setImageStore(imageStore);
         }
 
         updateSnapshotPayload(volume.getPoolId(), payload, isKvmAndFileBasedStorage, clusterId);
@@ -1736,6 +1742,12 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         snapshotOnPrimary.markBackedUp();
         _snapshotStoreDao.removeBySnapshotStore(snapshotId, snapshotOnPrimary.getDataStore().getId(), snapshotOnPrimary.getDataStore().getRole());
         snapshotDetailsDao.removeDetail(snapshotOnPrimary.getId(), AsyncJob.Constants.MS_ID);
+    }
+
+    private void handleErrorInUncreatedSnapshot(Long snapshotId) {
+        SnapshotVO snapshot = _snapshotDao.findById(snapshotId);
+        snapshot.setState(Snapshot.State.Error);
+        _snapshotDao.persist(snapshot);
     }
 
     @Override


### PR DESCRIPTION
### Description

If the environment has a malformed (wrong logic, syntax error, etc.) secondary storage selector heuristic rule, an exception is thrown during its interpretation. The snapshot creation process gets the environment's `SNAPSHOT` type secondary storage selectors and interprets its heuristic rule, if any was returned. However, this validation does not handle exceptions thrown by the interpreter.

With that, the snapshot record that was created in the `Allocated` state is never normalized, even though the creation process was finished prematurely due to the interpretation error. Therefore, changes were made to normalize the snapshot state to `Error` in these cases.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

First, I created a malformed secondary storage selector:

<details><summary>Secondary storage selector creation command</summary>

```bash
create secondarystorageselector name=a description=a type=SNAPSHOT zoneid=a9a3fc15-008f-48b1-8964-d946104b4b17 heuristicrule="if"
```

</details>

Then, I tried to create a volume snapshot, and validated that it was set to the `Allocated` state. After applying the changes, I repeated the process and validated that the snapshot was set to the `Error` state.