### PR TITLE
Add KMSWrappedKeyDao as a dependency for the Usage server

### DIFF
--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-common-daos-between-management-and-usage-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-common-daos-between-management-and-usage-context.xml
@@ -46,6 +46,7 @@
 	<bean id="hostTransferMapDaoImpl" class="com.cloud.cluster.agentlb.dao.HostTransferMapDaoImpl" />
 	<bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl" />
 	<bean id="imageStoreObjectDownloadDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreObjectDownloadDaoImpl" />
+	<bean id="kmsWrappedKeyDaoImpl" class="org.apache.cloudstack.kms.dao.KMSWrappedKeyDaoImpl" />
 	<bean id="networkOfferingDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingDaoImpl" />
 	<bean id="networkOfferingDetailsDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingDetailsDaoImpl" />
 	<bean id="networkOfferingServiceMapDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingServiceMapDaoImpl" />

--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -316,7 +316,6 @@
   <bean id="apiKeyPairPermissionsDaoImpl" class="org.apache.cloudstack.acl.dao.ApiKeyPairPermissionsDaoImpl" />
   <bean id="kmsKeyDaoImpl" class="org.apache.cloudstack.kms.dao.KMSKeyDaoImpl" />
   <bean id="kmsKekVersionDaoImpl" class="org.apache.cloudstack.kms.dao.KMSKekVersionDaoImpl" />
-  <bean id="kmsWrappedKeyDaoImpl" class="org.apache.cloudstack.kms.dao.KMSWrappedKeyDaoImpl" />
   <bean id="hsmProfileDaoImpl" class="org.apache.cloudstack.kms.dao.HSMProfileDaoImpl" />
   <bean id="hsmProfileDetailsDaoImpl" class="org.apache.cloudstack.kms.dao.HSMProfileDetailsDaoImpl" />
 </beans>


### PR DESCRIPTION
### Description

PR #12711 injected `KMSWrappedKeyDao` in `com.cloud.storage.dao.VolumeDao`, which is used by the Usage server. However, `KMSWrappedKeyDao` was not added as dependency for the Usage server. Due to this, the Usage server fails to start in the latest commit.

<details><summary>Logs</summary>

```
2026-07-05 21:21:42,389 ERROR [utils.component.ComponentContext] (main:[]) (logid:) Could not load bean due to: [Error creating bean with name 'volumeDaoImpl': Unsatisfied dependency expressed through field 'kmsWrappedKeyDao'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.cloudstack.kms.dao.KMSWrappedKeyDao' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@javax.inject.Inject()}]. The service will be stopped. Please investigate the cause of the error or contact your support team. org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'volumeDaoImpl': Unsatisfied dependency expressed through field 'kmsWrappedKeyDao'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.cloudstack.kms.dao.KMSWrappedKeyDao' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@javax.inject.Inject()}
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:660)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:640)
	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:119)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:399)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1431)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.configureBean(AbstractAutowireCapableBeanFactory.java:364)
	at com.cloud.utils.component.ComponentContext.initComponentsLifeCycle(ComponentContext.java:80)
	at com.cloud.usage.UsageServer.start(UsageServer.java:55)
	at com.cloud.usage.UsageServer.main(UsageServer.java:42)
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.cloudstack.kms.dao.KMSWrappedKeyDao' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@javax.inject.Inject()}
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1801)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1357)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1311)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:657)
	... 8 more
```

</details>

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

I built packages for this patch, installed them, and validated that the Usage server started successfully.

<details><summary>Logs</summary>

```
2026-07-05 21:49:01,539 INFO  [cloud.usage.UsageManagerImpl_EnhancerByCloudStack_c4597d1] (main:[]) (logid:) Starting Usage Manager
2026-07-05 21:49:01,618 INFO  [utils.component.ComponentContext] (main:[]) (logid:) Starting org.apache.cloudstack.quota.QuotaStatementImpl_EnhancerByCloudStack_9ed9c05c
2026-07-05 21:49:01,619 INFO  [cloudstack.quota.QuotaStatementImpl_EnhancerByCloudStack_9ed9c05c] (main:[]) (logid:) Starting Statement Manager
2026-07-05 21:49:01,619 INFO  [utils.component.ComponentContext] (main:[]) (logid:) Starting org.apache.cloudstack.quota.QuotaAlertManagerImpl_EnhancerByCloudStack_39561c98
2026-07-05 21:49:01,619 INFO  [cloudstack.quota.QuotaAlertManagerImpl_EnhancerByCloudStack_39561c98] (main:[]) (logid:) Starting Alert Manager
2026-07-05 21:49:01,619 INFO  [utils.component.ComponentContext] (main:[]) (logid:) Starting org.apache.cloudstack.quota.QuotaManagerImpl_EnhancerByCloudStack_7bfd14ca
2026-07-05 21:49:01,620 INFO  [cloudstack.quota.QuotaManagerImpl_EnhancerByCloudStack_7bfd14ca] (main:[]) (logid:) Starting Quota Manager
2026-07-05 21:49:01,620 INFO  [utils.component.ComponentContext] (main:[]) (logid:) Starting com.cloud.usage.UsageAlertManagerImpl_EnhancerByCloudStack_2cd965f1
2026-07-05 21:49:01,621 INFO  [cloud.usage.UsageServer] (main:[]) (logid:) UsageServer ready...
```