### PR TITLE
Don't set compressionstatus and validation status in backupVO and bac…

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/backup/BackupVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/backup/BackupVO.java
@@ -128,11 +128,10 @@ public class BackupVO implements Backup {
 
     public BackupVO() {
         this.uuid = UUID.randomUUID().toString();
-        this.compressionStatus = CompressionStatus.Uncompressed;
-        this.validationStatus = ValidationStatus.NotValidated;
     }
 
-    public BackupVO(String name, long vmId, long backupOfferingId, long accountId, long domainId, long zoneId, long virtualSize, Status status, Long backupScheduleId) {
+    public BackupVO(String name, long vmId, long backupOfferingId, long accountId, long domainId, long zoneId, long virtualSize,
+                    Status status, Long backupScheduleId, CompressionStatus compressionStatus, ValidationStatus validationStatus) {
         this.name = name;
         this.vmId = vmId;
         this.backupOfferingId = backupOfferingId;
@@ -144,8 +143,8 @@ public class BackupVO implements Backup {
         this.setType("FULL");
         this.uuid = UUID.randomUUID().toString();
         this.backupScheduleId = backupScheduleId;
-        this.compressionStatus = CompressionStatus.Uncompressed;
-        this.validationStatus = ValidationStatus.NotValidated;
+        this.compressionStatus = compressionStatus;
+        this.validationStatus = validationStatus;
     }
 
     @Override

--- a/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
+++ b/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
@@ -1071,7 +1071,8 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
         long vmId = vm.getId();
 
         BackupVO backup = new BackupVO(String.format("%s-%s", vm.getHostName(), DateUtil.getDateInSystemTimeZone()), vmId, vm.getBackupOfferingId(), accountId,
-                vm.getDomainId(), vm.getDataCenterId(), 0, Backup.Status.Queued, backupScheduleId);
+                vm.getDomainId(), vm.getDataCenterId(), 0, Backup.Status.Queued, backupScheduleId,
+                Backup.CompressionStatus.Uncompressed, Backup.ValidationStatus.NotValidated);
 
         VmWorkJobVO workJob = new VmWorkJobVO(AsyncJobExecutionContext.getOriginJobId(), userId, accountId, VmWorkTakeBackup.class.getName(), vmId, VirtualMachine.Type.Instance,
                 VmWorkJobVO.Step.Starting);

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -2653,11 +2653,15 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         response.setProtectedSize(backup.getProtectedSize());
         response.setStatus(backup.getStatus());
         response.setIntervalType("MANUAL");
-        response.setCompressionStatus(backup.getCompressionStatus());
-        if (backup.getUncompressedSize() != null && backup.getUncompressedSize() > 0) {
-            response.setUncompressedSize(backup.getUncompressedSize());
+        if (backup.getCompressionStatus() != null) {
+            response.setCompressionStatus(backup.getCompressionStatus());
+            if (backup.getUncompressedSize() != null && backup.getUncompressedSize() > 0) {
+                response.setUncompressedSize(backup.getUncompressedSize());
+            }
         }
-        response.setValidationStatus(backup.getValidationStatus());
+        if (backup.getValidationStatus() != null) {
+            response.setValidationStatus(backup.getValidationStatus());
+        }
         if (backup.getBackupScheduleId() != null) {
             BackupScheduleVO scheduleVO = backupScheduleDao.findById(backup.getBackupScheduleId());
             if (scheduleVO != null) {

--- a/ui/src/components/view/ListView.vue
+++ b/ui/src/components/view/ListView.vue
@@ -484,10 +484,10 @@
         />
       </template>
       <template v-if="column.key === 'compressionstatus'">
-        <status :text="text ? text : ''" displayText />
+        <status :text="text ? text : $t('label.unknown')" displayText />
       </template>
       <template v-if="column.key === 'validationstatus'">
-        <status :text="text ? text : ''" displayText />
+        <status :text="text ? text : $t('label.unknown')" displayText />
       </template>
       <template v-if="column.key === 'allocationstate'">
         <status

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1267,6 +1267,16 @@ export default {
           })
         }
 
+        if (this.apiName === 'listBackups') {
+          const kbossFields = ['compressionstatus', 'validationstatus']
+          const hasKbossData = this.items.some(backup => kbossFields.some(field => backup[field]))
+          if (!hasKbossData) {
+            this.columns = this.columns.filter(col => !kbossFields.includes(col.dataIndex))
+            this.allColumns = this.allColumns.filter(col => !kbossFields.includes(col.dataIndex))
+            this.selectedColumns = this.selectedColumns.filter(key => !kbossFields.includes(key))
+          }
+        }
+
         for (let idx = 0; idx < this.items.length; idx++) {
           this.items[idx].key = idx
           for (const key in customRender) {

--- a/ui/src/views/compute/InstanceTab.vue
+++ b/ui/src/views/compute/InstanceTab.vue
@@ -74,7 +74,9 @@
           apiName="listBackups"
           :resource="resource"
           :params="{virtualmachineid: dataResource.id}"
-          :columns="['name', 'status', 'compressionstatus', 'validationstatus', 'size', 'virtualsize', 'type', 'intervaltype', 'created']"
+          :columns="dataResource.backupprovider === 'kboss'
+            ? ['name', 'status', 'compressionstatus', 'validationstatus', 'size', 'virtualsize', 'type', 'intervaltype', 'created']
+            : ['name', 'status', 'size', 'virtualsize', 'type', 'intervaltype', 'created']"
           :routerlinks="(record) => { return { name: '/backup/' + record.id } }"
           :showSearch="false"/>
       </a-tab-pane>


### PR DESCRIPTION
…kupsResponse for non-kboss providers.

These columns are hidden in UI if they are not set.

### Description

This PR fixes #13660 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Created an Env with NAS plugin enabled.

#### Before fix:
<img width="1465" height="871" alt="Screenshot 2026-07-21 at 10 08 51 PM" src="https://github.com/user-attachments/assets/e8c5709f-1c71-4b7c-932a-2d1b4532472f" />

<img width="1465" height="871" alt="Screenshot 2026-07-21 at 10 08 29 PM" src="https://github.com/user-attachments/assets/21a9aa0c-5367-4bb3-8ae3-0fe5014de1ca" />

#### After fix:
<img width="1660" height="1025" alt="Screenshot 2026-07-21 at 9 51 54 PM" src="https://github.com/user-attachments/assets/9ca4df6c-a3c4-4520-aa53-a863afc40547" />

<img width="1660" height="1025" alt="Screenshot 2026-07-21 at 9 52 03 PM" src="https://github.com/user-attachments/assets/156e7d61-3400-4b77-b639-23a5b47fb4c3" />


Removed the Nas offering and assigned the VM to a Kboss offering and took another backup.
The fields are visible now. The older NAS backups show the fields as empty instead of `Uncompressed`

<img width="1660" height="1025" alt="Screenshot 2026-07-21 at 9 54 19 PM" src="https://github.com/user-attachments/assets/ab948628-0b08-447a-a760-5d9e80eb4be2" />
<img width="1660" height="1025" alt="Screenshot 2026-07-21 at 9 54 13 PM" src="https://github.com/user-attachments/assets/f6a0a2d7-80ab-4fb4-9130-e536bac39738" />



<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
