### PR TITLE
optimise prometheus scraping workflow

### DIFF
--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporter.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporter.java
@@ -18,7 +18,23 @@ package org.apache.cloudstack.metrics;
 
 public interface PrometheusExporter {
 
+    /**
+     * Update the Prometheus metrics in text format.
+     *
+     * NOTE: capacity data is refreshed independently by {@code AlertManagerImpl}'s own
+     * periodic {@code CapacityChecker} timer. Do NOT force a synchronous
+     * {@code recalculateCapacity()} call here: it spins up a fresh thread pool per host
+     * and per storage pool across ALL zones on every single scrape, so with Z zones a
+     * single Prometheus scrape triggered Z redundant full recalculations. That extra,
+     * uncoordinated load compounds over time and can lead to {@code scrape_duration_seconds}
+     * climbing until a management-server restart.
+     *
+     * @see PrometheusExporterImpl#updateMetrics()
+     */
     void updateMetrics();
 
+    /**
+     * @return the latest Prometheus metrics refreshed by {@link #updateMetrics()}.
+     */
     String getMetrics();
 }

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -101,6 +102,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     }
 
     private static List<Item> metricsItems = new ArrayList<>();
+    private volatile long lastMetricsUpdateTime = 0L;
 
     @Inject
     private DataCenterDao dcDao;
@@ -488,7 +490,15 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     }
 
     @Override
