### PR TITLE
Add missing project cleanups while deleting/moving user

### DIFF
--- a/api/src/main/java/com/cloud/projects/ProjectService.java
+++ b/api/src/main/java/com/cloud/projects/ProjectService.java
@@ -23,6 +23,7 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.projects.ProjectAccount.Role;
 import com.cloud.user.Account;
+import com.cloud.user.User;
 
 public interface ProjectService {
     /**
@@ -102,4 +103,5 @@ public interface ProjectService {
 
     boolean addUserToProject(Long projectId, String username, String email, Long projectRoleId, Role projectRole) throws ResourceAllocationException;
 
+    void moveProjectAssociationsToUser(User oldUser, User newUser) throws ResourceAllocationException;
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/user/MoveUserCmd.java
@@ -18,6 +18,7 @@ package org.apache.cloudstack.api.command.admin.user;
 
 import javax.inject.Inject;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandResourceType;
@@ -112,7 +113,7 @@ public class MoveUserCmd extends BaseCmd {
     }
 
     @Override
-    public void execute() {
+    public void execute() throws ResourceAllocationException {
         Preconditions.checkNotNull(getId(),"I have to have an user to move!");
         Preconditions.checkState(ObjectUtils.anyNotNull(getAccountId(),getAccountName()),"provide either an account name or an account id!");
 

--- a/api/src/main/java/org/apache/cloudstack/region/RegionService.java
+++ b/api/src/main/java/org/apache/cloudstack/region/RegionService.java
@@ -18,6 +18,7 @@ package org.apache.cloudstack.region;
 
 import java.util.List;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.apache.cloudstack.api.command.admin.account.DeleteAccountCmd;
 import org.apache.cloudstack.api.command.admin.account.DisableAccountCmd;
 import org.apache.cloudstack.api.command.admin.account.EnableAccountCmd;
@@ -116,7 +117,7 @@ public interface RegionService {
      * @param moveUserCmd
      * @return true if delete was successful, false otherwise
      */
-    boolean moveUser(MoveUserCmd moveUserCmd);
+    boolean moveUser(MoveUserCmd moveUserCmd) throws ResourceAllocationException;
 
     /**
      * update an existing domain

--- a/engine/schema/src/main/java/com/cloud/projects/ProjectAccountVO.java
+++ b/engine/schema/src/main/java/com/cloud/projects/ProjectAccountVO.java
@@ -110,6 +110,10 @@ public class ProjectAccountVO implements ProjectAccount, InternalIdentity {
         return projectAccountId;
     }
 
+    public void setAccountId(long accountId) {
+        this.accountId = accountId;
+    }
+
     public void setProjectRoleId(Long projectRoleId) {
         this.projectRoleId = projectRoleId;
     }

--- a/engine/schema/src/main/java/com/cloud/projects/ProjectInvitationVO.java
+++ b/engine/schema/src/main/java/com/cloud/projects/ProjectInvitationVO.java
@@ -102,6 +102,10 @@ public class ProjectInvitationVO implements ProjectInvitation {
         return forAccountId;
     }
 
+    public void setForAccountId(Long forAccountId) {
+        this.forAccountId = forAccountId;
+    }
+
     @Override
     public String getToken() {
         return token;

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.cloud.projects.ProjectAccount;
 import com.cloud.projects.ProjectAccountVO;
+import com.cloud.user.User;
 import com.cloud.utils.db.GenericDao;
 
 public interface ProjectAccountDao extends GenericDao<ProjectAccountVO, Long> {
@@ -54,4 +55,6 @@ public interface ProjectAccountDao extends GenericDao<ProjectAccountVO, Long> {
     List<ProjectAccountVO> listUsersOrAccountsByRole(long id);
 
     List<ProjectAccountVO> listBy(Long projectId, Long accountId, Long userId);
+
+    void move(User oldUser, User newUser);
 }

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
@@ -48,8 +48,6 @@ public interface ProjectAccountDao extends GenericDao<ProjectAccountVO, Long> {
 
     void removeAccountFromProjects(long accountId);
 
-    void removeUserFromProjects(long userId);
-
     boolean canUserModifyProject(long projectId, long accountId, long userId);
 
     List<ProjectAccountVO> listUsersOrAccountsByRole(long id);

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
@@ -52,4 +52,6 @@ public interface ProjectAccountDao extends GenericDao<ProjectAccountVO, Long> {
     boolean canUserModifyProject(long projectId, long accountId, long userId);
 
     List<ProjectAccountVO> listUsersOrAccountsByRole(long id);
+
+    List<ProjectAccountVO> listBy(Long projectId, Long accountId, Long userId);
 }

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
@@ -194,17 +194,6 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
     }
 
     @Override
-    public void removeUserFromProjects(long userId) {
-        SearchCriteria<ProjectAccountVO> sc = AllFieldsSearch.create();
-        sc.setParameters("userId", userId);
-
-        int removedCount = remove(sc);
-        if (removedCount > 0) {
-            logger.debug(String.format("Removed user [%s] from %s project(s).", userId, removedCount));
-        }
-    }
-
-    @Override
     public boolean canUserModifyProject(long projectId, long accountId, long userId) {
         SearchCriteria<ProjectAccountVO> sc = AllFieldsSearch.create();
         sc.setParameters("role",  ProjectAccount.Role.Admin);

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
@@ -18,6 +18,7 @@ package com.cloud.projects.dao;
 
 import java.util.List;
 
+import com.cloud.user.User;
 import org.springframework.stereotype.Component;
 
 import com.cloud.projects.ProjectAccount;
@@ -230,5 +231,15 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
         sc.setParametersIfNotNull("userId", userId);
         sc.setParametersIfNotNull("accountId", accountId);
         return listBy(sc);
+    }
+
+    @Override
+    public void move(User oldUser, User newUser) {
+        List<ProjectAccountVO> projectAccounts = listBy(null, oldUser.getAccountId(), oldUser.getId());
+        for (ProjectAccountVO projectAccount : projectAccounts) {
+            projectAccount.setAccountId(newUser.getAccountId());
+            projectAccount.setUserId(newUser.getId());
+            update(projectAccount.getId(), projectAccount);
+        }
     }
 }

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
@@ -222,4 +222,13 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
         sc.setParameters("projectRoleId", id);
         return listBy(sc);
     }
+
+    @Override
+    public List<ProjectAccountVO> listBy(Long projectId, Long accountId, Long userId) {
+        SearchCriteria<ProjectAccountVO> sc = AllFieldsSearch.create();
+        sc.setParametersIfNotNull("projectId", projectId);
+        sc.setParametersIfNotNull("userId", userId);
+        sc.setParametersIfNotNull("accountId", accountId);
+        return listBy(sc);
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDao.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.cloud.projects.ProjectInvitation.State;
 import com.cloud.projects.ProjectInvitationVO;
+import com.cloud.user.User;
 import com.cloud.utils.db.GenericDao;
 
 public interface ProjectInvitationDao extends GenericDao<ProjectInvitationVO, Long> {
@@ -45,4 +46,7 @@ public interface ProjectInvitationDao extends GenericDao<ProjectInvitationVO, Lo
 
     int removeBy(Long userId, Long accountId, Long projectId);
 
+    List<ProjectInvitationVO> listBy(Long projectId, Long accountId, Long userId);
+
+    void move(User oldUser, User newUser);
 }

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDao.java
@@ -43,4 +43,6 @@ public interface ProjectInvitationDao extends GenericDao<ProjectInvitationVO, Lo
 
     List<ProjectInvitationVO> listInvitationsToExpire(long timeOut);
 
+    int removeBy(Long userId, Long accountId, Long projectId);
+
 }

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDao.java
@@ -44,7 +44,7 @@ public interface ProjectInvitationDao extends GenericDao<ProjectInvitationVO, Lo
 
     List<ProjectInvitationVO> listInvitationsToExpire(long timeOut);
 
-    int removeBy(Long userId, Long accountId, Long projectId);
+    int removeBy(Long projectId, Long accountId, Long userId);
 
     List<ProjectInvitationVO> listBy(Long projectId, Long accountId, Long userId);
 

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
@@ -125,6 +125,19 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
     }
 
     @Override
+    public int removeBy(Long userId, Long accountId, Long projectId) {
+        SearchCriteria<ProjectInvitationVO> sc = AllFieldsSearch.create();
+
+        sc.setParametersIfNotNull("userId", userId);
+        sc.setParametersIfNotNull("accountId", accountId);
+        if (projectId != null && projectId != -1) {
+            sc.setParameters("projectId", projectId);
+        }
+
+        return remove(sc);
+    }
+
+    @Override
     public boolean isActive(long id, long timeout) {
         SearchCriteria<ProjectInvitationVO> sc = InactiveSearch.create();
 

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
@@ -19,6 +19,7 @@ package com.cloud.projects.dao;
 import java.sql.Date;
 import java.util.List;
 
+import com.cloud.user.User;
 import org.springframework.stereotype.Component;
 
 import com.cloud.projects.ProjectInvitation.State;
@@ -126,6 +127,27 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
 
     @Override
     public int removeBy(Long userId, Long accountId, Long projectId) {
+        SearchCriteria<ProjectInvitationVO> sc = prepareAllFieldsSearchCriteria(projectId, accountId, userId);
+        return remove(sc);
+    }
+
+    @Override
+    public List<ProjectInvitationVO> listBy(Long projectId, Long accountId, Long userId) {
+        SearchCriteria<ProjectInvitationVO> sc = prepareAllFieldsSearchCriteria(projectId, accountId, userId);
+        return listBy(sc);
+    }
+
+    @Override
+    public void move(User oldUser, User newUser) {
+        List<ProjectInvitationVO> projectInvitations = listBy(null, oldUser.getAccountId(), oldUser.getId());
+        for (ProjectInvitationVO projectInvitation : projectInvitations) {
+            projectInvitation.setForAccountId(newUser.getAccountId());
+            projectInvitation.setForUserId(newUser.getId());
+            update(projectInvitation.getId(), projectInvitation);
+        }
+    }
+
+    private SearchCriteria<ProjectInvitationVO> prepareAllFieldsSearchCriteria(Long projectId, Long accountId, Long userId) {
         SearchCriteria<ProjectInvitationVO> sc = AllFieldsSearch.create();
 
         sc.setParametersIfNotNull("userId", userId);
@@ -134,7 +156,7 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
             sc.setParameters("projectId", projectId);
         }
 
-        return remove(sc);
+        return sc;
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
@@ -126,7 +126,7 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
     }
 
     @Override
-    public int removeBy(Long userId, Long accountId, Long projectId) {
+    public int removeBy(Long projectId, Long accountId, Long userId) {
         SearchCriteria<ProjectInvitationVO> sc = prepareAllFieldsSearchCriteria(projectId, accountId, userId);
         return remove(sc);
     }

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42300-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42300-cleanup.sql
@@ -18,3 +18,6 @@
 --;
 -- Schema upgrade cleanup from 4.22.1.0 to 4.23.0.0
 --;
+
+-- Delete `project_account` entries for users that were removed
+DELETE FROM `cloud`.`project_account` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed`);

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42300-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42300-cleanup.sql
@@ -20,5 +20,5 @@
 --;
 
 -- Delete stale project association entries for users that were removed
-DELETE FROM `cloud`.`project_account` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed`);
-DELETE FROM `cloud`.`project_invitations` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed`);
+DELETE FROM `cloud`.`project_account` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed` IS NOT NULL);
+DELETE FROM `cloud`.`project_invitations` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed` IS NOT NULL);

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42300-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42300-cleanup.sql
@@ -19,5 +19,6 @@
 -- Schema upgrade cleanup from 4.22.1.0 to 4.23.0.0
 --;
 
--- Delete `project_account` entries for users that were removed
+-- Delete stale project association entries for users that were removed
 DELETE FROM `cloud`.`project_account` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed`);
+DELETE FROM `cloud`.`project_invitations` WHERE `user_id` IN (SELECT `id` FROM `cloud`.`user` WHERE `removed`);

--- a/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/LdapAuthenticator.java
+++ b/plugins/user-authenticators/ldap/src/main/java/org/apache/cloudstack/ldap/LdapAuthenticator.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.auth.UserAuthenticator;
 import org.apache.commons.collections.CollectionUtils;
@@ -170,7 +171,12 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
                         if (mappedAccount == null || mappedAccount.getRemoved() != null) {
                             throw new CloudRuntimeException("Mapped account for users does not exist. Please contact your administrator.");
                         }
-                        _accountManager.moveUser(userAccount.getId(), userAccount.getDomainId(), mappedAccount);
+                        try {
+                            _accountManager.moveUser(userAccount.getId(), userAccount.getDomainId(), mappedAccount);
+                        } catch (ResourceAllocationException e) {
+                            throw new CloudRuntimeException(String.format("Failed to move User [%s] to mapped Account [%s] due to insufficient Project limits.",
+                                    userAccount.getUsername(), mappedAccount.getAccountName()), e);
+                        }
                     }
                     // else { the user hasn't changed in ldap, the ldap group stayed the same, hurray, pass, fun thou self a lot of fun }
                 }

--- a/server/src/main/java/com/cloud/projects/ProjectManager.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManager.java
@@ -19,6 +19,7 @@ package com.cloud.projects;
 import java.util.List;
 
 import com.cloud.user.Account;
+import com.cloud.user.User;
 import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface ProjectManager extends ProjectService {
@@ -46,6 +47,8 @@ public interface ProjectManager extends ProjectService {
     boolean deleteProject(Account caller, long callerUserId, ProjectVO project);
 
     long getInvitationTimeout();
+
+    boolean cleanupProjectsForUser(Project project, User user);
 
     public static final String MESSAGE_CREATE_TUNGSTEN_PROJECT_EVENT = "Message.CreateTungstenProject.Event";
     public static final String MESSAGE_DELETE_TUNGSTEN_PROJECT_EVENT = "Message.DeleteTungstenProject.Event";

--- a/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
@@ -617,6 +617,37 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager, C
         }
     }
 
+    /**
+     * Transfers all project associations and project invitations from one user to another.
+     *
+     * @param oldUser the user whose project associations are being transferred
+     * @param newUser the user to whom the project associations are being transferred
+     * @throws ResourceAllocationException if there is an issue with allocating the required project resources to the new user
+     */
+    @Override
+    public void moveProjectAssociationsToUser(User oldUser, User newUser) throws ResourceAllocationException {
+        _projectInvitationDao.move(oldUser, newUser);
+
+        List<ProjectAccountVO> projectAccounts = _projectAccountDao.listBy(null, oldUser.getAccountId(), oldUser.getId());
+        if (projectAccounts.isEmpty()) {
+            return;
+        }
+
+        Account oldAccount = _accountDao.findById(oldUser.getAccountId());
+        Account newAccount = _accountDao.findById(newUser.getAccountId());
+        long requiredProjectsAmount = oldAccount.getId() != newAccount.getId()
+                ? projectAccounts.stream().filter(pa -> pa.getAccountRole() == ProjectAccount.Role.Admin).count()
+                : 0L;
+
+        try (CheckedReservation projectReservation = new CheckedReservation(newAccount, ResourceType.project, null, null, requiredProjectsAmount, reservationDao, _resourceLimitMgr)) {
+            _projectAccountDao.move(oldUser, newUser);
+            if (requiredProjectsAmount > 0) {
+                _resourceLimitMgr.incrementResourceCount(newAccount.getId(), ResourceType.project, requiredProjectsAmount);
+                _resourceLimitMgr.decrementResourceCount(oldAccount.getId(), ResourceType.project, requiredProjectsAmount);
+            }
+        }
+    }
+
     @Override
     public Project findByNameAndDomainId(String name, long domainId) {
         return _projectDao.findByNameAndDomain(name, domainId);
@@ -1056,7 +1087,7 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager, C
             long userId = user.getId();
             long accountId = user.getAccountId();
 
-            _projectInvitationDao.removeBy(projectId, userId, accountId);
+            _projectInvitationDao.removeBy(projectId, accountId, userId);
 
             List<ProjectAccountVO> projectAccounts = _projectAccountDao.listBy(projectId, accountId, userId);
             for (ProjectAccountVO projectAccount : projectAccounts) {
@@ -1064,23 +1095,11 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager, C
                 if (projectAccount.getAccountRole() == Role.Admin) {
                     _resourceLimitMgr.decrementResourceCount(accountId, ResourceType.project);
                 }
-                logger.debug("Removed user [{}] from project [{}].", user, project);
+                logger.debug("Removed user [{}] from project [{}].", user, projectAccount.getProjectId());
             }
 
             return !projectAccounts.isEmpty();
         });
