### PR TITLE
Linstor 4.22 shared storagepool support

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -658,10 +658,14 @@ public class KVMStorageProcessor implements StorageProcessor {
         final String secondaryStorageUrl = nfsStore.getUrl();
         KVMStoragePool secondaryStoragePool = null;
 
+        boolean srcConnected = false;
         try {
             final String volumeName = UUID.randomUUID().toString();
 
             final String destVolumeName = volumeName + "." + ImageFormat.QCOW2.getFileExtension();
+            // connect: a detached source volume may have no device yet on shared pools
+            srcConnected = storagePoolMgr.connectPhysicalDisk(
+                    primaryStore.getPoolType(), primaryStore.getUuid(), srcVolumePath, null);
             final KVMPhysicalDisk volume = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), srcVolumePath);
             volume.setFormat(PhysicalDiskFormat.valueOf(srcFormat.toString()));
 
@@ -680,6 +684,9 @@ public class KVMStorageProcessor implements StorageProcessor {
         } finally {
             srcVol.clearPassphrase();
             destVol.clearPassphrase();
+            if (srcConnected) {
+                storagePoolMgr.disconnectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), srcVolumePath);
+            }
             if (secondaryStoragePool != null) {
                 storagePoolMgr.deleteStoragePool(secondaryStoragePool.getType(), secondaryStoragePool.getUuid());
             }

--- a/plugins/storage/volume/linstor/CHANGELOG.md
+++ b/plugins/storage/volume/linstor/CHANGELOG.md
@@ -24,6 +24,20 @@ All notable changes to Linstor CloudStack plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-31]
+
+### Added
+
+- Support for shared (thick LVM) storage pools: resources on a shared LUN are
+  activated on at most one node; live migration uses the LINSTOR 1.29
+  make-available/unmake-available API (with fallback to the previous handling
+  for older controllers), snapshots work on thick LVM pools, and resources of
+  stopped VMs are activated on demand for start, snapshot backup and revert
+
+### Changed
+
+- java-linstor client updated to 0.8.0 (LINSTOR REST API 1.29.0)
+
 ## [2026-06-24]
 
 ### Fixed

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LinstorBackupSnapshotCommandWrapper.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LinstorBackupSnapshotCommandWrapper.java
@@ -68,13 +68,18 @@ public final class LinstorBackupSnapshotCommandWrapper
 
     private String lvmSetActive(boolean activate, String devMapperPath) {
         // lvm resolves /dev/mapper/vg-lv names textually, works also for inactive LVs
-        Script script = new Script("lvchange", Duration.millis(5000));
+        Script script = new Script("lvchange", Duration.millis(30000));
         if (activate) {
             script.add("-ay");
             script.add("-K"); // snapshot LVs carry the skip-activation flag
         } else {
             script.add("-an");
         }
+        // never talk to dmeventd: registering the snapshot for monitoring can block lvchange
+        // indefinitely (and with it the whole LVM lock on the node); a full-size thick COW
+        // snapshot cannot overflow, so monitoring is not needed for the backup window
+        script.add("--monitor");
+        script.add("n");
         script.add(devMapperPath);
         return script.execute();
     }

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LinstorBackupSnapshotCommandWrapper.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LinstorBackupSnapshotCommandWrapper.java
@@ -66,6 +66,19 @@ public final class LinstorBackupSnapshotCommandWrapper
         return script.execute();
     }
 
+    private String lvmSetActive(boolean activate, String devMapperPath) {
+        // lvm resolves /dev/mapper/vg-lv names textually, works also for inactive LVs
+        Script script = new Script("lvchange", Duration.millis(5000));
+        if (activate) {
+            script.add("-ay");
+            script.add("-K"); // snapshot LVs carry the skip-activation flag
+        } else {
+            script.add("-an");
+        }
+        script.add(devMapperPath);
+        return script.execute();
+    }
+
     private String qemuShrink(String path, long sizeByte, long timeout) {
         Script qemuImg = new Script("qemu-img", Duration.millis(timeout));
         qemuImg.add("resize");
@@ -146,6 +159,7 @@ public final class LinstorBackupSnapshotCommandWrapper
         final KVMStoragePoolManager storagePoolMgr = serverResource.getStoragePoolMgr();
         KVMStoragePool linstorPool = storagePoolMgr.getStoragePool(Storage.StoragePoolType.Linstor, src.getDataStore().getUuid());
         boolean zfsHidden = false;
+        String lvmSnapDev = null;  // vg/lv we activated for the copy, deactivated on cleanup
         String srcPath = src.getPath();
 
         if (linstorPool == null) {
@@ -169,6 +183,12 @@ public final class LinstorBackupSnapshotCommandWrapper
                     return new CopyCmdAnswer("Unable to unhide zfs snapshot device.");
                 }
                 srcPath = "/dev/zvol/" + srcPath.substring(6);
+            } else if (srcPath.startsWith("/dev/mapper/") && !new File(srcPath).exists()) {
+                // thick LVM snapshot LVs are created inactive with the skip-activation flag
+                if (lvmSetActive(true, srcPath) != null) {
+                    return new CopyCmdAnswer("Unable to activate LVM snapshot device " + srcPath);
+                }
+                lvmSnapDev = srcPath;
             }
 
             secondaryPool = storagePoolMgr.getStoragePoolByURI(dstDataStore.getUrl());
@@ -204,6 +224,9 @@ public final class LinstorBackupSnapshotCommandWrapper
             cleanupSecondaryPool(secondaryPool);
             if (zfsHidden) {
                 zfsSnapdev(true, src.getPath());
+            }
+            if (lvmSnapDev != null) {
+                lvmSetActive(false, lvmSnapDev);
             }
         }
     }

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -365,29 +365,40 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         }
 
         final DevelopersApi api = getLinstorAPI(pool);
+        final boolean liveMigrateApi = LinstorUtil.supportsLiveMigrateApi(api);
         String rscName;
