### PR TITLE
Scope host tag-rule matches to deployment plan in allocators

### DIFF
--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
@@ -182,6 +182,7 @@ public interface HostDao extends GenericDao<HostVO, Long>, StateDao<Status, Stat
     List<String> listOrderedHostsHypervisorVersionsInDatacenter(long datacenterId, HypervisorType hypervisorType);
 
     List<HostVO> findHostsWithTagRuleThatMatchComputeOferringTags(String computeOfferingTags);
+    List<HostVO> findHostsWithTagRuleThatMatchComputeOferringTags(String computeOfferingTags, Long clusterId, Long podId, Long dcId);
 
     List<Long> findClustersThatMatchHostTagRule(String computeOfferingTags);
 

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
@@ -1456,6 +1456,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         }
     }
 
+    @Override
     public List<HostVO> findHostsWithTagRuleThatMatchComputeOferringTags(String computeOfferingTags) {
         List<HostTagVO> hostTagVOList = _hostTagsDao.findHostRuleTags();
         List<HostVO> result = new ArrayList<>();
@@ -1466,6 +1467,20 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         }
 
         return result;
+    }
+
+    @Override
+    public List<HostVO> findHostsWithTagRuleThatMatchComputeOferringTags(String computeOfferingTags, Long clusterId, Long podId, Long dcId) {
+        List<HostVO> hosts = findHostsWithTagRuleThatMatchComputeOferringTags(computeOfferingTags);
+        if (dcId == null && podId == null && clusterId == null) {
+            return hosts;
+        }
+
+        return hosts.stream()
+                .filter(host -> host != null && (dcId == null || host.getDataCenterId() == dcId))
+                .filter(host -> podId == null || Objects.equals(host.getPodId(), podId))
+                .filter(host -> clusterId == null || Objects.equals(host.getClusterId(), clusterId))
+                .collect(Collectors.toList());
     }
 
     public List<Long> findClustersThatMatchHostTagRule(String computeOfferingTags) {

--- a/engine/schema/src/test/java/com/cloud/host/dao/HostDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/host/dao/HostDaoImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -228,6 +229,114 @@ public class HostDaoImplTest {
         assertEquals(1, result.size());
         assertEquals(Hypervisor.HypervisorType.VMware, result.get(0).first());
         assertEquals(CPU.CPUArch.amd64, result.get(0).second());
+    }
+
+    @Test
+    public void testFindHostsWithTagRuleThatMatchComputeOferringTagsScopedNoScopeReturnsAllMatches() {
+        String offeringTag = "ssd";
+        HostVO host1 = mock(HostVO.class);
+        HostVO host2 = mock(HostVO.class);
+        List<HostVO> unscopedMatches = List.of(host1, host2);
+        doReturn(unscopedMatches).when(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+
+        List<HostVO> result = hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, null, null, null);
+
+        assertEquals(unscopedMatches, result);
+    }
+
+    @Test
+    public void testFindHostsWithTagRuleThatMatchComputeOferringTagsScopedFiltersByDataCenter() {
+        String offeringTag = "ssd";
+        long dcId = 1L;
+        HostVO hostInZone = mock(HostVO.class);
+        when(hostInZone.getDataCenterId()).thenReturn(dcId);
+        HostVO hostInOtherZone = mock(HostVO.class);
+        when(hostInOtherZone.getDataCenterId()).thenReturn(2L);
+        doReturn(List.of(hostInZone, hostInOtherZone)).when(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+
+        List<HostVO> result = hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, null, null, dcId);
+
+        assertEquals(1, result.size());
+        Assert.assertSame(hostInZone, result.get(0));
+    }
+
+    @Test
+    public void testFindHostsWithTagRuleThatMatchComputeOferringTagsScopedFiltersByPodAndCluster() {
+        String offeringTag = "ssd";
+        long dcId = 1L;
+        Long podId = 2L;
+        Long clusterId = 3L;
+
+        HostVO matchingHost = mock(HostVO.class);
+        when(matchingHost.getDataCenterId()).thenReturn(dcId);
+        when(matchingHost.getPodId()).thenReturn(podId);
+        when(matchingHost.getClusterId()).thenReturn(clusterId);
+
+        HostVO wrongPodHost = mock(HostVO.class);
+        when(wrongPodHost.getDataCenterId()).thenReturn(dcId);
+        when(wrongPodHost.getPodId()).thenReturn(99L);
+
+        HostVO wrongClusterHost = mock(HostVO.class);
+        when(wrongClusterHost.getDataCenterId()).thenReturn(dcId);
+        when(wrongClusterHost.getPodId()).thenReturn(podId);
+        when(wrongClusterHost.getClusterId()).thenReturn(99L);
+
+        doReturn(List.of(matchingHost, wrongPodHost, wrongClusterHost)).when(hostDao)
+                .findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+
+        List<HostVO> result = hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+
+        assertEquals(1, result.size());
+        Assert.assertSame(matchingHost, result.get(0));
+    }
+
+    @Test
+    public void testFindHostsWithTagRuleThatMatchComputeOferringTagsScopedExcludesHostWithNullPod() {
+        String offeringTag = "ssd";
+        long dcId = 1L;
+        Long podId = 2L;
+        Long clusterId = 3L;
+
+        HostVO hostWithNoPod = mock(HostVO.class);
+        when(hostWithNoPod.getDataCenterId()).thenReturn(dcId);
+        when(hostWithNoPod.getPodId()).thenReturn(null);
+
+        doReturn(List.of(hostWithNoPod)).when(hostDao)
+                .findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+
+        List<HostVO> result = hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindHostsWithTagRuleThatMatchComputeOferringTagsScopedExcludesHostWithNullCluster() {
+        String offeringTag = "ssd";
+        long dcId = 1L;
+        Long podId = 2L;
+        Long clusterId = 3L;
+
+        HostVO hostWithNoCluster = mock(HostVO.class);
+        when(hostWithNoCluster.getDataCenterId()).thenReturn(dcId);
+        when(hostWithNoCluster.getPodId()).thenReturn(podId);
+        when(hostWithNoCluster.getClusterId()).thenReturn(null);
+
+        doReturn(List.of(hostWithNoCluster)).when(hostDao)
+                .findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+
+        List<HostVO> result = hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindHostsWithTagRuleThatMatchComputeOferringTagsScopedNoMatchesReturnsEmpty() {
+        String offeringTag = "ssd";
+        doReturn(new ArrayList<>()).when(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+
+        List<HostVO> result = hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, 3L, 2L, 1L);
+
+        Assert.assertTrue(result.isEmpty());
     }
 
     @Test

--- a/plugins/host-allocators/random/src/main/java/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
+++ b/plugins/host-allocators/random/src/main/java/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
@@ -122,7 +122,7 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
                 hostsCopy = _hostDao.listAllHostsThatHaveNoRuleTag(type, clusterId, podId, dcId);
             }
         }
-        hostsCopy = ListUtils.union(hostsCopy, _hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringHostTag));
+        hostsCopy = ListUtils.union(hostsCopy, _hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringHostTag, clusterId, podId, dcId));
 
         if (hostsCopy.isEmpty()) {
             logger.info("No suitable host found for VM [{}] in {}.", vmProfile, hostTag);

--- a/plugins/host-allocators/random/src/test/java/com/cloud/agent/manager/allocator/impl/RandomAllocatorTest.java
+++ b/plugins/host-allocators/random/src/test/java/com/cloud/agent/manager/allocator/impl/RandomAllocatorTest.java
@@ -39,6 +39,11 @@ import com.cloud.storage.VMTemplateVO;
 import com.cloud.utils.Pair;
 import com.cloud.vm.VirtualMachineProfile;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @RunWith(MockitoJUnitRunner.class)
 public class RandomAllocatorTest {
 
@@ -55,23 +60,23 @@ public class RandomAllocatorTest {
         Long id = 1L;
         String templateTag = "tag1";
         String offeringTag = "tag2";
-        HostVO host1 = Mockito.mock(HostVO.class);
-        HostVO host2 = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, offeringTag)).thenReturn(List.of(host1, host2));
+        HostVO host1 = mock(HostVO.class);
+        HostVO host2 = mock(HostVO.class);
+        when(hostDao.listByHostTag(type, id, id, id, offeringTag)).thenReturn(List.of(host1, host2));
 
         // No template tagged host
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(new ArrayList<>());
+        when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(new ArrayList<>());
         List<HostVO> result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, templateTag);
         Assert.assertTrue(CollectionUtils.isEmpty(result));
 
         // Different template tagged host
