### PR TITLE
fix: correctly handle NFS metalink templates - mount export dir, compute real file size

### DIFF
--- a/core/src/main/java/org/apache/cloudstack/direct/download/MetalinkDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/MetalinkDirectTemplateDownloader.java
@@ -154,8 +154,9 @@ public class MetalinkDirectTemplateDownloader extends DirectTemplateDownloaderIm
             if (url.endsWith("torrent")) {
                 continue;
             }
-            if (downloader.checkUrl(url)) {
-                return downloader.getRemoteFileSize(url, format);
+            DirectTemplateDownloader urlDownloader = createDownloaderForMetalinks(url, null, null, null, headers, connectTimeout, soTimeout, null, null);
+            if (urlDownloader != null && urlDownloader.checkUrl(url)) {
+                return urlDownloader.getRemoteFileSize(url, format);
             }
         }
         return null;

--- a/core/src/main/java/org/apache/cloudstack/direct/download/NfsDirectTemplateDownloader.java
+++ b/core/src/main/java/org/apache/cloudstack/direct/download/NfsDirectTemplateDownloader.java
@@ -22,8 +22,12 @@ import com.cloud.utils.Pair;
 import com.cloud.utils.UriUtils;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
+import com.cloud.utils.storage.QCOW2Utils;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -33,11 +37,13 @@ public class NfsDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
 
     private String srcHost;
     private String srcPath;
