### PR TITLE
Allow multiple simultaneous console viewers for KVM user VMs

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -53,3 +53,9 @@ example.ver.1 > example.ver.2:
     the guest while the NVRAM sidecar is copied, so that the captured firmware
     state is consistent with the disk snapshot. Non-UEFI VMs are unaffected and
     continue to snapshot live.
+
+KVM console:
+  * Added the global setting `consoleproxy.kvm.multiple.viewers.enabled` to allow
+    multiple users to simultaneously access the console of the same KVM user VM.
+    The setting defaults to false to preserve the existing single-viewer behavior.
+

--- a/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
+++ b/api/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManager.java
@@ -41,6 +41,13 @@ public interface ConsoleAccessManager extends Manager, Configurable {
             false,
             ConfigKey.Scope.Global);
 
+    ConfigKey<Boolean> KvmMultipleConsoleViewersEnabled = new ConfigKey<>("Advanced", Boolean.class,
+            "consoleproxy.kvm.multiple.viewers.enabled",
+            "false",
+            "Determines whether multiple simultaneous console viewers are allowed for the same KVM user VM",
+            true,
+            ConfigKey.Scope.Global);
+
     ConsoleEndpoint generateConsoleEndpoint(Long vmId, String extraSecurityToken, String clientAddress);
 
     boolean isSessionAllowed(String sessionUuid);

--- a/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImpl.java
@@ -160,7 +160,8 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey[] {
                 ConsoleAccessManager.ConsoleSessionCleanupInterval,
-                ConsoleAccessManager.ConsoleSessionCleanupRetentionHours
+                ConsoleAccessManager.ConsoleSessionCleanupRetentionHours,
+                ConsoleAccessManager.KvmMultipleConsoleViewersEnabled
         };
     }
 
@@ -474,6 +475,10 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
         return null;
     }
 
+    protected boolean isKvmMultipleConsoleViewersEnabled() {
+        return ConsoleAccessManager.KvmMultipleConsoleViewersEnabled.value();
+    }
+
     protected ConsoleConnectionDetails getConsoleConnectionDetails(VirtualMachine vm, HostVO host) {
         String locale = null;
         String tag = vm.getUuid();
@@ -507,6 +512,13 @@ public class ConsoleAccessManagerImpl extends ManagerBase implements ConsoleAcce
                     .getValue()));
             logger.debug("HyperV RDP port for {} on {} is: {}", vm, host, details.getPort());
         }
+
+        if (Hypervisor.HypervisorType.KVM.equals(host.getHypervisorType()) &&
+                VirtualMachine.Type.User.equals(vm.getType()) &&
+                isKvmMultipleConsoleViewersEnabled()) {
+            details.setSessionRequiresNewViewer(true);
+        }
+
         return details;
     }
 

--- a/server/src/test/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImplTest.java
@@ -546,6 +546,80 @@ public class ConsoleAccessManagerImplTest {
     }
 
     @Test
