### PR TITLE
wip: systemvm: enable IPv6 link-local on the control network

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -743,6 +743,7 @@ public class ApiConstants {
     public static final String LINMIN_APID = "linminapid";
     public static final String DHCP_SERVER_TYPE = "dhcpservertype";
     public static final String LINK_LOCAL_IP = "linklocalip";
+    public static final String LINK_LOCAL_IP6 = "linklocalip6";
     public static final String LINK_LOCAL_MAC_ADDRESS = "linklocalmacaddress";
     public static final String LINK_LOCAL_MAC_NETMASK = "linklocalnetmask";
     public static final String LINK_LOCAL_NETWORK_ID = "linklocalnetworkid";

--- a/api/src/main/java/org/apache/cloudstack/api/response/SystemVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SystemVmResponse.java
@@ -106,6 +106,10 @@ public class SystemVmResponse extends BaseResponseWithAnnotations {
     @Param(description = "The Control IP address for the System VM")
     private String linkLocalIp;
 
+    @SerializedName(ApiConstants.LINK_LOCAL_IP6)
+    @Param(description = "The Control IPv6 link-local address for the System VM, calculated from the link local MAC address", since = "4.23.0")
+    private String linkLocalIp6;
+
     @SerializedName(ApiConstants.LINK_LOCAL_MAC_ADDRESS)
     @Param(description = "The link local MAC address for the System VM")
     private String linkLocalMacAddress;
@@ -425,6 +429,14 @@ public class SystemVmResponse extends BaseResponseWithAnnotations {
 
     public void setLinkLocalIp(String linkLocalIp) {
         this.linkLocalIp = linkLocalIp;
+    }
+
+    public String getLinkLocalIp6() {
+        return linkLocalIp6;
+    }
+
+    public void setLinkLocalIp6(String linkLocalIp6) {
+        this.linkLocalIp6 = linkLocalIp6;
     }
 
     public String getLinkLocalMacAddress() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -510,6 +510,7 @@ public class BridgeVifDriver extends VifDriverBase {
             Script.runSimpleBashScript("ip link set " + privBrName + " up");
             Script.runSimpleBashScript("ip address add " + NetUtils.getLinkLocalAddressFromCIDR(_controlCidr) + " dev " + privBrName);
         }
+        enableBridgeIpv6LinkLocal(privBrName);
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/IvsVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/IvsVifDriver.java
@@ -279,6 +279,7 @@ public class IvsVifDriver extends VifDriverBase {
             Script.runSimpleBashScript("ip link add " + privBrName + " type bridge; ip link set " + privBrName + " up");
             Script.runSimpleBashScript("ip address add " + NetUtils.getLinkLocalAddressFromCIDR(_controlCidr) + " dev " + privBrName, _timeout);
         }
+        enableBridgeIpv6LinkLocal(privBrName);
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/OvsVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/OvsVifDriver.java
@@ -250,6 +250,7 @@ public class OvsVifDriver extends VifDriverBase {
         if (!isExistingBridge(privBrName)) {
             Script.runSimpleBashScript("ovs-vsctl add-br " + privBrName + "; ip link set " + privBrName + " up; ip address add " + NetUtils.getLinkLocalAddressFromCIDR(_controlCidr) + " dev " + privBrName, _timeout);
         }
+        enableBridgeIpv6LinkLocal(privBrName);
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
@@ -31,6 +31,7 @@ import org.libvirt.LibvirtException;
 
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.exception.InternalErrorException;
+import com.cloud.utils.script.Script;
 
 public abstract class VifDriverBase implements VifDriver {
 
@@ -79,6 +80,18 @@ public abstract class VifDriverBase implements VifDriver {
 
     public boolean isExistingBridge(String bridgeName) {
         return false;
+    }
+
+    /**
+     * Enable IPv6 on the control network bridge so the host can reach the
+     * IPv6 link-local address system VMs listen on. Only link-local is wanted,
+     * so Router Advertisements and SLAAC are disabled on the bridge.
+     */
+    protected void enableBridgeIpv6LinkLocal(String bridgeName) {
+        logger.info("Enabling IPv6 link-local on bridge {}", bridgeName);
+        Script.runSimpleBashScript("sysctl -qw net.ipv6.conf." + bridgeName + ".accept_ra=0" +
+                " net.ipv6.conf." + bridgeName + ".autoconf=0" +
+                " net.ipv6.conf." + bridgeName + ".disable_ipv6=0");
     }
 
     protected static int getNetworkRateKbps(NicTO nic) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1886,6 +1886,9 @@ public class ApiResponseHelper implements ResponseGenerator, ResourceIdSupport {
                         vmResponse.setLinkLocalIp(singleNicProfile.getIPv4Address());
                         vmResponse.setLinkLocalMacAddress(singleNicProfile.getMacAddress());
                         vmResponse.setLinkLocalNetmask(singleNicProfile.getIPv4Netmask());
+                        if (singleNicProfile.getMacAddress() != null) {
+                            vmResponse.setLinkLocalIp6(NetUtils.ipv6LinkLocal(singleNicProfile.getMacAddress()).toString());
+                        }
                     } else if (network.getTrafficType() == TrafficType.Public) {
                         vmResponse.setPublicIp(singleNicProfile.getIPv4Address());
                         vmResponse.setPublicMacAddress(singleNicProfile.getMacAddress());

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -232,6 +232,10 @@ class CsNetfilters(object):
         if hook == "input" or hook == "output":
             CsHelper.execute("nft add rule %s %s %s icmpv6 type { echo-request, echo-reply, \
                 nd-neighbor-solicit, nd-router-advert, nd-neighbor-advert } accept" % (address_family, table, chain))
+        if hook == "input":
+            # sshd listens on the IPv6 link-local address of the control interface,
+            # only allow this over link-local so no global address can reach it
+            CsHelper.execute("nft add rule %s %s %s ip6 saddr fe80::/10 ip6 daddr fe80::/10 tcp dport 3922 accept" % (address_family, table, chain))
         if hook == "input" or hook == "forward":
             CsHelper.execute("nft add rule %s %s %s ct state established,related accept" % (address_family, table, chain))
 

--- a/systemvm/debian/opt/cloud/bin/setup/common.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/common.sh
@@ -573,10 +573,42 @@ setup_dnsmasq() {
   fi
 }
 
+enable_ipv6_link_local() {
+  local eth=$1
+  log_it "Enabling IPv6 link-local on interface $eth"
+  # Generate the link-local address with EUI-64 based on the MAC address so
+  # the address can be calculated by the Management Server
+  sysctl -w net.ipv6.conf.${eth}.addr_gen_mode=0
+  # Only a link-local address is wanted, no SLAAC/RA configuration
+  sysctl -w net.ipv6.conf.${eth}.accept_ra=0
+  sysctl -w net.ipv6.conf.${eth}.autoconf=0
+  sysctl -w net.ipv6.conf.${eth}.disable_ipv6=0
+
+  # Wait for Duplicate Address Detection to complete so the address can be bound
+  LINK_LOCAL_IP6=""
+  local i
+  for i in $(seq 1 10); do
+    LINK_LOCAL_IP6=$(ip -6 addr show dev ${eth} scope link -tentative | grep -Po '(?<=inet6 )fe80:[0-9a-f:]+' | head -1)
+    [ -n "$LINK_LOCAL_IP6" ] && break
+    sleep 1
+  done
+
+  if [ -n "$LINK_LOCAL_IP6" ]; then
+    log_it "Interface $eth has IPv6 link-local address $LINK_LOCAL_IP6"
+  else
+    log_it "No IPv6 link-local address appeared on interface $eth"
+  fi
+}
+
 setup_sshd(){
   local ip=$1
   local eth=$2
-  [ -f /etc/ssh/sshd_config ] && sed -i -e "s/^[#]*ListenAddress.*$/ListenAddress $ip/" /etc/ssh/sshd_config
+  [ -f /etc/ssh/sshd_config ] && sed -i -e "/^ListenAddress fe80/d" -e "s/^[#]*ListenAddress.*$/ListenAddress $ip/" /etc/ssh/sshd_config
+  enable_ipv6_link_local $eth
+  if [ -n "$LINK_LOCAL_IP6" ]; then
+    log_it "Configuring sshd to also listen on ${LINK_LOCAL_IP6}%${eth}"
+    sed -i -e "/^ListenAddress $ip$/a ListenAddress ${LINK_LOCAL_IP6}%${eth}" /etc/ssh/sshd_config
+  fi
   sed -i "/3922/s/eth./$eth/" /etc/iptables/rules.v4
 }
 

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1599,6 +1599,7 @@
 "label.link": "Link",
 "label.link.domain.to.ldap": "Link domain to LDAP",
 "label.linklocalip": "Link-local/Control IP address",
+"label.linklocalip6": "Link-local/Control IPv6 address",
 "label.linux": "Linux",
 "label.list.ciscoasa1000v": "ASA 1000v",
 "label.list.ciscovnmc": "Cisco VNMC",

--- a/ui/src/config/section/infra/systemVms.js
+++ b/ui/src/config/section/infra/systemVms.js
@@ -25,8 +25,8 @@ export default {
   docHelp: 'adminguide/systemvm.html',
   permission: ['listSystemVms'],
   searchFilters: ['name', 'zoneid', 'podid', 'hostid', 'systemvmtype', 'storageid', 'arch'],
-  columns: ['name', 'state', 'agentstate', 'systemvmtype', 'publicip', 'privateip', 'linklocalip', 'version', 'hostname', 'arch', 'zonename'],
-  details: ['name', 'id', 'agentstate', 'systemvmtype', 'publicip', 'privateip', 'linklocalip', 'gateway', 'hostname', 'arch', 'version', 'zonename', 'created', 'activeviewersessions', 'isdynamicallyscalable', 'hostcontrolstate', 'storageip'],
+  columns: ['name', 'state', 'agentstate', 'systemvmtype', 'publicip', 'privateip', 'linklocalip', 'linklocalip6', 'version', 'hostname', 'arch', 'zonename'],
+  details: ['name', 'id', 'agentstate', 'systemvmtype', 'publicip', 'privateip', 'linklocalip', 'linklocalip6', 'gateway', 'hostname', 'arch', 'version', 'zonename', 'created', 'activeviewersessions', 'isdynamicallyscalable', 'hostcontrolstate', 'storageip'],
   resourceType: 'SystemVm',
   filters: () => {
     const filters = ['starting', 'running', 'stopping', 'stopped', 'destroyed', 'expunging', 'migrating', 'error', 'unknown', 'shutdown']


### PR DESCRIPTION
### Description

This PR enables IPv6 link-local addressing on the control (link-local) network of system VMs, alongside the existing 169.254.0.0/16 IPv4 addressing. With IPv6 explicitly enabled on the control network we can move our SSH commands (on at least KVM) to link local IPv6 and remove the 169.254.0.0/16 addressing in the future. That can significantly reduce the code-base inside CloudStack. That's not part of this PR yet.

The existing issue #9957 talks about this and this PR should be groundwork for that to be done in the future.

**System VM** (`common.sh`):
- The control NIC gets an IPv6 link-local address generated with EUI-64 (`addr_gen_mode=0`), so the address is deterministic and can be calculated from the NIC's MAC address
- Router Advertisements and SLAAC are disabled on the interface (`accept_ra=0`, `autoconf=0`); only the link-local address is configured
- `setup_sshd()` waits for Duplicate Address Detection to complete and adds a `ListenAddress fe80::...%ethX` entry to `sshd_config`, so sshd listens on both the IPv4 and IPv6 link-local addresses. The sed expressions are idempotent across reboots
- This works for all system VM types, as `setup_sshd()` is always handed the control interface (eth0 for CPVM/SSVM on KVM, eth1 for routers)

**Management Server / API**:
- `listSystemVms` now returns `linklocalip6`: the EUI-64 IPv6 link-local address calculated from the control NIC's MAC address using the existing (unit-tested) `NetUtils.ipv6LinkLocal()`. This performs the same U/L-bit flip + `ff:fe` expansion the kernel does, so the reported address always matches what the system VM configures
- New response field on `SystemVmResponse` (`since 4.23.0`)

**KVM agent**:
- When the control network is set up, the agent now enables IPv6 (link-local only, no RA/SLAAC) on the control bridge (`cloud0`) via a shared `enableBridgeIpv6LinkLocal()` helper in `VifDriverBase`, called from `BridgeVifDriver`, `OvsVifDriver` and `IvsVifDriver`
- This runs unconditionally on agent start, so hosts with a pre-existing `cloud0` bridge also get IPv6 enabled on it
- With this, the host can reach system VMs over the control network with e.g. `ssh -6 -p 3922 fe80::...%cloud0`

**UI**:
- The System VMs list and detail views show the new "Link-local/Control IPv6 address" field

This is a first step towards using IPv6 link-local instead of 169.254.0.0/16 on the control network. The Management Server still provisions system VMs over IPv4; nothing changes for existing deployments.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

- `api`, `server` and `plugins/hypervisors/kvm` compile cleanly
- `bash -n` on `common.sh`
- `NetUtils.ipv6LinkLocal()` is covered by existing unit tests in `NetUtilsTest` (`testIpv6LinkLocal`), verifying the EUI-64 calculation matches the kernel's