-    }
-
-    private void deletePendingInvite(Long projectId, User user) {
-        ProjectInvitation invite = _projectInvitationDao.findByUserIdProjectId(user.getId(), user.getAccountId(),  projectId);
-        if (invite != null) {
-            boolean success = _projectInvitationDao.remove(invite.getId());
-            if (success){
-                logger.info("Successfully deleted invite pending for the user : {}", user);
-            } else {
-                logger.info("Failed to delete project invite for user: {}", user);
-            }
-        }
     }
 
     public ProjectInvitation createAccountInvitation(Project project, Long accountId, Long userId, Role role, Long projectRoleId) {

--- a/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
@@ -1033,16 +1033,42 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager, C
         //verify permissions
         _accountMgr.checkAccess(caller, AccessType.ModifyProject, true, _accountMgr.getAccount(project.getProjectAccountId()));
 
-        //Check if the user exists in the project
-        ProjectAccount projectUser =  _projectAccountDao.findByProjectIdUserId(projectId, user.getAccountId(), user.getId());
-        if (projectUser == null) {
-            deletePendingInvite(projectId, user);
+        boolean success = cleanupProjectsForUser(project, user);
+        if (!success) {
             InvalidParameterValueException ex = new InvalidParameterValueException("User " + user.getUsername() + " is not assigned to the project with specified id");
-            // Use the projectVO object and not the projectAccount object to inject the projectId.
             ex.addProxyObject(project.getUuid(), "projectId");
             throw ex;
         }
-        return deleteUserFromProject(projectId, user);
+        return true;
+    }
+
+    /**
+     * Cleans up project associations and invitations for a specified user in a given project.
+     *
+     * @param project the project from which the user is being cleaned up; if null, cleanup applies to all projects associated with the user
+     * @param user the user whose project associations and invitations are being cleaned up
+     * @return true if any project accounts associated with the user were removed, false otherwise
+     */
+    @Override
+    public boolean cleanupProjectsForUser(Project project, User user) {
+        return Transaction.execute((TransactionCallback<Boolean>) status -> {
+            Long projectId = project != null ? project.getId() : null;
+            long userId = user.getId();
+            long accountId = user.getAccountId();
+
+            _projectInvitationDao.removeBy(projectId, userId, accountId);
+
+            List<ProjectAccountVO> projectAccounts = _projectAccountDao.listBy(projectId, accountId, userId);
+            for (ProjectAccountVO projectAccount : projectAccounts) {
+                _projectAccountDao.remove(projectAccount.getId());
+                if (projectAccount.getAccountRole() == Role.Admin) {
+                    _resourceLimitMgr.decrementResourceCount(accountId, ResourceType.project);
+                }
+                logger.debug("Removed user [{}] from project [{}].", user, project);
+            }
+
+            return !projectAccounts.isEmpty();
+        });
     }
 
     private void deletePendingInvite(Long projectId, User user) {
@@ -1055,29 +1081,6 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager, C
                 logger.info("Failed to delete project invite for user: {}", user);
             }
         }