-        HostVO host3 = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(List.of(host3));
+        HostVO host3 = mock(HostVO.class);
+        when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(List.of(host3));
         result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, templateTag);
         Assert.assertTrue(CollectionUtils.isEmpty(result));
 
         // Matching template tagged host
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(List.of(host1));
+        when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(List.of(host1));
         result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, templateTag);
         Assert.assertFalse(CollectionUtils.isEmpty(result));
         Assert.assertEquals(1, result.size());
@@ -95,28 +100,28 @@ public class RandomAllocatorTest {
         Long clusterId = 3L;
         String offeringTag = "compute";
 
-        DeploymentPlan plan = Mockito.mock(DeploymentPlan.class);
-        Mockito.when(plan.getDataCenterId()).thenReturn(dcId);
-        Mockito.when(plan.getPodId()).thenReturn(podId);
-        Mockito.when(plan.getClusterId()).thenReturn(clusterId);
+        DeploymentPlan plan = mock(DeploymentPlan.class);
+        when(plan.getDataCenterId()).thenReturn(dcId);
+        when(plan.getPodId()).thenReturn(podId);
+        when(plan.getClusterId()).thenReturn(clusterId);
 
-        VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
-        ServiceOffering offering = Mockito.mock(ServiceOffering.class);
-        VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
-        Mockito.when(vmProfile.getServiceOffering()).thenReturn(offering);
-        Mockito.when(vmProfile.getTemplate()).thenReturn(template);
-        Mockito.when(offering.getHostTag()).thenReturn(offeringTag);
+        VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
+        ServiceOffering offering = mock(ServiceOffering.class);
+        VMTemplateVO template = mock(VMTemplateVO.class);
+        when(vmProfile.getServiceOffering()).thenReturn(offering);
+        when(vmProfile.getTemplate()).thenReturn(template);
+        when(offering.getHostTag()).thenReturn(offeringTag);
 
-        HostVO host = Mockito.mock(HostVO.class);
+        HostVO host = mock(HostVO.class);
         List<Host> hosts = List.of(host);
-        Mockito.when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(List.of(host));
-        Mockito.when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
-        Mockito.when(capacityManager.checkIfHostHasCpuCapabilityAndCapacity(host, offering, true)).thenReturn(new Pair<>(true, true));
+        when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(List.of(host));
+        when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
+        when(capacityManager.checkIfHostHasCpuCapabilityAndCapacity(host, offering, true)).thenReturn(new Pair<>(true, true));
 
         List<Host> result = randomAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), hosts, 1, true);
 
         Assert.assertEquals(1, result.size());