+    private String fileName;
 
     private static final String mountCommand = "mount -t nfs %s %s";
 
     /**
-     * Parse url and set srcHost and srcPath
+     * Parse NFS URL and split the path into the export directory (mountable) and file name.
+     * For example, nfs://host/export/templates/file.qcow2 -> srcPath=/export/templates, fileName=file.qcow2
      */
     private void parseUrl() {
         URI uri = null;
@@ -47,6 +53,16 @@ public class NfsDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
             if (uri.getScheme() != null && uri.getScheme().equalsIgnoreCase("nfs")) {
                 srcHost = uri.getHost();
                 srcPath = uri.getPath();
+                if (srcPath != null) {
+                    int lastSlash = srcPath.lastIndexOf('/');
+                    if (lastSlash >= 0) {
+                        fileName = srcPath.substring(lastSlash + 1);
+                        srcPath = srcPath.substring(0, lastSlash);
+                    }
+                }
+                if (srcPath == null || srcPath.isEmpty()) {
+                    srcPath = "/";
+                }
             }
         } catch (URISyntaxException e) {
             throw new CloudRuntimeException("Invalid NFS url " + url + " caused error: " + e.getMessage());
@@ -66,12 +82,18 @@ public class NfsDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
     @Override
     public Pair<Boolean, String> downloadTemplate() {
         String mountSrcUuid = UUID.randomUUID().toString();
-        String mount = String.format(mountCommand, srcHost + ":" + srcPath, "/mnt/" + mountSrcUuid);
+        String mountPoint = "/mnt/" + mountSrcUuid;
+        String mount = String.format(mountCommand, srcHost + ":" + srcPath, mountPoint);
         Script.runSimpleBashScript(mount);
         String downloadDir = getDestPoolPath() + File.separator + getDirectDownloadTempPath(getTemplateId());
-        setDownloadedFilePath(downloadDir + File.separator + getTemporaryFileName());
-        Script.runSimpleBashScript("cp /mnt/" + mountSrcUuid + srcPath + " " + getDownloadedFilePath());
-        Script.runSimpleBashScript("umount /mnt/" + mountSrcUuid);
+        String destPath = downloadDir + File.separator + getTemporaryFileName();
+        setDownloadedFilePath(destPath);
+        if (fileName != null && !fileName.isEmpty()) {
+            Script.runSimpleBashScript("cp " + mountPoint + "/" + fileName + " " + destPath);
+        } else {
+            Script.runSimpleBashScript("cp " + mountPoint + " " + destPath);
+        }
+        Script.runSimpleBashScript("umount " + mountPoint);
         return new Pair<>(true, getDownloadedFilePath());
     }
 
@@ -88,7 +110,31 @@ public class NfsDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
 
     @Override
     public Long getRemoteFileSize(String url, String format) {
-        return null;
+        String mountSrcUuid = UUID.randomUUID().toString();
+        String mountPoint = "/mnt/" + mountSrcUuid;
+        Script.runSimpleBashScript("mkdir -p " + mountPoint);
+        Script.runSimpleBashScript(String.format(mountCommand, srcHost + ":" + srcPath, mountPoint));
+        try {
+            File file = new File(mountPoint + "/" + (fileName != null ? fileName : ""));
+            if (!file.exists()) {
+                logger.error(String.format("File not found on NFS mount: %s", file.getAbsolutePath()));
+                return null;
+            }
+            if ("qcow2".equalsIgnoreCase(format) && fileName != null && !fileName.isEmpty()) {
+                try (InputStream is = new FileInputStream(file)) {
+                    return QCOW2Utils.getVirtualSize(is, false);
+                } catch (IOException e) {
+                    logger.warn(String.format("Could not read qcow2 virtual size for NFS file %s, falling back to file length: %s", url, e.getMessage()));
+                }
+            }
+            return file.length();
+        } catch (Exception e) {
+            logger.error(String.format("Could not get remote file size for NFS URL: %s due to: %s", url, e.getMessage()), e);
+            return null;
+        } finally {
+            Script.runSimpleBashScript("umount -l " + mountPoint + " 2>/dev/null");
+            Script.runSimpleBashScript("rmdir " + mountPoint + " 2>/dev/null");
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #13916
Fixes #13917

## Description

Fixes two related bugs in NFS direct download for metalink templates:

### Bug 1: Template size is incorrect (#13916)

`NfsDirectTemplateDownloader.getRemoteFileSize()` returned `null` unconditionally, so the template size was never computed for NFS metalink URLs. This caused the template size to be stored as a garbage value (e.g., `7235435666033759572` bytes ≈ 6580590 TB).

**Fix**: Implement `getRemoteFileSize()` in `NfsDirectTemplateDownloader`:
- Mount the NFS export directory
- For qcow2 format: read the virtual size from the qcow2 header using `QCOW2Utils.getVirtualSize()`
- For other formats: use `File.length()`
- Clean up the mount afterwards

### Bug 2: Unable to launch VM with NFS metalink template (#13917)

Two issues in the NFS downloader:

1. **Mount path was wrong**: `NfsDirectTemplateDownloader.parseUrl()` used the full NFS path (including the file name) as the mount source. `mount -t nfs host:/export/templates/file.qcow2` tries to mount a file as a filesystem, which fails with exit code 32. The fix splits the URL path into the export directory (mountable) and the file name.

2. **Wrong downloader type in metalink**: `MetalinkDirectTemplateDownloader.getRemoteFileSize()` used the metalink-level downloader (typically `HttpDirectTemplateDownloader`) to check inner URLs of all types, including NFS URLs. This caused `checkUrl()` and `getRemoteFileSize()` to be called on the wrong downloader type. The fix creates the correct downloader per URL type using `createDownloaderForMetalinks()`.

### Changes

**NfsDirectTemplateDownloader.java:**
- Added `fileName` field to store the file name extracted from the NFS URL
- `parseUrl()`: split the NFS path into export directory (`srcPath`) and file name (`fileName`)
- `downloadTemplate()`: mount the export directory, copy the file from the correct mount point path
- `getRemoteFileSize()`: NEW implementation — mount NFS, read file size, unmount. Supports qcow2 virtual size via `QCOW2Utils`

**MetalinkDirectTemplateDownloader.java:**
- `getRemoteFileSize()`: use `createDownloaderForMetalinks()` to create the correct downloader type per inner URL, instead of reusing the outer metalink downloader
