### PR TITLE
Redact sensitive duplicate query parameter values in ApiServlet logs

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -522,7 +522,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                     if(parameterMap.putIfAbsent(param.getName(), new String[]{param.getValue()}) != null) {
                         String message = String.format("Query parameter '%s' has multiple values %s. Only the last value will be respected." +
                             "It is advised to pass only a single parameter", param.getName(),
-                            ApiServlet.formatValuesForLog(param.getName(), (String[]) parameterMap.get(param.getName())));
+                            StringUtils.formatValuesForLog(param.getName(), (String[]) parameterMap.get(param.getName())));
                         logger.warn(StringUtils.cleanString(message));
                     }
                 }

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -520,8 +520,9 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                         continue;
                     }
                     if(parameterMap.putIfAbsent(param.getName(), new String[]{param.getValue()}) != null) {
-                        String message = String.format("Query parameter '%s' has multiple values [%s, %s]. Only the last value will be respected." +
-                            "It is advised to pass only a single parameter", param.getName(), param.getValue(), parameterMap.get(param.getName()));
+                        String message = String.format("Query parameter '%s' has multiple values %s. Only the last value will be respected." +
+                            "It is advised to pass only a single parameter", param.getName(),
+                            ApiServlet.formatValuesForLog(param.getName(), (String[]) parameterMap.get(param.getName())));
                         logger.warn(StringUtils.cleanString(message));
                     }
                 }

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.servlet.ServletConfig;
@@ -78,7 +79,19 @@ public class ApiServlet extends HttpServlet {
     protected static Logger LOGGER = LogManager.getLogger(ApiServlet.class);
     private static final Logger ACCESSLOGGER = LogManager.getLogger("apiserver." + ApiServlet.class.getName());
     private static final String REPLACEMENT = "_";
-    private static final String LOGGER_REPLACEMENTS = "[\n\r\t]";
+private static final String REDACTED = "REDACTED";
+private static final String LOGGER_REPLACEMENTS = "[\n\r\t]";
+
+private static final Set<String> SENSITIVE_PARAMETER_KEYWORDS = Set.of(
+    "password",
+    "privatekey",
+    "accesskey",
+    "secretkey",
+    "apikey",
+    "signature",
+    "sessionkey",
+    "token"
+);
 
     @Inject
     ApiServerService apiServer;
@@ -161,11 +174,31 @@ public class ApiServlet extends HttpServlet {
         params.forEach((k, v) -> {
             if (v.length > 1) {
                 String message = String.format("Query parameter '%s' has multiple values %s. Only the last value will be respected." +
-                    "It is advised to pass only a single parameter", k, Arrays.toString(v));
+                    "It is advised to pass only a single parameter", k, formatValuesForLog(k, v));
                 LOGGER.warn(message);
             }
         });
     }
