### PR TITLE
packaging: align mysql connector with Marvin

### DIFF
--- a/packaging/el8/cloud.spec
+++ b/packaging/el8/cloud.spec
@@ -339,8 +339,8 @@ ln -sf /etc/%{name}/ui/config.json ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/confi
 # Package mysql-connector-python (bundled to avoid dependency on external community repo)
 # Version 8.0.31 is the last version supporting Python 3.6 (EL8)
 wget -P ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup/wheel https://files.pythonhosted.org/packages/08/1f/42d74bae9dd6dcfec67c9ed0f3fa482b1ae5ac5f117ca82ab589ecb3ca19/mysql_connector_python-8.0.31-py2.py3-none-any.whl
-# Version 8.3.0 supports Python 3.8 to 3.12 (EL9, EL10)
-wget -P ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup/wheel https://files.pythonhosted.org/packages/53/ed/26a4b8cacb8852c6fd97d2d58a7f2591c41989807ea82bd8d9725a4e6937/mysql_connector_python-8.3.0-py2.py3-none-any.whl
+# Version 8.4.0 supports Python 3.8 to 3.12 (EL9, EL10)
+wget -P ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup/wheel https://files.pythonhosted.org/packages/d3/fb/c28d1cd952da61f8f27173ce5172f89a65d55b430961a0104b7b294a9bfa/mysql_connector_python-8.4.0-py2.py3-none-any.whl
 
 chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
@@ -459,8 +459,8 @@ fi
 %post management
 # Install mysql-connector-python wheel
 # Detect Python version to install compatible wheel
-if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 7) else 1)'; then
-    pip3 install %{_datadir}/%{name}-management/setup/wheel/mysql_connector_python-8.3.0-py2.py3-none-any.whl
+if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)'; then
+    pip3 install %{_datadir}/%{name}-management/setup/wheel/mysql_connector_python-8.4.0-py2.py3-none-any.whl
 else
     pip3 install %{_datadir}/%{name}-management/setup/wheel/mysql_connector_python-8.0.31-py2.py3-none-any.whl
 fi
@@ -598,7 +598,7 @@ if [ -f "/usr/share/cloudstack-common/scripts/installer/cloudstack-help-text" ];
 fi
 
 %post marvin
-pip3 install --upgrade https://files.pythonhosted.org/packages/08/1f/42d74bae9dd6dcfec67c9ed0f3fa482b1ae5ac5f117ca82ab589ecb3ca19/mysql_connector_python-8.0.31-py2.py3-none-any.whl
+pip3 install --upgrade https://files.pythonhosted.org/packages/d3/fb/c28d1cd952da61f8f27173ce5172f89a65d55b430961a0104b7b294a9bfa/mysql_connector_python-8.4.0-py2.py3-none-any.whl
 pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 
 #No default permission as the permission setup is complex

--- a/packaging/suse15/cloud.spec
+++ b/packaging/suse15/cloud.spec
@@ -339,8 +339,8 @@ ln -sf /etc/%{name}/ui/config.json ${RPM_BUILD_ROOT}%{_datadir}/%{name}-ui/confi
 # Package mysql-connector-python (bundled to avoid dependency on external community repo)
 # Version 8.0.31 is the last version supporting Python 3.6 (EL8)
 wget -P ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup/wheel https://files.pythonhosted.org/packages/08/1f/42d74bae9dd6dcfec67c9ed0f3fa482b1ae5ac5f117ca82ab589ecb3ca19/mysql_connector_python-8.0.31-py2.py3-none-any.whl
-# Version 8.3.0 supports Python 3.8 to 3.12 (EL9, EL10)
-wget -P ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup/wheel https://files.pythonhosted.org/packages/53/ed/26a4b8cacb8852c6fd97d2d58a7f2591c41989807ea82bd8d9725a4e6937/mysql_connector_python-8.3.0-py2.py3-none-any.whl
+# Version 8.4.0 supports Python 3.8 to 3.12 (EL9, EL10)
+wget -P ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup/wheel https://files.pythonhosted.org/packages/d3/fb/c28d1cd952da61f8f27173ce5172f89a65d55b430961a0104b7b294a9bfa/mysql_connector_python-8.4.0-py2.py3-none-any.whl
 
 chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
@@ -459,8 +459,8 @@ fi
 %post management
 # Install mysql-connector-python wheel
 # Detect Python version to install compatible wheel
-if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 7) else 1)'; then
-    pip3 install %{_datadir}/%{name}-management/setup/wheel/mysql_connector_python-8.3.0-py2.py3-none-any.whl
+if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)'; then
+    pip3 install %{_datadir}/%{name}-management/setup/wheel/mysql_connector_python-8.4.0-py2.py3-none-any.whl
 else
     pip3 install %{_datadir}/%{name}-management/setup/wheel/mysql_connector_python-8.0.31-py2.py3-none-any.whl
 fi
@@ -598,7 +598,7 @@ if [ -f "/usr/share/cloudstack-common/scripts/installer/cloudstack-help-text" ];
 fi
 
 %post marvin
-pip3 install --upgrade https://files.pythonhosted.org/packages/08/1f/42d74bae9dd6dcfec67c9ed0f3fa482b1ae5ac5f117ca82ab589ecb3ca19/mysql_connector_python-8.0.31-py2.py3-none-any.whl
+pip3 install --upgrade https://files.pythonhosted.org/packages/d3/fb/c28d1cd952da61f8f27173ce5172f89a65d55b430961a0104b7b294a9bfa/mysql_connector_python-8.4.0-py2.py3-none-any.whl
 pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 
 #No default permission as the permission setup is complex


### PR DESCRIPTION
### Description

This is a small follow-up for #13482.

In #13482 the Marvin dependency was changed to `mysql-connector-python >= 8.4.0`. The older 8.0.31 connector was installed on the Marvin node and caused smoke test failures when testing against OL10, Debian 12 and SUSE15 management environments.

However, the RPM specs were not updated at the same time. Current situation is:

- Marvin `%post` still explicitly installs 8.0.31 before it installs Marvin, while Marvin asks for 8.4.0 or newer;
- management package installs 8.3.0 on the newer Python path;
- this path is selected from Python 3.7, while connector 8.4.0 requires Python 3.8 or newer.

Management and Marvin are normally installed on different machines, so this is not a clash between two packages on the same server. Still, each RPM package should install a connector version which matches the component inside that package.

This PR changes both EL and SUSE RPM specs:

- management installs exact 8.4.0 on Python 3.8 or newer;
- old Python path keeps 8.0.31;
- Python version check is corrected from 3.7 to 3.8;
- Marvin `%post` installs exact 8.4.0 before installing Marvin.

I checked the current 4.23 RC branches and `main`, and the same old blocks are still present there. This PR targets `4.22`, so it can be merged forward after that.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

Tests done locally:

- both changed specs parsed with native `rpmspec -P` on Oracle Linux 8.10;
- official 8.4.0 wheel SHA-256 was verified;
- 8.0.31 was installed and imported on Python 3.6, with clean `pip check`;
- 8.4.0 was installed and imported on Python 3.12, its `Requires-Python: >=3.8` metadata was verified, with clean `pip check`;
- both management and Marvin installation commands were tested starting from installed 9.4.0, and both correctly finished with exact 8.4.0;
- EL and SUSE connector blocks were checked to stay identical.

The upstream multi-distribution package build was also requested on this PR.
