### PR TITLE
nasbackup: fix backup stopped vm on Ubuntu 26.04

### DIFF
--- a/scripts/vm/hypervisor/kvm/nasbackup.sh
+++ b/scripts/vm/hypervisor/kvm/nasbackup.sh
@@ -433,7 +433,7 @@ backup_stopped_vm() {
   done
   sync
 
-  ls -l --numeric-uid-gid $dest | awk '{print $5}'
+  find "$dest" -type f -exec stat -c '%s' {} +
 }
 
 delete_backup() {


### PR DESCRIPTION
backing up stopped vm failed on Ubuntu 26.04 failed with error
```
2026-07-17 09:47:56,636 DEBUG [resource.wrapper.LibvirtTakeBackupCommandWrapper] (AgentRequest-Handler-4:[]) (logid:fd553fbe) Wei Parsing backup size line: Jul
2026-07-17 09:47:56,636 WARN  [cloud.agent.Agent] (AgentRequest-Handler-4:[]) (logid:fd553fbe) Caught: java.lang.NumberFormatException: For input string: "Jul"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
        at java.base/java.lang.Long.parseLong(Long.java:711)
        at java.base/java.lang.Long.parseLong(Long.java:836)
        at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtTakeBackupCommandWrapper.parseBackupSize(LibvirtTakeBackupCommandWrapper.java:230)
        at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtTakeBackupCommandWrapper.execute(LibvirtTakeBackupCommandWrapper.java:111)
        at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtTakeBackupCommandWrapper.execute(LibvirtTakeBackupCommandWrapper.java:42)
        at com.cloud.hypervisor.kvm.resource.wrapper.LibvirtRequestWrapper.execute(LibvirtRequestWrapper.java:78)
        at com.cloud.hypervisor.kvm.resource.LibvirtComputingResource.executeRequest(LibvirtComputingResource.java:2407)
```

it is due to different format of "ls -l" command:

```
kvm1:~# ls -l /tmp/csbackup.2CsWP/i-2-582-VM/2026.07.17.09.47.45/
total 1475240
-rw-r--r--+1 root root 1510539264 Jul 17 10:07 root.49d59058-90ce-4fba-bee6-da6d626065dd.qcow2

kvm1:~# ls -l --numeric-uid-gid /tmp/csbackup.2CsWP/i-2-582-VM/2026.07.17.09.47.45/ | awk '{print $5}'

Jul

kvm1:~# find /tmp/csbackup.2CsWP/i-2-582-VM/2026.07.17.09.47.45/ -type f -exec stat -c '%s' {} +
1510539264
```

### Description

This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
