### PR TITLE
xenserver/xcpng: do not bypass secondary storage when copy volumes between pools

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -472,7 +472,15 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                 return true;
             }
 
+            if (Hypervisor.HypervisorType.XenServer.equals(((VolumeInfo) srcData).getHypervisorType())) {
+                return false;
+            }
+
             if (destData instanceof VolumeInfo) {
+                if (Hypervisor.HypervisorType.XenServer.equals(((VolumeInfo) destData).getHypervisorType())) {
+                    return false;
+                }
+
                 Scope srcDataStoreScope = srcData.getDataStore().getScope();
                 Scope destDataStoreScope = destData.getDataStore().getScope();
                 logger.info("srcDataStoreScope: {}, srcData pool type: {}; destDataStoreScope: {}, destData pool type: {}",

--- a/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategyTest.java
+++ b/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategyTest.java
@@ -123,6 +123,7 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageForUnsupportedDataObject() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
 
         TemplateObject destTemplateInfo = Mockito.spy(new TemplateObject());
 
@@ -136,12 +137,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageForUnsupportedSrcPoolType() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.PowerFlex).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();
@@ -157,12 +160,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageForUnsupportedDestPoolType() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.NetworkFilesystem).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();
@@ -178,12 +183,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageWithZoneWideNFSPoolsInSameZone() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.NetworkFilesystem).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();
@@ -199,12 +206,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageWithClusterWideNFSPoolsInSameCluster() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ClusterScope(5L, 2L, 1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.NetworkFilesystem).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ClusterScope(5L, 2L, 1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();
@@ -220,12 +229,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageWithLocalAndClusterWideNFSPoolsInSameCluster() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new HostScope(1L, 1L, 1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.Filesystem).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ClusterScope(1L, 1L, 1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();
@@ -244,12 +255,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageWithLocalAndZoneWideNFSPoolsInSameZone() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new HostScope(1L, 1L, 1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.Filesystem).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();
@@ -268,12 +281,14 @@ public class AncientDataMotionStrategyTest {
     @Test
     public void testCanBypassSecondaryStorageWithClusterWideNFSAndZoneWideNFSPoolsInSameZone() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         VolumeObject srcVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(srcVolumeInfo).getHypervisorType();
         DataStore srcDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ClusterScope(5L, 2L, 1L)).when(srcDataStore).getScope();
         Mockito.doReturn(srcDataStore).when(srcVolumeInfo).getDataStore();
         Mockito.doReturn(Storage.StoragePoolType.NetworkFilesystem).when(srcVolumeInfo).getStoragePoolType();
 
         VolumeObject destVolumeInfo = Mockito.spy(new VolumeObject());
+        Mockito.doReturn(HypervisorType.KVM).when(destVolumeInfo).getHypervisorType();
         DataStore destDataStore = Mockito.mock(DataStore.class);
         Mockito.doReturn(new ZoneScope(1L)).when(destDataStore).getScope();
         Mockito.doReturn(destDataStore).when(destVolumeInfo).getDataStore();


### PR DESCRIPTION
### Description

This PR fixes an issue found by smoke test `test_snapshots.py`


```
======================================================================
ERROR: Test listing volume snapshots with removed data stores
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/marvin/lib/decoratorGenerators.py", line 30, in test_wrapper
    return test(self, *args, **kwargs)
  File "/marvin/tests/smoke/test_snapshots.py", line 329, in test_02_list_snapshots_with_removed_data_store
    Volume.migrate(self.apiclient,
  File "/usr/local/lib/python3.9/site-packages/marvin/lib/base.py", line 1384, in migrate
    return (apiclient.migrateVolume(cmd))
  File "/usr/local/lib/python3.9/site-packages/marvin/cloudstackAPI/cloudstackAPIClient.py", line 2466, in migrateVolume
    response = self.connection.marvinRequest(command, response_type=response, method=method)
  File "/usr/local/lib/python3.9/site-packages/marvin/cloudstackConnection.py", line 382, in marvinRequest
    raise e
  File "/usr/local/lib/python3.9/site-packages/marvin/cloudstackConnection.py", line 377, in marvinRequest
    raise self.__lastError
  File "/usr/local/lib/python3.9/site-packages/marvin/cloudstackConnection.py", line 104, in __poll
    raise Exception("Job failed: %s"\
Exception: Job failed: {accountid : 'ace6439d-47aa-11f1-9730-1e00b0000364', account : 'admin', domainid : '5fd28bae-47aa-11f1-9730-1e00b0000364', domainpath : 'ROOT', userid : 'ace709e4-47aa-11f1-9730-1e00b0000364', cmd : 'org.apache.cloudstack.api.command.admin.volume.MigrateVolumeCmdByAdmin', jobprocstatus : 0, jobresultcode : 530, jobresulttype : 'object', jobresult : {errorcode : 530, errortext : 'Resource [StoragePool:9] is unreachable: Volume [{"name":"Test Volume-JE9STT","uuid":"bea8024b-f56a-4b64-a9fa-abc6cdf876b2"}] migration failed due to [Resource returned null answer].'}, jobinstancetype : 'Volume', jobinstanceid : 'bea8024b-f56a-4b64-a9fa-abc6cdf876b2', created : '2026-05-06T19:13:15+0000', completed : '2026-05-06T19:13:15+0000', jobid : '9872cf1e-9f67-4881-947b-9cbafa49ef3f', jobstatus : 2}
```

the issue is because secondary storage is bypassed during offline volume migration, but the volume copy from primary to primary is not implemented for xenserver/xcp
```
    @Override
    public Answer copyVolumeFromPrimaryToPrimary(CopyCommand cmd) {
        return null;
    }       
```

as a workaround, do not bypass the secondary storage for volume on xen/xcp and rollback the previous logic so that offline volume migration will work (via secondary storage).


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
