### PR TITLE
test: read and set nas.backup.incremental.enabled for the test zone

### DIFF
--- a/test/integration/smoke/test_backup_recovery_nas.py
+++ b/test/integration/smoke/test_backup_recovery_nas.py
@@ -56,7 +56,7 @@ class TestNASBackupAndRecovery(cloudstackTestCase):
         # Check backup configuration values, set them to enable the nas provider
         backup_enabled_cfg = Configurations.list(cls.api_client, name='backup.framework.enabled')
         backup_provider_cfg = Configurations.list(cls.api_client, name='backup.framework.provider.plugin')
-        incremental_backup_enabled_cfg = Configurations.list(cls.api_client, name='nas.backup.incremental.enabled')
+        incremental_backup_enabled_cfg = Configurations.list(cls.api_client, name='nas.backup.incremental.enabled', zoneid=cls.zone.id)
         cls.backup_enabled = backup_enabled_cfg[0].value
         cls.backup_provider = backup_provider_cfg[0].value
         cls.incremental_backup_enabled = incremental_backup_enabled_cfg[0].value
@@ -66,7 +66,7 @@ class TestNASBackupAndRecovery(cloudstackTestCase):
         if cls.backup_provider != "nas":
             Configurations.update(cls.api_client, 'backup.framework.provider.plugin', value='nas')
         if cls.incremental_backup_enabled == "false":
-            Configurations.update(cls.api_client, 'nas.backup.incremental.enabled', value='true')
+            Configurations.update(cls.api_client, 'nas.backup.incremental.enabled', value='true', zoneid=cls.zone.id)
 
         cls.account = Account.create(cls.api_client, cls.services["account"], domainid=cls.domain.id)
 
@@ -99,7 +99,7 @@ class TestNASBackupAndRecovery(cloudstackTestCase):
             if cls.backup_provider != "nas":
                 Configurations.update(cls.api_client, 'backup.framework.provider.plugin', value=cls.backup_provider)
             if cls.incremental_backup_enabled == "false":
-                Configurations.update(cls.api_client, 'nas.backup.incremental.enabled', value="false")
+                Configurations.update(cls.api_client, 'nas.backup.incremental.enabled', value="false", zoneid=cls.zone.id)
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
 


### PR DESCRIPTION
### Description

`nas.backup.incremental.enabled` is a zone-scoped setting, but `test_backup_recovery_nas.py` read and updated it without a `zoneid`, so a zone override in the test environment would make the suite read the wrong value (and restore the wrong one in `tearDownClass`). This passes `zoneid=cls.zone.id` on the read and on both updates, the same way `test_backup_recovery_veeam.py` handles zone-scoped settings.

Noted by the Copilot review on the 4.22 backport #13877; this is the main-side fix so both branches stay in sync.

### Types of changes

- [x] Test change only (no functional change)

### How Has This Been Tested?

Python syntax check; the change is limited to three Marvin calls in `setUpClass`/`tearDownClass`.