### PR TITLE
(KBOSS) Add synchronous backup compression flag

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -1489,6 +1489,7 @@ public class ApiConstants {
     public static final String SCHEDULED = "scheduled";
     public static final String SCHEDULED_DATE = "scheduleddate";
     public static final String BACKUP_PROVIDER = "backupprovider";
+    public static final String COMPRESS_ASYNC = "compressasync";
 
     /**
      * This enum specifies IO Drivers, each option controls specific policies on I/O.

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/backup/CreateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/backup/CreateBackupOfferingCmd.java
@@ -34,7 +34,7 @@ import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.backup.Backup;
 import org.apache.cloudstack.backup.BackupManager;
 import org.apache.cloudstack.backup.BackupOffering;
-
+import org.apache.commons.lang3.BooleanUtils;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -171,7 +171,7 @@ public class CreateBackupOfferingCmd extends BaseCmd {
     }
 
     public boolean isCompressAsync() {
-        return Boolean.TRUE.equals(this.compressAsync);
+        return BooleanUtils.toBooleanDefaultIfNull(this.compressAsync, true);
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/backup/CreateBackupOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/backup/CreateBackupOfferingCmd.java
@@ -92,6 +92,10 @@ public class CreateBackupOfferingCmd extends BaseCmd {
             description = "Restrict the backup offering to the Domains identified by these IDs.")
     private List<Long> domainIds;
 
+    @Parameter(name = ApiConstants.COMPRESS_ASYNC, type = CommandType.BOOLEAN, description = "Whether to compress synchronously during backup creation, or asynchronously later. " +
+            "Default true.")
+    private Boolean compressAsync;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -164,6 +168,10 @@ public class CreateBackupOfferingCmd extends BaseCmd {
 
     public Boolean getUserDrivenBackups() {
         return userDrivenBackups;
+    }
+
+    public boolean isCompressAsync() {
+        return Boolean.TRUE.equals(this.compressAsync);
     }
 
     /////////////////////////////////////////////////////

--- a/core/src/main/java/org/apache/cloudstack/backup/TakeKbossBackupCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/backup/TakeKbossBackupCommand.java
@@ -42,7 +42,16 @@ public class TakeKbossBackupCommand extends Command {
 
     private boolean isolated;
 
-    public TakeKbossBackupCommand(boolean quiesceVm, boolean runningVM, boolean endChain, String vmName, String imageStoreUrl, List<String> backupChainImageStoreUrls, List<KbossTO> kbossTOS, boolean isolated) {
+    private boolean compress;
+
+    private Backup.CompressionLibrary compressionLib;
+
+    private Integer coroutines;
+
+    private Integer rateLimit;
+
+    public TakeKbossBackupCommand(boolean quiesceVm, boolean runningVM, boolean endChain, String vmName, String imageStoreUrl, List<String> backupChainImageStoreUrls,
+            List<KbossTO> kbossTOS, boolean isolated) {
         this.quiesceVm = quiesceVm;
         this.runningVM = runningVM;
         this.endChain = endChain;
@@ -83,6 +92,38 @@ public class TakeKbossBackupCommand extends Command {
 
     public boolean isIsolated() {
         return isolated;
+    }
+
+    public void setRateLimit(Integer rateLimit) {
+        this.rateLimit = rateLimit;
+    }
+
+    public void setCoroutines(Integer coroutines) {
+        this.coroutines = coroutines;
+    }
+
+    public void setCompressionLib(Backup.CompressionLibrary compressionLib) {
+        this.compressionLib = compressionLib;
+    }
+
+    public void setCompress(boolean compress) {
+        this.compress = compress;
+    }
+
+    public boolean isCompress() {
+        return compress;
+    }
+
+    public Backup.CompressionLibrary getCompressionLib() {
+        return compressionLib;
+    }
+
+    public Integer getCoroutines() {
+        return coroutines;
+    }
+
+    public Integer getRateLimit() {
+        return rateLimit;
     }
 
     @Override

--- a/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
+++ b/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
@@ -448,8 +448,12 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
                     parentBackupDeltasOnPrimary, volumeUuidToDeltaPrimaryRef, volumeUuidToDeltaSecondaryRef, succeedingVmSnapshot, kbossTO);
         }
 
+        boolean supportsCompression = offeringSupportsCompression(newBackupJoin);
+
         TakeKbossBackupCommand command = new TakeKbossBackupCommand(quiesceVm, runningVm, newBackupJoin.getEndOfChain(), userVm.getInstanceName(), imageStore.getUri(),
                 chainImageStoreUrls, kbossTOs, isolated);
+
+        boolean compressNow = checkSyncCompressionAndConfigureCommand(backupOfferingVO, supportsCompression, command, hostVO);
 
         Answer answer = sendBackupCommand(hostId, command);
 
@@ -459,18 +463,32 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
         }
 
         processBackupSuccess(runningVm, volumeTOs, volumeUuidToDeltaPrimaryRef, volumeUuidToDeltaSecondaryRef, (TakeKbossBackupAnswer)answer, parentBackupDeltasOnPrimary,
-                succeedingVmSnapshotList, backupVO, fullBackup, userVm, hostId, newBackupJoin.getEndOfChain(), isolated);
+                succeedingVmSnapshotList, backupVO, fullBackup, userVm, hostId, newBackupJoin.getEndOfChain(), isolated, compressNow);
 
         if (!isolated) {
             updateCurrentBackup(newBackupJoin);
         }
 
-        if (offeringSupportsCompression(newBackupJoin)) {
+        if (supportsCompression && !compressNow) {
             compressBackupAsync(newBackupJoin, backup.getZoneId(), userVm.getAccountId());
         } else {
             validateBackupAsyncIfHasOfferingSupport(newBackupJoin, backup.getZoneId(), userVm.getAccountId());
         }
         return new Pair<>(Boolean.TRUE, backupVO.getId());
+    }
+
+    protected boolean checkSyncCompressionAndConfigureCommand(BackupOfferingVO backupOfferingVO, boolean supportsCompression, TakeKbossBackupCommand command, HostVO hostVO) {
+        BackupOfferingDetailsVO compressAsync = backupOfferingDetailsDao.findDetail(backupOfferingVO.getId(), ApiConstants.COMPRESS_ASYNC);
+        boolean compressNow = compressAsync != null && !Boolean.parseBoolean(compressAsync.getValue()) && supportsCompression;
+
+        if (compressNow) {
+            BackupOfferingDetailsVO detail = backupOfferingDetailsDao.findDetail(backupOfferingVO.getId(), ApiConstants.COMPRESSION_LIBRARY);
+            command.setCompress(true);
+            command.setCompressionLib(detail == null ? null : Backup.CompressionLibrary.valueOf(detail.getValue()));
+            command.setCoroutines(backupCompressionCoroutines.valueIn(hostVO.getClusterId()));
+            command.setRateLimit(backupCompressionRateLimit.valueIn(hostVO.getClusterId()));
+        }
+        return compressNow;
     }
 
     @Override
@@ -2084,7 +2102,8 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
 
     protected void processBackupSuccess(boolean runningVm, List<VolumeObjectTO> volumeTOs, HashMap<String, InternalBackupStoragePoolVO> volumeUuidToDeltaPrimaryRef,
             HashMap<String, InternalBackupDataStoreVO> volumeUuidToDeltaSecondaryRef, TakeKbossBackupAnswer answer, List<InternalBackupStoragePoolVO> parentBackupDeltasOnPrimary,
-            List<VMSnapshotVO> succeedingVmSnapshots, BackupVO backupVO, boolean fullBackup, VirtualMachine userVm, Long hostId, boolean endChain, boolean isolated) {
+            List<VMSnapshotVO> succeedingVmSnapshots, BackupVO backupVO, boolean fullBackup, VirtualMachine userVm, Long hostId, boolean endChain, boolean isolated,
+            boolean compressNow) {
         long physicalBackupSize = 0;
         logger.debug("Processing backup [{}] success.", backupVO.getUuid());
         for (VolumeObjectTO volumeObjectTO : volumeTOs) {
@@ -2094,6 +2113,9 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
 
         expungeOldDeltasAndUpdateVmSnapshotIfNeeded(parentBackupDeltasOnPrimary, succeedingVmSnapshots.isEmpty() ? null : succeedingVmSnapshots.get(0));
 
+        if (compressNow) {
+            backupVO.setCompressionStatus(Backup.CompressionStatus.Compressed);
+        }
         backupVO.setSize(physicalBackupSize);
         backupVO.setStatus(Backup.Status.BackedUp);
         backupVO.setBackedUpVolumes(backupManager.createVolumeInfoFromVolumes(new ArrayList<>(volumeDao.findByInstance(userVm.getId()))));

--- a/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
+++ b/plugins/backup/kboss/src/main/java/org/apache/cloudstack/backup/KbossBackupProvider.java
@@ -484,7 +484,7 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
         if (compressNow) {
             BackupOfferingDetailsVO detail = backupOfferingDetailsDao.findDetail(backupOfferingVO.getId(), ApiConstants.COMPRESSION_LIBRARY);
             command.setCompress(true);
-            command.setCompressionLib(detail == null ? null : Backup.CompressionLibrary.valueOf(detail.getValue()));
+            command.setCompressionLib(detail == null ? Backup.CompressionLibrary.zstd : Backup.CompressionLibrary.valueOf(detail.getValue()));
             command.setCoroutines(backupCompressionCoroutines.valueIn(hostVO.getClusterId()));
             command.setRateLimit(backupCompressionRateLimit.valueIn(hostVO.getClusterId()));
         }
@@ -800,7 +800,7 @@ public class KbossBackupProvider extends AdapterBase implements InternalBackupPr
         BackupOfferingDetailsVO detail = backupOfferingDetailsDao.findDetail(backupOfferingVO.getId(), ApiConstants.COMPRESSION_LIBRARY);
         List<InternalBackupJoinVO> backupChain = getBackupJoinParents(backupVO, true);
         List<String> chainImageStoreUrls = getChainImageStoreUrls(backupChain);
-        CompressBackupCommand cmd = new CompressBackupCommand(deltasToCompressAndParents, chainImageStoreUrls, minFreeStorage, detail == null ? null :
+        CompressBackupCommand cmd = new CompressBackupCommand(deltasToCompressAndParents, chainImageStoreUrls, minFreeStorage, detail == null ? Backup.CompressionLibrary.zstd :
                 Backup.CompressionLibrary.valueOf(detail.getValue()), backupCompressionCoroutines.valueIn(hostVO.getClusterId()),
                 backupCompressionRateLimit.valueIn(hostVO.getClusterId()));
         cmd.setWait(backupCompressionTimeout.valueIn(hostVO.getClusterId()));

--- a/plugins/backup/kboss/src/test/java/org/apache/cloudstack/backup/KbossBackupProviderTest.java
+++ b/plugins/backup/kboss/src/test/java/org/apache/cloudstack/backup/KbossBackupProviderTest.java
@@ -787,6 +787,8 @@ public class KbossBackupProviderTest {
         doNothing().when(kbossBackupProviderSpy).validateStorages(any(), any());
         doReturn(internalBackupJoinVoMock).when(internalBackupJoinDaoMock).findById(any());
         doReturn(dataStoreMock).when(kbossBackupProviderSpy).getImageStoreForBackup(any(), any());
+        doReturn(false).when(kbossBackupProviderSpy).offeringSupportsCompression(any());
+        doReturn(false).when(kbossBackupProviderSpy).checkSyncCompressionAndConfigureCommand(any(), anyBoolean(), any(), any());
 
         Pair<Boolean, Long> result = kbossBackupProviderSpy.orchestrateTakeBackup(backupVoMock, false, true);
         assertFalse(result.first());
@@ -815,9 +817,10 @@ public class KbossBackupProviderTest {
         doReturn(takeKbossBackupAnswerMock).when(kbossBackupProviderSpy).sendBackupCommand(anyLong(), any());
         doReturn(true).when(takeKbossBackupAnswerMock).getResult();
         doNothing().when(kbossBackupProviderSpy).processBackupSuccess(anyBoolean(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
-                anyLong(), anyBoolean(), anyBoolean());
-        doReturn(true).when(kbossBackupProviderSpy).offeringSupportsCompression(internalBackupJoinVoMock);
+                anyLong(), anyBoolean(), anyBoolean(), anyBoolean());
         doNothing().when(kbossBackupProviderSpy).compressBackupAsync(internalBackupJoinVoMock, 0, 0);
+        doReturn(true).when(kbossBackupProviderSpy).offeringSupportsCompression(any());
+        doReturn(false).when(kbossBackupProviderSpy).checkSyncCompressionAndConfigureCommand(any(), anyBoolean(), any(), any());
 
         Pair<Boolean, Long> result = kbossBackupProviderSpy.orchestrateTakeBackup(backupVoMock, false, true);
         assertTrue(result.first());
@@ -825,7 +828,7 @@ public class KbossBackupProviderTest {
         verify(kbossBackupProviderSpy, Mockito.times(1)).setBackupAsIsolated(backupVoMock);
         verify(kbossBackupProviderSpy, Mockito.times(2)).createDeltaReferences(Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(), any(), any(), any(), any(), any(), any(), any());
         verify(kbossBackupProviderSpy, Mockito.times(1)).processBackupSuccess(anyBoolean(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
-                anyLong(), anyBoolean(), anyBoolean());
+                anyLong(), anyBoolean(), anyBoolean(), anyBoolean());
         verify(kbossBackupProviderSpy, Mockito.times(1)).compressBackupAsync(internalBackupJoinVoMock, 0, 0);
     }
 
@@ -850,9 +853,10 @@ public class KbossBackupProviderTest {
         doReturn(takeKbossBackupAnswerMock).when(kbossBackupProviderSpy).sendBackupCommand(anyLong(), any());
         doReturn(true).when(takeKbossBackupAnswerMock).getResult();
         doNothing().when(kbossBackupProviderSpy).processBackupSuccess(anyBoolean(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
-                anyLong(), anyBoolean(), anyBoolean());
-        doReturn(false).when(kbossBackupProviderSpy).offeringSupportsCompression(internalBackupJoinVoMock);
+                anyLong(), anyBoolean(), anyBoolean(), anyBoolean());
         doNothing().when(kbossBackupProviderSpy).validateBackupAsyncIfHasOfferingSupport(any(), anyLong(), anyLong());
+        doReturn(false).when(kbossBackupProviderSpy).offeringSupportsCompression(any());
+        doReturn(false).when(kbossBackupProviderSpy).checkSyncCompressionAndConfigureCommand(any(), anyBoolean(), any(), any());
 
         Pair<Boolean, Long> result = kbossBackupProviderSpy.orchestrateTakeBackup(backupVoMock, false, false);
         assertTrue(result.first());
@@ -861,7 +865,7 @@ public class KbossBackupProviderTest {
         verify(internalBackupDataStoreDaoMock).listByBackupId(0);
         verify(kbossBackupProviderSpy, Mockito.times(2)).createDeltaReferences(Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(), any(), any(), any(), any(), any(), any(), any());
         verify(kbossBackupProviderSpy, Mockito.times(1)).processBackupSuccess(anyBoolean(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
-                anyLong(), anyBoolean(), anyBoolean());
+                anyLong(), anyBoolean(), anyBoolean(), anyBoolean());
         verify(kbossBackupProviderSpy, Mockito.times(1)).validateBackupAsyncIfHasOfferingSupport(internalBackupJoinVoMock, 0, 0);
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCompressBackupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCompressBackupCommandWrapper.java
@@ -82,7 +82,7 @@ public class LibvirtCompressBackupCommandWrapper extends CommandWrapper<Compress
 
                 HashMap<String, String> options = new HashMap<>();
                 Backup.CompressionLibrary compressionLib = getCompressionLibrary(command, fullDeltaPath);
-                setCompressionTypeOptionIfAvailable(qemuImg, options, compressionLib);
+                qemuImg.setCompressionTypeOptionIfAvailable(options, compressionLib);
                 int coroutines = command.getCoroutines();
                 logger.info("Starting compression for backup delta [{}] with parent [{}] using [{}] coroutines.", child, parent, coroutines);
                 qemuImg.convert(originalBackup, compressedBackup, backingFile, options, null, new QemuImageOptions(originalBackup.getFormat(), originalBackup.getFileName(),
@@ -109,18 +109,6 @@ public class LibvirtCompressBackupCommandWrapper extends CommandWrapper<Compress
         }
 
         return command.getRateLimit();
-    }
-
-    /**
-     * Sets the compression type option if qemu-img is at least in version 5.1. Otherwise, will not set it and qemu will use zlib.
-     * */
-    private void setCompressionTypeOptionIfAvailable(QemuImg qemuImg, HashMap<String, String> options, Backup.CompressionLibrary compressionLib) {
-        if (qemuImg.getVersion() >= QemuImg.QEMU_5_1) {
-            options.put(COMPRESSION_TYPE, compressionLib.name());
-            return;
-        }
-        logger.warn("Qemu is at a lower version than 5.1, we will not be able to use zstd to compress backups. Only zlib is supported for this version. Current version is [{}].",
-                qemuImg.getVersion());
     }
 
     private Backup.CompressionLibrary getCompressionLibrary(CompressBackupCommand command, String fullDeltaPath) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtTakeKbossBackupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtTakeKbossBackupCommandWrapper.java
@@ -105,7 +105,7 @@ public class LibvirtTakeKbossBackupCommandWrapper extends CommandWrapper<TakeKbo
 
                 logger.debug("Backing up volume [{}].", volumeUuid);
                 Pair<String, Long> deltaPathOnSecondaryAndSize = copyBackupDeltaToSecondary(storagePoolManager, kbossTO, command.getBackupChainImageStoreUrls(),
-                        command.getImageStoreUrl(), maxWaitInMillis);
+                        command.getImageStoreUrl(), maxWaitInMillis, command);
 
                 mapVolumeUuidToDeltaPathOnSecondaryAndDeltaSize.put(volumeUuid, deltaPathOnSecondaryAndSize);
                 maxWaitInMillis = calculateRemainingTime(maxWaitInMillis, startTimeMillis);
