### PR TITLE
api,server: prevent npe on reset pass for expunged vm

### DIFF
--- a/api/src/main/java/com/cloud/vm/UserVmService.java
+++ b/api/src/main/java/com/cloud/vm/UserVmService.java
@@ -93,7 +93,7 @@ public interface UserVmService {
      *            - the command specifying vmId, password
      * @return the VM if reset worked successfully, null otherwise
      */
-    UserVm resetVMPassword(ResetVMPasswordCmd cmd, String password) throws ResourceUnavailableException, InsufficientCapacityException;
+    UserVm resetVMPassword(ResetVMPasswordCmd cmd) throws ResourceUnavailableException, InsufficientCapacityException;
 
     /**
      * Resets the SSH Key of a virtual machine.

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ResetVMPasswordCmd.java
@@ -16,8 +16,6 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.vm;
 
-import org.apache.commons.lang3.StringUtils;
-
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.APICommand;
@@ -116,16 +114,8 @@ public class ResetVMPasswordCmd extends BaseAsyncCmd implements UserCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException {
-        password = getPassword();
-        UserVm vm = _responseGenerator.findUserVmById(getId());
-        if (StringUtils.isBlank(password)) {
-            password = _mgr.generateRandomPassword();
-            logger.debug(String.format("Resetting VM [%s] password to a randomly generated password.", vm.getUuid()));
-        } else {
-            logger.debug(String.format("Resetting VM [%s] password to password defined by user.", vm.getUuid()));
-        }
         CallContext.current().setEventDetails("Vm Id: " + getId());
-        UserVm result = _userVmService.resetVMPassword(this, password);
+        UserVm result = _userVmService.resetVMPassword(this);
         if (result != null){
             UserVmResponse response = _responseGenerator.createUserVmResponse(getResponseView(), "virtualmachine", result).get(0);
             response.setResponseName(getCommandName());

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -249,12 +249,12 @@ import com.cloud.hypervisor.kvm.dpdk.DpdkHelper;
 import com.cloud.kubernetes.cluster.KubernetesServiceHelper;
 import com.cloud.network.IpAddressManager;
 import com.cloud.network.Network;
-import com.cloud.network.NetworkService;
 import com.cloud.network.Network.GuestType;
 import com.cloud.network.Network.IpAddresses;
 import com.cloud.network.Network.Provider;
 import com.cloud.network.Network.Service;
 import com.cloud.network.NetworkModel;
+import com.cloud.network.NetworkService;
 import com.cloud.network.Networks.TrafficType;
 import com.cloud.network.PhysicalNetwork;
 import com.cloud.network.as.AutoScaleManager;
@@ -837,7 +837,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_VM_RESETPASSWORD, eventDescription = "resetting Vm password", async = true)
-    public UserVm resetVMPassword(ResetVMPasswordCmd cmd, String password) throws ResourceUnavailableException, InsufficientCapacityException {
+    public UserVm resetVMPassword(ResetVMPasswordCmd cmd) throws ResourceUnavailableException, InsufficientCapacityException {
         Account caller = CallContext.current().getCallingAccount();
         Long vmId = cmd.getId();
         UserVmVO userVm = _vmDao.findById(cmd.getId());
@@ -846,6 +846,14 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (userVm == null) {
             throw new InvalidParameterValueException("unable to find an Instance with id " + cmd.getId());
         }
+
+        String logSuffix = "password defined by user";
+        String password = cmd.getPassword();
+        if (StringUtils.isBlank(password)) {
+            password = _mgr.generateRandomPassword();
+            logSuffix = "a randomly generated password";
+        }
+        logger.debug("Resetting {} password to {}.", userVm, logSuffix);
 
         _vmDao.loadDetails(userVm);
 


### PR DESCRIPTION
### Description

Fixes NPE observed when calling resetPasswordForVirtualMachine API for an expunged VM.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Before:

```
(localcloud) 🐱 > reset passwordforvirtualmachine id=6aa8552f-a0ca-4520-9359-c26e06c22e4c
{
  "account": "admin1",
  "accountid": "7ef3edd8-b4ca-46b4-97d0-e7bebeb8704d",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ResetVMPasswordCmdByAdmin",
  "completed": "2026-06-24T05:01:50+0000",
  "created": "2026-06-24T05:01:30+0000",
  "domainid": "cc89a62c-6a12-11f1-bcb1-525400491d42",
  "domainpath": "ROOT",
  "jobid": "6725d884-236b-4482-b96b-964a54b6b5ea",
  "jobinstanceid": "6aa8552f-a0ca-4520-9359-c26e06c22e4c",
  "jobinstancetype": "VirtualMachine",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 530,
    "errortext": "Cannot invoke \"com.cloud.uservm.UserVm.getUuid()\" because \"vm\" is null"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "7c01a5fa-8d06-402a-8932-e6673470ac6b"
}
```

```
2026-06-24 05:01:50,231 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-6:[ctx-463637d6, job-16856]) (logid:6725d884) Unexpected exception while executing org.apache.cloudstack.api.command.admin.vm.ResetVMPasswordCmdByAdmin java.lang.NullPointerException: Cannot invoke "com.cloud.uservm.UserVm.getUuid()" because "vm" is null
	at org.apache.cloudstack.api.command.user.vm.ResetVMPasswordCmd.execute(ResetVMPasswordCmd.java:123)
	at com.cloud.api.ApiDispatcher.dispatch(ApiDispatcher.java:173)
	at com.cloud.api.ApiAsyncJobDispatcher.runJob(ApiAsyncJobDispatcher.java:110)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.runInContext(AsyncJobManagerImpl.java:649)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:56)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:103)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:53)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46)
	at org.apache.cloudstack.framework.jobs.impl.AsyncJobManagerImpl$5.run(AsyncJobManagerImpl.java:597)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

After:
```
(localcloud) 🐱 > reset passwordforvirtualmachine id=6aa8552f-a0ca-4520-9359-c26e06c22e4c
{
  "account": "admin1",
  "accountid": "7ef3edd8-b4ca-46b4-97d0-e7bebeb8704d",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.ResetVMPasswordCmdByAdmin",
  "completed": "2026-06-24T05:17:43+0000",
  "created": "2026-06-24T05:17:43+0000",
  "domainid": "cc89a62c-6a12-11f1-bcb1-525400491d42",
  "domainpath": "ROOT",
  "jobid": "eeb141fa-93f2-49b5-9af7-3aed32f5184e",
  "jobinstanceid": "6aa8552f-a0ca-4520-9359-c26e06c22e4c",
  "jobinstancetype": "VirtualMachine",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 431,
    "errortext": "unable to find an Instance with id 5"
  },
  "jobresultcode": 431,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "7c01a5fa-8d06-402a-8932-e6673470ac6b"
}
🙈 Error: async API failed for job eeb141fa-93f2-49b5-9af7-3aed32f5184e
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
