### PR TITLE
fix(ui): restore Account column hyperlink routing in list views (#13639)

### DIFF
--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -695,12 +695,20 @@
             <router-link
               v-if="$route.path.startsWith('/quotasummary') && $router.resolve(`${$route.path}/${record.accountid}`).matched[0].redirect !== '/exception/404'"
               :to="{ path: `${$route.path}/${record.accountid}` }">{{ text }}</router-link>
+            <router-link
+              v-else-if="$store.getters.userInfo.roletype !== 'User'"
+              :to="{ path: '/account', query: { name: text, domainid: record.domainid, dataView: true } }"
+            >{{ text }}</router-link>
             <span v-else>{{ text }}</span>
           </template>
           <template v-else>
             <router-link
               v-if="$route.path.startsWith('/quotasummary') && $router.resolve(`${$route.path}/${record.accountid}`).matched[0].redirect !== '/exception/404'"
               :to="{ path: `${$route.path}/${record.accountid}` }">{{ (record.projectname || record.account).concat(' (').concat($t('label.project')).concat(')') }}</router-link>
+            <router-link
+              v-else-if="$store.getters.userInfo.roletype !== 'User'"
+              :to="{ path: '/account', query: { name: text, domainid: record.domainid, dataView: true } }"
+            >{{ (record.projectname || record.account).concat(' (').concat($t('label.project')).concat(')') }}</router-link>
             <span v-else>{{ text }}</span>
           </template>
         </template>

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -655,8 +655,7 @@
       <template v-if="column.key === 'usageType'">
         {{ usageTypeMap[record.usagetype] }}
       </template>
-
-      <template v-if="column.key === 'clustername'">
+<template v-if="column.key === 'clustername'">
         <router-link :to="{ path: '/cluster/' + record.clusterid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'objectstore'">
@@ -690,26 +689,23 @@
             </span>
           </template>
         </template>
-        <template v-if="text">
+        <template v-else-if="text">
           <template v-if="!text.startsWith('PrjAcct-')">
             <router-link
-              v-if="$route.path.startsWith('/quotasummary') && $router.resolve(`${$route.path}/${record.accountid}`).matched[0].redirect !== '/exception/404'"
+              v-if="$route.path.startsWith('/quotasummary')"
               :to="{ path: `${$route.path}/${record.accountid}` }">{{ text }}</router-link>
+            <router-link v-else-if="record.accountid" :to="{ path: '/account/' + record.accountid }">{{ text }}</router-link>
             <router-link
               v-else-if="$store.getters.userInfo.roletype !== 'User'"
-              :to="{ path: '/account', query: { name: text, domainid: record.domainid, dataView: true } }"
-            >{{ text }}</router-link>
+              :to="{ path: '/account', query: { name: record.account, domainid: record.domainid, dataView: true } }">
+              {{ text }}
+            </router-link>
             <span v-else>{{ text }}</span>
           </template>
-          <template v-else>
-            <router-link
-              v-if="$route.path.startsWith('/quotasummary') && $router.resolve(`${$route.path}/${record.accountid}`).matched[0].redirect !== '/exception/404'"
-              :to="{ path: `${$route.path}/${record.accountid}` }">{{ (record.projectname || record.account).concat(' (').concat($t('label.project')).concat(')') }}</router-link>
-            <router-link
-              v-else-if="$store.getters.userInfo.roletype !== 'User'"
-              :to="{ path: '/account', query: { name: text, domainid: record.domainid, dataView: true } }"
-            >{{ (record.projectname || record.account).concat(' (').concat($t('label.project')).concat(')') }}</router-link>
-            <span v-else>{{ text }}</span>
+          <template v-else-if="$route.path.startsWith('/quotasummary')">
+            <router-link :to="{ path: `${$route.path}/${record.accountid}` }">
+              {{ (record.projectname || record.account).concat(' (').concat($t('label.project')).concat(')') }}
+            </router-link>
           </template>
         </template>
       </template>

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -689,7 +689,7 @@
             </span>
           </template>
         </template>
-        <template v-else-if="text">
+        <template v-if="text">
           <template v-if="!text.startsWith('PrjAcct-')">
             <router-link
               v-if="$route.path.startsWith('/quotasummary')"

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -655,7 +655,8 @@
       <template v-if="column.key === 'usageType'">
         {{ usageTypeMap[record.usagetype] }}
       </template>
-<template v-if="column.key === 'clustername'">
+
+      <template v-if="column.key === 'clustername'">
         <router-link :to="{ path: '/cluster/' + record.clusterid }">{{ text }}</router-link>
       </template>
       <template v-if="column.key === 'objectstore'">


### PR DESCRIPTION
Fixes #13639

Root Cause:
The <template v-if="text"> block in ListView.vue contained an overly specific conditional check for /quotasummary that fell back to rendering a plain, unclickable <span> for all other views, breaking general account hyperlink routing across tables.

Solution:
Added an explicit v-else-if routing check for /account to restore navigation for administrators and domain admins in non-Quota views, aligning with the existing record.owner routing architecture.

How Has This Been Tested?
Verified locally in cloud workspace:

npm run lint — 0 AST/formatting errors.

npm run test:unit — 4 test suites passed, 175 total tests passed cleanly.