### PR TITLE
UI: fix usage records end date with local timezone

### DIFF
--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -598,7 +598,7 @@ export default {
       if (values.dateRange) {
         if (this.$store.getters.usebrowsertimezone) {
           params.startdate = dayjs.utc(dayjs(values.dateRange[0]).startOf('day')).format('YYYY-MM-DD HH:mm:ss')
-          params.enddate = dayjs.utc(dayjs(values.dateRange[0]).endOf('day')).format('YYYY-MM-DD HH:mm:ss')
+          params.enddate = dayjs.utc(dayjs(values.dateRange[1]).endOf('day')).format('YYYY-MM-DD HH:mm:ss')
         } else {
           params.startdate = dayjs(values.dateRange[0]).startOf('day').format('YYYY-MM-DD HH:mm:ss')
           params.enddate = dayjs(values.dateRange[1]).endOf('day').format('YYYY-MM-DD HH:mm:ss')

--- a/ui/src/views/infra/UsageRecords.vue
+++ b/ui/src/views/infra/UsageRecords.vue
@@ -595,7 +595,7 @@ export default {
         page: page || this.page,
         pagesize: pageSize || this.pageSize
       }
-      if (values.dateRange) {
+      if (Array.isArray(values.dateRange) && values.dateRange[0] && values.dateRange[1]) {
         if (this.$store.getters.usebrowsertimezone) {
           params.startdate = dayjs.utc(dayjs(values.dateRange[0]).startOf('day')).format('YYYY-MM-DD HH:mm:ss')
           params.enddate = dayjs.utc(dayjs(values.dateRange[1]).endOf('day')).format('YYYY-MM-DD HH:mm:ss')

--- a/ui/tests/unit/views/infra/UsageRecords.spec.js
+++ b/ui/tests/unit/views/infra/UsageRecords.spec.js
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import UsageRecords from '@/views/infra/UsageRecords'
+
+const originalTimezone = process.env.TZ
+
+const getParams = (dateRange, useBrowserTimezone) => {
+  return UsageRecords.methods.getParams.call({
+    form: { dateRange },
+    handleRemoveFields: values => values,
+    page: 1,
+    pageSize: 20,
+    $store: {
+      getters: { usebrowsertimezone: useBrowserTimezone }
+    }
+  })
+}
+
+describe('Views > infra > UsageRecords.vue', () => {
+  beforeAll(() => {
+    process.env.TZ = 'Europe/London'
+  })
+
+  afterAll(() => {
+    if (originalTimezone === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = originalTimezone
+    }
+  })
+
+  describe('getParams()', () => {
+    it('uses both selected dates when converting a local-timezone range to UTC', () => {
+      const params = getParams(['2026-07-26', '2026-08-02'], true)
+
+      expect(params.startdate).toBe('2026-07-25 23:00:00')
+      expect(params.enddate).toBe('2026-08-02 22:59:59')
+    })
+
+    it('uses the selected end date when the range crosses daylight-saving time', () => {
+      const params = getParams(['2026-03-28', '2026-03-30'], true)
+
+      expect(params.startdate).toBe('2026-03-28 00:00:00')
+      expect(params.enddate).toBe('2026-03-30 22:59:59')
+    })
+
+    it('preserves both selected dates when browser-timezone conversion is disabled', () => {
+      const params = getParams(['2026-07-26', '2026-08-02'], false)
+
+      expect(params.startdate).toBe('2026-07-26 00:00:00')
+      expect(params.enddate).toBe('2026-08-02 23:59:59')
+    })
+  })
+})

--- a/ui/tests/unit/views/infra/UsageRecords.spec.js
+++ b/ui/tests/unit/views/infra/UsageRecords.spec.js
@@ -63,5 +63,19 @@ describe('Views > infra > UsageRecords.vue', () => {
       expect(params.startdate).toBe('2026-07-26 00:00:00')
       expect(params.enddate).toBe('2026-08-02 23:59:59')
     })
+
+    it('omits date parameters when no range is selected', () => {
+      const params = getParams([], true)
+
+      expect(params).not.toHaveProperty('startdate')
+      expect(params).not.toHaveProperty('enddate')
+    })
+
+    it('omits date parameters when the selected range is incomplete', () => {
+      const params = getParams([dateWithOffset('2026-07-26', 60)], true)
+
+      expect(params).not.toHaveProperty('startdate')
+      expect(params).not.toHaveProperty('enddate')
+    })
   })
 })

--- a/ui/tests/unit/views/infra/UsageRecords.spec.js
+++ b/ui/tests/unit/views/infra/UsageRecords.spec.js
@@ -15,9 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
 import UsageRecords from '@/views/infra/UsageRecords'
 
-const originalTimezone = process.env.TZ
+dayjs.extend(utc)
+
+const dateWithOffset = (date, offsetMinutes) => dayjs(date).utcOffset(offsetMinutes, true)
 
 const getParams = (dateRange, useBrowserTimezone) => {
   return UsageRecords.methods.getParams.call({
@@ -32,28 +36,22 @@ const getParams = (dateRange, useBrowserTimezone) => {
 }
 
 describe('Views > infra > UsageRecords.vue', () => {
-  beforeAll(() => {
-    process.env.TZ = 'Europe/London'
-  })
-
-  afterAll(() => {
-    if (originalTimezone === undefined) {
-      delete process.env.TZ
-    } else {
-      process.env.TZ = originalTimezone
-    }
-  })
-
   describe('getParams()', () => {
     it('uses both selected dates when converting a local-timezone range to UTC', () => {
-      const params = getParams(['2026-07-26', '2026-08-02'], true)
+      const params = getParams([
+        dateWithOffset('2026-07-26', 60),
+        dateWithOffset('2026-08-02', 60)
+      ], true)
 
       expect(params.startdate).toBe('2026-07-25 23:00:00')
       expect(params.enddate).toBe('2026-08-02 22:59:59')
     })
 
     it('uses the selected end date when the range crosses daylight-saving time', () => {
-      const params = getParams(['2026-03-28', '2026-03-30'], true)
+      const params = getParams([
+        dateWithOffset('2026-03-28', 0),
+        dateWithOffset('2026-03-30', 60)
+      ], true)
 
       expect(params.startdate).toBe('2026-03-28 00:00:00')
       expect(params.enddate).toBe('2026-03-30 22:59:59')


### PR DESCRIPTION
### Description

This PR fixes the Usage Records date range when the user enables the local-timezone preference.

`UsageRecords.getParams` correctly used the first selected date for `startdate`, but also used that same first element for `enddate` in the local-timezone branch. Any multi-day selection was therefore reduced to the first day after conversion to UTC. The non-local-timezone branch already used the selected end date correctly.

The local-timezone `enddate` now uses `dateRange[1]`. No API parameters, timezone-conversion behavior, pagination, or unrelated UI paths are changed.

A focused regression test covers a multi-day range with a non-zero UTC offset, a range crossing a daylight-saving transition, and the existing local-timezone-disabled behavior.

Fixes #13581

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

Not applicable.

### How Has This Been Tested?

Validation results:

```text
UsageRecords.spec.js
Tests: 3 passed, 3 total

Complete UI unit suite
Test Suites: 5 passed, 5 total
Tests: 178 passed, 178 total
```

The UI lint completed with no errors, and the production UI build completed successfully using the repository's pinned Node 16.20.2 runtime.

The request windows were also checked read-only against a CloudStack 4.22.1 environment. For a selected eight-day range, the valid unconverted and correctly converted windows each returned 2,800 records; the original one-day window produced by the wrong index returned zero records.

### How did you try to break this feature and the system with this change?

The regression test uses `Europe/London` so the expected UTC values have a non-zero offset. A second range crosses the 2026 spring daylight-saving boundary to verify that the selected end date and its own offset are both used. The local-timezone-disabled branch is retained as a control to prove its existing start and end dates are unchanged.

The production diff changes only the array index used by the local-timezone `enddate` expression. The complete UI unit suite, lint, production build, and `git diff --check` all pass.
