### PR TITLE
kubernetes: clean up temporary provisioning scripts on the management server

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterActionWorker.java
@@ -761,6 +761,25 @@ public class KubernetesClusterActionWorker {
         }
     }
 
+    /**
+     * Deletes the local temporary copies of the scripts created by {@link #retrieveScriptFiles()}
+     * once they have been copied to the cluster node(s). Without this, every deploy/autoscale/PV-cleanup
+     * action leaks a *.sh file in the management server's tmp directory.
+     */
+    protected void cleanupScriptFiles() {
+        deleteScriptFileQuietly(deploySecretsScriptFile);
+        deleteScriptFileQuietly(deployProviderScriptFile);
+        deleteScriptFileQuietly(deployCsiDriverScriptFile);
+        deleteScriptFileQuietly(deletePvScriptFile);
+        deleteScriptFileQuietly(autoscaleScriptFile);
+    }
+
+    protected void deleteScriptFileQuietly(File file) {
+        if (file != null && file.exists() && !file.delete()) {
+            logger.debug("Failed to delete temporary Kubernetes cluster script file: {}", file.getAbsolutePath());
+        }
+    }
+
     protected boolean taintControlNodes() {
         StringBuilder commands = new StringBuilder();
         List<KubernetesClusterVmMapVO> vmMapVOList = getKubernetesClusterVMMaps();
@@ -820,7 +839,11 @@ public class KubernetesClusterActionWorker {
             if (!result.first()) {
                 logMessage(Level.INFO, "Provider files missing. Adding them now", null);
                 retrieveScriptFiles();
-                copyScripts(publicIpAddress, sshPort);
+                try {
+                    copyScripts(publicIpAddress, sshPort);
+                } finally {
+                    cleanupScriptFiles();
+                }
 
                 if (!createCloudStackSecret(keys)) {
                     logTransitStateAndThrow(Level.ERROR, String.format("Failed to setup keys for Kubernetes cluster %s",
@@ -857,7 +880,11 @@ public class KubernetesClusterActionWorker {
             if (!result.first()) {
                 logMessage(Level.INFO, "CSI files missing. Adding them now", null);
                 retrieveScriptFiles();
-                copyScripts(publicIpAddress, sshPort);
+                try {
+                    copyScripts(publicIpAddress, sshPort);
+                } finally {
+                    cleanupScriptFiles();
+                }
 
                 if (!createCloudStackSecret(keys)) {
                     logTransitStateAndThrow(Level.ERROR, String.format("Failed to setup keys for Kubernetes cluster %s",

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -951,7 +951,11 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
                 if (!result.first()) {
                     logMessage(Level.INFO, "Autoscaling files missing. Adding them now", null);
                     retrieveScriptFiles();
-                    copyScripts(publicIpAddress, sshPort);
+                    try {
+                        copyScripts(publicIpAddress, sshPort);
+                    } finally {
+                        cleanupScriptFiles();
+                    }
 
                     if (!createCloudStackSecret(keys)) {
                         logTransitStateAndThrow(Level.ERROR, String.format("Failed to setup keys for Kubernetes cluster %s",
@@ -1003,19 +1007,23 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
             if (Boolean.FALSE.equals(result.first())) {
                 logMessage(Level.INFO, "PV delete script missing. Adding it now", null);
                 retrieveScriptFiles();
-                if (deletePvScriptFile != null) {
-                    copyScriptFile(publicIpAddress, sshPort, deletePvScriptFile, deletePvScriptFilename);
-                    logMessage(Level.INFO, "Executing PV deletion script (this may take several minutes)...", null);
-                    result = SshHelper.sshExecute(publicIpAddress, sshPort, getControlNodeLoginUser(),
-                            pkFile, null, command, 10000, 10000, 600000); // 10 minute timeout
-                    if (Boolean.FALSE.equals(result.first())) {
-                        logMessage(Level.ERROR, "PV deletion script failed: " + result.second(), null);
-                        throw new CloudRuntimeException(result.second());
+                try {
+                    if (deletePvScriptFile != null) {
+                        copyScriptFile(publicIpAddress, sshPort, deletePvScriptFile, deletePvScriptFilename);
+                        logMessage(Level.INFO, "Executing PV deletion script (this may take several minutes)...", null);
+                        result = SshHelper.sshExecute(publicIpAddress, sshPort, getControlNodeLoginUser(),
+                                pkFile, null, command, 10000, 10000, 600000); // 10 minute timeout
+                        if (Boolean.FALSE.equals(result.first())) {
+                            logMessage(Level.ERROR, "PV deletion script failed: " + result.second(), null);
+                            throw new CloudRuntimeException(result.second());
+                        }
+                        logMessage(Level.INFO, "PV deletion script completed successfully", null);
+                    } else {
+                        logMessage(Level.WARN, "PV delete script file not found in resources, skipping PV deletion", null);
+                        return false;
                     }
-                    logMessage(Level.INFO, "PV deletion script completed successfully", null);
-                } else {
-                    logMessage(Level.WARN, "PV delete script file not found in resources, skipping PV deletion", null);
-                    return false;
+                } finally {
+                    cleanupScriptFiles();
                 }
             } else {
                 logMessage(Level.INFO, "PV deletion script completed successfully", null);

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterUpgradeWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterUpgradeWorker.java
@@ -63,6 +63,12 @@ public class KubernetesClusterUpgradeWorker extends KubernetesClusterActionWorke
         upgradeScriptFile = retrieveScriptFile(upgradeScriptFilename);
     }
 
+    @Override
+    protected void cleanupScriptFiles() {
+        super.cleanupScriptFiles();
+        deleteScriptFileQuietly(upgradeScriptFile);
+    }
+
     private Pair<Boolean, String> runInstallScriptOnVM(final UserVm vm, final int index) throws Exception {
         int nodeSshPort = sshPort == 22 ? sshPort : sshPort + index;
         String nodeAddress = (index > 0 && sshPort == 22) ? vm.getPrivateIpAddress() : publicIpAddress;
@@ -176,7 +182,11 @@ public class KubernetesClusterUpgradeWorker extends KubernetesClusterActionWorke
         retrieveScriptFiles();
         stateTransitTo(kubernetesCluster.getId(), KubernetesCluster.Event.UpgradeRequested);
         attachIsoKubernetesVMs(clusterVMs, upgradeVersion);
-        upgradeKubernetesClusterNodes();
+        try {
+            upgradeKubernetesClusterNodes();
+        } finally {
+            cleanupScriptFiles();
+        }
         detachIsoKubernetesVMs(clusterVMs);
         KubernetesClusterVO kubernetesClusterVO = kubernetesClusterDao.findById(kubernetesCluster.getId());
         kubernetesClusterVO.setKubernetesVersionId(upgradeVersion.getId());

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterActionWorkerTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterActionWorkerTest.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.kubernetes.cluster.actionworkers;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -228,5 +229,49 @@ public class KubernetesClusterActionWorkerTest {
         Assert.assertEquals(2, result.size());
         Assert.assertTrue(result.contains(99L));
         Assert.assertTrue(result.contains(2L));
+    }
+
+    @Test
+    public void testCleanupScriptFilesDeletesAllTempFiles() throws Exception {
+        actionWorker.deploySecretsScriptFile = File.createTempFile("deploy-cloudstack-secret", ".sh");
+        actionWorker.deployProviderScriptFile = File.createTempFile("deploy-provider", ".sh");
+        actionWorker.deployCsiDriverScriptFile = File.createTempFile("deploy-csi-driver", ".sh");
+        actionWorker.deletePvScriptFile = File.createTempFile("delete-pv-reclaimpolicy-delete", ".sh");
+        actionWorker.autoscaleScriptFile = File.createTempFile("autoscale-kube-cluster", ".sh");
+
+        List<File> files = Arrays.asList(actionWorker.deploySecretsScriptFile, actionWorker.deployProviderScriptFile,
+                actionWorker.deployCsiDriverScriptFile, actionWorker.deletePvScriptFile, actionWorker.autoscaleScriptFile);
+        for (File f : files) {
+            Assert.assertTrue(f.exists());
+        }
+
+        actionWorker.cleanupScriptFiles();
+
+        for (File f : files) {
+            Assert.assertFalse("Temporary script file should have been deleted: " + f.getAbsolutePath(), f.exists());
+        }
+    }
+
+    @Test
+    public void testDeleteScriptFileQuietlyHandlesNullAndMissingFiles() throws Exception {
+        // null must not throw
+        actionWorker.deleteScriptFileQuietly(null);
+
+        // a File that does not exist must not throw
+        File missing = new File(System.getProperty("java.io.tmpdir"), "cks-nonexistent-" + UUID.randomUUID() + ".sh");
+        Assert.assertFalse(missing.exists());
+        actionWorker.deleteScriptFileQuietly(missing);
+
+        // an existing file is deleted
+        File present = File.createTempFile("cks-present", ".sh");
+        Assert.assertTrue(present.exists());
+        actionWorker.deleteScriptFileQuietly(present);
+        Assert.assertFalse(present.exists());
+    }
+
+    @Test
+    public void testCleanupScriptFilesWithNullFieldsDoesNotThrow() {
+        // No retrieveScriptFiles() was called, so all file fields are null.
+        actionWorker.cleanupScriptFiles();
     }
 }


### PR DESCRIPTION
### Description

The CKS action workers copy provisioning scripts to the cluster nodes via
`retrieveScriptFiles()` + `copyScripts()` / `copyScriptFile()`. Each script is
written to a local temp file with `File.createTempFile(filename, ".sh")` in
`retrieveScriptFile()`, but that local copy on the management server is **never
deleted** after it has been SCP'd to the node.

As a result, every cluster deploy, provider/CSI deploy, autoscale enable, PV
cleanup and Kubernetes upgrade leaks one `*.sh` file per script into the
management server's temp directory, growing without bound over the cluster
lifetime:

```
-rw-r--r--. 1 cloud cloud 3230 ... autoscale-kube-cluster10402639792822688389.sh
-rw-r--r--. 1 cloud cloud 7197 ... delete-pv-reclaimpolicy-delete10664788910304997694.sh
-rw-r--r--. 1 cloud cloud 2303 ... deploy-cloudstack-secret10522058804386657778.sh
-rw-r--r--. 1 cloud cloud 1811 ... deploy-csi-driver1118819744193036791.sh
-rw-r--r--. 1 cloud cloud 1472 ... deploy-provider10072339396849174814.sh
-rw-r--r--. 1 cloud cloud 4971 ... upgrade-kubernetes.sh10982436999748062804.sh
... (dozens more, one set per CKS action)
```

This PR adds `cleanupScriptFiles()` / `deleteScriptFileQuietly()` to the base
`KubernetesClusterActionWorker` and invokes it in a `finally` block around
every copy site:

- `KubernetesClusterActionWorker.deployProvider()`
- `KubernetesClusterActionWorker.deployCsiDriver()`
- `KubernetesClusterResourceModifierActionWorker.autoscaleCluster()`
- `KubernetesClusterResourceModifierActionWorker.deletePVsWithReclaimPolicyDelete()`
- `KubernetesClusterUpgradeWorker` (overrides `cleanupScriptFiles()` to also remove
  its `upgrade-kubernetes.sh` temp file, cleaned up after the per-node upgrade loop
  completes since the same file is reused across nodes)

There is no functional change to the provisioning itself: the scripts are still
written, copied and executed exactly as before; only the leftover local copies
on the management server are removed once they have been transferred.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Bug Severity
- [x] Minor

Observed on a CloudStack 4.22.1 management server running CKS clusters; the code
path is unchanged on `main`.