### PR TITLE
Packaging: accept normalized Marvin archive names

### DIFF
--- a/debian/cloudstack-marvin.install
+++ b/debian/cloudstack-marvin.install
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/usr/share/cloudstack-marvin/Marvin*.tar.gz
+/usr/share/cloudstack-marvin/[Mm]arvin*.tar.gz

--- a/debian/cloudstack-marvin.install
+++ b/debian/cloudstack-marvin.install
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/usr/share/cloudstack-marvin/[Mm]arvin*.tar.gz
+/usr/share/cloudstack-marvin/[Mm]arvin-*.tar.gz

--- a/debian/cloudstack-marvin.postinst
+++ b/debian/cloudstack-marvin.postinst
@@ -20,4 +20,4 @@
 set -e
 
 python3 -m pip install --upgrade pip
-python3 -m pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
+python3 -m pip install --upgrade /usr/share/cloudstack-marvin/[Mm]arvin-*.tar.gz

--- a/debian/rules
+++ b/debian/rules
@@ -177,7 +177,7 @@ override_dh_auto_install:
 
 	# cloudstack-marvin
 	mkdir -p $(DESTDIR)/usr/share/$(PACKAGE)-marvin
-	cp tools/marvin/dist/Marvin-*.tar.gz $(DESTDIR)/usr/share/$(PACKAGE)-marvin/
+	cp tools/marvin/dist/[Mm]arvin-*.tar.gz $(DESTDIR)/usr/share/$(PACKAGE)-marvin/
 
 	# cloudstack-integration-tests
 	mkdir -p $(DESTDIR)/usr/share/$(PACKAGE)-integration-tests

--- a/packaging/el8/cloud.spec
+++ b/packaging/el8/cloud.spec
@@ -392,7 +392,7 @@ install -D usage/target/transformed/cloudstack-usage.logrotate ${RPM_BUILD_ROOT}
 
 # Marvin
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-marvin
-cp tools/marvin/dist/Marvin-*.tar.gz ${RPM_BUILD_ROOT}%{_datadir}/%{name}-marvin/
+cp tools/marvin/dist/[Mm]arvin-*.tar.gz ${RPM_BUILD_ROOT}%{_datadir}/%{name}-marvin/
 
 # integration-tests
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-integration-tests
@@ -601,7 +601,7 @@ fi
 
 %post marvin
 pip3 install --upgrade https://files.pythonhosted.org/packages/08/1f/42d74bae9dd6dcfec67c9ed0f3fa482b1ae5ac5f117ca82ab589ecb3ca19/mysql_connector_python-8.0.31-py2.py3-none-any.whl
-pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
+pip3 install --upgrade /usr/share/cloudstack-marvin/[Mm]arvin-*.tar.gz
 
 #No default permission as the permission setup is complex
 %files management
@@ -711,7 +711,7 @@ pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 %{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
 
 %files marvin
-%attr(0644,root,root) %{_datadir}/%{name}-marvin/Marvin*.tar.gz
+%attr(0644,root,root) %{_datadir}/%{name}-marvin/[Mm]arvin-*.tar.gz
 %{_defaultdocdir}/%{name}-marvin-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-marvin-%{version}/NOTICE
 

--- a/packaging/suse15/cloud.spec
+++ b/packaging/suse15/cloud.spec
@@ -390,7 +390,7 @@ install -D usage/target/transformed/cloudstack-usage.logrotate ${RPM_BUILD_ROOT}
 
 # Marvin
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-marvin
-cp tools/marvin/dist/Marvin-*.tar.gz ${RPM_BUILD_ROOT}%{_datadir}/%{name}-marvin/
+cp tools/marvin/dist/[Mm]arvin-*.tar.gz ${RPM_BUILD_ROOT}%{_datadir}/%{name}-marvin/
 
 # integration-tests
 mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-integration-tests
@@ -599,7 +599,7 @@ fi
 
 %post marvin
 pip3 install --upgrade https://files.pythonhosted.org/packages/08/1f/42d74bae9dd6dcfec67c9ed0f3fa482b1ae5ac5f117ca82ab589ecb3ca19/mysql_connector_python-8.0.31-py2.py3-none-any.whl
-pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
+pip3 install --upgrade /usr/share/cloudstack-marvin/[Mm]arvin-*.tar.gz
 
 #No default permission as the permission setup is complex
 %files management
@@ -709,7 +709,7 @@ pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 %{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
 
 %files marvin
-%attr(0644,root,root) %{_datadir}/%{name}-marvin/Marvin*.tar.gz
+%attr(0644,root,root) %{_datadir}/%{name}-marvin/[Mm]arvin-*.tar.gz
 %{_defaultdocdir}/%{name}-marvin-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-marvin-%{version}/NOTICE
 


### PR DESCRIPTION
## Summary

Setuptools 69.3.0 introduced PEP 625-compliant normalization of
source-distribution filenames.

Although the Python project is declared as `name="Marvin"`, current
Setuptools versions produce:

    marvin-<version>.tar.gz

Older versions may still produce:

    Marvin-<version>.tar.gz

Update the Debian packaging consumers to match `[Mm]arvin-*.tar.gz`,
allowing both forms to remain supported.

This only changes archive discovery during packaging and installation.
It does not alter the Marvin archive contents or CloudStack runtime
behaviour.

still need review
packaging/el8/cloud.spec
packaging/suse15/cloud.spec
tools/marvin/pom.xml

will tighten patterns