-        Mockito.verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
-        Mockito.verify(hostDao, Mockito.never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+        verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+        verify(hostDao, never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
     }
 }

--- a/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -198,7 +198,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             clusterHosts.retainAll(hostsMatchingUefiTag);
         }
 
-        clusterHosts.addAll(_hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(hostTagOnOffering));
+        clusterHosts.addAll(_hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(hostTagOnOffering, clusterId, podId, dcId));
 
 
         if (clusterHosts.isEmpty()) {
@@ -274,7 +274,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             }
         }
 
-        hostsCopy.addAll(_hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(hostTagOnOffering));
+        hostsCopy.addAll(_hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(hostTagOnOffering, clusterId, podId, dcId));
 
         if (!hostsCopy.isEmpty()) {
             suitableHosts = allocateTo(plan, offering, template, avoid, hostsCopy, returnUpTo, considerReservedCapacity, account);

--- a/server/src/test/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocatorTest.java
+++ b/server/src/test/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocatorTest.java
@@ -39,6 +39,12 @@ import com.cloud.user.Account;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.UserVmDetailsDao;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @RunWith(MockitoJUnitRunner.class)
 public class FirstFitAllocatorTest {
 
@@ -58,32 +64,32 @@ public class FirstFitAllocatorTest {
         Long clusterId = 3L;
         String offeringTag = "compute";
 
-        DeploymentPlan plan = Mockito.mock(DeploymentPlan.class);
-        Mockito.when(plan.getDataCenterId()).thenReturn(dcId);
-        Mockito.when(plan.getPodId()).thenReturn(podId);
-        Mockito.when(plan.getClusterId()).thenReturn(clusterId);
+        DeploymentPlan plan = mock(DeploymentPlan.class);
+        when(plan.getDataCenterId()).thenReturn(dcId);
+        when(plan.getPodId()).thenReturn(podId);
+        when(plan.getClusterId()).thenReturn(clusterId);
 
-        VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
-        ServiceOffering offering = Mockito.mock(ServiceOffering.class);
-        VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
-        Account account = Mockito.mock(Account.class);
-        Mockito.when(vmProfile.getServiceOffering()).thenReturn(offering);
-        Mockito.when(vmProfile.getTemplate()).thenReturn(template);
-        Mockito.when(vmProfile.getOwner()).thenReturn(account);
-        Mockito.when(offering.getHostTag()).thenReturn(offeringTag);
+        VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
+        ServiceOffering offering = mock(ServiceOffering.class);
+        VMTemplateVO template = mock(VMTemplateVO.class);
+        Account account = mock(Account.class);
+        when(vmProfile.getServiceOffering()).thenReturn(offering);
+        when(vmProfile.getTemplate()).thenReturn(template);
+        when(vmProfile.getOwner()).thenReturn(account);
+        when(offering.getHostTag()).thenReturn(offeringTag);
 
-        HostVO host = Mockito.mock(HostVO.class);
+        HostVO host = mock(HostVO.class);
         List<Host> selectedHosts = List.of(host);
-        Mockito.when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(List.of(host));
-        Mockito.when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
-        Mockito.doReturn(selectedHosts).when(firstFitAllocator).allocateTo(
+        when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(List.of(host));
+        when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
+        doReturn(selectedHosts).when(firstFitAllocator).allocateTo(
                 Mockito.eq(plan), Mockito.eq(offering), Mockito.eq(template), Mockito.any(ExcludeList.class), Mockito.anyList(), Mockito.eq(1), Mockito.eq(true), Mockito.eq(account));
 
         List<Host> result = firstFitAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), selectedHosts, 1, true);
 
         Assert.assertEquals(1, result.size());
-        Mockito.verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
-        Mockito.verify(hostDao, Mockito.never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+        verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+        verify(hostDao, never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
     }
 
     @Test
@@ -94,33 +100,33 @@ public class FirstFitAllocatorTest {
         Long clusterId = 3L;
         String offeringTag = "compute";
 
-        DeploymentPlan plan = Mockito.mock(DeploymentPlan.class);
-        Mockito.when(plan.getDataCenterId()).thenReturn(dcId);
-        Mockito.when(plan.getPodId()).thenReturn(podId);
-        Mockito.when(plan.getClusterId()).thenReturn(clusterId);
+        DeploymentPlan plan = mock(DeploymentPlan.class);
+        when(plan.getDataCenterId()).thenReturn(dcId);
+        when(plan.getPodId()).thenReturn(podId);
+        when(plan.getClusterId()).thenReturn(clusterId);
 
-        VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
-        ServiceOffering offering = Mockito.mock(ServiceOffering.class);
-        VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
-        Account account = Mockito.mock(Account.class);
-        Mockito.when(vmProfile.getServiceOffering()).thenReturn(offering);
-        Mockito.when(vmProfile.getTemplate()).thenReturn(template);
-        Mockito.when(vmProfile.getOwner()).thenReturn(account);
-        Mockito.when(offering.getHostTag()).thenReturn(offeringTag);
-        Mockito.when(userVmDetailsDao.findDetail(Mockito.anyLong(), Mockito.eq("UEFI"))).thenReturn(null);
+        VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
+        ServiceOffering offering = mock(ServiceOffering.class);
+        VMTemplateVO template = mock(VMTemplateVO.class);
+        Account account = mock(Account.class);
+        when(vmProfile.getServiceOffering()).thenReturn(offering);
+        when(vmProfile.getTemplate()).thenReturn(template);
+        when(vmProfile.getOwner()).thenReturn(account);
+        when(offering.getHostTag()).thenReturn(offeringTag);
+        when(userVmDetailsDao.findDetail(Mockito.anyLong(), Mockito.eq("UEFI"))).thenReturn(null);
 
-        HostVO host = Mockito.mock(HostVO.class);
+        HostVO host = mock(HostVO.class);
         List<Host> selectedHosts = List.of(host);
-        Mockito.when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(new ArrayList<>(List.of(host)));
-        Mockito.when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
-        Mockito.when(hostDao.listAllUpAndEnabledNonHAHosts(type, clusterId, podId, dcId, null)).thenReturn(new ArrayList<>());
-        Mockito.doReturn(selectedHosts).when(firstFitAllocator).allocateTo(
+        when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(new ArrayList<>(List.of(host)));
+        when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
+        when(hostDao.listAllUpAndEnabledNonHAHosts(type, clusterId, podId, dcId, null)).thenReturn(new ArrayList<>());
+        doReturn(selectedHosts).when(firstFitAllocator).allocateTo(
                 Mockito.eq(plan), Mockito.eq(offering), Mockito.eq(template), Mockito.any(ExcludeList.class), Mockito.anyList(), Mockito.eq(1), Mockito.eq(true), Mockito.eq(account));
 
         List<Host> result = firstFitAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), 1, true);
 
         Assert.assertEquals(1, result.size());
-        Mockito.verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
-        Mockito.verify(hostDao, Mockito.never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+        verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+        verify(hostDao, never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
     }
 }

--- a/server/src/test/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocatorTest.java
+++ b/server/src/test/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocatorTest.java
@@ -19,13 +19,13 @@ package com.cloud.agent.manager.allocator.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloud.deploy.DeploymentPlan;
@@ -33,62 +33,22 @@ import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
-import com.cloud.capacity.CapacityManager;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.storage.VMTemplateVO;
-import com.cloud.utils.Pair;
+import com.cloud.user.Account;
 import com.cloud.vm.VirtualMachineProfile;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RandomAllocatorTest {
+public class FirstFitAllocatorTest {
 
     @Mock
     HostDao hostDao;
-    @Mock
-    CapacityManager capacityManager;
+    @Spy
     @InjectMocks
-    RandomAllocator randomAllocator;
+    FirstFitAllocator firstFitAllocator;
 
     @Test
-    public void testListHostsByTags() {
-        Host.Type type = Host.Type.Routing;
-        Long id = 1L;
-        String templateTag = "tag1";
-        String offeringTag = "tag2";
-        HostVO host1 = Mockito.mock(HostVO.class);
-        HostVO host2 = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, offeringTag)).thenReturn(List.of(host1, host2));
-
-        // No template tagged host
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(new ArrayList<>());
-        List<HostVO> result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, templateTag);
-        Assert.assertTrue(CollectionUtils.isEmpty(result));
-
-        // Different template tagged host
-        HostVO host3 = Mockito.mock(HostVO.class);
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(List.of(host3));
-        result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, templateTag);
-        Assert.assertTrue(CollectionUtils.isEmpty(result));
-
-        // Matching template tagged host
-        Mockito.when(hostDao.listByHostTag(type, id, id, id, templateTag)).thenReturn(List.of(host1));
-        result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, templateTag);
-        Assert.assertFalse(CollectionUtils.isEmpty(result));
-        Assert.assertEquals(1, result.size());
-
-        // No template tag
-        result = randomAllocator.listHostsByTags(type, id, id, id, offeringTag, null);
-        Assert.assertFalse(CollectionUtils.isEmpty(result));
-        Assert.assertEquals(2, result.size());
-
-        // No offering tag
-        result = randomAllocator.listHostsByTags(type, id, id, id, null, templateTag);
-        Assert.assertFalse(CollectionUtils.isEmpty(result));
-        Assert.assertEquals(1, result.size());
-    }
-
-    @Test
-    public void testAllocateToUsesScopedRuleTagLookup() {
+    public void testAllocateToWithHostsUsesScopedRuleTagLookup() {
         Host.Type type = Host.Type.Routing;
         long dcId = 1L;
         Long podId = 2L;
@@ -103,17 +63,20 @@ public class RandomAllocatorTest {
         VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
         ServiceOffering offering = Mockito.mock(ServiceOffering.class);
         VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
+        Account account = Mockito.mock(Account.class);
         Mockito.when(vmProfile.getServiceOffering()).thenReturn(offering);
         Mockito.when(vmProfile.getTemplate()).thenReturn(template);
+        Mockito.when(vmProfile.getOwner()).thenReturn(account);
         Mockito.when(offering.getHostTag()).thenReturn(offeringTag);
 
         HostVO host = Mockito.mock(HostVO.class);
-        List<Host> hosts = List.of(host);
+        List<Host> selectedHosts = List.of(host);
         Mockito.when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(List.of(host));
         Mockito.when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
-        Mockito.when(capacityManager.checkIfHostHasCpuCapabilityAndCapacity(host, offering, true)).thenReturn(new Pair<>(true, true));
+        Mockito.doReturn(selectedHosts).when(firstFitAllocator).allocateTo(
+                Mockito.eq(plan), Mockito.eq(offering), Mockito.eq(template), Mockito.any(ExcludeList.class), Mockito.anyList(), Mockito.eq(1), Mockito.eq(true), Mockito.eq(account));
 
-        List<Host> result = randomAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), hosts, 1, true);
+        List<Host> result = firstFitAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), selectedHosts, 1, true);
 
         Assert.assertEquals(1, result.size());
         Mockito.verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);

