### PR TITLE
Include the database changes from #13019 in the 4.22.1 -> 4.23.0 upgrade path

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42300.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42300.java
@@ -21,6 +21,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.cloud.utils.crypt.DBEncryptionUtil;
 import com.cloud.utils.exception.CloudRuntimeException;
@@ -51,6 +53,7 @@ public class Upgrade42210to42300 extends DbUpgradeAbstractImpl implements DbUpgr
     @Override
     public void performDataMigration(Connection conn) {
         unhideJsInterpretationEnabled(conn);
+        dropUsageVmInstanceIndex(conn);
     }
 
     protected void unhideJsInterpretationEnabled(Connection conn) {
@@ -88,5 +91,12 @@ public class Upgrade42210to42300 extends DbUpgradeAbstractImpl implements DbUpgr
         } catch (CloudRuntimeException e) {
             logger.warn("Error while decrypting configuration 'js.interpretation.enabled'. The configuration may already be decrypted.");
         }
+    }
+
+    private void dropUsageVmInstanceIndex(Connection conn) {
+        final List<String> indexList = new ArrayList<>();
+        logger.debug("Dropping index vm_instance_id from usage_vm_instance table if it exists");
+        indexList.add("vm_instance_id");
+        DbUpgradeUtils.dropKeysIfExist(conn, "cloud_usage.usage_vm_instance", indexList, false);
     }
 }


### PR DESCRIPTION
### Description

This PR adds the database changes from #13019 to the 4.22.1 -> 4.23.0 upgrade script, so that they also apply for users upgrading from 4.21.0/4.22.0/4.22.1 to 4.23.0. We will also have to include this in the 4.22.1 -> 4.22.2 script in the future.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I executed the 4.20.3.0 -> 4.23.0 and 4.22.1.0 -> 4.23.0 upgrades in a test environment. I verified that they finished successfully and that the index was correctly removed.