### PR TITLE
fix: SSVM entity download URL creation: ensure userdata base dir exists and is writable by www-data

### DIFF
--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadManagerImpl.java
@@ -276,13 +276,24 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         // Create the directory structure so that its visible under apache server root
         String extractDir = BASE_EXTRACT_PATH;
         extractDir = extractDir + cmd.getFilepathInExtractURL() + File.separator;
+        // Ensure the base extract directory exists and is owned by www-data so that
+        // the www-data user can create the per-entity subdirectory inside it.
+        Script baseDirCommand = new Script("/bin/bash", logger);
+        baseDirCommand.add("-c");
+        baseDirCommand.add("mkdir -p " + BASE_EXTRACT_PATH + " && chown www-data:www-data " + BASE_EXTRACT_PATH);
+        String result = baseDirCommand.execute();
+        if (result != null) {
+            String errorString = "Error in creating base extract directory =" + result;
+            logger.error(errorString);
+            return new CreateEntityDownloadURLAnswer(errorString, CreateEntityDownloadURLAnswer.RESULT_FAILURE);
+        }
         Script command = new Script("/bin/su", logger);
         command.add("-s");
         command.add("/bin/bash");
         command.add("-c");
         command.add("mkdir -p " + extractDir);
         command.add("www-data");
-        String result = command.execute();
+        result = command.execute();
         if (result != null) {
             String errorString = "Error in creating directory =" + result;
             logger.error(errorString);


### PR DESCRIPTION
### Problem

When `handleCreateEntityURLCommand` runs on the SSVM (Secondary Storage VM) to build a download URL for e.g. `getDiagnosticsData`, it creates `/var/www/html/userdata/<uuid>/` as the `www-data` user via `su www-data -c "mkdir -p ..."`. On stock systemvm templates (`systemvm-kvm-4.22.0`) the `/var/www/html/userdata` base directory does not exist, and `/var/www/html` is not writable by `www-data`, so the `mkdir` fails with:

```
Unable to create a link for entity at diagnostics//diagnostics_files_<timestamp>.zip on ssvm,
Error in creating directory =mkdir: cannot create directory '/var/www/html/userdata/<uuid>/': Permission denied
```

This affects `getDiagnosticsData`, `extractVolume`, `extractTemplate` and any other operation that calls `CreateEntityDownloadURLCommand`.

### Fix

Create the base extract directory (`/var/www/html/userdata/`) and set its ownership to `www-data:www-data` before the privilege-dropped `su www-data` call that creates the per-entity subdirectory. This self-heals the SSVM on first use -- the directory is created by the root process that owns the service, then handed over to `www-data` for the downstream Apache docroot operations.

### Changes

**`UploadManagerImpl.java`** -- `handleCreateEntityURLCommand`: add `mkdir -p BASE_EXTRACT_PATH && chown www-data:www-data BASE_EXTRACT_PATH` before the existing `su www-data` subdirectory creation.

+12 / -1 lines.

Closes #13959