### PR TITLE
Delete user-project mappings on project deletion

### DIFF
--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
@@ -52,7 +52,6 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
         ProjectAccountSearch = createSearchBuilder();
         ProjectAccountSearch.and("projectId", ProjectAccountSearch.entity().getProjectId(), SearchCriteria.Op.EQ);
         ProjectAccountSearch.and("accountId", ProjectAccountSearch.entity().getAccountId(), SearchCriteria.Op.EQ);
-        ProjectAccountSearch.and("userId", ProjectAccountSearch.entity().getUserId(), Op.NULL);
         ProjectAccountSearch.done();
 
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42030to42040.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42030to42040.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.upgrade.dao;
 
+import com.cloud.utils.exception.CloudRuntimeException;
+
 import java.io.InputStream;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -40,7 +42,13 @@ public class Upgrade42030to42040 extends DbUpgradeAbstractImpl implements DbUpgr
 
     @Override
     public InputStream[] getPrepareScripts() {
-        return null;
+        final String scriptFile = "META-INF/db/schema-42030to42040.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
     }
 
     @Override

--- a/engine/schema/src/main/resources/META-INF/db/schema-42030to42040.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42030to42040.sql
@@ -1,0 +1,24 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.20.3.0 to 4.20.4.0
+--;
+
+-- Normalization of project accounts for deleted projects
+
+DELETE pa FROM project_account pa JOIN projects p ON pa.project_id = p.id WHERE p.removed IS NOT NULL AND pa.user_id IS NOT NULL;


### PR DESCRIPTION
### Description

When a user is added to a project, and this project is then deleted, the user-project mapping is never removed from the database. Thus, when attempting to delete the user's account, an error is returned stating that the account is still linked to a project.

Therefore, this PR deletes the invalid user-project mappings and fixes the project deletion process in CloudStack.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

1. A new project belonging to a domain admin account was created and a user was added to it.
2. In the database, I observed that `select * from project_account` had the entries for 1 account and 1 user belonging to the project.
3. I deleted the project.
4. I the database, using the same command, I observed that the mappings were removed after project deletion.
5. I deleted the user's account without receiving any errors.

