### PR TITLE
Fix and de-risk UserVmManagerImpl external-DHCP startup scan

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -190,4 +190,6 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
     int getVmCountByOfferingId(Long serviceOfferingId);
 
     int getVmCountByOfferingNotInDomain(Long serviceOfferingId, List<Long> domainIds);
+
+    List<VMInstanceVO> listByIds(List<Long> ids);
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -21,6 +21,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -1264,8 +1265,8 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
 
     @Override
     public List<VMInstanceVO> listByIds(List<Long> ids) {
-        if (ids == null || ids.isEmpty()) {
-            return new ArrayList<>();
+        if (CollectionUtils.isEmpty(ids)) {
+            return Collections.emptyList();
         }
         SearchBuilder<VMInstanceVO> sb = createSearchBuilder();
         sb.and("id", sb.entity().getId(), Op.IN);

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -1261,4 +1261,17 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         List<Integer> count = customSearch(sc, null);
         return count.get(0);
     }
+
+    @Override
+    public List<VMInstanceVO> listByIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return new ArrayList<>();
+        }
+        SearchBuilder<VMInstanceVO> sb = createSearchBuilder();
+        sb.and("id", sb.entity().getId(), Op.IN);
+        sb.done();
+        SearchCriteria<VMInstanceVO> sc = sb.create();
+        sc.setParameters("id", ids.toArray());
+        return listBy(sc);
+    }
 }

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -965,7 +965,11 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
 
         Network network = _networksDao.findById(networkId);
 
