### PR TITLE
Ignore projectid=-1 on Quota summary

### DIFF
--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
@@ -116,6 +116,9 @@ public class QuotaSummaryCmd extends BaseListCmd {
     }
 
     public Long getProjectId() {
+        if (projectId == null || projectId == -1L) {
+            return null;
+        }
         return projectId;
     }
 
@@ -129,9 +132,10 @@ public class QuotaSummaryCmd extends BaseListCmd {
 
     @Override
     public long getEntityOwnerId() {
-        if (ObjectUtils.allNull(accountId, accountName, projectId)) {
+        Long convertedProjectId = getProjectId();
+        if (ObjectUtils.allNull(accountId, accountName, convertedProjectId)) {
             return -1;
         }
-        return _accountService.finalizeAccountId(accountId, accountName, domainId, projectId);
+        return _accountService.finalizeAccountId(accountId, accountName, domainId, convertedProjectId);
     }
 }

--- a/ui/src/config/section/plugin/quota.js
+++ b/ui/src/config/section/plugin/quota.js
@@ -30,11 +30,7 @@ export default {
       title: 'label.quota.summary',
       icon: 'bars-outlined',
       permission: ['quotaSummary'],
-      customParamHandler: (params, query) => {
-        const result = { ...params, ignoreproject: true }
-        delete result.projectid
-        return result
-      },
+      customParamHandler: (params, query) => { return { ...params, ignoreproject: true } },
       tabs: [
         {
           name: 'consumption',

--- a/ui/src/config/section/plugin/quota.js
+++ b/ui/src/config/section/plugin/quota.js
@@ -30,7 +30,11 @@ export default {
       title: 'label.quota.summary',
       icon: 'bars-outlined',
       permission: ['quotaSummary'],
-      customParamHandler: (params, query) => { return { ...params, ignoreproject: true } },
+      customParamHandler: (params, query) => {
+        const result = { ...params, ignoreproject: true }
+        delete result.projectid
+        return result
+      },
       tabs: [
         {
           name: 'consumption',


### PR DESCRIPTION
### Description

This fixes a minor bug in the Quota UI.

Enabling the projects toggle on any page makes the UI send `projectid=-1` to APIs; however, this parameter makes the Quota summary page display an error. This is because a special handling for `projectid=-1` was never implemented on `quotaSummary`, since it already returns entries for the accessible projects ever since it was introduced. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Without the patch, I verified that enabling the projects toggle and switching to the Quota summary page would display an error.

<details>
<summary> Error when accessing the Quota summary page </summary>
<img width="3186" height="901" alt="image" src="https://github.com/user-attachments/assets/fc446308-1318-4576-a042-b7000748fbfc" />

</details>

Applying these changes allows the Quota summary page to load as intended when repeating the same steps.

<details>
<summary> Quota summary page loaded successfully </summary>
<img width="3186" height="1038" alt="image" src="https://github.com/user-attachments/assets/c5d60fc7-a687-41f9-9c4f-c57de4668266" />

</details>