### PR TITLE
Flxcld 2859 management server async job issue

### DIFF
--- a/.github/workflows/trigger-package-and-publish.yml
+++ b/.github/workflows/trigger-package-and-publish.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: concordia-linux-cpu4-ram14gi
+    runs-on: flexcloud-rocky
     env:
       target_owner: "${{ secrets.TARGET_OWNER }}"
       target_name: "${{ secrets.TARGET_NAME }}"

--- a/.github/workflows/trigger-package-and-publish.yml
+++ b/.github/workflows/trigger-package-and-publish.yml
@@ -1,0 +1,93 @@
+name: Trigger Package and Publish
+
+on:
+  push:
+    branches:
+      - "att/**"
+  workflow_dispatch:
+    inputs:
+      trigger-type:
+        description: "How to trigger the target workflow"
+        required: true
+        type: choice
+        options:
+        - api
+        - workflow-run
+
+jobs:
+  trigger:
+    runs-on: concordia-linux-cpu4-ram14gi
+    env:
+      target_owner: "${{ secrets.TARGET_OWNER }}"
+      target_name: "${{ secrets.TARGET_NAME }}"
+      target_workflow: "${{ secrets.TARGET_WORKFLOW }}"
+      event_type: "${{ secrets.TARGET_EVENT_TYPE }}"
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Install DNF Config Manager
+        run: |
+          sudo dnf -y install 'dnf-command(config-manager)'
+
+      - name: Install GitHub CLI
+        run: |
+          sudo dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          sudo dnf -y install gh
+
+      - name: Install gettext (for envsubvst)
+        run: |
+          sudo dnf -y install gettext
+
+      - name: Install YQ
+        run: |
+          sudo curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq   
+
+      - name: Authenticate GitHub CLI Using Access Token
+        run: |
+          echo "${{ secrets.TARGET_REPOSITORY_ACCESS_TOKEN }}" | gh auth login --with-token
+          gh auth status
+
+      # Triggering workflows via the API is meant to be used by external systems.
+      - name: Trigger Workflow in Target Repository (api)
+        if: "${{ github.event.inputs.trigger-type == 'api'}}"
+        run: |
+          event_data=$(cat <<EOM | yq -o json -I 0 '.'
+          event_type: "${{ env.event_type }}"
+          client_payload:
+            reference:
+              name: "${{ github.ref_name }}"
+              ref: "${{ github.ref }}"
+              type: "${{ github.ref_type }}"
+              sha: "${{ github.sha }}"
+            repository:
+              name: "${{ github.repository }}"
+              url: "${{ github.repositoryUrl }}"
+            run:
+              id: "${{ github.run_id }}"
+              iteration: "${{ github.run_number }}"
+            workflow:
+              name:  "${{ github.workflow }}"
+              ref: "${{ github.workflow_ref }}"
+              sha: "${{ github.workflow_sha }}"
+          EOM
+          )
+          echo "${event_data}" | \
+            gh api --verbose \
+              -X POST \
+              --input - \
+              /repos/${{ env.target_owner }}/${{ env.target_name }}/dispatches \
+              ;
+
+      # Triggering workflows via workflow execution is preferred when within the GitHub ecosystem.
+      - name: Trigger Workflow in Target Repository (workflow run)
+        if: "${{ github.event.inputs.trigger-type == 'workflow-run' }}"
+        run: |
+          gh workflow run \
+            ${{ env.target_workflow }} \
+            --repo ${{ env.target_owner }}/${{ env.target_name }} \
+            --ref 4.22 \
+            --field branch-name=${{ github.ref_name }} \
+            ;

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ tools/marvin/marvin/cloudstackAPI/*
 unittest
 venv
 waf-*
+.envrc
 
 # this ignores _all files starting with '.'. Don't do that!
 #.*

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -209,8 +209,10 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.StorageAccessException;
 import com.cloud.exception.StorageUnavailableException;
+import com.cloud.ha.HaWorkVO;
 import com.cloud.ha.HighAvailabilityManager;
 import com.cloud.ha.HighAvailabilityManager.WorkType;
+import com.cloud.ha.dao.HighAvailabilityDao;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
@@ -360,6 +362,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     private VolumeDao _volsDao;
     @Inject
     private HighAvailabilityManager _haMgr;
+    @Inject
+    private HighAvailabilityDao _haDao;
     @Inject
     private HostPodDao _podDao;
     @Inject
@@ -5395,9 +5399,43 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     && HaVmRestartHostUp.value()
                     && vm.getHypervisorType() != HypervisorType.VMware
                     && vm.getHypervisorType() != HypervisorType.Hyperv) {
-                logger.info("Detected out-of-band stop of a HA enabled VM {}, will schedule restart.", vm);
+                logger.info("Detected out-of-band stop of HA enabled VM {}, transitioning to Stopped and scheduling HA restart (investigate=false).", vm);
                 if (!_haMgr.hasPendingHaWork(vm.getId())) {
-                    _haMgr.scheduleRestart(vm, true);
+                    // The power state report already confirmed the VM is off
+                    // (e.g. OOM-killed QEMU process). We cannot use _haMgr.scheduleRestart() because it
+                    // calls advanceStop(), which submits a VM work job and blocks waiting for completion.
+                    // This code runs on the AgentManager-Handler thread, and the VM job queue does not
+                    // dispatch jobs from this context — causing an indefinite block that leaves the VM
+                    // stuck in Running. Instead we release resources, transition to Stopped, and insert
+                    // an HA work item directly into op_ha_work (Step.Scheduled) for the HA worker to pick up.
+                    final VirtualMachineProfile profile = new VirtualMachineProfileImpl(vm);
+                    releaseVmResources(profile, true);
+
+                    // Save lastHostId before transition (stateTransitTo sets hostId=null)
+                    final Long lastHostId = vm.getHostId();
+                    try {
+                        stateTransitTo(vm, VirtualMachine.Event.FollowAgentPowerOffReport, null);
+                    } catch (final NoTransitionException e) {
+                        logger.warn("Failed to transition VM {} to Stopped state: {}", vm, e.getMessage());
+                        return;
+                    }
+
+                    _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_SYNC, vm.getDataCenterId(), vm.getPodIdToDeployIn(),
+                            VM_SYNC_ALERT_SUBJECT, String.format("VM %s(%s) stopped out-of-band (OOM-killed or crashed). HA restart scheduled.",
+                                    vm.getHostName(), vm.getInstanceName()));
+
+                    // Insert HA work item directly — bypasses advanceStop/job queue entirely
+                    final VMInstanceVO refreshedVm = _vmDao.findByUuid(vm.getUuid());
+                    final Long haHostId = lastHostId != null ? lastHostId : refreshedVm.getLastHostId();
+                    if (haHostId == null || haHostId == 0L) {
+                        logger.warn("Cannot schedule HA for VM {} — no valid host_id available (would violate FK constraint).", vm);
+                    } else {
+                        final HaWorkVO work = new HaWorkVO(refreshedVm.getId(), refreshedVm.getType(),
+                                WorkType.HA, HighAvailabilityManager.Step.Scheduled, haHostId,
+                                refreshedVm.getState(), 0, refreshedVm.getUpdated(), null);
+                        _haDao.persist(work);
+                        logger.info("Scheduled VM for HA: {}", refreshedVm);
+                    }
                 } else {
                     logger.info("VM {} already has a pending HA task working on it.", vm);
                 }

--- a/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/KvmNonManagedStorageSystemDataMotionTest.java
+++ b/engine/storage/datamotion/src/test/java/org/apache/cloudstack/storage/motion/KvmNonManagedStorageSystemDataMotionTest.java
@@ -124,6 +124,8 @@ public class KvmNonManagedStorageSystemDataMotionTest {
     Host host1;
     @Mock
     Host host2;
+    @Mock
+    com.cloud.vm.VirtualMachine attachedVm;
 
     Map<VolumeInfo, DataStore> migrationMap;
 
@@ -476,6 +478,23 @@ public class KvmNonManagedStorageSystemDataMotionTest {
     @Test
     public void testVerifyLiveMigrationMapForKVM() {
         kvmNonManagedStorageDataMotionStrategy.verifyLiveMigrationForKVM(migrationMap);
+    }
+
+    @Test
+    public void testVerifyLiveMigrationMapForKVMManagedFiberChannelAllowed() {
+        lenient().when(pool1.isManaged()).thenReturn(true);
+        lenient().when(pool2.isManaged()).thenReturn(true);
+        lenient().when(pool1.getPoolType()).thenReturn(Storage.StoragePoolType.FiberChannel);
+        lenient().when(pool2.getPoolType()).thenReturn(Storage.StoragePoolType.FiberChannel);
+        lenient().when(pool1.getId()).thenReturn(POOL_1_ID);
+        lenient().when(pool2.getId()).thenReturn(POOL_2_ID);
+        lenient().when(volumeInfo1.getAttachedVM()).thenReturn(attachedVm);
+        when(attachedVm.getState()).thenReturn(com.cloud.vm.VirtualMachine.State.Running);
+
+        Map<VolumeInfo, DataStore> fiberChannelMigrationMap = new HashMap<>();
+        fiberChannelMigrationMap.put(volumeInfo1, dataStore2);
+
+        kvmNonManagedStorageDataMotionStrategy.verifyLiveMigrationForKVM(fiberChannelMigrationMap);
     }
 
     @Test(expected = CloudRuntimeException.class)

--- a/engine/userdata/src/main/java/org/apache/cloudstack/userdata/UserDataManagerImpl.java
+++ b/engine/userdata/src/main/java/org/apache/cloudstack/userdata/UserDataManagerImpl.java
@@ -154,7 +154,7 @@ public class UserDataManagerImpl extends ManagerBase implements UserDataManager 
             throw new InvalidParameterValueException("User data is too short.");
         }
 
-        logger.trace(String.format("Decoded user data: [%s].", decodedUserData));
+        logger.trace(String.format("Decoded user data: [%s].", new String(decodedUserData)));
         int userDataLength = userData.length();
         int decodedUserDataLength = decodedUserData.length;
         logger.info(String.format("Configured base64 encoded user data size: %d bytes, actual user data size: %d bytes", userDataLength, decodedUserDataLength));

--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -1153,7 +1153,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                     final List<AsyncJobVO> jobs = _jobDao.getResetJobs(msid);
                     for (final AsyncJobVO job : jobs) {
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Cancel left-over job-" + job.getId());
+                            logger.debug("Cancel left-over job-{} for msid {}", job.getId(), msid);
                         }
                         cleanupResources(job);
                         job.setStatus(JobInfo.Status.FAILED);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -533,6 +533,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         POWER_STATES_TABLE.put(DomainState.VIR_DOMAIN_BLOCKED, PowerState.PowerOn);
         POWER_STATES_TABLE.put(DomainState.VIR_DOMAIN_NOSTATE, PowerState.PowerUnknown);
         POWER_STATES_TABLE.put(DomainState.VIR_DOMAIN_SHUTDOWN, PowerState.PowerOff);
+        // Report crashed domains as PowerOff immediately instead of omitting them
+        // from the report (which delays detection via the "missing VM" threshold).
+        POWER_STATES_TABLE.put(DomainState.VIR_DOMAIN_CRASHED, PowerState.PowerOff);
     }
 
     public VirtualRoutingResource virtRouterResource;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -5788,7 +5788,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
         for (String snapshotName: snapshotNames) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(String.format("Cleaning snapshot [%s] of VM [%s] metadata.", snapshotNames, dm.getName()));
+                LOGGER.debug(String.format("Cleaning snapshot [%s] of VM [%s] metadata.", snapshotName, dm.getName()));
             }
             DomainSnapshot snapshot = dm.snapshotLookupByName(snapshotName);
             snapshot.delete(flags); // clean metadata of vm snapshot

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1132,6 +1132,10 @@ public class LibvirtVMDef {
             this._serial = serial;
         }
 
+        public String getSerial() {
+            return _serial;
+        }
+
         public void setLibvirtDiskEncryptDetails(LibvirtDiskEncryptDetails details)
         {
             this.encryptDetails = details;

--- a/plugins/storage/volume/primera/src/main/java/org/apache/cloudstack/storage/datastore/adapter/primera/PrimeraAdapter.java
+++ b/plugins/storage/volume/primera/src/main/java/org/apache/cloudstack/storage/datastore/adapter/primera/PrimeraAdapter.java
@@ -384,6 +384,7 @@ public class PrimeraAdapter implements ProviderAdapter {
             // Online copy configuration: immediate clone with deduplication and compression
             parms.setOnline(true);
             parms.setDestCPG(cpg);
+            parms.setSnapCPG(snapCpg);
             parms.setTpvv(false);
             parms.setReduce(true);
             logger.debug("PrimeraAdapter: Configuring online copy - destination CPG: '{}', deduplication enabled, thin provisioning disabled", cpg);

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -718,7 +718,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             logger.info(ex.getDescription());
             throw ex;
         } catch (final Exception ex) {
-            logger.error("unhandled exception executing api command: " + ((command == null) ? "null" : command), ex);
+            logger.error("unhandled exception executing api command: " + ((command == null || command.length == 0) ? "null" : command[0]), ex);
             String errorMsg = ex.getMessage();
             if (!accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())) {
                 // hide internal details to non-admin user for security reason

--- a/server/src/main/java/com/cloud/hypervisor/CloudZonesStartupProcessor.java
+++ b/server/src/main/java/com/cloud/hypervisor/CloudZonesStartupProcessor.java
@@ -24,6 +24,8 @@ import javax.naming.ConfigurationException;
 
 import org.springframework.stereotype.Component;
 
+import org.apache.cloudstack.utils.identity.ManagementServerNode;
+
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.StartupCommandProcessor;
 import com.cloud.agent.api.StartupCommand;
@@ -38,7 +40,6 @@ import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.utils.component.AdapterBase;
-import com.cloud.utils.net.MacAddress;
 import com.cloud.utils.net.NetUtils;
 
 /**
@@ -62,7 +63,7 @@ public class CloudZonesStartupProcessor extends AdapterBase implements StartupCo
         if (_nodeId == -1) {
             // FIXME: We really should not do this like this. It should be done
             // at config time and is stored as a config variable.
-            _nodeId = MacAddress.getMacAddress().toLong();
+            _nodeId = ManagementServerNode.getManagementServerId();
         }
         return true;
     }

--- a/server/src/main/java/com/cloud/network/NetworkUsageManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkUsageManagerImpl.java
@@ -34,6 +34,7 @@ import org.apache.cloudstack.api.command.admin.usage.AddTrafficMonitorCmd;
 import org.apache.cloudstack.api.command.admin.usage.DeleteTrafficMonitorCmd;
 import org.apache.cloudstack.api.command.admin.usage.ListTrafficMonitorsCmd;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.utils.identity.ManagementServerNode;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.Listener;
@@ -88,7 +89,6 @@ import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.net.MacAddress;
 
 @Component
 public class NetworkUsageManagerImpl extends ManagerBase implements NetworkUsageService, NetworkUsageManager, ResourceStateAdapter {
@@ -251,7 +251,7 @@ public class NetworkUsageManagerImpl extends ManagerBase implements NetworkUsage
 
         private int _interval;
 
-        private final long mgmtSrvrId = MacAddress.getMacAddress().toLong();
+        private final long mgmtSrvrId = ManagementServerNode.getManagementServerId();
 
         protected DirectNetworkStatsListener(int interval) {
             _interval = interval;

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -250,7 +250,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.StateListener;
 import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.utils.net.Ip;
-import com.cloud.utils.net.MacAddress;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.Nic;
@@ -365,7 +364,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     private int _routerExtraPublicNics = 2;
     private int _usageAggregationRange = 1440;
     private String _usageTimeZone = "GMT";
-    private final long mgmtSrvrId = MacAddress.getMacAddress().toLong();
+    private final long mgmtSrvrId = ManagementServerNode.getManagementServerId();
     private static final int ACQUIRE_GLOBAL_LOCK_TIMEOUT_FOR_COOPERATION = 5; // 5 seconds
     private boolean _dailyOrHourly = false;
 

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -843,7 +843,6 @@ import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.StateMachine2;
-import com.cloud.utils.net.MacAddress;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.utils.security.CertificateHelper;
 import com.cloud.utils.ssh.SSHKeysHelper;
@@ -1196,7 +1195,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public long getId() {
-        return MacAddress.getMacAddress().toLong();
+        return ManagementServerNode.getManagementServerId();
     }
 
     protected void checkPortParameters(final String publicPort, final String privatePort, final String privateIp, final String proto) {

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -147,7 +147,6 @@ import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.net.MacAddress;
 import com.cloud.utils.script.Script;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.UserVmManager;
@@ -382,7 +381,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     private ScheduledExecutorService _diskStatsUpdateExecutor;
     private int _usageAggregationRange = 1440;
     private String _usageTimeZone = "GMT";
-    private final long mgmtSrvrId = MacAddress.getMacAddress().toLong();
+    private final long mgmtSrvrId = ManagementServerNode.getManagementServerId();
     private static final int ACQUIRE_GLOBAL_LOCK_TIMEOUT_FOR_COOPERATION = 5;    // 5 seconds
     private boolean _dailyOrHourly = false;
     protected long managementServerNodeId = ManagementServerNode.getManagementServerId();

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -2887,7 +2887,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         }
 
         if (ArrayUtils.isNotEmpty(hostStorageAccessGroups)) {
-            logger.debug(String.format("Storage access groups on the host %s are %s", host, hostStorageAccessGroups));
+            logger.debug(String.format("Storage access groups on the host %s are %s", host, Arrays.toString(hostStorageAccessGroups)));
         }
 
         if (CollectionUtils.isNotEmpty(storagePoolAccessGroups)) {

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -44,6 +44,7 @@
 "label.accounttype": "Account type",
 "label.acl.export": "Export ACL rules",
 "label.acl.id": "ACL ID",
+"label.aclname": "ACL name",
 "label.acl.rules": "ACL rules",
 "label.acl.reason.description": "Enter the reason behind an ACL rule.",
 "label.aclid": "ACL",

--- a/ui/src/views/AutogenView.vue
+++ b/ui/src/views/AutogenView.vue
@@ -1997,8 +1997,13 @@ export default {
     },
     onSearch (opts) {
       const query = Object.assign({}, this.$route.query)
-      const searchFilters = this.$route?.meta?.searchFilters || []
-      searchFilters.forEach(key => delete query[key])
+      let searchFilters = this.$route?.meta?.searchFilters || []
+      if (typeof searchFilters === 'function') {
+        searchFilters = searchFilters()
+      }
+      if (Array.isArray(searchFilters)) {
+        searchFilters.forEach(key => delete query[key])
+      }
       delete query.name
       delete query.templatetype
       delete query.keyword

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -148,6 +148,7 @@
                       @handle-image-search-filter="filters => fetchImages(filters)"
                       @update-image="updateFieldValue"
                       @update-disk-size="updateFieldValue"
+                      @change-root-disk-override-checked="val => { showRootDiskSizeChanger = val; form.rootdisksizeitem = val }"
                       @change-iso-hypervisor="value => form.hypervisor = value" />
                     <a-card
                       v-else
@@ -2030,6 +2031,8 @@ export default {
           this.updateTemplateParameters()
           var size = template.size / (1024 * 1024 * 1024) || 0 // bytes to GB
           this.dataPreFill.minrootdisksize = Math.ceil(size)
+          this.dataPreFill.rootdisksize = Math.ceil(size)
+          this.form.rootdisksize = Math.ceil(size)
           this.updateTemplateLinkedUserData(template.userdataid)
           this.userdataDefaultOverridePolicy = template.userdatapolicy
           this.form.dynamicscalingenabled = template.isdynamicallyscalable

--- a/ui/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/ui/src/views/network/CreateIsolatedNetworkForm.vue
@@ -551,7 +551,7 @@ export default {
       this.networkOfferings = []
       this.selectedNetworkOffering = {}
       getAPI('listNetworkOfferings', params).then(json => {
-        this.networkOfferings = json.listnetworkofferingsresponse.networkoffering
+        this.networkOfferings = json.listnetworkofferingsresponse.networkoffering || []
         this.networkOfferings = this.networkOfferings.filter(offering => offering.fornsx === this.selectedZone.isnsxenabled)
         if (!this.selectedZone.routedmodeenabled) {
           this.networkOfferings = this.networkOfferings.filter(offering => offering.networkmode !== 'ROUTED')

--- a/ui/src/views/network/CreateNetworkPermission.vue
+++ b/ui/src/views/network/CreateNetworkPermission.vue
@@ -49,6 +49,7 @@
               api="listProjects"
               :apiParams="projectsApiParams"
               resourceType="project"
+              :pageSize="100"
               defaultIcon="project-outlined" />
           </a-form-item>
           <a-form-item v-if="!isAdminOrDomainAdmin()">
@@ -121,7 +122,9 @@ export default {
     },
     projectsApiParams () {
       return {
-        details: 'min'
+        details: 'min',
+        listall: true,
+        timestamp: this.timestamp
       }
     }
   },

--- a/utils/src/main/java/org/apache/cloudstack/utils/identity/ManagementServerNode.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/identity/ManagementServerNode.java
@@ -19,7 +19,9 @@
 
 package org.apache.cloudstack.utils.identity;
 
-
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.component.ComponentLifecycle;
@@ -27,9 +29,80 @@ import com.cloud.utils.component.SystemIntegrityChecker;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.MacAddress;
 
+/**
+ * Canonical source of the management-server node id ({@code msid}).
+ *
+ * <p>By default the id is derived from the host hardware MAC address. When the MAC address is
+ * not stable across restarts, the {@code msid} changes, which orphans the {@code mshost} row
+ * and breaks async jobs, HA work ({@code fk_op_ha_work__mgmt_server_id}), and router/stats
+ * ownership.
+ *
+ * <p>Setting the environment variable {@code CLOUDSTACK_MSID_FROM_FQDN=true} (or the system
+ * property {@code cloudstack.msid.from.fqdn=true}) instead derives the id from a SHA-256 hash
+ * of the node FQDN, which stays stable across restarts. All node-identity consumers must
+ * obtain the id from {@link #getManagementServerId()} so they agree on the same value.
+ */
 public class ManagementServerNode extends AdapterBase implements SystemIntegrityChecker {
 
-    private static final long s_nodeId = MacAddress.getMacAddress().toLong();
+    private static final String FQDN_ENV_VAR = "CLOUDSTACK_MSID_FROM_FQDN";
+    private static final String FQDN_SYS_PROP = "cloudstack.msid.from.fqdn";
+
+    private static String s_nodeIdSource;
+    private static Exception s_initError;
+    private static final long s_nodeId = initNodeId();
+
+    private static long initNodeId() {
+        if (isFqdnModeEnabled()) {
+            return generateIdFromFqdn();
+        }
+        s_nodeIdSource = "mac-address";
+        return MacAddress.getMacAddress().toLong();
+    }
+
+    private static boolean isFqdnModeEnabled() {
+        return isTruthy(System.getenv(FQDN_ENV_VAR)) || isTruthy(System.getProperty(FQDN_SYS_PROP));
+    }
+
+    private static boolean isTruthy(String value) {
+        if (value == null) {
+            return false;
+        }
+        String trimmed = value.trim();
+        return "true".equalsIgnoreCase(trimmed) || "1".equals(trimmed) || "yes".equalsIgnoreCase(trimmed);
+    }
+
+    /**
+     * Derives a stable node id from a SHA-256 hash of the local FQDN.
+     *
+     * <p>On failure it records the cause and returns {@code 0} (an invalid id) rather than
+     * silently reverting to an unstable MAC-based id. The invalid id makes {@link #check()}
+     * fail the system-integrity check, which stops startup cleanly via {@link #start()}
+     * instead of raising an {@code ExceptionInInitializerError} from static initialization.
+     *
+     * @return a positive, non-zero 48-bit id, or {@code 0} if it cannot be derived
+     */
+    private static long generateIdFromFqdn() {
+        try {
+            String fqdn = InetAddress.getLocalHost().getCanonicalHostName();
+            s_nodeIdSource = "fqdn:" + fqdn;
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(fqdn.getBytes(StandardCharsets.UTF_8));
+            long id = 0;
+            for (int i = 0; i < 6; i++) {
+                id = (id << 8) | (hash[i] & 0xFF);
+            }
+            // Ensure positive and non-zero
+            id = id & 0x7FFFFFFFFFFFFFFFL;
+            if (id == 0) {
+                id = 1;
+            }
+            return id;
+        } catch (Exception e) {
+            s_nodeIdSource = "fqdn-error";
+            s_initError = e;
+            return 0;
+        }
+    }
 
     public ManagementServerNode() {
         setRunLevel(ComponentLifecycle.RUN_LEVEL_FRAMEWORK_BOOTSTRAP);
@@ -38,7 +111,8 @@ public class ManagementServerNode extends AdapterBase implements SystemIntegrity
     @Override
     public void check() {
         if (s_nodeId <= 0) {
-            throw new CloudRuntimeException("Unable to get the management server node id");
+            throw new CloudRuntimeException(
+                    "Unable to derive the management server node id (source: " + s_nodeIdSource + ")", s_initError);
         }
     }
 
@@ -50,10 +124,11 @@ public class ManagementServerNode extends AdapterBase implements SystemIntegrity
     public boolean start() {
         try {
             check();
-        } catch (Exception e) {
-            logger.error("System integrity check exception", e);
-            System.exit(1);
+        } catch (CloudRuntimeException e) {
+            logger.error("System integrity check failed for the management server node id", e);
+            throw e;
         }
+        logger.info("Management server node id: {} (source: {})", s_nodeId, s_nodeIdSource);
         return true;
     }
 }

--- a/utils/src/main/java/org/apache/cloudstack/utils/identity/ManagementServerNode.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/identity/ManagementServerNode.java
@@ -46,62 +46,107 @@ public class ManagementServerNode extends AdapterBase implements SystemIntegrity
 
     private static final String FQDN_ENV_VAR = "CLOUDSTACK_MSID_FROM_FQDN";
     private static final String FQDN_SYS_PROP = "cloudstack.msid.from.fqdn";
+    private static final String IDENTITY_ENV_VAR = "CLOUDSTACK_MSID_IDENTITY";
+    private static final String IDENTITY_SYS_PROP = "cloudstack.msid.identity";
+    private static final String HOSTNAME_ENV_VAR = "HOSTNAME";
+    private static final String POD_NAMESPACE_ENV_VAR = "POD_NAMESPACE";
+
+    // op_lock.mac is varchar(17) and holds the msid, so the id must stay within the 48-bit MAC address range.
+    private static final int MSID_BYTES = 6;
 
     private static String s_nodeIdSource;
-    private static Exception s_initError;
     private static final long s_nodeId = initNodeId();
 
     private static long initNodeId() {
-        if (isFqdnModeEnabled()) {
-            return generateIdFromFqdn();
+        if (isTruthy(System.getenv(FQDN_ENV_VAR)) || isTruthy(System.getProperty(FQDN_SYS_PROP))) {
+            return generateIdFromStableIdentity();
         }
+
         s_nodeIdSource = "mac-address";
         return MacAddress.getMacAddress().toLong();
     }
 
-    private static boolean isFqdnModeEnabled() {
-        return isTruthy(System.getenv(FQDN_ENV_VAR)) || isTruthy(System.getProperty(FQDN_SYS_PROP));
+    static String resolveNodeIdentity(String explicitIdentity, String hostnameEnv, String podNamespaceEnv,
+            String detectedHostName, String canonicalHostName) {
+        String configuredIdentity = trimToNull(explicitIdentity);
+        if (configuredIdentity != null) {
+            return configuredIdentity;
+        }
+
+        String hostName = trimToNull(hostnameEnv);
+        if (hostName != null) {
+            String podNamespace = trimToNull(podNamespaceEnv);
+            return podNamespace == null ? hostName : hostName + "." + podNamespace;
+        }
+
+        String detected = trimToNull(detectedHostName);
+        String canonical = trimToNull(canonicalHostName);
+        if (detected != null && canonical != null && !detected.equals(canonical)) {
+            return detected + "|" + canonical;
+        }
+
+        return canonical != null ? canonical : detected;
+    }
+
+    static long hashNodeIdentity(String nodeIdentity) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(nodeIdentity.getBytes(StandardCharsets.UTF_8));
+            long id = 0;
+            for (int i = 0; i < MSID_BYTES; i++) {
+                id = (id << 8) | (hash[i] & 0xFFL);
+            }
+
+            return id == 0 ? 1 : id;
+        } catch (NoSuchAlgorithmException e) {
+            throw new CloudRuntimeException("SHA-256 algorithm not available for management server ID generation", e);
+        }
+    }
+
+    private static long generateIdFromStableIdentity() {
+        try {
+            InetAddress localHost = InetAddress.getLocalHost();
+            String nodeIdentity = resolveNodeIdentity(
+                    firstNonBlank(System.getProperty(IDENTITY_SYS_PROP), System.getenv(IDENTITY_ENV_VAR)),
+                    System.getenv(HOSTNAME_ENV_VAR),
+                    System.getenv(POD_NAMESPACE_ENV_VAR),
+                    localHost.getHostName(),
+                    localHost.getCanonicalHostName());
+
+            if (nodeIdentity == null) {
+                throw new CloudRuntimeException("Unable to resolve a stable management server identity");
+            }
+
+            s_nodeIdSource = "identity:" + nodeIdentity;
+            return hashNodeIdentity(nodeIdentity);
+        } catch (CloudRuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CloudRuntimeException("Unable to generate management server ID from host identity", e);
+        }
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        String value = trimToNull(first);
+        return value != null ? value : trimToNull(second);
     }
 
     private static boolean isTruthy(String value) {
         if (value == null) {
             return false;
         }
+
         String trimmed = value.trim();
         return "true".equalsIgnoreCase(trimmed) || "1".equals(trimmed) || "yes".equalsIgnoreCase(trimmed);
     }
 
-    /**
-     * Derives a stable node id from a SHA-256 hash of the local FQDN.
-     *
-     * <p>On failure it records the cause and returns {@code 0} (an invalid id) rather than
-     * silently reverting to an unstable MAC-based id. The invalid id makes {@link #check()}
-     * fail the system-integrity check, which stops startup cleanly via {@link #start()}
-     * instead of raising an {@code ExceptionInInitializerError} from static initialization.
-     *
-     * @return a positive, non-zero 48-bit id, or {@code 0} if it cannot be derived
-     */
-    private static long generateIdFromFqdn() {
-        try {
-            String fqdn = InetAddress.getLocalHost().getCanonicalHostName();
-            s_nodeIdSource = "fqdn:" + fqdn;
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(fqdn.getBytes(StandardCharsets.UTF_8));
-            long id = 0;
-            for (int i = 0; i < 6; i++) {
-                id = (id << 8) | (hash[i] & 0xFF);
-            }
-            // Ensure positive and non-zero
-            id = id & 0x7FFFFFFFFFFFFFFFL;
-            if (id == 0) {
-                id = 1;
-            }
-            return id;
-        } catch (Exception e) {
-            s_nodeIdSource = "fqdn-error";
-            s_initError = e;
-            return 0;
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
         }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     public ManagementServerNode() {
@@ -111,8 +156,7 @@ public class ManagementServerNode extends AdapterBase implements SystemIntegrity
     @Override
     public void check() {
         if (s_nodeId <= 0) {
-            throw new CloudRuntimeException(
-                    "Unable to derive the management server node id (source: " + s_nodeIdSource + ")", s_initError);
+            throw new CloudRuntimeException("Unable to get the management server node id");
         }
     }
 
@@ -124,10 +168,11 @@ public class ManagementServerNode extends AdapterBase implements SystemIntegrity
     public boolean start() {
         try {
             check();
-        } catch (CloudRuntimeException e) {
-            logger.error("System integrity check failed for the management server node id", e);
-            throw e;
+        } catch (Exception e) {
+            logger.error("System integrity check exception", e);
+            System.exit(1);
         }
+
         logger.info("Management server node id: {} (source: {})", s_nodeId, s_nodeIdSource);
         return true;
     }

--- a/utils/src/test/java/org/apache/cloudstack/utils/identity/ManagementServerNodeTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/identity/ManagementServerNodeTest.java
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.utils.identity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class ManagementServerNodeTest {
+
+    private static final String FQDN_SYS_PROP = "cloudstack.msid.from.fqdn";
+
+    @After
+    public void tearDown() {
+        System.clearProperty(FQDN_SYS_PROP);
+    }
+
+    private static boolean invokeIsTruthy(String value) throws Exception {
+        Method m = ManagementServerNode.class.getDeclaredMethod("isTruthy", String.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(null, value);
+    }
+
+    private static boolean invokeIsFqdnModeEnabled() throws Exception {
+        Method m = ManagementServerNode.class.getDeclaredMethod("isFqdnModeEnabled");
+        m.setAccessible(true);
+        return (boolean) m.invoke(null);
+    }
+
+    private static long invokeGenerateIdFromFqdn() throws Exception {
+        Method m = ManagementServerNode.class.getDeclaredMethod("generateIdFromFqdn");
+        m.setAccessible(true);
+        return (long) m.invoke(null);
+    }
+
+    @Test
+    public void testGetManagementServerIdIsPositive() {
+        assertTrue("Node id must be a positive, non-zero value", ManagementServerNode.getManagementServerId() > 0);
+    }
+
+    @Test
+    public void testCheckPassesWithValidNodeId() {
+        // Node id is derived at class-load time and should be valid, so check() must not throw.
+        new ManagementServerNode().check();
+    }
+
+    @Test
+    public void testStartReturnsTrueWithValidNodeId() {
+        // With a valid node id, start() must succeed and return true without terminating the JVM.
+        assertTrue(new ManagementServerNode().start());
+    }
+
+    @Test
+    public void testIsTruthyRecognizesTrueValues() throws Exception {
+        assertTrue(invokeIsTruthy("true"));
+        assertTrue(invokeIsTruthy("TRUE"));
+        assertTrue(invokeIsTruthy("True"));
+        assertTrue(invokeIsTruthy("1"));
+        assertTrue(invokeIsTruthy("yes"));
+        assertTrue(invokeIsTruthy("YES"));
+    }
+
+    @Test
+    public void testIsTruthyTrimsWhitespace() throws Exception {
+        assertTrue(invokeIsTruthy("  true  "));
+        assertTrue(invokeIsTruthy("\t1\n"));
+        assertTrue(invokeIsTruthy(" yes "));
+    }
+
+    @Test
+    public void testIsTruthyRejectsFalseValues() throws Exception {
+        assertFalse(invokeIsTruthy(null));
+        assertFalse(invokeIsTruthy(""));
+        assertFalse(invokeIsTruthy("   "));
+        assertFalse(invokeIsTruthy("false"));
+        assertFalse(invokeIsTruthy("0"));
+        assertFalse(invokeIsTruthy("no"));
+        assertFalse(invokeIsTruthy("enabled"));
+        assertFalse(invokeIsTruthy("2"));
+    }
+
+    @Test
+    public void testIsFqdnModeEnabledDefaultsFalse() throws Exception {
+        System.clearProperty(FQDN_SYS_PROP);
+        assertFalse(invokeIsFqdnModeEnabled());
+    }
+
+    @Test
+    public void testIsFqdnModeEnabledWhenSystemPropertyTruthy() throws Exception {
+        System.setProperty(FQDN_SYS_PROP, "true");
+        assertTrue(invokeIsFqdnModeEnabled());
+    }
+
+    @Test
+    public void testIsFqdnModeEnabledWhenSystemPropertyFalsy() throws Exception {
+        System.setProperty(FQDN_SYS_PROP, "false");
+        assertFalse(invokeIsFqdnModeEnabled());
+    }
+
+    @Test
+    public void testGenerateIdFromFqdnIsPositiveAndNonZero() throws Exception {
+        long id = invokeGenerateIdFromFqdn();
+        assertTrue("Generated id must be positive and non-zero", id > 0);
+    }
+
+    @Test
+    public void testGenerateIdFromFqdnFitsIn48Bits() throws Exception {
+        long id = invokeGenerateIdFromFqdn();
+        assertTrue("Generated id must fit within 48 bits", id <= 0xFFFFFFFFFFFFL);
+    }
+
+    @Test
+    public void testGenerateIdFromFqdnIsDeterministic() throws Exception {
+        long first = invokeGenerateIdFromFqdn();
+        long second = invokeGenerateIdFromFqdn();
+        assertEquals("Generated id must be stable across calls for the same FQDN", first, second);
+    }
+}


### PR DESCRIPTION
### Description

Running the managment server in kubernetes produces unwanted issues with jobs due to mac address being used as a msid.  The updated code ensures integrity of the msid by using the FQDN during generation.  By using the FQDN the msid will be same between bounces.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

#### Bug Severity

- [ ] BLOCKER
- [X] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?
Running in Kubernetes, start/stopping/scaling the stateful set.

#### How did you try to break this feature and the system with this change?
Running CloudStack management server in kubernetes repoduces the issue.  Reviewing the creation of new msid entries for each combination of mac address.