### PR TITLE
Addition of type and VM filter in the backup listing API 

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/backup/ListBackupsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/backup/ListBackupsCmd.java
@@ -97,7 +97,7 @@ public class ListBackupsCmd extends BaseListProjectAndAccountResourcesCmd {
 
     @Parameter(name = ApiConstants.TYPE,
             type = CommandType.STRING,
-            since = "4.23.0",
+            since = "4.24.0",
             description = "list backups by type")
     private String backupType;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/backup/ListBackupsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/backup/ListBackupsCmd.java
@@ -95,6 +95,12 @@ public class ListBackupsCmd extends BaseListProjectAndAccountResourcesCmd {
             description = "list backups by status")
     private String backupStatus;
 
+    @Parameter(name = ApiConstants.TYPE,
+            type = CommandType.STRING,
+            since = "4.23.0",
+            description = "list backups by type")
+    private String backupType;
+
     @Parameter(name = ApiConstants.LIST_VM_DETAILS,
             type = CommandType.BOOLEAN,
             since = "4.21.0",
@@ -127,6 +133,10 @@ public class ListBackupsCmd extends BaseListProjectAndAccountResourcesCmd {
 
     public String getBackupStatus() {
         return backupStatus;
+    }
+
+    public String getBackupType() {
+        return backupType;
     }
 
     public Boolean getListVmDetails() {

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -1232,6 +1232,7 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         final Long zoneId = cmd.getZoneId();
         final Long backupOfferingId = cmd.getBackupOfferingId();
         final Backup.Status backupStatus = validateBackupStatus(cmd.getBackupStatus());
+        final String backupType = cmd.getBackupType();
         final Account caller = CallContext.current().getCallingAccount();
         final String keyword = cmd.getKeyword();
         List<Long> permittedAccounts = new ArrayList<Long>();
@@ -1264,6 +1265,7 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         // incremental chain GC can sweep them once their last descendant is deleted.
         sb.and("statusNeq", sb.entity().getStatus(), SearchCriteria.Op.NEQ);
         sb.and("backupStatus", sb.entity().getStatus(), SearchCriteria.Op.EQ);
+        sb.and("backupType", sb.entity().getType(), SearchCriteria.Op.EQ);
 
         if (keyword != null) {
             sb.and().op("keywordName", sb.entity().getName(), SearchCriteria.Op.LIKE);
@@ -1298,6 +1300,8 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         }
 
         sc.setParametersIfNotNull("backupStatus", backupStatus);
+
+        sc.setParametersIfNotNull("backupType", backupType);
 
         if (keyword != null) {
             String keywordMatch = "%" + keyword + "%";

--- a/ui/src/components/view/SearchView.vue
+++ b/ui/src/components/view/SearchView.vue
@@ -334,7 +334,7 @@ export default {
         }
         if (['zoneid', 'domainid', 'imagestoreid', 'storageid', 'state', 'account', 'hypervisor', 'level',
           'clusterid', 'podid', 'groupid', 'entitytype', 'accounttype', 'systemvmtype', 'scope', 'provider',
-          'type', 'scope', 'managementserverid', 'serviceofferingid',
+          'scope', 'managementserverid', 'serviceofferingid',
           'diskofferingid', 'networkid', 'usagetype', 'restartrequired', 'gpuenabled',
           'displaynetwork', 'guestiptype', 'usersource', 'arch', 'oscategoryid', 'templatetype', 'gpucardid', 'vgpuprofileid',
           'extensionid', 'backupoffering', 'volumeid', 'virtualmachineid', 'hsmprofileid', 'kmskeyid', 'status'].includes(item)

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -495,10 +495,8 @@ export default {
       params: { listvmdetails: 'true' },
       columns: ['name', 'status', 'compressionstatus', 'validationstatus', 'size', 'virtualsize', 'virtualmachinename', 'backupofferingname', 'intervaltype', 'type', 'created', 'account', 'domain', 'zone'],
       details: ['name', 'description', 'virtualmachinename', 'id', 'intervaltype', 'type', 'externalid', 'size', 'virtualsize', 'volumes', 'backupofferingname', 'zone', 'account', 'domain', 'created'],
-      searchFilters: () => {
-        var filters = ['name', 'zoneid', 'domainid', 'account', 'backupofferingid', 'status']
-        return filters
-      },
+      searchFilters: ['name', 'zoneid', 'domainid', 'account', 'backupofferingid', 'status', 'type', 'virtualmachineid'],
+
       tabs: [
         {
           name: 'details',

--- a/ui/src/config/section/storage.js
+++ b/ui/src/config/section/storage.js
@@ -496,7 +496,6 @@ export default {
       columns: ['name', 'status', 'compressionstatus', 'validationstatus', 'size', 'virtualsize', 'virtualmachinename', 'backupofferingname', 'intervaltype', 'type', 'created', 'account', 'domain', 'zone'],
       details: ['name', 'description', 'virtualmachinename', 'id', 'intervaltype', 'type', 'externalid', 'size', 'virtualsize', 'volumes', 'backupofferingname', 'zone', 'account', 'domain', 'created'],
       searchFilters: ['name', 'zoneid', 'domainid', 'account', 'backupofferingid', 'status', 'type', 'virtualmachineid'],
-
       tabs: [
         {
           name: 'details',


### PR DESCRIPTION

### Description

Currently, the `listBackups` API does not allow listing backups based on their type. Changes have been made to the API to allow backups to be listed informing a specific type. In addition, although the API already supports the filtering of backups by VM, support for this parameter had not been added to the GUI. Therefore, the GUI backup filter has been extended to support the search by both type and VM.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### Screenshots (if appropriate):

<details> 
<summary> Example of a <code>listBackups</code> API call </summary>

![type-full-api-call](https://github.com/user-attachments/assets/f9b91a9e-1a1f-42a3-81f2-eb64474ba118)

</details>

<details> 
<summary> <code>listBackups</code> API call when filtering by a non-existent type </summary>

![non-existent-type-api-call](https://github.com/user-attachments/assets/5cbe7a27-b419-4bbe-acee-98bbe3dccbaa)

</details>

<details> 
<summary> Filtering field in the GUI </summary>

![base-ui](https://github.com/user-attachments/assets/3ad7d9c0-c60d-418b-ba15-94875960f649)

![filter-by-vm](https://github.com/user-attachments/assets/9609007e-f7c0-441a-8e7b-c8a95b90e37e)

![filter-by-type](https://github.com/user-attachments/assets/902addb5-c458-4490-95ea-c42729dee0fb)

![filter-by-unavailable-type](https://github.com/user-attachments/assets/6f742c91-c235-49a6-8803-63d66670421a)

</details>

### How Has This Been Tested?

- I checked the possibility of filtering backups by type.
- I checked the possibility of filtering backups by VM.
- I checked the response generated when attempting to pass a non-existent type or VM via CloudMonkey.
- I checked the response generated when attempting to pass a non-existent type or VM via the browser URL.
