### PR TITLE
Fix block commit wait when using libvirt events

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BlockCommitListener.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BlockCommitListener.java
@@ -37,7 +37,8 @@ public class BlockCommitListener implements BlockJobListener {
     protected BlockCommitListener(String vmName, String logid) {
         this.vmName = vmName;
         this.logid = logid;
-        logger = LogManager.getLogger(getClass());
+        this.logger = LogManager.getLogger(getClass());
+        this.result = String.format("Failed to block commit disk of VM [%s]. Libvirt did not launch an event for it.", vmName);
     }
 
     protected String getResult() {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BlockCommitListener.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BlockCommitListener.java
@@ -27,22 +27,37 @@ import org.libvirt.event.BlockJobListener;
 import org.libvirt.event.BlockJobStatus;
 import org.libvirt.event.BlockJobType;
 
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
 public class BlockCommitListener implements BlockJobListener {
     private String result;
     private String vmName;
 
     private Logger logger;
     private String logid;
+    private Semaphore semaphore;
 
     protected BlockCommitListener(String vmName, String logid) {
         this.vmName = vmName;
         this.logid = logid;
         this.logger = LogManager.getLogger(getClass());
+        this.semaphore = new Semaphore(0);
         this.result = String.format("Failed to block commit disk of VM [%s]. Libvirt did not launch an event for it.", vmName);
     }
 
-    protected String getResult() {
+    protected String getResult(int timeout) {
+        this.waitBlockCommit(timeout);
         return result;
+    }
+
+    protected void waitBlockCommit(int timeout) {
+        try {
+            logger.debug("Trying to acquire result semaphore. If the correct event was not launched, will wait for [{}] seconds before giving up.", timeout);
+            this.semaphore.tryAcquire(timeout, TimeUnit.SECONDS);
+        } catch (InterruptedException ex) {
+            logger.error("Thread that was tracking the progress for the block commit job of vm {} was interrupted.", vmName, ex);
+        }
     }
 
     @Override
@@ -56,6 +71,7 @@ public class BlockCommitListener implements BlockJobListener {
         switch (status) {
             case COMPLETED:
                 result = null;
+                semaphore.release();
                 return;
             case READY:
                 try {
@@ -63,10 +79,12 @@ public class BlockCommitListener implements BlockJobListener {
                     domain.blockJobAbort(diskPath, Domain.BlockJobAbortFlags.PIVOT);
                 } catch (LibvirtException ex) {
                     result = String.format("Failed to pivot disk due to [%s].", ex.getMessage());
+                    semaphore.release();
                 }
                 return;
             default:
                 result = String.format("Failed to block commit disk with status [%s].", status);
+                semaphore.release();
         }
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -6652,6 +6652,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
 
         BlockCommitListener blockCommitListener = getBlockCommitListener(vmName);
+        int remainingTimeout = 0;
+        String mergeResult = "Got an exception during block commit wait. Check earlier logs for more info.";
         try {
             vm.addBlockJobListener(blockCommitListener);
 
@@ -6660,12 +6662,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             vm.blockCommit(diskLabel, baseFilePath, topFilePath, 0, commitFlags);
 
-            checkBlockCommitProgress(vm, diskLabel, vmName, snapshotName, topFilePath, baseFilePath);
+            remainingTimeout = checkBlockCommitProgress(vm, diskLabel, vmName, snapshotName, topFilePath, baseFilePath);
+            mergeResult = blockCommitListener.getResult(remainingTimeout);
         } finally {
             vm.removeBlockJobListener(blockCommitListener);
         }
 
-        String mergeResult = blockCommitListener.getResult();
         if (mergeResult != null) {
             String commitError = String.format("Failed the block commit of top file [%s] into base file [%s] for snapshot [%s] of VM [%s]. The job will be left running to avoid" +
                     " data corruption, but ACS will return an error and volume [%s] will need to be normalized manually. If the commit involved the active image, the pivot will" +
@@ -6730,7 +6732,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return new BlockCommitListener(vmName, ThreadContext.get("logcontextid"));
     }
 
-    protected void checkBlockCommitProgress(Domain vm, String diskLabel, String vmName, String snapshotName, String topFilePath, String baseFilePath) {
+    protected int checkBlockCommitProgress(Domain vm, String diskLabel, String vmName, String snapshotName, String topFilePath, String baseFilePath) {
         int timeout = qcow2DeltaMergeTimeout;
         DomainBlockJobInfo result;
         long lastCommittedBytes = 0;
@@ -6751,12 +6753,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 result = vm.getBlockJobInfo(diskLabel, 0);
             } catch (LibvirtException ex) {
                 logger.warn("Exception while getting block job info {}: [{}].", partialLog, ex.getMessage(), ex);
-                return;
+                return timeout;
             }
 
             if (result == null || result.type == 0 && result.end == 0 && result.cur == 0) {
                 logger.debug("Block commit job {} has already finished.", partialLog);
-                return;
+                return timeout;
             }
 
             long currentCommittedBytes = result.cur;
@@ -6766,7 +6768,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             lastCommittedBytes = currentCommittedBytes;
             endBytes = result.end;
         }
-        logger.warn("Block commit {} has timed out after waiting at least {} seconds. The progress of the operation was [{}] of [{}].", partialLog, qcow2DeltaMergeTimeout, lastCommittedBytes, endBytes);
+        logger.warn("Block commit {} has timed out after waiting at least {} seconds. The progress of the operation was [{}] of [{}].", partialLog,
+                qcow2DeltaMergeTimeout, lastCommittedBytes, endBytes);
+        return 0;
     }
 
     /**

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -6656,8 +6656,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             vm.addBlockJobListener(blockCommitListener);
 
             logger.info("Starting block commit of QCOW2 delta [{}] of VM [{}]. Using parameters: diskLabel [{}]; baseFilePath [{}]; topFilePath [{}]; commitFlags [{}]",
-                    snapshotName,
-                    vmName, diskLabel, baseFilePath, topFilePath, commitFlags);
+                    snapshotName, vmName, diskLabel, baseFilePath, topFilePath, commitFlags);
 
             vm.blockCommit(diskLabel, baseFilePath, topFilePath, 0, commitFlags);
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -6697,7 +6698,7 @@ public class LibvirtComputingResourceTest {
             threadContextMockedStatic.when(() ->
                     ThreadContext.get(Mockito.anyString())).thenReturn("logid");
             Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
-            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult(anyInt());
             Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doReturn(null).when(domainMock).getBlockJobInfo(Mockito.anyString(), Mockito.anyInt());
             Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
@@ -6726,7 +6727,7 @@ public class LibvirtComputingResourceTest {
             threadContextMockedStatic.when(() ->
                     ThreadContext.get(Mockito.anyString())).thenReturn("logid");
             Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
-            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult(anyInt());
             Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
             Mockito.doNothing().when(libvirtComputingResourceSpy).manuallyDeleteUnusedSnapshotFile(Mockito.anyBoolean(), Mockito.anyString());
@@ -6753,7 +6754,7 @@ public class LibvirtComputingResourceTest {
             libvirtUtilitiesHelperMockedStatic.when(() -> LibvirtUtilitiesHelper.isLibvirtSupportingFlagDeleteOnCommandVirshBlockcommit(Mockito.any())).thenReturn(true);
             threadContextMockedStatic.when(() -> ThreadContext.get(Mockito.anyString())).thenReturn("logid");
             Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
-            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult(anyInt());
             Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doReturn(null).when(domainMock).getBlockJobInfo(Mockito.anyString(), Mockito.anyInt());
             Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
@@ -6781,7 +6782,7 @@ public class LibvirtComputingResourceTest {
             libvirtUtilitiesHelperMockedStatic.when(() -> LibvirtUtilitiesHelper.isLibvirtSupportingFlagDeleteOnCommandVirshBlockcommit(Mockito.any())).thenReturn(false);
             threadContextMockedStatic.when(() -> ThreadContext.get(Mockito.anyString())).thenReturn("logid");
             Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
-            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult(anyInt());
             Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doReturn(null).when(domainMock).getBlockJobInfo(Mockito.anyString(), Mockito.anyInt());
             Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
@@ -6811,7 +6812,7 @@ public class LibvirtComputingResourceTest {
             Mockito.doNothing().when(domainMock).removeBlockJobListener(Mockito.any());
 
             Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
-            Mockito.doReturn("Failed").when(blockCommitListenerMock).getResult();
+            Mockito.doReturn("Failed").when(blockCommitListenerMock).getResult(anyInt());
 
             String diskLabel = "vda";
             String baseFilePath = "/file";

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -6696,9 +6696,11 @@ public class LibvirtComputingResourceTest {
 
             threadContextMockedStatic.when(() ->
                     ThreadContext.get(Mockito.anyString())).thenReturn("logid");
-            Mockito.doNothing().when(domainMock).addBlockJobListener(Mockito.any());
+            Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doReturn(null).when(domainMock).getBlockJobInfo(Mockito.anyString(), Mockito.anyInt());
-            Mockito.doNothing().when(domainMock).removeBlockJobListener(Mockito.any());
+            Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
 
             String diskLabel = "vda";
             String baseFilePath = "/file";
@@ -6723,8 +6725,10 @@ public class LibvirtComputingResourceTest {
 
             threadContextMockedStatic.when(() ->
                     ThreadContext.get(Mockito.anyString())).thenReturn("logid");
-            Mockito.doNothing().when(domainMock).addBlockJobListener(Mockito.any());
-            Mockito.doNothing().when(domainMock).removeBlockJobListener(Mockito.any());
+            Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
+            Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
             Mockito.doNothing().when(libvirtComputingResourceSpy).manuallyDeleteUnusedSnapshotFile(Mockito.anyBoolean(), Mockito.anyString());
 
             String diskLabel = "vda";
@@ -6748,9 +6752,11 @@ public class LibvirtComputingResourceTest {
             libvirtComputingResourceSpy.qcow2DeltaMergeTimeout = 10;
             libvirtUtilitiesHelperMockedStatic.when(() -> LibvirtUtilitiesHelper.isLibvirtSupportingFlagDeleteOnCommandVirshBlockcommit(Mockito.any())).thenReturn(true);
             threadContextMockedStatic.when(() -> ThreadContext.get(Mockito.anyString())).thenReturn("logid");
-            Mockito.doNothing().when(domainMock).addBlockJobListener(Mockito.any());
+            Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doReturn(null).when(domainMock).getBlockJobInfo(Mockito.anyString(), Mockito.anyInt());
-            Mockito.doNothing().when(domainMock).removeBlockJobListener(Mockito.any());
+            Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
             Mockito.doNothing().when(libvirtComputingResourceSpy).manuallyDeleteUnusedSnapshotFile(Mockito.anyBoolean(), Mockito.anyString());
 
             String diskLabel = "vda";
@@ -6774,9 +6780,11 @@ public class LibvirtComputingResourceTest {
             libvirtComputingResourceSpy.qcow2DeltaMergeTimeout = 10;
             libvirtUtilitiesHelperMockedStatic.when(() -> LibvirtUtilitiesHelper.isLibvirtSupportingFlagDeleteOnCommandVirshBlockcommit(Mockito.any())).thenReturn(false);
             threadContextMockedStatic.when(() -> ThreadContext.get(Mockito.anyString())).thenReturn("logid");
-            Mockito.doNothing().when(domainMock).addBlockJobListener(Mockito.any());
+            Mockito.doReturn(blockCommitListenerMock).when(libvirtComputingResourceSpy).getBlockCommitListener(Mockito.any());
+            Mockito.doReturn(null).when(blockCommitListenerMock).getResult();
+            Mockito.doNothing().when(domainMock).addBlockJobListener(blockCommitListenerMock);
             Mockito.doReturn(null).when(domainMock).getBlockJobInfo(Mockito.anyString(), Mockito.anyInt());
-            Mockito.doNothing().when(domainMock).removeBlockJobListener(Mockito.any());
+            Mockito.doNothing().when(domainMock).removeBlockJobListener(blockCommitListenerMock);
             Mockito.doNothing().when(libvirtComputingResourceSpy).manuallyDeleteUnusedSnapshotFile(Mockito.anyBoolean(), Mockito.anyString());
 
             String diskLabel = "vda";


### PR DESCRIPTION
### Description

There is a bug in the VM volume block-commit process that affects the KBOSS backup, volume snapshot, and VM snapshot processes, where if the waiting process finishes without Libvirt throwing an event, ACS assumes the process finished successfully. 

This PR fixes this situation, so that the process is only considered successful when the correct event is thrown by Libvirt.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

In the `agent.properties` file, I changed `libvirt.events.enabled` to true and `qcow2.delta.merge.timeout` to 1. 
I took a (non-incremental) volume snapshot of a VM and while the snapshot was being copied to the secondary storage, I wrote 1GB of data into the volume, so that the block commit would not be instantaneous.
- Before the patch, ACS considered that the block commit was a success (even though it was still being done)
- After the patch, an error is thrown, as expected.