### PR TITLE
doc: add API parameter syntax examples for nodeofferings and nodetemp…

### DIFF
--- a/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/command/user/kubernetes/cluster/CreateKubernetesClusterCmd.java
+++ b/plugins/integrations/kubernetes-service/src/main/java/org/apache/cloudstack/api/command/user/kubernetes/cluster/CreateKubernetesClusterCmd.java
@@ -116,13 +116,17 @@ public class CreateKubernetesClusterCmd extends BaseAsyncCreateCmd {
 
     @ACL(accessType = AccessType.UseEntry)
     @Parameter(name = ApiConstants.NODE_TYPE_OFFERING_MAP, type = CommandType.MAP,
-            description = "(Optional) Node Type to Service Offering ID mapping. If provided, it overrides the serviceofferingid parameter",
+            description = "(Optional) Node Type to Service Offering ID mapping. If provided, it overrides the serviceofferingid parameter. " +
+                    "Example: nodeofferings[0].node=\"control\"&nodeofferings[0].offering=\"<service-offering-uuid>\"&" +
+                    "nodeofferings[1].node=\"worker\"&nodeofferings[1].offering=\"<service-offering-uuid>\"",
             since = "4.21.0")
     private Map<String, Map<String, String>> serviceOfferingNodeTypeMap;
 
     @ACL(accessType = AccessType.UseEntry)
     @Parameter(name = ApiConstants.NODE_TYPE_TEMPLATE_MAP, type = CommandType.MAP,
-            description = "(Optional) Node Type to Template ID mapping. If provided, it overrides the default template: System VM template",
+            description = "(Optional) Node Type to Template ID mapping. If provided, it overrides the default template: System VM template. " +
+                    "Example: nodetemplates[0].node=\"control\"&nodetemplates[0].template=\"<template-uuid>\"&" +
+                    "nodetemplates[1].node=\"worker\"&nodetemplates[1].template=\"<template-uuid>\"",
             since = "4.21.0")
     private Map<String, Map<String, String>> templateNodeTypeMap;
 


### PR DESCRIPTION
## Description

The API documentation for `createKubernetesCluster` does not include syntax examples for the `nodeofferings` and `nodetemplates` parameters, making it difficult for users to specify different service offerings and templates for control vs worker nodes.

This PR adds usage examples to the `@Parameter` descriptions, following the same inline example pattern already used by the `cniconfigdetails` parameter in the same file.

## Examples added

**nodeofferings:**
nodeofferings[0].node="control"&nodeofferings[0].offering="<service-offering-uuid>"&
nodeofferings[1].node="worker"&nodeofferings[1].offering="<service-offering-uuid>"

**nodetemplates:**
nodetemplates[0].node="control"&nodetemplates[0].template="<template-uuid>"&
nodetemplates[1].node="worker"&nodetemplates[1].template="<template-uuid>"

## Context

Discussion: https://github.com/apache/cloudstack/discussions/13395

Thanks to @Pearl1594 for providing the syntax and @DaanHoogland for guiding the contribution process.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (API parameter descriptions)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Code formatted according to project style
- [x] Self-reviewed the changes
- [x] No new warnings generated
- [x] Documentation updated (this IS the documentation update)
