### PR TITLE
Make AgentConnectTaskPool core and max pool sizes configurable via global config

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -220,6 +220,9 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
     private boolean _reconcileCommandsEnabled = false;
     private Integer _reconcileCommandInterval;
 
+    private static final int AGENT_CONNECT_CORE_POOL_SIZE = 100;
+    private static final int AGENT_CONNECT_MAX_POOL_SIZE = 500;
+
     @Inject
     ResourceManager _resourceMgr;
     @Inject
@@ -427,9 +430,26 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
     }
 
     private void initConnectExecutor() {
-        _connectExecutor = new ThreadPoolExecutor(AgentConnectExecutorCorePoolSize.value(), AgentConnectExecutorMaxPoolSize.value(), 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamedThreadFactory("AgentConnectTaskPool"));
+        Pair<Integer, Integer> poolSizeValues = retrieveAgentConnectPoolCoreSizeAndMaxSize();
+        _connectExecutor = new ThreadPoolExecutor(poolSizeValues.first(), poolSizeValues.second(), 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamedThreadFactory("AgentConnectTaskPool"));
         // allow core threads to time out even when there are no items in the queue
         _connectExecutor.allowCoreThreadTimeOut(true);
+    }
+
+    private Pair<Integer, Integer> retrieveAgentConnectPoolCoreSizeAndMaxSize() {
+        Integer agentConnectCorePoolSize = AgentConnectExecutorCorePoolSize.value();
+        Integer agentConnectMaxSize = AgentConnectExecutorMaxPoolSize.value();
+        if (agentConnectCorePoolSize == null || agentConnectCorePoolSize < 0 || agentConnectMaxSize == null || agentConnectMaxSize < 0) {
+            logger.warn("Invalid agent connect pool size values. Defaulting to core pool size {} and max pool size {}", AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
+            return new Pair<>(AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
+
+        }
+        if (agentConnectMaxSize > agentConnectCorePoolSize) {
+            logger.warn("Max agent connect pool size {} is greater than core pool size {}. " +
+                    "Defaulting to core pool size {} and max pool size {}", agentConnectMaxSize, agentConnectCorePoolSize, AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
+            return new Pair<>(AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
+        }
+        return new Pair<>(agentConnectCorePoolSize, agentConnectMaxSize);
     }
 
     private void initAndScheduleMonitorExecutor() {

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -248,6 +248,10 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
             "Percentage (as a value between 0 and 1) of direct.agent.pool.size to be used as upper thread cap for a single direct agent to process requests", false);
     protected final ConfigKey<Boolean> CheckTxnBeforeSending = new ConfigKey<>("Developer", Boolean.class, "check.txn.before.sending.agent.commands", "false",
             "This parameter allows developers to enable a check to see if a transaction wraps commands that are sent to the resource.  This is not to be enabled on production systems.", true);
+    protected final ConfigKey<Integer> AgentConnectExecutorCorePoolSize = new ConfigKey<>("Advanced", Integer.class, "agent.connect.executor.core.pool.size", "100",
+            "Core pool size for the thread pool that handles agent connect tasks.", false);
+    protected final ConfigKey<Integer> AgentConnectExecutorMaxPoolSize = new ConfigKey<>("Advanced", Integer.class, "agent.connect.executor.max.pool.size", "500",
+            "Maximum pool size for the thread pool that handles agent connect tasks.", false);
 
     public static final List<Host.Type> HOST_DOWN_ALERT_UNSUPPORTED_HOST_TYPES = Arrays.asList(
             Host.Type.SecondaryStorage,
@@ -423,7 +427,7 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
     }
 
     private void initConnectExecutor() {
-        _connectExecutor = new ThreadPoolExecutor(100, 500, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamedThreadFactory("AgentConnectTaskPool"));
+        _connectExecutor = new ThreadPoolExecutor(AgentConnectExecutorCorePoolSize.value(), AgentConnectExecutorMaxPoolSize.value(), 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamedThreadFactory("AgentConnectTaskPool"));
         // allow core threads to time out even when there are no items in the queue
         _connectExecutor.allowCoreThreadTimeOut(true);
     }
@@ -2136,7 +2140,7 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
         return new ConfigKey<?>[] { CheckTxnBeforeSending, Workers, Port, Wait, AlertWait, DirectAgentLoadSize,
                 DirectAgentPoolSize, DirectAgentThreadCap, EnableKVMAutoEnableDisable, ReadyCommandWait,
                 GranularWaitTimeForCommands, RemoteAgentSslHandshakeTimeout, RemoteAgentMaxConcurrentNewConnections,
-                RemoteAgentNewConnectionsMonitorInterval, KVMHostDiscoverySshPort };
+                RemoteAgentNewConnectionsMonitorInterval, KVMHostDiscoverySshPort, AgentConnectExecutorCorePoolSize, AgentConnectExecutorMaxPoolSize };
     }
 
     protected class SetHostParamsListener implements Listener {

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -444,8 +444,8 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
             return new Pair<>(AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
 
         }
-        if (agentConnectMaxSize > agentConnectCorePoolSize) {
-            logger.warn("Max agent connect pool size {} is greater than core pool size {}. " +
+        if (agentConnectMaxSize < agentConnectCorePoolSize) {
+            logger.warn("Max agent connect pool size {} is lower than core pool size {}. " +
                     "Defaulting to core pool size {} and max pool size {}", agentConnectMaxSize, agentConnectCorePoolSize, AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
             return new Pair<>(AGENT_CONNECT_CORE_POOL_SIZE, AGENT_CONNECT_MAX_POOL_SIZE);
         }


### PR DESCRIPTION
### Description

This PR replaces the hardcoded values of 100/500 in initConnectExecutor() with ConfigKeys:
- `agent.connect.executor.core.pool.size` (default 100) and 
- `agent.connect.executor.max.pool.size` (default 500)

In case the pool size > max pool size, the default values 100/500 will be used to prevent exceptions on startup

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
