### PR TITLE
[ConsoleProxy] Performance fixes on concurrency and closing console sessions sockets and introduce reconnection window for console sessions

### DIFF
--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManager.java
@@ -84,6 +84,9 @@ public interface ConsoleProxyManager extends Manager, ConsoleProxyService {
     ConfigKey<Boolean> ConsoleProxyDisableRpFilter = new ConfigKey<>(Boolean.class, "consoleproxy.disable.rpfilter", "Console Proxy", "true",
             "disable rp_filter on console proxy VM public interface", true, ConfigKey.Scope.Zone, null);
 
+    ConfigKey<Long> ConsoleProxySessionReconnectionWindow = new ConfigKey<>(Long.class, "consoleproxy.session.reconnection.window", "Console Proxy", "0",
+            "Reconnection window (in milliseconds) for client IPs to the same session on console proxy VM", true, ConfigKey.Scope.Zone, null);
+
     ConfigKey<Integer> ConsoleProxyLaunchMax = new ConfigKey<>(Integer.class, "consoleproxy.launch.max", "Console Proxy", "10",
             "maximum number of console proxy instances per zone can be launched", false, ConfigKey.Scope.Zone, null);
 

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -1210,6 +1210,10 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
         if (Boolean.TRUE.equals(disableRpFilter)) {
             buf.append(" disable_rp_filter=true");
         }
+        Long sessionReconnectionWindow = ConsoleProxySessionReconnectionWindow.valueIn(datacenterId);
+        if (sessionReconnectionWindow != null && sessionReconnectionWindow > 0) {
+            buf.append(" session_reconnection_window=").append(sessionReconnectionWindow);
+        }
 
         String msPublicKey = configurationDao.getValue("ssh.publickey");
         buf.append(" authorized_key=").append(VirtualMachineGuru.getEncodedMsPublicKey(msPublicKey));
@@ -1588,7 +1592,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
         return new ConfigKey<?>[] {ConsoleProxySslEnabled, NoVncConsoleDefault, NoVncConsoleSourceIpCheckEnabled, ConsoleProxyServiceOffering,
                                    ConsoleProxyCapacityStandby, ConsoleProxyCapacityScanInterval, ConsoleProxyRestart, ConsoleProxyUrlDomain, ConsoleProxySessionMax, ConsoleProxySessionTimeout, ConsoleProxyDisableRpFilter, ConsoleProxyLaunchMax,
                                    ConsoleProxyManagementLastState, ConsoleProxyServiceManagementState, NoVncConsoleShowDot,
-                                   ConsoleProxyVmUserData};
+                                   ConsoleProxyVmUserData, ConsoleProxySessionReconnectionWindow};
     }
 
     protected ConsoleProxyStatus parseJsonToConsoleProxyStatus(String json) throws JsonParseException {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
@@ -83,8 +82,10 @@ public class ConsoleProxy {
     static String encryptorPassword = "Dummy";
     static final String[] skipProperties = new String[]{"certificate", "cacertificate", "keystore_password", "privatekey"};
 
-    static Set<String> allowedSessions = new HashSet<>();
+    static Set<String> allowedSessions = ConcurrentHashMap.newKeySet();
+    private static final Object allowedSessionsLock = new Object();
 
+    // Invoked through reflection
     public static void addAllowedSession(String sessionUuid) {
         allowedSessions.add(sessionUuid);
     }
@@ -209,13 +210,15 @@ public class ConsoleProxy {
         }
 
         String sessionUuid = param.getSessionUuid();
-        if (allowedSessions.contains(sessionUuid)) {
-            LOGGER.debug("Acquiring the session " + sessionUuid + " not available for future use");
-            allowedSessions.remove(sessionUuid);
-        } else {
-            LOGGER.info("Session " + sessionUuid + " has already been used, cannot connect");
-            authResult.setSuccess(false);
-            return authResult;
+        synchronized (allowedSessionsLock) {
+            if (allowedSessions.contains(sessionUuid)) {
+                LOGGER.debug("Acquiring the session " + sessionUuid + " not available for future use");
+                allowedSessions.remove(sessionUuid);
+            } else {
+                LOGGER.info("Session " + sessionUuid + " has already been used, cannot connect");
+                authResult.setSuccess(false);
+                return authResult;
+            }
         }
 
         String websocketUrl = param.getWebsocketUrl();

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -628,7 +628,7 @@ public class ConsoleProxy {
                 } catch (IOException e) {
                     LOGGER.error("Exception while disconnect session of novnc viewer object: " + viewer, e);
                 }
-                removeViewer(viewer);
+                viewer.closeClient();
                 viewer = new ConsoleProxyNoVncClient(session);
                 viewer.initClient(param);
                 connectionMap.put(clientKey, viewer);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -85,9 +85,57 @@ public class ConsoleProxy {
     static Set<String> allowedSessions = ConcurrentHashMap.newKeySet();
     private static final Object allowedSessionsLock = new Object();
 
+    private static final Map<String, ReconnectGrant> sessionReconnectGrants = new ConcurrentHashMap<>();
+    static int sessionReconnectGraceSeconds = 1;
+
     // Invoked through reflection
     public static void addAllowedSession(String sessionUuid) {
         allowedSessions.add(sessionUuid);
+    }
+
+    /**
+     * Grant a short, single-use window to reconnect with the same session UUID in case of a disconnection.
+     * The grant is bound to the client IP that was using the session so it cannot be redeemed by another client.
+     * @param sessionUuid session UUID to grant a reconnect window for
+     * @param clientIp source IP of the client the session was granted to
+     */
+    public static void grantReconnectWindow(String sessionUuid, String clientIp) {
+        sessionReconnectGrants.put(sessionUuid, new ReconnectGrant(System.currentTimeMillis() + sessionReconnectGraceSeconds * 1000L, clientIp));
+    }
+
+    private static boolean consumeReconnectGrant(String sessionUuid, String clientIp) {
+        ReconnectGrant grant = sessionReconnectGrants.remove(sessionUuid);
+        if (grant == null || grant.isExpired(System.currentTimeMillis())) {
+            return false;
+        }
+        if (grant.clientIp != null && !grant.clientIp.equals(clientIp)) {
+            LOGGER.warn("Rejecting reconnect for session " + sessionUuid + " as it was requested from IP " +
+                    clientIp + " but the reconnect window was granted to IP " + grant.clientIp);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Drops expired, unclaimed reconnect grants so sessionReconnectGrants doesn't grow unbounded
+     * when a client never reconnects after a disconnection. Invoked periodically by {@link ConsoleProxyGCThread}.
+     */
+    static void cleanupExpiredReconnectGrants() {
+        sessionReconnectGrants.entrySet().removeIf(entry -> entry.getValue().isExpired(System.currentTimeMillis()));
+    }
+
+    private static final class ReconnectGrant {
+        final long expiryMillis;
+        final String clientIp;
+
+        ReconnectGrant(long expiryMillis, String clientIp) {
+            this.expiryMillis = expiryMillis;
+            this.clientIp = clientIp;
+        }
+
+        boolean isExpired(long now) {
+            return now >= expiryMillis;
+        }
     }
 
     private static void configLog4j() {
@@ -167,6 +215,12 @@ public class ConsoleProxy {
             defaultBufferSize = Integer.parseInt(s);
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
         }
+
+        s = conf.getProperty("consoleproxy.sessionReconnectGraceSeconds");
+        if (s != null) {
+            sessionReconnectGraceSeconds = Integer.parseInt(s);
+            LOGGER.info("Setting sessionReconnectGraceSeconds=" + sessionReconnectGraceSeconds);
+        }
     }
 
     public static ConsoleProxyServerFactory getHttpServerFactory() {
@@ -211,9 +265,10 @@ public class ConsoleProxy {
 
         String sessionUuid = param.getSessionUuid();
         synchronized (allowedSessionsLock) {
-            if (allowedSessions.contains(sessionUuid)) {
-                LOGGER.debug("Acquiring the session " + sessionUuid + " not available for future use");
-                allowedSessions.remove(sessionUuid);
+            if (allowedSessions.remove(sessionUuid)) {
+                LOGGER.debug("Acquiring the session " + sessionUuid + " for use");
+            } else if (consumeReconnectGrant(sessionUuid, param.getClientIp())) {
+                LOGGER.info("Reconnecting the session " + sessionUuid + " after a dropped connection");
             } else {
                 LOGGER.info("Session " + sessionUuid + " has already been used, cannot connect");
                 authResult.setSuccess(false);

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxy.java
@@ -86,7 +86,7 @@ public class ConsoleProxy {
     private static final Object allowedSessionsLock = new Object();
 
     private static final Map<String, ReconnectGrant> sessionReconnectGrants = new ConcurrentHashMap<>();
-    static int sessionReconnectGraceSeconds = 1;
+    private static long sessionReconnectionWindowMs = 0L;
 
     // Invoked through reflection
     public static void addAllowedSession(String sessionUuid) {
@@ -94,23 +94,34 @@ public class ConsoleProxy {
     }
 
     /**
-     * Grant a short, single-use window to reconnect with the same session UUID in case of a disconnection.
+     * Grant the client IP a reconnection window of #{@link #sessionReconnectionWindowMs} ms to the same session UUID in case of a disconnection.
      * The grant is bound to the client IP that was using the session so it cannot be redeemed by another client.
      * @param sessionUuid session UUID to grant a reconnect window for
      * @param clientIp source IP of the client the session was granted to
      */
-    public static void grantReconnectWindow(String sessionUuid, String clientIp) {
-        sessionReconnectGrants.put(sessionUuid, new ReconnectGrant(System.currentTimeMillis() + sessionReconnectGraceSeconds * 1000L, clientIp));
+    public static void grantReconnectWindowForSessionAndClientIp(String sessionUuid, String clientIp) {
+        if (sessionReconnectionWindowMs > 0) {
+            ReconnectGrant grant = new ReconnectGrant(System.currentTimeMillis() + sessionReconnectionWindowMs, clientIp);
+            sessionReconnectGrants.put(sessionUuid, grant);
+        }
     }
 
-    private static boolean consumeReconnectGrant(String sessionUuid, String clientIp) {
+    /**
+     * True if the session UUID has been granted reconnection, within the reconnection window #{@link #sessionReconnectionWindowMs}.
+     */
+    private static boolean isSessionReconnectionGrantedForClientIp(String sessionUuid, String clientIp) {
         ReconnectGrant grant = sessionReconnectGrants.remove(sessionUuid);
-        if (grant == null || grant.isExpired(System.currentTimeMillis())) {
+        if (grant == null) {
+            return false;
+        }
+        if (grant.isExpired(System.currentTimeMillis())) {
+            LOGGER.warn("Rejecting reconnection for session {} as the reconnect window: {}ms is already expired",
+                    sessionUuid, sessionReconnectionWindowMs);
             return false;
         }
         if (grant.clientIp != null && !grant.clientIp.equals(clientIp)) {
-            LOGGER.warn("Rejecting reconnect for session " + sessionUuid + " as it was requested from IP " +
-                    clientIp + " but the reconnect window was granted to IP " + grant.clientIp);
+            LOGGER.warn("Rejecting reconnection for session {} as it was requested from IP {} " +
+                    "but the session was granted to IP {}", sessionUuid, clientIp, grant.clientIp);
             return false;
         }
         return true;
@@ -216,10 +227,10 @@ public class ConsoleProxy {
             LOGGER.info("Setting defaultBufferSize=" + defaultBufferSize);
         }
 
-        s = conf.getProperty("consoleproxy.sessionReconnectGraceSeconds");
+        s = conf.getProperty("session_reconnection_window");
         if (s != null) {
-            sessionReconnectGraceSeconds = Integer.parseInt(s);
-            LOGGER.info("Setting sessionReconnectGraceSeconds=" + sessionReconnectGraceSeconds);
+            sessionReconnectionWindowMs = Long.parseLong(s);
+            LOGGER.info("Setting sessionReconnectionWindowMs=" + sessionReconnectionWindowMs);
         }
     }
 
@@ -266,11 +277,12 @@ public class ConsoleProxy {
         String sessionUuid = param.getSessionUuid();
         synchronized (allowedSessionsLock) {
             if (allowedSessions.remove(sessionUuid)) {
-                LOGGER.debug("Acquiring the session " + sessionUuid + " for use");
-            } else if (consumeReconnectGrant(sessionUuid, param.getClientIp())) {
-                LOGGER.info("Reconnecting the session " + sessionUuid + " after a dropped connection");
+                LOGGER.debug("Acquiring the session {} from client IP {}", sessionUuid, param.getClientIp());
+            } else if (isSessionReconnectionGrantedForClientIp(sessionUuid, param.getClientIp())) {
+                LOGGER.info("Reconnecting the session {} after a dropped connection", sessionUuid);
+                return authResult;
             } else {
-                LOGGER.info("Session " + sessionUuid + " has already been used, cannot connect");
+                LOGGER.info("Invalid or already used session {}, cannot connect", sessionUuid);
                 authResult.setSuccess(false);
                 return authResult;
             }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyGCThread.java
@@ -75,6 +75,7 @@ public class ConsoleProxyGCThread extends Thread {
 
         while (true) {
             cleanupLogging();
+            ConsoleProxy.cleanupExpiredReconnectGrants();
             bReportLoad = false;
 
             if (logger.isDebugEnabled()) {

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVNCHandler.java
@@ -175,12 +175,20 @@ public class ConsoleProxyNoVNCHandler extends WebSocketHandler {
 
     @OnWebSocketClose
     public void onClose(Session session, int statusCode, String reason) throws IOException, InterruptedException {
-        String sessionSourceIp = session.getRemoteAddress().getAddress().getHostAddress();
-        logger.debug("Closing WebSocket session [source IP: {}, status code: {}].", sessionSourceIp, statusCode);
         if (viewer != null) {
-            ConsoleProxy.removeViewer(viewer);
+            viewer.closeClient();
         }
-        logger.debug("WebSocket session [source IP: {}, status code: {}] closed successfully.", sessionSourceIp, statusCode);
+        String sessionSourceIp = getRemoteAddressSafely(session);
+        logger.debug("WebSocket session [source IP: {}, status code: {}, reason: {}] closed successfully.", sessionSourceIp, statusCode, reason);
+    }
+
+    private String getRemoteAddressSafely(Session session) {
+        try {
+            return session.getRemoteAddress().getAddress().getHostAddress();
+        } catch (Exception e) {
+            logger.debug("Failed to get remote address from WebSocket session", e);
+            return "unknown";
+        }
     }
 
     @OnWebSocketFrame

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
@@ -374,6 +374,9 @@ public class ConsoleProxyNoVncClient implements ConsoleProxyClient {
         this.connectionAlive = false;
         // Clear buffer reference to allow GC when client disconnects
         this.readBuffer = null;
+        if (client != null) {
+            client.close();
+        }
         ConsoleProxy.removeViewer(this);
     }
 

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
@@ -177,6 +177,7 @@ public class ConsoleProxyNoVncClient implements ConsoleProxyClient {
                         }
                     }
                     logger.info("Connection with client [{}] [IP: {}] is dead.", clientId, clientSourceIp);
+                    ConsoleProxy.grantReconnectWindow(sessionUuid, clientSourceIp);
                 } catch (IOException e) {
                     logger.error("Error on VNC client", e);
                 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyNoVncClient.java
@@ -177,7 +177,7 @@ public class ConsoleProxyNoVncClient implements ConsoleProxyClient {
                         }
                     }
                     logger.info("Connection with client [{}] [IP: {}] is dead.", clientId, clientSourceIp);
-                    ConsoleProxy.grantReconnectWindow(sessionUuid, clientSourceIp);
+                    ConsoleProxy.grantReconnectWindowForSessionAndClientIp(sessionUuid, clientSourceIp);
                 } catch (IOException e) {
                     logger.error("Error on VNC client", e);
                 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/NoVncClient.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/NoVncClient.java
@@ -129,6 +129,28 @@ public class NoVncClient {
         }
     }
 
+    public void close() {
+        if (nioSocketConnection != null) {
+            nioSocketConnection.close();
+        }
+        if (webSocketReverseProxy != null) {
+            webSocketReverseProxy.close();
+        }
+        if (socket != null) {
+            try {
+                if (is != null) {
+                    is.close();
+                }
+                if (os != null) {
+                    os.close();
+                }
+                socket.close();
+            } catch (IOException e) {
+                logger.debug("Error closing socket: " + e.getMessage(), e);
+            }
+        }
+    }
+
     private void setTunnelSocketStreams() throws IOException {
         this.is = new DataInputStream(this.socket.getInputStream());
         this.os = new DataOutputStream(this.socket.getOutputStream());

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/network/NioSocket.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/network/NioSocket.java
@@ -120,4 +120,28 @@ public class NioSocket {
             return 0;
         }
     }
+
+    public void close() {
+        try {
+            if (socketChannel != null) {
+                socketChannel.close();
+            }
+        } catch (IOException e) {
+            logger.debug("Error closing socket channel: " + e.getMessage(), e);
+        }
+        try {
+            if (readSelector != null) {
+                readSelector.close();
+            }
+        } catch (IOException e) {
+            logger.debug("Error closing read selector: " + e.getMessage(), e);
+        }
+        try {
+            if (writeSelector != null) {
+                writeSelector.close();
+            }
+        } catch (IOException e) {
+            logger.debug("Error closing write selector: " + e.getMessage(), e);
+        }
+    }
 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/network/NioSocketHandler.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/network/NioSocketHandler.java
@@ -41,4 +41,5 @@ public interface NioSocketHandler {
     void flushWriteBuffer();
     void startTLSConnection(NioSocketSSLEngineManager sslEngineManager);
     boolean isTLSConnection();
+    void close();
 }

--- a/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/network/NioSocketHandlerImpl.java
+++ b/services/console-proxy/server/src/main/java/com/cloud/consoleproxy/vnc/network/NioSocketHandlerImpl.java
@@ -28,10 +28,12 @@ public class NioSocketHandlerImpl implements NioSocketHandler {
     private NioSocketInputStream inputStream;
     private NioSocketOutputStream outputStream;
     private boolean isTLS = false;
+    private final NioSocket socket;
 
     protected Logger logger = LogManager.getLogger(getClass());
 
     public NioSocketHandlerImpl(NioSocket socket) {
+        this.socket = socket;
         this.inputStream = new NioSocketInputStream(ConsoleProxy.defaultBufferSize, socket);
         this.outputStream = new NioSocketOutputStream(ConsoleProxy.defaultBufferSize, socket);
     }
@@ -108,5 +110,10 @@ public class NioSocketHandlerImpl implements NioSocketHandler {
     @Override
     public NioSocketOutputStream getOutputStream() {
         return outputStream;
+    }
+
+    @Override
+    public void close() {
+        socket.close();
     }
 }

--- a/systemvm/agent/conf/consoleproxy.properties
+++ b/systemvm/agent/conf/consoleproxy.properties
@@ -22,3 +22,4 @@ consoleproxy.jarDir=./applet/
 consoleproxy.viewerLinger=180
 consoleproxy.reconnectMaxRetry=5
 consoleproxy.defaultBufferSize=65536
+consoleproxy.sessionReconnectGraceSeconds=1

--- a/systemvm/agent/conf/consoleproxy.properties
+++ b/systemvm/agent/conf/consoleproxy.properties
@@ -22,4 +22,3 @@ consoleproxy.jarDir=./applet/
 consoleproxy.viewerLinger=180
 consoleproxy.reconnectMaxRetry=5
 consoleproxy.defaultBufferSize=65536
-consoleproxy.sessionReconnectGraceSeconds=1


### PR DESCRIPTION
### Description

This PR addresses 3 issues:

- In case of concurrent console proxy requests, 2 different threads could modify the allowedSessions set and cause problems accessing the console sessions\
- Partial fix for the issue #13422: in cases in which a session has been properly acquired but after a few seconds declared as dead and then tried to reconnect, the CPVM prevented it as the session has already been acquired.
   - To fix this, a new zone setting is added `consoleproxy.session.reconnection.window` with default value = 0, which sets a reconnection window for the same client IP once a connection is declared as dead.
- After closing the browser tab for a VM console session, it was observed that the connection remained open on the KVM host's VNC port.

    - Before the fix: After opening multiple sessions for the same VM, each new session opens a new socket connection on the KVM host on the VNC port but was not closed after closing the console browser tab.
````
[root@ref-trl-12127-k-Mol9-nicolas-vazquez-kvm2 ~]# ss -tnp | grep 5901
ESTAB 0      55              10.0.33.112:5901           10.0.39.91:43024 users:(("qemu-kvm",pid=77212,fd=38))                                     
ESTAB 0      55              10.0.33.112:5901           10.0.39.91:51796 users:(("qemu-kvm",pid=77212,fd=36))                                     
ESTAB 0      0               10.0.33.112:5901           10.0.39.91:43008 users:(("qemu-kvm",pid=77212,fd=37))                                     
ESTAB 0      0               10.0.33.112:5901           10.0.39.91:60794 users:(("qemu-kvm",pid=77212,fd=35))  
````

   - After the fix: Each time a console session is acquired, then only one socket connection remains open per VM, and when it is closed then no connections remain open:
````
[root@ref-trl-12127-k-Mol9-nicolas-vazquez-kvm2 ~]# ss -tnp | grep 5901
[root@ref-trl-12127-k-Mol9-nicolas-vazquez-kvm2 ~]# ss -tnp | grep 5901
ESTAB 0      0               10.0.33.112:5901           10.0.39.99:41826 users:(("qemu-kvm",pid=77212,fd=35))                                     
[root@ref-trl-12127-k-Mol9-nicolas-vazquez-kvm2 ~]# ss -tnp | grep 5901
[root@ref-trl-12127-k-Mol9-nicolas-vazquez-kvm2 ~]# ss -tnp | grep 5901
ESTAB 0      0               10.0.33.112:5901           10.0.39.99:36836 users:(("qemu-kvm",pid=77212,fd=35))   
````

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

- Replaced the `agent.zip` file on `/usr/share/cloudstack-common/vms/` for each KVM host and recreated the CPVM
- Acquired multiple console sessions and verified the the established using the `ss -tnp` command for VM's VNC ports
- Using the default value `consoleproxy.session.reconnection.window` = 0, observe no changes on console sessions reconnection
- Set `consoleproxy.session.reconnection.window` = 5000, recreate CPVM. Observe refreshing the browser tab allows the same client to reclaim back/reconnect to the same session. Also, if another session acquires the console session, the previous session could be reclaimed back within the reconnection window timeframe

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
