### PR TITLE
db: pin utf8mb4_general_ci as the default connection collation

### DIFF
--- a/framework/db/pom.xml
+++ b/framework/db/pom.xml
@@ -75,7 +75,17 @@
                 <configuration>
                     <excludes>
                         <exclude>com/cloud/utils/testcase/*TestCase*</exclude>
-                        <exclude>com/cloud/utils/db/*Test*</exclude>
+                        <!-- The test classes below are excluded because they require a live database. The remaining
+                             ones in com/cloud/utils/db are plain unit tests and must run in the build. -->
+                        <exclude>com/cloud/utils/db/DbTest*</exclude>
+                        <exclude>com/cloud/utils/db/ElementCollectionTest*</exclude>
+                        <exclude>com/cloud/utils/db/FilterTest*</exclude>
+                        <exclude>com/cloud/utils/db/GenericDaoBaseTest*</exclude>
+                        <exclude>com/cloud/utils/db/GlobalLockTest*</exclude>
+                        <exclude>com/cloud/utils/db/GroupByTest*</exclude>
+                        <exclude>com/cloud/utils/db/Merovingian2Test*</exclude>
+                        <exclude>com/cloud/utils/db/TestTransaction*</exclude>
+                        <exclude>com/cloud/utils/db/TransactionContextBuilderTest*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -87,9 +87,9 @@ public class TransactionLegacy implements Closeable {
     public static final short CONNECTED_DB = -1;
     public static final String CONNECTION_PARAMS = "scrollTolerantForwardOnly=true";
 
-    protected static final String CONNECTION_COLLATION_PARAM = "connectionCollation";
-    protected static final String CHARACTER_ENCODING_PARAM = "characterEncoding";
-    public static final String DEFAULT_CONNECTION_COLLATION = "utf8mb4_general_ci";
+    private static final String CONNECTION_COLLATION_PARAM = "connectionCollation";
+    private static final String CHARACTER_ENCODING_PARAM = "characterEncoding";
+    private static final String DEFAULT_CONNECTION_COLLATION = "utf8mb4_general_ci";
 
     private static AtomicLong s_id = new AtomicLong();
     private static final TransactionMBeanImpl s_mbean = new TransactionMBeanImpl();

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 
 import javax.sql.DataSource;
 
@@ -87,6 +88,13 @@ public class TransactionLegacy implements Closeable {
     public static final short CONNECTED_DB = -1;
     public static final String CONNECTION_PARAMS = "scrollTolerantForwardOnly=true";
 
+    /**
+     * Format of the pattern that matches a parameter of a connection URI: the name must be at the start of the URI
+     * parameters or right after a parameter separator, and must be followed by "=". Searching for the bare name would
+     * consider the parameter as configured when it is just part of a host, of a database name or of the value of
+     * another parameter.
+     */
+    private static final String URI_PARAM_PATTERN_FORMAT = "(?:^|[?&])%s=";
     private static final String CONNECTION_COLLATION_PARAM = "connectionCollation";
     private static final String CHARACTER_ENCODING_PARAM = "characterEncoding";
     private static final String DEFAULT_CONNECTION_COLLATION = "utf8mb4_general_ci";
