### PR TITLE
server: stop NoTransitionException warning spam for fenced hosts in HA manager

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/ha/HAManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/HAManagerImpl.java
@@ -221,13 +221,16 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
         return resource;
     }
 
-    private HAProvider<HAResource> validateAndFindHAProvider(final HAConfig haConfig, final HAResource resource) {
+    HAProvider<HAResource> validateAndFindHAProvider(final HAConfig haConfig, final HAResource resource) {
         if (haConfig == null) {
             return null;
         }
         final HAProvider<HAResource> haProvider = haProviderMap.get(haConfig.getHaProvider());
         if (haProvider != null && !haProvider.isEligible(resource)) {
-            if (haConfig.getState() != HAConfig.HAState.Ineligible) {
+            // A fenced host is expected to be ineligible as fencing puts it in maintenance mode;
+            // it must remain Fenced until a health check passes (Fenced -> HealthCheckPassed -> Ineligible),
+            // so there is no Fenced -> Ineligible transition to attempt here.
+            if (haConfig.getState() != HAConfig.HAState.Ineligible && haConfig.getState() != HAConfig.HAState.Fenced) {
                 transitionHAState(HAConfig.Event.Ineligible, haConfig);
             }
             return null;

--- a/server/src/test/java/org/apache/cloudstack/ha/HAManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/ha/HAManagerImplTest.java
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.ha;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cloudstack.ha.provider.HAProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HAManagerImplTest {
+
+    private static final String HA_PROVIDER_NAME = "kvmhaprovider";
+
+    @Mock
+    private HAConfig haConfig;
+
+    @Mock
+    private HAResource resource;
+
+    @Mock
+    private HAProvider<HAResource> haProvider;
+
+    private HAManagerImpl haManager;
+
+    @Before
+    public void setUp() throws Exception {
+        haManager = Mockito.spy(new HAManagerImpl());
+
+        final Map<String, HAProvider<HAResource>> haProviderMap = new HashMap<>();
+        haProviderMap.put(HA_PROVIDER_NAME, haProvider);
+        final Field field = HAManagerImpl.class.getDeclaredField("haProviderMap");
+        field.setAccessible(true);
+        field.set(haManager, haProviderMap);
+
+        Mockito.when(haConfig.getHaProvider()).thenReturn(HA_PROVIDER_NAME);
+    }
+
+    @Test
+    public void validateAndFindHAProviderFencedHostDoesNotAttemptIneligibleTransition() {
+        // A fenced host is put in maintenance mode by the fencing flow and is therefore
+        // ineligible; the FSM has no Fenced -> Ineligible transition, so none must be attempted
+        // (it would log a NoTransitionException warning on every poll round otherwise).
+        Mockito.when(haProvider.isEligible(resource)).thenReturn(false);
+        Mockito.when(haConfig.getState()).thenReturn(HAConfig.HAState.Fenced);
+
+        assertNull(haManager.validateAndFindHAProvider(haConfig, resource));
+
+        Mockito.verify(haManager, Mockito.never()).transitionHAState(Mockito.any(HAConfig.Event.class), Mockito.any(HAConfig.class));
+    }
+
+    @Test
+    public void validateAndFindHAProviderIneligibleResourceTransitionsToIneligible() {
+        Mockito.when(haProvider.isEligible(resource)).thenReturn(false);
+        Mockito.when(haConfig.getState()).thenReturn(HAConfig.HAState.Available);
+        Mockito.doReturn(true).when(haManager).transitionHAState(Mockito.any(HAConfig.Event.class), Mockito.any(HAConfig.class));
+
+        assertNull(haManager.validateAndFindHAProvider(haConfig, resource));
+
+        Mockito.verify(haManager).transitionHAState(HAConfig.Event.Ineligible, haConfig);
+    }
+
+    @Test
+    public void validateAndFindHAProviderAlreadyIneligibleDoesNotRetransition() {
+        Mockito.when(haProvider.isEligible(resource)).thenReturn(false);
+        Mockito.when(haConfig.getState()).thenReturn(HAConfig.HAState.Ineligible);
+
+        assertNull(haManager.validateAndFindHAProvider(haConfig, resource));
+
+        Mockito.verify(haManager, Mockito.never()).transitionHAState(Mockito.any(HAConfig.Event.class), Mockito.any(HAConfig.class));
+    }
+
+    @Test
+    public void validateAndFindHAProviderEligibleResourceTransitionsBackFromIneligible() {
+        Mockito.when(haProvider.isEligible(resource)).thenReturn(true);
+        Mockito.when(haConfig.getState()).thenReturn(HAConfig.HAState.Ineligible);
+        Mockito.doReturn(true).when(haManager).transitionHAState(Mockito.any(HAConfig.Event.class), Mockito.any(HAConfig.class));
+
+        assertEquals(haProvider, haManager.validateAndFindHAProvider(haConfig, resource));
+
+        Mockito.verify(haManager).transitionHAState(HAConfig.Event.Eligible, haConfig);
+    }
+}


### PR DESCRIPTION
### Description
After the Host HA framework successfully fences a host, `FenceTask` puts it
into maintenance mode, which makes the host ineligible for the HA provider
(`KVMHAProvider.isEligible()` returns false for hosts in maintenance).

The `HAManagerBgPollTask` then attempts an `Ineligible` transition on every
poll round via `validateAndFindHAProvider()`, but the HA state machine
intentionally has no `Fenced -> Ineligible` transition — a fenced host must
remain `Fenced` until a health check passes
(`Fenced -> HealthCheckPassed -> Ineligible`).

The result is an endless stream of warnings, every poll round, for every
fenced host, until the operator resolves the host:

```
WARN [o.a.c.h.HAManagerImpl] (BackgroundTaskPollManager-3:[ctx-...]) Unable to find
next HA state for current HA state=[Fenced] for event=[Ineligible] for host
Host {"id":10,...} with id 10. com.cloud.utils.fsm.NoTransitionException:
Unable to transition to a new state from Fenced via Ineligible
```

This PR skips the `Ineligible` transition attempt for hosts in `Fenced`
state, since their ineligibility is expected (fencing puts them in
maintenance) and the intended exit from `Fenced` is via a passing health
check. There is no behavioural change otherwise: the host is still skipped
by the poll task while fenced and ineligible.

Deliberately NOT added: an FSM transition `Fenced -> Ineligible` via
`Event.Ineligible`. That would make the `Fenced` state effectively last only
until the next poll round (fencing always puts the host in maintenance →
always ineligible), breaking the sticky-Fenced semantics that
`isVMAliveOnHost()` and `getHostStatusFromHAConfig()` rely on while the
VM HA restart work items for the fenced host are being processed.

Covered by new unit tests (fenced case plus regression cases for the
existing eligibility logic).

Observed on 4.22.1.0 with KVM Host HA + IPMI OOBM; code path unchanged on main.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Bug Severity
- [x] Minor

### How Has This Been Tested?
- New unit tests in `HAManagerImplTest` (4/4 pass)
- `mvn -pl server -am test` builds green including checkstyle