### PR TITLE
docs: fix broken star history chart by using a new provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The following provides more details on the included cryptographic software:
 
 ## Star History
 
-[![Apache CloudStack Star History](https://api.star-history.com/svg?repos=apache/cloudstack&type=Date)](https://www.star-history.com/#apache/cloudstack&Date)
+[![Apache CloudStack Star History](https://star-history.dera.page/svg?repos=apache/cloudstack&type=Date)](https://star-history.dera.page/#apache/cloudstack&Date)
 
 ## Contributors
 


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub now restricts the stargazer API to repository owners only. This change points the image and link to star-history.dera.page, a token-free alternative that requires no extra configuration or API tokens.

<!--- PR Title should follow the format: [Type][Scope]: Description. If the scope is not applicable, replace with a dash. --->