### PR TITLE
fix: correct VM snapshot usage attribution (two defects)

### DIFF
--- a/usage/src/main/java/com/cloud/usage/parser/VMSnapshotUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/VMSnapshotUsageParser.java
@@ -65,7 +65,7 @@ public class VMSnapshotUsageParser extends UsageParser {
             long zoneId = usageRec.getZoneId();
             Long volId = usageRec.getVolumeId();
             long vmId = usageRec.getVmId();
-            String key = vmId + ":" + volId;
+            String key = vmId + ":" + volId + ":" + usageRec.getVmSnapshotId();
             if (usageRec.getCreated().before(startDate)) {
                 unprocessedUsage.put(key, usageRec);
                 continue;
@@ -85,7 +85,7 @@ public class VMSnapshotUsageParser extends UsageParser {
             long duration = (createDate.getTime() - previousCreated.getTime()) + 1;
 
             createUsageRecord(UsageTypes.VM_SNAPSHOT, duration, previousCreated, createDate, account, volId, zoneId, previousEvent.getDiskOfferingId(), vmId,
-                previousEvent.getSize(), usageRec.getVmSnapshotId());
+                previousEvent.getSize(), previousEvent.getVmSnapshotId());
             previousEvent.setProcessed(new Date());
             usageVMSnapshotDao.update(previousEvent);
 


### PR DESCRIPTION
### Fixes #13921

Two defects corrected in `VMSnapshotUsageParser`:

1. **Wrong snapshot ID label in usage record**: `createUsageRecord()` used the current snapshot's ID (`usageRec.getVmSnapshotId()`) while duration, size, and disk offering came from the previous event. Changed to `previousEvent.getVmSnapshotId()`.

2. **Concurrent snapshot key collision**: The `unprocessedUsage` map keyed entries by `vmId + ":" + volId` only, so concurrent snapshots of the same volume overwrote each other. Added `vmSnapshotId` to the key to distinguish them.

### Root cause

From the issue body:

> Net effect: the first snapshot's usage is credited to the second snapshot, and the first snapshot stops accruing usage even though it still exists and is Ready.