--- a/server/src/test/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocatorTest.java
+++ b/server/src/test/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocatorTest.java
@@ -37,12 +37,15 @@ import com.cloud.offering.ServiceOffering;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.user.Account;
 import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.UserVmDetailsDao;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FirstFitAllocatorTest {
 
     @Mock
     HostDao hostDao;
+    @Mock
+    UserVmDetailsDao userVmDetailsDao;
     @Spy
     @InjectMocks
     FirstFitAllocator firstFitAllocator;
@@ -77,6 +80,44 @@ public class FirstFitAllocatorTest {
                 Mockito.eq(plan), Mockito.eq(offering), Mockito.eq(template), Mockito.any(ExcludeList.class), Mockito.anyList(), Mockito.eq(1), Mockito.eq(true), Mockito.eq(account));
 
         List<Host> result = firstFitAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), selectedHosts, 1, true);
+
+        Assert.assertEquals(1, result.size());
+        Mockito.verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);
+        Mockito.verify(hostDao, Mockito.never()).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag);
+    }
+
+    @Test
+    public void testAllocateToWithoutHostsUsesScopedRuleTagLookup() {
+        Host.Type type = Host.Type.Routing;
+        long dcId = 1L;
+        Long podId = 2L;
+        Long clusterId = 3L;
+        String offeringTag = "compute";
+
+        DeploymentPlan plan = Mockito.mock(DeploymentPlan.class);
+        Mockito.when(plan.getDataCenterId()).thenReturn(dcId);
+        Mockito.when(plan.getPodId()).thenReturn(podId);
+        Mockito.when(plan.getClusterId()).thenReturn(clusterId);
+
+        VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
+        ServiceOffering offering = Mockito.mock(ServiceOffering.class);
+        VMTemplateVO template = Mockito.mock(VMTemplateVO.class);
+        Account account = Mockito.mock(Account.class);
+        Mockito.when(vmProfile.getServiceOffering()).thenReturn(offering);
+        Mockito.when(vmProfile.getTemplate()).thenReturn(template);
+        Mockito.when(vmProfile.getOwner()).thenReturn(account);
+        Mockito.when(offering.getHostTag()).thenReturn(offeringTag);
+        Mockito.when(userVmDetailsDao.findDetail(Mockito.anyLong(), Mockito.eq("UEFI"))).thenReturn(null);
+
+        HostVO host = Mockito.mock(HostVO.class);
+        List<Host> selectedHosts = List.of(host);
+        Mockito.when(hostDao.listByHostTag(type, clusterId, podId, dcId, offeringTag)).thenReturn(new ArrayList<>(List.of(host)));
+        Mockito.when(hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId)).thenReturn(new ArrayList<>());
+        Mockito.when(hostDao.listAllUpAndEnabledNonHAHosts(type, clusterId, podId, dcId, null)).thenReturn(new ArrayList<>());
+        Mockito.doReturn(selectedHosts).when(firstFitAllocator).allocateTo(
+                Mockito.eq(plan), Mockito.eq(offering), Mockito.eq(template), Mockito.any(ExcludeList.class), Mockito.anyList(), Mockito.eq(1), Mockito.eq(true), Mockito.eq(account));
+
+        List<Host> result = firstFitAllocator.allocateTo(vmProfile, plan, type, new ExcludeList(), 1, true);
 
         Assert.assertEquals(1, result.size());
         Mockito.verify(hostDao).findHostsWithTagRuleThatMatchComputeOferringTags(offeringTag, clusterId, podId, dcId);


