### PR TITLE
Add AGENTS.md + SECURITY.md wiring for security-model discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Agent Guide for cloudstack
+# Agent Guide for Apache CloudStack
 
 This file is read by automated agents (security scanners, code
 analyzers, AI assistants) operating on this repository.
@@ -29,4 +29,4 @@ Security model: [SECURITY.md](./SECURITY.md)
 Agents that scan this repository should consult `SECURITY.md` and the
 threat model it links before reporting issues.
 
-The project-wide security threat model lives in draft-THREAT-MODEL.md (merged via #13293); SECURITY.md points to it.
+The project-wide security threat model is linked from `SECURITY.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Agent Guide for cloudstack
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+The project-wide security threat model lives in draft-THREAT-MODEL.md (merged via #13293); SECURITY.md points to it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,9 @@ under the License.
 ## Reporting a Vulnerability
 
 `apache/cloudstack` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
-vulnerabilities privately to `security@apache.org`; do not open public
-GitHub issues or pull requests for security reports.
+vulnerabilities privately to `security@apache.org`; do not open public GitHub issues or pull requests for security reports.
+
+For more details, see https://cloudstack.apache.org/security.html.
 
 ## Threat Model
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/cloudstack` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in the project-wide threat model:
+[draft-THREAT-MODEL.md](draft-THREAT-MODEL.md).


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** It changes no threat-model content; it only adds the discoverability wiring around it.

`apache/cloudstack` now carries the project-wide security threat model (`draft-THREAT-MODEL.md`, merged in #13293), but there's no `AGENTS.md` / `SECURITY.md` chain leading to it. This PR adds:

- `SECURITY.md` — the standard ASF disclosure-policy pointer (report suspected vulnerabilities privately to `security@apache.org`) plus a "Threat Model" section linking to `draft-THREAT-MODEL.md`.
- `AGENTS.md` — a Security section pointing agents at `SECURITY.md`, so an automated scanner can mechanically follow `AGENTS.md` → `SECURITY.md` → `draft-THREAT-MODEL.md`.

Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting; those scans refuse to run unless the model is reachable by that chain. The model content is untouched — I linked `draft-THREAT-MODEL.md` as-named, so if you later rename or relocate it, just update the one link in `SECURITY.md`. Questions / pushback welcome.
