### PR TITLE
Correction in the assignment of the limit value of VPCs 

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/DomainResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DomainResponse.java
@@ -357,7 +357,7 @@ public class DomainResponse extends BaseResponseWithAnnotations implements Resou
 
     @Override
     public void setVpcLimit(String vpcLimit) {
-        this.vpcLimit = networkLimit;
+        this.vpcLimit = vpcLimit;
     }
 
     @Override


### PR DESCRIPTION
### Description

Currently, when listing the domains with the `listDomains` API, the VPC (`vpclimit`) limits displayed the value of the network limits (`networklimit`). This inconsistency has been corrected, so that the limit of VPCs are displayed correctly.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [x] Trivial

### Screenshots (if appropriate):

<details> 
<summary> Before changes </summary>

![limit-set-before](https://github.com/user-attachments/assets/c4e48007-7216-4ab8-a481-9d52c4a00744)

![limit-values-before](https://github.com/user-attachments/assets/52ab117a-5081-4ad8-8a7e-1aecf0684f82)

</details>

<details> 
<summary> After changes </summary>

![limit-set-after](https://github.com/user-attachments/assets/2d0e6a9c-6a9a-4b5d-8d10-e1dcb8058aa4)

![limit-values-after](https://github.com/user-attachments/assets/f458e6b4-73ad-4244-a6fb-8257a2f6587e)

</details>

### How Has This Been Tested?

- I verified whether the VPC limit value displayed in the graphical interface actually matched the configured VPC limit value.
