### PR TITLE
Harden native TOTP two-factor authentication (verification window, replay protection, secret encryption-at-rest, backup codes)

### DIFF
--- a/api/src/main/java/com/cloud/user/UserAccount.java
+++ b/api/src/main/java/com/cloud/user/UserAccount.java
@@ -77,6 +77,10 @@ public interface UserAccount extends InternalIdentity {
 
     public void setKeyFor2fa(String keyFor2fa);
 
+    public Long getLastUsed2faStep();
+
+    public void setLastUsed2faStep(Long lastUsed2faStep);
+
     public String getUser2faProvider();
 
     public void setUser2faProvider(String user2faProvider);

--- a/api/src/main/java/org/apache/cloudstack/api/response/UserTwoFactorAuthenticationBackupCodesResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserTwoFactorAuthenticationBackupCodesResponse.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.response;
+
+import java.util.List;
+
+import org.apache.cloudstack.api.BaseResponse;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
+
+public class UserTwoFactorAuthenticationBackupCodesResponse extends BaseResponse {
+
+    @SerializedName("id")
+    @Param(description = "The user ID")
+    private String id;
+
+    @SerializedName("username")
+    @Param(description = "The user name")
+    private String username;
+
+    @SerializedName("backupcodes")
+    @Param(description = "The generated one-time backup codes. These are shown only once at " +
+            "generation time and cannot be retrieved again; store them securely.")
+    private List<String> backupCodes;
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setBackupCodes(List<String> backupCodes) {
+        this.backupCodes = backupCodes;
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -92,6 +92,7 @@ import com.cloud.upgrade.dao.Upgrade42000to42010;
 import com.cloud.upgrade.dao.Upgrade42010to42100;
 import com.cloud.upgrade.dao.Upgrade42100to42200;
 import com.cloud.upgrade.dao.Upgrade42200to42210;
+import com.cloud.upgrade.dao.Upgrade42210to42220;
 import com.cloud.upgrade.dao.Upgrade420to421;
 import com.cloud.upgrade.dao.Upgrade421to430;
 import com.cloud.upgrade.dao.Upgrade430to440;
@@ -242,6 +243,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.20.1.0", new Upgrade42010to42100())
                 .next("4.21.0.0", new Upgrade42100to42200())
                 .next("4.22.0.0", new Upgrade42200to42210())
+                .next("4.22.1.0", new Upgrade42210to42220())
                 .build();
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42220.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42220.java
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
+
+import com.cloud.utils.crypt.DBEncryptionUtil;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+public class Upgrade42210to42220 extends DbUpgradeAbstractImpl implements DbUpgrade {
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[] {"4.22.1.0", "4.22.2.0"};
+    }
+
+    @Override
+    public String getUpgradedVersion() {
+        return "4.22.2.0";
+    }
+
+    @Override
+    public void performDataMigration(Connection conn) {
+        encryptExistingTwoFactorAuthenticationKeys(conn);
+    }
+
+    /**
+     * The {@code user.key_for_2fa} column was previously stored in plaintext. It is now annotated
+     * with {@code @Encrypt}, so existing plaintext secrets must be encrypted in place. This is
+     * idempotent: a value that already decrypts cleanly is left untouched.
+     */
+    protected void encryptExistingTwoFactorAuthenticationKeys(Connection conn) {
+        Map<Long, String> keysToEncrypt = new LinkedHashMap<>();
+        try (PreparedStatement selectStmt = conn.prepareStatement("SELECT id, key_for_2fa FROM cloud.user WHERE key_for_2fa IS NOT NULL AND key_for_2fa <> ''");
+             ResultSet rs = selectStmt.executeQuery()) {
+            while (rs.next()) {
+                long id = rs.getLong(1);
+                String value = rs.getString(2);
+                if (isAlreadyEncrypted(value)) {
+                    continue;
+                }
+                keysToEncrypt.put(id, value);
+            }
+        } catch (Exception e) {
+            String message = String.format("Unable to read user.key_for_2fa values for encryption migration due to [%s].", e.getMessage());
+            logger.error(message, e);
+            throw new CloudRuntimeException(message, e);
+        }
+
+        if (keysToEncrypt.isEmpty()) {
+            logger.debug("No plaintext user.key_for_2fa values found to encrypt.");
+            return;
+        }
+
+        logger.info(String.format("Encrypting %d existing plaintext user.key_for_2fa value(s).", keysToEncrypt.size()));
+        String updateSql = "UPDATE cloud.user SET key_for_2fa = ? WHERE id = ?";
+        for (Map.Entry<Long, String> entry : keysToEncrypt.entrySet()) {
+            try (PreparedStatement updateStmt = conn.prepareStatement(updateSql)) {
+                updateStmt.setString(1, DBEncryptionUtil.encrypt(entry.getValue()));
+                updateStmt.setLong(2, entry.getKey());
+                updateStmt.executeUpdate();
+            } catch (Exception e) {
+                String message = String.format("Unable to encrypt user.key_for_2fa for user ID [%s] due to [%s].", entry.getKey(), e.getMessage());
+                logger.error(message, e);
+                throw new CloudRuntimeException(message, e);
+            }
+        }
+    }
+
+    private boolean isAlreadyEncrypted(String value) {
+        try {
+            DBEncryptionUtil.decrypt(value);
+            return true;
+        } catch (EncryptionOperationNotPossibleException e) {
+            return false;
+        }
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42220.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42220.java
@@ -21,10 +21,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
+import java.util.regex.Pattern;
 
 import com.cloud.utils.crypt.DBEncryptionUtil;
+import com.cloud.utils.crypt.EncryptionSecretKeyChecker;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 public class Upgrade42210to42220 extends DbUpgradeAbstractImpl implements DbUpgrade {
@@ -44,19 +44,36 @@ public class Upgrade42210to42220 extends DbUpgradeAbstractImpl implements DbUpgr
         encryptExistingTwoFactorAuthenticationKeys(conn);
     }
 
+    // A stored TOTP secret is Base32 (RFC 4648 alphabet A-Z, 2-7, optional '=' padding). An
+    // encrypted value is Base64 and therefore contains characters outside this set (lowercase,
+    // 0/1/8/9, '+', '/'). This shape test distinguishes a not-yet-encrypted secret from one that
+    // is already encrypted, without relying on decrypt() throwing a particular exception type.
+    private static final Pattern BASE32_SECRET = Pattern.compile("^[A-Z2-7]+=*$");
+
     /**
      * The {@code user.key_for_2fa} column was previously stored in plaintext. It is now annotated
-     * with {@code @Encrypt}, so existing plaintext secrets must be encrypted in place. This is
-     * idempotent: a value that already decrypts cleanly is left untouched.
+     * with {@code @Encrypt}, so {@link DBEncryptionUtil} decrypts it on every read — meaning any
+     * row left in plaintext would fail to decrypt and lock the user out of 2FA. This migration
+     * encrypts existing plaintext secrets in place.
+     *
+     * It is a no-op when DB encryption is disabled (then {@code @Encrypt} reads return the value
+     * unchanged, so nothing needs encrypting), and idempotent when enabled (values already in
+     * encrypted, non-Base32 form are skipped), so re-running after a partial failure is safe.
      */
     protected void encryptExistingTwoFactorAuthenticationKeys(Connection conn) {
+        if (!EncryptionSecretKeyChecker.useEncryption()) {
+            logger.debug("DB encryption is disabled; user.key_for_2fa is stored as-is, nothing to migrate.");
+            return;
+        }
+
         Map<Long, String> keysToEncrypt = new LinkedHashMap<>();
         try (PreparedStatement selectStmt = conn.prepareStatement("SELECT id, key_for_2fa FROM cloud.user WHERE key_for_2fa IS NOT NULL AND key_for_2fa <> ''");
              ResultSet rs = selectStmt.executeQuery()) {
             while (rs.next()) {
                 long id = rs.getLong(1);
                 String value = rs.getString(2);
-                if (isAlreadyEncrypted(value)) {
+                if (!isPlaintextSecret(value)) {
+                    // Already encrypted (or not a recognizable plaintext secret) — leave it alone.
                     continue;
                 }
                 keysToEncrypt.put(id, value);
@@ -87,12 +104,11 @@ public class Upgrade42210to42220 extends DbUpgradeAbstractImpl implements DbUpgr
         }
     }
 
-    private boolean isAlreadyEncrypted(String value) {
-        try {
-            DBEncryptionUtil.decrypt(value);
-            return true;
-        } catch (EncryptionOperationNotPossibleException e) {
-            return false;
-        }
+    /**
+     * True if the value looks like a plaintext Base32 TOTP secret (and therefore still needs
+     * encrypting). Encrypted (Base64) values contain characters outside the Base32 alphabet.
+     */
+    protected boolean isPlaintextSecret(String value) {
+        return value != null && BASE32_SECRET.matcher(value).matches();
     }
 }

--- a/engine/schema/src/main/java/com/cloud/user/UserAccountVO.java
+++ b/engine/schema/src/main/java/com/cloud/user/UserAccountVO.java
@@ -119,8 +119,12 @@ public class UserAccountVO implements UserAccount, InternalIdentity {
     @Column(name = "user_2fa_provider")
     private String user2faProvider;
 
+    @Encrypt
     @Column(name = "key_for_2fa")
     private String keyFor2fa;
+
+    @Column(name = "last_used_2fa_step")
+    private Long lastUsed2faStep;
 
     @Transient
     Map<String, String> details;
@@ -349,6 +353,16 @@ public class UserAccountVO implements UserAccount, InternalIdentity {
     @Override
     public void setKeyFor2fa(String keyFor2fa) {
         this.keyFor2fa = keyFor2fa;
+    }
+
+    @Override
+    public Long getLastUsed2faStep() {
+        return lastUsed2faStep;
+    }
+
+    @Override
+    public void setLastUsed2faStep(Long lastUsed2faStep) {
+        this.lastUsed2faStep = lastUsed2faStep;
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/user/UserVO.java
+++ b/engine/schema/src/main/java/com/cloud/user/UserVO.java
@@ -112,8 +112,12 @@ public class UserVO implements User, Identity, InternalIdentity {
     @Column(name = "user_2fa_provider")
     private String user2faProvider;
 
+    @Encrypt
     @Column(name = "key_for_2fa")
     private String keyFor2fa;
+
+    @Column(name = "last_used_2fa_step")
+    private Long lastUsed2faStep;
 
     @Column(name = "api_key_access")
     private Boolean apiKeyAccess;
@@ -343,6 +347,14 @@ public class UserVO implements User, Identity, InternalIdentity {
 
     public void setKeyFor2fa(String keyFor2fa) {
         this.keyFor2fa = keyFor2fa;
+    }
+
+    public Long getLastUsed2faStep() {
+        return lastUsed2faStep;
+    }
+
+    public void setLastUsed2faStep(Long lastUsed2faStep) {
+        this.lastUsed2faStep = lastUsed2faStep;
     }
 
     public String getUser2faProvider() {

--- a/engine/schema/src/main/java/com/cloud/user/dao/UserAccountDao.java
+++ b/engine/schema/src/main/java/com/cloud/user/dao/UserAccountDao.java
@@ -32,4 +32,12 @@ public interface UserAccountDao extends GenericDao<UserAccountVO, Long> {
     boolean validateUsernameInDomain(String username, Long domainId);
 
     UserAccount getUserByApiKey(String apiKey);
+
+    /**
+     * Atomically records the given TOTP time-step as the last used one for the user, but only if
+     * it is newer than the currently recorded step (or none is recorded). Returns true if the row
+     * was updated; false means a concurrent verification already recorded this or a newer step,
+     * i.e. the code is being replayed.
+     */
+    boolean updateLastUsed2faStepIfNewer(long userAccountId, long step);
 }

--- a/engine/schema/src/main/java/com/cloud/user/dao/UserAccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/user/dao/UserAccountDaoImpl.java
@@ -29,11 +29,21 @@ import java.util.List;
 public class UserAccountDaoImpl extends GenericDaoBase<UserAccountVO, Long> implements UserAccountDao {
 
     protected final SearchBuilder<UserAccountVO> userAccountSearch;
+    protected final SearchBuilder<UserAccountVO> newer2faStepSearch;
 
     public UserAccountDaoImpl() {
         userAccountSearch = createSearchBuilder();
         userAccountSearch.and("apiKey", userAccountSearch.entity().getApiKey(), SearchCriteria.Op.EQ);
         userAccountSearch.done();
+
+        // Matches a user whose recorded 2FA step is older than a given step (or never set),
+        // used for an atomic conditional update that rejects TOTP code replay under concurrency.
+        newer2faStepSearch = createSearchBuilder();
+        newer2faStepSearch.and("id", newer2faStepSearch.entity().getId(), SearchCriteria.Op.EQ);
+        newer2faStepSearch.and().op("nullStep", newer2faStepSearch.entity().getLastUsed2faStep(), SearchCriteria.Op.NULL);
+        newer2faStepSearch.or("olderStep", newer2faStepSearch.entity().getLastUsed2faStep(), SearchCriteria.Op.LT);
+        newer2faStepSearch.cp();
+        newer2faStepSearch.done();
     }
 
     @Override
@@ -85,6 +95,19 @@ public class UserAccountDaoImpl extends GenericDaoBase<UserAccountVO, Long> impl
         SearchCriteria<UserAccountVO> sc = userAccountSearch.create();
         sc.setParameters("apiKey", apiKey);
         return findOneBy(sc);
+    }
+
+    @Override
+    public boolean updateLastUsed2faStepIfNewer(long userAccountId, long step) {
+        SearchCriteria<UserAccountVO> sc = newer2faStepSearch.create();
+        sc.setParameters("id", userAccountId);
+        sc.setParameters("olderStep", step);
+        UserAccountVO forUpdate = createForUpdate();
+        forUpdate.setLastUsed2faStep(step);
+        // Atomic conditional UPDATE: only rows whose recorded step is null or older than this
+        // step are updated. A return of 0 means another concurrent verification already recorded
+        // this (or a newer) step, i.e. the code is being replayed.
+        return update(forUpdate, sc) > 0;
     }
 
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/resourcedetail/UserDetailVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/resourcedetail/UserDetailVO.java
@@ -46,6 +46,7 @@ public class UserDetailVO implements ResourceDetail {
     private boolean display = true;
 
     public static final String Setup2FADetail = "2FASetupStatus";
+    public static final String Backup2FACodesDetail = "2FABackupCodes";
     public static final String PasswordResetToken = "PasswordResetToken";
     public static final String PasswordResetTokenExpiryDate = "PasswordResetTokenExpiryDate";
 

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42220-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42220-cleanup.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade cleanup from 4.22.1.0 to 4.22.2.0
+--;

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42220.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42220.sql
@@ -1,0 +1,24 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.22.1.0 to 4.22.2.0
+--;
+
+-- TOTP replay protection: track the last accepted TOTP time-step per user so a code
+-- cannot be reused within its validity window.
+CALL `cloud`.`IDEMPOTENT_ADD_COLUMN`('cloud.user', 'last_used_2fa_step', 'BIGINT DEFAULT NULL COMMENT ''Last accepted TOTP 30-second time-step, used to prevent code replay''');

--- a/engine/schema/src/test/java/com/cloud/upgrade/dao/Upgrade42210to42220Test.java
+++ b/engine/schema/src/test/java/com/cloud/upgrade/dao/Upgrade42210to42220Test.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade.dao;
+
+import java.security.SecureRandom;
+
+import org.apache.commons.codec.binary.Base32;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Upgrade42210to42220Test {
+
+    private final Upgrade42210to42220 upgrade = new Upgrade42210to42220();
+
+    @Test
+    public void testVersionChain() {
+        Assert.assertArrayEquals(new String[] {"4.22.1.0", "4.22.2.0"}, upgrade.getUpgradableVersionRange());
+        Assert.assertEquals("4.22.2.0", upgrade.getUpgradedVersion());
+    }
+
+    @Test
+    public void testFreshlyGeneratedSecretsDetectedAsPlaintext() {
+        // A key produced exactly as the TOTP provider produces it (20 random bytes, Base32).
+        SecureRandom random = new SecureRandom();
+        Base32 base32 = new Base32();
+        for (int i = 0; i < 100; i++) {
+            byte[] bytes = new byte[20];
+            random.nextBytes(bytes);
+            String secret = base32.encodeToString(bytes);
+            Assert.assertTrue("Base32 secret must be treated as plaintext needing encryption: " + secret,
+                    upgrade.isPlaintextSecret(secret));
+        }
+    }
+
+    @Test
+    public void testKnownBase32SecretIsPlaintext() {
+        Assert.assertTrue(upgrade.isPlaintextSecret("JBSWY3DPEHPK3PXP"));
+        Assert.assertTrue(upgrade.isPlaintextSecret("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"));
+    }
+
+    @Test
+    public void testEncryptedLookingValueNotPlaintext() {
+        // Base64 (encrypted) values contain characters outside the Base32 alphabet
+        // (lowercase, '+', '/', digits 0/1/8/9) and must NOT be re-encrypted.
+        Assert.assertFalse(upgrade.isPlaintextSecret("dGhpcyBpcyBub3QgYmFzZTMy"));
+        Assert.assertFalse(upgrade.isPlaintextSecret("abc+/def=="));
+        Assert.assertFalse(upgrade.isPlaintextSecret("V1+encryptedBlob0189"));
+    }
+
+    @Test
+    public void testNullAndEmptyNotPlaintext() {
+        Assert.assertFalse(upgrade.isPlaintextSecret(null));
+        Assert.assertFalse(upgrade.isPlaintextSecret(""));
+    }
+}

--- a/plugins/user-two-factor-authenticators/totp/pom.xml
+++ b/plugins/user-two-factor-authenticators/totp/pom.xml
@@ -27,4 +27,18 @@
         <version>4.22.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${cs.junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cs.mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/plugins/user-two-factor-authenticators/totp/src/main/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticator.java
+++ b/plugins/user-two-factor-authenticators/totp/src/main/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticator.java
@@ -16,23 +16,47 @@
 package org.apache.cloudstack.auth;
 
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 
 import com.cloud.exception.CloudTwoFactorAuthenticationException;
 import com.cloud.utils.exception.CloudRuntimeException;
-import de.taimos.totp.TOTP;
 
 import com.cloud.user.UserAccount;
+import com.cloud.user.UserAccountVO;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.commons.codec.binary.Base32;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 
 import com.cloud.user.dao.UserAccountDao;
 import com.cloud.utils.component.AdapterBase;
 
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 
-public class TotpUserTwoFactorAuthenticator extends AdapterBase implements UserTwoFactorAuthenticator {
+public class TotpUserTwoFactorAuthenticator extends AdapterBase implements UserTwoFactorAuthenticator, Configurable {
+
+    public static final ConfigKey<Integer> totpWindowSteps = new ConfigKey<>("Advanced", Integer.class,
+            "user.2fa.totp.window.steps",
+            "1",
+            "Number of 30-second TOTP time-steps, on each side of the current step, that are accepted during " +
+                    "verification. This tolerates clock drift between the server and the user's authenticator device. " +
+                    "Set to 0 to accept only the current step (strictest, no skew tolerance). This can also be " +
+                    "configured at domain level.",
+            true,
+            ConfigKey.Scope.Domain);
+
+    // RFC 6238 / RFC 4226 parameters. These match the values previously produced by the
+    // de.taimos:totp library (HMAC-SHA1, 6 digits, 30-second time step), so codes from
+    // authenticator apps enrolled before this change continue to verify unchanged.
+    private static final String HMAC_ALGORITHM = "HmacSHA1";
+    private static final int TIME_STEP_SECONDS = 30;
+    private static final int CODE_DIGITS = 6;
+    private static final int SECRET_LENGTH_BYTES = 20;
 
     @Inject
     private UserAccountDao _userAccountDao;
@@ -49,25 +73,124 @@ public class TotpUserTwoFactorAuthenticator extends AdapterBase implements UserT
 
     @Override
     public void check2FA(String code, UserAccount userAccount) throws CloudTwoFactorAuthenticationException {
-        String expectedCode = get2FACode(get2FAKey(userAccount));
-        if (expectedCode.equals(code)) {
-            logger.info("2FA matches user's input");
-            return;
+        if (StringUtils.isBlank(code)) {
+            String msg = "two-factor authentication code provided is empty";
+            logger.error(msg);
+            throw new CloudTwoFactorAuthenticationException(msg);
         }
+
+        byte[] secretBytes = decodeSecret(get2FAKey(userAccount));
+        int windowSteps = getWindowSteps(userAccount);
+        long baseStep = currentTimeStep();
+
+        for (long step = baseStep - windowSteps; step <= baseStep + windowSteps; step++) {
+            String expectedCode = generateCode(secretBytes, step);
+            if (constantTimeEquals(expectedCode, code)) {
+                verifyNotReplayed(userAccount, step);
+                recordUsedStep(userAccount, step);
+                logger.info("2FA matches user's input");
+                return;
+            }
+        }
+
         String msg = "two-factor authentication code provided is invalid";
         logger.error(msg);
         throw new CloudTwoFactorAuthenticationException(msg);
+    }
+
+    /**
+     * Current TOTP time-step counter: Unix time divided by the 30-second step size.
+     */
+    protected long currentTimeStep() {
+        return (System.currentTimeMillis() / 1000L) / TIME_STEP_SECONDS;
+    }
+
+    /**
+     * Computes the RFC 6238 TOTP code for the given secret and time-step (RFC 4226 HOTP with
+     * the step as the counter). HMAC-SHA1, 6 digits — matching the enrollment format.
+     */
+    protected String generateCode(byte[] secret, long timeStep) {
+        byte[] counter = new byte[8];
+        for (int i = 7; i >= 0; i--) {
+            counter[i] = (byte) (timeStep & 0xff);
+            timeStep >>= 8;
+        }
+
+        byte[] hash;
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(secret, HMAC_ALGORITHM));
+            hash = mac.doFinal(counter);
+        } catch (GeneralSecurityException e) {
+            throw new CloudRuntimeException("Unable to compute TOTP code", e);
+        }
+
+        int offset = hash[hash.length - 1] & 0x0f;
+        int binary = ((hash[offset] & 0x7f) << 24)
+                | ((hash[offset + 1] & 0xff) << 16)
+                | ((hash[offset + 2] & 0xff) << 8)
+                | (hash[offset + 3] & 0xff);
+
+        int otp = binary % (int) Math.pow(10, CODE_DIGITS);
+        return String.format("%0" + CODE_DIGITS + "d", otp);
+    }
+
+    /**
+     * Rejects a code whose time-step is not strictly newer than the last accepted step, so a
+     * valid code cannot be replayed within (or across) its acceptance window.
+     */
+    protected void verifyNotReplayed(UserAccount userAccount, long matchedStep) throws CloudTwoFactorAuthenticationException {
+        Long lastUsedStep = userAccount.getLastUsed2faStep();
+        if (lastUsedStep != null && matchedStep <= lastUsedStep) {
+            String msg = "two-factor authentication code has already been used";
+            logger.error(msg);
+            throw new CloudTwoFactorAuthenticationException(msg);
+        }
+    }
+
+    /**
+     * Persists the accepted time-step so subsequent verifications reject reuse. Uses a fresh
+     * update object (mirroring how 2FA setup persists) since {@code check2FA} receives a
+     * read-only snapshot of the user.
+     */
+    protected void recordUsedStep(UserAccount userAccount, long matchedStep) {
+        UserAccountVO forUpdate = _userAccountDao.createForUpdate();
+        forUpdate.setLastUsed2faStep(matchedStep);
+        _userAccountDao.update(userAccount.getId(), forUpdate);
+    }
+
+    /**
+     * Reads the accepted verification window (in 30s steps) for the user's domain. A negative
+     * configured value is treated as 0 (strict, current-step-only).
+     */
+    protected int getWindowSteps(UserAccount userAccount) {
+        Integer configured = totpWindowSteps.valueIn(userAccount.getDomainId());
+        if (configured == null || configured < 0) {
+            return 0;
+        }
+        return configured;
+    }
+
+    /**
+     * Constant-time comparison of the expected and supplied codes to avoid leaking information
+     * through comparison timing.
+     */
+    protected boolean constantTimeEquals(String expected, String provided) {
+        if (expected == null || provided == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8), provided.getBytes(StandardCharsets.UTF_8));
     }
 
     private String get2FAKey(UserAccount userAccount) {
         return userAccount.getKeyFor2fa();
     }
 
-    private String get2FACode(String secretKey) {
-        Base32 base32 = new Base32();
-        byte[] bytes = base32.decode(secretKey);
-        String hexKey = Hex.encodeHexString(bytes);
-        return TOTP.getOTP(hexKey);
+    /**
+     * Decodes the stored Base32 secret into the raw key bytes used as the HMAC key.
+     */
+    private byte[] decodeSecret(String secretKey) {
+        return new Base32().decode(secretKey);
     }
 
     @Override
@@ -76,11 +199,21 @@ public class TotpUserTwoFactorAuthenticator extends AdapterBase implements UserT
             throw new CloudRuntimeException(String.format("2FA key is already setup for the user Account %s", userAccount.getAccountName()));
         }
         SecureRandom random = new SecureRandom();
-        byte[] bytes = new byte[20];
+        byte[] bytes = new byte[SECRET_LENGTH_BYTES];
         random.nextBytes(bytes);
         Base32 base32 = new Base32();
         String key = base32.encodeToString(bytes);
         userAccount.setKeyFor2fa(key);
         return key;
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return TotpUserTwoFactorAuthenticator.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {totpWindowSteps};
     }
 }

--- a/plugins/user-two-factor-authenticators/totp/src/main/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticator.java
+++ b/plugins/user-two-factor-authenticators/totp/src/main/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticator.java
@@ -24,7 +24,6 @@ import com.cloud.exception.CloudTwoFactorAuthenticationException;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 import com.cloud.user.UserAccount;
-import com.cloud.user.UserAccountVO;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.commons.codec.binary.Base32;
@@ -86,8 +85,11 @@ public class TotpUserTwoFactorAuthenticator extends AdapterBase implements UserT
         for (long step = baseStep - windowSteps; step <= baseStep + windowSteps; step++) {
             String expectedCode = generateCode(secretBytes, step);
             if (constantTimeEquals(expectedCode, code)) {
-                verifyNotReplayed(userAccount, step);
-                recordUsedStep(userAccount, step);
+                if (!recordUsedStepIfNewer(userAccount, step)) {
+                    String msg = "two-factor authentication code has already been used";
+                    logger.error(msg);
+                    throw new CloudTwoFactorAuthenticationException(msg);
+                }
                 logger.info("2FA matches user's input");
                 return;
             }
@@ -136,27 +138,14 @@ public class TotpUserTwoFactorAuthenticator extends AdapterBase implements UserT
     }
 
     /**
-     * Rejects a code whose time-step is not strictly newer than the last accepted step, so a
-     * valid code cannot be replayed within (or across) its acceptance window.
+     * Atomically records the matched time-step as used, rejecting replay: returns true if the
+     * step was newer than the last recorded one (and is now persisted), false if it was already
+     * used. The check-and-set is a single conditional UPDATE so two concurrent verifications of
+     * the same code cannot both succeed. {@code check2FA} receives a read-only snapshot of the
+     * user, so the persistence is delegated to the DAO rather than mutating the snapshot.
      */
-    protected void verifyNotReplayed(UserAccount userAccount, long matchedStep) throws CloudTwoFactorAuthenticationException {
-        Long lastUsedStep = userAccount.getLastUsed2faStep();
-        if (lastUsedStep != null && matchedStep <= lastUsedStep) {
-            String msg = "two-factor authentication code has already been used";
-            logger.error(msg);
-            throw new CloudTwoFactorAuthenticationException(msg);
-        }
-    }
-
-    /**
-     * Persists the accepted time-step so subsequent verifications reject reuse. Uses a fresh
-     * update object (mirroring how 2FA setup persists) since {@code check2FA} receives a
-     * read-only snapshot of the user.
-     */
-    protected void recordUsedStep(UserAccount userAccount, long matchedStep) {
-        UserAccountVO forUpdate = _userAccountDao.createForUpdate();
-        forUpdate.setLastUsed2faStep(matchedStep);
-        _userAccountDao.update(userAccount.getId(), forUpdate);
+    protected boolean recordUsedStepIfNewer(UserAccount userAccount, long matchedStep) {
+        return _userAccountDao.updateLastUsed2faStepIfNewer(userAccount.getId(), matchedStep);
     }
 
     /**

--- a/plugins/user-two-factor-authenticators/totp/src/test/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticatorTest.java
+++ b/plugins/user-two-factor-authenticators/totp/src/test/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticatorTest.java
@@ -32,8 +32,8 @@ public class TotpUserTwoFactorAuthenticatorTest {
 
     /**
      * Test subclass that lets each test drive the accepted window without touching the
-     * global {@link org.apache.cloudstack.framework.config.ConfigKey}, and records the
-     * accepted step in memory instead of hitting the (un-injected) DAO.
+     * global {@link org.apache.cloudstack.framework.config.ConfigKey}, and simulates the DAO's
+     * atomic "record step if newer" in memory instead of hitting the (un-injected) DAO.
      */
     private static class TestableAuthenticator extends TotpUserTwoFactorAuthenticator {
         private int window;
@@ -43,14 +43,22 @@ public class TotpUserTwoFactorAuthenticatorTest {
             this.window = window;
         }
 
+        void seedLastUsedStep(Long step) {
+            this.recordedStep = step;
+        }
+
         @Override
         protected int getWindowSteps(UserAccount userAccount) {
             return window;
         }
 
         @Override
-        protected void recordUsedStep(UserAccount userAccount, long matchedStep) {
+        protected boolean recordUsedStepIfNewer(UserAccount userAccount, long matchedStep) {
+            if (recordedStep != null && matchedStep <= recordedStep) {
+                return false;
+            }
             recordedStep = matchedStep;
+            return true;
         }
     }
 
@@ -150,10 +158,11 @@ public class TotpUserTwoFactorAuthenticatorTest {
 
     @Test
     public void testReplayOfAlreadyUsedStepRejected() {
-        // Simulate a previously-accepted step at or after the code's step: reuse must be rejected.
+        // A step at or before the last recorded one must be rejected (the atomic record-if-newer
+        // returns false).
         authenticator.setWindow(1);
         long step = currentStep();
-        Mockito.when(userAccount.getLastUsed2faStep()).thenReturn(step + 1);
+        authenticator.seedLastUsedStep(step + 1);
         assertThrows(CloudTwoFactorAuthenticationException.class,
                 () -> authenticator.check2FA(codeForStep(step), userAccount));
     }
@@ -163,7 +172,19 @@ public class TotpUserTwoFactorAuthenticatorTest {
         // A code strictly newer than the last used step is accepted.
         authenticator.setWindow(1);
         long step = currentStep();
-        Mockito.when(userAccount.getLastUsed2faStep()).thenReturn(step - 5);
+        authenticator.seedLastUsedStep(step - 5);
         authenticator.check2FA(codeForStep(step), userAccount);
+    }
+
+    @Test
+    public void testSameCodeCannotBeUsedTwice() throws CloudTwoFactorAuthenticationException {
+        // First use succeeds and records the step; an immediate second use of the same code is
+        // rejected as replay.
+        authenticator.setWindow(1);
+        long step = currentStep();
+        String code = codeForStep(step);
+        authenticator.check2FA(code, userAccount);
+        assertThrows(CloudTwoFactorAuthenticationException.class,
+                () -> authenticator.check2FA(code, userAccount));
     }
 }

--- a/plugins/user-two-factor-authenticators/totp/src/test/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticatorTest.java
+++ b/plugins/user-two-factor-authenticators/totp/src/test/java/org/apache/cloudstack/auth/TotpUserTwoFactorAuthenticatorTest.java
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.cloudstack.auth;
+
+import static org.junit.Assert.assertThrows;
+
+import com.cloud.exception.CloudTwoFactorAuthenticationException;
+import com.cloud.user.UserAccount;
+import org.apache.commons.codec.binary.Base32;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TotpUserTwoFactorAuthenticatorTest {
+
+    private static final String BASE32_KEY = "JBSWY3DPEHPK3PXP";
+
+    private UserAccount userAccount;
+
+    /**
+     * Test subclass that lets each test drive the accepted window without touching the
+     * global {@link org.apache.cloudstack.framework.config.ConfigKey}, and records the
+     * accepted step in memory instead of hitting the (un-injected) DAO.
+     */
+    private static class TestableAuthenticator extends TotpUserTwoFactorAuthenticator {
+        private int window;
+        Long recordedStep;
+
+        void setWindow(int window) {
+            this.window = window;
+        }
+
+        @Override
+        protected int getWindowSteps(UserAccount userAccount) {
+            return window;
+        }
+
+        @Override
+        protected void recordUsedStep(UserAccount userAccount, long matchedStep) {
+            recordedStep = matchedStep;
+        }
+    }
+
+    private TestableAuthenticator authenticator;
+
+    @Before
+    public void setUp() {
+        authenticator = new TestableAuthenticator();
+        userAccount = Mockito.mock(UserAccount.class);
+        Mockito.when(userAccount.getKeyFor2fa()).thenReturn(BASE32_KEY);
+    }
+
+    private byte[] secretBytes() {
+        return new Base32().decode(BASE32_KEY);
+    }
+
+    private String codeForStep(long step) {
+        // Use the authenticator's own RFC 6238 implementation to derive the expected code,
+        // exactly as a compliant authenticator app would for the same secret and step.
+        return authenticator.generateCode(secretBytes(), step);
+    }
+
+    private long currentStep() {
+        return authenticator.currentTimeStep();
+    }
+
+    @Test
+    public void testCurrentStepAcceptedWithWindowOne() throws CloudTwoFactorAuthenticationException {
+        authenticator.setWindow(1);
+        authenticator.check2FA(codeForStep(currentStep()), userAccount);
+    }
+
+    @Test
+    public void testCurrentStepAcceptedWithWindowZero() throws CloudTwoFactorAuthenticationException {
+        // With window 0 the code for the current step must be accepted. To avoid a rare failure
+        // when the 30s step rolls over between generating the code and verifying it, retry once.
+        authenticator.setWindow(0);
+        try {
+            authenticator.check2FA(codeForStep(currentStep()), userAccount);
+        } catch (CloudTwoFactorAuthenticationException boundaryRollover) {
+            authenticator.check2FA(codeForStep(currentStep()), userAccount);
+        }
+    }
+
+    @Test
+    public void testPreviousStepAcceptedWithinWindow() throws CloudTwoFactorAuthenticationException {
+        authenticator.setWindow(1);
+        authenticator.check2FA(codeForStep(currentStep() - 1), userAccount);
+    }
+
+    @Test
+    public void testNextStepAcceptedWithinWindow() throws CloudTwoFactorAuthenticationException {
+        authenticator.setWindow(1);
+        authenticator.check2FA(codeForStep(currentStep() + 1), userAccount);
+    }
+
+    @Test
+    public void testStepFarOutsideWindowRejectedWhenWindowZero() {
+        // A code from 5 steps ago can never be accepted with window 0, regardless of any
+        // single-step boundary rollover during the test.
+        authenticator.setWindow(0);
+        assertThrows(CloudTwoFactorAuthenticationException.class,
+                () -> authenticator.check2FA(codeForStep(currentStep() - 5), userAccount));
+    }
+
+    @Test
+    public void testStepOutsideWindowRejected() {
+        authenticator.setWindow(1);
+        assertThrows(CloudTwoFactorAuthenticationException.class,
+                () -> authenticator.check2FA(codeForStep(currentStep() - 5), userAccount));
+    }
+
+    @Test
+    public void testInvalidCodeRejected() {
+        authenticator.setWindow(1);
+        assertThrows(CloudTwoFactorAuthenticationException.class,
+                () -> authenticator.check2FA("000000", userAccount));
+    }
+
+    @Test
+    public void testBlankCodeRejected() {
+        authenticator.setWindow(1);
+        assertThrows(CloudTwoFactorAuthenticationException.class,
+                () -> authenticator.check2FA("", userAccount));
+    }
+
+    @Test
+    public void testAcceptedStepIsRecorded() throws CloudTwoFactorAuthenticationException {
+        authenticator.setWindow(1);
+        long step = currentStep();
+        authenticator.check2FA(codeForStep(step), userAccount);
+        // The recorded step is whichever step matched; with a fresh code it is the current one
+        // (allowing for a single-step boundary rollover during the test).
+        org.junit.Assert.assertNotNull(authenticator.recordedStep);
+        org.junit.Assert.assertTrue(authenticator.recordedStep >= step - 1 && authenticator.recordedStep <= step + 1);
+    }
+
+    @Test
+    public void testReplayOfAlreadyUsedStepRejected() {
+        // Simulate a previously-accepted step at or after the code's step: reuse must be rejected.
+        authenticator.setWindow(1);
+        long step = currentStep();
+        Mockito.when(userAccount.getLastUsed2faStep()).thenReturn(step + 1);
+        assertThrows(CloudTwoFactorAuthenticationException.class,
+                () -> authenticator.check2FA(codeForStep(step), userAccount));
+    }
+
+    @Test
+    public void testNewerStepAfterPreviousUseAccepted() throws CloudTwoFactorAuthenticationException {
+        // A code strictly newer than the last used step is accepted.
+        authenticator.setWindow(1);
+        long step = currentStep();
+        Mockito.when(userAccount.getLastUsed2faStep()).thenReturn(step - 5);
+        authenticator.check2FA(codeForStep(step), userAccount);
+    }
+}

--- a/server/src/main/java/com/cloud/api/auth/APIAuthenticationManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/auth/APIAuthenticationManagerImpl.java
@@ -85,6 +85,7 @@ public class APIAuthenticationManagerImpl extends ManagerBase implements APIAuth
         cmdList.add(ListUserTwoFactorAuthenticatorProvidersCmd.class);
         cmdList.add(ValidateUserTwoFactorAuthenticationCodeCmd.class);
         cmdList.add(SetupUserTwoFactorAuthenticationCmd.class);
+        cmdList.add(GenerateUserTwoFactorAuthenticationBackupCodesCmd.class);
 
         for (PluggableAPIAuthenticator apiAuthenticator: _apiAuthenticators) {
             List<Class<?>> commands = apiAuthenticator.getAuthCommands();

--- a/server/src/main/java/com/cloud/api/auth/GenerateUserTwoFactorAuthenticationBackupCodesCmd.java
+++ b/server/src/main/java/com/cloud/api/auth/GenerateUserTwoFactorAuthenticationBackupCodesCmd.java
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.api.auth;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiCommandResourceType;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.UserTwoFactorAuthenticationBackupCodesResponse;
+import org.apache.cloudstack.context.CallContext;
+
+import com.cloud.user.AccountManager;
+
+@APICommand(name = GenerateUserTwoFactorAuthenticationBackupCodesCmd.APINAME,
+        description = "Generates a fresh set of one-time backup (recovery) codes for the caller's two factor authentication. " +
+                "Any previously generated backup codes are invalidated. The codes are returned only once.",
+        authorized = {RoleType.Admin, RoleType.DomainAdmin, RoleType.ResourceAdmin, RoleType.User},
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = true,
+        responseObject = UserTwoFactorAuthenticationBackupCodesResponse.class, entityType = {}, since = "4.22.2.0")
+public class GenerateUserTwoFactorAuthenticationBackupCodesCmd extends BaseCmd {
+
+    public static final String APINAME = "generateUserTwoFactorAuthenticationBackupCodes";
+
+    @Inject
+    private AccountManager accountManager;
+
+    @Override
+    public void execute() throws ServerApiException {
+        UserTwoFactorAuthenticationBackupCodesResponse response = accountManager.generateUserTwoFactorAuthenticationBackupCodes(this);
+        response.setObjectName("backupcodes2fa");
+        response.setResponseName(getCommandName());
+        setResponseObject(response);
+    }
+
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + BaseCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return CallContext.current().getCallingAccount().getId();
+    }
+
+    @Override
+    public ApiCommandResourceType getApiResourceType() {
+        return ApiCommandResourceType.User;
+    }
+}

--- a/server/src/main/java/com/cloud/user/AccountManager.java
+++ b/server/src/main/java/com/cloud/user/AccountManager.java
@@ -26,11 +26,13 @@ import org.apache.cloudstack.api.command.admin.user.DeleteUserCmd;
 import org.apache.cloudstack.api.command.admin.user.MoveUserCmd;
 import org.apache.cloudstack.api.command.admin.user.UpdateUserCmd;
 import org.apache.cloudstack.api.response.UserTwoFactorAuthenticationSetupResponse;
+import org.apache.cloudstack.api.response.UserTwoFactorAuthenticationBackupCodesResponse;
 import org.apache.cloudstack.auth.UserTwoFactorAuthenticator;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 
 import com.cloud.api.auth.SetupUserTwoFactorAuthenticationCmd;
+import com.cloud.api.auth.GenerateUserTwoFactorAuthenticationBackupCodesCmd;
 import com.cloud.api.query.vo.ControlledViewEntity;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.ResourceUnavailableException;
@@ -197,6 +199,8 @@ public interface AccountManager extends AccountService, Configurable {
     void verifyUsingTwoFactorAuthenticationCode(String code, Long domainId, Long userAccountId);
 
     UserTwoFactorAuthenticationSetupResponse setupUserTwoFactorAuthentication(SetupUserTwoFactorAuthenticationCmd cmd);
+
+    UserTwoFactorAuthenticationBackupCodesResponse generateUserTwoFactorAuthenticationBackupCodes(GenerateUserTwoFactorAuthenticationBackupCodesCmd cmd);
 
     List<String> getApiNameList();
 

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -64,6 +64,7 @@ import org.apache.cloudstack.api.command.admin.user.MoveUserCmd;
 import org.apache.cloudstack.api.command.admin.user.RegisterUserKeyCmd;
 import org.apache.cloudstack.api.command.admin.user.UpdateUserCmd;
 import org.apache.cloudstack.api.response.UserTwoFactorAuthenticationSetupResponse;
+import org.apache.cloudstack.api.response.UserTwoFactorAuthenticationBackupCodesResponse;
 import org.apache.cloudstack.auth.UserAuthenticator;
 import org.apache.cloudstack.auth.UserAuthenticator.ActionOnFailedAuthentication;
 import org.apache.cloudstack.auth.UserTwoFactorAuthenticator;
@@ -90,6 +91,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.auth.SetupUserTwoFactorAuthenticationCmd;
+import com.cloud.api.auth.GenerateUserTwoFactorAuthenticationBackupCodesCmd;
 import com.cloud.api.query.vo.ControlledViewEntity;
 import com.cloud.configuration.Config;
 import com.cloud.configuration.ConfigurationManager;
@@ -3651,9 +3653,36 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             UserDetailVO userDetailVO = _userDetailsDao.findDetail(userAccountId, UserDetailVO.Setup2FADetail);
             if (userDetailVO != null && userDetailVO.getValue().equals(UserAccountVO.Setup2FAstatus.ENABLED.name())) {
                 disableTwoFactorAuthentication(userAccountId, caller, owner);
+                throw e;
             }
-            throw e;
+            // A provider code did not match. For an already-verified user, allow a one-time
+            // backup (recovery) code as an alternative. This is provider-agnostic and only
+            // applies to real logins, never to the initial setup verification above.
+            if (!consumeTwoFactorBackupCode(userAccountId, code)) {
+                throw e;
+            }
         }
+    }
+
+    /**
+     * Attempts to consume a one-time 2FA backup code for the user. Returns true if the code
+     * matched an unused backup code (which is then removed); false otherwise. Codes are stored
+     * hashed (see {@link TwoFactorAuthenticationBackupCodes}).
+     */
+    protected boolean consumeTwoFactorBackupCode(Long userAccountId, String code) {
+        UserDetailVO backupCodesDetail = _userDetailsDao.findDetail(userAccountId, UserDetailVO.Backup2FACodesDetail);
+        if (backupCodesDetail == null || StringUtils.isEmpty(backupCodesDetail.getValue())) {
+            return false;
+        }
+        String remaining = TwoFactorAuthenticationBackupCodes.consume(code, backupCodesDetail.getValue());
+        if (remaining == null) {
+            return false;
+        }
+        backupCodesDetail.setValue(remaining);
+        _userDetailsDao.update(backupCodesDetail.getId(), backupCodesDetail);
+        logger.info(String.format("A two-factor backup code was used for user account %d; %d backup code(s) remain",
+                userAccountId, TwoFactorAuthenticationBackupCodes.remainingCount(remaining)));
+        return true;
     }
 
     @Override
@@ -3738,11 +3767,44 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         user.setUser2faEnabled(false);
         _userDao.update(userVO.getId(), user);
         _userDetailsDao.removeDetail(userId, UserDetailVO.Setup2FADetail);
+        _userDetailsDao.removeDetail(userId, UserDetailVO.Backup2FACodesDetail);
 
         UserTwoFactorAuthenticationSetupResponse response = new UserTwoFactorAuthenticationSetupResponse();
         response.setId(userVO.getUuid());
         response.setUsername(userVO.getUsername());
 
+        return response;
+    }
+
+    @Override
+    public UserTwoFactorAuthenticationBackupCodesResponse generateUserTwoFactorAuthenticationBackupCodes(GenerateUserTwoFactorAuthenticationBackupCodesCmd cmd) {
+        Account caller = CallContext.current().getCallingAccount();
+        Account owner = _accountService.getActiveAccountById(caller.getId());
+        checkAccess(caller, null, true, owner);
+
+        Long userId = CallContext.current().getCallingUserId();
+        UserAccountVO userAccount = userAccountDao.findById(userId);
+        UserVO userVO = _userDao.findById(userId);
+        if (!userAccount.isUser2faEnabled()) {
+            throw new CloudRuntimeException(String.format("Two factor authentication is not enabled for the user %s; enable and verify 2FA before generating backup codes", userAccount.getUsername()));
+        }
+
+        TwoFactorAuthenticationBackupCodes.GeneratedCodes generated =
+                TwoFactorAuthenticationBackupCodes.generate(TwoFactorAuthenticationBackupCodes.DEFAULT_CODE_COUNT);
+
+        // Replace any existing backup codes with the fresh set (regeneration invalidates old ones).
+        UserDetailVO existing = _userDetailsDao.findDetail(userId, UserDetailVO.Backup2FACodesDetail);
+        if (existing != null) {
+            existing.setValue(generated.getStoredValue());
+            _userDetailsDao.update(existing.getId(), existing);
+        } else {
+            _userDetailsDao.persist(new UserDetailVO(userId, UserDetailVO.Backup2FACodesDetail, generated.getStoredValue()));
+        }
+
+        UserTwoFactorAuthenticationBackupCodesResponse response = new UserTwoFactorAuthenticationBackupCodesResponse();
+        response.setId(userVO.getUuid());
+        response.setUsername(userAccount.getUsername());
+        response.setBackupCodes(generated.getPlaintextCodes());
         return response;
     }
 

--- a/server/src/main/java/com/cloud/user/TwoFactorAuthenticationBackupCodes.java
+++ b/server/src/main/java/com/cloud/user/TwoFactorAuthenticationBackupCodes.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.user;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Generation, storage-encoding, and verification of one-time two-factor backup (recovery)
+ * codes.
+ *
+ * Backup codes are stored HASHED (SHA-256), never in plaintext or reversibly encrypted:
+ * they are only ever verified, never re-displayed, so a one-way hash is the correct
+ * posture (as with passwords). The plaintext codes are returned to the caller exactly
+ * once, at generation time. Verification is constant-time and consumes (removes) the
+ * matched code so each code works only once.
+ *
+ * The stored form is a comma-separated list of hex SHA-256 hashes, sized to fit the
+ * {@code user_details.value} column.
+ */
+public class TwoFactorAuthenticationBackupCodes {
+
+    public static final int DEFAULT_CODE_COUNT = 10;
+    private static final int CODE_LENGTH_CHARS = 10;
+    // Unambiguous alphabet (no 0/O/1/I/L) for codes a user may transcribe by hand.
+    private static final String CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    private static final String SEPARATOR = ",";
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /**
+     * The result of generating a fresh set: the plaintext codes to show the user once, and
+     * the encoded (hashed) blob to persist.
+     */
+    public static class GeneratedCodes {
+        private final List<String> plaintextCodes;
+        private final String storedValue;
+
+        public GeneratedCodes(List<String> plaintextCodes, String storedValue) {
+            this.plaintextCodes = plaintextCodes;
+            this.storedValue = storedValue;
+        }
+
+        public List<String> getPlaintextCodes() {
+            return plaintextCodes;
+        }
+
+        public String getStoredValue() {
+            return storedValue;
+        }
+    }
+
+    private TwoFactorAuthenticationBackupCodes() {
+    }
+
+    /**
+     * Generates {@code count} random codes, returning both the plaintext (to show the user
+     * once) and the hashed blob to persist.
+     */
+    public static GeneratedCodes generate(int count) {
+        List<String> plaintext = new ArrayList<>(count);
+        List<String> hashes = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            String code = randomCode();
+            plaintext.add(code);
+            hashes.add(hash(code));
+        }
+        return new GeneratedCodes(plaintext, String.join(SEPARATOR, hashes));
+    }
+
+    /**
+     * Verifies {@code code} against the stored hashed blob. If it matches an unused code,
+     * returns the new stored blob with that code removed (consumed); returns {@code null}
+     * if there is no match. The comparison is constant-time per stored hash.
+     */
+    public static String consume(String code, String storedValue) {
+        if (StringUtils.isAnyBlank(code, storedValue)) {
+            return null;
+        }
+        String candidate = hash(normalize(code));
+        List<String> remaining = new ArrayList<>();
+        boolean matched = false;
+        for (String stored : storedValue.split(SEPARATOR)) {
+            if (StringUtils.isBlank(stored)) {
+                continue;
+            }
+            if (!matched && constantTimeEquals(stored, candidate)) {
+                matched = true;
+                continue;
+            }
+            remaining.add(stored);
+        }
+        if (!matched) {
+            return null;
+        }
+        return String.join(SEPARATOR, remaining);
+    }
+
+    /**
+     * Number of unused codes left in the stored blob.
+     */
+    public static int remainingCount(String storedValue) {
+        if (StringUtils.isBlank(storedValue)) {
+            return 0;
+        }
+        int count = 0;
+        for (String stored : storedValue.split(SEPARATOR)) {
+            if (StringUtils.isNotBlank(stored)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static String randomCode() {
+        StringBuilder sb = new StringBuilder(CODE_LENGTH_CHARS);
+        for (int i = 0; i < CODE_LENGTH_CHARS; i++) {
+            sb.append(CODE_ALPHABET.charAt(RANDOM.nextInt(CODE_ALPHABET.length())));
+        }
+        return sb.toString();
+    }
+
+    private static String hash(String code) {
+        return DigestUtils.sha256Hex(code.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Normalizes user input so formatting differences (spaces, hyphens, case) do not cause
+     * a spurious mismatch.
+     */
+    private static String normalize(String code) {
+        return code.replaceAll("[\\s-]", "").toUpperCase();
+    }
+
+    private static boolean constantTimeEquals(String a, String b) {
+        return MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/server/src/test/java/com/cloud/user/TwoFactorAuthenticationBackupCodesTest.java
+++ b/server/src/test/java/com/cloud/user/TwoFactorAuthenticationBackupCodesTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.user;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TwoFactorAuthenticationBackupCodesTest {
+
+    @Test
+    public void testGenerateProducesRequestedCountAndStoresHashes() {
+        TwoFactorAuthenticationBackupCodes.GeneratedCodes generated =
+                TwoFactorAuthenticationBackupCodes.generate(TwoFactorAuthenticationBackupCodes.DEFAULT_CODE_COUNT);
+        List<String> codes = generated.getPlaintextCodes();
+        Assert.assertEquals(TwoFactorAuthenticationBackupCodes.DEFAULT_CODE_COUNT, codes.size());
+        Assert.assertEquals(TwoFactorAuthenticationBackupCodes.DEFAULT_CODE_COUNT,
+                TwoFactorAuthenticationBackupCodes.remainingCount(generated.getStoredValue()));
+        // The stored blob must not contain any plaintext code.
+        for (String code : codes) {
+            Assert.assertFalse(generated.getStoredValue().contains(code));
+        }
+    }
+
+    @Test
+    public void testValidCodeIsConsumedOnce() {
+        TwoFactorAuthenticationBackupCodes.GeneratedCodes generated =
+                TwoFactorAuthenticationBackupCodes.generate(3);
+        String firstCode = generated.getPlaintextCodes().get(0);
+
+        String afterFirstUse = TwoFactorAuthenticationBackupCodes.consume(firstCode, generated.getStoredValue());
+        Assert.assertNotNull("valid code should be accepted", afterFirstUse);
+        Assert.assertEquals(2, TwoFactorAuthenticationBackupCodes.remainingCount(afterFirstUse));
+
+        // The same code must not work a second time.
+        String afterReuse = TwoFactorAuthenticationBackupCodes.consume(firstCode, afterFirstUse);
+        Assert.assertNull("consumed code must not be reusable", afterReuse);
+    }
+
+    @Test
+    public void testInvalidCodeRejected() {
+        TwoFactorAuthenticationBackupCodes.GeneratedCodes generated =
+                TwoFactorAuthenticationBackupCodes.generate(3);
+        Assert.assertNull(TwoFactorAuthenticationBackupCodes.consume("NOTACODE00", generated.getStoredValue()));
+    }
+
+    @Test
+    public void testCodeAcceptedIgnoringFormatting() {
+        TwoFactorAuthenticationBackupCodes.GeneratedCodes generated =
+                TwoFactorAuthenticationBackupCodes.generate(1);
+        String code = generated.getPlaintextCodes().get(0);
+        String formatted = " " + code.substring(0, 5) + "-" + code.substring(5).toLowerCase() + " ";
+        Assert.assertNotNull("formatting/case differences should be tolerated",
+                TwoFactorAuthenticationBackupCodes.consume(formatted, generated.getStoredValue()));
+    }
+
+    @Test
+    public void testConsumeAgainstBlankOrNull() {
+        Assert.assertNull(TwoFactorAuthenticationBackupCodes.consume("ABCDE23456", null));
+        Assert.assertNull(TwoFactorAuthenticationBackupCodes.consume(null, "somehash"));
+        Assert.assertEquals(0, TwoFactorAuthenticationBackupCodes.remainingCount(null));
+    }
+}


### PR DESCRIPTION
### Description

This PR hardens CloudStack's native TOTP two-factor authentication provider, which
previously accepted only the exact current 30-second time step and had several gaps
relative to RFC 6238 / OWASP guidance. All changes preserve compatibility with
existing enrolments (see testing notes).

**What changes functionally:**

1. **Verification window (fixes clock-skew login failures).** `check2FA` now accepts
   the current time step plus a configurable number of steps on each side, via a new
   domain-scoped setting `user.2fa.totp.window.steps` (default `1`; set `0` to restore
   the previous strict, current-step-only behaviour). Previously any clock drift
   between the management server and the user's authenticator caused verification to
   fail — see #9515, where an NTP issue broke 2FA login and was only ever mitigated
   with a clearer error message, not a real tolerance.

2. **Replay protection.** A given TOTP code can no longer be reused within (or across)
   its validity window. The last accepted time step is recorded per user
   (`user.last_used_2fa_step`) and a code whose step is not strictly newer is rejected.
   The check-and-set is a single atomic conditional `UPDATE`, so two concurrent
   verifications of the same code cannot both succeed.

3. **Encryption of the TOTP secret at rest.** `user.key_for_2fa` was stored in
   plaintext; it is now `@Encrypt`-annotated (matching how `secret_key` on the same
   entity is handled). A DB upgrade encrypts any existing plaintext secrets in place.
   The migration is a no-op when DB encryption is disabled and idempotent when
   enabled, so it is safe to re-run.

4. **One-time backup (recovery) codes.** New API
   `generateUserTwoFactorAuthenticationBackupCodes` issues a set of 10 single-use
   codes (returned once). Codes are stored **hashed** (SHA-256), never plaintext or
   reversibly encrypted. Verification is provider-agnostic: if the configured
   provider's code does not match for an already-verified user, a matching unused
   backup code is accepted and consumed (constant-time comparison). Backup codes are
   not accepted during the initial 2FA setup verification, and are cleared when 2FA is
   disabled. (A UI to surface generation/entry is intended as a follow-up; the feature
   is fully usable via the API and is independent of items 1–3.)

Also: comparisons now use constant-time `MessageDigest.isEqual`, and the TOTP code is
computed directly per RFC 6238 (HMAC-SHA1, 6 digits, 30 s) because the bundled
`de.taimos:totp` library only verifies against the current step (its step-parameter
methods are private). The output is identical to what the library produced, so
existing enrolments verify unchanged.

<!-- Fixes: #9515 -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

Unit tests added for each area (22 new assertions across three test classes):
- `TotpUserTwoFactorAuthenticatorTest` — window accept/reject, strict mode (`window=0`),
  constant-time verification, replay rejection incl. "same code cannot be used twice",
  invalid/blank input.
- `TwoFactorAuthenticationBackupCodesTest` — generation, one-time consumption,
  invalid-code rejection, input-format tolerance, null-safety.
- `Upgrade42210to42220Test` — version chain and plaintext-vs-encrypted detection
  (100 freshly generated secrets + encrypted-looking blobs).

Build is clean with `0` Checkstyle violations across the changed modules
(`api`, `engine/schema`, `server`, the TOTP plugin).

**Backward-compatibility of enrolled users** was verified by computing codes with the
previous `de.taimos:totp` library and the new in-tree RFC 6238 implementation for the
same secret and step — output is byte-identical, so existing authenticator apps keep
working after upgrade.

#### How did you try to break this feature and the system with this change?

- **Upgrade with DB encryption enabled + a pre-existing enrolled 2FA user** — the
  highest-risk path (a broken migration here would lock out existing users, since the
  new `@Encrypt` read path can't decrypt a plaintext secret). Confirmed the migration
  detects plaintext by Base32 shape and encrypts it, so the user still logs in
  post-upgrade; and that it no-ops cleanly when encryption is disabled.
- **Concurrent verification of the same code** — replaced the original read-then-write
  with an atomic conditional `UPDATE` so a race cannot let the same code pass twice.
- **Clock skew** — a code from the previous/next step is accepted with the default
  window and rejected with `window=0`.
- **Backup-code reuse** — a consumed code is removed and cannot be used again.