-    }
-
-    @DB
-    private boolean deleteUserFromProject(Long projectId, User user) {
-        return Transaction.execute(new TransactionCallback<Boolean>() {
-            @Override
-            public Boolean doInTransaction(TransactionStatus status) {
-                boolean success = true;
-                ProjectAccountVO projectAccount = _projectAccountDao.findByProjectIdUserId(projectId, user.getAccountId(), user.getId());
-                success = _projectAccountDao.remove(projectAccount.getId());
-                if (projectAccount.getAccountRole() == Role.Admin) {
-                    _resourceLimitMgr.decrementResourceCount(user.getAccountId(), ResourceType.project);
-                }
-                if (success) {
-                    logger.debug("Removed user {} from project. Removing any invite sent to the user", user);
-                    ProjectInvitation invite = _projectInvitationDao.findByUserIdProjectId(user.getId(), user.getAccountId(),  projectId);
-                    if (invite != null) {
-                        success = success && _projectInvitationDao.remove(invite.getId());
-                    }
-                }
-                return success;
-            }
-        });
     }
 
     public ProjectInvitation createAccountInvitation(Project project, Long accountId, Long userId, Role role, Long projectRoleId) {

--- a/server/src/main/java/com/cloud/user/AccountManager.java
+++ b/server/src/main/java/com/cloud/user/AccountManager.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.apikeypair.ApiKeyPair;
 import org.apache.cloudstack.api.command.admin.account.UpdateAccountCmd;
@@ -148,7 +149,7 @@ public interface AccountManager extends AccountService, Configurable {
      * moves a user to another account within the same domain
      * @return true if the user was successfully moved
      */
-    boolean moveUser(MoveUserCmd moveUserCmd);
+    boolean moveUser(MoveUserCmd moveUserCmd) throws ResourceAllocationException;
 
     @Override
     UserAccount updateUser(UpdateUserCmd cmd);
@@ -190,7 +191,7 @@ public interface AccountManager extends AccountService, Configurable {
     ConfigKey<Boolean> UseSecretKeyInResponse = new ConfigKey<Boolean>("Advanced", Boolean.class, "use.secret.key.in.response", "false",
             "This parameter allows the users to enable or disable of showing secret key as a part of response for various APIs. By default it is set to false.", true);
 
-    boolean moveUser(long id, Long domainId, Account newAccount);
+    boolean moveUser(long id, Long domainId, Account newAccount) throws ResourceAllocationException;
 
     UserTwoFactorAuthenticator getUserTwoFactorAuthenticator(final Long domainId, final Long userAccountId);
 

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -45,6 +45,7 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.projects.dao.ProjectInvitationDao;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.user.dao.SSHKeyPairDao;
 import com.cloud.user.dao.UserAccountDao;
@@ -314,6 +315,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     private DomainDao _domainDao;
     @Inject
     private ProjectAccountDao _projectAccountDao;
+    @Inject
+    private ProjectInvitationDao projectInvitationDao;
     @Inject
     private IPAddressDao _ipAddressDao;
     @Inject
@@ -2521,16 +2524,18 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         checkAccountAndAccess(user, account);
         verifyCallerPrivilegeForUserOrAccountOperations(user);
 
-        return Transaction.execute((TransactionCallback<Boolean>) status -> deleteAndCleanupUser(user));
+        return deleteAndCleanupUser(user);
     }
 
     protected boolean deleteAndCleanupUser(User user) {
-        long userId = user.getId();
+        return Transaction.execute((TransactionCallback<Boolean>) status -> {
+            long userId = user.getId();
 
-        removeUserApiKeys(userId);
-        _projectMgr.cleanupProjectsForUser(null, user);
+            removeUserApiKeys(userId);
+            _projectMgr.cleanupProjectsForUser(null, user);
 
-        return _userDao.remove(userId);
+            return _userDao.remove(userId);
+        });
     }
 
     @Override
@@ -2573,6 +2578,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 newUser.setAccountId(newAccountId);
                 boolean success = _userDao.remove(user.getId());
                 UserVO persisted = _userDao.persist(newUser);
+                projectInvitationDao.move(user, persisted);
+                _projectAccountDao.move(user, persisted);
                 return success && persisted.getUuid().equals(user.getExternalEntity());
             }
         });

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2528,7 +2528,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         long userId = user.getId();
 
         removeUserApiKeys(userId);
