### PR TITLE
Network: default egress policy Allow for Isolated networks on fresh installations

### DIFF
--- a/api/src/test/java/org/apache/cloudstack/api/command/admin/network/CreateNetworkOfferingCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/admin/network/CreateNetworkOfferingCmdTest.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.admin.network;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateNetworkOfferingCmdTest {
+
+    @Test
+    public void testEgressDefaultPolicyIsAllowWhenParameterOmitted() {
+        CreateNetworkOfferingCmd cmd = new CreateNetworkOfferingCmd();
+        assertEquals("createNetworkOffering must default to egress Allow when egressdefaultpolicy is not specified",
+                Boolean.TRUE, cmd.getEgressDefaultPolicy());
+    }
+
+    @Test
+    public void testEgressDefaultPolicyExplicitDenyIsHonored() {
+        CreateNetworkOfferingCmd cmd = new CreateNetworkOfferingCmd();
+        ReflectionTestUtils.setField(cmd, "egressDefaultPolicy", Boolean.FALSE);
+        assertEquals(Boolean.FALSE, cmd.getEgressDefaultPolicy());
+    }
+
+    @Test
+    public void testEgressDefaultPolicyExplicitAllowIsHonored() {
+        CreateNetworkOfferingCmd cmd = new CreateNetworkOfferingCmd();
+        ReflectionTestUtils.setField(cmd, "egressDefaultPolicy", Boolean.TRUE);
+        assertEquals(Boolean.TRUE, cmd.getEgressDefaultPolicy());
+    }
+}

--- a/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
@@ -346,6 +346,10 @@ public class NetworkOfferingVO implements NetworkOffering {
         return egressdefaultpolicy;
     }
 
+    public void setEgressDefaultPolicy(boolean egressDefaultPolicy) {
+        this.egressdefaultpolicy = egressDefaultPolicy;
+    }
+
     public NetworkOfferingVO(String name, String displayText, TrafficType trafficType, boolean systemOnly, boolean specifyVlan, Integer rateMbps,
             Integer multicastRateMbps, boolean isDefault, Availability availability, String tags, Network.GuestType guestType, boolean conserveMode,
             boolean specifyIpRanges, boolean isPersistent, boolean internalLb, boolean publicLb, boolean isForVpc) {

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -1067,6 +1067,12 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                                 Network.GuestType.Isolated, true, false, false, false, true, false);
 
                 defaultIsolatedSourceNatEnabledNetworkOffering.setState(NetworkOffering.State.Enabled);
+                // Default egress policy is Allow on fresh installations, consistent with the
+                // createNetworkOffering API default (egressdefaultpolicy=true when not specified).
+                // Existing installations are not affected: this method only runs on first boot
+                // (guarded by the "init" configuration flag) and persistDefaultNetworkOffering()
+                // never updates an already existing offering.
+                defaultIsolatedSourceNatEnabledNetworkOffering.setEgressDefaultPolicy(true);
                 defaultIsolatedSourceNatEnabledNetworkOffering.setSupportsVmAutoScaling(true);
                 defaultIsolatedSourceNatEnabledNetworkOffering = _networkOfferingDao.persistDefaultNetworkOffering(defaultIsolatedSourceNatEnabledNetworkOffering);
 
@@ -1084,6 +1090,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                                 false, true, null, null, true, Availability.Optional, null, Network.GuestType.Isolated, true, true, false, false, false, false);
 
                 defaultIsolatedEnabledNetworkOffering.setState(NetworkOffering.State.Enabled);
