### PR TITLE
Make AgentManagerImpl.handleCommands resilient to listener exceptions

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -456,8 +456,13 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
 
     public void handleCommands(final AgentAttache attache, final long sequence, final Command[] cmds) {
         for (final Pair<Integer, Listener> listener : _cmdMonitors) {
-            final boolean processed = listener.second().processCommands(attache.getId(), sequence, cmds);
-            logger.trace("SeqA {}-{}: {} by {}", attache.getId(), sequence, (processed ? "processed" : "not processed"), listener.getClass());
+            try {
+                final boolean processed = listener.second().processCommands(attache.getId(), sequence, cmds);
+                logger.trace("SeqA {}-{}: {} by {}", attache.getId(), sequence, (processed ? "processed" : "not processed"), listener.second().getClass());
+            } catch (final Exception e) {
+                logger.warn("Listener {} threw an exception processing commands for agent {} seq {}; continuing to next listener",
+                        listener.second().getClass().getName(), attache.getId(), sequence, e);
+            }
         }
     }
 

--- a/engine/orchestration/src/test/java/com/cloud/agent/manager/AgentManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/agent/manager/AgentManagerImplTest.java
@@ -18,6 +18,7 @@ package com.cloud.agent.manager;
 
 import com.cloud.agent.Listener;
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.Command;
 import com.cloud.agent.api.ReadyCommand;
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupRoutingCommand;
@@ -136,5 +137,85 @@ public class AgentManagerImplTest {
         Mockito.when(host.getDetail(Host.HOST_SSH_PORT)).thenReturn(String.valueOf(3922));
         int hostSshPort = mgr.getHostSshPort(host);
         Assert.assertEquals(3922, hostSshPort);
+    }
+
+    /*
+     * When the first registered listener throws a RuntimeException,
+     * handleCommands must catch it, log a warning, and continue so that
+     * the second listener still runs.
+     */
+    @Test
+    public void testHandleCommandsListenerExceptionDoesNotAbortLoop() throws Exception {
+        Listener throwingListener = Mockito.mock(Listener.class);
+        Mockito.when(throwingListener.processCommands(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenThrow(new RuntimeException("simulated NPE from power-state sync"));
+
+        Listener goodListener = Mockito.mock(Listener.class);
+        Mockito.when(goodListener.processCommands(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenReturn(true);
+
+        mgr._cmdMonitors = new ArrayList<>();
+        mgr._cmdMonitors.add(new Pair<>(1, throwingListener));
+        mgr._cmdMonitors.add(new Pair<>(2, goodListener));
+
+        Command[] cmds = new Command[]{Mockito.mock(Command.class)};
+
+        // Must not throw; the exception from throwingListener must be swallowed.
+        mgr.handleCommands(attache, 1L, cmds);
+
+        // The second listener must still have been invoked.
+        Mockito.verify(goodListener, Mockito.times(1))
+                .processCommands(Mockito.eq(attache.getId()), Mockito.eq(1L), Mockito.eq(cmds));
+    }
+
+    @Test
+    public void testHandleCommandsAllListenersSucceed() throws Exception {
+        Listener listenerA = Mockito.mock(Listener.class);
+        Mockito.when(listenerA.processCommands(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenReturn(true);
+
+        Listener listenerB = Mockito.mock(Listener.class);
+        Mockito.when(listenerB.processCommands(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenReturn(false);
+
+        mgr._cmdMonitors = new ArrayList<>();
+        mgr._cmdMonitors.add(new Pair<>(1, listenerA));
+        mgr._cmdMonitors.add(new Pair<>(2, listenerB));
+
+        Command[] cmds = new Command[]{Mockito.mock(Command.class)};
+        mgr.handleCommands(attache, 1L, cmds);
+
+        Mockito.verify(listenerA, Mockito.times(1))
+                .processCommands(Mockito.eq(attache.getId()), Mockito.eq(1L), Mockito.eq(cmds));
+        Mockito.verify(listenerB, Mockito.times(1))
+                .processCommands(Mockito.eq(attache.getId()), Mockito.eq(1L), Mockito.eq(cmds));
+    }
+
+    /*
+     * Simulates the reported failure: a power-state sync listener throws
+     * partway through, and a downstream ping-style listener must still run
+     * so pingBy() isn't starved.
+     */
+    @Test
+    public void testHandleCommandsThrowingListenerDoesNotStarveDownstreamListener() throws Exception {
+        Listener powerStateSyncListener = Mockito.mock(Listener.class);
+        Mockito.when(powerStateSyncListener.processCommands(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenThrow(new NullPointerException("hostId was null in isPowerStateInSyncWithInstanceState"));
+
+        Listener pingListener = Mockito.mock(Listener.class);
+        Mockito.when(pingListener.processCommands(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenReturn(false);
+
+        mgr._cmdMonitors = new ArrayList<>();
+        mgr._cmdMonitors.add(new Pair<>(1, powerStateSyncListener));
+        mgr._cmdMonitors.add(new Pair<>(2, pingListener));
+
+        Command[] cmds = new Command[]{Mockito.mock(Command.class)};
+
+        // Before the fix this would abort on the NPE and pingListener would never run.
+        mgr.handleCommands(attache, 42L, cmds);
+
+        Mockito.verify(pingListener, Mockito.times(1))
+                .processCommands(Mockito.eq(attache.getId()), Mockito.eq(42L), Mockito.eq(cmds));
     }
 }

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -355,6 +355,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         IdsPowerStateSelectSearch = createSearchBuilder();
         IdsPowerStateSelectSearch.and("id", IdsPowerStateSelectSearch.entity().getId(), Op.IN);
         IdsPowerStateSelectSearch.selectFields(IdsPowerStateSelectSearch.entity().getId(),
+                IdsPowerStateSelectSearch.entity().getHostId(),
                 IdsPowerStateSelectSearch.entity().getPowerHostId(),
                 IdsPowerStateSelectSearch.entity().getPowerState(),
                 IdsPowerStateSelectSearch.entity().getPowerStateUpdateCount(),

--- a/engine/schema/src/test/java/com/cloud/vm/dao/VMInstanceDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/vm/dao/VMInstanceDaoImplTest.java
@@ -210,6 +210,53 @@ public class VMInstanceDaoImplTest {
         assertTrue(result);
     }
 
+    /*
+     * Mirrors testUpdatePowerStateNoChangeMaxUpdatesInvalidStateVmStopped but with a null
+     * hostId (the default from setUp), which is what happens when the row was loaded through
+     * a partial-select projection that doesn't include hostId. isPowerStateInSyncWithInstanceState
+     * must not NPE on the null hostId, and must still detect the state is out-of-sync.
+     */
+    @Test
+    public void testUpdatePowerStateNoChangeMaxUpdatesInvalidStateVmStoppedNullHostId() {
+        when(vm.getPowerStateUpdateTime()).thenReturn(null);
+        when(vm.getPowerHostId()).thenReturn(1L);
+        when(vm.getPowerState()).thenReturn(VirtualMachine.PowerState.PowerOn);
+        when(vm.getState()).thenReturn(Stopped);
+        doReturn(vm).when(vmInstanceDao).findById(anyLong());
+        doReturn(true).when(vmInstanceDao).update(anyLong(), any());
+
+        boolean result = vmInstanceDao.updatePowerState(1L, 1L, VirtualMachine.PowerState.PowerOn, new Date());
+
+        verify(vm, times(1)).setPowerState(any());
+        verify(vm, times(1)).setPowerHostId(anyLong());
+        verify(vm, times(1)).setPowerStateUpdateCount(1);
+        verify(vm, times(1)).setPowerStateUpdateTime(any(Date.class));
+
+        assertTrue(result);
+    }
+
+    /*
+     * Mirrors testUpdatePowerStateNoChangeMaxUpdatesInvalidStateVmRunning but with a null hostId.
+     */
+    @Test
+    public void testUpdatePowerStateNoChangeMaxUpdatesInvalidStateVmRunningNullHostId() {
+        when(vm.getPowerStateUpdateTime()).thenReturn(null);
+        when(vm.getPowerHostId()).thenReturn(1L);
+        when(vm.getPowerState()).thenReturn(VirtualMachine.PowerState.PowerOff);
+        when(vm.getState()).thenReturn(Running);
+        doReturn(vm).when(vmInstanceDao).findById(anyLong());
+        doReturn(true).when(vmInstanceDao).update(anyLong(), any());
+
+        boolean result = vmInstanceDao.updatePowerState(1L, 1L, VirtualMachine.PowerState.PowerOff, new Date());
+
+        verify(vm, times(1)).setPowerState(any());
+        verify(vm, times(1)).setPowerHostId(anyLong());
+        verify(vm, times(1)).setPowerStateUpdateCount(1);
+        verify(vm, times(1)).setPowerStateUpdateTime(any(Date.class));
+
+        assertTrue(result);
+    }
+
     @Test
     public void testSearchRemovedByRemoveDate() {
         SearchBuilder<VMInstanceVO> sb = Mockito.mock(SearchBuilder.class);


### PR DESCRIPTION
### Description

If one listener in `handleCommands` throws, the whole loop stops and every listener after it never runs. This can starve `pingBy()` and cause fake ping timeouts.

This wraps each listener call in a try/catch, so one bad listener just logs a warning and the rest still run. Also fixed a trace log nearby that was logging the wrong class (the `Pair` wrapper instead of the listener).

Also added the missing `hostId` field to `IdsPowerStateSelectSearch`. Without it, VMs loaded through that path always showed a null host, even when they had one. Not a crash, just a wrong log message.

### Types of changes

- [x] Bug fix

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Major

### How Has This Been Tested?

Added tests: a throwing listener doesn't block the next one, and existing behavior with only successful listeners is unchanged. Also added tests for the null-hostId case, which had no coverage before.