+    public void getConsoleConnectionDetailsRequiresNewViewerForKVMUserVmWhenMultipleViewersEnabled() {
+        VirtualMachine vm = Mockito.mock(VirtualMachine.class);
+        HostVO host = Mockito.mock(HostVO.class);
+        String hostAddress = "192.168.1.100";
+        int port = 5900;
+        Pair<String, Integer> hostPortInfo = new Pair<>(hostAddress, port);
+
+        Mockito.when(vm.getUuid()).thenReturn("vm-uuid");
+        Mockito.when(vm.getHostName()).thenReturn("vm-hostname");
+        Mockito.when(vm.getVncPassword()).thenReturn("vnc-password");
+        Mockito.when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(host.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        Mockito.when(vmInstanceDetailsDao.listDetailsKeyPairs(Mockito.anyLong(), Mockito.anyList())).thenReturn(Map.of());
+        Mockito.when(managementServer.getVncPort(vm)).thenReturn(hostPortInfo);
+        Mockito.doReturn(new Ternary<>(hostAddress, null, null))
+                .when(consoleAccessManager).parseHostInfo(Mockito.anyString());
+        Mockito.doReturn(true).when(consoleAccessManager).isKvmMultipleConsoleViewersEnabled();
+
+        ConsoleConnectionDetails result = consoleAccessManager.getConsoleConnectionDetails(vm, host);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isSessionRequiresNewViewer());
+    }
+
+    @Test
+    public void getConsoleConnectionDetailsDoesNotRequireNewViewerForKVMUserVmWhenMultipleViewersDisabled() {
+        VirtualMachine vm = Mockito.mock(VirtualMachine.class);
+        HostVO host = Mockito.mock(HostVO.class);
+        String hostAddress = "192.168.1.100";
+        int port = 5900;
+        Pair<String, Integer> hostPortInfo = new Pair<>(hostAddress, port);
+
+        Mockito.when(vm.getUuid()).thenReturn("vm-uuid");
+        Mockito.when(vm.getHostName()).thenReturn("vm-hostname");
+        Mockito.when(vm.getVncPassword()).thenReturn("vnc-password");
+        Mockito.when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        Mockito.when(host.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        Mockito.when(vmInstanceDetailsDao.listDetailsKeyPairs(Mockito.anyLong(), Mockito.anyList())).thenReturn(Map.of());
+        Mockito.when(managementServer.getVncPort(vm)).thenReturn(hostPortInfo);
+        Mockito.doReturn(new Ternary<>(hostAddress, null, null))
+                .when(consoleAccessManager).parseHostInfo(Mockito.anyString());
+        Mockito.doReturn(false).when(consoleAccessManager).isKvmMultipleConsoleViewersEnabled();
+
+        ConsoleConnectionDetails result = consoleAccessManager.getConsoleConnectionDetails(vm, host);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isSessionRequiresNewViewer());
+    }
+
+    @Test
+    public void getConsoleConnectionDetailsDoesNotRequireNewViewerForKVMSystemVmWhenMultipleViewersEnabled() {
+        VirtualMachine vm = Mockito.mock(VirtualMachine.class);
+        HostVO host = Mockito.mock(HostVO.class);
+        String hostAddress = "192.168.1.100";
+        int port = 5900;
+        Pair<String, Integer> hostPortInfo = new Pair<>(hostAddress, port);
+
+        Mockito.when(vm.getUuid()).thenReturn("vm-uuid");
+        Mockito.when(vm.getHostName()).thenReturn("vm-hostname");
+        Mockito.when(vm.getVncPassword()).thenReturn("vnc-password");
+        Mockito.when(vm.getType()).thenReturn(VirtualMachine.Type.DomainRouter);
+        Mockito.when(host.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        Mockito.when(vmInstanceDetailsDao.listDetailsKeyPairs(Mockito.anyLong(), Mockito.anyList())).thenReturn(Map.of());
+        Mockito.when(managementServer.getVncPort(vm)).thenReturn(hostPortInfo);
+        Mockito.doReturn(new Ternary<>(hostAddress, null, null))
+                .when(consoleAccessManager).parseHostInfo(Mockito.anyString());
+
+        ConsoleConnectionDetails result = consoleAccessManager.getConsoleConnectionDetails(vm, host);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isSessionRequiresNewViewer());
+    }
+
+    @Test
     public void getConsoleConnectionDetailsReturnsDetailsWithRDPForHyperV() {
         VirtualMachine vm = Mockito.mock(VirtualMachine.class);
         HostVO host = Mockito.mock(HostVO.class);

--- a/server/src/test/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/consoleproxy/ConsoleAccessManagerImplTest.java
@@ -596,7 +596,7 @@ public class ConsoleAccessManagerImplTest {
     }
 
     @Test
-    public void getConsoleConnectionDetailsDoesNotRequireNewViewerForKVMSystemVmWhenMultipleViewersEnabled() {
+    public void getConsoleConnectionDetailsDoesNotRequireNewViewerForKVMSystemVm() {
         VirtualMachine vm = Mockito.mock(VirtualMachine.class);
         HostVO host = Mockito.mock(HostVO.class);
         String hostAddress = "192.168.1.100";
@@ -612,11 +612,11 @@ public class ConsoleAccessManagerImplTest {
         Mockito.when(managementServer.getVncPort(vm)).thenReturn(hostPortInfo);
         Mockito.doReturn(new Ternary<>(hostAddress, null, null))
                 .when(consoleAccessManager).parseHostInfo(Mockito.anyString());
-
         ConsoleConnectionDetails result = consoleAccessManager.getConsoleConnectionDetails(vm, host);
 
         Assert.assertNotNull(result);
         Assert.assertFalse(result.isSessionRequiresNewViewer());
+        Mockito.verify(consoleAccessManager, Mockito.never()).isKvmMultipleConsoleViewersEnabled();
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR adds support for multiple simultaneous console viewers for the same KVM user VM.

Currently, console proxy sessions for a VM use the VM client tag as the viewer key. When a second user opens the console for the same VM, the existing viewer is replaced and the first user's console session is disconnected.

CloudStack already supports using a unique console session UUID as the viewer key when `sessionRequiresNewViewer` is enabled. This change exposes that existing capability for KVM user VMs through a new global setting:

`consoleproxy.kvm.multiple.viewers.enabled`

The setting defaults to `false`, preserving the existing single-viewer behavior.

When enabled for a KVM user VM, each console request uses a unique viewer session, allowing multiple users to access the same VM console simultaneously.

The change is limited to KVM user VMs. System VMs and other hypervisors retain their existing console behavior.

Fixes: #13869

### Types of changes

* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (improves an existing feature and functionality)
* [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
* [ ] Build/CI
* [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

* [ ] Major
* [x] Minor

#### Bug Severity

* [ ] BLOCKER
* [ ] Critical
* [ ] Major
* [ ] Minor
* [ ] Trivial

### Screenshots (if appropriate)

N/A

### How Has This Been Tested?

Unit tests were added to `ConsoleAccessManagerImplTest` covering:

* KVM user VM with multiple console viewers enabled: a new viewer is required.
* KVM user VM with multiple console viewers disabled: existing single-viewer behavior is preserved.
* KVM system VM: multiple-viewer behavior is not applied and the setting is not consulted.

Focused unit test:

`mvn -pl server -Dtest=ConsoleAccessManagerImplTest test`

Result:

`Tests run: 39, Failures: 0, Errors: 0, Skipped: 0`

`BUILD SUCCESS`

The CloudStack CI-style build was also executed:

`mvn -B -P developer,systemvm -Dsimulator -Dnoredist clean install -T$(nproc)`

Result:

`BUILD SUCCESS`

The feature was additionally validated manually with CloudStack 4.22.1.0 and KVM. With the existing behavior, opening the same VM console from a second user disconnects the first user. After enabling per-session viewers, two users were able to remain connected to the same KVM VM console simultaneously.

### How did you try to break this feature and the system with this change?

The global setting defaults to `false`, and unit testing verifies that the existing single-viewer behavior remains unchanged when it is disabled.

The feature is explicitly restricted to KVM user VMs. The feature is explicitly restricted to KVM user VMs. A unit test verifies that KVM system VMs do not receive the new viewer behavior and that the multiple-viewer setting is not consulted.

Existing Hyper-V and external-console tests in `ConsoleAccessManagerImplTest` also continue to pass.

The complete CloudStack developer/systemvm simulator build passed after the change.

### Reviewer Test Procedure

1. Deploy the change to a CloudStack environment using KVM.
2. In **Global Settings**, locate:
   `consoleproxy.kvm.multiple.viewers.enabled`
3. Set the value to `true`.
4. Open the console of the same running KVM user VM from two separate CloudStack user sessions or browser sessions.
5. Verify that:
   - Both console sessions remain connected.
   - Opening the second console does not disconnect the first.
   - Both users can view the same VM console.
   - Keyboard and mouse input continue to function from both sessions.
6. Close one of the console sessions and verify that the other session remains connected.
7. Open another console session for the same VM and verify that it can connect without disconnecting the existing viewer.
8. Set `consoleproxy.kvm.multiple.viewers.enabled` back to `false`.
9. Open two fresh console sessions for the same KVM user VM.
10. Verify that the existing single-viewer behavior is restored: opening the second console replaces/disconnects the first viewer.
11. Optionally verify that enabling the setting does not change console behavior for KVM system VMs or non-KVM hypervisors.