### PR TITLE
Fix KBOSS backup creation edge case

### DIFF
--- a/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
+++ b/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
@@ -1819,8 +1819,8 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
             succeedingDeltaPaths = gatherSnapshotReferencesOfChildrenSnapshot(List.of(volumeObjectTO), succeedingVmSnapshot).getOrDefault(volumeObjectTO.getVolumeId(), List.of())
                     .stream().map(SnapshotDataStoreVO::getInstallPath).collect(Collectors.toList());
 
-            if (!childIsVolume && !runningVm && succeedingDeltaPaths.isEmpty()) {
-                succeedingDeltaPaths = List.of(volumeObjectTO.getPath());
+            if (!childIsVolume && !runningVm && succeedingVmSnapshot.getCurrent()) {
+                succeedingDeltaPaths.add(volumeObjectTO.getPath());
                 logger.debug("Since the last backup delta of volume [{}] is succeeded by a snapshot and the delta created by this snapshot is also the volume, it will have to be" +
                         " rebased. Setting it as the grand-child.", volumeObjectTO.getUuid());
             }

--- a/plugins/backup/kboss/src/test/java/org/apache/cloudstack/backup/KbossBackupProviderTest.java
+++ b/plugins/backup/kboss/src/test/java/org/apache/cloudstack/backup/KbossBackupProviderTest.java
@@ -2318,6 +2318,7 @@ public class KbossBackupProviderTest {
         doReturn("parent-path").when(internalBackupStoragePoolVoMock).getBackupDeltaParentPath();
         doReturn("child-path").when(internalBackupStoragePoolVoMock).getBackupDeltaPath();
         doReturn("/volume/path").when(volumeObjectToMock).getPath();
+        doReturn(true).when(vmSnapshotVoMock).getCurrent();
 
         doReturn(Map.of()).when(kbossBackupProviderSpy)
                 .gatherSnapshotReferencesOfChildrenSnapshot(List.of(volumeObjectToMock), vmSnapshotVoMock);


### PR DESCRIPTION
### Description

If a new incremental backup is created for a stopped VM, that has a delta tree with more than one branch for one of its volumes, and the VM snapshot following the last backup is the current one, a problem occurs during backup creation where the current VM snapshot delta is not rebased to its new parent, causing subsequent backups to fail and the chain to become inconsistent.

This PR fixes this issue.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

### Test description

With a stopped VM, the following tests were performed:

| Test                                                                                                                             | Previous result                                                                       | Result with patch            |
| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------- |
| Take a backup, a VM snapshot, and a new backup                                                                                   | Success and consistent chain                                                          | Success and consistent chain |
| Take a backup, two consecutive VM snapshots, revert to the first VM snapshot, take a new VM snapshot, and then take a new backup | Success and consistent chain                                                          | Success and consistent chain |
| Take a backup, two consecutive VM snapshots, revert to the first VM snapshot, and then take a new backup                         | **Success, but the chain becomes inconsistent, making it impossible to start the VM** | Success and consistent chain |