@@ -1275,8 +1283,20 @@ public class TransactionLegacy implements Closeable {
      * @param connectionUri the connection URI configured by the operator.
      */
     protected static boolean shouldPinConnectionCollation(String connectionUri) {
-        return !StringUtils.containsIgnoreCase(connectionUri, CONNECTION_COLLATION_PARAM)
-                && !StringUtils.containsIgnoreCase(connectionUri, CHARACTER_ENCODING_PARAM);
+        return !containsUriParam(connectionUri, CONNECTION_COLLATION_PARAM)
+                && !containsUriParam(connectionUri, CHARACTER_ENCODING_PARAM);
+    }
+
+    /**
+     * Informs whether the given parameter is defined in the connection URI.
+     *
+     * @param connectionUri the connection URI configured by the operator; it also accepts only the parameters of a URI,
+     *                      as in {@code db.<schema>.url.params};
+     * @param param the name of the parameter to look for.
+     */
+    protected static boolean containsUriParam(String connectionUri, String param) {
+        Pattern pattern = Pattern.compile(String.format(URI_PARAM_PATTERN_FORMAT, Pattern.quote(param)), Pattern.CASE_INSENSITIVE);
+        return pattern.matcher(StringUtils.defaultString(connectionUri)).find();
     }
 
     /**

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -87,6 +87,10 @@ public class TransactionLegacy implements Closeable {
     public static final short CONNECTED_DB = -1;
     public static final String CONNECTION_PARAMS = "scrollTolerantForwardOnly=true";
 
+    protected static final String CONNECTION_COLLATION_PARAM = "connectionCollation";
+    protected static final String CHARACTER_ENCODING_PARAM = "characterEncoding";
+    public static final String DEFAULT_CONNECTION_COLLATION = "utf8mb4_general_ci";
+
     private static AtomicLong s_id = new AtomicLong();
     private static final TransactionMBeanImpl s_mbean = new TransactionMBeanImpl();
     static {
@@ -1196,6 +1200,9 @@ public class TransactionLegacy implements Closeable {
 
             connectionUri = propertyUri;
         }
+
+        connectionUri = addDefaultConnectionCollation(connectionUri, driver);
+
         LOGGER.info("Using the following URI to connect to {} database [{}].", schema, connectionUri);
         return new Pair<>(connectionUri, driver);
     }
@@ -1258,6 +1265,37 @@ public class TransactionLegacy implements Closeable {
         connectionUri.append(CONNECTION_PARAMS);
 
         return connectionUri.toString();
+    }
+
+    /**
+     * Informs whether {@link #DEFAULT_CONNECTION_COLLATION} should be added to a connection URI. It is only added for
+     * connections that do not already define the charset or the collation, either through {@code db.<schema>.url.params}
+     * or directly in {@code db.<schema>.uri}.
+     *
+     * @param connectionParams the parameters configured by the operator; either the value of
+     *                         {@code db.<schema>.url.params} or the whole {@code db.<schema>.uri}.
+     */
+    protected static boolean shouldPinConnectionCollation(String connectionParams) {
+        return !StringUtils.containsIgnoreCase(connectionParams, CONNECTION_COLLATION_PARAM)
+                && !StringUtils.containsIgnoreCase(connectionParams, CHARACTER_ENCODING_PARAM);
+    }
+
+    /**
+     * Adds {@link #DEFAULT_CONNECTION_COLLATION} to a connection URI provided either through
+     * {@code db.<schema>.url.params} or directly in {@code db.<schema>.uri}, keeping the URI untouched if the operator
+     * already defined the charset or the collation in it.
+     */
+    protected static String addDefaultConnectionCollation(String connectionUri, String driver) {
+        if (!shouldPinConnectionCollation(connectionUri)) {
+            return connectionUri;
+        }
+
+        String separator = "?";
+        if (StringUtils.contains(connectionUri, "?")) {
+            separator = StringUtils.endsWithAny(connectionUri, "?", "&") ? StringUtils.EMPTY : "&";
+        }
+
+        return String.format("%s%s%s=%s", connectionUri, separator, CONNECTION_COLLATION_PARAM, DEFAULT_CONNECTION_COLLATION);
     }
 
     /**

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -1201,7 +1201,7 @@ public class TransactionLegacy implements Closeable {
             connectionUri = propertyUri;
         }
 
-        connectionUri = addDefaultConnectionCollation(connectionUri, driver);
+        connectionUri = addDefaultConnectionCollation(connectionUri);
 
         LOGGER.info("Using the following URI to connect to {} database [{}].", schema, connectionUri);
         return new Pair<>(connectionUri, driver);
@@ -1272,20 +1272,19 @@ public class TransactionLegacy implements Closeable {
      * connections that do not already define the charset or the collation, either through {@code db.<schema>.url.params}
      * or directly in {@code db.<schema>.uri}.
      *
-     * @param connectionParams the parameters configured by the operator; either the value of
-     *                         {@code db.<schema>.url.params} or the whole {@code db.<schema>.uri}.
+     * @param connectionUri the connection URI configured by the operator.
      */
-    protected static boolean shouldPinConnectionCollation(String connectionParams) {
-        return !StringUtils.containsIgnoreCase(connectionParams, CONNECTION_COLLATION_PARAM)
-                && !StringUtils.containsIgnoreCase(connectionParams, CHARACTER_ENCODING_PARAM);
+    protected static boolean shouldPinConnectionCollation(String connectionUri) {
+        return !StringUtils.containsIgnoreCase(connectionUri, CONNECTION_COLLATION_PARAM)
+                && !StringUtils.containsIgnoreCase(connectionUri, CHARACTER_ENCODING_PARAM);
     }
 
     /**
-     * Adds {@link #DEFAULT_CONNECTION_COLLATION} to a connection URI provided either through
+     * Adds {@link #DEFAULT_CONNECTION_COLLATION} to a connection URI configured either through
      * {@code db.<schema>.url.params} or directly in {@code db.<schema>.uri}, keeping the URI untouched if the operator
      * already defined the charset or the collation in it.
      */
-    protected static String addDefaultConnectionCollation(String connectionUri, String driver) {
+    protected static String addDefaultConnectionCollation(String connectionUri) {
         if (!shouldPinConnectionCollation(connectionUri)) {
             return connectionUri;
         }

--- a/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
+++ b/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
@@ -213,28 +213,28 @@ public class TransactionLegacyTest {
 
     @Test
     public void addDefaultConnectionCollationTestUriWithoutParametersAddsTheQueryStringSeparator() {
-        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name", "jdbc:mysql");
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name");
 
         Assert.assertEquals("jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_general_ci", result);
     }
 
     @Test
     public void addDefaultConnectionCollationTestUriWithParametersAddsTheParameterSeparator() {
-        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?someParams", "jdbc:mysql");
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?someParams");
 
         Assert.assertEquals("jdbc:mysql://host:5555/name?someParams&connectionCollation=utf8mb4_general_ci", result);
     }
 
     @Test
     public void addDefaultConnectionCollationTestUriEndingWithQueryStringSeparatorDoesNotDuplicateIt() {
-        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?", "jdbc:mysql");
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?");
 
         Assert.assertEquals("jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_general_ci", result);
     }
 
     @Test
     public void addDefaultConnectionCollationTestUriEndingWithParameterSeparatorDoesNotDuplicateIt() {
-        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?someParams&", "jdbc:mysql");
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?someParams&");
 
         Assert.assertEquals("jdbc:mysql://host:5555/name?someParams&connectionCollation=utf8mb4_general_ci", result);
     }
@@ -243,13 +243,13 @@ public class TransactionLegacyTest {
     public void addDefaultConnectionCollationTestUriDefiningConnectionCollationKeepsItUntouched() {
         String uri = "jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_unicode_ci";
 
-        Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri, "jdbc:mysql"));
+        Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri));
     }
 
     @Test
     public void addDefaultConnectionCollationTestUriDefiningCharacterEncodingKeepsItUntouched() {
         String uri = "jdbc:mysql://host:5555/name?characterEncoding=UTF-8";
 
-        Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri, "jdbc:mysql"));
+        Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri));
     }
 }