-        _projectAccountDao.removeUserFromProjects(userId);
+        _projectMgr.cleanupProjectsForUser(null, user);
 
         return _userDao.remove(userId);
     }

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -45,11 +45,13 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.exception.ResourceAllocationException;
 import com.cloud.projects.dao.ProjectInvitationDao;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.user.dao.SSHKeyPairDao;
 import com.cloud.user.dao.UserAccountDao;
 import com.cloud.user.dao.UserDao;
+import com.cloud.utils.db.TransactionCallbackWithException;
 import org.apache.cloudstack.acl.APIChecker;
 import org.apache.cloudstack.acl.ApiKeyPairManagerImpl;
 import org.apache.cloudstack.acl.ApiKeyPairPermissionVO;
@@ -2527,6 +2529,12 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return deleteAndCleanupUser(user);
     }
 
+    /**
+     * Removes the specified user and performs cleanup operations associated with the user.
+     *
+     * @param user the user to be deleted and cleaned up
+     * @return true if the user was successfully marked as removed, false otherwise
+     */
     protected boolean deleteAndCleanupUser(User user) {
         return Transaction.execute((TransactionCallback<Boolean>) status -> {
             long userId = user.getId();
@@ -2540,7 +2548,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_USER_MOVE, eventDescription = "moving User to a new account")
-    public boolean moveUser(MoveUserCmd cmd) {
+    public boolean moveUser(MoveUserCmd cmd) throws ResourceAllocationException {
         final Long id = cmd.getId();
         UserVO user = getValidUserVO(id);
         Account oldAccount = _accountDao.findById(user.getAccountId());
@@ -2554,7 +2562,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
-    public boolean moveUser(long id, Long domainId, Account newAccount) {
+    public boolean moveUser(long id, Long domainId, Account newAccount) throws ResourceAllocationException {
         UserVO user = getValidUserVO(id);
         Account oldAccount = _accountDao.findById(user.getAccountId());
         checkAccountAndAccess(user, oldAccount);
@@ -2562,26 +2570,22 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         return moveUser(user, newAccount.getId());
     }
 
-    private boolean moveUser(UserVO user, long newAccountId) {
+    private boolean moveUser(UserVO user, long newAccountId) throws ResourceAllocationException {
         if (newAccountId == user.getAccountId()) {
             // could do a not silent fail but the objective of the user is reached
             return true; // no need to create a new user object for this user
         }
 
-        return Transaction.execute(new TransactionCallback<>() {
-            @Override
-            public Boolean doInTransaction(TransactionStatus status) {
-                UserVO newUser = new UserVO(user);
-                user.setExternalEntity(user.getUuid());
-                user.setUuid(UUID.randomUUID().toString());
-                _userDao.update(user.getId(), user);
-                newUser.setAccountId(newAccountId);
-                boolean success = _userDao.remove(user.getId());
-                UserVO persisted = _userDao.persist(newUser);
-                projectInvitationDao.move(user, persisted);
-                _projectAccountDao.move(user, persisted);
-                return success && persisted.getUuid().equals(user.getExternalEntity());
-            }
+        return Transaction.execute((TransactionCallbackWithException<Boolean, ResourceAllocationException>) status -> {
+            UserVO newUser = new UserVO(user);
+            user.setExternalEntity(user.getUuid());
+            user.setUuid(UUID.randomUUID().toString());
+            _userDao.update(user.getId(), user);
+            newUser.setAccountId(newAccountId);
+            UserVO persisted = _userDao.persist(newUser);
+            _projectMgr.moveProjectAssociationsToUser(user, persisted);
+            boolean success = _userDao.remove(user.getId());
+            return success && persisted.getUuid().equals(user.getExternalEntity());
         });
     }
 

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2521,9 +2521,16 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         checkAccountAndAccess(user, account);
         verifyCallerPrivilegeForUserOrAccountOperations(user);
 
-        removeUserApiKeys(id);
+        return Transaction.execute((TransactionCallback<Boolean>) status -> deleteAndCleanupUser(user));
+    }
 
-        return _userDao.remove(id);
+    protected boolean deleteAndCleanupUser(User user) {
+        long userId = user.getId();
+
+        removeUserApiKeys(userId);
+        _projectAccountDao.removeUserFromProjects(userId);
+
+        return _userDao.remove(userId);
     }
 
     @Override

--- a/server/src/main/java/org/apache/cloudstack/region/RegionManager.java
+++ b/server/src/main/java/org/apache/cloudstack/region/RegionManager.java
@@ -18,6 +18,7 @@ package org.apache.cloudstack.region;
 
 import java.util.List;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.apache.cloudstack.api.command.admin.account.UpdateAccountCmd;
 import org.apache.cloudstack.api.command.admin.domain.UpdateDomainCmd;
 import org.apache.cloudstack.api.command.admin.user.DeleteUserCmd;
@@ -128,7 +129,7 @@ public interface RegionManager {
      * @param moveUserCmd
      * @return
      */
-    boolean moveUser(MoveUserCmd moveUserCmd);
+    boolean moveUser(MoveUserCmd moveUserCmd) throws ResourceAllocationException;
 
     /**
      * update an existing domain

--- a/server/src/main/java/org/apache/cloudstack/region/RegionManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/region/RegionManagerImpl.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.apache.cloudstack.api.command.admin.user.MoveUserCmd;
 import org.springframework.stereotype.Component;
 
@@ -227,7 +228,7 @@ public class RegionManagerImpl extends ManagerBase implements RegionManager, Man
      * {@inheritDoc}
      */
     @Override
-    public boolean moveUser(MoveUserCmd cmd) {
+    public boolean moveUser(MoveUserCmd cmd) throws ResourceAllocationException {
         return _accountMgr.moveUser(cmd);
     }
 

--- a/server/src/main/java/org/apache/cloudstack/region/RegionServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/region/RegionServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.exception.ResourceAllocationException;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.command.admin.account.DeleteAccountCmd;
@@ -154,7 +155,7 @@ public class RegionServiceImpl extends ManagerBase implements RegionService, Man
      * {@inheritDoc}
      */
     @Override
-    public boolean moveUser(MoveUserCmd cmd) {
+    public boolean moveUser(MoveUserCmd cmd) throws ResourceAllocationException {
         return _regionMgr.moveUser(cmd);
     }
 

--- a/server/src/test/java/com/cloud/projects/MockProjectManagerImpl.java
+++ b/server/src/test/java/com/cloud/projects/MockProjectManagerImpl.java
@@ -21,6 +21,7 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.projects.ProjectAccount.Role;
 import com.cloud.user.Account;
+import com.cloud.user.User;
 import com.cloud.utils.component.ManagerBase;
 
 import javax.naming.ConfigurationException;
@@ -212,6 +213,12 @@ public class MockProjectManagerImpl extends ManagerBase implements ProjectManage
     public long getInvitationTimeout() {
         // TODO Auto-generated method stub
         return 0;
+    }
+
+    @Override
+    public boolean cleanupProjectsForUser(Project project, User user) {
+        // TODO Auto-generated method stub
+        return false;
     }
 
     @Override

--- a/server/src/test/java/com/cloud/projects/MockProjectManagerImpl.java
+++ b/server/src/test/java/com/cloud/projects/MockProjectManagerImpl.java
@@ -222,6 +222,11 @@ public class MockProjectManagerImpl extends ManagerBase implements ProjectManage
     }
 
     @Override
+    public void moveProjectAssociationsToUser(User oldUser, User newUser) throws ResourceAllocationException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
     public Project findByProjectAccountIdIncludingRemoved(long projectAccountId) {
         return null;
     }

--- a/server/src/test/java/com/cloud/projects/ProjectManagerImplTest.java
+++ b/server/src/test/java/com/cloud/projects/ProjectManagerImplTest.java
@@ -17,9 +17,11 @@
 package com.cloud.projects;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.cloudstack.acl.ControlledEntity;
+import org.apache.cloudstack.reservation.dao.ReservationDao;
 import org.apache.cloudstack.webhook.WebhookHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Assert;
@@ -28,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Spy;
@@ -35,7 +38,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
+import com.cloud.configuration.Resource.ResourceType;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.projects.ProjectAccount.Role;
+import com.cloud.projects.dao.ProjectAccountDao;
 import com.cloud.projects.dao.ProjectDao;
+import com.cloud.projects.dao.ProjectInvitationDao;
+import com.cloud.resourcelimit.CheckedReservation;
+import com.cloud.user.AccountVO;
+import com.cloud.user.ResourceLimitService;
+import com.cloud.user.User;
+import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.component.ComponentContext;
 
 
@@ -48,6 +61,21 @@ public class ProjectManagerImplTest {
 
     @Mock
     ProjectDao projectDao;
+
+    @Mock
+    ProjectInvitationDao projectInvitationDao;
+
+    @Mock
+    ProjectAccountDao projectAccountDao;
+
+    @Mock
+    AccountDao accountDao;
+
+    @Mock
+    ResourceLimitService resourceLimitMgr;
+
+    @Mock
+    ReservationDao reservationDao;
 
     List<ProjectVO> updateProjects;
 
@@ -127,5 +155,159 @@ public class ProjectManagerImplTest {
                     projectManager.listWebhooksForProject(Mockito.mock(Project.class));
             Assert.assertTrue(CollectionUtils.isEmpty(result));
         }
+    }
+
+    @Test
+    public void cleanupProjectsForUserTestNoAssociationsReturnsFalse() {
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.getId()).thenReturn(100L);
+        User user = mockUser(1L, 10L);
+        Mockito.when(projectAccountDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                .thenReturn(Collections.emptyList());
+
+        boolean result = projectManager.cleanupProjectsForUser(project, user);
+
+        Assert.assertFalse(result);
+        Mockito.verify(projectInvitationDao).removeBy(100L, 10L, 1L);
+        Mockito.verify(projectAccountDao, Mockito.never()).remove(Mockito.anyLong());
+        Mockito.verify(resourceLimitMgr, Mockito.never()).decrementResourceCount(Mockito.anyLong(), Mockito.any(ResourceType.class));
+    }
+
+    @Test
+    public void cleanupProjectsForUserTestRemovesAdminAndRegularAssociations() {
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.getId()).thenReturn(100L);
+        User user = mockUser(1L, 10L);
+        ProjectAccountVO admin = mockProjectAccount(1L, Role.Admin);
+        ProjectAccountVO regular = mockProjectAccount(2L, Role.Regular);
+        Mockito.when(projectAccountDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                .thenReturn(List.of(admin, regular));
+
+        boolean result = projectManager.cleanupProjectsForUser(project, user);
+
+        Assert.assertTrue(result);
+        Mockito.verify(projectInvitationDao).removeBy(100L, 10L, 1L);
+        Mockito.verify(projectAccountDao).remove(1L);
+        Mockito.verify(projectAccountDao).remove(2L);
+        Mockito.verify(resourceLimitMgr).decrementResourceCount(10L, ResourceType.project);
+    }
+
+    @Test
+    public void cleanupProjectsForUserTestNullProject() {
+        User user = mockUser(1L, 10L);
+        ProjectAccountVO admin = mockProjectAccount(1L, Role.Admin);
+        Mockito.when(projectAccountDao.listBy(Mockito.isNull(), Mockito.eq(10L), Mockito.eq(1L)))
+                .thenReturn(List.of(admin));
+
+        boolean result = projectManager.cleanupProjectsForUser(null, user);
+
+        Assert.assertTrue(result);
+        Mockito.verify(projectInvitationDao).removeBy(Mockito.isNull(), Mockito.eq(10L), Mockito.eq(1L));
+        Mockito.verify(projectAccountDao).remove(1L);
+        Mockito.verify(resourceLimitMgr).decrementResourceCount(10L, ResourceType.project);
+    }
+
+    @Test
+    public void moveProjectAssociationsToUserTestNoProjectAccounts() throws ResourceAllocationException {
+        User oldUser = mockUser(1L, 10L);
+        User newUser = mockUser(2L, 20L);
+        Mockito.when(projectAccountDao.listBy(Mockito.isNull(), Mockito.eq(10L), Mockito.eq(1L)))
+                .thenReturn(Collections.emptyList());
+
+        projectManager.moveProjectAssociationsToUser(oldUser, newUser);
+
+        Mockito.verify(projectInvitationDao).move(oldUser, newUser);
+        Mockito.verify(projectAccountDao, Mockito.never()).move(Mockito.any(), Mockito.any());
+        Mockito.verifyNoInteractions(accountDao);
+        Mockito.verifyNoInteractions(resourceLimitMgr);
+    }
+
+    @Test
+    public void moveProjectAssociationsToUserTestSameAccount() throws ResourceAllocationException {
+        User oldUser = mockUser(1L, 10L);
+        User newUser = mockUser(2L, 10L);
+        ProjectAccountVO regular = mockProjectAccount(1L, Role.Regular);
+        Mockito.when(projectAccountDao.listBy(Mockito.isNull(), Mockito.eq(10L), Mockito.eq(1L)))
+                .thenReturn(List.of(regular));
+        AccountVO oldAccount = mockAccount(10L);
+        AccountVO newAccount = mockAccount(10L);
+        Mockito.when(accountDao.findById(10L)).thenReturn(oldAccount).thenReturn(newAccount);
+
+        try (MockedConstruction<CheckedReservation> ignored = Mockito.mockConstruction(CheckedReservation.class)) {
+            projectManager.moveProjectAssociationsToUser(oldUser, newUser);
+        }
+
+        Mockito.verify(projectInvitationDao).move(oldUser, newUser);
+        Mockito.verify(projectAccountDao).move(oldUser, newUser);
+        Mockito.verify(resourceLimitMgr, Mockito.never())
+                .incrementResourceCount(Mockito.anyLong(), Mockito.any(ResourceType.class), Mockito.anyLong());
+        Mockito.verify(resourceLimitMgr, Mockito.never())
+                .decrementResourceCount(Mockito.anyLong(), Mockito.any(ResourceType.class), Mockito.anyLong());
+    }
+
+    @Test
+    public void moveProjectAssociationsToUserTestDifferentAccountsWithAdminRole() throws ResourceAllocationException {
+        User oldUser = mockUser(1L, 10L);
+        User newUser = mockUser(2L, 20L);
+        ProjectAccountVO admin = mockProjectAccount(1L, Role.Admin);
+        Mockito.when(projectAccountDao.listBy(Mockito.isNull(), Mockito.eq(10L), Mockito.eq(1L)))
+                .thenReturn(List.of(admin));
+        AccountVO oldAccount = mockAccount(10L);
+        AccountVO newAccount = mockAccount(20L);
+        Mockito.when(accountDao.findById(10L)).thenReturn(oldAccount);
+        Mockito.when(accountDao.findById(20L)).thenReturn(newAccount);
+
+        try (MockedConstruction<CheckedReservation> ignored = Mockito.mockConstruction(CheckedReservation.class)) {
+            projectManager.moveProjectAssociationsToUser(oldUser, newUser);
+        }
+
+        Mockito.verify(projectInvitationDao).move(oldUser, newUser);
+        Mockito.verify(projectAccountDao).move(oldUser, newUser);
+        Mockito.verify(resourceLimitMgr).incrementResourceCount(20L, ResourceType.project, 1L);
+        Mockito.verify(resourceLimitMgr).decrementResourceCount(10L, ResourceType.project, 1L);
+    }
+
+    @Test
+    public void moveProjectAssociationsToUserTestDifferentAccountsWithoutAdminRole() throws ResourceAllocationException {
+        User oldUser = mockUser(1L, 10L);
+        User newUser = mockUser(2L, 20L);
+        ProjectAccountVO regular = mockProjectAccount(1L, Role.Regular);
+        Mockito.when(projectAccountDao.listBy(Mockito.isNull(), Mockito.eq(10L), Mockito.eq(1L)))
+                .thenReturn(List.of(regular));
+        AccountVO oldAccount = mockAccount(10L);
+        AccountVO newAccount = mockAccount(20L);
+        Mockito.when(accountDao.findById(10L)).thenReturn(oldAccount);
+        Mockito.when(accountDao.findById(20L)).thenReturn(newAccount);
+
+        try (MockedConstruction<CheckedReservation> ignored = Mockito.mockConstruction(CheckedReservation.class)) {
+            projectManager.moveProjectAssociationsToUser(oldUser, newUser);
+        }
+
+        Mockito.verify(projectInvitationDao).move(oldUser, newUser);
+        Mockito.verify(projectAccountDao).move(oldUser, newUser);
+        Mockito.verify(resourceLimitMgr, Mockito.never())
+                .incrementResourceCount(Mockito.anyLong(), Mockito.any(ResourceType.class), Mockito.anyLong());
+        Mockito.verify(resourceLimitMgr, Mockito.never())
+                .decrementResourceCount(Mockito.anyLong(), Mockito.any(ResourceType.class), Mockito.anyLong());
+    }
+
+    private User mockUser(long id, long accountId) {
+        User user = Mockito.mock(User.class);
+        Mockito.when(user.getId()).thenReturn(id);
+        Mockito.when(user.getAccountId()).thenReturn(accountId);
+        return user;
+    }
+
+    private AccountVO mockAccount(long id) {
+        AccountVO account = Mockito.mock(AccountVO.class);
+        Mockito.when(account.getId()).thenReturn(id);
+        return account;
+    }
+
+    private ProjectAccountVO mockProjectAccount(long id, Role role) {
+        ProjectAccountVO projectAccount = Mockito.mock(ProjectAccountVO.class);
+        Mockito.when(projectAccount.getId()).thenReturn(id);
+        Mockito.when(projectAccount.getAccountRole()).thenReturn(role);
+        return projectAccount;
     }
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -2136,11 +2136,11 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
     public void deleteAndCleanupUserTestUserCleanup() {
         long userId = userVoMock.getId();
         Mockito.doNothing().when(accountManagerImpl).removeUserApiKeys(userId);
-        Mockito.doNothing().when(_projectAccountDao).removeUserFromProjects(userId);
+        Mockito.doNothing().when(_projectMgr).cleanupProjectsForUser(null, userVoMock);
 
         accountManagerImpl.deleteAndCleanupUser(userVoMock);
 
         Mockito.verify(accountManagerImpl).removeUserApiKeys(userId);
-        Mockito.verify(_projectAccountDao).removeUserFromProjects(userId);
+        Mockito.verify(_projectMgr).cleanupProjectsForUser(null, userVoMock);
     }
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -2131,4 +2131,16 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
         );
         Assert.assertNotNull(userResultVO);
     }
+
+    @Test
+    public void deleteAndCleanupUserTestUserCleanup() {
+        long userId = userVoMock.getId();
+        Mockito.doNothing().when(accountManagerImpl).removeUserApiKeys(userId);
+        Mockito.doNothing().when(_projectAccountDao).removeUserFromProjects(userId);
+
+        accountManagerImpl.deleteAndCleanupUser(userVoMock);
+
+        Mockito.verify(accountManagerImpl).removeUserApiKeys(userId);
+        Mockito.verify(_projectAccountDao).removeUserFromProjects(userId);
+    }
 }

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -2136,7 +2136,7 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
     public void deleteAndCleanupUserTestUserCleanup() {
         long userId = userVoMock.getId();
         Mockito.doNothing().when(accountManagerImpl).removeUserApiKeys(userId);
-        Mockito.doNothing().when(_projectMgr).cleanupProjectsForUser(null, userVoMock);
+        Mockito.doReturn(true).when(_projectMgr).cleanupProjectsForUser(null, userVoMock);
 
         accountManagerImpl.deleteAndCleanupUser(userVoMock);
 


### PR DESCRIPTION
### Description

This PR adds missing `project_account` and `project_invitation` cleanups while deleting/moving a user. Some of these changes were missing on the merge-forward of #10008.

Closes #13796.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?

#### DB upgrade

- Upgrade 4.22.1 -> 4.23.0 with existing stale project_account + project_invitations: stale rows purged.

#### User cleanup

- Delete user who's a member of 2 projects: project_account rows removed.
- Delete user with pending project invitations: project_invitations rows removed.
- Delete user who's a Project Admin: project resource count on their account decremented by 1.
- Delete user with no project memberships: still succeeds.

#### Remove user from a project

- Remove regular user: association removed.
- Remove Project Admin user: association removed and project count decremented.

#### Move user

- Move regular user to another account: project_account + project_invitations rows now point to the new user+account.
- Move Project Admin user to another account: new account's project count incremented, old account's decremented.
- Move Project Admin user across accounts when target account is at its project limit: ResourceAllocationException + full rollback.