+                // This offering carries no Firewall service, so the flag is not enforced anywhere;
+                // it is set for consistency so API responses do not advertise a misleading Deny policy.
+                defaultIsolatedEnabledNetworkOffering.setEgressDefaultPolicy(true);
                 defaultIsolatedEnabledNetworkOffering = _networkOfferingDao.persistDefaultNetworkOffering(defaultIsolatedEnabledNetworkOffering);
 
                 for (Service service : defaultIsolatedNetworkOfferingProviders.keySet()) {

--- a/server/src/test/java/com/cloud/server/ConfigurationServerImplTest.java
+++ b/server/src/test/java/com/cloud/server/ConfigurationServerImplTest.java
@@ -23,6 +23,8 @@ import com.cloud.dc.dao.HostPodDao;
 import com.cloud.dc.dao.VlanDao;
 import com.cloud.domain.dao.DomainDao;
 import com.cloud.network.dao.NetworkDao;
+import com.cloud.offering.NetworkOffering;
+import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import com.cloud.service.dao.ServiceOfferingDao;
@@ -35,11 +37,15 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigurationServerImplTest {
@@ -121,5 +127,38 @@ public class ConfigurationServerImplTest {
         Mockito.verify(_mgrService, Mockito.times(1)).generateRandomPassword();
         //teardown
         System.setProperty("user.name", realusername);
+    }
+
+    @Test
+    public void testCreateDefaultNetworkOfferingsSeedsIsolatedOfferingsWithEgressAllow() {
+        Mockito.when(_networkOfferingDao.persistDefaultNetworkOffering(Mockito.any(NetworkOfferingVO.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        try (TransactionLegacy txn = TransactionLegacy.open("testCreateDefaultNetworkOfferings")) {
+            configurationServer.createDefaultNetworkOfferings();
+        }
+
+        ArgumentCaptor<NetworkOfferingVO> captor = ArgumentCaptor.forClass(NetworkOfferingVO.class);
+        Mockito.verify(_networkOfferingDao, Mockito.atLeastOnce()).persistDefaultNetworkOffering(captor.capture());
+
+        Map<String, NetworkOfferingVO> offeringsByName = new HashMap<>();
+        for (NetworkOfferingVO offering : captor.getAllValues()) {
+            offeringsByName.putIfAbsent(offering.getUniqueName(), offering);
+        }
+
+        NetworkOfferingVO isolatedSourceNatOffering = offeringsByName.get(NetworkOffering.DefaultIsolatedNetworkOfferingWithSourceNatService);
+        Assert.assertNotNull(isolatedSourceNatOffering);
+        Assert.assertTrue("Built-in Isolated source-NAT offering must be seeded with egress default policy Allow on fresh installations",
+                isolatedSourceNatOffering.isEgressDefaultPolicy());
+
+        NetworkOfferingVO isolatedOffering = offeringsByName.get(NetworkOffering.DefaultIsolatedNetworkOffering);
+        Assert.assertNotNull(isolatedOffering);
+        Assert.assertTrue("Built-in Isolated (no source-NAT) offering must be seeded with egress default policy Allow on fresh installations",
+                isolatedOffering.isEgressDefaultPolicy());
+
+        NetworkOfferingVO sharedOffering = offeringsByName.get(NetworkOffering.DefaultSharedNetworkOffering);
+        Assert.assertNotNull(sharedOffering);
+        Assert.assertFalse("Built-in Shared offering seeding must remain unchanged",
+                sharedOffering.isEgressDefaultPolicy());
     }
 }

--- a/ui/src/views/offering/AddNetworkOffering.vue
+++ b/ui/src/views/offering/AddNetworkOffering.vue
@@ -704,7 +704,7 @@ export default {
         isolation: 'dedicated',
         conservemode: true,
         availability: 'optional',
-        egressdefaultpolicy: 'deny',
+        egressdefaultpolicy: 'allow',
         ispublic: this.isPublic,
         nsxsupportlb: true,
         routingmode: 'static'


### PR DESCRIPTION
## Problem

On a fresh CloudStack installation, the built-in `DefaultIsolatedNetworkOfferingWithSourceNatService` offering — the `Availability.Required` offering that auto-creates a user's first isolated network at VM deployment — is persisted with `egress_default_policy = false` (Deny). The very first thing almost every new user hits is "my VMs have no internet", and the offering's egress policy is immutable after creation (`updateNetworkOffering` does not expose `egressdefaultpolicy`), so it cannot be fixed without DB surgery or recreating offerings and networks.

This Deny default is a historical artifact, inconsistent with the rest of the codebase:

- **The API already defaults to Allow.** `NetworkOfferingBaseCmd.getEgressDefaultPolicy()` returns `true` when the `egressdefaultpolicy` parameter is omitted, so offerings created via API/cloudmonkey default to Allow. Only the seeded built-in offering and the UI form said Deny.
- **The UI contradicted the API.** The Add Network Offering form preselected Deny and sent an explicit `egressdefaultpolicy=false`, overriding the API default for every offering created through the UI.
- **The Kubernetes service requires Allow.** `KubernetesClusterManagerImpl` rejects non-VPC offerings with egress Deny and creates its own default offering with `egressdefaultpolicy = true`; the shipped default isolated offering cannot be used for CKS today.
- **VPC tiers have no baked-in Deny** — allow-all (`default_allow` ACL) is a first-class choice.

## What this PR changes

Scope is deliberately **fresh installations and new offerings only**:

1. **`ConfigurationServerImpl.createDefaultNetworkOfferings()`**: both built-in Isolated offerings are now seeded with `egress_default_policy = true` (Allow). For `DefaultIsolatedNetworkOffering` (no SourceNat, no Firewall service) the flag is not enforced anywhere; it is set for consistency so API responses don't advertise a misleading Deny policy.
2. **`AddNetworkOffering.vue`**: the Egress default policy radio now preselects **Allow**, aligning the UI with the documented API default. The parameter is still sent explicitly when Deny is selected; admins retain the choice per offering.
3. **`NetworkOfferingVO`**: adds the missing `setEgressDefaultPolicy(boolean)` setter.
4. **Tests**: `ConfigurationServerImplTest` verifies the seeded isolated offerings carry Allow (and that the shared offering seeding is unchanged); a new `CreateNetworkOfferingCmdTest` locks in the API behavior — Allow when the parameter is omitted, explicit Allow/Deny honored.

No global setting is introduced. Per-offering configurability already exists via the `egressdefaultpolicy` parameter, and a global setting would have had confusing dual semantics: consumed once at first-boot seeding (before an operator can realistically set it, since the configuration row does not exist yet at that point) versus consumed live by every later `createNetworkOffering` call — the two could silently disagree. It would also have applied to Shared/L2/VPC offering creation despite its Isolated-scoped name.

## Backward compatibility — existing installations provably untouched

- `createDefaultNetworkOfferings()` runs **only on first boot**, guarded by the `init` configuration flag in `persistDefaultValues()`. It never executes on an upgraded installation.
- `NetworkOfferingDaoImpl.persistDefaultNetworkOffering()` is find-or-create by unique name; it **never updates an existing row**.
- **No upgrade SQL is shipped, deliberately.** Egress enforcement is evaluated live from the offering row (`offering.isEgressDefaultPolicy()` in `NetworkOrchestrator`/`CommandSetupHelper`) on every VR rule programming, so flipping existing rows would silently change the egress behavior of every existing isolated network — including networks created *after* the upgrade from the pre-existing built-in offering. On upgraded clouds, the built-in offering (and all networks using it, old and new) therefore keeps Deny. Giving upgraded clouds an Allow default for *new* networks without touching existing ones requires a new/versioned built-in offering and is left as an explicit follow-up.
- No schema change, no API change, no VR/systemvm change. The egress-Allow path (System rule → `FW_EGRESS_RULES` default ACCEPT, user rules inverted to DROP) is already exercised today by any admin-created Allow offering.

## How to test

1. Fresh install (or simulator): `listNetworkOfferings name=DefaultIsolatedNetworkOfferingWithSourceNatService` → `egressdefaultpolicy: true`.
2. Deploy a VM without a network → isolated network auto-created → on the VR, `iptables -S FW_EGRESS_RULES` shows default ACCEPT; guest has outbound connectivity with no egress rules configured.
3. Add an egress rule → confirms inverted (DROP) rule semantics still apply.
4. Upgrade an existing DB → `select name, egress_default_policy from network_offerings where name like 'DefaultIsolated%';` unchanged (0 for pre-existing rows).
5. UI → Add Network Offering with Firewall service checked → Egress default policy preselects Allow; selecting Deny still creates a Deny offering.
6. Unit tests: `ConfigurationServerImplTest#testCreateDefaultNetworkOfferingsSeedsIsolatedOfferingsWithEgressAllow`, `CreateNetworkOfferingCmdTest`.

## Alternatives considered

- **Global setting** (`network.isolated.default.egress.policy.allow`, earlier revision of this PR): dropped for the lifecycle/naming reasons above.
- **Upgrade-time SQL flipping existing offerings**: rejected — changes egress behavior of existing networks in the field.
- **A new/versioned Allow built-in offering for upgraded clouds** (with the legacy Deny offering hidden from new network creation): viable follow-up PR, kept out of this one to keep the scope reviewable.
