### PR TITLE
fix: percent-encode vCenter datacenter/cluster/host names in virt-v2v URIs

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConvertInstanceCommandWrapper.java
@@ -19,7 +19,7 @@
 package com.cloud.hypervisor.kvm.resource.wrapper;
 
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -214,10 +214,10 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
         if (StringUtils.isNotBlank(path)) {
             logger.info("({}) VM path: {}", originalVMName, path);
             return String.format("vi://%s:%s@%s/%s/%s/%s",
-                    encodedUsername, encodedPassword, vcenter, datacenter, path, vm);
+                    encodedUsername, encodedPassword, vcenter, encodePathSegments(datacenter), encodePathSegments(path), encodePathSegment(vm));
         }
         return String.format("vi://%s:%s@%s/%s/vm/%s",
-                encodedUsername, encodedPassword, vcenter, datacenter, vm);
+                encodedUsername, encodedPassword, vcenter, encodePathSegments(datacenter), encodePathSegment(vm));
     }
 
     protected void sanitizeDisksPath(List<LibvirtVMDef.DiskDef> disks) {
@@ -296,7 +296,28 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
     }
 
     protected String encodeUsername(String username) {
-        return URLEncoder.encode(username, Charset.defaultCharset());
+        return URLEncoder.encode(username, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private String encodePathSegment(String value) {
+        if (StringUtils.isBlank(value)) {
+            return value;
+        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private String encodePathSegments(String value) {
+        if (StringUtils.isBlank(value)) {
+            return value;
+        }
+        StringBuilder encoded = new StringBuilder();
+        for (String seg : value.split("/", -1)) {
+            if (encoded.length() > 0) {
+                encoded.append("/");
+            }
+            encoded.append(encodePathSegment(seg));
+        }
+        return encoded.toString();
     }
 
     private String resolveVddkSetting(String commandValue, String agentValue) {
@@ -477,14 +498,14 @@ public class LibvirtConvertInstanceCommandWrapper extends CommandWrapper<Convert
                 .append("@")
                 .append(vcenter)
                 .append("/")
-                .append(datacenter);
+                .append(encodePathSegments(datacenter));
 
         if (StringUtils.isNotBlank(cluster)) {
-            url.append("/").append(cluster);
+            url.append("/").append(encodePathSegments(cluster));
         }
 
         if (StringUtils.isNotBlank(host)) {
-            url.append("/").append(host);
+            url.append("/").append(encodePathSegment(host));
         }
 
         url.append("?no_verify=1");


### PR DESCRIPTION
Fixes #13920

## Summary

`LibvirtConvertInstanceCommandWrapper` builds vpx:// and vi:// connection URIs for virt-v2v by concatenating vCenter datacenter/cluster/host names without percent-encoding them. A datacenter (or cluster/host) name containing a space — valid in vSphere — produces an invalid URI, and VM import from VMware fails.

## Changes

- **`encodePathSegment`** — percent-encodes a single URI path segment using `%20` for spaces (not `+`)
- **`encodePathSegments`** — splits on `/` and encodes each sub-segment individually, preserving literal `/` separators for folder-nested names (e.g. `MyFolder/MyDC`)
- **`buildVpxUrl`** — now calls `encodePathSegments` on datacenter and cluster, `encodePathSegment` on host
- **`getExportOVAUrlFromRemoteInstance`** — now calls `encodePathSegments` on datacenter and path, `encodePathSegment` on vm
- **`encodeUsername`** — fixed to use explicit `UTF-8` charset and `%20` instead of `+` for spaces (libvirt only decodes `%20` in URI authority segments)

## Testing

Manual test: with a datacenter named `QA Lab`, the vpx:// URL now correctly becomes:
```
vpx://Administrator%40vsphere.local@203.0.113.10/QA%20Lab/cluster-a/203.0.113.20?no_verify=1
```