### PR TITLE
Management ip address resolution

### DIFF
--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -109,6 +109,13 @@ public class AgentProperties{
     public static final Property<String> PRIVATE_NETWORK_DEVICE = new Property<>("private.network.device", "cloudbr1");
 
     /**
+     * Private NIC device address. If this property is commented, it will be autodetected on service startup.<br>
+     * Data type: String.<br>
+     * Default value: <code>cloudbr1</code>
+     */
+    public static final Property<String> PRIVATE_NETWORK_DEVICE_ADDRESS = new Property<>("private.network.address", null, String.class);
+
+    /**
      * Guest NIC device. If this property is commented, the value of the private NIC device will be used.<br>
      * Data type: String.<br>
      * Default value: the private NIC device value.

--- a/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
+++ b/agent/src/main/java/com/cloud/agent/properties/AgentProperties.java
@@ -109,9 +109,9 @@ public class AgentProperties{
     public static final Property<String> PRIVATE_NETWORK_DEVICE = new Property<>("private.network.device", "cloudbr1");
 
     /**
-     * Private NIC device address. If this property is commented, it will be autodetected on service startup.<br>
+     * Private NIC IP address. If this property is commented or empty, it will be autodetected on service startup.<br>
      * Data type: String.<br>
-     * Default value: <code>cloudbr1</code>
+     * Default value: <code>null</code>
      */
     public static final Property<String> PRIVATE_NETWORK_DEVICE_ADDRESS = new Property<>("private.network.address", null, String.class);
 

--- a/core/src/main/java/com/cloud/resource/ServerResourceBase.java
+++ b/core/src/main/java/com/cloud/resource/ServerResourceBase.java
@@ -22,6 +22,9 @@ package com.cloud.resource;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
@@ -29,8 +32,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.naming.ConfigurationException;
 
@@ -76,6 +81,12 @@ public abstract class ServerResourceBase implements ServerResource {
         defineResourceNetworkInterfaces(params);
 
         if (privateNic == null) {
+            checkForPrivateInterfaceDefinedByIp(params);
+        }
+        if (privateNic == null) {
+            tryToAutoDiscoverResourcePrivateNetworkInterfaceByRouteLookup(params);
+        }
+        if (privateNic == null) {
             tryToAutoDiscoverResourcePrivateNetworkInterface();
         }
 
@@ -106,8 +117,74 @@ public abstract class ServerResourceBase implements ServerResource {
         this.storageNic2 = NetUtils.getNetworkInterface(storageNic2);
     }
 
+    private void checkForPrivateInterfaceDefinedByIp(Map<String, Object> params) {
+        final String ifAddr = (String) params.get("private.network.address");
+        if (ifAddr != null) {
+            logger.debug(String.format("Trying to use private address to resolve interface: [%s]", ifAddr));
+            try {
+                InetAddress rawAddr = InetAddress.getByAddress(InetAddress.getByName(ifAddr).getAddress());
+                final NetworkInterface nic = NetworkInterface.getByInetAddress(rawAddr);
+                if (nic != null) {
+                    logger.info(String.format("Using NIC [%s] as private NIC. Source: InterfaceAddress [%s]", nic, ifAddr));
+                    privateNic = nic;
+                } else {
+                    logger.info(String.format("Unable to found private NIC with defined ip [%s]", ifAddr));
+                }
+            } catch (Throwable e) {
+                 // Logging only, if this method was unnable to find a valid interface, iteration will be tested
+                logger.info(String.format("Unable to use private address to get the management interface: [%s]", e.getMessage()));
+            }
+        }
+    }
+
+    private String[] collectMgmtHostIp(Map<String, Object> params) {
+        final String hosts = (String) params.get("host");
+        if (hosts != null && hosts.trim().length() > 0) {
+            logger.info(String.format("Parsing host setting: [%s]", hosts));
+            final Set<String> hostCollection = new LinkedHashSet<String>();
+            if (hosts.contains(",")) {
+                for(final String ip : hosts.split(",")) {
+                    final String h = ip.contains("@") ? ip.split("@")[0] : ip;
+                    hostCollection.add(h.trim());
+                }
+            } else {
+                hostCollection.add(hosts.trim());
+            }
+            return hostCollection.isEmpty() ? null : hostCollection.toArray(new String[0]);
+        }
+        return null;
+    }
+
+    protected void tryToAutoDiscoverResourcePrivateNetworkInterfaceByRouteLookup(Map<String, Object> params) throws ConfigurationException {
+        logger.info("Trying to autodiscover this resource's private network interface by route lookup");
+        final String[] mgmtIps = collectMgmtHostIp(params);
+        if (mgmtIps == null) {
+            logger.info("Unable to resolve any management server ip address. Aborting private network search by route lookup.");
+            return;
+        }
+        for (String mgmtIp : mgmtIps) {
+            logger.info(String.format("Using management server IP [%s] to lookup", mgmtIp));
+            try {
+                try (DatagramSocket socket = new DatagramSocket()) {
+                    socket.connect(new InetSocketAddress(mgmtIp, 8250));
+                    // Asking for source address to mgmgt destination to O.S routing tables.
+                    InetAddress localAddress = socket.getLocalAddress();
+                    NetworkInterface nic = NetworkInterface.getByInetAddress(localAddress);
+                    if (nic != null) {
+                        logger.info(String.format("Using NIC [%s] as private NIC.", nic));
+                        privateNic = nic;
+                        break;
+                    }
+                }
+            } catch (Throwable e) {
+                // Logging only, if this method was unnable to find a valid interface, iteration will be tested
+                logger.debug(String.format("Unable to use routing table to determine private management interface: [%s]", e.getMessage()));
+            }
+        }
+    }
+
     protected void tryToAutoDiscoverResourcePrivateNetworkInterface() throws ConfigurationException {
-        logger.info("Trying to autodiscover this resource's private network interface.");
+        logger.info("Trying to autodiscover this resource's private network interface by simple iteration.");
 
         List<NetworkInterface> nics;
         try {

--- a/core/src/main/java/com/cloud/resource/ServerResourceBase.java
+++ b/core/src/main/java/com/cloud/resource/ServerResourceBase.java
@@ -155,7 +155,7 @@ public abstract class ServerResourceBase implements ServerResource {
         return null;
     }
 
-    protected void tryToAutoDiscoverResourcePrivateNetworkInterfaceByRouteLookup(Map<String, Object> params) throws ConfigurationException {
+    private void tryToAutoDiscoverResourcePrivateNetworkInterfaceByRouteLookup(Map<String, Object> params) throws ConfigurationException {
         logger.info("Trying to autodiscover this resource's private network interface by route lookup");
         final String[] mgmtIps = collectMgmtHostIp(params);
         if (mgmtIps == null) {

--- a/core/src/main/java/com/cloud/resource/ServerResourceBase.java
+++ b/core/src/main/java/com/cloud/resource/ServerResourceBase.java
@@ -131,7 +131,7 @@ public abstract class ServerResourceBase implements ServerResource {
                     logger.info(String.format("Unable to found private NIC with defined ip [%s]", ifAddr));
                 }
             } catch (Throwable e) {
-                 // Logging only, if this method was unnable to find a valid interface, iteration will be tested
+                 // Logging only, if this method was unable to find a valid interface, iteration will be tested
                 logger.info(String.format("Unable to use private address to get the management interface: [%s]", e.getMessage()));
             }
         }
@@ -177,7 +177,7 @@ public abstract class ServerResourceBase implements ServerResource {
                     }
                 }
             } catch (Throwable e) {
-                // Logging only, if this method was unnable to find a valid interface, iteration will be tested
+                // Logging only, if this method was unable to find a valid interface, iteration will be tested
                 logger.debug(String.format("Unable to use routing table to determine private management interface: [%s]", e.getMessage()));
             }
         }

--- a/core/src/main/java/com/cloud/resource/ServerResourceBase.java
+++ b/core/src/main/java/com/cloud/resource/ServerResourceBase.java
@@ -118,7 +118,7 @@ public abstract class ServerResourceBase implements ServerResource {
     }
 
     private void checkForPrivateInterfaceDefinedByIp(Map<String, Object> params) {
-        final String ifAddr = (String) params.get("private.network.address");
+        final String ifAddr = StringUtils.trimToNull((String) params.get("private.network.address"));
         if (ifAddr != null) {
             logger.debug(String.format("Trying to use private address to resolve interface: [%s]", ifAddr));
             try {

--- a/core/src/main/java/com/cloud/resource/ServerResourceBase.java
+++ b/core/src/main/java/com/cloud/resource/ServerResourceBase.java
@@ -125,14 +125,14 @@ public abstract class ServerResourceBase implements ServerResource {
                 InetAddress rawAddr = InetAddress.getByAddress(InetAddress.getByName(ifAddr).getAddress());
                 final NetworkInterface nic = NetworkInterface.getByInetAddress(rawAddr);
                 if (nic != null) {
-                    logger.info(String.format("Using NIC [%s] as private NIC. Source: InterfaceAddress [%s]", nic, ifAddr));
+                    logger.info("Using NIC [{}] as private NIC. Source: InterfaceAddress [{}]", nic, ifAddr);
                     privateNic = nic;
                 } else {
-                    logger.info(String.format("Unable to found private NIC with defined ip [%s]", ifAddr));
+                    logger.info("Unable to found private NIC with defined ip [{}]", ifAddr);
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                  // Logging only, if this method was unable to find a valid interface, iteration will be tested
-                logger.info(String.format("Unable to use private address to get the management interface: [%s]", e.getMessage()));
+                logger.info("Unable to use private address to get the management interface: [{}]", e.getMessage());
             }
         }
     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1007,6 +1007,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     @Override
     public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
+        params.put(AgentProperties.HOST.getName(), AgentPropertiesFileHandler.getPropertyValue(AgentProperties.HOST));
+        params.put(AgentProperties.PRIVATE_NETWORK_DEVICE_ADDRESS.getName(), AgentPropertiesFileHandler.getPropertyValue(AgentProperties.PRIVATE_NETWORK_DEVICE_ADDRESS));
         boolean success = super.configure(name, params);
         if (!success) {
             return false;


### PR DESCRIPTION
### Description

This PR solves a situation when the management network interface does not have a defined IP address.
When this interface is a bridge, the management ip can be placed directly in the bridge (more common) and sometimes in virtual interfaces linked to it.
On this scenarios, the cloudstack agent iterates over all interfaces and select the first one with a valid ip address.
This brings unpredictable behavior, like choosing wrong interface address, and publishing this address to management servers, causing problems with migrations, guest consoles for example.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->
I've added two new ways to search for the correct management address:
 - First and more "secure" is to explicitly define the management ip address on agent.properties. The agent will find the interface bound to this address and configure it as private interface.
 - If configuring this address is not desirable, agent will get the management server addresses, and try to establish a socket (without tcp overhead) with it. If it suceeds, will possible to collect the source ip address used to reach management servers. I belive that this is a more assertive way to find out the host management address.
 If the above methods don't work, the actual behavior is used without changes.

<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
1. Setup a Full L3 network design, with management defined as a traffic label over a "virtual physical address".
2. Create a bridge and setup a vxlan interface with this bridge as master interface.
3. Define a veth interface and define the bridge as master for this interface too.
4. Derfine in this veth interface, the IP address that will be used to reach the management servers.
5. Theres no guarantee that this will be the IP address reported to the management server.


Fixes: #13519

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
I have two hipervisors in production with this changes. Whitout it, I can't make my cluster to work well, cause I can't do migrations and open guest instances terminal
To test it I used both the explicit configuration and route based detection for several days, marking servers for maintenance, rebooting hypervisors and management servers.

#### How did you try to break this feature and the system with this change?
Configuring an invalid Ip address as management address. The setting was ignored as expected, because no interface was found with it. System fallback to another methods.

