### PR TITLE
Enforce oauth2.plugins as an allow-list for OAuth2 login providers

### DIFF
--- a/plugins/user-authenticators/oauth2/src/main/java/org/apache/cloudstack/oauth2/OAuth2AuthManagerImpl.java
+++ b/plugins/user-authenticators/oauth2/src/main/java/org/apache/cloudstack/oauth2/OAuth2AuthManagerImpl.java
@@ -120,7 +120,16 @@ public class OAuth2AuthManagerImpl extends ManagerBase implements OAuth2AuthMana
 
     @Override
     public List<UserOAuth2Authenticator> listUserOAuth2AuthenticationProviders() {
-        return userOAuth2AuthenticationProviders;
+        if (userOAuth2AuthenticationProviders == null) {
+            return userOAuth2AuthenticationProviders;
+        }
+        List<UserOAuth2Authenticator> allowed = new ArrayList<>();
+        for (UserOAuth2Authenticator provider : userOAuth2AuthenticationProviders) {
+            if (isProviderAllowed(provider.getName())) {
+                allowed.add(provider);
+            }
+        }
+        return allowed;
     }
 
     @Override
@@ -128,10 +137,24 @@ public class OAuth2AuthManagerImpl extends ManagerBase implements OAuth2AuthMana
         if (StringUtils.isEmpty(providerName)) {
             throw new CloudRuntimeException("OAuth2 authentication provider name is empty");
         }
-        if (!userOAuth2AuthenticationProvidersMap.containsKey(providerName.toLowerCase())) {
+        if (!userOAuth2AuthenticationProvidersMap.containsKey(providerName.toLowerCase()) || !isProviderAllowed(providerName)) {
             throw new CloudRuntimeException(String.format("Failed to find OAuth2 authentication provider by the name: %s.", providerName));
         }
         return userOAuth2AuthenticationProvidersMap.get(providerName.toLowerCase());
+    }
+
+    // oauth2.plugins is an allow-list: a provider must be named in it to be usable at all.
+    protected boolean isProviderAllowed(String providerName) {
+        String allowedPlugins = OAuth2AuthManager.OAuth2Plugins.value();
+        if (StringUtils.isEmpty(allowedPlugins)) {
+            return true;
+        }
+        for (String allowed : allowedPlugins.trim().split("\\s*,\\s*")) {
+            if (allowed.equalsIgnoreCase(providerName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public List<UserOAuth2Authenticator> getUserOAuth2AuthenticationProviders() {

--- a/plugins/user-authenticators/oauth2/src/test/java/org/apache/cloudstack/oauth2/OAuth2AuthManagerImplTest.java
+++ b/plugins/user-authenticators/oauth2/src/test/java/org/apache/cloudstack/oauth2/OAuth2AuthManagerImplTest.java
@@ -24,6 +24,7 @@ import com.cloud.domain.DomainVO;
 import com.cloud.user.DomainService;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.auth.UserOAuth2Authenticator;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.framework.messagebus.MessageSubscriber;
 import org.apache.cloudstack.oauth2.api.command.DeleteOAuthProviderCmd;
@@ -49,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
@@ -523,6 +525,50 @@ public class OAuth2AuthManagerImplTest {
         } catch (CloudRuntimeException e) {
             assertTrue(e.getMessage().contains("nonexistent"));
         }
+    }
+
+    @Test
+    public void testGetUserOAuth2AuthenticationProviderRejectsProviderNotInPluginsList() {
+        UserOAuth2Authenticator googleAuthenticator = Mockito.mock(UserOAuth2Authenticator.class);
+        OAuth2AuthManagerImpl.userOAuth2AuthenticationProvidersMap.put("google", googleAuthenticator);
+        try {
+            Mockito.doReturn(false).when(_authManager).isProviderAllowed("google");
+
+            try {
+                _authManager.getUserOAuth2AuthenticationProvider("google");
+                Assert.fail("Expected CloudRuntimeException was not thrown");
+            } catch (CloudRuntimeException e) {
+                assertTrue(e.getMessage().contains("google"));
+            }
+        } finally {
+            OAuth2AuthManagerImpl.userOAuth2AuthenticationProvidersMap.remove("google");
+        }
+    }
+
+    @Test
+    public void testListUserOAuth2AuthenticationProvidersFiltersOutDisallowedPlugins() {
+        UserOAuth2Authenticator googleAuthenticator = Mockito.mock(UserOAuth2Authenticator.class);
+        when(googleAuthenticator.getName()).thenReturn("google");
+        UserOAuth2Authenticator keycloakAuthenticator = Mockito.mock(UserOAuth2Authenticator.class);
+        when(keycloakAuthenticator.getName()).thenReturn("keycloak");
+        _authManager.setUserOAuth2AuthenticationProviders(Arrays.asList(googleAuthenticator, keycloakAuthenticator));
+
+        Mockito.doReturn(true).when(_authManager).isProviderAllowed("google");
+        Mockito.doReturn(false).when(_authManager).isProviderAllowed("keycloak");
+
+        List<UserOAuth2Authenticator> result = _authManager.listUserOAuth2AuthenticationProviders();
+
+        assertEquals(1, result.size());
+        assertEquals("google", result.get(0).getName());
+    }
+
+    @Test
+    public void testIsProviderAllowedMatchesConfiguredPluginsListCaseInsensitively() {
+        // no ConfigDepot is wired in this unit test, so OAuth2Plugins.value() falls back to
+        // its default of "google,github"
+        assertTrue(_authManager.isProviderAllowed("google"));
+        assertTrue(_authManager.isProviderAllowed("Google"));
+        assertFalse(_authManager.isProviderAllowed("keycloak"));
     }
 
     //  Multiple-domain OAuth tests


### PR DESCRIPTION
Fixes #13862.

`oauth2.plugins` (default `google,github`, described as "List of OAuth plugins") was declared as a `ConfigKey` but never read anywhere. Actual provider availability was determined entirely by which Spring beans exist plus `oauth2.plugins.exclude`, so changing `oauth2.plugins` was a complete no-op, an admin could set it to `github,keycloak` and `google` would remain fully functional.

This wires it up as an allow-list: a provider must be named in `oauth2.plugins` to be usable.

- `OAuth2AuthManagerImpl.getUserOAuth2AuthenticationProvider()` now rejects any provider not in the configured list (covers both the `oauthlogin` and `verifyOAuthCodeAndGetUser` paths, since both resolve the provider through this method).
- `OAuth2AuthManagerImpl.listUserOAuth2AuthenticationProviders()` filters the same way, so `listOauthProvider` no longer reports a disallowed provider as enabled.
- Match is case-insensitive, consistent with how provider names are looked up elsewhere in this class.

Added test coverage for the allow-list check itself and for both call sites.