### PR TITLE
backport: usage: widen usage_volume unique key to include vm_id (#13909)

### DIFF
--- a/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -94,6 +94,7 @@ import com.cloud.upgrade.dao.Upgrade42030to42040;
 import com.cloud.upgrade.dao.Upgrade42040to42100;
 import com.cloud.upgrade.dao.Upgrade42100to42200;
 import com.cloud.upgrade.dao.Upgrade42200to42210;
+import com.cloud.upgrade.dao.Upgrade42210to42220;
 import com.cloud.upgrade.dao.Upgrade420to421;
 import com.cloud.upgrade.dao.Upgrade421to430;
 import com.cloud.upgrade.dao.Upgrade430to440;
@@ -246,6 +247,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 .next("4.20.4.0", new Upgrade42040to42100())
                 .next("4.21.0.0", new Upgrade42100to42200())
                 .next("4.22.0.0", new Upgrade42200to42210())
+                .next("4.22.1.0", new Upgrade42210to42220())
                 .build();
     }
 

--- a/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42220.java
+++ b/engine/schema/src/main/java/com/cloud/upgrade/dao/Upgrade42210to42220.java
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.upgrade.dao;
+
+public class Upgrade42210to42220 extends DbUpgradeAbstractImpl implements DbUpgrade {
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[] {"4.22.1.0", "4.22.2.0"};
+    }
+
+    @Override
+    public String getUpgradedVersion() {
+        return "4.22.2.0";
+    }
+}

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42220-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42220-cleanup.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade cleanup from 4.22.1.0 to 4.22.2.0
+--;

--- a/engine/schema/src/main/resources/META-INF/db/schema-42210to42220.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-42210to42220.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.22.1.0 to 4.22.2.0
+--;
+
+-- Widen the unique key on cloud_usage.usage_volume to include vm_id, so the cumulative and
+-- per-VM volume usage records introduced in 4.22.1 can coexist. See #13399.
+CALL `cloud_usage`.`IDEMPOTENT_DROP_INDEX`('id', 'cloud_usage.usage_volume');
+CALL `cloud_usage`.`IDEMPOTENT_ADD_UNIQUE_INDEX`('cloud_usage.usage_volume', 'id', '(volume_id ASC, created ASC, vm_id ASC)');


### PR DESCRIPTION
### Description

Backport of #13909 to `4.22`, per @winterhazel's guidance on that PR, targeting 4.22.2 as @abh1sar flagged. The DDL is identical to what merged on main.

It also creates the 4.22.1.0 to 4.22.2.0 upgrade path, which didn't exist yet. The chain in `DatabaseUpgradeChecker` ended at `Upgrade42200to42210`, and since the branch is already `4.22.2.0-SNAPSHOT`, 4.22.2.0 is the declared next version. Nothing had needed a schema change on 4.22 since 4.22.1.0 was cut, so nobody had reason to add it.

The CALLs can't go into `schema-42200to42210.sql` instead. Every 4.22.1.0 install has already run that file, and those are the affected clusters. The `-cleanup.sql` has no statements in it, but the file has to exist: `getCleanupScripts()` throws if it's absent.

See #13909 for the note on NULL semantics in the widened key, and on this preventing the problem rather than remediating clusters that already have it.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Not tested end to end. The environment where this was found has since been rebuilt, so I can't exercise a 4.22.1.0 to 4.22.2.0 upgrade myself.

What I can attest to:

- The DDL is byte-identical to what merged on main in #13909, which passed packaging on el8/el9/el10/debian/suse15 and a Trillian smoke run there (156 pass, 0 errors, tid-16778).
- The narrow `UNIQUE KEY id (volume_id, created)` was confirmed by `SHOW CREATE TABLE` against a restored backup of a live 4.22.1.0 install, alongside the `vm_id` column added by #11531.
- The key name `id` is set explicitly by `schema-41600to41610.sql:72`, so the drop targets a name present on any install that has passed through 4.16.1.0.
- Widening a unique key is strictly less restrictive, so no existing row can violate the new constraint and the DDL can't fail on data.
- Both procedures carry `CONTINUE HANDLER`s (1091 and 1061), so a re-run or a resumed upgrade is a no-op.

The new upgrade path is the part that genuinely wants a reviewer with an environment. `Upgrade42210to42220` is the first 4.22.1 to 4.22.2 step on this branch, and its script filenames are derived from `getUpgradableVersionRange()` rather than declared, so the naming is mechanically correct. But nobody has run a real upgrade through it. I'd appreciate someone doing that before merge.

#### How did you try to break this feature and the system with this change?

Reasoned through the failure modes rather than executing them, since I have no environment to run an upgrade in.

- A 4.22.0.x cluster upgrading straight to 4.22.2.0. Traced the chain: `Upgrade42200to42210` runs first and adds `vm_id` with the narrow key, then `Upgrade42210to42220` widens it. Both populations land correct.
- A cluster where an operator has already widened the key by hand. `IDEMPOTENT_DROP_INDEX` drops the three-column key and `IDEMPOTENT_ADD_UNIQUE_INDEX` recreates it identically, so the net effect is the same.
- A re-run or a resumed upgrade. Handlers 1091 and 1061 swallow the missing-index and duplicate-key-name cases, so both CALLs are no-ops second time round.
- A missing or misnamed cleanup script. `getCleanupScripts()` throws `CloudRuntimeException` when the file is absent, so that fails the upgrade rather than silently skipping it. Both script names derive from `getUpgradableVersionRange()`, so they can't drift from the class referencing them.
- Existing data violating the widened key. That can't happen; the new key is less restrictive than the one it replaces.