### PR TITLE
fix: scope VPC SNAT rule to exclude locally-generated packets (#13942)

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -889,7 +889,7 @@ class CsIP:
                     ["nat", "", "-A POSTROUTING -j SNAT -o %s --to-source %s" % (self.dev, self.address['public_ip'])])
             elif cmdline.get_source_nat_ip() and not self.is_private_gateway():
                 self.fw.append(
-                    ["nat", "", "-A POSTROUTING -j SNAT -o %s --to-source %s" % (self.dev, cmdline.get_source_nat_ip())])
+                    ["nat", "", "-A POSTROUTING -m addrtype ! --src-type LOCAL -j SNAT -o %s --to-source %s" % (self.dev, cmdline.get_source_nat_ip())])
 
     def list(self):
         self.iplist = {}


### PR DESCRIPTION
### Problem

On a VPC with public IPs from more than one range/VLAN, the virtual router installs an unscoped source NAT rule on every public interface using the single VPC source NAT address. Because the rule has no source match (`-s`), it also rewrites traffic the router itself originates, so the VR cannot emit packets with the correct source address from any public interface other than the source-NAT one.

### Fix

Add `-m addrtype ! --src-type LOCAL` to the `elif` SNAT rule generated in `CsAddress.py`. This excludes packets whose source is an address on the router, while forwarded (guest) traffic still matches and is SNATed as before.

### Verification

The reporter verified the fix manually on the VR:
```
iptables -t nat -D POSTROUTING -o eth2 -j SNAT --to-source 10.1.30.5
iptables -t nat -A POSTROUTING -o eth2 -m addrtype ! --src-type LOCAL -j SNAT --to-source 10.1.30.5
```

Closes: #13942