### PR TITLE
KVM: fix host.volume.encryption always false with qemu-img >= 10.1 (help header changed) [4.22]

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -927,7 +927,10 @@ public class QemuImg {
     }
 
     protected static boolean helpSupportsImageFormat(String text, QemuImg.PhysicalDiskFormat format) {
-        Pattern pattern = Pattern.compile("Supported\\sformats:[a-zA-Z0-9-_\\s]*?\\b" + format + "\\b", CASE_INSENSITIVE);
+        // QEMU >= 10.1.0 changed the qemu-img --help header from
+        // "Supported formats:" to "Supported image formats:", so the word
+        // "image" must be treated as optional here.
+        Pattern pattern = Pattern.compile("Supported\\s(image\\s)?formats:[a-zA-Z0-9-_\\s]*?\\b" + format + "\\b", CASE_INSENSITIVE);
         return pattern.matcher(text).find();
     }
 

--- a/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/qemu/QemuImgTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/org/apache/cloudstack/utils/qemu/QemuImgTest.java
@@ -391,6 +391,21 @@ public class QemuImgTest {
     }
 
     @Test
+    public void testHelpSupportsImageFormatQemu101Header() throws QemuImgException, LibvirtException {
+        // qemu-img 10.1.0 (e.g. RHEL 9.8: qemu-kvm-10.1.0-17.el9_8.3) changed the
+        // help header from "Supported formats:" to "Supported image formats:"
+        String help = "Supported image formats:\n" +
+                "  blkdebug blklogwrites blkverify compress copy-before-write copy-on-read\n" +
+                "  file ftp ftps host_cdrom host_device http https io_uring luks nbd null-aio\n" +
+                "  null-co nvme nvme-io_uring preallocate qcow2 quorum raw rbd\n" +
+                "  snapshot-access throttle vdi vhdx virtio-blk-vfio-pci\n" +
+                "  virtio-blk-vhost-user virtio-blk-vhost-vdpa vmdk vpc\n";
+        Assert.assertTrue("should support luks", QemuImg.helpSupportsImageFormat(help, PhysicalDiskFormat.LUKS));
+        Assert.assertTrue("should support qcow2", QemuImg.helpSupportsImageFormat(help, PhysicalDiskFormat.QCOW2));
+        Assert.assertFalse("should not support sheepdog", QemuImg.helpSupportsImageFormat(help, PhysicalDiskFormat.SHEEPDOG));
+    }
+
+    @Test
     public void testCheckAndRepair() throws LibvirtException {
         String filename = "/tmp/" + UUID.randomUUID() + ".qcow2";
 


### PR DESCRIPTION
### Description
Backport of #13583 to the 4.22 branch.

Fixes KVM volume encryption detection on hosts with qemu-img >= 10.1.0.

QEMU changed the `qemu-img --help` supported-formats header from
"Supported formats:" to "Supported image formats:" in 10.1.0. The detection
regex in `QemuImg.helpSupportsImageFormat()` no longer matched, so
`hostSupportsVolumeEncryption()` returned false and `host.volume.encryption`
was stored as false, blocking encrypted offerings on affected hosts (e.g.
RHEL 9.8 shipping qemu-img 10.1.0).

The regex now treats the "image" keyword as optional and is covered by unit
tests for both the legacy and the new header, plus a negative case.

Cherry-picked cleanly from main (commit cd1c42750a) onto 4.22, no conflicts.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Bug Severity
- [x] Major