### PR DESCRIPTION
Fixes: #11083

## Problem

`FirstFitAllocator` and `RandomAllocator` both call
`HostDao#findHostsWithTagRuleThatMatchComputeOferringTags(String)` to pick up hosts whose
host tag is defined as a *rule* (a boolean/regex expression, e.g. `!ssd`) rather than a
literal string, so they match the compute offering's host tag.

That DAO method evaluates every rule-tagged host in the **entire installation** against the
offering tag and returns all matches, with no zone/pod/cluster filtering. The allocators then
unconditionally `addAll`/`union` those hosts into the candidate list for the current
deployment plan:

```java
// before — unscoped: can return hosts from any zone/pod/cluster
clusterHosts.addAll(_hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(hostTagOnOffering));
```

As a result, a host in a different datacenter/pod/cluster than the one being deployed into —
but whose rule tag happens to match the offering's host tag — can be added as an allocation
candidate. Once storage-pool selection is scoped correctly but the host list isn't, the two
diverge and valid host+pool pairings that should have worked can be rejected, or (in the
FirstFitAllocator path) a host outside the deployment's scope can be picked entirely.

This reproduces most easily in a setup combining host tags and storage tags with more than
one pod/cluster/zone and a host tag configured as a rule.

## Fix

- Added a scoped overload on `HostDao`:
  `findHostsWithTagRuleThatMatchComputeOferringTags(String computeOfferingTags, Long clusterId, Long podId, Long dcId)`,
  implemented in `HostDaoImpl` by reusing the existing rule evaluation and filtering the
  matched hosts down to the given zone/pod/cluster.
- `FirstFitAllocator` (both `allocateTo` overloads) and `RandomAllocator` now call the scoped
  overload with the deployment plan's `dcId`/`podId`/`clusterId` instead of the unscoped one.
- On `main`, the rule-tag lookup lives in the shared `BaseAllocator#addHostsBasedOnTagRules`
  helper (used by both allocators); that helper and its two call sites were updated the same
  way.

```java
// after — scoped to the deployment plan
clusterHosts.addAll(
    _hostDao.findHostsWithTagRuleThatMatchComputeOferringTags(hostTagOnOffering, clusterId, podId, dcId)
);
```

The old unscoped overload is left in place since it's still the correct primitive for the
handful of call sites (e.g. `findClustersThatMatchHostTagRule`) that intentionally look
system-wide.

## Testing

Added/extended unit tests to assert the allocators call the scoped DAO overload (and never
fall back to the unscoped one) when resolving rule-tagged hosts:

- `FirstFitAllocatorTest` (new on 4.20/4.22; extended on main)
- `RandomAllocatorTest`
- `BaseAllocatorTest` (main only, covers the shared helper directly)
### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