--- a/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
+++ b/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
@@ -47,7 +47,8 @@ public class TransactionLegacyTest {
 
         Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
 
-        Assert.assertEquals("driver://host:5555/name?autoReconnect=false&someParams", result.first());
+        Assert.assertEquals("driver://host:5555/name?autoReconnect=false&someParams&scrollTolerantForwardOnly=true"
+                + "&connectionCollation=utf8mb4_general_ci", result.first());
         Assert.assertEquals("driver", result.second());
     }
 
@@ -57,7 +58,7 @@ public class TransactionLegacyTest {
 
         Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
 
-        Assert.assertEquals("jdbc:driver:myFavoriteUri", result.first());
+        Assert.assertEquals("jdbc:driver:myFavoriteUri?connectionCollation=utf8mb4_general_ci", result.first());
         Assert.assertEquals("jdbc:driver", result.second());
     }
 
@@ -65,7 +66,7 @@ public class TransactionLegacyTest {
     public void getPropertiesAndBuildConnectionUriTestDbHaDisabled() {
         String result = TransactionLegacy.getPropertiesAndBuildConnectionUri(properties, "strat", "driver", true, "cloud");
 
-        Assert.assertEquals("driver://host:5555/name?autoReconnect=false&someParams&useSSL=true", result);
+        Assert.assertEquals("driver://host:5555/name?autoReconnect=false&someParams&useSSL=true&scrollTolerantForwardOnly=true", result);
     }
 
     @Test
@@ -82,14 +83,14 @@ public class TransactionLegacyTest {
         String result = TransactionLegacy.getPropertiesAndBuildConnectionUri(properties, "strat", "driver", true, "cloud");
 
         Assert.assertEquals("driver://host,second_host:5555/name?autoReconnect=false&someParams&useSSL=true&failOverReadOnly=true&reconnectAtTxEnd=false&autoReconnectFor"
-                + "Pools=true&secondsBeforeRetrySource=25&queriesBeforeRetrySource=105&initialTimeout=1000&loadBalanceStrategy=strat", result);
+                + "Pools=true&secondsBeforeRetrySource=25&queriesBeforeRetrySource=105&initialTimeout=1000&loadBalanceStrategy=strat&scrollTolerantForwardOnly=true", result);
     }
 
     @Test
     public void buildConnectionUriTestDbHaDisabled() {
         String result = TransactionLegacy.buildConnectionUri(null, "driver", false, "host", null, 5555, "cloud", false, null, null);
 
-        Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false", result);
+        Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false&scrollTolerantForwardOnly=true", result);
     }
 
     @Test
