### PR TITLE
UI: expose network ACL replacement from VPC tiers

### DIFF
--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -56,6 +56,12 @@
                 <router-link :to="{ path: '/acllist/' + network.aclid }">
                   {{ network.aclname }}
                 </router-link>
+                <tooltip-button
+                  :tooltip="$t('label.replace.acl')"
+                  icon="swap-outlined"
+                  size="small"
+                  :disabled="!('replaceNetworkACLList' in $store.getters.apis)"
+                  @onClick="() => handleOpenReplaceAclAction(network)" />
               </div>
             </div>
           </div>
@@ -368,14 +374,17 @@ import { ref, reactive, toRaw } from 'vue'
 import { postAPI, getAPI } from '@/api'
 import { mixinForm } from '@/utils/mixin'
 import Status from '@/components/widgets/Status'
+import TooltipButton from '@/components/widgets/TooltipButton'
 import TooltipLabel from '@/components/widgets/TooltipLabel'
 import { getNetmaskFromCidr } from '@/utils/network'
+import eventBus from '@/config/eventBus'
 
 export default {
   name: 'VpcTiersTab',
   mixins: [mixinForm],
   components: {
     Status,
+    TooltipButton,
     TooltipLabel
   },
   props: {
@@ -723,6 +732,39 @@ export default {
         acl: [{ required: true, message: this.$t('label.required') }],
         vlan: [{ required: true, message: this.$t('message.please.enter.value') }]
       }
+    },
+    handleOpenReplaceAclAction (network) {
+      const action = this.$router.resolve({ path: '/guestnetwork/' + network.id })
+        .meta.actions?.find(candidate => candidate.dataView && candidate.api === 'replaceNetworkACLList')
+      const apis = this.$store.getters.apis
+      const tierResource = { ...network, vpcid: network.vpcid || this.resource.id }
+      const aclMapping = action?.mapping?.aclid
+      const networkMapping = action?.mapping?.networkid
+      if (!action || !(action.api in apis) ||
+        typeof aclMapping?.params !== 'function' ||
+        typeof networkMapping?.value !== 'function' ||
+        (action.show && !action.show(tierResource, this.$store.getters)) ||
+        (action.disabled && action.disabled(tierResource, this.$store.getters))) {
+        return
+      }
+      eventBus.emit('exec-action', {
+        action: {
+          ...action,
+          resource: this.resource,
+          mapping: {
+            ...action.mapping,
+            aclid: {
+              ...aclMapping,
+              params: aclMapping.params.bind(null, tierResource)
+            },
+            networkid: {
+              ...networkMapping,
+              value: networkMapping.value.bind(null, tierResource)
+            }
+          }
+        },
+        isGroupAction: false
+      })
     },
     handleAddInternalLB (id) {
       this.initForm()

--- a/ui/tests/unit/views/network/VpcTiersTab.spec.js
+++ b/ui/tests/unit/views/network/VpcTiersTab.spec.js
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { flushPromises, shallowMount } from '@vue/test-utils'
+
+import mockAxios from '../../../mock/mockAxios'
+import common from '../../../common'
+import eventBus from '@/config/eventBus'
+import TooltipButton from '@/components/widgets/TooltipButton'
+import VpcTiersTab from '@/views/network/VpcTiersTab'
+
+jest.mock('axios', () => mockAxios)
+jest.mock('@/vue-app', () => ({
+  vueProps: {
+    $localStorage: {
+      get: jest.fn(() => null)
+    }
+  }
+}))
+
+const networkSection = require('@/config/section/network').default
+
+const vpc = {
+  id: 'vpc-id',
+  zoneid: 'zone-id',
+  vpcofferingid: 'vpc-offering-id',
+  service: [],
+  network: [{
+    id: 'tier-id',
+    zoneid: 'zone-id',
+    networkofferingid: 'network-offering-id',
+    name: 'tier',
+    state: 'Implemented',
+    cidr: '10.0.0.0/24',
+    aclid: 'acl-id',
+    aclname: 'ACL',
+    service: []
+  }]
+}
+
+const registeredReplaceAction = networkSection.children
+  .find(section => section.name === 'guestnetwork')
+  .actions.find(action => action.api === 'replaceNetworkACLList')
+
+const createReplaceAction = (overrides = {}) => ({
+  ...registeredReplaceAction,
+  ...overrides
+})
+
+const createWrapper = ({ permission = true, action = createReplaceAction() } = {}) => {
+  const store = common.createMockStore({
+    user: {
+      apis: permission ? { replaceNetworkACLList: {} } : {},
+      info: {}
+    }
+  })
+  const router = {
+    resolve: jest.fn(() => ({
+      meta: { actions: action ? [action] : [] }
+    }))
+  }
+  const wrapper = shallowMount(VpcTiersTab, {
+    props: { resource: vpc },
+    global: {
+      renderStubDefaultSlot: true,
+      plugins: [store],
+      mocks: {
+        $t: key => key,
+        $route: { path: '/vpc/vpc-id', query: {}, params: {} },
+        $router: router,
+        $notifyError: jest.fn()
+      },
+      provide: {
+        parentFetchData: jest.fn()
+      }
+    }
+  })
+  return { wrapper, router }
+}
+
+const findReplaceButton = wrapper => wrapper.findAllComponents(TooltipButton)
+  .find(button => button.props('tooltip') === 'label.replace.acl')
+
+describe('VPC tier ACL action reuse', () => {
+  let execAction
+
+  beforeEach(() => {
+    execAction = jest.fn()
+    eventBus.on('exec-action', execAction)
+    mockAxios.mockReset()
+    mockAxios.mockImplementation(request => {
+      switch (request.params?.command) {
+        case 'listZones':
+          return Promise.resolve({ listzonesresponse: { zone: [{}] } })
+        case 'listVPCOfferings':
+          return Promise.resolve({ listvpcofferingsresponse: { vpcoffering: [{}] } })
+        case 'listLoadBalancers':
+          return Promise.resolve({ listloadbalancersresponse: { loadbalancer: [], count: 0 } })
+        case 'listVirtualMachines':
+          return Promise.resolve({ listvirtualmachinesresponse: { virtualmachine: [], count: 0 } })
+        case 'listNetworkOfferings':
+          return Promise.resolve({ listnetworkofferingsresponse: { networkoffering: [{ supportsinternallb: false }] } })
+        case 'listNetworks':
+          return Promise.resolve({ listnetworksresponse: { network: [] } })
+        default:
+          return Promise.resolve({})
+      }
+    })
+  })
+
+  afterEach(() => {
+    eventBus.off('exec-action', execAction)
+  })
+
+  it('dispatches the existing registered action with tier-specific mappings', async () => {
+    const registeredAction = createReplaceAction()
+    const originalAclParams = registeredAction.mapping.aclid.params
+    const originalNetworkValue = registeredAction.mapping.networkid.value
+    const { wrapper, router } = createWrapper({ action: registeredAction })
+    await flushPromises()
+
+    const replaceButton = findReplaceButton(wrapper)
+    expect(replaceButton).toBeDefined()
+    expect(replaceButton.props('disabled')).toBe(false)
+
+    mockAxios.mockClear()
+    replaceButton.vm.$emit('onClick')
+    await wrapper.vm.$nextTick()
+
+    expect(router.resolve).toHaveBeenCalledWith({ path: '/guestnetwork/tier-id' })
+    expect(execAction).toHaveBeenCalledTimes(1)
+    const payload = execAction.mock.calls[0][0]
+    expect(payload.isGroupAction).toBe(false)
+    expect(payload.action.api).toBe('replaceNetworkACLList')
+    expect(payload.action).not.toBe(registeredAction)
+    expect(payload.action.resource).toEqual(vpc)
+    expect(payload.action.resource.id).toBe('vpc-id')
+    expect(payload.action.mapping).not.toBe(registeredAction.mapping)
+    expect(payload.action.mapping.aclid.params(payload.action.resource)).toEqual({ vpcid: 'vpc-id' })
+    expect(payload.action.mapping.networkid.value(payload.action.resource)).toBe('tier-id')
+    expect(payload.action.mapping.aclid.params).not.toBe(originalAclParams)
+    expect(payload.action.mapping.networkid.value).not.toBe(originalNetworkValue)
+    expect(registeredAction.mapping.aclid.params).toBe(originalAclParams)
+    expect(registeredAction.mapping.networkid.value).toBe(originalNetworkValue)
+    expect(mockAxios).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('keeps the shortcut disabled and does not dispatch without API permission', async () => {
+    const { wrapper } = createWrapper({ permission: false })
+    await flushPromises()
+
+    const replaceButton = findReplaceButton(wrapper)
+    expect(replaceButton).toBeDefined()
+    expect(replaceButton.props('disabled')).toBe(true)
+
+    wrapper.vm.handleOpenReplaceAclAction(vpc.network[0])
+    expect(execAction).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it.each([
+    ['missing', null],
+    ['hidden', createReplaceAction({ show: () => false })],
+    ['disabled', createReplaceAction({ disabled: () => true })],
+    ['non-data-view', createReplaceAction({ dataView: false })],
+    ['ACL mapping without parameters', createReplaceAction({
+      mapping: {
+        ...registeredReplaceAction.mapping,
+        aclid: { api: 'listNetworkACLLists' }
+      }
+    })],
+    ['network mapping without a value', createReplaceAction({
+      mapping: {
+        ...registeredReplaceAction.mapping,
+        networkid: {}
+      }
+    })]
+  ])('does not dispatch a %s registered action', async (name, action) => {
+    const { wrapper } = createWrapper({ action })
+    await flushPromises()
+
+    wrapper.vm.handleOpenReplaceAclAction(vpc.network[0])
+    expect(execAction).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Expose the existing `replaceNetworkACLList` action beside each ACL in the VPC tiers overview.

This is an additional entry point to the existing guest-network action. It does not add another modal, form, API call, async-job poller, refresh path, or notification path.

## Implementation

- Resolve the registered guest-network `replaceNetworkACLList` action from router metadata.
- Reuse its existing arguments, ACL-list mapping, submission, async-job polling, refresh, notification, and documentation behavior.
- Bind the registered ACL and network mapping functions to the selected tier.
- Keep the parent VPC as the action view resource so opening the action does not replace the VPC detail page resource with a tier.
- Fail closed when the API permission, registered action, visibility/disabled policy, or required mappings are unavailable.
- Leave the existing replace-ACL action on the tier detail page unchanged.

## Scope

- UI-only change for the current `main` development line (`4.23.0.0-SNAPSHOT`).
- No linked issue; this is a UI enhancement.
- No server, API, schema, ACL-semantics, dependency, workflow, or CI configuration changes.
- No new translation keys.

## Validation

Validated locally on candidate `0c36798508e655a7ee3cd1ee6f6ba7b8c57b31ac` with Node.js 16.20.2 and the committed lockfile:

- Focused suite: 1 suite, 8 tests passed, 0 snapshots.
- Full UI unit suite: 5 suites, 183 tests passed, 0 snapshots.
- Full UI lint: no errors.
- Production UI build: completed successfully; only the repository's existing bundle-size warnings were reported.
- `git diff --check`: clean.
- Merge-tree check against Apache GitBox `main` at `dd3427d91401f820ba5746403696a6146ab42328`: conflict-free.
- Controlled fault: binding `networkid` to the parent VPC instead of the selected tier failed for the intended reason (`tier-id` expected, `vpc-id` received), then passed after restoring the canonical tier binding.

## UI QA

- UI QA build passed: `QA-JID-975`.
- Live QA environment: https://qa.cloudstack.cloud/simulator/pr/13794
- Verified in a headed Google Chrome session through VPC -> Admin VPC -> Networks.
- Confirmed the shortcut appears beside each tier ACL, displays the `Replace ACL` tooltip, opens the existing canonical replacement form, and loads ACL choices scoped to the selected VPC.
- Cancelled without submitting an infrastructure mutation; the simulator baseline remained unchanged.

![VPC tiers overview with the ACL replacement shortcut](https://github.com/user-attachments/assets/41a4aedb-5af7-4529-9c45-5200519d0523)

## Current candidate

- PR/fork head: `0c36798508e655a7ee3cd1ee6f6ba7b8c57b31ac`
- Target: Apache CloudStack `main` at `dd3427d91401f820ba5746403696a6146ab42328`
- Exact range: `dd3427d91401f820ba5746403696a6146ab42328..0c36798508e655a7ee3cd1ee6f6ba7b8c57b31ac`
- One commit, two intended files, clean worktree, conflict-free merge-tree.
