### PR TITLE
CKS: handle VPC tiers without attached ACLs

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImpl.java
@@ -602,7 +602,7 @@ public class KubernetesClusterManagerImpl extends ManagerBase implements Kuberne
         if (Network.State.Allocated.equals(network.getState())) { // Allocated networks won't have IP and rules
             return;
         }
-        if (network.getNetworkACLId() == NetworkACL.DEFAULT_DENY) {
+        if (Objects.equals(network.getNetworkACLId(), NetworkACL.DEFAULT_DENY)) {
             throw new InvalidParameterValueException(String.format("Network ID: %s can not be used for Kubernetes cluster as it uses default deny ACL", network.getUuid()));
         }
     }

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorker.java
@@ -717,7 +717,7 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
     }
 
     protected void createVpcTierAclRules(Network network) throws ManagementServerException {
-        if (network.getNetworkACLId() == NetworkACL.DEFAULT_ALLOW) {
+        if (Objects.equals(network.getNetworkACLId(), NetworkACL.DEFAULT_ALLOW)) {
             return;
         }
         // ACL rule for API access for control node VMs
@@ -746,7 +746,8 @@ public class KubernetesClusterResourceModifierActionWorker extends KubernetesClu
     }
 
     protected void removeVpcTierAclRules(Network network) throws ManagementServerException {
-        if (network.getNetworkACLId() == NetworkACL.DEFAULT_ALLOW) {
+        Long networkAclId = network.getNetworkACLId();
+        if (networkAclId == null || Objects.equals(networkAclId, NetworkACL.DEFAULT_ALLOW)) {
             return;
         }
         // ACL rule for API access for control node VMs

--- a/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterStartWorker.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterStartWorker.java
@@ -646,7 +646,7 @@ public class KubernetesClusterStartWorker extends KubernetesClusterResourceModif
             try {
                 if (Objects.isNull(network.getVpcId())) {
                     provisionFirewallRules(publicIp, owner, etcdStartPort, etcdStartPort);
-                } else if (network.getNetworkACLId() != NetworkACL.DEFAULT_ALLOW) {
+                } else if (!Objects.equals(network.getNetworkACLId(), NetworkACL.DEFAULT_ALLOW)) {
                     try {
                         provisionVpcTierAllowPortACLRule(network, ETCD_NODE_CLIENT_REQUEST_PORT, ETCD_NODE_CLIENT_REQUEST_PORT);
                         if (logger.isInfoEnabled()) {

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/KubernetesClusterManagerImplTest.java
@@ -131,6 +131,14 @@ public class KubernetesClusterManagerImplTest {
     }
 
     @Test
+    public void testValidateVpcTierWithoutAcl() {
+        Network network = Mockito.mock(Network.class);
+        Mockito.when(network.getState()).thenReturn(Network.State.Implemented);
+        Mockito.when(network.getNetworkACLId()).thenReturn(null);
+        kubernetesClusterManager.validateVpcTier(network);
+    }
+
+    @Test
     public void validateIsolatedNetworkIpRulesNoRules() {
         long ipId = 1L;
         FirewallRule.Purpose purpose = FirewallRule.Purpose.Firewall;

--- a/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorkerTest.java
+++ b/plugins/integrations/kubernetes-service/src/test/java/com/cloud/kubernetes/cluster/actionworkers/KubernetesClusterResourceModifierActionWorkerTest.java
@@ -17,17 +17,28 @@
 
 package com.cloud.kubernetes.cluster.actionworkers;
 
+import java.util.List;
+
 import com.cloud.kubernetes.cluster.KubernetesCluster;
 import com.cloud.kubernetes.cluster.KubernetesClusterManagerImpl;
 import com.cloud.kubernetes.cluster.dao.KubernetesClusterDao;
 import com.cloud.kubernetes.cluster.dao.KubernetesClusterDetailsDao;
 import com.cloud.kubernetes.cluster.dao.KubernetesClusterVmMapDao;
 import com.cloud.kubernetes.version.dao.KubernetesSupportedVersionDao;
+import com.cloud.network.IpAddress;
+import com.cloud.network.Network;
+import com.cloud.network.dao.IPAddressDao;
+import com.cloud.network.dao.IPAddressVO;
+import com.cloud.network.vpc.NetworkACL;
+import com.cloud.user.Account;
+import com.cloud.uservm.UserVm;
+import org.apache.cloudstack.context.CallContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -51,7 +62,52 @@ public class KubernetesClusterResourceModifierActionWorkerTest {
     @Mock
     private KubernetesCluster kubernetesClusterMock;
 
-    private KubernetesClusterResourceModifierActionWorker kubernetesClusterResourceModifierActionWorker;
+    @Mock
+    private IPAddressDao ipAddressDaoMock;
+
+    @Mock
+    private Account accountMock;
+
+    private TestKubernetesClusterResourceModifierActionWorker kubernetesClusterResourceModifierActionWorker;
+
+    private static class TestKubernetesClusterResourceModifierActionWorker extends KubernetesClusterResourceModifierActionWorker {
+        private int provisionAclRuleCalls;
+        private int removeAclRuleCalls;
+
+        TestKubernetesClusterResourceModifierActionWorker(KubernetesCluster kubernetesCluster, KubernetesClusterManagerImpl clusterManager) {
+            super(kubernetesCluster, clusterManager);
+        }
+
+        @Override
+        protected void provisionVpcTierAllowPortACLRule(Network network, int startPort, int endPort) {
+            provisionAclRuleCalls++;
+        }
+
+        @Override
+        protected void removeVpcTierAllowPortACLRule(Network network, int startPort, int endPort) {
+            removeAclRuleCalls++;
+        }
+    }
+
+    private static class TestKubernetesClusterStartWorker extends KubernetesClusterStartWorker {
+        private int provisionAclRuleCalls;
+        private int provisionPortForwardingRuleCalls;
+
+        TestKubernetesClusterStartWorker(KubernetesCluster kubernetesCluster, KubernetesClusterManagerImpl clusterManager) {
+            super(kubernetesCluster, clusterManager);
+        }
+
+        @Override
+        protected void provisionVpcTierAllowPortACLRule(Network network, int startPort, int endPort) {
+            provisionAclRuleCalls++;
+        }
+
+        @Override
+        protected void provisionPublicIpPortForwardingRule(IpAddress publicIp, Network network, Account account,
+                long vmId, int sourcePort, int destPort) {
+            provisionPortForwardingRuleCalls++;
+        }
+    }
 
     @Before
     public void setUp() {
@@ -60,7 +116,7 @@ public class KubernetesClusterResourceModifierActionWorkerTest {
         kubernetesClusterManagerMock.kubernetesClusterDetailsDao = kubernetesClusterDetailsDaoMock;
         kubernetesClusterManagerMock.kubernetesClusterVmMapDao = kubernetesClusterVmMapDaoMock;
 
-        kubernetesClusterResourceModifierActionWorker = new KubernetesClusterResourceModifierActionWorker(kubernetesClusterMock, kubernetesClusterManagerMock);
+        kubernetesClusterResourceModifierActionWorker = new TestKubernetesClusterResourceModifierActionWorker(kubernetesClusterMock, kubernetesClusterManagerMock);
     }
 
     @Test
@@ -134,5 +190,68 @@ public class KubernetesClusterResourceModifierActionWorkerTest {
 
         Mockito.when(kubernetesClusterMock.getName()).thenReturn(originalPrefix);
         Assert.assertEquals(expectedPrefix, kubernetesClusterResourceModifierActionWorker.getKubernetesClusterNodeNamePrefix());
+    }
+
+    @Test
+    public void createVpcTierAclRulesWithoutAclProvisionsRules() throws Exception {
+        Network network = Mockito.mock(Network.class);
+        Mockito.when(network.getNetworkACLId()).thenReturn(null);
+
+        try (MockedStatic<CallContext> ignored = Mockito.mockStatic(CallContext.class)) {
+            kubernetesClusterResourceModifierActionWorker.createVpcTierAclRules(network);
+        }
+
+        Assert.assertEquals(2, kubernetesClusterResourceModifierActionWorker.provisionAclRuleCalls);
+    }
+
+    @Test
+    public void createVpcTierAclRulesWithDefaultAllowDoesNotProvisionRules() throws Exception {
+        Network network = Mockito.mock(Network.class);
+        Mockito.when(network.getNetworkACLId()).thenReturn(NetworkACL.DEFAULT_ALLOW);
+
+        kubernetesClusterResourceModifierActionWorker.createVpcTierAclRules(network);
+
+        Assert.assertEquals(0, kubernetesClusterResourceModifierActionWorker.provisionAclRuleCalls);
+    }
+
+    @Test
+    public void removeVpcTierAclRulesWithoutAclDoesNotRemoveRules() throws Exception {
+        Network network = Mockito.mock(Network.class);
+        Mockito.when(network.getNetworkACLId()).thenReturn(null);
+
+        kubernetesClusterResourceModifierActionWorker.removeVpcTierAclRules(network);
+
+        Assert.assertEquals(0, kubernetesClusterResourceModifierActionWorker.removeAclRuleCalls);
+    }
+
+    @Test
+    public void removeVpcTierAclRulesWithCustomAclRemovesRules() throws Exception {
+        Network network = Mockito.mock(Network.class);
+        Mockito.when(network.getNetworkACLId()).thenReturn(3L);
+
+        kubernetesClusterResourceModifierActionWorker.removeVpcTierAclRules(network);
+
+        Assert.assertEquals(2, kubernetesClusterResourceModifierActionWorker.removeAclRuleCalls);
+    }
+
+    @Test
+    public void setupKubernetesEtcdNetworkRulesWithoutAclProvisionsAclRule() throws Exception {
+        Network network = Mockito.mock(Network.class);
+        Mockito.when(network.getVpcId()).thenReturn(1L);
+        Mockito.when(network.getNetworkACLId()).thenReturn(null);
+        UserVm etcdVm = Mockito.mock(UserVm.class);
+        Mockito.when(etcdVm.getId()).thenReturn(1L);
+        IPAddressVO publicIp = Mockito.mock(IPAddressVO.class);
+        Mockito.when(ipAddressDaoMock.findByIpAndDcId(Mockito.anyLong(), Mockito.anyString())).thenReturn(publicIp);
+
+        TestKubernetesClusterStartWorker worker = new TestKubernetesClusterStartWorker(kubernetesClusterMock, kubernetesClusterManagerMock);
+        worker.ipAddressDao = ipAddressDaoMock;
+        worker.owner = accountMock;
+        worker.publicIpAddress = "192.0.2.1";
+
+        worker.setupKubernetesEtcdNetworkRules(List.of(etcdVm), network);
+
+        Assert.assertEquals(1, worker.provisionAclRuleCalls);
+        Assert.assertEquals(1, worker.provisionPortForwardingRuleCalls);
     }
 }


### PR DESCRIPTION
### Description

Fixes #13761.

CKS can throw a `NullPointerException` when a VPC tier has no attached network ACL. The ACL ID is a nullable `Long`, but CKS compares it with primitive default-ACL constants, causing null unboxing.

This fixes the comparisons in tier validation, API/SSH ACL-rule provisioning, etcd setup and ACL-rule cleanup.

For an ACL-capable tier without an attached ACL, provisioning continues through the existing ACL service, which can create and attach the missing list. Cleanup skips ACL-rule removal when the tier still has no attached ACL. Existing handling of default-allow, default-deny and custom ACLs is retained.

The issue was reported on CloudStack 4.22.1.0 with NSX-backed networking. This PR targets `4.22`.

### Types of changes

- [ ] Breaking change
- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Cleanup
- [ ] Build/CI
- [ ] Test-only change

### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

Tested with Java 17 at commit `644c644e2d31e7ddcd9949614fc1316165f89460`.

| Tests | Run | Failures | Errors | Skipped |
| --- | ---: | ---: | ---: | ---: |
| Focused CKS tests | 42 | 0 | 0 | 0 |
| Full Kubernetes Service module | 84 | 0 | 0 | 0 |
| `NetworkACLServiceImplTest` | 104 | 0 | 0 | 0 |

The 42 focused tests are included in the 84 Kubernetes Service module tests.

[Build and test log](https://github.com/apache/cloudstack/actions/runs/30664383809/job/91603578803)

### How did you try to break this feature and the system with this change?

The four null-ACL regression cases reproduce the original `NullPointerException` without the production fix and pass with it.

The added tests cover:

- Validation of an implemented tier without an ACL.
- API/SSH and etcd provisioning when the ACL is absent.
- Skipping ACL-rule removal when no ACL is attached.
- Skipping provisioning with default-allow and retaining removal calls with a custom ACL.

The worker tests verify calls to the provisioning and removal helpers. The existing ACL-service unit tests separately cover creating and attaching a missing ACL, reusing an attached ACL, and creation or attachment failures. 

Was tested end to end on another install weeks ago I will test again the moment I have resources free.