@@ -165,7 +165,7 @@ public class LibvirtTakeKbossBackupCommandWrapper extends CommandWrapper<TakeKbo
      * If there were snapshots created after the last backup, they'll be copied alongside and merged in the secondary storage.
      * */
     protected Pair<String, Long> copyBackupDeltaToSecondary(KVMStoragePoolManager storagePoolManager, KbossTO kbossTO, List<String> chainImageStoreUrls, String imageStoreUrl,
-            int waitInMillis) {
+            int waitInMillis, TakeKbossBackupCommand command) {
         VolumeObjectTO delta = kbossTO.getVolumeObjectTO();
         String parentDeltaPathOnSecondary = kbossTO.getPathBackupParentOnSecondary();
         List<String> deltaPathsToCopy = CollectionUtils.isEmpty(kbossTO.getVmSnapshotDeltaPaths()) ? new ArrayList<>() : new ArrayList<>(kbossTO.getVmSnapshotDeltaPaths());
@@ -199,7 +199,7 @@ public class LibvirtTakeKbossBackupCommandWrapper extends CommandWrapper<TakeKbo
                 }
 
                 String backupDeltaFullPathOnPrimary = primaryPool.getLocalPathFor(deltaPathsToCopy.remove(0));
-                convertDeltaToSecondary(backupDeltaFullPathOnPrimary, backupDeltaFullPathOnSecondary, parentBackupFullPath, delta.getUuid(), waitInMillis);
+                convertDeltaToSecondary(backupDeltaFullPathOnPrimary, backupDeltaFullPathOnSecondary, parentBackupFullPath, delta.getUuid(), waitInMillis, command);
 
                 if (!deltaPathsToCopy.isEmpty()) {
                     parentDeltaPathOnSecondary = topDelta;
@@ -282,7 +282,8 @@ public class LibvirtTakeKbossBackupCommandWrapper extends CommandWrapper<TakeKbo
      * @param volumeUuid volume uuid, used for logging.
      * @param waitInMillis timeout in milliseconds.
      * */
-    protected void convertDeltaToSecondary(String pathDeltaOnPrimary, String pathDeltaOnSecondary, String pathParentOnSecondary, String volumeUuid, int waitInMillis)
+    protected void convertDeltaToSecondary(String pathDeltaOnPrimary, String pathDeltaOnSecondary, String pathParentOnSecondary, String volumeUuid, int waitInMillis,
+            TakeKbossBackupCommand command)
             throws QemuImgException, LibvirtException {
         QemuImgFile backupDestination = new QemuImgFile(pathDeltaOnSecondary, QemuImg.PhysicalDiskFormat.QCOW2);
         QemuImgFile backupOrigin = new QemuImgFile(pathDeltaOnPrimary, QemuImg.PhysicalDiskFormat.QCOW2);
@@ -297,8 +298,13 @@ public class LibvirtTakeKbossBackupCommandWrapper extends CommandWrapper<TakeKbo
         createDirsIfNeeded(pathDeltaOnSecondary, volumeUuid);
 
         QemuImg qemuImg = new QemuImg(waitInMillis);
-        qemuImg.convert(backupOrigin, backupDestination, parentBackup, null, null,  new QemuImageOptions(backupOrigin.getFormat(), backupOrigin.getFileName(), null), null,
-                true, false, false, false, null, null);
+        Map<String, String> options = new HashMap<>();
+        if (command.isCompress()) {
+            qemuImg.setCompressionTypeOptionIfAvailable(options, command.getCompressionLib());
+        }
+        qemuImg.convert(backupOrigin, backupDestination, parentBackup, options, null,  new QemuImageOptions(backupOrigin.getFormat(), backupOrigin.getFileName(), null), null,
+                true, false, false, command.isCompress(), command.getCoroutines(), command.getRateLimit());
+
     }
 
 

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -1079,6 +1079,10 @@ public class QemuImg {
      * Sets the compression type option if qemu-img is at least in version 5.1. Otherwise, will not set it and qemu will use zlib.
      * */
     public void setCompressionTypeOptionIfAvailable(Map<String, String> options, Backup.CompressionLibrary compressionLib) {
+        if (compressionLib == null) {
+            logger.debug("No compression lib informed, using the default.");
+            return;
+        }
         if (getVersion() >= QemuImg.QEMU_5_1) {
             options.put(LibvirtCompressBackupCommandWrapper.COMPRESSION_TYPE, compressionLib.name());
             return;

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import com.cloud.hypervisor.kvm.resource.wrapper.LibvirtCompressBackupCommandWrapper;
+import org.apache.cloudstack.backup.Backup;
 import org.apache.cloudstack.storage.formatinspector.Qcow2Inspector;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.NotImplementedException;
@@ -1072,5 +1074,18 @@ public class QemuImg {
     public long getVersion() {
         return this.version;
     }
+
+    /**
+     * Sets the compression type option if qemu-img is at least in version 5.1. Otherwise, will not set it and qemu will use zlib.
+     * */
+    public void setCompressionTypeOptionIfAvailable(Map<String, String> options, Backup.CompressionLibrary compressionLib) {
+        if (getVersion() >= QemuImg.QEMU_5_1) {
+            options.put(LibvirtCompressBackupCommandWrapper.COMPRESSION_TYPE, compressionLib.name());
+            return;
+        }
+        logger.warn("Qemu is at a lower version than 5.1, we will not be able to use zstd to compress backups. Only zlib is supported for this version. Current version is [{}].",
+                getVersion());
+    }
+
 
 }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirTakeKbossBackupCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirTakeKbossBackupCommandWrapperTest.java
@@ -189,10 +189,10 @@ public class LibvirTakeKbossBackupCommandWrapperTest {
         doReturn(secondaryUrl).when(takeKbossBackupCommandMock).getImageStoreUrl();
         Pair<String, Long> pair1 = new Pair<>("p1", 10L);
         doReturn(pair1).when(libvirtTakeKbossBackupCommandWrapperSpy).copyBackupDeltaToSecondary(eq(kvmStoragePoolManagerMock), eq(kbossTO1), anyList(),
-                        eq(secondaryUrl), anyInt());
+                        eq(secondaryUrl), anyInt(), any());
         Pair<String, Long> pair2 = new Pair<>("p2", 13L);
         doReturn(pair2).when(libvirtTakeKbossBackupCommandWrapperSpy).copyBackupDeltaToSecondary(eq(kvmStoragePoolManagerMock), eq(kbossTO2), anyList(),
-                eq(secondaryUrl), anyInt());
+                eq(secondaryUrl), anyInt(), any());
 
         libvirtTakeKbossBackupCommandWrapperSpy.backupVolumes(takeKbossBackupCommandMock, libvirtComputingResourceMock, kvmStoragePoolManagerMock, List.of(kbossTO1, kbossTO2),
                 volumeTosAndNewPaths, "tst", false, mapVolumeUuidToDeltaPathOnSecondaryAndDeltaSize);
@@ -276,13 +276,14 @@ public class LibvirTakeKbossBackupCommandWrapperTest {
         doReturn(parentBackupFullPath).when(kvmStoragePool2).getLocalPathFor(parentPath);
         doReturn(backupDeltaFullPathOnPrimary1).when(kvmStoragePool3).getLocalPathFor(deltaPath2);
         doReturn(backupDeltaFullPathOnSecondary1).when(kvmStoragePool1).getLocalPathFor(deltaPath1);
-        doNothing().when(libvirtTakeKbossBackupCommandWrapperSpy).convertDeltaToSecondary(backupDeltaFullPathOnPrimary1, backupDeltaFullPathOnSecondary1, parentBackupFullPath, volUuid1, 100000);
+        doNothing().when(libvirtTakeKbossBackupCommandWrapperSpy).convertDeltaToSecondary(backupDeltaFullPathOnPrimary1, backupDeltaFullPathOnSecondary1, parentBackupFullPath,
+                volUuid1, 100000, takeKbossBackupCommandMock);
 
         doReturn(randomPath1).when(libvirtTakeKbossBackupCommandWrapperSpy).getRelativePathOnSecondaryForBackup(anyLong(), anyLong(), any());
         doReturn("random2").when(kvmStoragePool1).getLocalPathFor(randomPath1);
         doReturn(backupDeltaFullPathOnPrimary2).when(kvmStoragePool3).getLocalPathFor(volumePath);
         doNothing().when(libvirtTakeKbossBackupCommandWrapperSpy).convertDeltaToSecondary(eq(backupDeltaFullPathOnPrimary2), eq("random2"), eq(backupDeltaFullPathOnSecondary1),
-                any(), anyInt());
+                any(), anyInt(), any());
 
         doNothing().when(libvirtTakeKbossBackupCommandWrapperSpy).commitTopDeltaOnBaseBackupOnSecondaryIfNeeded(randomPath1, deltaPath1, kvmStoragePool1,
                 backupDeltaFullPathOnSecondary1, 100000);
@@ -291,15 +292,16 @@ public class LibvirTakeKbossBackupCommandWrapperTest {
         try(MockedStatic<Files> filesMockedStatic = Mockito.mockStatic(Files.class)) {
             filesMockedStatic.when(() -> Files.size(any())).thenReturn(1000L);
             Pair<String, Long> result = libvirtTakeKbossBackupCommandWrapperSpy.copyBackupDeltaToSecondary(kvmStoragePoolManagerMock, kbossTO1, List.of(secondaryUrl2),
-                    secondaryUrl, 100000);
+                    secondaryUrl, 100000, takeKbossBackupCommandMock);
 
             assertEquals(deltaPath1, result.first());
             assertEquals(Long.valueOf(1000L), result.second());
         }
 
-        verify(libvirtTakeKbossBackupCommandWrapperSpy).convertDeltaToSecondary(backupDeltaFullPathOnPrimary1, backupDeltaFullPathOnSecondary1, parentBackupFullPath, volUuid1, 100000);
+        verify(libvirtTakeKbossBackupCommandWrapperSpy).convertDeltaToSecondary(backupDeltaFullPathOnPrimary1, backupDeltaFullPathOnSecondary1, parentBackupFullPath, volUuid1,
+                100000, takeKbossBackupCommandMock);
         verify(libvirtTakeKbossBackupCommandWrapperSpy).convertDeltaToSecondary(eq(backupDeltaFullPathOnPrimary2), eq("random2"), eq(backupDeltaFullPathOnSecondary1),
-                any(), anyInt());
+                any(), anyInt(), any());
         verify(libvirtTakeKbossBackupCommandWrapperSpy).commitTopDeltaOnBaseBackupOnSecondaryIfNeeded(randomPath1, deltaPath1, kvmStoragePool1,
                 backupDeltaFullPathOnSecondary1, 100000);
         verify(libvirtTakeKbossBackupCommandWrapperSpy).removeTemporaryDeltas(any(), anyBoolean());

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -406,6 +406,9 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         if (cmd.isAllowQuickRestore()) {
             detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.ALLOW_QUICK_RESTORE, "true", true));
         }
