### PR TITLE
dns: prevent creation of cross-tenant conflicting DNS zones in the same server

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/dns/DnsProviderManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/dns/DnsProviderManagerImpl.java
@@ -184,6 +184,11 @@ public class DnsProviderManagerImpl extends ManagerBase implements DnsProviderMa
             publicDomainSuffix = DnsProviderUtil.normalizeDomainForDb(publicDomainSuffix);
         }
 
+        if (isDnsPublic && StringUtils.isBlank(publicDomainSuffix)) {
+            throw new InvalidParameterValueException("A public DNS server requires a public domain suffix so that " +
+                    "DNS zones created by other accounts are contained under it.");
+        }
+
         DnsProviderType type = cmd.getProvider();
         DnsServerVO server = new DnsServerVO(cmd.getName(), cmd.getUrl(), cmd.getPort(), type,
                 cmd.getDnsUserName(), cmd.getDnsApiKey(), isDnsPublic, publicDomainSuffix, cmd.getNameServers(),
@@ -273,12 +278,20 @@ public class DnsProviderManagerImpl extends ManagerBase implements DnsProviderMa
         if (accountMgr.isRootAdmin(caller.getId()) || accountMgr.isDomainAdmin(caller.getId())) {
             if (cmd.isPublic() != null) {
                 boolean isPublic = BooleanUtils.isTrue(cmd.isPublic());
-                dnsServer.setPublicServer(isPublic);
 
                 String publicDomainSuffix = null;
-                if (isPublic && StringUtils.isNotBlank(cmd.getPublicDomainSuffix())) {
-                    publicDomainSuffix = DnsProviderUtil.normalizeDomainForDb(cmd.getPublicDomainSuffix());
+                if (isPublic) {
+                    if (StringUtils.isNotBlank(cmd.getPublicDomainSuffix())) {
+                        publicDomainSuffix = DnsProviderUtil.normalizeDomainForDb(cmd.getPublicDomainSuffix());
+                    } else {
+                        publicDomainSuffix = dnsServer.getPublicDomainSuffix();
+                    }
+                    if (StringUtils.isBlank(publicDomainSuffix)) {
+                        throw new InvalidParameterValueException("A public DNS server requires a public domain " +
+                                "suffix so that DNS zones created by other accounts are contained under it.");
+                    }
                 }
+                dnsServer.setPublicServer(isPublic);
                 dnsServer.setPublicDomainSuffix(publicDomainSuffix);
             }
         }
@@ -590,6 +603,7 @@ public class DnsProviderManagerImpl extends ManagerBase implements DnsProviderMa
                 throw new PermissionDeniedException("You do not have permission to use this DNS server.");
             }
             dnsZoneName = DnsProviderUtil.appendPublicSuffixToZone(dnsZoneName, server.getPublicDomainSuffix());
+            checkDnsZoneNameConflictsAcrossAccounts(dnsZoneName, server.getId(), caller.getId());
         }
         DnsZone.ZoneType type = cmd.getType();
         DnsZoneVO existing = dnsZoneDao.findByNameServerAndType(dnsZoneName, server.getId(), type);
@@ -598,6 +612,28 @@ public class DnsProviderManagerImpl extends ManagerBase implements DnsProviderMa
         }
         DnsZoneVO dnsZoneVO = new DnsZoneVO(dnsZoneName, type, server.getId(), caller.getId(), caller.getDomainId(), cmd.getDescription());
         return dnsZoneDao.persist(dnsZoneVO);