@@ -98,20 +99,157 @@ public class TransactionLegacyTest {
 
         String result = TransactionLegacy.buildConnectionUri("strat", "driver", false, "host", "second_host", 5555, "cloud", false, null, "dbHaParams");
 
-        Assert.assertEquals("driver://host,second_host:5555/cloud?autoReconnect=false&dbHaParams&loadBalanceStrategy=strat", result);
+        Assert.assertEquals("driver://host,second_host:5555/cloud?autoReconnect=false&dbHaParams&loadBalanceStrategy=strat&scrollTolerantForwardOnly=true", result);
     }
 
     @Test
     public void buildConnectionUriTestUrlParamsNotNull() {
         String result = TransactionLegacy.buildConnectionUri(null, "driver", false, "host", null, 5555, "cloud", false, "urlParams", null);
 
-        Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false&urlParams", result);
+        Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false&urlParams&scrollTolerantForwardOnly=true", result);
     }
 
     @Test
     public void buildConnectionUriTestUseSslTrue() {
         String result = TransactionLegacy.buildConnectionUri(null, "driver", true, "host", null, 5555, "cloud", false, null, null);
 
-        Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false&useSSL=true", result);
+        Assert.assertEquals("driver://host:5555/cloud?autoReconnect=false&useSSL=true&scrollTolerantForwardOnly=true", result);
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithoutUriAndUrlParamsDefiningConnectionCollationDoesNotPinTheDefaultOne() {
+        properties.setProperty("db.cloud.uri", "");
+        properties.setProperty("db.cloud.driver", "driver");
+        properties.setProperty("db.cloud.url.params", "connectionCollation=utf8mb4_unicode_ci");
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals("driver://host:5555/name?autoReconnect=false&connectionCollation=utf8mb4_unicode_ci"
+                + "&scrollTolerantForwardOnly=true", result.first());
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithoutUriAndUrlParamsDefiningCharacterEncodingDoesNotPinTheDefaultCollation() {
+        properties.setProperty("db.cloud.uri", "");
+        properties.setProperty("db.cloud.driver", "driver");
+        properties.setProperty("db.cloud.url.params", "characterEncoding=UTF-8");
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals("driver://host:5555/name?autoReconnect=false&characterEncoding=UTF-8&scrollTolerantForwardOnly=true",
+                result.first());
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithUriWithoutParametersPinsTheDefaultCollation() {
+        properties.setProperty("db.cloud.uri", "jdbc:mysql://host:5555/name");
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_general_ci", result.first());
+        Assert.assertEquals("jdbc:mysql", result.second());
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithUriWithParametersPinsTheDefaultCollation() {
+        properties.setProperty("db.cloud.uri", "jdbc:mysql://host:5555/name?autoReconnect=false&someParams");
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/name?autoReconnect=false&someParams&connectionCollation=utf8mb4_general_ci",
+                result.first());
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithUriDefiningConnectionCollationKeepsItUntouched() {
+        String uri = "jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_unicode_ci";
+        properties.setProperty("db.cloud.uri", uri);
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals(uri, result.first());
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithUriDefiningCharacterEncodingKeepsItUntouched() {
+        String uri = "jdbc:mysql://host:5555/name?characterEncoding=UTF-8";
+        properties.setProperty("db.cloud.uri", uri);
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals(uri, result.first());
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestNullConnectionParamsReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation(null));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestEmptyConnectionParamsReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation(""));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestConnectionParamsWithoutCollationAndEncodingReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("cachePrepStmts=true&serverTimezone=UTC"));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestConnectionParamsWithConnectionCollationReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.shouldPinConnectionCollation("cachePrepStmts=true&connectionCollation=utf8mb4_unicode_ci"));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestConnectionParamsWithCharacterEncodingReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.shouldPinConnectionCollation("cachePrepStmts=true&characterEncoding=UTF-8"));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestIsCaseInsensitive() {
+        Assert.assertFalse(TransactionLegacy.shouldPinConnectionCollation("CONNECTIONCOLLATION=utf8mb4_unicode_ci"));
+        Assert.assertFalse(TransactionLegacy.shouldPinConnectionCollation("characterencoding=UTF-8"));
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriWithoutParametersAddsTheQueryStringSeparator() {
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name", "jdbc:mysql");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_general_ci", result);
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriWithParametersAddsTheParameterSeparator() {
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?someParams", "jdbc:mysql");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/name?someParams&connectionCollation=utf8mb4_general_ci", result);
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriEndingWithQueryStringSeparatorDoesNotDuplicateIt() {
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?", "jdbc:mysql");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_general_ci", result);
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriEndingWithParameterSeparatorDoesNotDuplicateIt() {
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/name?someParams&", "jdbc:mysql");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/name?someParams&connectionCollation=utf8mb4_general_ci", result);
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriDefiningConnectionCollationKeepsItUntouched() {
+        String uri = "jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_unicode_ci";
+
+        Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri, "jdbc:mysql"));
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriDefiningCharacterEncodingKeepsItUntouched() {
+        String uri = "jdbc:mysql://host:5555/name?characterEncoding=UTF-8";
+
+        Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri, "jdbc:mysql"));
     }
 }