-        if (network != null && network.getGuestType() != GuestType.Shared) {
+        if (network == null) {
+            return false;
+        }
+
+        if (network.getGuestType() != GuestType.Shared) {
             return false;
         }
 

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -54,6 +54,7 @@ import javax.naming.ConfigurationException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.cloud.utils.Profiler;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -2452,33 +2453,53 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     public boolean start() {
         _executor.scheduleWithFixedDelay(new ExpungeTask(), _expungeInterval, _expungeInterval, TimeUnit.SECONDS);
         _vmIpFetchExecutor.scheduleWithFixedDelay(new VmIpFetchTask(), VmIpFetchWaitInterval.value(), VmIpFetchWaitInterval.value(), TimeUnit.SECONDS);
-        loadVmDetailsInMapForExternalDhcpIp();
+        _vmIpFetchExecutor.submit(this::loadVmDetailsInMapForExternalDhcpIp);
         return true;
     }
 
-    private void loadVmDetailsInMapForExternalDhcpIp() {
+    protected void loadVmDetailsInMapForExternalDhcpIp() {
+        try {
+            Profiler profiler = new Profiler();
+            profiler.start();
 
-        List<NetworkVO> networks = _networkDao.listByGuestType(Network.GuestType.Shared);
-        networks.addAll(_networkDao.listByGuestType(Network.GuestType.L2));
+            List<NetworkVO> networks = _networkDao.listByGuestType(Network.GuestType.Shared);
+            Map<Long, Boolean> offeringWithoutServices = new HashMap<>();
+            int networksScanned = 0;
+            int nicsAdded = 0;
 
-        for (NetworkVO network: networks) {
-            if (GuestType.L2.equals(network.getGuestType()) || _networkModel.isSharedNetworkWithoutServices(network.getId())) {
-                List<NicVO> nics = _nicDao.listByNetworkId(network.getId());
+            for (NetworkVO network : networks) {
+                boolean withoutServices = offeringWithoutServices.computeIfAbsent(network.getNetworkOfferingId(),
+                        offeringId -> _networkModel.listNetworkOfferingServices(offeringId).isEmpty());
+                if (!withoutServices) {
+                    continue;
+                }
+                networksScanned++;
 
-                for (NicVO nic : nics) {
-                    if (nic.getIPv4Address() == null) {
-                        long nicId = nic.getId();
-                        long vmId = nic.getInstanceId();
-                        VMInstanceVO vmInstance = _vmInstanceDao.findById(vmId);
+                List<NicVO> nullIpNics = _nicDao.listByNetworkId(network.getId()).stream()
+                        .filter(nic -> nic.getIPv4Address() == null)
+                        .collect(Collectors.toList());
+                if (nullIpNics.isEmpty()) {
+                    continue;
+                }
 
-                        // only load running vms. For stopped vms get loaded on starting
-                        if (vmInstance != null && vmInstance.getState() == State.Running) {
-                            VmAndCountDetails vmAndCount = new VmAndCountDetails(vmId, VmIpFetchTrialMax.value());
-                            vmIdCountMap.put(nicId, vmAndCount);
-                        }
+                List<Long> vmIds = nullIpNics.stream().map(NicVO::getInstanceId).distinct().collect(Collectors.toList());
+                Map<Long, VMInstanceVO> runningVmsById = _vmInstanceDao.listByIds(vmIds).stream()
+                        .filter(vm -> vm != null && vm.getState() == State.Running)
+                        .collect(Collectors.toMap(VMInstanceVO::getId, vm -> vm));
+
+                for (NicVO nic : nullIpNics) {
+                    if (runningVmsById.containsKey(nic.getInstanceId())) {
+                        vmIdCountMap.put(nic.getId(), new VmAndCountDetails(nic.getInstanceId(), VmIpFetchTrialMax.value()));
+                        nicsAdded++;
                     }
                 }
             }
+
+            profiler.stop();
+            logger.info("External-DHCP VM-IP map seeded: {} shared-without-service networks, {} nics added, took {} ms",
+                    networksScanned, nicsAdded, profiler.getDurationInMillis());
+        } catch (Exception e) {
+            logger.error("Failed to seed external-DHCP VM-IP retrieval map", e);
         }
     }
 

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2463,14 +2463,16 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             profiler.start();
 
             List<NetworkVO> networks = _networkDao.listByGuestType(Network.GuestType.Shared);
+            networks.addAll(_networkDao.listByGuestType(Network.GuestType.L2));
             Map<Long, Boolean> offeringWithoutServices = new HashMap<>();
             int networksScanned = 0;
             int nicsAdded = 0;
 
             for (NetworkVO network : networks) {
-                boolean withoutServices = offeringWithoutServices.computeIfAbsent(network.getNetworkOfferingId(),
-                        offeringId -> _networkModel.listNetworkOfferingServices(offeringId).isEmpty());
-                if (!withoutServices) {
+                boolean eligible = Network.GuestType.L2.equals(network.getGuestType())
+                        || offeringWithoutServices.computeIfAbsent(network.getNetworkOfferingId(),
+                                offeringId -> _networkModel.listNetworkOfferingServices(offeringId).isEmpty());
+                if (!eligible) {
                     continue;
                 }
                 networksScanned++;
@@ -2496,7 +2498,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             }
 
             profiler.stop();
-            logger.info("External-DHCP VM-IP map seeded: {} shared-without-service networks, {} nics added, took {} ms",
+            logger.info("External-DHCP VM-IP map seeded: {} shared-without-service/L2 networks, {} nics added, took {} ms",
                     networksScanned, nicsAdded, profiler.getDurationInMillis());
         } catch (Exception e) {
             logger.error("Failed to seed external-DHCP VM-IP retrieval map", e);

--- a/server/src/test/java/com/cloud/network/NetworkModelImplTest.java
+++ b/server/src/test/java/com/cloud/network/NetworkModelImplTest.java
@@ -21,6 +21,7 @@ import com.cloud.dc.VlanVO;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.network.addr.PublicIp;
 import com.cloud.network.dao.IPAddressVO;
+import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkServiceMapDao;
 import com.cloud.network.dao.NetworkServiceMapVO;
 import com.cloud.network.dao.NetworkVO;
@@ -231,5 +232,14 @@ public class NetworkModelImplTest {
         ipToServices.put(publicIpAddress2, services2);
         Map<Network.Provider, ArrayList<PublicIpAddress>> result = networkModel.getProviderToIpList(network, ipToServices);
         Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testIsSharedNetworkWithoutServicesReturnsFalseWhenNetworkMissing() {
+        NetworkDao networksDao = Mockito.mock(NetworkDao.class);
+        ReflectionTestUtils.setField(networkModel, "_networksDao", networksDao);
+        Mockito.when(networksDao.findById(123L)).thenReturn(null);
+
+        Assert.assertFalse(networkModel.isSharedNetworkWithoutServices(123L));
     }
 }

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -33,9 +33,11 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,6 +47,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.vm.dao.VMInstanceDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.api.ApiConstants;
@@ -187,6 +190,9 @@ public class UserVmManagerImplTest {
 
     @Mock
     protected NicDao nicDao;
+
+    @Mock
+    protected VMInstanceDao vmInstanceDao;
 
     @Mock
     private NetworkDao _networkDao;
@@ -3206,5 +3212,60 @@ public class UserVmManagerImplTest {
         InvalidParameterValueException ex = Assert.assertThrows(InvalidParameterValueException.class, () ->
                 userVmManagerImpl.verifyVmLimits(userVmVoMock, customParameters));
         Assert.assertTrue(ex.getMessage().startsWith("The CPU speed of this offering"));
+    }
+
+    @Test
+    public void testLoadVmDetailsInMapForExternalDhcpIpSeedsOnlyRunningNullIpNics() {
+        NetworkVO network = mock(NetworkVO.class);
+        when(network.getId()).thenReturn(100L);
+        when(network.getNetworkOfferingId()).thenReturn(7L);
+        when(_networkDao.listByGuestType(Network.GuestType.Shared)).thenReturn(Arrays.asList(network));
+        when(networkModel.listNetworkOfferingServices(7L)).thenReturn(new ArrayList<>());
+
+        NicVO runningNullIp = mock(NicVO.class);
+        when(runningNullIp.getId()).thenReturn(11L);
+        when(runningNullIp.getInstanceId()).thenReturn(1000L);
+        when(runningNullIp.getIPv4Address()).thenReturn(null);
+
+        NicVO withIp = mock(NicVO.class);
+        when(withIp.getIPv4Address()).thenReturn("10.1.1.5");
+
+        NicVO stoppedNullIp = mock(NicVO.class);
+        when(stoppedNullIp.getInstanceId()).thenReturn(2000L);
+        when(stoppedNullIp.getIPv4Address()).thenReturn(null);
+
+        when(nicDao.listByNetworkId(100L)).thenReturn(Arrays.asList(runningNullIp, withIp, stoppedNullIp));
+
+        VMInstanceVO running = mock(VMInstanceVO.class);
+        when(running.getId()).thenReturn(1000L);
+        when(running.getState()).thenReturn(VirtualMachine.State.Running);
+        VMInstanceVO stopped = mock(VMInstanceVO.class);
+        when(stopped.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(vmInstanceDao.listByIds(Mockito.anyList())).thenReturn(Arrays.asList(running, stopped));
+
+        userVmManagerImpl.loadVmDetailsInMapForExternalDhcpIp();
+
+        @SuppressWarnings("unchecked")
+        Map<Long, ?> vmIdCountMap = (Map<Long, ?>) ReflectionTestUtils.getField(userVmManagerImpl, "vmIdCountMap");
+        assertNotNull(vmIdCountMap);
+        assertEquals(1, vmIdCountMap.size());
+        assertTrue(vmIdCountMap.containsKey(11L));
+        assertFalse(vmIdCountMap.containsKey(12L));
+        Mockito.verify(vmInstanceDao, times(1)).listByIds(Mockito.anyList());
+        Mockito.verify(vmInstanceDao, Mockito.never()).findById(Mockito.anyLong());
+    }
+
+    @Test
+    public void testStartSeedsExternalDhcpMapAsynchronously() {
+        java.util.concurrent.ScheduledExecutorService expungeExecutor = mock(java.util.concurrent.ScheduledExecutorService.class);
+        java.util.concurrent.ScheduledExecutorService ipFetchExecutor = mock(java.util.concurrent.ScheduledExecutorService.class);
+        ReflectionTestUtils.setField(userVmManagerImpl, "_executor", expungeExecutor);
+        ReflectionTestUtils.setField(userVmManagerImpl, "_vmIpFetchExecutor", ipFetchExecutor);
+
+        boolean result = userVmManagerImpl.start();
+
+        assertTrue(result);
+        Mockito.verify(ipFetchExecutor, times(1)).submit(any(Runnable.class));
+        Mockito.verify(userVmManagerImpl, Mockito.never()).loadVmDetailsInMapForExternalDhcpIp();
     }
 }

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -3220,6 +3220,7 @@ public class UserVmManagerImplTest {
         when(network.getId()).thenReturn(100L);
         when(network.getNetworkOfferingId()).thenReturn(7L);
         when(_networkDao.listByGuestType(Network.GuestType.Shared)).thenReturn(Arrays.asList(network));
+        when(_networkDao.listByGuestType(Network.GuestType.L2)).thenReturn(new ArrayList<>());
         when(networkModel.listNetworkOfferingServices(7L)).thenReturn(new ArrayList<>());
 
         NicVO runningNullIp = mock(NicVO.class);
@@ -3253,6 +3254,34 @@ public class UserVmManagerImplTest {
         assertFalse(vmIdCountMap.containsKey(12L));
         Mockito.verify(vmInstanceDao, times(1)).listByIds(Mockito.anyList());
         Mockito.verify(vmInstanceDao, Mockito.never()).findById(Mockito.anyLong());
+    }
+
+    @Test
+    public void testLoadVmDetailsInMapForExternalDhcpIpSeedsL2NetworksUnconditionally() {
+        NetworkVO l2Network = mock(NetworkVO.class);
+        when(l2Network.getId()).thenReturn(200L);
+        when(l2Network.getGuestType()).thenReturn(Network.GuestType.L2);
+        when(_networkDao.listByGuestType(Network.GuestType.Shared)).thenReturn(new ArrayList<>());
+        when(_networkDao.listByGuestType(Network.GuestType.L2)).thenReturn(Arrays.asList(l2Network));
+
+        NicVO runningNullIp = mock(NicVO.class);
+        when(runningNullIp.getId()).thenReturn(21L);
+        when(runningNullIp.getInstanceId()).thenReturn(3000L);
+        when(runningNullIp.getIPv4Address()).thenReturn(null);
+        when(nicDao.listByNetworkId(200L)).thenReturn(Arrays.asList(runningNullIp));
+
+        VMInstanceVO running = mock(VMInstanceVO.class);
+        when(running.getId()).thenReturn(3000L);
+        when(running.getState()).thenReturn(VirtualMachine.State.Running);
+        when(vmInstanceDao.listByIds(Mockito.anyList())).thenReturn(Arrays.asList(running));
+
+        userVmManagerImpl.loadVmDetailsInMapForExternalDhcpIp();
+
+        @SuppressWarnings("unchecked")
+        Map<Long, ?> vmIdCountMap = (Map<Long, ?>) ReflectionTestUtils.getField(userVmManagerImpl, "vmIdCountMap");
+        assertNotNull(vmIdCountMap);
+        assertTrue(vmIdCountMap.containsKey(21L));
+        Mockito.verify(networkModel, Mockito.never()).listNetworkOfferingServices(Mockito.anyLong());
     }
 
     @Test


### PR DESCRIPTION
### Description

UserVmManagerImpl.start() synchronously ran loadVmDetailsInMapForExternalDhcpIp() on the management-server startup thread. Because the CloudStack lifecycle runs every bean's start() sequentially on main before the agent listener (port 8250) is bound, this scan sat directly on the path to agent readiness.

Actual behaviour: on large, DB-contended clusters the scan blocked the agent listener bind for many minutes: 0.8 - 36.9 min observed across some prod environment and repeatedly crashed with a NullPointerException in NetworkModelImpl.isSharedNetworkWithoutServices when a network was removed mid-scan (10 occurrences on 7 hosts / 3 clusters).

Expected behaviour: the management server becomes agent-ready without this scan gating startup, and a concurrently-removed network never crashes it.

Changes:

NetworkModelImpl.isSharedNetworkWithoutServices: guard against a null network from findById (fixes the NPE for all callers).
UserVmManagerImpl.start(): seed the external-DHCP map asynchronously so it no longer gates agent readiness (it is only a warm-start cache for VmIpFetchTask).
loadVmDetailsInMapForExternalDhcpIp: replace the per-NIC findById N+1 with a batched listByIds, memoize the per-offering "without services" check, and add a Profiler timing summary line.
Add unit tests for the null-guard, the batched/filtered seeding, and the async submission.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
