### PR TITLE
Fix/13612 template cleanup on domain delete

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1016,7 +1016,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 logger.debug("Successfully deleted snapshots directories for all volumes under account {} across all zones", account);
             }
 
-            
+
             // clean up templates
             List<VMTemplateVO> userTemplates = _templateDao.listByAccountId(accountId);
             boolean allTemplatesDeleted = true;

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -1016,15 +1016,20 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 logger.debug("Successfully deleted snapshots directories for all volumes under account {} across all zones", account);
             }
 
+            
             // clean up templates
             List<VMTemplateVO> userTemplates = _templateDao.listByAccountId(accountId);
             boolean allTemplatesDeleted = true;
             for (VMTemplateVO template : userTemplates) {
                 if (template.getRemoved() == null) {
                     try {
-                        allTemplatesDeleted = _tmpltMgr.delete(callerUserId, template.getId(), null);
+                        // Fix 1: Prevent boolean overwriting by checking failure explicitly
+                        if (!_tmpltMgr.delete(callerUserId, template.getId(), null)) {
+                            logger.warn("TemplateManager returned false when deleting template {} for account {}", template, account);
+                            allTemplatesDeleted = false;
+                        }
                     } catch (Exception e) {
-                        logger.warn("Failed to delete template {} while removing account {} due to: ", template, account, e);
+                        logger.warn("Failed to delete template {} while removing account {} due to exception: ", template, account, e);
                         allTemplatesDeleted = false;
                     }
                 }


### PR DESCRIPTION
### Description

This PR fixes an issue where templates belonging to child accounts within a domain were not properly tracked during automated account and domain cleanup, causing domain deletion to fail due to orphaned storage resources.

**Functional Changes:**
* Updated `AccountManagerImpl.cleanupAccount` to explicitly check the boolean return value of `_tmpltMgr.delete(...)`.
* Prevented the `allTemplatesDeleted` tracking flag from being overwritten on subsequent loop iterations if an earlier template deletion fails.
* Ensured that any failed template deletion correctly sets `accountCleanupNeeded = true`, preventing premature domain teardowns when child resources remain active in secondary storage.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] My changes generate no new warnings or checkstyle errors.