### PR TITLE
Fix type parameter in listBackupServiceJobs API

### DIFF
--- a/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/InternalBackupServiceJobDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/InternalBackupServiceJobDao.java
@@ -32,7 +32,7 @@ public interface InternalBackupServiceJobDao extends GenericDao<InternalBackupSe
 
     List<InternalBackupServiceJobVO> listExecutingJobsByHostsAndStartTimeBeforeAndTypeIn(Object[] hostIds, Date date, InternalBackupServiceJobType... jobTypes);
 
-    Pair<List<InternalBackupServiceJobVO>, Integer> searchAndCountForListApi(Long id, Long backupId, Long hostId, Long zoneId, InternalBackupServiceJobType type, boolean executing,
+    Pair<List<InternalBackupServiceJobVO>, Integer> searchAndCountForListApi(Long id, Long backupId, Long hostId, Long zoneId, String type, boolean executing,
             boolean scheduled, Long startIndex, Long pageSize);
 
     void update(InternalBackupServiceJobVO job);

--- a/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/InternalBackupServiceJobDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/backup/dao/InternalBackupServiceJobDaoImpl.java
@@ -98,7 +98,7 @@ public class InternalBackupServiceJobDaoImpl extends GenericDaoBase<InternalBack
     }
 
     @Override
-    public Pair<List<InternalBackupServiceJobVO>, Integer> searchAndCountForListApi(Long id, Long backupId, Long hostId, Long zoneId, InternalBackupServiceJobType type, boolean executing,
+    public Pair<List<InternalBackupServiceJobVO>, Integer> searchAndCountForListApi(Long id, Long backupId, Long hostId, Long zoneId, String type, boolean executing,
             boolean scheduled, Long startIndex, Long pageSize) {
         SearchBuilder<InternalBackupServiceJobVO> sb = createSearchBuilder();
 
@@ -122,7 +122,7 @@ public class InternalBackupServiceJobDaoImpl extends GenericDaoBase<InternalBack
         sc.setParametersIfNotNull(HOST_ID, hostId);
         sc.setParametersIfNotNull(ZONE_ID, zoneId);
         if (type != null) {
-            sc.setParameters(TYPE, type);
+            sc.setParameters(TYPE, InternalBackupServiceJobType.valueOf(type));
         }
 
         Filter filter = new Filter(InternalBackupServiceJobVO.class, "created", false, startIndex, pageSize);

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -158,7 +158,6 @@ import org.apache.cloudstack.api.response.UserVmResponse;
 import org.apache.cloudstack.api.response.VirtualMachineResponse;
 import org.apache.cloudstack.api.response.VolumeResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
-import org.apache.cloudstack.backup.InternalBackupServiceJobType;
 import org.apache.cloudstack.backup.InternalBackupServiceJobVO;
 import org.apache.cloudstack.backup.BackupOfferingVO;
 import org.apache.cloudstack.backup.BackupVO;
@@ -6400,7 +6399,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
     private Pair<List<InternalBackupServiceJobVO>, Integer> listBackupServiceJobsInternal(ListBackupServiceJobsCmd cmd) {
         return internalBackupServiceJobDao.searchAndCountForListApi(cmd.getId(), cmd.getBackupId(), cmd.getHostId(), cmd.getZoneId(),
-                InternalBackupServiceJobType.valueOf(cmd.getType()), cmd.getExecuting(), cmd.getScheduled(), cmd.getStartIndex(), cmd.getPageSizeVal());
+                cmd.getType(), cmd.getExecuting(), cmd.getScheduled(), cmd.getStartIndex(), cmd.getPageSizeVal());
     }
 
     @Override

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -6378,7 +6378,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
     public ListResponse<BackupServiceJobResponse> listBackupServiceJobs(ListBackupServiceJobsCmd cmd) {
         ListResponse<BackupServiceJobResponse> responses = new ListResponse<>();
         Pair<List<InternalBackupServiceJobVO>, Integer> result = listBackupServiceJobsInternal(cmd);
-        List<BackupServiceJobResponse> compressionJobResponses = new ArrayList<>();
+        List<BackupServiceJobResponse> backupServiceJobResponses = new ArrayList<>();
 
         for (InternalBackupServiceJobVO jobVO : result.first()) {
             BackupVO backup = backupDao.findByIdIncludingRemoved(jobVO.getBackupId());
@@ -6390,10 +6390,10 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             if (jobVO.getHostId() != null) {
                 response.setHostId(hostDao.findByIdIncludingRemoved(jobVO.getHostId()).getUuid());
             }
-            compressionJobResponses.add(response);
+            backupServiceJobResponses.add(response);
         }
 
-        responses.setResponses(compressionJobResponses, result.second());
+        responses.setResponses(backupServiceJobResponses, result.second());
         return responses;
     }
 


### PR DESCRIPTION
### Description

The parameter `type` of the listBackupServiceJobs is not required. However, the current implementation fails with a NPE if the `type` is not informed. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I called the API informing the `type` parameter and it was OK. I then called the API without informing it and it was OK as well.