+        if (cmd.isCompressAsync()) {
+            detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.COMPRESS_ASYNC, "true", true));
+        }
         if (cmd.getBackupChainSize() != null) {
             detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.BACKUP_CHAIN_SIZE, cmd.getBackupChainSize().toString(), true));
         }

--- a/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/backup/BackupManagerImpl.java
@@ -396,6 +396,7 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         }
         if (cmd.isCompress()) {
             detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.COMPRESS, "true", true));
+            detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.COMPRESS_ASYNC, Boolean.toString(cmd.isCompressAsync()), true));
         }
         if (cmd.isValidate()) {
             detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.VALIDATE, "true", true));
@@ -405,9 +406,6 @@ public class BackupManagerImpl extends ManagerBase implements BackupManager {
         }
         if (cmd.isAllowQuickRestore()) {
             detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.ALLOW_QUICK_RESTORE, "true", true));
-        }
-        if (cmd.isCompressAsync()) {
-            detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.COMPRESS_ASYNC, "true", true));
         }
         if (cmd.getBackupChainSize() != null) {
             detailsVOList.add(new BackupOfferingDetailsVO(savedOffering.getId(), ApiConstants.BACKUP_CHAIN_SIZE, cmd.getBackupChainSize().toString(), true));

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -629,6 +629,7 @@
 "label.complete": "Complete",
 "label.completed": "Completed",
 "label.compress": "Compress",
+"label.compressasync": "Compress asynchronously",
 "label.compressionstatus": "Compression status",
 "label.compressionlibrary": "Compression library",
 "label.compute": "Compute",

--- a/ui/public/locales/pt_BR.json
+++ b/ui/public/locales/pt_BR.json
@@ -563,6 +563,7 @@
 "label.community": "Comunidade",
 "label.complete": "Complete",
 "label.compress": "Comprimir",
+"label.compressasync": "Comprimir assincronamente",
 "label.compressionstatus": "Estado de compress\u00e3o",
 "label.compressionlibrary": "Biblioteca de compress\u00e3o",
 "label.compute": "Computa\u00e7\u00e3o",

--- a/ui/src/views/offering/CreateBackupOffering.vue
+++ b/ui/src/views/offering/CreateBackupOffering.vue
@@ -96,6 +96,9 @@
       <a-form-item name="compress" ref="compress" :label="$t('label.compress')">
         <a-switch v-model:checked="form.compress" />
       </a-form-item>
+      <a-form-item name="compressasync" ref="compressasync" :label="$t('label.compressasync')" v-if="form.compress">
+        <a-switch v-model:checked="form.compressasync" />
+      </a-form-item>
       <a-form-item name="compressionlibrary" ref="compressionlibrary" v-if="form.compress">
         <template #label>
           <tooltip-label :title="$t('label.compressionlibrary')" :tooltip="apiParams.compressionlibrary.description"/>
@@ -193,6 +196,7 @@ export default {
         allowuserdrivenbackups: true,
         ispublic: true,
         compress: false,
+        compressasync: true,
         validate: false,
         allowquickrestore: true,
         allowextractfile: true,


### PR DESCRIPTION
### Description

Currently, the backup compression process is always performed asynchronously; the existing backup is compressed into a new file, which then replaces the original. However, when using immutable storage, this behavior increases storage usage because the original backup file cannot be deleted.

To address this, the `compress_async` flag, defaulting to `true`, has been added to backup offerings. The default setting maintains the current behavior. When the flag is set to `false`, compression occurs during backup creation, resulting in only a single file copy. However, enabling synchronous backup compression slows down the backup creation process and makes it prone to timeouts unless the timeout settings are adjusted accordingly.

It is important to note that the flag only applies to backup offerings that have the `compress` flag set to `true`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

### Test description

1. I created a new backup offering with `compressasync` = false, and another without specifying `compressasync`.
2. I created the "sync" and "async" VMs and assigned the respective offerings to each VM.
3. I created backups using each of the VMs. I observed that the backups created with the "async" VM maintained the previous behavior, whereas the backups created with the "sync" VM were compressed during creation.