+
+    static boolean isSensitiveParameter(String parameterName) {
+    if (parameterName == null) {
+        return false;
+    }
+
+    String lowerCaseParameter = parameterName.toLowerCase();
+    return SENSITIVE_PARAMETER_KEYWORDS.stream()
+            .anyMatch(lowerCaseParameter::contains);
+}
+
+static String formatValuesForLog(String parameterName, String[] values) {
+    if (!isSensitiveParameter(parameterName)) {
+        return Arrays.toString(values);
+    }
+
+    String[] masked = new String[values.length];
+    Arrays.fill(masked, REDACTED);
+    return Arrays.toString(masked);
+}
 
     void processRequestInContext(final HttpServletRequest req, final HttpServletResponse resp) {
         InetAddress remoteAddress = null;

--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 import javax.servlet.ServletConfig;
@@ -79,19 +78,7 @@ public class ApiServlet extends HttpServlet {
     protected static Logger LOGGER = LogManager.getLogger(ApiServlet.class);
     private static final Logger ACCESSLOGGER = LogManager.getLogger("apiserver." + ApiServlet.class.getName());
     private static final String REPLACEMENT = "_";
-private static final String REDACTED = "REDACTED";
 private static final String LOGGER_REPLACEMENTS = "[\n\r\t]";
-
-private static final Set<String> SENSITIVE_PARAMETER_KEYWORDS = Set.of(
-    "password",
-    "privatekey",
-    "accesskey",
-    "secretkey",
-    "apikey",
-    "signature",
-    "sessionkey",
-    "token"
-);
 
     @Inject
     ApiServerService apiServer;
@@ -174,31 +161,11 @@ private static final Set<String> SENSITIVE_PARAMETER_KEYWORDS = Set.of(
         params.forEach((k, v) -> {
             if (v.length > 1) {
                 String message = String.format("Query parameter '%s' has multiple values %s. Only the last value will be respected." +
-                    "It is advised to pass only a single parameter", k, formatValuesForLog(k, v));
+                    "It is advised to pass only a single parameter", k, StringUtils.formatValuesForLog(k, v));
                 LOGGER.warn(message);
             }
         });
     }
-
-    static boolean isSensitiveParameter(String parameterName) {
-    if (parameterName == null) {
-        return false;
-    }
-
-    String lowerCaseParameter = parameterName.toLowerCase();
-    return SENSITIVE_PARAMETER_KEYWORDS.stream()
-            .anyMatch(lowerCaseParameter::contains);
-}
-
-static String formatValuesForLog(String parameterName, String[] values) {
-    if (!isSensitiveParameter(parameterName)) {
-        return Arrays.toString(values);
-    }
-
-    String[] masked = new String[values.length];
-    Arrays.fill(masked, REDACTED);
-    return Arrays.toString(masked);
-}
 
     void processRequestInContext(final HttpServletRequest req, final HttpServletResponse resp) {
         InetAddress remoteAddress = null;

--- a/server/src/test/java/com/cloud/api/ApiServletTest.java
+++ b/server/src/test/java/com/cloud/api/ApiServletTest.java
@@ -432,4 +432,29 @@ public class ApiServletTest {
 
         Assert.assertEquals(false, result);
     }
+    @Test
+    public void testFormatValuesForLogMasksSensitiveParameters() {
+        String result = ApiServlet.formatValuesForLog(
+            "password",
+            new String[]{"SECRET_ONE", "SECRET_TWO"});
+
+        Assert.assertEquals("[REDACTED, REDACTED]", result);
+    }
+
+    @Test
+    public void testFormatValuesForLogDoesNotMaskNormalParameters() {
+        String result = ApiServlet.formatValuesForLog(
+            "username",
+            new String[]{"alice", "bob"});
+
+        Assert.assertEquals("[alice, bob]", result);
+    }
+
+    @Test
+    public void testIsSensitiveParameter() {
+        Assert.assertTrue(ApiServlet.isSensitiveParameter("adminpassword"));
+        Assert.assertTrue(ApiServlet.isSensitiveParameter("usersecretkey"));
+        Assert.assertTrue(ApiServlet.isSensitiveParameter("sessiontoken"));
+        Assert.assertFalse(ApiServlet.isSensitiveParameter("username"));
+    }
 }

--- a/utils/src/main/java/com/cloud/utils/StringUtils.java
+++ b/utils/src/main/java/com/cloud/utils/StringUtils.java
@@ -25,9 +25,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Locale;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -168,6 +170,39 @@ public class StringUtils extends org.apache.commons.lang3.StringUtils {
     private static final Pattern REGEX_PASSWORD_DETAILS_INDEX = Pattern.compile("details(\\[|%5B)\\d*(\\]|%5D)");
 
     private static final Pattern REGEX_REDUNDANT_AND = Pattern.compile("(&|%26)(&|%26)+");
+
+    private static final String REDACTED = "REDACTED";
+
+    private static final Set<String> SENSITIVE_PARAMETER_KEYWORDS = Set.of(
+            "password",
+            "privatekey",
+            "accesskey",
+            "secretkey",
+            "apikey",
+            "signature",
+            "sessionkey",
+            "token"
+    );
+
+    public static boolean isSensitiveParameter(final String parameterName) {
+        if (parameterName == null) {
+            return false;
+        }
+
+        final String normalized = parameterName.toLowerCase(Locale.ROOT);
+        return SENSITIVE_PARAMETER_KEYWORDS.stream()
+                .anyMatch(normalized::contains);
+    }
+
+    public static String formatValuesForLog(final String parameterName, final String[] values) {
+        if (!isSensitiveParameter(parameterName)) {
+            return Arrays.toString(values);
+        }
+
+        final String[] masked = new String[values.length];
+        Arrays.fill(masked, REDACTED);
+        return Arrays.toString(masked);
+    }
 
     // Responsible for stripping sensitive content from request and response strings
     public static String cleanString(final String stringToClean) {

--- a/utils/src/main/java/com/cloud/utils/StringUtils.java
+++ b/utils/src/main/java/com/cloud/utils/StringUtils.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;


### PR DESCRIPTION
## Description

This PR manually backports the fix from #13559 to the 4.20 LTS branch.

### Changes
- Redact duplicate values for sensitive query parameters before logging in `ApiServlet`.
- Add helper methods to identify sensitive parameters and format logged values.
- Backport the corresponding unit tests.

This backport includes the changes applicable to the 4.20 branch.

Fixes #13311