### PR TITLE
Only request metric collections for hosts connected to the MS

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1226,6 +1226,14 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
                 Map<Object, Object> metrics = new HashMap<>();
                 for (HostVO host : hosts) {
+                    if (host.getHypervisorType() == HypervisorType.KVM && ManagementServerNode.getManagementServerId() != host.getManagementServerId()) {
+                        // When there are multiple Management Server nodes on the environment, all of them request stat collections for the same VM in different moments; with that,
+                        // the interval from "vm.stats.interval" is not respected. Also, the stats commands are routed to the Management Server connected to the Agent where the VM is running.
+                        // Furthermore, the number of stat entries on the DB scales with the number of Management Servers. Therefore, we only request the stat collections from
+                        // hosts connected to the Management Server, honoring the interval, presenting the correct data, and reducing the necessary storage to store the VMs stats.
+                        logger.debug("Skipping VM stat collection for [{}] as it is connected to another Management Server node [{}].", host, host.getManagementServerId());
+                        continue;
+                    }
                     Date timestamp = new Date();
                     Pair<Map<Long, VMInstanceVO>, Map<String, Long>> vmsAndMap = getVmMapForStatsForHost(host);
                     Map<Long, VMInstanceVO> vmMap = vmsAndMap.first();

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1226,7 +1226,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
                 Map<Object, Object> metrics = new HashMap<>();
                 for (HostVO host : hosts) {
-                    if (host.getHypervisorType() == HypervisorType.KVM && ManagementServerNode.getManagementServerId() != host.getManagementServerId()) {
+                    if (HypervisorType.KVM.equals(host.getHypervisorType()) && ManagementServerNode.getManagementServerId() != host.getManagementServerId()) {
                         // When there are multiple Management Server nodes on the environment, all of them request stat collections for the same VM in different moments; with that,
                         // the interval from "vm.stats.interval" is not respected. Also, the stats commands are routed to the Management Server connected to the Agent where the VM is running.
                         // Furthermore, the number of stat entries on the DB scales with the number of Management Servers. Therefore, we only request the stat collections from

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1227,10 +1227,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                 Map<Object, Object> metrics = new HashMap<>();
                 for (HostVO host : hosts) {
                     if (HypervisorType.KVM.equals(host.getHypervisorType()) && ManagementServerNode.getManagementServerId() != host.getManagementServerId()) {
-                        // When there are multiple Management Server nodes on the environment, all of them request stat collections for the same VM in different moments; with that,
-                        // the interval from "vm.stats.interval" is not respected. Also, the stats commands are routed to the Management Server connected to the Agent where the VM is running.
-                        // Furthermore, the number of stat entries on the DB scales with the number of Management Servers. Therefore, we only request the stat collections from
-                        // hosts connected to the Management Server, honoring the interval, presenting the correct data, and reducing the necessary storage to store the VMs stats.
                         logger.debug("Skipping VM stat collection for [{}] as it is connected to another Management Server node [{}].", host, host.getManagementServerId());
                         continue;
                     }


### PR DESCRIPTION
### Description

Currently, KVM metric collections are performed for each Management Server independently. This process sends command to the Agents, requesting a collection of VM metrics. The Agent receives the command, collects the current metrics, compares it with the previous collection, and sends the final results to the MS that requested the metrics. Finally, the MS saves the data to the DB.

The new metrics are compared to the previous metrics collected, regardless of the MS that triggered the process. Thus, the collection interval depends on the interval between the Management Servers, and not the interval defined in the configuration. This does not affect the authenticity of the data, however, it disregards the configured timeout.

To prevent this situation, the source code has been adjusted, guaranteeing that the MS only sends metric collection commands to hosts connected to it.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### How Has This Been Tested?

- In an environment with two MSs, I verified that VM metric collection occured normally for the VMs on hosts connected to the MS.
- For the remaining hosts, the collection did not occur.
 