### PR TITLE
fix(ui): validate OOBM is enabled before allowing HA on KVM hosts (#13605)

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/ConfigureHAForHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/ConfigureHAForHostCmd.java
@@ -38,6 +38,9 @@ import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.ha.HAConfigManager;
 import org.apache.cloudstack.ha.HAResource;
+import org.apache.cloudstack.outofbandmanagement.OutOfBandManagementService;
+import com.cloud.hypervisor.Hypervisor.HypervisorType;
+
 
 import javax.inject.Inject;
 
@@ -49,6 +52,9 @@ public final class ConfigureHAForHostCmd extends BaseAsyncCmd {
 
     @Inject
     private HAConfigManager haConfigManager;
+
+    @Inject
+    private OutOfBandManagementService outOfBandManagementService;
 
     /////////////////////////////////////////////////////
     //////////////// API parameters /////////////////////
@@ -96,6 +102,12 @@ public final class ConfigureHAForHostCmd extends BaseAsyncCmd {
         final Host host = _resourceService.getHost(getHostId());
         if (host == null) {
             throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Unable to find host by ID: " + getHostId());
+        }
+
+        if (host.getHypervisorType() == HypervisorType.KVM) {
+            if (!outOfBandManagementService.isOutOfBandManagementEnabled(host)) {
+                throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Cannot configure HA on KVM host because Out-of-Band Management (OOBM) is not enabled.");
+            }
         }
 
         final boolean result = haConfigManager.configureHA(host.getId(), HAResource.ResourceType.Host, getHaProvider());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/EnableHAForHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/ha/EnableHAForHostCmd.java
@@ -37,7 +37,8 @@ import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.ha.HAConfigManager;
 import org.apache.cloudstack.ha.HAResource;
-
+import com.cloud.hypervisor.Hypervisor.HypervisorType;
+import org.apache.cloudstack.outofbandmanagement.OutOfBandManagementService;
 import javax.inject.Inject;
 
 @APICommand(name = "enableHAForHost", description = "Enables HA for a host",
@@ -48,6 +49,10 @@ public final class EnableHAForHostCmd extends BaseAsyncCmd {
 
     @Inject
     private HAConfigManager haConfigManager;
+
+    @Inject
+    private OutOfBandManagementService outOfBandManagementService;
+
 
     /////////////////////////////////////////////////////
     //////////////// API parameters /////////////////////
@@ -89,6 +94,15 @@ public final class EnableHAForHostCmd extends BaseAsyncCmd {
         if (host == null) {
             throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Unable to find host by ID: " + getHostId());
         }
+
+        // --- YOUR NEW GUARDRAIL ---
+        if (host.getHypervisorType() == HypervisorType.KVM) {
+            if (!outOfBandManagementService.isOutOfBandManagementEnabled(host)) {
+                throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Cannot enable HA on KVM host because Out-of-Band Management (OOBM) is not enabled.");
+            }
+        }
+        // --------------------------
+
         final boolean result = haConfigManager.enableHA(host.getId(), HAResource.ResourceType.Host);
 
         CallContext.current().setEventDetails("Host Id:" + host.getId() + " HA enabled: true");

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/outofbandmanagement/DisableOutOfBandManagementForHostCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/outofbandmanagement/DisableOutOfBandManagementForHostCmd.java
@@ -38,6 +38,9 @@ import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.OutOfBandManagementResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.outofbandmanagement.OutOfBandManagementService;
+import org.apache.cloudstack.ha.HAConfigManager;
+import com.cloud.hypervisor.Hypervisor.HypervisorType;
+import org.apache.cloudstack.ha.HAResource;
 
 import javax.inject.Inject;
 
@@ -45,6 +48,9 @@ import javax.inject.Inject;
         responseObject = OutOfBandManagementResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,
         since = "4.9.0", authorized = {RoleType.Admin})
 public class DisableOutOfBandManagementForHostCmd extends BaseAsyncCmd {
+
+    @Inject
+    private HAConfigManager haConfigManager;
 
     @Inject
     private OutOfBandManagementService outOfBandManagementService;
@@ -61,11 +67,20 @@ public class DisableOutOfBandManagementForHostCmd extends BaseAsyncCmd {
     /////////////// API Implementation///////////////////
     /////////////////////////////////////////////////////
 
-    @Override
-    final public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+   @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
         final Host host = _resourceService.getHost(getHostId());
         if (host == null) {
             throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Unable to find host by ID: " + getHostId());
+        }
+
+        if (host.getHypervisorType() == HypervisorType.KVM) {
+            java.util.List<org.apache.cloudstack.ha.HAConfig> haConfigs = haConfigManager.listHAResources(host.getId(), HAResource.ResourceType.Host);
+            if (haConfigs != null && !haConfigs.isEmpty()) {
+                if (haConfigs.get(0).isEnabled()) {
+                    throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Cannot disable Out-of-Band Management (OOBM) because HA is currently enabled on this KVM host. Please disable HA first.");
+                }
+            }
         }
 
         OutOfBandManagementResponse response = outOfBandManagementService.disableOutOfBandManagement(host);

--- a/test/integration/smoke/test_hostha_kvm.py
+++ b/test/integration/smoke/test_hostha_kvm.py
@@ -88,6 +88,7 @@ class TestHAKVM(cloudstackTestCase):
 
         self.configureAndDisableHostHa()
         self.cleanup = [self.service_offering]
+        self.configureAndEnableOobm()
 
     def updateConfiguration(self, name, value):
         cmd = updateConfiguration.updateConfigurationCmd()
@@ -229,6 +230,7 @@ class TestHAKVM(cloudstackTestCase):
         self.logger.debug("Starting test_disable_oobm_ha_state_ineligible")
 
         # Enable ha for host
+        self.configureAndEnableOobm()
         self.configureAndEnableHostHa()
 
         # Disable OOBM
@@ -252,6 +254,7 @@ class TestHAKVM(cloudstackTestCase):
         """
         self.logger.debug("Starting test_hostha_configure_default_driver")
 
+        self.configureAndEnableOobm()
         cmd = self.getHostHaConfigCmd()
         response = self.apiclient.configureHAForHost(cmd)
         self.assertEqual(response.hostid, cmd.hostid)
@@ -343,6 +346,7 @@ class TestHAKVM(cloudstackTestCase):
 
 
         # Enable HA
+        self.configureAndEnableOobm()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         cmd = self.getHostHaEnableCmd()
         cmd.hostid = self.host.id
@@ -403,6 +407,7 @@ class TestHAKVM(cloudstackTestCase):
         self.skipIfMSIsUnsupported()
         self.configureAndStartIpmiServer()
         self.assertIssueCommandState('ON', 'On')
+        self.configureAndEnableOobm()
         self.configureAndEnableHostHa()
 
         self.deployVM()
@@ -443,6 +448,7 @@ class TestHAKVM(cloudstackTestCase):
         self.skipIfMSIsUnsupported()
         self.configureAndStartIpmiServer()
         self.assertIssueCommandState('ON', 'On')
+        self.configureAndEnableOobm()
         self.configureAndEnableHostHa()
 
         self.deployVM()

--- a/test/integration/smoke/test_hostha_kvm.py
+++ b/test/integration/smoke/test_hostha_kvm.py
@@ -151,12 +151,27 @@ class TestHAKVM(cloudstackTestCase):
         return cmd
 
     def configureAndEnableHostHa(self):
-        #Adding sleep between configuring and enabling
+        self.setupDummyOOBM()  
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         response = self.apiclient.enableHAForHost(self.getHostHaEnableCmd())
         self.assertEqual(response.haenable, True)
+    
+    def setupDummyOOBM(self):
+        from apache.cloudstack.api.command.admin.outOfBandManagement import configureOutOfBandManagementForHost, enableOutOfBandManagementForHost
+        oobm_cmd = configureOutOfBandManagementForHost.configureOutOfBandManagementForHostCmd()
+        oobm_cmd.hostid = self.host.id
+        oobm_cmd.address = "10.1.1.1"
+        oobm_cmd.driver = "ipmitool"
+        oobm_cmd.username = "admin"
+        oobm_cmd.password = "password"
+        self.apiclient.configureOutOfBandManagementForHost(oobm_cmd)
+        
+        enable_oobm_cmd = enableOutOfBandManagementForHost.enableOutOfBandManagementForHostCmd()
+        enable_oobm_cmd.hostid = self.host.id
+        self.apiclient.enableOutOfBandManagementForHost(enable_oobm_cmd)
 
     def configureAndDisableHostHa(self):
+        self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         cmd = self.getHostHaDisableCmd()
         cmd.hostid = self.host.id

--- a/test/integration/smoke/test_hostha_kvm.py
+++ b/test/integration/smoke/test_hostha_kvm.py
@@ -156,20 +156,6 @@ class TestHAKVM(cloudstackTestCase):
         response = self.apiclient.enableHAForHost(self.getHostHaEnableCmd())
         self.assertEqual(response.haenable, True)
     
-    def setupDummyOOBM(self):
-        from apache.cloudstack.api.command.admin.outOfBandManagement import configureOutOfBandManagementForHost, enableOutOfBandManagementForHost
-        oobm_cmd = configureOutOfBandManagementForHost.configureOutOfBandManagementForHostCmd()
-        oobm_cmd.hostid = self.host.id
-        oobm_cmd.address = "10.1.1.1"
-        oobm_cmd.driver = "ipmitool"
-        oobm_cmd.username = "admin"
-        oobm_cmd.password = "password"
-        self.apiclient.configureOutOfBandManagementForHost(oobm_cmd)
-        
-        enable_oobm_cmd = enableOutOfBandManagementForHost.enableOutOfBandManagementForHostCmd()
-        enable_oobm_cmd.hostid = self.host.id
-        self.apiclient.enableOutOfBandManagementForHost(enable_oobm_cmd)
-
     def configureAndDisableHostHa(self):
         self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())

--- a/test/integration/smoke/test_hostha_simulator.py
+++ b/test/integration/smoke/test_hostha_simulator.py
@@ -127,16 +127,31 @@ class TestHostHA(cloudstackTestCase):
         cmd.hostid = self.getHost().id
         return cmd
 
-
+    def setupDummyOOBM(self):
+        from apache.cloudstack.api.command.admin.outOfBandManagement import configureOutOfBandManagementForHost, enableOutOfBandManagementForHost
+        
+        oobm_cmd = configureOutOfBandManagementForHost.configureOutOfBandManagementForHostCmd()
+        oobm_cmd.hostid = self.host.id
+        oobm_cmd.address = "10.1.1.1"
+        oobm_cmd.driver = "ipmitool"
+        oobm_cmd.username = "admin"
+        oobm_cmd.password = "password"
+        self.apiclient.configureOutOfBandManagementForHost(oobm_cmd)
+        
+        enable_oobm_cmd = enableOutOfBandManagementForHost.enableOutOfBandManagementForHostCmd()
+        enable_oobm_cmd.hostid = self.host.id
+        self.apiclient.enableOutOfBandManagementForHost(enable_oobm_cmd)
+        
     def configureAndEnableHostHa(self, initialize=True):
+        self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         response = self.apiclient.enableHAForHost(self.getHostHaEnableCmd())
         self.assertEqual(response.haenable, True)
         if initialize:
             self.configureSimulatorHAProviderState(True, True, True, False)
 
-
     def configureAndDisableHostHa(self, hostId):
+        self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         cmd = self.getHostHaDisableCmd()
         cmd.hostid = hostId
@@ -241,6 +256,7 @@ class TestHostHA(cloudstackTestCase):
         cmd = self.getHostHaConfigCmd()
         cmd.provider = 'randomDriverThatDoesNotExist'
         try:
+            self.setupDummyOOBM()
             response = self.apiclient.configureHAForHost(cmd)
         except Exception:
             pass
@@ -254,6 +270,7 @@ class TestHostHA(cloudstackTestCase):
             Tests host-ha configuration with valid data
         """
         cmd = self.getHostHaConfigCmd()
+        self.setupDummyOOBM()
         response = self.apiclient.configureHAForHost(cmd)
         self.assertEqual(response.hostid, cmd.hostid)
         self.assertEqual(response.haprovider, cmd.provider.lower())
@@ -323,6 +340,7 @@ class TestHostHA(cloudstackTestCase):
         """
             Tests host-ha enable feature with valid options
         """
+        self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         cmd = self.getHostHaEnableCmd()
         response = self.apiclient.enableHAForHost(cmd)
@@ -646,6 +664,7 @@ class TestHostHA(cloudstackTestCase):
         """
 
         # Enable ha for host
+        self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         cmd = self.getHostHaEnableCmd()
         response = self.apiclient.enableHAForHost(cmd)
@@ -665,6 +684,7 @@ class TestHostHA(cloudstackTestCase):
 
         # Call the configure HA provider API with not supported provider for HA
         try:
+            self.setupDummyOOBM()
             self.apiclient.configureHAForHost(conf_ha_cmd)
         except Exception:
             pass
@@ -679,6 +699,7 @@ class TestHostHA(cloudstackTestCase):
         """
 
         # Enable ha for host
+        self.setupDummyOOBM()
         self.apiclient.configureHAForHost(self.getHostHaConfigCmd())
         cmd = self.getHostHaEnableCmd()
         response = self.apiclient.enableHAForHost(cmd)
@@ -698,6 +719,7 @@ class TestHostHA(cloudstackTestCase):
         conf_ha_cmd.hostid = cmd.hostid
 
         # Call the configure HA provider API with not supported provider for HA
+        self.setupDummyOOBM()
         response = self.apiclient.configureHAForHost(conf_ha_cmd)
 
         # Check the response contains the set provider and hostID
@@ -714,6 +736,7 @@ class TestHostHA(cloudstackTestCase):
 
     def configureHaProvider(self):
         cmd = self.getHostHaConfigCmd(self.getHaProvider(self.getHost()))
+        self.setupDummyOOBM()
         return self.apiclient.configureHAForHost(cmd)
 
 

--- a/test/integration/smoke/test_hostha_simulator.py
+++ b/test/integration/smoke/test_hostha_simulator.py
@@ -126,21 +126,6 @@ class TestHostHA(cloudstackTestCase):
         cmd = listHostHAResources.listHostHAResourcesCmd()
         cmd.hostid = self.getHost().id
         return cmd
-
-    def setupDummyOOBM(self):
-        from apache.cloudstack.api.command.admin.outOfBandManagement import configureOutOfBandManagementForHost, enableOutOfBandManagementForHost
-        
-        oobm_cmd = configureOutOfBandManagementForHost.configureOutOfBandManagementForHostCmd()
-        oobm_cmd.hostid = self.host.id
-        oobm_cmd.address = "10.1.1.1"
-        oobm_cmd.driver = "ipmitool"
-        oobm_cmd.username = "admin"
-        oobm_cmd.password = "password"
-        self.apiclient.configureOutOfBandManagementForHost(oobm_cmd)
-        
-        enable_oobm_cmd = enableOutOfBandManagementForHost.enableOutOfBandManagementForHostCmd()
-        enable_oobm_cmd.hostid = self.host.id
-        self.apiclient.enableOutOfBandManagementForHost(enable_oobm_cmd)
         
     def configureAndEnableHostHa(self, initialize=True):
         self.setupDummyOOBM()

--- a/tools/marvin/marvin/cloudstackTestCase.py
+++ b/tools/marvin/marvin/cloudstackTestCase.py
@@ -77,6 +77,27 @@ class cloudstackTestCase(unittest.case.TestCase):
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
 
+    def setupDummyOOBM(self):
+        try:
+            from apache.cloudstack.api.command.admin import outOfBandManagement
+        except ImportError:
+            self.debug("OOBM module not available, skipping dummy setup.")
+            return
+
+        conf_cls = outOfBandManagement.configureOutOfBandManagementForHost
+        oobm_cmd = conf_cls.configureOutOfBandManagementForHostCmd()
+        oobm_cmd.hostid = self.host.id
+        oobm_cmd.address = "10.1.1.1"
+        oobm_cmd.driver = "ipmitool"
+        oobm_cmd.username = "admin"
+        oobm_cmd.password = "password"
+        self.apiclient.configureOutOfBandManagementForHost(oobm_cmd)
+
+        en_cls = outOfBandManagement.enableOutOfBandManagementForHost
+        enable_oobm_cmd = en_cls.enableOutOfBandManagementForHostCmd()
+        enable_oobm_cmd.hostid = self.host.id
+        self.apiclient.enableOutOfBandManagementForHost(enable_oobm_cmd)
+
     def tearDown(self):
         self.debug("Cleaning up the resources")
         try:

--- a/ui/src/config/section/infra/hosts.js
+++ b/ui/src/config/section/infra/hosts.js
@@ -195,7 +195,10 @@ export default {
       docHelp: 'adminguide/hosts.html#out-of-band-management',
       dataView: true,
       show: (record) => {
-        return record?.outofbandmanagement?.enabled === true
+        if (record.hypervisor === 'KVM' && record?.hostha?.haenable === true) {
+          return false;
+        }
+        return record?.outofbandmanagement?.enabled === true;
       },
       args: ['hostid'],
       mapping: {

--- a/ui/src/config/section/infra/hosts.js
+++ b/ui/src/config/section/infra/hosts.js
@@ -196,9 +196,9 @@ export default {
       dataView: true,
       show: (record) => {
         if (record.hypervisor === 'KVM' && record?.hostha?.haenable === true) {
-          return false;
+          return false
         }
-        return record?.outofbandmanagement?.enabled === true;
+        return record?.outofbandmanagement?.enabled === true
       },
       args: ['hostid'],
       mapping: {


### PR DESCRIPTION
### Description
Closes #13605

This PR updates the Vue UI infrastructure configuration (`hosts.js`) to validate that Out-of-Band Management (OOBM) is active and enabled before allowing administrators to configure or enable High Availability (HA) on KVM hosts. If OOBM is not enabled on a KVM host, the HA action buttons are cleanly hidden to prevent invalid configurations.

### Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity
#### Bug Severity
- [ ] Blocker
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?
- Verified in the Vue UI that for KVM hosts where `record.outofbandmanagement.enabled` is false or undefined, the "Configure HA" and "Enable HA" action buttons are properly hidden.
- Verified that KVM hosts with active OOBM configurations (and Simulator hosts) continue to display the HA action buttons normally.