### PR TITLE
fix: release START_TXN nesting level on persist() SQLException path (#13905)

### DIFF
--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -1625,6 +1625,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         final TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         String sql = null;
+        boolean committed = false;
         try {
             txn.start();
             for (final Pair<String, Attribute[]> pair : _insertSqls) {
@@ -1673,6 +1674,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
                 insertElementCollection(entity, _idAttributes.get(_table)[0], id, ecAttributes);
             }
             txn.commit();
+            committed = true;
         } catch (final SQLException e) {
             logger.error("DB Exception on: " + pstmt, e);
             handleEntityExistsException(e);
@@ -1681,6 +1683,10 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             throw new CloudRuntimeException("Problem with getting the ec attribute ", e);
         } catch (IllegalAccessException e) {
             throw new CloudRuntimeException("Problem with getting the ec attribute ", e);
+        } finally {
+            if (!committed) {
+                txn.rollback();
+            }
         }
 
         return _idField != null ? findByIdIncludingRemoved(id) : null;


### PR DESCRIPTION
### Description

`GenericDaoBase.persist()` calls `txn.start()` which pushes a `START_TXN` nesting level onto the caller's transaction stack. When the insert throws `SQLException`, the catch block rethrows without reaching `txn.commit()`, so the pushed nesting level is leaked. The caller's later `commit()` then finds the transaction unbalanced and silently no-ops (logging only `txn: Commit called when it is not a transaction`), discarding everything the caller believed it committed.

Callers that deliberately catch `EntityExistsException` to log-and-continue cannot actually continue, because the enclosing transaction is already unrecoverable — this converts a single constraint violation into permanent failure (see #13399).

### Fix

Track commit success via a `committed` flag; in a `finally` block, roll back the transaction when the commit was not reached, restoring the caller's transaction to a balanced state.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Refactoring (non-breaking change which restructures existing code)
- [ ] Documentation update

### How has this been tested?

Code-review level only — the change adds a rollback guard to the existing try/catch structure. Existing tests cover DAO persist paths.

Closes #13905

<!-- readthedocs-preview cloudstack start -->
<!-- readthedocs-preview cloudstack end -->
<!-- policy-exclude -->