### PR TITLE
fix: bound the usage event rewind to prevent unbounded re-aggregation

### DIFF
--- a/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/main/java/com/cloud/usage/UsageManagerImpl.java
@@ -103,6 +103,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     private static final int HOURLY_TIME = 60;
     private static final int DAILY_TIME = 60 * 24;
     private static final int THREE_DAYS_IN_MINUTES = 60 * 24 * 3;
+    private static final long MAX_EVENT_REWIND_MILLIS = 24L * 60 * 60 * 1000;
 
     @Inject
     private AccountDao _accountDao;
@@ -699,7 +700,10 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 if ((events != null) && (events.size() > 0)) {
                     Date oldestEventDate = events.get(0).getCreateDate();
                     if (oldestEventDate.getTime() < startDateMillis) {
-                        startDateMillis = oldestEventDate.getTime();
+                        // Bound the rewind so a single un-processable event cannot pin the
+                        // aggregation window to an arbitrarily old date and cause unbounded
+                        // re-aggregation of the entire history on every run.
+                        startDateMillis = Math.max(oldestEventDate.getTime(), startDateMillis - MAX_EVENT_REWIND_MILLIS);
                         startDate = new Date(startDateMillis);
                     }
 


### PR DESCRIPTION
Fixes #13906

### Problem
`UsageManagerImpl.parse()` rewinds the aggregation start date to the oldest unprocessed event, but has no bound on how far back it can rewind. If an event cannot be successfully processed, the rewind pins the window to that event's date permanently. Each subsequent run re-aggregates from that date to the present, growing by one aggregation period per run while the job keeps reporting `success = 1`.

Reported symptoms (4.22.1.0):
- 1,678 consecutive successful jobs whose `start_millis` never advanced past a single event 71 days earlier
- `exec_time` up to 42.6 min per hourly run, growing by 24 aggregation periods/day
- `cloud_usage` at 54.4M rows / 14 GB, mostly duplicate replayed rows
- Not specific to one event type (also #13112 on 4.21.0.0)

### Fix
Bound the rewind to a 24-hour window. The rewind exists to absorb clock skew between the cloud and usage databases (events created during the previous run window), not to replay the full history. Events older than 24h from the current window start will still be retried, but the aggregation window will not be rewound to them.

```java
startDateMillis = Math.max(oldestEventDate.getTime(), startDateMillis - MAX_EVENT_REWIND_MILLIS);
```

### Testing
- Unit test added? No (existing test class only covers event handlers; parse() has no prior tests)
- Verified the constant is referenced exactly twice (declaration + rewind bound)
- No behavior change for events within the 24h boundary window — they still rewind the window as before