+    }
+
+    /**
+     * Rejects a DNS zone name that is equal to, a DNS child of, or a DNS parent of an existing zone owned by a
+     * different account on the same DNS server. Without this, a co-tenant could register e.g.
+     * {@code www.victimzone.<suffix>} on a shared public server and shadow the victim's records in the
+     * authoritative name server, since the more specific zone wins resolution.
+     */
+    private void checkDnsZoneNameConflictsAcrossAccounts(String dnsZoneName, long dnsServerId, long callerAccountId) {
+        String requestedName = dnsZoneName.toLowerCase();
+        List<DnsZoneVO> existingZones = dnsZoneDao.listByDnsServerId(dnsServerId);
+        for (DnsZoneVO zone : existingZones) {
+            if (zone.getAccountId() == callerAccountId) {
+                continue;
+            }
+            String existingName = zone.getName().toLowerCase();
+            if (requestedName.equals(existingName) || requestedName.endsWith("." + existingName)
+                    || existingName.endsWith("." + requestedName)) {
+                throw new PermissionDeniedException(String.format("DNS zone name %s conflicts with an existing DNS " +
+                        "zone owned by another account on this DNS server.", dnsZoneName));
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/apache/cloudstack/dns/dao/DnsZoneDao.java
+++ b/server/src/main/java/org/apache/cloudstack/dns/dao/DnsZoneDao.java
@@ -34,4 +34,6 @@ public interface DnsZoneDao extends GenericDao<DnsZoneVO, Long> {
                                                String keyword, Filter filter);
 
     List<Long> findDnsZoneIdsByServerId(long dnsServerId);
+
+    List<DnsZoneVO> listByDnsServerId(long dnsServerId);
 }

--- a/server/src/main/java/org/apache/cloudstack/dns/dao/DnsZoneDaoImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/dns/dao/DnsZoneDaoImpl.java
@@ -35,17 +35,22 @@ import com.cloud.utils.db.SearchCriteria;
 
 @Component
 public class DnsZoneDaoImpl extends GenericDaoBase<DnsZoneVO, Long> implements DnsZoneDao {
-    SearchBuilder<DnsZoneVO> DnsServerSearch;
+    SearchBuilder<DnsZoneVO> DnsServerZoneIdsSearch;
+    SearchBuilder<DnsZoneVO> DnsServerZonesSearch;
     SearchBuilder<DnsZoneVO> AccountSearch;
     SearchBuilder<DnsZoneVO> NameServerTypeSearch;
 
     public DnsZoneDaoImpl() {
         super();
 
-        DnsServerSearch  = createSearchBuilder();
-        DnsServerSearch.selectFields(DnsServerSearch.entity().getId());
-        DnsServerSearch.and(ApiConstants.DNS_SERVER_ID, DnsServerSearch.entity().getDnsServerId(), SearchCriteria.Op.EQ);
-        DnsServerSearch.done();
+        DnsServerZoneIdsSearch = createSearchBuilder();
+        DnsServerZoneIdsSearch.selectFields(DnsServerZoneIdsSearch.entity().getId());
+        DnsServerZoneIdsSearch.and(ApiConstants.DNS_SERVER_ID, DnsServerZoneIdsSearch.entity().getDnsServerId(), SearchCriteria.Op.EQ);
+        DnsServerZoneIdsSearch.done();
+
+        DnsServerZonesSearch = createSearchBuilder();
+        DnsServerZonesSearch.and(ApiConstants.DNS_SERVER_ID, DnsServerZonesSearch.entity().getDnsServerId(), SearchCriteria.Op.EQ);
+        DnsServerZonesSearch.done();
 
         AccountSearch = createSearchBuilder();
         AccountSearch.and(ApiConstants.ACCOUNT_ID, AccountSearch.entity().getAccountId(), SearchCriteria.Op.EQ);
@@ -116,8 +121,15 @@ public class DnsZoneDaoImpl extends GenericDaoBase<DnsZoneVO, Long> implements D
         return searchAndCount(sc, filter);
     }
 
+    @Override
+    public List<DnsZoneVO> listByDnsServerId(long dnsServerId) {
+        SearchCriteria<DnsZoneVO> sc = DnsServerZonesSearch.create();
+        sc.setParameters(ApiConstants.DNS_SERVER_ID, dnsServerId);
+        return listBy(sc);
+    }
+
     public List<Long> findDnsZoneIdsByServerId(long dnsServerId) {
-        SearchCriteria<DnsZoneVO> sc = DnsServerSearch.create();
+        SearchCriteria<DnsZoneVO> sc = DnsServerZoneIdsSearch.create();
         sc.setParameters(ApiConstants.DNS_SERVER_ID, dnsServerId);
         List<DnsZoneVO> dnsZones = listBy(sc);
         if (CollectionUtils.isEmpty(dnsZones)) {

--- a/server/src/test/java/org/apache/cloudstack/dns/DnsProviderManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/dns/DnsProviderManagerImplTest.java
@@ -262,6 +262,60 @@ public class DnsProviderManagerImplTest {
         manager.allocateDnsZone(cmd);
     }
 
+    @Test(expected = PermissionDeniedException.class)
+    public void testAllocateDnsZoneNonOwnerShadowingOtherAccountZoneRejected() {
+        CreateDnsZoneCmd cmd = mock(CreateDnsZoneCmd.class);
+        when(cmd.getName()).thenReturn("www.tenant1.cloud.example");
+        when(cmd.getDnsServerId()).thenReturn(SERVER_ID);
+        when(dnsServerDao.findById(SERVER_ID)).thenReturn(serverVO);
+        Mockito.doReturn(SERVER_ID).when(serverVO).getId();
+        Mockito.doReturn(ACCOUNT_ID + 99).when(serverVO).getAccountId(); // different owner
+        Mockito.doReturn(true).when(serverVO).getPublicServer();
+        Mockito.doReturn("cloud.example").when(serverVO).getPublicDomainSuffix();
+        DnsZoneVO victimZone = new DnsZoneVO("tenant1.cloud.example", DnsZone.ZoneType.Public, SERVER_ID,
+                ACCOUNT_ID + 50, DOMAIN_ID, "victim zone");
+        when(dnsZoneDao.listByDnsServerId(SERVER_ID)).thenReturn(Collections.singletonList(victimZone));
+
+        manager.allocateDnsZone(cmd);
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void testAllocateDnsZoneNonOwnerParentOfOtherAccountZoneRejected() {
+        CreateDnsZoneCmd cmd = mock(CreateDnsZoneCmd.class);
+        when(cmd.getName()).thenReturn("tenant1.cloud.example");
+        when(cmd.getDnsServerId()).thenReturn(SERVER_ID);
+        when(dnsServerDao.findById(SERVER_ID)).thenReturn(serverVO);
+        Mockito.doReturn(SERVER_ID).when(serverVO).getId();
+        Mockito.doReturn(ACCOUNT_ID + 99).when(serverVO).getAccountId(); // different owner
+        Mockito.doReturn(true).when(serverVO).getPublicServer();
+        Mockito.doReturn("cloud.example").when(serverVO).getPublicDomainSuffix();
+        DnsZoneVO victimZone = new DnsZoneVO("www.tenant1.cloud.example", DnsZone.ZoneType.Public, SERVER_ID,
+                ACCOUNT_ID + 50, DOMAIN_ID, "victim zone");
+        when(dnsZoneDao.listByDnsServerId(SERVER_ID)).thenReturn(Collections.singletonList(victimZone));
+
+        manager.allocateDnsZone(cmd);
+    }
+
+    @Test
+    public void testAllocateDnsZoneNonOwnerPublicServerSuccess() {
+        CreateDnsZoneCmd cmd = mock(CreateDnsZoneCmd.class);
+        when(cmd.getName()).thenReturn("tenant2.cloud.example");
+        when(cmd.getDnsServerId()).thenReturn(SERVER_ID);
+        when(cmd.getType()).thenReturn(DnsZone.ZoneType.Public);
+        when(dnsServerDao.findById(SERVER_ID)).thenReturn(serverVO);
+        Mockito.doReturn(SERVER_ID).when(serverVO).getId();
+        Mockito.doReturn(ACCOUNT_ID + 99).when(serverVO).getAccountId(); // different owner
+        Mockito.doReturn(true).when(serverVO).getPublicServer();
+        Mockito.doReturn("cloud.example").when(serverVO).getPublicDomainSuffix();
+        when(dnsZoneDao.listByDnsServerId(SERVER_ID)).thenReturn(Collections.emptyList());
+        when(dnsZoneDao.findByNameServerAndType(anyString(), anyLong(), any())).thenReturn(null);
+        when(dnsZoneDao.persist(any(DnsZoneVO.class))).thenReturn(zoneVO);
+
+        DnsZone result = manager.allocateDnsZone(cmd);
+        assertNotNull(result);
+        verify(dnsZoneDao).persist(Mockito.argThat(z -> "tenant2.cloud.example".equals(((DnsZoneVO) z).getName())));
+    }
+
     @Test(expected = CloudRuntimeException.class)
     public void testProvisionDnsZoneNotFound() {
         when(dnsZoneDao.findById(ZONE_ID)).thenReturn(null);
@@ -804,6 +858,28 @@ public class DnsProviderManagerImplTest {
         assertNotNull(result);
         verify(dnsServerDao).persist(Mockito.argThat(
                 s -> !((DnsServerVO) s).getPublicServer() && ((DnsServerVO) s).getPublicDomainSuffix() == null));
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testAddDnsServerPublicWithoutSuffixRejected() {
+        org.apache.cloudstack.api.command.user.dns.AddDnsServerCmd cmd = mock(
+                org.apache.cloudstack.api.command.user.dns.AddDnsServerCmd.class);
+        when(accountMgr.isRootAdmin(callerMock.getId())).thenReturn(true);
+        when(cmd.getUrl()).thenReturn("http://newpdns:8081");
+        when(cmd.isPublic()).thenReturn(true);
+        when(dnsServerDao.findByUrlAndAccount(anyString(), anyLong())).thenReturn(null);
+        manager.addDnsServer(cmd);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testUpdateDnsServerPublicWithoutSuffixRejected() {
+        org.apache.cloudstack.api.command.user.dns.UpdateDnsServerCmd cmd = mock(
+                org.apache.cloudstack.api.command.user.dns.UpdateDnsServerCmd.class);
+        when(cmd.getId()).thenReturn(SERVER_ID);
+        when(cmd.isPublic()).thenReturn(true);
+        when(accountMgr.isRootAdmin(callerMock.getId())).thenReturn(true);
+        when(dnsServerDao.findById(SERVER_ID)).thenReturn(serverVO);
+        manager.updateDnsServer(cmd);
     }
 
     @Test(expected = CloudRuntimeException.class)

--- a/ui/src/views/network/dns/AddDnsServer.vue
+++ b/ui/src/views/network/dns/AddDnsServer.vue
@@ -205,7 +205,10 @@ export default {
       ]
     }
     if (this.isAdminOrDomainAdmin()) {
-      this.rules.publicdomainsuffix = [{ validator: this.validatePublicDomainSuffix }]
+      this.rules.publicdomainsuffix = [{
+        required: true,
+        validator: this.validatePublicDomainSuffix
+      }]
     }
     this.fetchProviders()
   },
@@ -331,7 +334,7 @@ export default {
     validatePublicDomainSuffix (rule, value) {
       const normalized = value?.toLowerCase().trim()
       if (!normalized) {
-        return Promise.resolve()
+        return Promise.reject(new Error(this.$t('message.error.required.input')))
       }
       if (!FQDN_REGEX.test(normalized)) {
         return Promise.reject(new Error('Invalid domain suffix'))

--- a/ui/src/views/network/dns/UpdateDnsServer.vue
+++ b/ui/src/views/network/dns/UpdateDnsServer.vue
@@ -164,7 +164,10 @@ export default {
       ]
     }
     if (this.isAdminOrDomainAdmin()) {
-      this.rules.publicdomainsuffix = [{ validator: this.validatePublicDomainSuffix }]
+      this.rules.publicdomainsuffix = [{
+        required: true,
+        validator: this.validatePublicDomainSuffix
+      }]
     }
     this.form.name = this.resource.name
     this.form.url = this.resource.url
@@ -272,7 +275,7 @@ export default {
     validatePublicDomainSuffix (rule, value) {
       const normalized = value?.toLowerCase().trim()
       if (!normalized) {
-        return Promise.resolve()
+        return Promise.reject(new Error(this.$t('message.error.required.input')))
       }
       if (!FQDN_REGEX.test(normalized)) {
         return Promise.reject(new Error('Invalid domain suffix'))


### PR DESCRIPTION
### Description

`allocateDnsZone` allows users to register DNS zones that conflict with DNS zones from the same server belonging to other users, which consequently allows them to shadow DNS records belonging to other users.

**Example:** Victim tenant runs `tenant1.cloud.example` with www → 203.0.113.10 on a shared public server (suffix `cloud.example`). A co-tenant calls `createDnsZone name=www.tenant1.cloud.example dnsserverid=<shared>` — accepted as-is — then adds an apex A record to their own IP; every resolver using that PowerDNS now resolves the victim's hostname to the attacker.

This patch rejects zones that overlap another tenant's zone as either a DNS parent or child, and also requires a non-blank `publicDomainSuffix` for public servers. It was mostly generated using AI tools, but reviewed and tested by a human.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [X] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

I reproduced the example scenario before the patch, and verified that it is not reproducible anymore after the changes.