### PR TITLE
quota: skip usage records registering the period a volume has been attached

### DIFF
--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -54,6 +54,7 @@ import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
 import org.apache.cloudstack.quota.vo.QuotaTariffUsageVO;
 import org.apache.cloudstack.quota.vo.QuotaTariffVO;
 import org.apache.cloudstack.quota.vo.QuotaUsageVO;
+import org.apache.cloudstack.usage.UsageTypes;
 import org.apache.cloudstack.usage.UsageUnitTypes;
 import org.apache.cloudstack.utils.bytescale.ByteScaleUtils;
 import org.apache.cloudstack.utils.jsinterpreter.JsInterpreter;
@@ -364,6 +365,11 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         if (Boolean.FALSE.equals(QuotaConfig.QuotaAccountEnabled.valueIn(accountVO.getAccountId()))) {
             logger.debug("Considering usage record [{}] as calculated and skipping it because account [{}] has the quota plugin disabled.",
                     usageRecord.toString(usageAggregationTimeZone), accountVO.reflectionToString());
+            return false;
+        }
+        if (usageRecord.getUsageType() == UsageTypes.VOLUME && usageRecord.getVmInstanceId() != null) {
+            logger.debug("Considering usage record [{}] as calculated and skipping it because it represents the period " +
+                    "a volume has remained attached to an instance, which Quota does not handle.", usageRecord.toString(usageAggregationTimeZone));
             return false;
         }
         return true;

--- a/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
+++ b/framework/quota/src/test/java/org/apache/cloudstack/quota/QuotaManagerImplTest.java
@@ -26,12 +26,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.impl.ConfigDepotImpl;
 import org.apache.cloudstack.quota.activationrule.presetvariables.Domain;
 import org.apache.cloudstack.quota.activationrule.presetvariables.GenericPresetVariable;
 import org.apache.cloudstack.quota.activationrule.presetvariables.PresetVariableHelper;
 import org.apache.cloudstack.quota.activationrule.presetvariables.PresetVariables;
 import org.apache.cloudstack.quota.activationrule.presetvariables.Tariff;
 import org.apache.cloudstack.quota.activationrule.presetvariables.Value;
+import org.apache.cloudstack.quota.constant.QuotaConfig;
 import org.apache.cloudstack.quota.constant.QuotaTypes;
 import org.apache.cloudstack.quota.dao.QuotaTariffDao;
 import org.apache.cloudstack.quota.dao.QuotaTariffUsageDao;
@@ -39,10 +42,13 @@ import org.apache.cloudstack.quota.dao.QuotaUsageDao;
 import org.apache.cloudstack.quota.vo.QuotaTariffUsageVO;
 import org.apache.cloudstack.quota.vo.QuotaTariffVO;
 import org.apache.cloudstack.quota.vo.QuotaUsageVO;
+import org.apache.cloudstack.usage.UsageTypes;
 import org.apache.cloudstack.usage.UsageUnitTypes;
 import org.apache.cloudstack.utils.bytescale.ByteScaleUtils;
 import org.apache.cloudstack.utils.jsinterpreter.JsInterpreter;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -95,7 +101,20 @@ public class QuotaManagerImplTest {
     @Mock
     QuotaTariffUsageDao quotaTariffUsageDaoMock;
 
+    @Mock
+    ConfigDepotImpl configDepotImplMock;
+
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Before
+    public void setup() {
+        ConfigKey.init(configDepotImplMock);
+    }
+
+    @After
+    public void tearDown() {
+        ConfigKey.init(null);
+    }
 
     @Test
     public void isLockableTestValidateAccountTypes() {
@@ -111,6 +130,49 @@ public class QuotaManagerImplTest {
                 Assert.assertFalse(quotaManagerImplSpy.isLockable(accountVO));
             }
         });
+    }
+
+    @Test
+    public void shouldCalculateUsageRecordTestQuotaIsDisabledForAccountReturnFalse() {
+        Mockito.doReturn(1L).when(accountVoMock).getAccountId();
+        Mockito.doReturn("false").when(configDepotImplMock).getConfigStringValue(Mockito.eq(QuotaConfig.QuotaAccountEnabled.key()), Mockito.eq(ConfigKey.Scope.Account),
+                Mockito.eq(1L));
+
+        boolean result = quotaManagerImplSpy.shouldCalculateUsageRecord(accountVoMock, usageVoMock);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void shouldCalculateUsageRecordTestQuotaIsEnabledForAccountAndUsageRecordIsVolumeWithVmInstanceIdReturnFalse() {
+        Mockito.doReturn(1L).when(accountVoMock).getAccountId();
+        Mockito.doReturn(UsageTypes.VOLUME).when(usageVoMock).getUsageType();
+        Mockito.doReturn(1L).when(usageVoMock).getVmInstanceId();
+
+        boolean result = quotaManagerImplSpy.shouldCalculateUsageRecord(accountVoMock, usageVoMock);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void shouldCalculateUsageRecordTestQuotaIsEnabledForAccountAndUsageRecordIsVolumeWithoutVmInstanceIdReturnTrue() {
+        Mockito.doReturn(1L).when(accountVoMock).getAccountId();
+        Mockito.doReturn(UsageTypes.VOLUME).when(usageVoMock).getUsageType();
+        Mockito.doReturn(null).when(usageVoMock).getVmInstanceId();
+
+        boolean result = quotaManagerImplSpy.shouldCalculateUsageRecord(accountVoMock, usageVoMock);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void shouldCalculateUsageRecordTestQuotaIsEnabledForAccountAndUsageRecordIsNotVolumeReturnTrue() {
+        Mockito.doReturn(1L).when(accountVoMock).getAccountId();
+        Mockito.doReturn(UsageTypes.RUNNING_VM).when(usageVoMock).getUsageType();
+
+        boolean result = quotaManagerImplSpy.shouldCalculateUsageRecord(accountVoMock, usageVoMock);
+
+        Assert.assertTrue(result);
     }
 
     @Test


### PR DESCRIPTION
### Description

This is a follow-up of #11531 and #13909.

With #11531, the Usage server can now create up to 2 usage records for a single volume for the same period; one registers the time the volume remained allocated, while the other the time it remained attached to an instance. This results in a duplicate Quota value calculation for the volume.

For now, skip the Quota calculation for the volume usage records associating it to an instance.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

1. I enabled Quota and configured a volume tariff.
2. I created 2 volumes.
3. I attached only 1 of the volumes to an instance.
4. I ran the Usage job.
5. I verified that both the attached volume and the volume that was not attached had the same Quota consumption.