-    public void updateMetrics() {
+    public synchronized void updateMetrics() {
+        final long minIntervalMs = TimeUnit.SECONDS.toMillis(PrometheusExporterServer.PrometheusExporterMinRefreshInterval.value());
+        final long now = System.currentTimeMillis();
+        if (now - lastMetricsUpdateTime < minIntervalMs) {
+            logger.debug("Skipping metrics recomputation, last update was " + (now - lastMetricsUpdateTime) + "ms ago (min interval: " + minIntervalMs + "ms)");
+            return;
+        }
+
+        final long startNanos = System.nanoTime();
         final List<Item> latestMetricsItems = new ArrayList<Item>();
         try {
             for (final DataCenterVO dc : dcDao.listAll()) {
@@ -508,8 +518,12 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             addDomainResourceCount(latestMetricsItems);
         } catch (Exception e) {
             logger.warn("Getting metrics failed ", e);
+        } finally {
+            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            logger.info("Prometheus metrics update completed in " + elapsedMs + " ms");
         }
         metricsItems = latestMetricsItems;
+        lastMetricsUpdateTime = System.currentTimeMillis();
     }
 
     @Override

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -491,14 +491,6 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     public void updateMetrics() {
         final List<Item> latestMetricsItems = new ArrayList<Item>();
         try {
-            // NOTE: capacity data is refreshed independently by AlertManagerImpl's own
-            // periodic CapacityChecker timer (see AlertManagerImpl#start()). Do NOT force a
-            // synchronous recalculateCapacity() here: it spins up a fresh thread pool per host
-            // and per storage pool across ALL zones on every single scrape, so with Z zones a
-            // single Prometheus scrape triggered Z redundant full recalculations. That extra,
-            // uncoordinated load compounds over time (thread churn + overlapping runs with the
-            // timer) and was the cause of https://github.com/apache/cloudstack/issues/13586
-            // (scrape_duration_seconds climbing until a management-server restart).
             for (final DataCenterVO dc : dcDao.listAll()) {
                 final String zoneName = dc.getName();
                 final String zoneUuid = dc.getUuid();

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -32,7 +32,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.commons.lang3.StringUtils;
 
-import com.cloud.alert.AlertManager;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.DomainJoinDao;
 import com.cloud.api.query.dao.StoragePoolJoinDao;
@@ -125,8 +124,6 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     private ImageStoreDao imageStoreDao;
     @Inject
     private DomainJoinDao domainDao;
-    @Inject
-    private AlertManager alertManager;
     @Inject
     DedicatedResourceDao _dedicatedDao;
     @Inject
@@ -494,10 +491,17 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
     public void updateMetrics() {
         final List<Item> latestMetricsItems = new ArrayList<Item>();
         try {
+            // NOTE: capacity data is refreshed independently by AlertManagerImpl's own
+            // periodic CapacityChecker timer (see AlertManagerImpl#start()). Do NOT force a
+            // synchronous recalculateCapacity() here: it spins up a fresh thread pool per host
+            // and per storage pool across ALL zones on every single scrape, so with Z zones a
+            // single Prometheus scrape triggered Z redundant full recalculations. That extra,
+            // uncoordinated load compounds over time (thread churn + overlapping runs with the
+            // timer) and was the cause of https://github.com/apache/cloudstack/issues/13586
+            // (scrape_duration_seconds climbing until a management-server restart).
             for (final DataCenterVO dc : dcDao.listAll()) {
                 final String zoneName = dc.getName();
                 final String zoneUuid = dc.getUuid();
-                alertManager.recalculateCapacity();
                 addHostMetrics(latestMetricsItems, dc.getId(), zoneName, zoneUuid);
                 addVMMetrics(latestMetricsItems, dc.getId(), zoneName, zoneUuid);
                 addVolumeMetrics(latestMetricsItems, dc.getId(), zoneName, zoneUuid);

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterImpl.java
@@ -494,7 +494,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
         final long minIntervalMs = TimeUnit.SECONDS.toMillis(PrometheusExporterServer.PrometheusExporterMinRefreshInterval.value());
         final long now = System.currentTimeMillis();
         if (now - lastMetricsUpdateTime < minIntervalMs) {
-            logger.debug("Skipping metrics recomputation, last update was " + (now - lastMetricsUpdateTime) + "ms ago (min interval: " + minIntervalMs + "ms)");
+            logger.debug("Skipping metrics recomputation, last update was {}ms ago (min interval: {}ms)", now - lastMetricsUpdateTime, minIntervalMs);
             return;
         }
 
@@ -520,7 +520,7 @@ public class PrometheusExporterImpl extends ManagerBase implements PrometheusExp
             logger.warn("Getting metrics failed ", e);
         } finally {
             final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-            logger.info("Prometheus metrics update completed in " + elapsedMs + " ms");
+            logger.info("Prometheus metrics update completed in {} ms", elapsedMs);
         }
         metricsItems = latestMetricsItems;
         lastMetricsUpdateTime = System.currentTimeMillis();

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServer.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServer.java
@@ -33,4 +33,7 @@ public interface PrometheusExporterServer extends Manager {
 
     ConfigKey<Integer> PrometheusExporterOfferingCountLimit = new ConfigKey<>("Advanced", Integer.class, "prometheus.exporter.offering.output.limit", "-1",
             "Limit the number of output for cloudstack_vms_total_by_size to the provided value. -1 for unlimited output.", true);
+
+    ConfigKey<Integer> PrometheusExporterMinRefreshInterval = new ConfigKey<>("Advanced", Integer.class, "prometheus.exporter.metrics.min.refresh.interval", "5",
+            "Minimum interval in seconds between metrics recomputations. Scrapes arriving faster than this interval reuse the previously computed metrics.", true, EnablePrometheusExporter.key());
 }

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
@@ -110,7 +110,6 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
     @Override
     public boolean stop() {
         if (httpServer != null) {
-            httpServer.setExecutor(null);
             httpServer.stop(0);
             logger.debug("Stopped Prometheus exporter http server");
         }

--- a/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
+++ b/plugins/integrations/prometheus/src/main/java/org/apache/cloudstack/metrics/PrometheusExporterServerImpl.java
@@ -29,10 +29,13 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class PrometheusExporterServerImpl extends ManagerBase implements PrometheusExporterServer, Configurable {
 
     private static HttpServer httpServer;
+    private ExecutorService httpExecutor;
 
     @Inject
     private PrometheusExporter prometheusExporter;
@@ -79,6 +82,8 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
         if (EnablePrometheusExporter.value()) {
             try {
                 httpServer = HttpServer.create(new InetSocketAddress(PrometheusExporterServerPort.value()), 0);
+                httpExecutor = Executors.newFixedThreadPool(2);
+                httpServer.setExecutor(httpExecutor);
                 httpServer.createContext("/metrics", new ExporterHandler(prometheusExporter));
                 httpServer.createContext("/", new HttpHandler() {
                     @Override
@@ -105,9 +110,15 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
     @Override
     public boolean stop() {
         if (httpServer != null) {
+            httpServer.setExecutor(null);
             httpServer.stop(0);
             logger.debug("Stopped Prometheus exporter http server");
         }
+        if (httpExecutor != null) {
+            httpExecutor.shutdownNow();
+            logger.debug("Shut down Prometheus exporter http executor");
+        }
+        httpExecutor = null;
         return true;
     }
 
@@ -122,7 +133,8 @@ public class PrometheusExporterServerImpl extends ManagerBase implements Prometh
                 EnablePrometheusExporter,
                 PrometheusExporterServerPort,
                 PrometheusExporterAllowedAddresses,
-                PrometheusExporterOfferingCountLimit
+                PrometheusExporterOfferingCountLimit,
+                PrometheusExporterMinRefreshInterval
         };
     }
 }

--- a/plugins/integrations/prometheus/src/test/java/org/apache/cloudstack/metrics/PrometheusExporterImplTest.java
+++ b/plugins/integrations/prometheus/src/test/java/org/apache/cloudstack/metrics/PrometheusExporterImplTest.java
@@ -18,6 +18,15 @@ package org.apache.cloudstack.metrics;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import com.cloud.dc.dao.DataCenterDao;
 
 import org.junit.Test;
 
@@ -104,5 +113,67 @@ public class PrometheusExporterImplTest {
         String metricsString = item.toMetricsString();
         assertTrue("Metric should contain correct timestamp value",
                 metricsString.endsWith(" " + CERT_EXPIRY_EPOCH));
+    }
+
+    /**
+     * Two rapid calls to updateMetrics() within the min refresh interval
+     * should result in only one actual recomputation (one call to dcDao.listAll()).
+     */
+    @Test
+    public void testUpdateMetricsTTLGuardSkipsSecondCall() throws Exception {
+        PrometheusExporterImpl exporter = new PrometheusExporterImpl();
+
+        DataCenterDao mockDcDao = mock(DataCenterDao.class);
+        when(mockDcDao.listAll()).thenReturn(Collections.emptyList());
+        setField(exporter, "dcDao", mockDcDao);
+
+        // First call should trigger recomputation
+        exporter.updateMetrics();
+        // Second immediate call should be skipped by the TTL guard
+        exporter.updateMetrics();
+
+        verify(mockDcDao, times(1)).listAll();
+    }
+
+    /**
+     * After the min refresh interval has elapsed, updateMetrics() should
+     * trigger a fresh recomputation.
+     */
+    @Test
+    public void testUpdateMetricsTTLGuardAllowsAfterInterval() throws Exception {
+        PrometheusExporterImpl exporter = new PrometheusExporterImpl();
+
+        DataCenterDao mockDcDao = mock(DataCenterDao.class);
+        when(mockDcDao.listAll()).thenReturn(Collections.emptyList());
+        setField(exporter, "dcDao", mockDcDao);
+
+        // First call
+        exporter.updateMetrics();
+
+        // Simulate that the min interval has already elapsed by resetting lastMetricsUpdateTime
+        setField(exporter, "lastMetricsUpdateTime", 0L);
+
+        // Second call should now trigger recomputation
+        exporter.updateMetrics();
+
+        verify(mockDcDao, times(2)).listAll();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = null;
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                field = clazz.getDeclaredField(fieldName);
+                break;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        if (field == null) {
+            throw new NoSuchFieldException(fieldName);
+        }
+        field.setAccessible(true);
+        field.set(target, value);
     }
 }

--- a/plugins/integrations/prometheus/src/test/java/org/apache/cloudstack/metrics/PrometheusExporterServerImplTest.java
+++ b/plugins/integrations/prometheus/src/test/java/org/apache/cloudstack/metrics/PrometheusExporterServerImplTest.java
@@ -86,7 +86,7 @@ public class PrometheusExporterServerImplTest {
     }
 
     @Test
-    public void testStopWhenNeverStartedDoesNotThrow() throws Exception {
+    public void testStopWhenNeverStartedDoesNotThrow() {
         boolean result = server.stop();
 
         assertTrue("stop() should return true even if the server was never started", result);

--- a/plugins/integrations/prometheus/src/test/java/org/apache/cloudstack/metrics/PrometheusExporterServerImplTest.java
+++ b/plugins/integrations/prometheus/src/test/java/org/apache/cloudstack/metrics/PrometheusExporterServerImplTest.java
@@ -1,0 +1,271 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.metrics;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.impl.ConfigDepotImpl;
+
+public class PrometheusExporterServerImplTest {
+
+    private PrometheusExporterServerImpl server;
+    private ConfigDepotImpl mockDepot;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new PrometheusExporterServerImpl();
+        mockDepot = mock(ConfigDepotImpl.class);
+        setConfigDepot(mockDepot);
+        // EnablePrometheusExporter is a non-dynamic ConfigKey, so its cached _value survives
+        // across tests (and even across test classes sharing this JVM) unless cleared here:
+        // isDynamic()==false means value() only re-reads the (mocked) depot while _value==null.
+        resetConfigKeyValue(PrometheusExporterServer.EnablePrometheusExporter);
+        setStaticField("httpServer", null);
+        setInstanceField(server, "httpExecutor", null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        setConfigDepot(null);
+        resetConfigKeyValue(PrometheusExporterServer.EnablePrometheusExporter);
+        setStaticField("httpServer", null);
+    }
+
+    @Test
+    public void testStartWhenDisabledDoesNotCreateServerOrExecutor() throws Exception {
+        stubConfigValue(PrometheusExporterServer.EnablePrometheusExporter, "false");
+
+        boolean result = server.start();
+
+        assertTrue("start() should always return true", result);
+        assertNull("httpServer should not be created when the exporter is disabled", getStaticField("httpServer"));
+        assertNull("httpExecutor should not be created when the exporter is disabled", getInstanceField(server, "httpExecutor"));
+    }
+
+    @Test
+    public void testStopWhenNeverStartedDoesNotThrow() throws Exception {
+        boolean result = server.stop();
+
+        assertTrue("stop() should return true even if the server was never started", result);
+    }
+
+    @Test
+    public void testStopShutsDownExecutorAndClosesServer() throws Exception {
+        stubConfigValue(PrometheusExporterServer.EnablePrometheusExporter, "true");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterServerPort, "0");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterAllowedAddresses, "127.0.0.1");
+
+        assertTrue(server.start());
+
+        HttpServer startedHttpServer = (HttpServer) getStaticField("httpServer");
+        ExecutorService startedExecutor = (ExecutorService) getInstanceField(server, "httpExecutor");
+        int port = startedHttpServer.getAddress().getPort();
+
+        assertFalse("Executor should be alive right after start()", startedExecutor.isShutdown());
+
+        server.stop();
+
+        assertTrue("stop() should shut down the http executor", startedExecutor.isShutdown());
+        assertNull("httpExecutor field should be cleared after stop()", getInstanceField(server, "httpExecutor"));
+
+        try {
+            new Socket("127.0.0.1", port).close();
+            org.junit.Assert.fail("Server socket should no longer accept connections after stop()");
+        } catch (ConnectException expected) {
+            // expected: the listening socket was closed by stop()
+        }
+    }
+
+    @Test
+    public void testStartCreatesFixedThreadPoolOfTwoAndWiresItToTheServer() throws Exception {
+        stubConfigValue(PrometheusExporterServer.EnablePrometheusExporter, "true");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterServerPort, "0");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterAllowedAddresses, "127.0.0.1");
+
+        assertTrue(server.start());
+
+        Object executor = getInstanceField(server, "httpExecutor");
+        assertTrue("httpExecutor should be a ThreadPoolExecutor", executor instanceof ThreadPoolExecutor);
+        assertEquals("httpExecutor should be a fixed pool of 2 threads", 2, ((ThreadPoolExecutor) executor).getMaximumPoolSize());
+    }
+
+    @Test
+    public void testAllowedRemoteAddressReceivesMetrics() throws Exception {
+        PrometheusExporter mockExporter = mock(PrometheusExporter.class);
+        when(mockExporter.getMetrics()).thenReturn("cloudstack_test_metric 1");
+        setInstanceField(server, "prometheusExporter", mockExporter);
+
+        stubConfigValue(PrometheusExporterServer.EnablePrometheusExporter, "true");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterServerPort, "0");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterAllowedAddresses, "127.0.0.1");
+
+        assertTrue(server.start());
+        int port = ((HttpServer) getStaticField("httpServer")).getAddress().getPort();
+
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port + "/metrics").openConnection();
+        try {
+            assertEquals(200, connection.getResponseCode());
+            String body = readFully(connection.getInputStream());
+            assertEquals("cloudstack_test_metric 1", body);
+        } finally {
+            connection.disconnect();
+        }
+
+        verify(mockExporter, times(1)).updateMetrics();
+        verify(mockExporter, times(1)).getMetrics();
+    }
+
+    @Test
+    public void testDisallowedRemoteAddressReceivesForbidden() throws Exception {
+        PrometheusExporter mockExporter = mock(PrometheusExporter.class);
+        setInstanceField(server, "prometheusExporter", mockExporter);
+
+        stubConfigValue(PrometheusExporterServer.EnablePrometheusExporter, "true");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterServerPort, "0");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterAllowedAddresses, "10.0.0.1");
+
+        assertTrue(server.start());
+        int port = ((HttpServer) getStaticField("httpServer")).getAddress().getPort();
+
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port + "/metrics").openConnection();
+        try {
+            assertEquals(403, connection.getResponseCode());
+            String body = readFully(connection.getErrorStream());
+            assertEquals("Forbidden", body);
+        } finally {
+            connection.disconnect();
+        }
+
+        verify(mockExporter, times(0)).updateMetrics();
+    }
+
+    @Test
+    public void testRootPathReturnsLandingPage() throws Exception {
+        stubConfigValue(PrometheusExporterServer.EnablePrometheusExporter, "true");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterServerPort, "0");
+        stubConfigValue(PrometheusExporterServer.PrometheusExporterAllowedAddresses, "127.0.0.1");
+
+        assertTrue(server.start());
+        int port = ((HttpServer) getStaticField("httpServer")).getAddress().getPort();
+
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port + "/").openConnection();
+        try {
+            assertEquals(200, connection.getResponseCode());
+            String body = readFully(connection.getInputStream());
+            assertTrue("Landing page should link to /metrics", body.contains("/metrics"));
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    @Test
+    public void testGetConfigComponentName() {
+        assertEquals("PrometheusExporter", server.getConfigComponentName());
+    }
+
+    @Test
+    public void testGetConfigKeysIncludesMinRefreshIntervalAddedByTheScrapeThrottlingFix() {
+        ConfigKey<?>[] keys = server.getConfigKeys();
+
+        assertArrayEquals(new ConfigKey<?>[]{
+                PrometheusExporterServer.EnablePrometheusExporter,
+                PrometheusExporterServer.PrometheusExporterServerPort,
+                PrometheusExporterServer.PrometheusExporterAllowedAddresses,
+                PrometheusExporterServer.PrometheusExporterOfferingCountLimit,
+                PrometheusExporterServer.PrometheusExporterMinRefreshInterval
+        }, keys);
+    }
+
+    private static String readFully(InputStream inputStream) throws Exception {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[1024];
+        int bytesRead;
+        while ((bytesRead = inputStream.read(chunk)) != -1) {
+            buffer.write(chunk, 0, bytesRead);
+        }
+        return buffer.toString(StandardCharsets.UTF_8.name());
+    }
+
+    private void stubConfigValue(ConfigKey<?> configKey, String value) {
+        when(mockDepot.getConfigStringValue(eq(configKey.key()), eq(ConfigKey.Scope.Global), isNull())).thenReturn(value);
+    }
+
+    private static void setConfigDepot(ConfigDepotImpl depot) throws Exception {
+        Field field = ConfigKey.class.getDeclaredField("s_depot");
+        field.setAccessible(true);
+        field.set(null, depot);
+    }
+
+    private static void resetConfigKeyValue(ConfigKey<?> configKey) throws Exception {
+        Field field = ConfigKey.class.getDeclaredField("_value");
+        field.setAccessible(true);
+        field.set(configKey, null);
+    }
+
+    private static void setStaticField(String fieldName, Object value) throws Exception {
+        Field field = PrometheusExporterServerImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private static Object getStaticField(String fieldName) throws Exception {
+        Field field = PrometheusExporterServerImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    private static void setInstanceField(Object target, String fieldName, Object value) throws Exception {
+        Field field = PrometheusExporterServerImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object getInstanceField(Object target, String fieldName) throws Exception {
+        Field field = PrometheusExporterServerImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -161,6 +161,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
 
     private final ExecutorService _executor;
 
+    private ExecutorService _capacityExecutorService;
+
     protected SMTPMailSender mailSender;
     protected String[] recipients = null;
     protected String senderAddress = null;
@@ -249,6 +251,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
     @Override
     public boolean stop() {
         _timer.cancel();
+        if (_capacityExecutorService != null) {
+            _capacityExecutorService.shutdown();
+        }
         return true;
     }
 
@@ -282,6 +287,24 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
     }
 
     /**
+     * Shared, long-lived pool for capacity recalculation, reused across every
+     * recalculateHostCapacities()/recalculateStorageCapacities() call instead of creating and
+     * tearing down a new thread pool per invocation. Repeatedly creating/shutting down pools was
+     * unnecessary overhead under frequent callers (e.g. the Prometheus exporter used to trigger a
+     * full recalculation on every scrape, see https://github.com/apache/cloudstack/issues/13586).
+     * Lazily created so this remains safe for callers that invoke the recalculate methods directly
+     * without going through configure()/start() (e.g. unit tests).
+     */
+    private synchronized ExecutorService getCapacityExecutorService() {
+        if (_capacityExecutorService == null || _capacityExecutorService.isShutdown()) {
+            _capacityExecutorService = Executors.newFixedThreadPool(
+                    Math.max(1, CapacityManager.CapacityCalculateWorkers.value()),
+                    new NamedThreadFactory("Capacity-Calculator"));
+        }
+        return _capacityExecutorService;
+    }
+
+    /**
      * Recalculates the capacities of hosts, including CPU and RAM.
      */
     protected void recalculateHostCapacities() {
@@ -290,10 +313,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
             return;
         }
         ConcurrentHashMap<Long, Future<Void>> futures = new ConcurrentHashMap<>();
-        ExecutorService executorService = Executors.newFixedThreadPool(Math.max(1,
-                Math.min(CapacityManager.CapacityCalculateWorkers.value(), hostIds.size())));
         for (Long hostId : hostIds) {
-            futures.put(hostId, executorService.submit(() -> {
+            futures.put(hostId, getCapacityExecutorService().submit(() -> {
                 final HostVO host = hostDao.findById(hostId);
                 _capacityMgr.updateCapacityForHost(host);
                 return null;
@@ -307,7 +328,6 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                         entry.getKey(), e.getMessage()), e);
             }
         }
-        executorService.shutdown();
     }
 
     protected void recalculateStorageCapacities() {
@@ -316,10 +336,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
             return;
         }
         ConcurrentHashMap<Long, Future<Void>> futures = new ConcurrentHashMap<>();
-        ExecutorService executorService = Executors.newFixedThreadPool(Math.max(1,
-                Math.min(CapacityManager.CapacityCalculateWorkers.value(), storagePoolIds.size())));
         for (Long poolId: storagePoolIds) {
-            futures.put(poolId, executorService.submit(() -> {
+            futures.put(poolId, getCapacityExecutorService().submit(() -> {
                 Transaction.execute(new TransactionCallbackNoReturn() {
                     @Override
                     public void doInTransactionWithoutResult(TransactionStatus status) {
@@ -343,7 +361,6 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                         entry.getKey(), e.getMessage()), e);
             }
         }
-        executorService.shutdown();
     }
 
     @Override

--- a/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/main/java/com/cloud/alert/AlertManagerImpl.java
@@ -161,7 +161,7 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
 
     private final ExecutorService _executor;
 
-    private ExecutorService _capacityExecutorService;
+    private ExecutorService capacityExecutorService;
 
     protected SMTPMailSender mailSender;
     protected String[] recipients = null;
@@ -251,8 +251,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
     @Override
     public boolean stop() {
         _timer.cancel();
-        if (_capacityExecutorService != null) {
-            _capacityExecutorService.shutdown();
+        if (capacityExecutorService != null) {
+            capacityExecutorService.shutdown();
         }
         return true;
     }
@@ -296,12 +296,12 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
      * without going through configure()/start() (e.g. unit tests).
      */
     private synchronized ExecutorService getCapacityExecutorService() {
-        if (_capacityExecutorService == null || _capacityExecutorService.isShutdown()) {
-            _capacityExecutorService = Executors.newFixedThreadPool(
+        if (capacityExecutorService == null || capacityExecutorService.isShutdown()) {
+            capacityExecutorService = Executors.newFixedThreadPool(
                     Math.max(1, CapacityManager.CapacityCalculateWorkers.value()),
                     new NamedThreadFactory("Capacity-Calculator"));
         }
-        return _capacityExecutorService;
+        return capacityExecutorService;
     }
 
     /**

--- a/server/src/test/java/com/cloud/alert/AlertManagerImplTest.java
+++ b/server/src/test/java/com/cloud/alert/AlertManagerImplTest.java
@@ -263,7 +263,8 @@ public class AlertManagerImplTest {
     @Test
     public void testRecalculateHostCapacitiesReusesExecutorAcrossCalls() throws Exception {
         Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+        HostVO hostMock = Mockito.mock(HostVO.class);
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(hostMock);
 
         alertManagerImplMock.recalculateHostCapacities();
         ExecutorService firstExecutor = getCapacityExecutorService();
@@ -281,7 +282,8 @@ public class AlertManagerImplTest {
     @Test
     public void testRecalculateHostCapacitiesRecreatesExecutorAfterShutdown() throws Exception {
         Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+        HostVO hostMock = Mockito.mock(HostVO.class);
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(hostMock);
 
         alertManagerImplMock.recalculateHostCapacities();
         ExecutorService firstExecutor = getCapacityExecutorService();
@@ -299,7 +301,8 @@ public class AlertManagerImplTest {
         Timer timerMock = Mockito.mock(Timer.class);
         setTimer(timerMock);
         Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+        HostVO hostMock = Mockito.mock(HostVO.class);
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(hostMock);
         alertManagerImplMock.recalculateHostCapacities();
 
         boolean result = alertManagerImplMock.stop();

--- a/server/src/test/java/com/cloud/alert/AlertManagerImplTest.java
+++ b/server/src/test/java/com/cloud/alert/AlertManagerImplTest.java
@@ -17,7 +17,10 @@
 package com.cloud.alert;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Timer;
+import java.util.concurrent.ExecutorService;
 
 import javax.mail.MessagingException;
 
@@ -218,5 +221,115 @@ public class AlertManagerImplTest {
         alertManagerImplMock.recalculateStorageCapacities();
         Mockito.verify(storageManager, Mockito.times(2)).createCapacityEntry(sharedPool, Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED, 10L);
         Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(nonSharedPool, Capacity.CAPACITY_TYPE_LOCAL_STORAGE, 20L);
+    }
+
+    @Test
+    public void testRecalculateHostCapacitiesWithEmptyHostList() throws Exception {
+        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of());
+        alertManagerImplMock.recalculateHostCapacities();
+        Mockito.verify(hostDao, Mockito.never()).findById(Mockito.anyLong());
+        Mockito.verify(capacityManager, Mockito.never()).updateCapacityForHost(Mockito.any());
+        assertNull("executor should never be created when there is nothing to submit", getCapacityExecutorService());
+    }
+
+    @Test
+    public void testRecalculateStorageCapacitiesWithEmptyPoolList() throws Exception {
+        Mockito.when(primaryDataStoreDao.listAllIds()).thenReturn(List.of());
+        alertManagerImplMock.recalculateStorageCapacities();
+        Mockito.verify(primaryDataStoreDao, Mockito.never()).findById(Mockito.anyLong());
+        Mockito.verify(storageManager, Mockito.never()).createCapacityEntry(Mockito.any(), Mockito.anyShort(), Mockito.anyLong());
+        assertNull("executor should never be created when there is nothing to submit", getCapacityExecutorService());
+    }
+
+    @Test
+    public void testRecalculateHostCapacitiesLogsAndContinuesOnTaskFailure() {
+        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L, 2L, 3L));
+        HostVO host1 = Mockito.mock(HostVO.class);
+        HostVO host2 = Mockito.mock(HostVO.class);
+        HostVO host3 = Mockito.mock(HostVO.class);
+        Mockito.when(hostDao.findById(1L)).thenReturn(host1);
+        Mockito.when(hostDao.findById(2L)).thenReturn(host2);
+        Mockito.when(hostDao.findById(3L)).thenReturn(host3);
+        Mockito.doThrow(new RuntimeException("boom")).when(capacityManager).updateCapacityForHost(host2);
+
+        alertManagerImplMock.recalculateHostCapacities();
+
+        Mockito.verify(capacityManager).updateCapacityForHost(host1);
+        Mockito.verify(capacityManager).updateCapacityForHost(host2);
+        Mockito.verify(capacityManager).updateCapacityForHost(host3);
+        Mockito.verify(alertManagerImplMock.logger).error(Mockito.anyString(), Mockito.any(Throwable.class));
+    }
+
+    @Test
+    public void testRecalculateHostCapacitiesReusesExecutorAcrossCalls() throws Exception {
+        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+
+        alertManagerImplMock.recalculateHostCapacities();
+        ExecutorService firstExecutor = getCapacityExecutorService();
+        assertNotNull(firstExecutor);
+
+        Mockito.when(primaryDataStoreDao.listAllIds()).thenReturn(List.of(101L));
+        StoragePoolVO pool = Mockito.mock(StoragePoolVO.class);
+        Mockito.when(primaryDataStoreDao.findById(101L)).thenReturn(pool);
+        alertManagerImplMock.recalculateStorageCapacities();
+
+        assertEquals("host and storage recalculation should share the same long-lived pool",
+                firstExecutor, getCapacityExecutorService());
+    }
+
+    @Test
+    public void testRecalculateHostCapacitiesRecreatesExecutorAfterShutdown() throws Exception {
+        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+
+        alertManagerImplMock.recalculateHostCapacities();
+        ExecutorService firstExecutor = getCapacityExecutorService();
+        firstExecutor.shutdown();
+
+        alertManagerImplMock.recalculateHostCapacities();
+        ExecutorService secondExecutor = getCapacityExecutorService();
+
+        Assert.assertNotEquals("a shut down executor should be replaced rather than reused", firstExecutor, secondExecutor);
+        Assert.assertFalse(secondExecutor.isShutdown());
+    }
+
+    @Test
+    public void testStopShutsDownCapacityExecutorServiceWhenPresent() throws Exception {
+        Timer timerMock = Mockito.mock(Timer.class);
+        setTimer(timerMock);
+        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(HostVO.class));
+        alertManagerImplMock.recalculateHostCapacities();
+
+        boolean result = alertManagerImplMock.stop();
+
+        Assert.assertTrue(result);
+        Mockito.verify(timerMock).cancel();
+        Assert.assertTrue(getCapacityExecutorService().isShutdown());
+    }
+
+    @Test
+    public void testStopDoesNotThrowWhenCapacityExecutorServiceNeverCreated() throws Exception {
+        Timer timerMock = Mockito.mock(Timer.class);
+        setTimer(timerMock);
+
+        boolean result = alertManagerImplMock.stop();
+
+        Assert.assertTrue(result);
+        Mockito.verify(timerMock).cancel();
+        assertNull(getCapacityExecutorService());
+    }
+
+    private ExecutorService getCapacityExecutorService() throws Exception {
+        Field field = AlertManagerImpl.class.getDeclaredField("capacityExecutorService");
+        field.setAccessible(true);
+        return (ExecutorService) field.get(alertManagerImplMock);
+    }
+
+    private void setTimer(Timer timer) throws Exception {
+        Field field = AlertManagerImpl.class.getDeclaredField("_timer");
+        field.setAccessible(true);
+        field.set(alertManagerImplMock, timer);
     }
 }

--- a/server/src/test/java/com/cloud/alert/AlertManagerImplTest.java
+++ b/server/src/test/java/com/cloud/alert/AlertManagerImplTest.java
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -57,7 +56,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AlertManagerImplTest {
@@ -110,15 +119,15 @@ public class AlertManagerImplTest {
 
     private void sendMessage() {
         try {
-            DataCenterVO zone = Mockito.mock(DataCenterVO.class);
-            Mockito.when(zone.getId()).thenReturn(0L);
-            Mockito.when(_dcDao.findById(0L)).thenReturn(zone);
-            HostPodVO pod = Mockito.mock(HostPodVO.class);
-            Mockito.when(pod.getId()).thenReturn(1L);
-            Mockito.when(_podDao.findById(1L)).thenReturn(pod);
-            ClusterVO cluster = Mockito.mock(ClusterVO.class);
-            Mockito.when(cluster.getId()).thenReturn(1L);
-            Mockito.when(_clusterDao.findById(1L)).thenReturn(cluster);
+            DataCenterVO zone = mock(DataCenterVO.class);
+            when(zone.getId()).thenReturn(0L);
+            when(_dcDao.findById(0L)).thenReturn(zone);
+            HostPodVO pod = mock(HostPodVO.class);
+            when(pod.getId()).thenReturn(1L);
+            when(_podDao.findById(1L)).thenReturn(pod);
+            ClusterVO cluster = mock(ClusterVO.class);
+            when(cluster.getId()).thenReturn(1L);
+            when(_clusterDao.findById(1L)).thenReturn(cluster);
 
             alertManagerImplMock.sendAlert(AlertManager.AlertType.ALERT_TYPE_CPU, 0, 1L, 1L, "", "");
         } catch (UnsupportedEncodingException | MessagingException e) {
@@ -128,39 +137,39 @@ public class AlertManagerImplTest {
 
     @Test
     public void sendAlertTestSendMail() {
-        Mockito.doReturn(null).when(_alertDao).getLastAlert(Mockito.anyShort(), Mockito.anyLong(),
-                Mockito.anyLong(), Mockito.anyLong());
-        Mockito.doReturn(null).when(_alertDao).persist(any());
+        doReturn(null).when(_alertDao).getLastAlert(anyShort(), anyLong(),
+                anyLong(), anyLong());
+        doReturn(null).when(_alertDao).persist(any());
         alertManagerImplMock.recipients = new String[]{""};
 
         sendMessage();
 
-        Mockito.verify(alertManagerImplMock).sendMessage(any());
+        verify(alertManagerImplMock).sendMessage(any());
     }
 
     @Test
     public void sendAlertTestDebugLogging() {
-        Mockito.doReturn(0).when(alertVOMock).getSentCount();
-        Mockito.doReturn(alertVOMock).when(_alertDao).getLastAlert(Mockito.anyShort(), Mockito.anyLong(),
-                Mockito.anyLong(), Mockito.anyLong());
+        doReturn(0).when(alertVOMock).getSentCount();
+        doReturn(alertVOMock).when(_alertDao).getLastAlert(anyShort(), anyLong(),
+                anyLong(), anyLong());
 
         sendMessage();
 
-        Mockito.verify(alertManagerImplMock.logger).debug(Mockito.anyString());
-        Mockito.verify(alertManagerImplMock, Mockito.never()).sendMessage(any());
+        verify(alertManagerImplMock.logger).debug(anyString());
+        verify(alertManagerImplMock, never()).sendMessage(any());
     }
 
     @Test
     public void sendAlertTestWarnLogging() {
-        Mockito.doReturn(null).when(_alertDao).getLastAlert(Mockito.anyShort(), Mockito.anyLong(),
-                Mockito.anyLong(), Mockito.anyLong());
-        Mockito.doReturn(null).when(_alertDao).persist(Mockito.any());
+        doReturn(null).when(_alertDao).getLastAlert(anyShort(), anyLong(),
+                anyLong(), anyLong());
+        doReturn(null).when(_alertDao).persist(any());
         alertManagerImplMock.recipients = null;
 
         sendMessage();
 
-        Mockito.verify(alertManagerImplMock.logger, Mockito.times(2)).warn(Mockito.anyString());
-        Mockito.verify(alertManagerImplMock, Mockito.never()).sendMessage(any());
+        verify(alertManagerImplMock.logger, times(2)).warn(anyString());
+        verify(alertManagerImplMock, never()).sendMessage(any());
     }
 
     @Test
@@ -196,83 +205,83 @@ public class AlertManagerImplTest {
     @Test
     public void testRecalculateHostCapacities() {
         List<Long> mockHostIds = List.of(1L, 2L, 3L);
-        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(mockHostIds);
-        HostVO host = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
-        Mockito.doNothing().when(capacityManager).updateCapacityForHost(host);
+        when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(mockHostIds);
+        HostVO host = mock(HostVO.class);
+        when(hostDao.findById(anyLong())).thenReturn(host);
+        doNothing().when(capacityManager).updateCapacityForHost(host);
         alertManagerImplMock.recalculateHostCapacities();
-        Mockito.verify(hostDao, Mockito.times(3)).findById(Mockito.anyLong());
-        Mockito.verify(capacityManager, Mockito.times(3)).updateCapacityForHost(host);
+        verify(hostDao, times(3)).findById(anyLong());
+        verify(capacityManager, times(3)).updateCapacityForHost(host);
     }
 
     @Test
     public void testRecalculateStorageCapacities() {
         List<Long> mockPoolIds = List.of(101L, 102L, 103L);
-        Mockito.when(primaryDataStoreDao.listAllIds()).thenReturn(mockPoolIds);
-        StoragePoolVO sharedPool = Mockito.mock(StoragePoolVO.class);
-        Mockito.when(sharedPool.isShared()).thenReturn(true);
-        Mockito.when(primaryDataStoreDao.findById(mockPoolIds.get(0))).thenReturn(sharedPool);
-        Mockito.when(primaryDataStoreDao.findById(mockPoolIds.get(1))).thenReturn(sharedPool);
-        StoragePoolVO nonSharedPool = Mockito.mock(StoragePoolVO.class);
-        Mockito.when(nonSharedPool.isShared()).thenReturn(false);
-        Mockito.when(primaryDataStoreDao.findById(mockPoolIds.get(2))).thenReturn(nonSharedPool);
-        Mockito.when(capacityManager.getAllocatedPoolCapacity(sharedPool, null)).thenReturn(10L);
-        Mockito.when(capacityManager.getAllocatedPoolCapacity(nonSharedPool, null)).thenReturn(20L);
+        when(primaryDataStoreDao.listAllIds()).thenReturn(mockPoolIds);
+        StoragePoolVO sharedPool = mock(StoragePoolVO.class);
+        when(sharedPool.isShared()).thenReturn(true);
+        when(primaryDataStoreDao.findById(mockPoolIds.get(0))).thenReturn(sharedPool);
+        when(primaryDataStoreDao.findById(mockPoolIds.get(1))).thenReturn(sharedPool);
+        StoragePoolVO nonSharedPool = mock(StoragePoolVO.class);
+        when(nonSharedPool.isShared()).thenReturn(false);
+        when(primaryDataStoreDao.findById(mockPoolIds.get(2))).thenReturn(nonSharedPool);
+        when(capacityManager.getAllocatedPoolCapacity(sharedPool, null)).thenReturn(10L);
+        when(capacityManager.getAllocatedPoolCapacity(nonSharedPool, null)).thenReturn(20L);
         alertManagerImplMock.recalculateStorageCapacities();
-        Mockito.verify(storageManager, Mockito.times(2)).createCapacityEntry(sharedPool, Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED, 10L);
-        Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(nonSharedPool, Capacity.CAPACITY_TYPE_LOCAL_STORAGE, 20L);
+        verify(storageManager, times(2)).createCapacityEntry(sharedPool, Capacity.CAPACITY_TYPE_STORAGE_ALLOCATED, 10L);
+        verify(storageManager, times(1)).createCapacityEntry(nonSharedPool, Capacity.CAPACITY_TYPE_LOCAL_STORAGE, 20L);
     }
 
     @Test
     public void testRecalculateHostCapacitiesWithEmptyHostList() throws Exception {
-        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of());
+        when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of());
         alertManagerImplMock.recalculateHostCapacities();
-        Mockito.verify(hostDao, Mockito.never()).findById(Mockito.anyLong());
-        Mockito.verify(capacityManager, Mockito.never()).updateCapacityForHost(Mockito.any());
+        verify(hostDao, never()).findById(anyLong());
+        verify(capacityManager, never()).updateCapacityForHost(any());
         assertNull("executor should never be created when there is nothing to submit", getCapacityExecutorService());
     }
 
     @Test
     public void testRecalculateStorageCapacitiesWithEmptyPoolList() throws Exception {
-        Mockito.when(primaryDataStoreDao.listAllIds()).thenReturn(List.of());
+        when(primaryDataStoreDao.listAllIds()).thenReturn(List.of());
         alertManagerImplMock.recalculateStorageCapacities();
-        Mockito.verify(primaryDataStoreDao, Mockito.never()).findById(Mockito.anyLong());
-        Mockito.verify(storageManager, Mockito.never()).createCapacityEntry(Mockito.any(), Mockito.anyShort(), Mockito.anyLong());
+        verify(primaryDataStoreDao, never()).findById(anyLong());
+        verify(storageManager, never()).createCapacityEntry(any(), anyShort(), anyLong());
         assertNull("executor should never be created when there is nothing to submit", getCapacityExecutorService());
     }
 
     @Test
     public void testRecalculateHostCapacitiesLogsAndContinuesOnTaskFailure() {
-        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L, 2L, 3L));
-        HostVO host1 = Mockito.mock(HostVO.class);
-        HostVO host2 = Mockito.mock(HostVO.class);
-        HostVO host3 = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.findById(1L)).thenReturn(host1);
-        Mockito.when(hostDao.findById(2L)).thenReturn(host2);
-        Mockito.when(hostDao.findById(3L)).thenReturn(host3);
-        Mockito.doThrow(new RuntimeException("boom")).when(capacityManager).updateCapacityForHost(host2);
+        when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L, 2L, 3L));
+        HostVO host1 = mock(HostVO.class);
+        HostVO host2 = mock(HostVO.class);
+        HostVO host3 = mock(HostVO.class);
+        when(hostDao.findById(1L)).thenReturn(host1);
+        when(hostDao.findById(2L)).thenReturn(host2);
+        when(hostDao.findById(3L)).thenReturn(host3);
+        doThrow(new RuntimeException("boom")).when(capacityManager).updateCapacityForHost(host2);
 
         alertManagerImplMock.recalculateHostCapacities();
 
-        Mockito.verify(capacityManager).updateCapacityForHost(host1);
-        Mockito.verify(capacityManager).updateCapacityForHost(host2);
-        Mockito.verify(capacityManager).updateCapacityForHost(host3);
-        Mockito.verify(alertManagerImplMock.logger).error(Mockito.anyString(), Mockito.any(Throwable.class));
+        verify(capacityManager).updateCapacityForHost(host1);
+        verify(capacityManager).updateCapacityForHost(host2);
+        verify(capacityManager).updateCapacityForHost(host3);
+        verify(alertManagerImplMock.logger).error(anyString(), any(Throwable.class));
     }
 
     @Test
     public void testRecalculateHostCapacitiesReusesExecutorAcrossCalls() throws Exception {
-        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
-        HostVO hostMock = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(hostMock);
+        when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
+        HostVO hostMock = mock(HostVO.class);
+        when(hostDao.findById(anyLong())).thenReturn(hostMock);
 
         alertManagerImplMock.recalculateHostCapacities();
         ExecutorService firstExecutor = getCapacityExecutorService();
         assertNotNull(firstExecutor);
 
-        Mockito.when(primaryDataStoreDao.listAllIds()).thenReturn(List.of(101L));
-        StoragePoolVO pool = Mockito.mock(StoragePoolVO.class);
-        Mockito.when(primaryDataStoreDao.findById(101L)).thenReturn(pool);
+        when(primaryDataStoreDao.listAllIds()).thenReturn(List.of(101L));
+        StoragePoolVO pool = mock(StoragePoolVO.class);
+        when(primaryDataStoreDao.findById(101L)).thenReturn(pool);
         alertManagerImplMock.recalculateStorageCapacities();
 
         assertEquals("host and storage recalculation should share the same long-lived pool",
@@ -281,9 +290,9 @@ public class AlertManagerImplTest {
 
     @Test
     public void testRecalculateHostCapacitiesRecreatesExecutorAfterShutdown() throws Exception {
-        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
-        HostVO hostMock = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(hostMock);
+        when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
+        HostVO hostMock = mock(HostVO.class);
+        when(hostDao.findById(anyLong())).thenReturn(hostMock);
 
         alertManagerImplMock.recalculateHostCapacities();
         ExecutorService firstExecutor = getCapacityExecutorService();
@@ -298,29 +307,29 @@ public class AlertManagerImplTest {
 
     @Test
     public void testStopShutsDownCapacityExecutorServiceWhenPresent() throws Exception {
-        Timer timerMock = Mockito.mock(Timer.class);
+        Timer timerMock = mock(Timer.class);
         setTimer(timerMock);
-        Mockito.when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
-        HostVO hostMock = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(hostMock);
+        when(hostDao.listIdsByType(Host.Type.Routing)).thenReturn(List.of(1L));
+        HostVO hostMock = mock(HostVO.class);
+        when(hostDao.findById(anyLong())).thenReturn(hostMock);
         alertManagerImplMock.recalculateHostCapacities();
 
         boolean result = alertManagerImplMock.stop();
 
         Assert.assertTrue(result);
-        Mockito.verify(timerMock).cancel();
+        verify(timerMock).cancel();
         Assert.assertTrue(getCapacityExecutorService().isShutdown());
     }
 
     @Test
     public void testStopDoesNotThrowWhenCapacityExecutorServiceNeverCreated() throws Exception {
-        Timer timerMock = Mockito.mock(Timer.class);
+        Timer timerMock = mock(Timer.class);
         setTimer(timerMock);
 
         boolean result = alertManagerImplMock.stop();
 
         Assert.assertTrue(result);
-        Mockito.verify(timerMock).cancel();
+        verify(timerMock).cancel();
         assertNull(getCapacityExecutorService());
     }
 


### PR DESCRIPTION
### Description

This PR...
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #13586


1. Removes alertManager.recalculateCapacity() from PrometheusExporterImpl.updateMetrics(). This is the actual fix — it stops the exporter from forcing a full, thread-pool-churning, all-zone capacity recalculation on every single scrape. The exporter should just read CapacityDao, which AlertManagerImpl's own timer already keeps current. This alone should flatten the scrape_duration curve.
2. Reuses a single long-lived ExecutorService in AlertManagerImpl instead of creating/tearing one down on every recalculateHostCapacities()/recalculateStorageCapacities() call. Cheap, low-risk, and removes the thread-churn contributor even for the timer-driven path.

this should solve the issue, but claude suggested the following improvements as well:

3. Give the exporter's HttpServer an explicit bounded executor (httpServer.setExecutor(Executors.newFixedThreadPool(2))) so one slow scrape can't serialize/queue all others.
4. Add a short TTL/in-flight guard around updateMetrics() (e.g., skip recompute if last run was < N seconds ago, or synchronize so concurrent scrapes share one in-progress computation) so scrape frequency can never multiply backend load.
5. Instrument: log/measure updateMetrics() wall-clock time so the reporter (and CI) can confirm which sub-metric collector is actually slow and verify the fix closes the growth.

if anyone wants to, these are nice to haves/good first issue ;)

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
