### PR TITLE
fix: resolve account for SNAPSHOT data objects in DownloadListener (fixes #13900)

### DIFF
--- a/server/src/main/java/com/cloud/storage/download/DownloadListener.java
+++ b/server/src/main/java/com/cloud/storage/download/DownloadListener.java
@@ -29,8 +29,10 @@ import com.cloud.configuration.Resource;
 import com.cloud.resourcelimit.CheckedReservation;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.VolumeVO;
+import com.cloud.storage.SnapshotVO;
 import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VolumeDao;
+import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.user.ResourceLimitService;
@@ -163,6 +165,8 @@ public class DownloadListener implements Listener {
     @Inject
     ReservationDao _reservationDao;
 
+    @Inject
+    private SnapshotDao _snapshotDao;
     private LazyCache<Long, List<Hypervisor.HypervisorType>> zoneHypervisorsCache;
 
     private List<Hypervisor.HypervisorType> listAvailHypervisorInZone(long zoneId) {
@@ -275,7 +279,9 @@ public class DownloadListener implements Listener {
         } else if (DataObjectType.VOLUME.equals(object.getType())) {
             VolumeVO v = _volumeDao.findById(object.getId());
             return v != null ? v.getAccountId() : null;
-        }
+        } else if (DataObjectType.SNAPSHOT.equals(object.getType())) {
+            SnapshotVO s = _snapshotDao.findById(object.getId());
+            return s != null ? s.getAccountId() : null;
         return null;
     }
 


### PR DESCRIPTION
### Fixes

Fixes #13900

### Root cause

`DownloadListener.getAccountIdForDataObject()` only handles `TEMPLATE` and `VOLUME` data object types. For `SNAPSHOT` data objects it falls through and returns `null`, so `checkAndUpdateResourceLimits()` calls `_accountMgr.getAccount(null)` — the account lookup fails, resource-limit accounting is skipped, the download is never marked successful, and `copySnapshot` between zones times out after ~90s even though the destination SSVM already finished downloading the snapshot files.

### Fix

Add a `SNAPSHOT` branch to `getAccountIdForDataObject()` that looks up the snapshot's account via `SnapshotDao.findById()`, mirroring the existing `TEMPLATE`/`VOLUME` branches. The downloaded snapshot files are already present on the destination store; only the account attribution and resource-count update were missing.

### Testing

- `mvn -pl server -am compile` passes
- No new dependencies — `SnapshotDao` is already used elsewhere in the server module
