### PR TITLE
fix: include VXLAN persistent networks in cleanup resource dispatch

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1603,8 +1603,9 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     }
 
     private boolean networkMeetsPersistenceCriteria(NetworkVO network, NetworkOfferingVO offering, boolean cleanup) {
+        BroadcastDomainType broadcastDomainType = network.getBroadcastUri() != null ? BroadcastDomainType.getSchemeValue(network.getBroadcastUri()) : null;
         boolean criteriaMet = offering.isPersistent() &&
-                (network.getBroadcastUri() != null && BroadcastDomainType.getSchemeValue(network.getBroadcastUri()) == BroadcastDomainType.Vlan);
+                (broadcastDomainType == BroadcastDomainType.Vlan || broadcastDomainType == BroadcastDomainType.Vxlan);
         if (!cleanup) {
             return criteriaMet && network.getGuestType() == GuestType.L2;
         } else {


### PR DESCRIPTION
### Description
Fixes #13966

`cleanupPersistentnNetworkResources()` only sent `CleanupPersistentNetworkResourceCommand` for networks whose broadcast URI scheme was `vlan`. For `vxlan://` persistent networks the cleanup command was never dispatched, so bridges and VXLAN interfaces were left behind on every host that never ran a VM on the network.

`setupPersistentNetwork()` in `DefaultHostListener` creates resources for **all** persistent networks from `getAllPersistentNetworksFromZone()` with no isolation-method filter, so the removal path must accept both `Vlan` and `Vxlan` schemes to stay symmetric.

### Changes
- `engine/orchestration/.../NetworkOrchestrator.java`: `networkMeetsPersistenceCriteria()` now accepts both `BroadcastDomainType.Vlan` and `BroadcastDomainType.Vxlan` broadcast URI schemes (extracted to a local `broadcastDomainType` variable for null-safety and readability).

### Testing
- Code-level change only; the condition now matches the persistence criteria used at creation time for VXLAN networks. Verified the broadcast scheme enum values (`Vlan("vlan", Integer.class)`, `Vxlan("vxlan", Long.class)` in `Networks.java`).