--- a/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
+++ b/framework/db/src/test/java/com/cloud/utils/db/TransactionLegacyTest.java
@@ -252,4 +252,104 @@ public class TransactionLegacyTest {
 
         Assert.assertEquals(uri, TransactionLegacy.addDefaultConnectionCollation(uri));
     }
+
+    @Test
+    public void shouldPinConnectionCollationTestUriWithHostContainingTheParameterNamesReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://characterEncoding:5555/name"));
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://connectionCollation.example.com:5555/name?someParams"));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestUriWithDatabaseNameContainingTheParameterNamesReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://host:5555/connectionCollation"));
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://host:5555/characterEncoding?someParams"));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestParameterValueContainingTheParameterNamesReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://host:5555/name?user=connectionCollation"));
+        Assert.assertTrue(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://host:5555/name?user=characterEncoding&someParams"));
+    }
+
+    @Test
+    public void shouldPinConnectionCollationTestUriDefiningTheParametersAsTheFirstOneReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://host:5555/name?connectionCollation=utf8mb4_unicode_ci"));
+        Assert.assertFalse(TransactionLegacy.shouldPinConnectionCollation("jdbc:mysql://host:5555/name?characterEncoding=UTF-8&someParams"));
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriWithHostContainingTheParameterNamesAddsTheDefaultCollation() {
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://characterEncoding.example.com:5555/name");
+
+        Assert.assertEquals("jdbc:mysql://characterEncoding.example.com:5555/name?connectionCollation=utf8mb4_general_ci", result);
+    }
+
+    @Test
+    public void addDefaultConnectionCollationTestUriWithDatabaseNameContainingTheParameterNamesAddsTheDefaultCollation() {
+        String result = TransactionLegacy.addDefaultConnectionCollation("jdbc:mysql://host:5555/connectionCollation?someParams");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/connectionCollation?someParams&connectionCollation=utf8mb4_general_ci", result);
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithUriWhoseDatabaseNameContainsTheParameterNamePinsTheDefaultCollation() {
+        properties.setProperty("db.cloud.uri", "jdbc:mysql://host:5555/characterEncoding");
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals("jdbc:mysql://host:5555/characterEncoding?connectionCollation=utf8mb4_general_ci", result.first());
+    }
+
+    @Test
+    public void getConnectionUriAndDriverTestWithoutUriAndDatabaseNameContainingTheParameterNamePinsTheDefaultCollation() {
+        properties.setProperty("db.cloud.uri", "");
+        properties.setProperty("db.cloud.driver", "driver");
+        properties.setProperty("db.cloud.name", "connectionCollation");
+
+        Pair<String, String> result = TransactionLegacy.getConnectionUriAndDriver(properties, null, false, "cloud");
+
+        Assert.assertEquals("driver://host:5555/connectionCollation?autoReconnect=false&someParams&scrollTolerantForwardOnly=true"
+                + "&connectionCollation=utf8mb4_general_ci", result.first());
+    }
+
+    @Test
+    public void containsUriParamTestParamDefinedAsTheFirstOneReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.containsUriParam("jdbc:mysql://host:5555/name?serverTimezone=UTC", "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestParamDefinedAfterOtherParamsReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.containsUriParam("jdbc:mysql://host:5555/name?someParams&serverTimezone=UTC", "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestOnlyTheUriParamsReturnsTrue() {
+        Assert.assertTrue(TransactionLegacy.containsUriParam("serverTimezone=UTC&someParams", "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestParamIsPartOfTheHostOrOfTheDatabaseNameReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.containsUriParam("jdbc:mysql://serverTimezone:5555/name", "serverTimezone"));
+        Assert.assertFalse(TransactionLegacy.containsUriParam("jdbc:mysql://host:5555/serverTimezone?someParams", "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestParamIsTheValueOfAnotherParamReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.containsUriParam("jdbc:mysql://host:5555/name?user=serverTimezone", "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestParamIsNotDefinedReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.containsUriParam("jdbc:mysql://host:5555/name?someParams", "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestNullConnectionUriReturnsFalse() {
+        Assert.assertFalse(TransactionLegacy.containsUriParam(null, "serverTimezone"));
+    }
+
+    @Test
+    public void containsUriParamTestIsCaseInsensitive() {
+        Assert.assertTrue(TransactionLegacy.containsUriParam("jdbc:mysql://host:5555/name?SERVERTIMEZONE=UTC", "serverTimezone"));
+    }
 }


### PR DESCRIPTION
### Description

This change is related to Ubuntu 26.04 support.

The latest version of MariaDB for Ubuntu 26.04 is `11.8`; on version `11.6`, the default collation for the UTF-8 character set was changed from `utf8mb4_general_ci` to `utf8mb4_0900_ai_ci`. This results in some queries throwing exceptions due to the collation mix. For instance, the call to `listTemplates` by the instance deployment wizard throws the exception below.

```sh
2026-08-24 23:20:26,478 ERROR [c.c.a.q.d.TemplateJoinDaoImpl] (qtp888557915-28:[ctx-e2e22867, ctx-64ef36f1]) (logid:56439487) DB Exception on: HikariProxyPreparedStatement@1786128789 wrapping com.mysql.cj.jdbc.ServerPreparedStatement[186]: SELECT template_view.uuid, template_view.unique_name, template_view.name, template_view.format, template_view.public, template_view.featured, template_view.type, template_view.url, template_view.hvm, template_view.arch, template_view.bits, template_view.created, template_view.created_on_store, template_view.removed, template_view.checksum, template_view.display_text, template_view.enable_password, template_view.dynamically_scalable, template_view.guest_os_id, template_view.guest_os_uuid, template_view.guest_os_name, template_view.guest_os_category_id, template_view.bootable, template_view.prepopulate, template_view.cross_zones, template_view.hypervisor_type, template_view.extractable, template_view.source_template_id, template_view.source_template_uuid, template_view.template_tag, template_view.sort_key, template_view.enable_sshkey, template_view.account_id, template_view.account_uuid, template_view.account_name, template_view.account_type, template_view.domain_id, template_view.domain_uuid, template_view.domain_name, template_view.domain_path, template_view.project_id, template_view.project_uuid, template_view.project_name, template_view.data_center_id, template_view.data_center_uuid, template_view.data_center_name, template_view.store_scope, template_view.store_id, template_view.download_state, template_view.download_pct, template_view.error_str, template_view.size, template_view.physical_size, template_view.template_state, template_view.destroyed, template_view.lp_account_id, template_view.parent_template_id, template_view.parent_template_uuid, template_view.detail_name, template_view.detail_value, template_view.state, template_view.temp_zone_pair, template_view.direct_download, template_view.deploy_as_is, template_view.for_cks, template_view.user_data_id, template_view.user_data_uuid, template_view.user_data_name, template_view.user_data_policy, template_view.user_data_params, template_view.extension_id, template_view.extension_uuid, template_view.extension_name, template_view.id, template_view.tag_id, template_view.tag_uuid, template_view.tag_key, template_view.tag_value, template_view.tag_domain_id, template_view.tag_account_id, template_view.tag_resource_id, template_view.tag_resource_uuid, template_view.tag_resource_type, template_view.tag_customer, template_view.tag_account_name, template_view.tag_domain_uuid, template_view.tag_domain_name FROM template_view WHERE template_view.template_state IN ('Active','UploadAbandoned','UploadError','NotUploaded','UploadInProgress')  AND template_view.temp_zone_pair=x'3230345f31' ORDER BY template_view.sort_key ASC , template_view.temp_zone_pair ASC java.sql.SQLException: Illegal mix of collations (utf8mb4_general_ci,COERCIBLE) and (utf8mb4_0900_ai_ci,COERCIBLE) for operation '='
```

This PR pins `TransactionLegacy` to use `utf8mb4_general_ci` by default, unless specified in `db.<schema>.url.params` or `db.<schema>.uri`.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [X] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Some tests are still pending; so far, I've:

- Upgraded an all-in-one VM containing both the Management Server and the database from Ubuntu 24.04 to 26.04, and then installed the 4.23 packages.
  - Before the changes, I would get an exception in some queries.
  - After the changes, I did not get the exception anymore.

I will also test a fresh deployment without/with these changes.