### PR TITLE
Identify Guest Agent connection error by the code enum instead of message (KBOSS)

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -125,6 +125,7 @@ import org.libvirt.DomainInfo;
 import org.libvirt.DomainInfo.DomainState;
 import org.libvirt.DomainInterfaceStats;
 import org.libvirt.DomainSnapshot;
+import org.libvirt.Error;
 import org.libvirt.LibvirtException;
 import org.libvirt.MemoryStatistic;
 import org.libvirt.Network;
@@ -610,8 +611,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     public static final String CGROUP_V2 = "cgroup2fs";
 
-    public static final Integer AGENT_UNRESPONSIVE_ERROR_ORDINAL = 86;
-
+    public static final org.libvirt.Error.ErrorNumber AGENT_UNRESPONSIVE_ERROR = Error.ErrorNumber.VIR_ERR_AGENT_UNRESPONSIVE;
     /**
      * Virsh command to merge (blockcommit) snapshot into the base file.<br><br>
      * 1st parameter: VM's name;<br>
@@ -7185,7 +7185,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } catch (LibvirtException e) {
             String errorMsg = String.format("Creation of disk-only VM snapshot for VM [%s] failed due to %s.", vmName, e.getMessage());
             boolean isVmConsistent = false;
-            if (AGENT_UNRESPONSIVE_ERROR_ORDINAL.equals(e.getError().getCode().ordinal())) {
+            if (isGuestAgentUnresponsive(e)) {
                 errorMsg = "QEMU guest agent is not connected. If the VM has been recently started, it might connect soon. Otherwise the VM does not have the" +
                         " guest agent installed; thus the QuiesceVM parameter is not supported.";
                 isVmConsistent = true;
@@ -7201,6 +7201,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 }
             }
         }
+    }
+
+    public static boolean isGuestAgentUnresponsive(LibvirtException e) {
+        return AGENT_UNRESPONSIVE_ERROR.equals(e.getError().getCode());
     }
 
     public Map<String, Long> createDiskOnlyVMSnapshotOfStoppedVm(List<Pair<VolumeObjectTO, String>> volumeTosAndNewPaths, String vmName) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -610,7 +610,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     public static final String CGROUP_V2 = "cgroup2fs";
 
-    public static final String AGENT_IS_NOT_CONNECTED = "QEMU guest agent is not connected";
+    public static final Integer AGENT_UNRESPONSIVE_ERROR_ORDINAL = 86;
 
     /**
      * Virsh command to merge (blockcommit) snapshot into the base file.<br><br>
@@ -7185,7 +7185,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } catch (LibvirtException e) {
             String errorMsg = String.format("Creation of disk-only VM snapshot for VM [%s] failed due to %s.", vmName, e.getMessage());
             boolean isVmConsistent = false;
-            if (e.getMessage().contains(AGENT_IS_NOT_CONNECTED)) {
+            if (AGENT_UNRESPONSIVE_ERROR_ORDINAL.equals(e.getError().getCode().ordinal())) {
                 errorMsg = "QEMU guest agent is not connected. If the VM has been recently started, it might connect soon. Otherwise the VM does not have the" +
                         " guest agent installed; thus the QuiesceVM parameter is not supported.";
                 isVmConsistent = true;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtValidateKbossVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtValidateKbossVmCommandWrapper.java
@@ -92,7 +92,7 @@ public class LibvirtValidateKbossVmCommandWrapper extends CommandWrapper<Validat
                     return true;
                 }
             } catch (LibvirtException ex) {
-                if (!LibvirtComputingResource.AGENT_UNRESPONSIVE_ERROR_ORDINAL.equals(ex.getError().getCode().ordinal())) {
+                if (!LibvirtComputingResource.isGuestAgentUnresponsive(ex)) {
                     logger.error("Got an unexpected Libvirt Exception, giving up on validating VM [{}].", vm.getName(), ex);
                     throw ex;
                 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtValidateKbossVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtValidateKbossVmCommandWrapper.java
@@ -92,7 +92,7 @@ public class LibvirtValidateKbossVmCommandWrapper extends CommandWrapper<Validat
                     return true;
                 }
             } catch (LibvirtException ex) {
-                if (!ex.getMessage().contains(LibvirtComputingResource.AGENT_IS_NOT_CONNECTED)) {
+                if (!LibvirtComputingResource.AGENT_UNRESPONSIVE_ERROR_ORDINAL.equals(ex.getError().getCode().ordinal())) {
                     logger.error("Got an unexpected Libvirt Exception, giving up on validating VM [{}].", vm.getName(), ex);
                     throw ex;
                 }


### PR DESCRIPTION
### Description

When a backup fails because connection with the VM's guest agent failed, the VM remains consistent, therefore, there is no need to place it in the `BackupError` state. This validation, however is done by verifying the error message sent by Libvirt, which can be different on older versions. It also does not cover every case of Guest Agent connection failures, as Libvirt's code contains multiple places where this error is thrown, with different messages.

This PR changes this validation to use the errors enum instead of the message, to avoid these issues.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I disabled the Guest Agent on the VM and tried creating a backup, and verified that the backup failed but the VM was no placed in the  `BackupError` state. 