-        boolean usesDrbd;
+        boolean usesDrbd = false;
         try
         {
             rscName = findCorrectTemplateName(api, getLinstorRscName(volumePath), pool);
-            usesDrbd = usesDrbd(api, rscName);
 
-            if (isVMMigration && !usesDrbd) {
-                // create the resource on the new node, noop if already exists
-                ResourceCreate rc = new ResourceCreate();
-                Resource rsc = new Resource();
-                rsc.setNodeName(localNodeName);
-                rc.setResource(rsc);
-                ApiCallRcList answers = api.resourceCreateOnNode(rscName, localNodeName, rc);
-                checkLinstorAnswersThrow(answers);
-                // activate resource if there already was an inactive resource here
-                answers = api.activateRsc(rscName, localNodeName);
-                checkLinstorAnswersThrow(answers);
-            } else {
-                // DRBD resources just work with a diskless and don't have the activate/deactivate concept
+            if (liveMigrateApi) {
+                // controller >= 1.29 prepares the live migration itself:
+                // dual-primary for DRBD, activation on both nodes for shared storage pools
                 ResourceMakeAvailable rma = new ResourceMakeAvailable();
+                rma.autoManageDualPrimary(isVMMigration);
                 ApiCallRcList answers = api.resourceMakeAvailableOnNode(rscName, localNodeName, rma);
                 checkLinstorAnswersThrow(answers);
+            } else {
+                usesDrbd = usesDrbd(api, rscName);
+
+                if (isVMMigration && !usesDrbd) {
+                    // create the resource on the new node, noop if already exists
+                    ResourceCreate rc = new ResourceCreate();
+                    Resource rsc = new Resource();
+                    rsc.setNodeName(localNodeName);
+                    rc.setResource(rsc);
+                    ApiCallRcList answers = api.resourceCreateOnNode(rscName, localNodeName, rc);
+                    checkLinstorAnswersThrow(answers);
+                    // activate resource if there already was an inactive resource here
+                    answers = api.activateRsc(rscName, localNodeName);
+                    checkLinstorAnswersThrow(answers);
+                } else {
+                    // DRBD resources just work with a diskless and don't have the activate/deactivate concept
+                    ResourceMakeAvailable rma = new ResourceMakeAvailable();
+                    ApiCallRcList answers = api.resourceMakeAvailableOnNode(rscName, localNodeName, rma);
+                    checkLinstorAnswersThrow(answers);
+                }
             }
 
         } catch (ApiException apiEx) {
@@ -395,7 +406,7 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
             throw new CloudRuntimeException(apiEx.getBestMessage(), apiEx);
         }
 
-        if (isVMMigration && usesDrbd) {
+        if (!liveMigrateApi && isVMMigration && usesDrbd) {
             try {
                 allow2PrimariesIfInUse(api, rscName);
             } catch (ApiException apiEx) {
@@ -442,6 +453,28 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         removeTwoPrimariesRcProps(api, rscName, inUseNode, deleteProps);
     }
 
+    /**
+     * Revert a make-available after e.g. a live migration: removes dual-primary settings and
+     * deletes the resource on this node if that is possible without losing data
+     * (diskless or a redundant shared storage pool copy; tiebreaker and diskful resources are kept).
+     * No-op if the resource isn't deployed here, so it is safe to call on every disconnect.
+     */
+    private void unmakeAvailable(DevelopersApi api, String rscName) {
+        try {
+            ApiCallRcList answers = api.resourceUnmakeAvailableOnNode(rscName, localNodeName);
+            if (answers.hasError()) {
+                // e.g. FAIL_IN_USE: the resource is still in use on this node and is kept
+                logger.warn("Linstor: unmake-available {} on {}: {}",
+                        rscName, localNodeName, LinstorUtil.getBestErrorMessage(answers));
+            } else {
+                logLinstorAnswers(answers);
+            }
+        } catch (ApiException apiEx) {
+            logger.error(apiEx.getBestMessage());
+            // do not fail here, cleaning up after a disconnect isn't fatal
+        }
+    }
+
     private void deleteUnusedSharedResources(DevelopersApi api, Resource nodeRsc) {
         try {
             List<Resource> rscs = api.resourceList(nodeRsc.getName(), null, null);
@@ -486,9 +519,11 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         if (optRsc.isPresent()) {
             Resource rsc = optRsc.get();
 
+            if (LinstorUtil.supportsLiveMigrateApi(api)) {
+                unmakeAvailable(api, rsc.getName());
             // if it is a non DRBD resource(shared) we need to check if we are the last active one
             // on live migrate, we can have 2 active resources at the same time
-            if (rsc.getLayerObject().getDrbd() == null) {
+            } else if (rsc.getLayerObject().getDrbd() == null) {
                 deleteUnusedSharedResources(api, rsc);
             } else {
                 try {

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -51,6 +51,7 @@ import com.linbit.linstor.api.model.Properties;
 import com.linbit.linstor.api.model.ProviderKind;
 import com.linbit.linstor.api.model.Resource;
 import com.linbit.linstor.api.model.ResourceConnectionModify;
+import com.linbit.linstor.api.model.ResourceCreate;
 import com.linbit.linstor.api.model.ResourceDefinition;
 import com.linbit.linstor.api.model.ResourceDefinitionModify;
 import com.linbit.linstor.api.model.ResourceGroupSpawn;
@@ -239,21 +240,22 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
 
             String foundRscName = resourceDefinition != null ? resourceDefinition.getName() : rscName;
 
+            makeResourceAvailable(api, foundRscName, false);
+
             // query linstor for the device path
             List<ResourceWithVolumes> resources = api.viewResources(
-                Collections.emptyList(),
+                Collections.singletonList(localNodeName),
                 Collections.singletonList(foundRscName),
                 Collections.emptyList(),
                 null,
                 null,
                 null);
 
-            makeResourceAvailable(api, foundRscName, false);
-
             if (!resources.isEmpty() && !resources.get(0).getVolumes().isEmpty()) {
                 final String devPath = LinstorUtil.getDevicePathFromResource(resources.get(0));
                 logger.info("Linstor: Created drbd device: " + devPath);
-                final KVMPhysicalDisk kvmDisk = new KVMPhysicalDisk(devPath, name, pool);
+                final String diskName = foundRscName.substring(LinstorUtil.RSC_PREFIX.length());
+                final KVMPhysicalDisk kvmDisk = new KVMPhysicalDisk(devPath, diskName, pool);
                 kvmDisk.setFormat(QemuImg.PhysicalDiskFormat.RAW);
                 long allocatedKib = resources.get(0).getVolumes().get(0).getAllocatedSizeKib() != null ?
                         resources.get(0).getVolumes().get(0).getAllocatedSizeKib() : 0;
@@ -321,6 +323,37 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         }
     }
 
+    private boolean usesDrbd(DevelopersApi api, String rscName) throws ApiException {
+        List<ResourceWithVolumes> rscs = api.viewResources(
+                Collections.emptyList(),
+                Collections.singletonList(rscName),
+                null,
+                null,
+                null,
+                null);
+
+        for (ResourceWithVolumes rsc : rscs) {
+            if (rsc.getLayerObject().getDrbd() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private String findCorrectTemplateName(DevelopersApi api, String rscName, KVMStoragePool pool ) {
+        String templateName = rscName;
+        LinstorStoragePool lpool = (LinstorStoragePool) pool;
+        try {
+            ResourceDefinition resourceDefinition = LinstorUtil.findResourceDefinition(
+                    api, rscName, lpool.getResourceGroup());
+            templateName = resourceDefinition != null ? resourceDefinition.getName() : rscName;
+        } catch (ApiException e) {
+            logger.error("Error finding resource definition for {}", rscName);
+        }
+        return templateName;
+    }
+
     @Override
     public boolean connectPhysicalDisk(
             String volumePath, KVMStoragePool pool, Map<String, String> details, boolean isVMMigration)
@@ -333,20 +366,36 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
 
         final DevelopersApi api = getLinstorAPI(pool);
         String rscName;
+        boolean usesDrbd;
         try
         {
-            rscName = getLinstorRscName(volumePath);
+            rscName = findCorrectTemplateName(api, getLinstorRscName(volumePath), pool);
+            usesDrbd = usesDrbd(api, rscName);
 
-            ResourceMakeAvailable rma = new ResourceMakeAvailable();
-            ApiCallRcList answers = api.resourceMakeAvailableOnNode(rscName, localNodeName, rma);
-            checkLinstorAnswersThrow(answers);
+            if (isVMMigration && !usesDrbd) {
+                // create the resource on the new node, noop if already exists
+                ResourceCreate rc = new ResourceCreate();
+                Resource rsc = new Resource();
+                rsc.setNodeName(localNodeName);
+                rc.setResource(rsc);
+                ApiCallRcList answers = api.resourceCreateOnNode(rscName, localNodeName, rc);
+                checkLinstorAnswersThrow(answers);
+                // activate resource if there already was an inactive resource here
+                answers = api.activateRsc(rscName, localNodeName);
+                checkLinstorAnswersThrow(answers);
+            } else {
+                // DRBD resources just work with a diskless and don't have the activate/deactivate concept
+                ResourceMakeAvailable rma = new ResourceMakeAvailable();
+                ApiCallRcList answers = api.resourceMakeAvailableOnNode(rscName, localNodeName, rma);
+                checkLinstorAnswersThrow(answers);
+            }
 
         } catch (ApiException apiEx) {
             logger.error(apiEx);
             throw new CloudRuntimeException(apiEx.getBestMessage(), apiEx);
         }
 
-        if (isVMMigration) {
+        if (isVMMigration && usesDrbd) {
             try {
                 allow2PrimariesIfInUse(api, rscName);
             } catch (ApiException apiEx) {
@@ -393,13 +442,26 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         removeTwoPrimariesRcProps(api, rscName, inUseNode, deleteProps);
     }
 
+    private void deleteUnusedSharedResources(DevelopersApi api, Resource nodeRsc) {
+        try {
+            List<Resource> rscs = api.resourceList(nodeRsc.getName(), null, null);
+            if (rscs != null && rscs.stream()
+                    .filter(rsc -> rsc.getFlags() == null || !rsc.getFlags().contains(ApiConsts.FLAG_RSC_INACTIVE))
+                    .count() > 1) {
+                api.resourceDelete(nodeRsc.getName(), localNodeName, true);
+            }
+        } catch (ApiException apiEx) {
+            logger.error(apiEx.getBestMessage());
+        }
+    }
+
     private boolean tryDisconnectLinstor(String volumePath, KVMStoragePool pool)
     {
         if (volumePath == null) {
             return false;
         }
 
-        logger.debug("Linstor: Using storage pool: " + pool.getUuid());
+        logger.debug("Linstor: Using storage pool: {}", pool.getUuid());
         final DevelopersApi api = getLinstorAPI(pool);
 
         Optional<ResourceWithVolumes> optRsc;
@@ -423,33 +485,40 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
 
         if (optRsc.isPresent()) {
             Resource rsc = optRsc.get();
-            try {
-                String inUseNode = LinstorUtil.isResourceInUse(api, rsc.getName());
-                if (inUseNode != null && !inUseNode.equalsIgnoreCase(localNodeName)) {
-                    removeTwoPrimariesProps(api, inUseNode, rsc.getName());
-                }
-            } catch (ApiException apiEx) {
-                logger.error(apiEx.getBestMessage());
-                // do not fail here as removing allow-two-primaries property or deleting diskless isn't fatal
-            }
 
-            try {
-                // if diskless resource remove it, in the worst case it will be transformed to a tiebreaker
-                if (rsc.getFlags() != null &&
-                        rsc.getFlags().contains(ApiConsts.FLAG_DRBD_DISKLESS) &&
-                        !rsc.getFlags().contains(ApiConsts.FLAG_TIE_BREAKER)) {
-                    ApiCallRcList delAnswers = api.resourceDelete(rsc.getName(), localNodeName, true);
-                    logLinstorAnswers(delAnswers);
+            // if it is a non DRBD resource(shared) we need to check if we are the last active one
+            // on live migrate, we can have 2 active resources at the same time
+            if (rsc.getLayerObject().getDrbd() == null) {
+                deleteUnusedSharedResources(api, rsc);
+            } else {
+                try {
+                    String inUseNode = LinstorUtil.isResourceInUse(api, rsc.getName());
+                    if (inUseNode != null && !inUseNode.equalsIgnoreCase(localNodeName)) {
+                        removeTwoPrimariesProps(api, inUseNode, rsc.getName());
+                    }
+                } catch (ApiException apiEx) {
+                    logger.error(apiEx.getBestMessage());
+                    // do not fail here as removing allow-two-primaries property or deleting diskless isn't fatal
                 }
-            } catch (ApiException apiEx) {
-                logger.error(apiEx.getBestMessage());
-                // do not fail here as removing allow-two-primaries property or deleting diskless isn't fatal
+
+                try {
+                    // if diskless resource remove it, in the worst case it will be transformed to a tiebreaker
+                    if (rsc.getFlags() != null &&
+                            rsc.getFlags().contains(ApiConsts.FLAG_DRBD_DISKLESS) &&
+                            !rsc.getFlags().contains(ApiConsts.FLAG_TIE_BREAKER)) {
+                        ApiCallRcList delAnswers = api.resourceDelete(rsc.getName(), localNodeName, true);
+                        logLinstorAnswers(delAnswers);
+                    }
+                } catch (ApiException apiEx) {
+                    logger.error(apiEx.getBestMessage());
+                    // do not fail here as removing allow-two-primaries property or deleting diskless isn't fatal
+                }
             }
 
             return true;
         }
 
-        logger.warn("Linstor: Couldn't find resource for this path: " + volumePath);
+        logger.warn("Linstor: Couldn't find resource for this path: {}", volumePath);
         return false;
     }
 
@@ -654,14 +723,14 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
             name, QemuImg.PhysicalDiskFormat.RAW, provisioningType, disk.getVirtualSize(), null);
 
         final DevelopersApi api = getLinstorAPI(destPools);
-        setRscDfnAuxProperties(api, disk, destPools, name);
+        setRscDfnAuxProperties(api, disk, destPools, dstDisk.getName());
 
         logger.debug("Linstor.copyPhysicalDisk: dstPath: {}", dstDisk.getPath());
         final QemuImgFile destFile = new QemuImgFile(dstDisk.getPath());
         destFile.setFormat(dstDisk.getFormat());
         destFile.setSize(disk.getVirtualSize());
 
-        boolean zeroedDevice = LinstorUtil.resourceSupportZeroBlocks(destPools, getLinstorRscName(name));
+        boolean zeroedDevice = LinstorUtil.resourceSupportZeroBlocks(destPools, getLinstorRscName(dstDisk.getName()));
         try {
             final QemuImg qemu = new QemuImg(timeout, zeroedDevice, true);
             qemu.convert(srcFile, destFile);

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -374,7 +374,10 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
                 // controller >= 1.29 prepares the live migration itself:
                 // dual-primary for DRBD, activation on both nodes for shared storage pools
                 ResourceMakeAvailable rma = new ResourceMakeAvailable();
-                rma.autoManageDualPrimary(isVMMigration);
+                if (isVMMigration) {
+                    // only set when needed: older controllers reject the unknown property
+                    rma.autoManageDualPrimary(true);
+                }
                 ApiCallRcList answers = api.resourceMakeAvailableOnNode(rscName, localNodeName, rma);
                 checkLinstorAnswersThrow(answers);
             } else {

--- a/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
+++ b/plugins/storage/volume/linstor/src/main/java/com/cloud/hypervisor/kvm/storage/LinstorStorageAdaptor.java
@@ -48,7 +48,6 @@ import com.linbit.linstor.api.model.ApiCallRc;
 import com.linbit.linstor.api.model.ApiCallRcList;
 import com.linbit.linstor.api.model.Node;
 import com.linbit.linstor.api.model.Properties;
-import com.linbit.linstor.api.model.ProviderKind;
 import com.linbit.linstor.api.model.Resource;
 import com.linbit.linstor.api.model.ResourceConnectionModify;
 import com.linbit.linstor.api.model.ResourceCreate;
@@ -57,7 +56,6 @@ import com.linbit.linstor.api.model.ResourceDefinitionModify;
 import com.linbit.linstor.api.model.ResourceGroupSpawn;
 import com.linbit.linstor.api.model.ResourceMakeAvailable;
 import com.linbit.linstor.api.model.ResourceWithVolumes;
-import com.linbit.linstor.api.model.StoragePool;
 import com.linbit.linstor.api.model.VolumeDefinition;
 
 import java.io.File;
@@ -872,12 +870,7 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         DevelopersApi linstorApi = getLinstorAPI(pool);
         final String rscGroupName = pool.getResourceGroup();
         try {
-            List<StoragePool> storagePools = LinstorUtil.getRscGroupStoragePools(linstorApi, rscGroupName);
-
-            final long free = storagePools.stream()
-                .filter(sp -> sp.getProviderKind() != ProviderKind.DISKLESS)
-                .mapToLong(sp -> sp.getFreeCapacity() != null ? sp.getFreeCapacity() : 0L).sum() * 1024;  // linstor uses KiB
-
+            final long free = LinstorUtil.getFreeCapacityBytes(linstorApi, rscGroupName);
             logger.debug("Linstor: getAvailable() -> " + free);
             return free;
         } catch (ApiException apiEx) {
@@ -890,13 +883,7 @@ public class LinstorStorageAdaptor implements StorageAdaptor {
         DevelopersApi linstorApi = getLinstorAPI(pool);
         final String rscGroupName = pool.getResourceGroup();
         try {
-            List<StoragePool> storagePools = LinstorUtil.getRscGroupStoragePools(linstorApi, rscGroupName);
-
-            final long used = storagePools.stream()
-                .filter(sp -> sp.getProviderKind() != ProviderKind.DISKLESS)
-                .mapToLong(sp -> sp.getTotalCapacity() != null && sp.getFreeCapacity() != null ?
-                        sp.getTotalCapacity() - sp.getFreeCapacity() : 0L)
-                    .sum() * 1024; // linstor uses Kib
+            final long used = LinstorUtil.getUsedCapacityBytes(linstorApi, rscGroupName);
             logger.debug("Linstor: getUsed() -> " + used);
             return used;
         } catch (ApiException apiEx) {

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -661,18 +661,19 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             VirtualMachineManager.ExecuteInSequence.value());
 
         final StoragePool pool = (StoragePool) volumeInfo.getDataStore();
-        Optional<RemoteHostEndPoint> optEP = getDiskfullEP(linstorApi, pool, rscName);
-        if (optEP.isEmpty()) {
-            optEP = getLinstorEP(linstorApi, pool, rscName);
-        }
-
-        if (optEP.isPresent()) {
-            Answer answer = optEP.get().sendMessage(cmd);
-            if (!answer.getResult()) {
-                resultMsg = answer.getDetails();
-            }
+        Host diskfulHost = getDiskfullHost(linstorApi, pool, rscName);
+        Answer answer;
+        if (diskfulHost != null) {
+            answer = sendWithRscActivated(linstorApi, rscName, diskfulHost, cmd);
         } else {
-            resultMsg = "Unable to get matching Linstor endpoint.";
+            Optional<RemoteHostEndPoint> optEP = getLinstorEP(linstorApi, pool, rscName);
+            if (optEP.isEmpty()) {
+                return "Unable to get matching Linstor endpoint.";
+            }
+            answer = optEP.get().sendMessage(cmd);
+        }
+        if (!answer.getResult()) {
+            resultMsg = answer.getDetails();
         }
         return resultMsg;
     }
@@ -855,7 +856,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         return Optional.empty();
     }
 
-    private Optional<RemoteHostEndPoint> getDiskfullEP(DevelopersApi api, StoragePool storagePool, String rscName)
+    private Host getDiskfullHost(DevelopersApi api, StoragePool storagePool, String rscName)
             throws ApiException {
         List<com.linbit.linstor.api.model.StoragePool> linSPs = LinstorUtil.getDiskfulStoragePools(api, rscName);
         if (linSPs != null) {
@@ -864,11 +865,44 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                     .collect(Collectors.toList());
             Host host = getEnabledClusterHost(storagePool, linstorNodeNames);
             if (host != null) {
-                return Optional.of(RemoteHostEndPoint.getHypervisorHostEndPoint(host));
+                return host;
             }
         }
         logger.error("Linstor: No diskfull host found.");
-        return Optional.empty();
+        return null;
+    }
+
+    /**
+     * Send the given command to the host, temporarily activating the resource there if it is
+     * inactive (e.g. a shared storage pool resource of a stopped VM). Activation goes through
+     * the Linstor controller, so the shared-space activation lock is honored; the agent itself
+     * must only activate/deactivate the snapshot LV, never the resource.
+     */
+    private Answer sendWithRscActivated(DevelopersApi api, String rscName, Host host, CopyCommand cmd)
+            throws ApiException {
+        boolean activated = false;
+        if (LinstorUtil.isResourceInactiveOnNode(api, rscName, host.getName())) {
+            ApiCallRcList answers = api.activateRsc(rscName, host.getName());
+            if (answers.hasError()) {
+                throw new CloudRuntimeException(String.format(
+                        "Linstor: Unable to activate resource %s on node %s: %s",
+                        rscName, host.getName(), LinstorUtil.getBestErrorMessage(answers)));
+            }
+            activated = true;
+        }
+        try {
+            return RemoteHostEndPoint.getHypervisorHostEndPoint(host).sendMessage(cmd);
+        } finally {
+            if (activated) {
+                ApiCallRcList answers = api.deactivateRsc(rscName, host.getName());
+                if (answers.hasError()) {
+                    // don't fail the copy over cleanup, but a stray active resource on a shared
+                    // storage pool must be visible in the logs
+                    logger.error("Linstor: Unable to deactivate resource {} on node {}: {}",
+                            rscName, host.getName(), LinstorUtil.getBestErrorMessage(answers));
+                }
+            }
+        }
     }
 
     private String restoreResourceFromSnapshot(
@@ -1104,11 +1138,10 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             // volumes we never read the storage snapshot directly: restore the snapshot into a temporary
             // resource and back up its decrypted DRBD device instead, symmetric to the restore path.
             final boolean encrypted = snapshotObject.getBaseVolume().getPassphraseId() != null;
-            Optional<RemoteHostEndPoint> optEP = encrypted ?
-                Optional.empty() : getDiskfullEP(api, pool, rscName);
+            Host diskfulHost = encrypted ? null : getDiskfullHost(api, pool, rscName);
             Answer answer;
-            if (optEP.isPresent()) {
-                answer = optEP.get().sendMessage(cmd);
+            if (diskfulHost != null) {
+                answer = sendWithRscActivated(api, rscName, diskfulHost, cmd);
             } else {
                 logger.debug("No diskfull endpoint used to copy image (encrypted={}), using temporary resource",
                     encrypted);

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -436,6 +436,16 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                         cloneRequest.setVolumePassphrases(Collections.singletonList(utf8Passphrase));
                     }
                 }
+                // Shared storage pool templates are INACTIVE while unused (e.g. after a node
+                // reboot) and the clone source selection skips inactive resources. Activate one
+                // diskful resource and leave it active: concurrent clones share the source, so
+                // deactivating after a clone would race with other clones still using it.
+                final String activateNode = LinstorUtil.getDiskfulNodeToActivate(linstorApi, cloneRes);
+                if (activateNode != null) {
+                    logger.info("Linstor: activating template resource {} on {} for cloning",
+                            cloneRes, activateNode);
+                    LinstorUtil.checkLinstorAnswersThrow(linstorApi.activateRsc(cloneRes, activateNode));
+                }
                 ResourceDefinitionCloneStarted cloneStarted = linstorApi.resourceDefinitionClone(
                     cloneRes, cloneRequest);
 

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -251,7 +251,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
 
         try
         {
-            ApiCallRcList answers = linstorApi.resourceSnapshotDelete(rscDefName, snapshotName, Collections.emptyList());
+            ApiCallRcList answers = linstorApi.resourceSnapshotDelete(rscDefName, snapshotName, Collections.emptyList(), null);
             if (answers.hasError())
             {
                 for (ApiCallRc answer : answers)

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -921,8 +921,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         TemplateInfo tInfo = (TemplateInfo) dstData;
         final StoragePoolVO pool = _storagePoolDao.findById(dstData.getDataStore().getId());
         final DevelopersApi api = getLinstorAPI(pool);
-        final String rscName = LinstorUtil.RSC_PREFIX + dstData.getUuid();
-        boolean newCreated = LinstorUtil.createResourceBase(
+        Pair<String, Boolean> crResult = LinstorUtil.createResourceBase(
             LinstorUtil.RSC_PREFIX + dstData.getUuid(),
             tInfo.getSize(),
             tInfo.getName(),
@@ -936,7 +935,9 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
             false);
 
         Answer answer;
-        if (newCreated) {
+        boolean newRscCreated = crResult.second();
+        if (newRscCreated) {
+            String newRscName = crResult.first();
             int nMaxExecutionMinutes = NumbersUtil.parseInt(
                     _configDao.getValue(Config.SecStorageCmdExecutionTimeMax.key()), 30);
             CopyCommand cmd = new CopyCommand(
@@ -946,16 +947,16 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                     VirtualMachineManager.ExecuteInSequence.value());
 
             try {
-                Optional<RemoteHostEndPoint> optEP = getLinstorEP(api, pool, rscName);
+                Optional<RemoteHostEndPoint> optEP = getLinstorEP(api, pool, newRscName);
                 if (optEP.isPresent()) {
                     answer = optEP.get().sendMessage(cmd);
                 } else {
-                    deleteResourceDefinition(pool, rscName);
+                    deleteResourceDefinition(pool, newRscName);
                     throw new CloudRuntimeException("Unable to get matching Linstor endpoint.");
                 }
             } catch (ApiException exc) {
                 logger.error("copy template failed: ", exc);
-                deleteResourceDefinition(pool, rscName);
+                deleteResourceDefinition(pool, newRscName);
                 throw new CloudRuntimeException(exc.getBestMessage());
             }
         } else {

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -435,6 +435,15 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                         String utf8Passphrase = new String(volumeInfo.getPassphrase(), StandardCharsets.UTF_8);
                         cloneRequest.setVolumePassphrases(Collections.singletonList(utf8Passphrase));
                     }
+                } else {
+                    // pin the clone target to the resource group's layer stack (e.g. STORAGE on
+                    // shared pools); otherwise the target can end up with a default DRBD stack
+                    // that has no common clone strategy with the source
+                    List<LayerType> rgLayers = LinstorUtil.getRscGrpLayerList(
+                            linstorApi, LinstorUtil.getRscGrp(storagePoolVO));
+                    if (!rgLayers.isEmpty()) {
+                        cloneRequest.setLayerList(rgLayers);
+                    }
                 }
                 // Shared storage pool templates are INACTIVE while unused (e.g. after a node
                 // reboot) and the clone source selection skips inactive resources. Activate one

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -877,15 +877,17 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
 
     private Host getDiskfullHost(DevelopersApi api, StoragePool storagePool, String rscName)
             throws ApiException {
-        List<com.linbit.linstor.api.model.StoragePool> linSPs = LinstorUtil.getDiskfulStoragePools(api, rscName);
-        if (linSPs != null) {
-            List<String> linstorNodeNames = linSPs.stream()
-                    .map(com.linbit.linstor.api.model.StoragePool::getNodeName)
-                    .collect(Collectors.toList());
-            Host host = getEnabledClusterHost(storagePool, linstorNodeNames);
+        // Take the first diskful copy whose host can be used: the copies are ordered by how
+        // suited they are (in use, then active, then inactive), and for shared storage pools
+        // only the active node may be read, so the order must not be broken here.
+        for (com.linbit.linstor.api.model.StoragePool linSP
+                : LinstorUtil.getDiskfulStoragePoolsByPreference(api, rscName)) {
+            Host host = getEnabledClusterHost(storagePool, Collections.singletonList(linSP.getNodeName()));
             if (host != null) {
                 return host;
             }
+            logger.debug("Linstor: no usable cloudstack host for diskful node {}, trying next copy",
+                    linSP.getNodeName());
         }
         logger.error("Linstor: No diskfull host found.");
         return null;

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/LinstorPrimaryDataStoreLifeCycleImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/LinstorPrimaryDataStoreLifeCycleImpl.java
@@ -207,6 +207,16 @@ public class LinstorPrimaryDataStoreLifeCycleImpl extends BasePrimaryDataStoreLi
                     LinstorConfigurationManager.ApiToken.key(), DBEncryptionUtil.encrypt(apiToken), false);
         }
 
+        // Thickly provisioned storage (e.g. thick LVM, also used for shared storage pools) allocates
+        // the full volume size, so the pool capacity is a hard limit. The Linstor storage pool type
+        // allows over-provisioning for thin backends, so disable it per pool here instead.
+        if (dataStore != null && LinstorUtil.isThicklyProvisioned(url, resourceGroup, apiToken, insecureSsl)) {
+            logger.info("Linstor: {} is thickly provisioned, setting {} to 1.0",
+                    storagePoolName, CapacityManager.StorageOverprovisioningFactor.key());
+            storagePoolDetailsDao.addDetail(dataStore.getId(),
+                    CapacityManager.StorageOverprovisioningFactor.key(), "1.0", true);
+        }
+
         return dataStore;
     }
 

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -101,6 +101,49 @@ public class LinstorUtil {
         return new DevelopersApi(client);
     }
 
+    /**
+     * The REST API version of the connected controller, e.g. "1.29.1", or null if it could not be queried.
+     */
+    @Nullable
+    public static String getRestApiVersion(DevelopersApi api) {
+        try {
+            return api.controllerVersion().getRestApiVersion();
+        } catch (ApiException apiExc) {
+            LOGGER.warn("Unable to query controller API version: {}", apiExc.getBestMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Check if the connected controller supports the live-migration attach/detach API:
+     * make-available with auto_manage_dual_primary and unmake-available, added with REST API 1.29.0.
+     */
+    public static boolean supportsLiveMigrateApi(DevelopersApi api) {
+        return isVersionAtLeast(getRestApiVersion(api), 1, 29, 0);
+    }
+
+    static boolean isVersionAtLeast(String version, int major, int minor, int patch) {
+        if (version == null || version.isEmpty()) {
+            return false;
+        }
+        String[] parts = version.split("\\.");
+        try {
+            int maj = Integer.parseInt(parts[0]);
+            int min = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            int pat = parts.length > 2 ? Integer.parseInt(parts[2]) : 0;
+            if (maj != major) {
+                return maj > major;
+            }
+            if (min != minor) {
+                return min > minor;
+            }
+            return pat >= patch;
+        } catch (NumberFormatException nfExc) {
+            LOGGER.warn("Unable to parse controller API version '{}'", version);
+            return false;
+        }
+    }
+
     public static String getBestErrorMessage(ApiCallRcList answers) {
         return answers != null && !answers.isEmpty() ?
             answers.stream()

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -360,6 +360,32 @@ public class LinstorUtil {
     }
 
     /**
+     * If the resource has no active diskful deployment, return a node with an inactive
+     * diskful resource that could be activated (e.g. an unused template on a shared
+     * storage pool). Returns null if an active diskful resource exists or none is deployed.
+     */
+    public static String getDiskfulNodeToActivate(DevelopersApi api, String rscName) throws ApiException {
+        List<Resource> rscs = api.resourceList(rscName, null, null);
+        if (rscs == null) {
+            return null;
+        }
+        String inactiveDiskfulNode = null;
+        for (Resource rsc : rscs) {
+            List<String> flags = rsc.getFlags();
+            boolean diskless = flags != null &&
+                    (flags.contains(ApiConsts.FLAG_DISKLESS) || flags.contains(ApiConsts.FLAG_DRBD_DISKLESS));
+            if (diskless) {
+                continue;
+            }
+            if (flags == null || !flags.contains(ApiConsts.FLAG_RSC_INACTIVE)) {
+                return null; // active diskful resource exists
+            }
+            inactiveDiskfulNode = rsc.getNodeName();
+        }
+        return inactiveDiskfulNode;
+    }
+
+    /**
      * Check if the resource is deployed but inactive on the given node (e.g. a shared
      * storage pool resource of a stopped VM).
      */

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -195,8 +196,26 @@ public class LinstorUtil {
         return nodes.stream().map(Node::getName).collect(Collectors.toList());
     }
 
+    /**
+     * How suitable a diskful resource is for reading its data (snapshots, volume copies):
+     * the node it is in use on is best, then nodes with an active resource, then inactive ones.
+     * Thick LVM snapshots on shared storage pools (dm-snapshot) are not cluster aware, so they
+     * must be read on the node the origin volume is active on - callers must honor this order.
+     */
+    private static int diskfulPreference(ResourceWithVolumes rwv) {
+        if (rwv.getState() != null && Boolean.TRUE.equals(rwv.getState().isInUse())) {
+            return 2;
+        }
+        return rwv.getFlags() == null || !rwv.getFlags().contains(ApiConsts.FLAG_RSC_INACTIVE) ? 1 : 0;
+    }
+
+    /**
+     * All storage pools holding a diskful copy of the resource, best suited first
+     * (see {@link #diskfulPreference}). Callers that need a single pool should take the first
+     * one, callers picking a host should walk the list in order and use the first usable one.
+     */
     public static List<com.linbit.linstor.api.model.StoragePool>
-    getDiskfulStoragePools(@Nonnull DevelopersApi api, @Nonnull String rscName) throws ApiException
+    getDiskfulStoragePoolsByPreference(@Nonnull DevelopersApi api, @Nonnull String rscName) throws ApiException
     {
         List<ResourceWithVolumes> resources = api.viewResources(
                 Collections.emptyList(),
@@ -206,56 +225,50 @@ public class LinstorUtil {
                 null,
                 null);
 
-        String nodeName = null;
-        String storagePoolName = null;
-        int bestScore = -1;
-        for (ResourceWithVolumes rwv : resources) {
-            if (rwv.getVolumes().isEmpty()) {
-                continue;
-            }
-            Volume vol = rwv.getVolumes().get(0);
-            if (vol.getProviderKind() == ProviderKind.DISKLESS) {
-                continue;
-            }
-            // Prefer the in-use node, then nodes with an active (not INACTIVE) resource:
-            // thick LVM snapshots on shared storage pools (dm-snapshot) are not cluster aware
-            // and must be read on the node the origin volume is active on.
-            boolean inUse = rwv.getState() != null && Boolean.TRUE.equals(rwv.getState().isInUse());
-            boolean active = rwv.getFlags() == null || !rwv.getFlags().contains(ApiConsts.FLAG_RSC_INACTIVE);
-            int score = inUse ? 2 : (active ? 1 : 0);
-            if (score > bestScore) {
-                bestScore = score;
-                nodeName = rwv.getNodeName();
-                storagePoolName = vol.getStoragePoolName();
-                if (inUse) {
-                    break;
-                }
-            }
-        }
+        // node name -> storage pool name, ordered by how suited the copy is
+        List<Pair<String, String>> candidates = resources.stream()
+                .filter(rwv -> !rwv.getVolumes().isEmpty()
+                        && rwv.getVolumes().get(0).getProviderKind() != ProviderKind.DISKLESS)
+                .sorted(Comparator.comparingInt(LinstorUtil::diskfulPreference).reversed())
+                .map(rwv -> new Pair<>(rwv.getNodeName(), rwv.getVolumes().get(0).getStoragePoolName()))
+                .collect(Collectors.toList());
 
-        if (nodeName == null) {
-            return null;
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
         }
 
         List<com.linbit.linstor.api.model.StoragePool> sps = api.viewStoragePools(
-                Collections.singletonList(nodeName),
-                Collections.singletonList(storagePoolName),
+                candidates.stream().map(Pair::first).distinct().collect(Collectors.toList()),
+                candidates.stream().map(Pair::second).distinct().collect(Collectors.toList()),
                 Collections.emptyList(),
                 null,
                 null,
                 true
         );
-        return sps != null ? sps : Collections.emptyList();
+        if (sps == null) {
+            return Collections.emptyList();
+        }
+
+        // viewStoragePools does not keep our ordering, so re-apply it
+        List<com.linbit.linstor.api.model.StoragePool> ordered = new ArrayList<>();
+        for (Pair<String, String> candidate : candidates) {
+            sps.stream()
+                    .filter(sp -> candidate.first().equals(sp.getNodeName())
+                            && candidate.second().equals(sp.getStoragePoolName()))
+                    .findFirst()
+                    .ifPresent(ordered::add);
+        }
+        return ordered;
     }
 
+    /**
+     * The storage pool of the best suited diskful copy, null if the resource has none.
+     */
     public static com.linbit.linstor.api.model.StoragePool
     getDiskfulStoragePool(@Nonnull DevelopersApi api, @Nonnull String rscName) throws ApiException
     {
-        List<com.linbit.linstor.api.model.StoragePool> sps = getDiskfulStoragePools(api, rscName);
-        if (sps != null) {
-            return !sps.isEmpty() ? sps.get(0) : null;
-        }
-        return null;
+        List<com.linbit.linstor.api.model.StoragePool> sps = getDiskfulStoragePoolsByPreference(api, rscName);
+        return !sps.isEmpty() ? sps.get(0) : null;
     }
 
     public static String getSnapshotPath(com.linbit.linstor.api.model.StoragePool sp, String rscName, String snapshotName) {

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -428,6 +428,17 @@ public class LinstorUtil {
             }
         }
 
+        // Shared storage pool resources of stopped VMs are INACTIVE and report no device path.
+        // Callers like createVbd build the domain XML before connectPhysicalDisk activates the
+        // resource, so return the deterministic storage layer path here.
+        com.linbit.linstor.api.model.StoragePool sp = getDiskfulStoragePool(api, rscName);
+        if (sp != null && (sp.getProviderKind() == ProviderKind.LVM || sp.getProviderKind() == ProviderKind.LVM_THIN)) {
+            final String vg = sp.getProps().get("StorDriver/StorPoolName").split("/")[0];
+            final String path = String.format("/dev/%s/%s_00000", vg, rscName);
+            LOGGER.info("Linstor: no active device path for {}, using expected LVM path {}", rscName, path);
+            return path;
+        }
+
         final String errMsg = "viewResources didn't return resources or volumes for " + rscName + " with a device path";
         LOGGER.error(errMsg);
         throw new CloudRuntimeException("Linstor: " + errMsg);

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -328,6 +328,33 @@ public class LinstorUtil {
         return distinct;
     }
 
+    /**
+     * Storage provider kinds that allocate the full volume size up front. Such pools cannot be
+     * over-provisioned: their capacity is the real limit.
+     */
+    private static final Collection<ProviderKind> THICK_PROVIDER_KINDS = Arrays.asList(
+            ProviderKind.LVM, ProviderKind.ZFS, ProviderKind.FILE);
+
+    /**
+     * Check if all storage pools backing the resource group are thickly provisioned.
+     * Unknown/mixed setups are reported as thin, keeping the over-provisioning default.
+     */
+    public static boolean isThicklyProvisioned(String linstorUrl, String rscGroupName, String apiToken,
+                                               boolean insecureSsl) {
+        DevelopersApi api = getLinstorAPI(linstorUrl, apiToken, insecureSsl);
+        try {
+            return isThicklyProvisionedPools(getCapacityStoragePools(api, rscGroupName));
+        } catch (ApiException apiEx) {
+            LOGGER.warn("Unable to query storage pool provider kinds: {}", apiEx.getBestMessage());
+            return false;
+        }
+    }
+
+    static boolean isThicklyProvisionedPools(List<StoragePool> storagePools) {
+        return !storagePools.isEmpty() && storagePools.stream()
+                .allMatch(sp -> THICK_PROVIDER_KINDS.contains(sp.getProviderKind()));
+    }
+
     private static long sumTotalCapacity(List<StoragePool> storagePools) {
         return storagePools.stream()
                 .mapToLong(sp -> sp.getTotalCapacity() != null ? sp.getTotalCapacity() : 0L)

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -352,12 +352,12 @@ public class LinstorUtil {
                 null,
                 null);
         for (ResourceWithVolumes rsc : resources) {
-            if (!rsc.getVolumes().isEmpty()) {
+            if (!rsc.getVolumes().isEmpty() && rsc.getVolumes().get(0).getDevicePath() != null) {
                 return LinstorUtil.getDevicePathFromResource(rsc);
             }
         }
 
-        final String errMsg = "viewResources didn't return resources or volumes for " + rscName;
+        final String errMsg = "viewResources didn't return resources or volumes for " + rscName + " with a device path";
         LOGGER.error(errMsg);
         throw new CloudRuntimeException("Linstor: " + errMsg);
     }
@@ -695,7 +695,7 @@ public class LinstorUtil {
      * @param isTemplate indicates if the resource is a template
      * @return true if a new resource was created, false if it already existed or was reused.
      */
-    public static boolean createResourceBase(
+    public static Pair<String, Boolean> createResourceBase(
             String rscName, long sizeInBytes, String volName, String vmName,
             @Nullable Long passPhraseId, @Nullable byte[] passPhrase, DevelopersApi api,
             String rscGrp, long poolId, boolean isTemplate, boolean exactSize)
@@ -711,14 +711,14 @@ public class LinstorUtil {
                     existingRDs.stream().anyMatch(p -> p.first().getProps().containsKey(LinstorUtil.getTemplateForAuxPropKey(rscGrp)));
             if (!alreadyCreated) {
                 boolean createNewRsc = !foundShareableTemplate(api, rscName, rscGrp, existingRDs);
+                String newRscName = existingRDs.isEmpty() ? rscName : fullRscName;
                 if (createNewRsc) {
-                    String newRscName = existingRDs.isEmpty() ? rscName : fullRscName;
                     spawnResource(api, newRscName, sizeInBytes, isTemplate, rscGrp,
                             volName, vmName, passPhraseId, passPhrase, exactSize);
                 }
-                return createNewRsc;
+                return new Pair<>(newRscName, createNewRsc);
             }
-            return false;
+            return new Pair<>(rscName, false);
         } catch (ApiException apiEx)
         {
             LOGGER.error("Linstor: ApiEx - {}", apiEx.getMessage());

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -204,15 +204,28 @@ public class LinstorUtil {
 
         String nodeName = null;
         String storagePoolName = null;
+        int bestScore = -1;
         for (ResourceWithVolumes rwv : resources) {
             if (rwv.getVolumes().isEmpty()) {
                 continue;
             }
             Volume vol = rwv.getVolumes().get(0);
-            if (vol.getProviderKind() != ProviderKind.DISKLESS) {
+            if (vol.getProviderKind() == ProviderKind.DISKLESS) {
+                continue;
+            }
+            // Prefer the in-use node, then nodes with an active (not INACTIVE) resource:
+            // thick LVM snapshots on shared storage pools (dm-snapshot) are not cluster aware
+            // and must be read on the node the origin volume is active on.
+            boolean inUse = rwv.getState() != null && Boolean.TRUE.equals(rwv.getState().isInUse());
+            boolean active = rwv.getFlags() == null || !rwv.getFlags().contains(ApiConsts.FLAG_RSC_INACTIVE);
+            int score = inUse ? 2 : (active ? 1 : 0);
+            if (score > bestScore) {
+                bestScore = score;
                 nodeName = rwv.getNodeName();
                 storagePoolName = vol.getStoragePoolName();
-                break;
+                if (inUse) {
+                    break;
+                }
             }
         }
 
@@ -246,6 +259,7 @@ public class LinstorUtil {
         final String backingPool = sp.getProps().get("StorDriver/StorPoolName");
         final String path;
         switch (sp.getProviderKind()) {
+            case LVM:  // thick LVM snapshot LVs use the same naming scheme as thin
             case LVM_THIN:
                 path = String.format("/dev/mapper/%s-%s_%s_%s",
                     backingPool.split("/")[0], rscName.replace("-", "--"), suffix, snapshotName.replace("-", "--"));

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -796,6 +796,16 @@ public class LinstorUtil {
                 String utf8Passphrase = new String(passPhrase, StandardCharsets.UTF_8);
                 rscGrpSpawn.setVolumePassphrases(Collections.singletonList(utf8Passphrase));
             }
+        } else {
+            // spell out the resource group's layer stack instead of relying on the implicit
+            // default: a template spawned with a DRBD stack cannot be cloned into a
+            // STORAGE/LUKS resource of a shared storage pool later on
+            List<LayerType> rgLayers = getRscGrpLayerList(api, rscGrpName);
+            if (!rgLayers.isEmpty()) {
+                AutoSelectFilter asf = new AutoSelectFilter();
+                asf.setLayerStack(rgLayers.stream().map(LayerType::toString).collect(Collectors.toList()));
+                rscGrpSpawn.setSelectFilter(asf);
+            }
         }
 
         Properties props = new Properties();

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -41,13 +41,16 @@ import com.linbit.linstor.api.model.VolumeDefinitionModify;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
@@ -58,6 +61,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -299,15 +303,62 @@ public class LinstorUtil {
         );
     }
 
+    /**
+     * Diskful storage pools that contribute capacity, counting storage shared by multiple
+     * nodes only once. Nodes accessing the same shared space (e.g. a LUN with a shared LVM
+     * volume group) all report the full capacity of that space, so summing them as-is
+     * multiplies the real capacity by the number of nodes.
+     *
+     * Deduplication uses the free space manager name: node local storage pools get a
+     * per-node name ("node;pool"), pools sharing a space all report the shared space name.
+     */
+    public static List<StoragePool> getCapacityStoragePools(
+            @Nonnull DevelopersApi api, String rscGroupName) throws ApiException {
+        List<StoragePool> storagePools = getRscGroupStoragePools(api, rscGroupName);
+        List<StoragePool> distinct = new ArrayList<>();
+        Set<String> seenSpaces = new HashSet<>();
+        for (StoragePool sp : storagePools) {
+            if (sp.getProviderKind() == ProviderKind.DISKLESS) {
+                continue;
+            }
+            if (StringUtils.isEmpty(sp.getFreeSpaceMgrName()) || seenSpaces.add(sp.getFreeSpaceMgrName())) {
+                distinct.add(sp);
+            }
+        }
+        return distinct;
+    }
+
+    private static long sumTotalCapacity(List<StoragePool> storagePools) {
+        return storagePools.stream()
+                .mapToLong(sp -> sp.getTotalCapacity() != null ? sp.getTotalCapacity() : 0L)
+                .sum() * 1024;  // linstor uses KiB
+    }
+
+    private static long sumUsedCapacity(List<StoragePool> storagePools) {
+        return storagePools.stream()
+                .mapToLong(sp -> sp.getTotalCapacity() != null && sp.getFreeCapacity() != null ?
+                        sp.getTotalCapacity() - sp.getFreeCapacity() : 0L)
+                .sum() * 1024;  // linstor uses KiB
+    }
+
+    private static long sumFreeCapacity(List<StoragePool> storagePools) {
+        return storagePools.stream()
+                .mapToLong(sp -> sp.getFreeCapacity() != null ? sp.getFreeCapacity() : 0L)
+                .sum() * 1024;  // linstor uses KiB
+    }
+
+    public static long getFreeCapacityBytes(@Nonnull DevelopersApi api, String rscGroupName) throws ApiException {
+        return sumFreeCapacity(getCapacityStoragePools(api, rscGroupName));
+    }
+
+    public static long getUsedCapacityBytes(@Nonnull DevelopersApi api, String rscGroupName) throws ApiException {
+        return sumUsedCapacity(getCapacityStoragePools(api, rscGroupName));
+    }
+
     public static long getCapacityBytes(String linstorUrl, String rscGroupName, String apiToken, boolean insecureSsl) {
         DevelopersApi linstorApi = getLinstorAPI(linstorUrl, apiToken, insecureSsl);
         try {
-            List<StoragePool> storagePools = getRscGroupStoragePools(linstorApi, rscGroupName);
-
-            return storagePools.stream()
-                .filter(sp -> sp.getProviderKind() != ProviderKind.DISKLESS)
-                .mapToLong(sp -> sp.getTotalCapacity() != null ? sp.getTotalCapacity() : 0L)
-                .sum() * 1024;  // linstor uses kiB
+            return sumTotalCapacity(getCapacityStoragePools(linstorApi, rscGroupName));
         } catch (ApiException apiEx) {
             LOGGER.error(apiEx.getMessage());
             throw new CloudRuntimeException(apiEx);
@@ -317,18 +368,10 @@ public class LinstorUtil {
     public static Pair<Long, Long> getStorageStats(String linstorUrl, String rscGroupName, String apiToken, boolean insecureSsl) {
         DevelopersApi linstorApi = getLinstorAPI(linstorUrl, apiToken, insecureSsl);
         try {
-            List<StoragePool> storagePools = LinstorUtil.getRscGroupStoragePools(linstorApi, rscGroupName);
+            List<StoragePool> storagePools = getCapacityStoragePools(linstorApi, rscGroupName);
 
-            long capacity = storagePools.stream()
-                    .filter(sp -> sp.getProviderKind() != ProviderKind.DISKLESS)
-                    .mapToLong(sp -> sp.getTotalCapacity() != null ? sp.getTotalCapacity() : 0L)
-                    .sum() * 1024;  // linstor uses kiB
-
-            long used = storagePools.stream()
-                    .filter(sp -> sp.getProviderKind() != ProviderKind.DISKLESS)
-                    .mapToLong(sp -> sp.getTotalCapacity() != null && sp.getFreeCapacity() != null ?
-                            sp.getTotalCapacity() - sp.getFreeCapacity() : 0L)
-                    .sum() * 1024; // linstor uses Kib
+            long capacity = sumTotalCapacity(storagePools);
+            long used = sumUsedCapacity(storagePools);
             LOGGER.debug(
                     String.format("Linstor(%s;%s): storageStats -> %d/%d", linstorUrl, rscGroupName, capacity, used));
             return new Pair<>(capacity, used);

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -360,6 +360,20 @@ public class LinstorUtil {
     }
 
     /**
+     * Check if the resource is deployed but inactive on the given node (e.g. a shared
+     * storage pool resource of a stopped VM).
+     */
+    public static boolean isResourceInactiveOnNode(DevelopersApi api, String rscName, String nodeName)
+            throws ApiException {
+        List<Resource> rscs = api.resourceList(rscName, null, null);
+        if (rscs == null) {
+            return false;
+        }
+        return rscs.stream().anyMatch(rsc -> nodeName.equalsIgnoreCase(rsc.getNodeName()) &&
+                rsc.getFlags() != null && rsc.getFlags().contains(ApiConsts.FLAG_RSC_INACTIVE));
+    }
+
+    /**
      * Check if the given resources are diskless.
      *
      * @param api developer api object to use

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -717,6 +717,30 @@ public class LinstorUtil {
      * @param resourceGroup Resource group to get the encryption layer list
      * @return layer list with LUKS added
      */
+    /**
+     * The layer stack configured on the resource group, empty if none is set.
+     */
+    public static List<LayerType> getRscGrpLayerList(DevelopersApi api, String resourceGroup) {
+        try {
+            List<ResourceGroup> rscGrps = api.resourceGroupList(
+                    Collections.singletonList(resourceGroup), Collections.emptyList(), null, null);
+
+            if (CollectionUtils.isEmpty(rscGrps)) {
+                throw new CloudRuntimeException(
+                        String.format("Resource Group %s not found on Linstor cluster.", resourceGroup));
+            }
+
+            List<String> layerStack = rscGrps.get(0).getSelectFilter() != null ?
+                    rscGrps.get(0).getSelectFilter().getLayerStack() : Collections.emptyList();
+            return CollectionUtils.isNotEmpty(layerStack) ?
+                    layerStack.stream().map(LayerType::valueOf).collect(Collectors.toList()) :
+                    Collections.emptyList();
+        } catch (ApiException apiEx) {
+            LOGGER.error(apiEx.getBestMessage());
+            throw new CloudRuntimeException(apiEx.getBestMessage(), apiEx);
+        }
+    }
+
     public static List<LayerType> getEncryptedLayerList(DevelopersApi api, String resourceGroup) {
         try {
             List<ResourceGroup> rscGrps = api.resourceGroupList(

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/snapshot/LinstorVMSnapshotStrategy.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/snapshot/LinstorVMSnapshotStrategy.java
@@ -214,7 +214,7 @@ public class LinstorVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
     private String linstorDeleteSnapshot(final DevelopersApi api, final String rscName, final String snapshotName) {
         String resultMsg = null;
         try {
-            ApiCallRcList answers = api.resourceSnapshotDelete(rscName, snapshotName, Collections.emptyList());
+            ApiCallRcList answers = api.resourceSnapshotDelete(rscName, snapshotName, Collections.emptyList(), null);
             if (answers.hasError()) {
                 resultMsg = LinstorUtil.getBestErrorMessage(answers);
             }

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.storage.datastore.util;
 import com.linbit.linstor.api.ApiException;
 import com.linbit.linstor.api.DevelopersApi;
 import com.linbit.linstor.api.model.AutoSelectFilter;
+import com.linbit.linstor.api.model.ControllerVersion;
 import com.linbit.linstor.api.model.Node;
 import com.linbit.linstor.api.model.Properties;
 import com.linbit.linstor.api.model.ProviderKind;
@@ -113,6 +114,44 @@ public class LinstorUtilTest {
             String snapPath = LinstorUtil.getSnapshotPath(spZFS, "cs-cb32532a-dd8f-47e0-a81c-8a75573d3545", "snap2");
             Assert.assertEquals("zfs://linstorPool/cs-cb32532a-dd8f-47e0-a81c-8a75573d3545_00000@snap2", snapPath);
         }
+    }
+
+    @Test
+    public void testIsVersionAtLeast() {
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.29.1", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.29.2", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.30.0", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("2.0.0", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.30", 1, 29, 1));
+
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("1.29.0", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("1.29", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("1.28.5", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("0.99.9", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast(null, 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("garbage", 1, 29, 1));
+    }
+
+    private ControllerVersion controllerVersion(String restApiVersion) {
+        ControllerVersion version = new ControllerVersion();
+        version.setRestApiVersion(restApiVersion);
+        return version;
+    }
+
+    @Test
+    public void testSupportsLiveMigrateApi() throws ApiException {
+        DevelopersApi newCtrl = mock(DevelopersApi.class);
+        when(newCtrl.controllerVersion()).thenReturn(controllerVersion("1.29.0"));
+        Assert.assertTrue(LinstorUtil.supportsLiveMigrateApi(newCtrl));
+
+        DevelopersApi oldCtrl = mock(DevelopersApi.class);
+        when(oldCtrl.controllerVersion()).thenReturn(controllerVersion("1.28.3"));
+        Assert.assertFalse(LinstorUtil.supportsLiveMigrateApi(oldCtrl));
+
+        DevelopersApi unreachable = mock(DevelopersApi.class);
+        when(unreachable.controllerVersion()).thenThrow(new ApiException(503, "unavailable"));
+        Assert.assertFalse(LinstorUtil.supportsLiveMigrateApi(unreachable));
     }
 
     @Test

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -105,6 +105,17 @@ public class LinstorUtilTest {
         }
 
         {
+            StoragePool spLVM = new StoragePool();
+            Properties lvmProps = new Properties();
+            lvmProps.put("StorDriver/StorPoolName", "shared");
+            spLVM.setProps(lvmProps);
+            spLVM.setProviderKind(ProviderKind.LVM);
+            String snapPath = LinstorUtil.getSnapshotPath(spLVM, "cs-cb32532a-dd8f-47e0-a81c-8a75573d3545", "cs-6c6b4e95");
+            Assert.assertEquals(
+                "/dev/mapper/shared-cs--cb32532a--dd8f--47e0--a81c--8a75573d3545_00000_cs--6c6b4e95", snapPath);
+        }
+
+        {
             StoragePool spZFS = new StoragePool();
             Properties zfsProps = new Properties();
             zfsProps.put("StorDriver/StorPoolName", "linstorPool");

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -61,6 +61,15 @@ public class LinstorUtilTest {
         return sp;
     }
 
+    private StoragePool mockStoragePool(
+            String name, String node, ProviderKind kind, String freeSpaceMgrName, long totalKib, long freeKib) {
+        StoragePool sp = mockStoragePool(name, node, kind);
+        sp.setFreeSpaceMgrName(freeSpaceMgrName);
+        sp.setTotalCapacity(totalKib);
+        sp.setFreeCapacity(freeKib);
+        return sp;
+    }
+
     @Before
     public void setUp() throws ApiException {
         api = mock(DevelopersApi.class);
@@ -125,6 +134,36 @@ public class LinstorUtilTest {
             String snapPath = LinstorUtil.getSnapshotPath(spZFS, "cs-cb32532a-dd8f-47e0-a81c-8a75573d3545", "snap2");
             Assert.assertEquals("zfs://linstorPool/cs-cb32532a-dd8f-47e0-a81c-8a75573d3545_00000@snap2", snapPath);
         }
+    }
+
+    @Test
+    public void testGetCapacityStoragePoolsCountsSharedSpaceOnce() throws ApiException {
+        ResourceGroup sharedGroup = new ResourceGroup();
+        sharedGroup.setName("shared");
+        AutoSelectFilter asf = new AutoSelectFilter();
+        asf.setPlaceCount(1);
+        sharedGroup.setSelectFilter(asf);
+        when(api.resourceGroupList(Collections.singletonList("shared"), null, null, null))
+                .thenReturn(Collections.singletonList(sharedGroup));
+
+        // 3 nodes accessing the same shared space, each reporting the full 100 GiB, plus one
+        // node-local pool and a diskless pool which must be ignored
+        when(api.viewStoragePools(Collections.emptyList(), null, null, null, null, true))
+                .thenReturn(Arrays.asList(
+                        mockStoragePool("sharedpool", "nodeA", ProviderKind.LVM, "cs-shared", 104857600L, 52428800L),
+                        mockStoragePool("sharedpool", "nodeB", ProviderKind.LVM, "cs-shared", 104857600L, 52428800L),
+                        mockStoragePool("sharedpool", "nodeC", ProviderKind.LVM, "cs-shared", 104857600L, 52428800L),
+                        mockStoragePool("local", "nodeA", ProviderKind.LVM_THIN, "nodeA;local", 10485760L, 10485760L),
+                        mockStoragePool("diskless", "nodeB", ProviderKind.DISKLESS, "nodeB;diskless", 0L, 0L)
+                ));
+
+        List<StoragePool> pools = LinstorUtil.getCapacityStoragePools(api, "shared");
+        Assert.assertEquals(2, pools.size());
+        // 100 GiB shared (once) + 10 GiB local
+        Assert.assertEquals((104857600L + 10485760L) * 1024, LinstorUtil.getFreeCapacityBytes(api, "shared")
+                + LinstorUtil.getUsedCapacityBytes(api, "shared"));
+        // half of the shared space is used, the local pool is empty
+        Assert.assertEquals(52428800L * 1024, LinstorUtil.getUsedCapacityBytes(api, "shared"));
     }
 
     @Test

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -16,6 +16,10 @@
 // under the License.
 package org.apache.cloudstack.storage.datastore.util;
 
+import com.linbit.linstor.api.ApiConsts;
+import com.linbit.linstor.api.model.ResourceState;
+import com.linbit.linstor.api.model.ResourceWithVolumes;
+import com.linbit.linstor.api.model.Volume;
 import com.linbit.linstor.api.ApiException;
 import com.linbit.linstor.api.DevelopersApi;
 import com.linbit.linstor.api.model.AutoSelectFilter;
@@ -164,6 +168,63 @@ public class LinstorUtilTest {
                 + LinstorUtil.getUsedCapacityBytes(api, "shared"));
         // half of the shared space is used, the local pool is empty
         Assert.assertEquals(52428800L * 1024, LinstorUtil.getUsedCapacityBytes(api, "shared"));
+    }
+
+    private ResourceWithVolumes mockResource(String node, String pool, boolean inUse, boolean inactive) {
+        ResourceWithVolumes rwv = new ResourceWithVolumes();
+        rwv.setName("cs-test");
+        rwv.setNodeName(node);
+        Volume vol = new Volume();
+        vol.setProviderKind(ProviderKind.LVM);
+        vol.setStoragePoolName(pool);
+        rwv.setVolumes(Collections.singletonList(vol));
+        ResourceState state = new ResourceState();
+        state.setInUse(inUse);
+        rwv.setState(state);
+        if (inactive) {
+            rwv.setFlags(Collections.singletonList(ApiConsts.FLAG_RSC_INACTIVE));
+        }
+        return rwv;
+    }
+
+    @Test
+    public void testDiskfulStoragePoolsOrderedByPreference() throws ApiException {
+        // inactive copy first, in-use copy last: the result must be in-use, active, inactive
+        when(api.viewResources(Collections.emptyList(), Collections.singletonList("cs-test"),
+                Collections.emptyList(), Collections.emptyList(), null, null))
+                .thenReturn(Arrays.asList(
+                        mockResource("nodeC", "poolC", false, true),
+                        mockResource("nodeB", "poolB", false, false),
+                        mockResource("nodeA", "poolA", true, false)));
+        // the pools are queried in preference order (in use, active, inactive)
+        when(api.viewStoragePools(Arrays.asList("nodeA", "nodeB", "nodeC"),
+                Arrays.asList("poolA", "poolB", "poolC"), Collections.emptyList(), null, null, true))
+                .thenReturn(Arrays.asList(
+                        mockStoragePool("poolB", "nodeB", ProviderKind.LVM),
+                        mockStoragePool("poolA", "nodeA", ProviderKind.LVM),
+                        mockStoragePool("poolC", "nodeC", ProviderKind.LVM)));
+
+        List<StoragePool> pools = LinstorUtil.getDiskfulStoragePoolsByPreference(api, "cs-test");
+        Assert.assertEquals(Arrays.asList("nodeA", "nodeB", "nodeC"),
+                pools.stream().map(StoragePool::getNodeName).collect(Collectors.toList()));
+        // the single-pool accessor keeps returning the best suited copy
+        Assert.assertEquals("nodeA", LinstorUtil.getDiskfulStoragePool(api, "cs-test").getNodeName());
+    }
+
+    @Test
+    public void testDiskfulStoragePoolsIgnoresDiskless() throws ApiException {
+        ResourceWithVolumes diskless = new ResourceWithVolumes();
+        diskless.setName("cs-test");
+        diskless.setNodeName("nodeD");
+        Volume dlVol = new Volume();
+        dlVol.setProviderKind(ProviderKind.DISKLESS);
+        diskless.setVolumes(Collections.singletonList(dlVol));
+        when(api.viewResources(Collections.emptyList(), Collections.singletonList("cs-test"),
+                Collections.emptyList(), Collections.emptyList(), null, null))
+                .thenReturn(Collections.singletonList(diskless));
+
+        Assert.assertTrue(LinstorUtil.getDiskfulStoragePoolsByPreference(api, "cs-test").isEmpty());
+        Assert.assertNull(LinstorUtil.getDiskfulStoragePool(api, "cs-test"));
     }
 
     @Test

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -167,6 +167,20 @@ public class LinstorUtilTest {
     }
 
     @Test
+    public void testThickProviderKindDetection() {
+        Assert.assertTrue(LinstorUtil.isThicklyProvisionedPools(Arrays.asList(
+                mockStoragePool("sharedpool", "nodeA", ProviderKind.LVM, "cs-shared", 1L, 1L),
+                mockStoragePool("sharedpool", "nodeB", ProviderKind.LVM, "cs-shared", 1L, 1L))));
+        Assert.assertFalse(LinstorUtil.isThicklyProvisionedPools(Arrays.asList(
+                mockStoragePool("thinpool", "nodeA", ProviderKind.LVM_THIN, "nodeA;thinpool", 1L, 1L))));
+        // mixed setups keep the over-provisioning default
+        Assert.assertFalse(LinstorUtil.isThicklyProvisionedPools(Arrays.asList(
+                mockStoragePool("sharedpool", "nodeA", ProviderKind.LVM, "cs-shared", 1L, 1L),
+                mockStoragePool("thinpool", "nodeB", ProviderKind.LVM_THIN, "nodeB;thinpool", 1L, 1L))));
+        Assert.assertFalse(LinstorUtil.isThicklyProvisionedPools(Collections.emptyList()));
+    }
+
+    @Test
     public void testIsVersionAtLeast() {
         Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.29.1", 1, 29, 1));
         Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.29.2", 1, 29, 1));

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <cs.nitro.version>10.1</cs.nitro.version>
         <cs.opensaml.version>2.6.6</cs.opensaml.version>
         <cs.rados-java.version>0.6.0</cs.rados-java.version>
-        <cs.java-linstor.version>0.7.0</cs.java-linstor.version>
+        <cs.java-linstor.version>0.8.1</cs.java-linstor.version>
         <cs.reflections.version>0.10.2</cs.reflections.version>
         <cs.servicemix.version>3.4.4_1</cs.servicemix.version>
         <cs.servlet.version>4.0.1</cs.servlet.version>


### PR DESCRIPTION
### Description

This PR adds support for LINSTOR **shared storage pools** (thick LVM on a LUN that all
hypervisors can access, SAN-style) to the Linstor volume plugin.

Until now the plugin assumed every resource is DRBD replicated and thin provisioned. On a
shared storage pool the data exists once on the LUN, a resource is active on at most one
node at a time, there is no DRBD layer to make dual-primary, and the backing LVM is thick.
Functionally this changes:

* **Live migration** uses the LINSTOR 1.29 API: `make-available` with
  `auto_manage_dual_primary` prepares the destination (DRBD dual-primary, or activating the
  resource on both nodes for shared pools) and `unmake-available` reverts it on the source.
  The controller REST API version is probed once per controller; against controllers older
  than 1.29 the previous manual `allow-two-primaries` handling is used unchanged, so
  existing DRBD/thin deployments behave exactly as before.
* **Resources of stopped VMs** are INACTIVE on a shared pool and expose no device. They are
  now activated on demand (through the controller, so the shared-space lock is honored) for
  VM start, snapshot backup, snapshot revert and template cloning, and deactivated again
  afterwards.
* **Snapshots on thick LVM** work: the snapshot path is resolved for thick pools, the
  snapshot LV is temporarily activated for the copy to secondary storage (without
  registering it with `dmeventd`, which could block the node wide LVM lock), and the copy is
  routed to the node the volume is active on, because dm-snapshot is not cluster aware.
* **Capacity reporting** counts a shared space once instead of once per node (a 100 GiB LUN
  on three nodes was reported as 300 GiB), and thickly provisioned pools get a per pool
  `storage.overprovisioning.factor` of 1.0 at registration, since they cannot be over
  provisioned. Thin pools keep the current default.
* Resources and clone targets are created with the layer stack configured on the resource
  group instead of the implicit default, which otherwise produced DRBD resources in a
  STORAGE-only resource group.

One change is outside the plugin: `KVMStorageProcessor.copyVolumeFromPrimaryToSecondary()`
now connects the source volume before reading it and disconnects it afterwards, mirroring
what the VM start and attach flows do. Migrating a **detached** volume between pools
otherwise reads a device that was never connected, which fails for any storage driver that
exposes devices on demand.

Requires `java-linstor` 0.8.0 (LINSTOR REST API 1.29.0, shipped with linstor-server 1.35).

<!-- Fixes: # -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

n/a - no UI or API changes.

### How Has This Been Tested?

Two 3-node KVM clusters (Ubuntu 24.04, CloudStack 4.22, one management server each), so
both storage models and both controller API versions are covered:

| cluster | primary storage | LINSTOR REST API | code path |
| --- | --- | --- | --- |
| A | shared thick LVM: one 100 GiB LUN attached to all hosts, LVM VG with a LINSTOR shared space, resource group `STORAGE` layer only, place-count 1 | 1.29.0 (linstor-server 1.35) | new make-available/unmake-available |
| B | thin LVM (`lvmthin`) + DRBD, 2 replicas | 1.28.0 | version fallback to the previous handling |

Marvin, `test/integration/plugins/linstor`:

* `test_linstor_volumes.py` (15 tests): **15/15 pass on both clusters** - includes volume
  attach/detach/reboot, snapshot create, template from snapshot, volume migration to the
  same and to a distinct pool, and VM snapshot create/revert/delete.
* `test_linstor_encrypted_snapshots.py` (3 tests): **3/3 pass on cluster A**
  (revert of an encrypted root snapshot, create-volume-from-encrypted-snapshot is rejected,
  and the qcow2 on secondary storage is verified to be LUKS encrypted at rest). On cluster B
  the third test skips itself because it needs DB access from the test runner to locate the
  backed-up file.
* 9 plugin unit tests, incl. new ones for the shared-space capacity deduplication, thick
  provider-kind detection, diskful copy ordering and the controller version gate.

Manually verified on cluster A, checking the LINSTOR side after each step: VM deploy from
template, stop/start of a VM whose resource is INACTIVE, live migration (controller log
shows make-available on the destination and unmake-available on the source; the resource
ends up active on the destination only), snapshot of a running and of a stopped VM,
template from snapshot, volume migration between pools, and capacity (the 100 GiB LUN is
now reported as 100 GB instead of 599.98 GB).

#### How did you try to break this feature and the system with this change?

* **Old controller**: ran the full suite against a 1.28.0 controller. This surfaced that the
  regenerated client serialized `auto_manage_dual_primary` on *every* make-available (the
  generated field is initialized with its schema default), and LINSTOR rejects unknown
  properties - so template copies and VM starts failed even though the feature is version
  gated. Fixed by only setting the flag for migrations (and, in java-linstor, by serializing
  only explicitly set properties). Full suite passes on 1.28.0 afterwards, i.e. no
  regression for existing deployments.
* **Cold start**: rebooted all nodes, so every shared resource came back INACTIVE. That
  broke template cloning, VM start and snapshots, which all assumed an active resource;
  each path now activates on demand and was re-tested from a rebooted cluster.
* **Concurrency**: parallel deploys from the same template - deactivating the template right
  after a clone raced other clones still using it, so the template is left active.
* **Host loss**: a diskful copy whose host is down/disabled no longer forces a fallback to a
  temporary resource; all diskful copies are considered, in preference order.
* **Thin pools**: verified capacity, over-provisioning and snapshot behavior are unchanged
  for `lvmthin` (dedup keys on the shared space, thick detection requires all pools of the
  resource group to be thick, mixed setups keep the current default).
* **Encrypted (LUKS) volumes** on thick pools, snapshot on a stopped VM (resource inactive)
  and on a running VM, and repeated snapshot/delete cycles to check nothing is left behind
  in LINSTOR.
* **LVM edge cases**: `lvchange` registering a snapshot LV with `dmeventd` could hang and
  block the node wide LVM lock, wedging all storage operations on that host - the temporary
  activation now uses `--monitor n`.

Testing this also uncovered several LINSTOR server side issues (satellite startup probe
racing on a shared VG, snapshot rollback with an inactive copy, an io-suspend hang on
encrypted devices, a clone that never left `CLONING`); those are fixed in linstor-server
1.35 and are not CloudStack changes.
