### PR TITLE
Ensure compliance with storage access groups when mounting disabled storage pools

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
+++ b/engine/components-api/src/main/java/com/cloud/storage/StorageManager.java
@@ -432,4 +432,8 @@ public interface StorageManager extends StorageService {
     String[] getStorageAccessGroups(Long zoneId, Long podId, Long clusterId, Long hostId);
 
     CapacityVO getObjectStorageUsedStats(Long zoneId);
+
+    static ConfigKey<Boolean> getMountDisabledStoragePool() {
+        return MountDisabledStoragePool;
+    }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
@@ -91,6 +91,22 @@ public interface PrimaryDataStoreDao extends GenericDao<StoragePoolVO, Long> {
     List<StoragePoolVO> findDisabledPoolsByScope(long dcId, Long podId, Long clusterId, ScopeType scope);
 
     /**
+     * Finds disabled storage pools within the specified scope that are associated with the given storage access groups.
+     * This method is used to locate storage pools with 'Disabled' status that match specific storage access group
+     * filters.
+     *
+     * @param dcId the data center ID.
+     * @param podId the pod ID.
+     * @param clusterId the cluster ID.
+     * @param scope ZONE, CLUSTER OR HOST type scope
+     * @param storageAccessGroups array of storage access group names to match against.
+     *                           Only pools associated with these access groups will be returned.
+     *                           If null or empty, returns an empty list.
+     * @return a list of {@link StoragePoolVO} objects.
+     */
+    List<StoragePoolVO> findDisabledPoolsByScopeAndAccessGroups(long dcId, Long podId, Long clusterId, ScopeType scope, String[] storageAccessGroups);
+
+    /**
      * Find pool by UUID.
      *
      * @param uuid
@@ -167,7 +183,19 @@ public interface PrimaryDataStoreDao extends GenericDao<StoragePoolVO, Long> {
 
     List<StoragePoolVO> listByIds(List<Long> ids);
 
-    List<StoragePoolVO> findStoragePoolsByEmptyStorageAccessGroups(Long dcId, Long podId, Long clusterId, ScopeType scope, HypervisorType hypervisorType);
+    /**
+     * Finds storage pools that have no storage access groups associated with them within the specified criteria.
+     * This method identifies storage pools without access group restrictions.
+     *
+     * @param dcId the data center ID. Can be null to include all data centers.
+     * @param podId the pod ID. Can be null to include all pods.
+     * @param clusterId the cluster ID. Can be null to include all clusters.
+     * @param scope ZONE, CLUSTER or HOST type scope
+     * @param hypervisorType the hypervisor type filter. Can be null to include all hypervisor types.
+     * @param status the storage pool status to filter by.
+     * @return a list of {@link StoragePoolVO} objects that have no storage access groups associated.
+     */
+    List<StoragePoolVO> findStoragePoolsByEmptyStorageAccessGroups(Long dcId, Long podId, Long clusterId, ScopeType scope, HypervisorType hypervisorType, StoragePoolStatus status);
 
     List<StoragePoolVO> findPoolsByStorageTypeAndZone(Storage.StoragePoolType storageType, Long zoneId);
 

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
@@ -54,6 +54,7 @@ import com.cloud.utils.db.SearchCriteria.Func;
 import com.cloud.utils.db.SearchCriteria.Op;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.exception.CloudRuntimeException;
+import org.apache.commons.lang3.ArrayUtils;
 
 @DB()
 public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long> implements PrimaryDataStoreDao {
@@ -85,6 +86,37 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
     private final String ZoneWideStorageAccessGroupsForHostConnectionSqlSuffix = ") GROUP BY storage_pool_and_access_group_map.pool_id";
     private final String ZoneWideStorageAccessGroupsWithHypervisorTypeSqlPrefix = "SELECT storage_pool.* from storage_pool LEFT JOIN storage_pool_and_access_group_map ON storage_pool.id = storage_pool_and_access_group_map.pool_id WHERE storage_pool.removed is null and storage_pool.status = 'Up' and storage_pool.hypervisor = ? and storage_pool.data_center_id = ? and storage_pool.scope = ? and (";
     private final String ZoneWideStorageAccessGroupsWithHypervisorTypeSqlSuffix = ") GROUP BY storage_pool_and_access_group_map.pool_id";
+
+    /**
+     * SQL query prefix to find zone-wide disabled storage pools that are associated with specific storage access groups.
+     */
+    private final String ZoneWideDisabledStorageAccessGroupsSqlPrefix =
+            "SELECT storage_pool.* FROM storage_pool " +
+                    "LEFT JOIN storage_pool_and_access_group_map ON storage_pool.id = storage_pool_and_access_group_map.pool_id " +
+                    "WHERE storage_pool.removed IS NULL " +
+                    "  AND storage_pool.status = 'Disabled' " +
+                    "  AND storage_pool.data_center_id = ? " +
+                    "  AND storage_pool.scope = ? " +
+                    "  AND (";
+
+    /**
+     * SQL query prefix to find disabled storage pools with specific storage access groups. The query is used at the HOST scope.
+     */
+    private final String DisabledStorageAccessGroupsForHostConnectionSqlPrefix =
+            "SELECT storage_pool.* FROM storage_pool " +
+                    "LEFT JOIN storage_pool_and_access_group_map ON storage_pool.id = storage_pool_and_access_group_map.pool_id " +
+                    "WHERE storage_pool.removed IS NULL " +
+                    "  AND storage_pool.status = 'Disabled' " +
+                    "  AND storage_pool.data_center_id = ? " +
+                    "  AND (storage_pool.pod_id = ? OR storage_pool.pod_id IS NULL) " +
+                    "  AND storage_pool.scope = ? " +
+                    "  AND (";
+
+    /**
+     * SQL query suffix for disabled storage access groups queries. This suffix completes the query by grouping
+     * results by pool_id.
+     */
+    private final String DisabledStorageAccessGroupsSqlSuffix = ") GROUP BY storage_pool_and_access_group_map.pool_id";
 
     // Storage tags are now separate from storage_pool_details, leaving only details on that table
     protected final String TagsSqlPrefix = "SELECT storage_pool.* from storage_pool LEFT JOIN storage_pool_tags ON storage_pool.id = storage_pool_tags.pool_id WHERE storage_pool.removed is null and storage_pool.status = 'Up' AND storage_pool_tags.is_tag_a_rule = 0 and storage_pool.data_center_id = ? and (storage_pool.pod_id = ? or storage_pool.pod_id is null) and storage_pool.scope = ? and (";
@@ -569,6 +601,26 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
     }
 
     @Override
+    public List<StoragePoolVO> findDisabledPoolsByScopeAndAccessGroups(long dcId, Long podId, Long clusterId, ScopeType scope, String[] storageAccessGroups) {
+        if (ArrayUtils.isEmpty(storageAccessGroups)) {
+            return List.of();
+        }
+
+        List<StoragePoolVO> storagePools = null;
+        String sqlValues = getSqlValuesFromStorageAccessGroups(storageAccessGroups);
+
+        if (scope == ScopeType.ZONE) {
+            String sql = getSqlPreparedStatement(ZoneWideDisabledStorageAccessGroupsSqlPrefix, DisabledStorageAccessGroupsSqlSuffix, sqlValues, null);
+            storagePools = searchStoragePoolsPreparedStatement(sql, dcId, null, null, scope, null);
+        } else if ((scope == ScopeType.CLUSTER || scope == ScopeType.HOST) && podId != null && clusterId != null) {
+            String sql = getSqlPreparedStatement(DisabledStorageAccessGroupsForHostConnectionSqlPrefix, DisabledStorageAccessGroupsSqlSuffix, sqlValues, clusterId);
+            storagePools = searchStoragePoolsPreparedStatement(sql, dcId, podId, clusterId, scope, null);
+        }
+
+        return storagePools;
+    }
+
+    @Override
     public List<StoragePoolVO> findLocalStoragePoolsByTags(long dcId, long podId, Long clusterId, String[] tags, boolean validateTagRule) {
         return findLocalStoragePoolsByTags(dcId, podId, clusterId, tags, validateTagRule, null);
     }
@@ -691,7 +743,7 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
     }
 
     @Override
-    public List<StoragePoolVO> findStoragePoolsByEmptyStorageAccessGroups(Long dcId, Long podId, Long clusterId, ScopeType scope, HypervisorType hypervisorType) {
+    public List<StoragePoolVO> findStoragePoolsByEmptyStorageAccessGroups(Long dcId, Long podId, Long clusterId, ScopeType scope, HypervisorType hypervisorType, StoragePoolStatus status) {
         SearchBuilder<StoragePoolVO> poolSearch = createSearchBuilder();
         SearchBuilder<StoragePoolAndAccessGroupMapVO> storageAccessGroupsPoolSearch = _storagePoolAccessGroupMapDao.createSearchBuilder();
         // Set criteria for pools
@@ -709,7 +761,6 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
 
         SearchCriteria<StoragePoolVO> sc = poolSearch.create();
         sc.setParameters("scope", scope.toString());
-        sc.setParameters("status", Status.Up.toString());
 
         if (dcId != null) {
             sc.setParameters("datacenterid", dcId);
@@ -725,6 +776,10 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
 
         if (hypervisorType != null) {
             sc.setParameters("hypervisortype", hypervisorType);
+        }
+
+        if (status != null) {
+            sc.setParameters("status", status.toString());
         }
 
         return listBy(sc);

--- a/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -2744,8 +2744,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         allPoolsByTags.addAll(_storagePoolDao.findPoolsByAccessGroupsForHostConnection(dcId, podId, clusterId, ScopeType.CLUSTER, storageAccessGroups));
         allPoolsByTags.addAll(_storagePoolDao.findZoneWideStoragePoolsByAccessGroupsForHostConnection(dcId, storageAccessGroups));
         if (includeEmptyTags) {
-            allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, podId, clusterId, ScopeType.CLUSTER, null));
-            allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, null, null, ScopeType.ZONE, null));
+            allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, podId, clusterId, ScopeType.CLUSTER, null, StoragePoolStatus.Up));
+            allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, null, null, ScopeType.ZONE, null, StoragePoolStatus.Up));
         }
 
         return allPoolsByTags;
@@ -2753,8 +2753,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
     private List<StoragePoolVO> getStoragePoolsByEmptyStorageAccessGroups(Long dcId, Long podId, Long clusterId) {
         List<StoragePoolVO> allPoolsByTags = new ArrayList<>();
-        allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, podId, clusterId, ScopeType.CLUSTER, null));
-        allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, null, null, ScopeType.ZONE, null));
+        allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, podId, clusterId, ScopeType.CLUSTER, null, StoragePoolStatus.Up));
+        allPoolsByTags.addAll(_storagePoolDao.findStoragePoolsByEmptyStorageAccessGroups(dcId, null, null, ScopeType.ZONE, null, StoragePoolStatus.Up));
 
         return allPoolsByTags;
     }

--- a/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
+++ b/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
@@ -25,6 +25,7 @@ import com.cloud.dc.dao.ClusterDao;
 import com.cloud.dc.dao.HostPodDao;
 import com.cloud.exception.StorageConflictException;
 import com.cloud.storage.StorageManager;
+import com.cloud.storage.StoragePoolStatus;
 import com.cloud.storage.dao.StoragePoolHostDao;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.Profiler;
@@ -123,21 +124,21 @@ public class StoragePoolMonitor implements Listener {
             List<StoragePoolVO> pools = new ArrayList<>();
             // SAG -> Storage Access Group
             if (ArrayUtils.isEmpty(sags)) {
-                List<StoragePoolVO> clusterStoragePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, null);
-                List<StoragePoolVO> storagePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, null);
-                List<StoragePoolVO> zoneStoragePoolsByHypervisor = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, scCmd.getHypervisorType());
+                List<StoragePoolVO> clusterStoragePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, null, StoragePoolStatus.Up);
+                List<StoragePoolVO> storagePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, null, StoragePoolStatus.Up);
+                List<StoragePoolVO> zoneStoragePoolsByHypervisor = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, scCmd.getHypervisorType(), StoragePoolStatus.Up);
                 storagePoolsByEmptySAGs.retainAll(zoneStoragePoolsByHypervisor);
                 pools.addAll(storagePoolsByEmptySAGs);
                 pools.addAll(clusterStoragePoolsByEmptySAGs);
-                List<StoragePoolVO> zoneStoragePoolsByAnyHypervisor = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, HypervisorType.Any);
+                List<StoragePoolVO> zoneStoragePoolsByAnyHypervisor = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, HypervisorType.Any, StoragePoolStatus.Up);
                 pools.addAll(zoneStoragePoolsByAnyHypervisor);
             } else {
                 List<StoragePoolVO> storagePoolsBySAGs = new ArrayList<>();
                 List<StoragePoolVO> clusterStoragePoolsBySAGs = _poolDao.findPoolsByAccessGroupsForHostConnection(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, sags);
-                List<StoragePoolVO> clusterStoragePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, null);
+                List<StoragePoolVO> clusterStoragePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, null, StoragePoolStatus.Up);
                 List<StoragePoolVO> zoneStoragePoolsBySAGs = _poolDao.findZoneWideStoragePoolsByAccessGroupsAndHypervisorTypeForHostConnection(host.getDataCenterId(), sags, scCmd.getHypervisorType());
                 List<StoragePoolVO> zoneStoragePoolsByHypervisorTypeAny = _poolDao.findZoneWideStoragePoolsByAccessGroupsAndHypervisorTypeForHostConnection(host.getDataCenterId(), sags, HypervisorType.Any);
-                List<StoragePoolVO> zoneStoragePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, null);
+                List<StoragePoolVO> zoneStoragePoolsByEmptySAGs = _poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, null, StoragePoolStatus.Up);
 
                 storagePoolsBySAGs.addAll(zoneStoragePoolsBySAGs);
                 storagePoolsBySAGs.addAll(zoneStoragePoolsByEmptySAGs);
@@ -148,13 +149,15 @@ public class StoragePoolMonitor implements Listener {
             }
 
             // get the zone wide disabled pools list if global setting is true.
-            if (StorageManager.MountDisabledStoragePool.value()) {
-                pools.addAll(_poolDao.findDisabledPoolsByScope(host.getDataCenterId(), null, null, ScopeType.ZONE));
+            if (StorageManager.getMountDisabledStoragePool().value()) {
+                pools.addAll(_poolDao.findDisabledPoolsByScopeAndAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, sags));
+                pools.addAll(_poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), null, null, ScopeType.ZONE, null, StoragePoolStatus.Disabled));
             }
 
             // get the cluster wide disabled pool list
-            if (StorageManager.MountDisabledStoragePool.valueIn(host.getClusterId())) {
-                pools.addAll(_poolDao.findDisabledPoolsByScope(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER));
+            if (StorageManager.getMountDisabledStoragePool().valueIn(host.getClusterId())) {
+                pools.addAll(_poolDao.findDisabledPoolsByScopeAndAccessGroups(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, sags));
+                pools.addAll(_poolDao.findStoragePoolsByEmptyStorageAccessGroups(host.getDataCenterId(), host.getPodId(), host.getClusterId(), ScopeType.CLUSTER, null, StoragePoolStatus.Disabled));
             }
 
             List<StoragePoolHostVO> previouslyConnectedPools = new ArrayList<>();

--- a/server/src/test/java/com/cloud/storage/listener/StoragePoolMonitorTest.java
+++ b/server/src/test/java/com/cloud/storage/listener/StoragePoolMonitorTest.java
@@ -22,17 +22,27 @@ import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.storage.ScopeType;
 import com.cloud.storage.Storage;
+import com.cloud.storage.StorageManager;
 import com.cloud.storage.StorageManagerImpl;
 import com.cloud.storage.StoragePoolStatus;
 import com.cloud.storage.dao.StoragePoolHostDao;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
 public class StoragePoolMonitorTest {
 
     private StorageManagerImpl storageManager;
@@ -45,9 +55,9 @@ public class StoragePoolMonitorTest {
 
     @Before
     public void setUp() throws Exception {
-        storageManager = Mockito.mock(StorageManagerImpl.class);
-        poolDao = Mockito.mock(PrimaryDataStoreDao.class);
-        storagePoolHostDao = Mockito.mock(StoragePoolHostDao.class);
+        storageManager = mock(StorageManagerImpl.class);
+        poolDao = mock(PrimaryDataStoreDao.class);
+        storagePoolHostDao = mock(StoragePoolHostDao.class);
 
         storagePoolMonitor = new StoragePoolMonitor(storageManager, poolDao, storagePoolHostDao, null);
         host = new HostVO("some-uuid");
@@ -62,21 +72,21 @@ public class StoragePoolMonitorTest {
 
     @Test
     public void testProcessConnectStoragePoolNormal() throws Exception {
-        HostVO hostMock = Mockito.mock(HostVO.class);
-        StartupRoutingCommand startupRoutingCommand = Mockito.mock(StartupRoutingCommand.class);
-        StoragePoolVO poolMock = Mockito.mock(StoragePoolVO.class);
-        Mockito.when(poolMock.getScope()).thenReturn(ScopeType.CLUSTER);
-        Mockito.when(poolMock.getStatus()).thenReturn(StoragePoolStatus.Up);
-        Mockito.when(poolMock.getId()).thenReturn(123L);
-        Mockito.when(poolMock.getPoolType()).thenReturn(Storage.StoragePoolType.Filesystem);
+        HostVO hostMock = mock(HostVO.class);
+        StartupRoutingCommand startupRoutingCommand = mock(StartupRoutingCommand.class);
+        StoragePoolVO poolMock = mock(StoragePoolVO.class);
+        Mockito.lenient().when(poolMock.getScope()).thenReturn(ScopeType.CLUSTER);
+        Mockito.lenient().when(poolMock.getStatus()).thenReturn(StoragePoolStatus.Up);
+        Mockito.lenient().when(poolMock.getId()).thenReturn(123L);
+        Mockito.lenient().when(poolMock.getPoolType()).thenReturn(Storage.StoragePoolType.Filesystem);
         Mockito.when(hostMock.getDataCenterId()).thenReturn(1L);
         Mockito.when(hostMock.getPodId()).thenReturn(1L);
         Mockito.when(hostMock.getClusterId()).thenReturn(1L);
         Mockito.when(startupRoutingCommand.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
-        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, null)).thenReturn(Collections.singletonList(pool));
-        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, null)).thenReturn(Collections.<StoragePoolVO>emptyList());
-        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, Hypervisor.HypervisorType.KVM)).thenReturn(Collections.<StoragePoolVO>emptyList());
-        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, Hypervisor.HypervisorType.Any)).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, null, StoragePoolStatus.Up)).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, null, StoragePoolStatus.Up)).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, Hypervisor.HypervisorType.KVM, StoragePoolStatus.Up)).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, Hypervisor.HypervisorType.Any, StoragePoolStatus.Up)).thenReturn(Collections.<StoragePoolVO>emptyList());
         Mockito.doReturn(true).when(storageManager).connectHostToSharedPool(hostMock, 123L);
 
         storagePoolMonitor.processConnect(hostMock, startupRoutingCommand, false);
@@ -87,11 +97,81 @@ public class StoragePoolMonitorTest {
 
     @Test
     public void testProcessConnectStoragePoolFailureOnHost() throws Exception {
-        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
-        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class), Mockito.anyBoolean())).thenReturn(Collections.<StoragePoolVO>emptyList());
-        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
-        Mockito.doThrow(new StorageUnavailableException("unable to mount storage", 123L)).when(storageManager).connectHostToSharedPool(Mockito.any(), Mockito.anyLong());
+        Mockito.lenient().when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.lenient().when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class), Mockito.anyBoolean())).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.lenient().when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.lenient().doThrow(new StorageUnavailableException("unable to mount storage", 123L)).when(storageManager).connectHostToSharedPool(Mockito.any(), Mockito.anyLong());
 
         storagePoolMonitor.processConnect(host, cmd, false);
+    }
+
+    @Test
+    public void testProcessConnectWithMountDisabledStoragePoolEnabled() throws Exception {
+        StoragePoolVO disabledZonePool = new StoragePoolVO();
+        disabledZonePool.setId(200L);
+        disabledZonePool.setScope(ScopeType.ZONE);
+        disabledZonePool.setStatus(StoragePoolStatus.Disabled);
+        disabledZonePool.setPoolType(Storage.StoragePoolType.NetworkFilesystem);
+
+        StoragePoolVO disabledClusterPool = new StoragePoolVO();
+        disabledClusterPool.setId(201L);
+        disabledClusterPool.setScope(ScopeType.CLUSTER);
+        disabledClusterPool.setStatus(StoragePoolStatus.Disabled);
+        disabledClusterPool.setPoolType(Storage.StoragePoolType.NetworkFilesystem);
+        HostVO hostMock = mock(HostVO.class);
+        StartupRoutingCommand startupRoutingCommand = mock(StartupRoutingCommand.class);
+        Mockito.when(hostMock.getDataCenterId()).thenReturn(1L);
+        Mockito.when(hostMock.getPodId()).thenReturn(1L);
+        Mockito.when(hostMock.getClusterId()).thenReturn(1L);
+        Mockito.when(hostMock.getId()).thenReturn(1L);
+        Mockito.when(startupRoutingCommand.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+
+        try (MockedStatic<StorageManager> storageManagerMockedStatic = Mockito.mockStatic(StorageManager.class)) {
+            ConfigKey<Boolean> mockConfigKey = mock(ConfigKey.class);
+            Mockito.when(mockConfigKey.value()).thenReturn(true);
+            Mockito.when(mockConfigKey.valueIn(1L)).thenReturn(true);
+
+            storageManagerMockedStatic.when(StorageManager::getMountDisabledStoragePool).thenReturn(mockConfigKey);
+
+            Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, null, StoragePoolStatus.Up))
+                    .thenReturn(new ArrayList<>());
+            Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, null, StoragePoolStatus.Up))
+                    .thenReturn(new ArrayList<>());
+            Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, Hypervisor.HypervisorType.KVM, StoragePoolStatus.Up))
+                    .thenReturn(new ArrayList<>());
+            Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, Hypervisor.HypervisorType.Any, StoragePoolStatus.Up))
+                    .thenReturn(new ArrayList<>());
+
+            List<StoragePoolVO> zoneDisabledPoolsBySAG = new ArrayList<>();
+            zoneDisabledPoolsBySAG.add(disabledZonePool);
+            Mockito.when(poolDao.findDisabledPoolsByScopeAndAccessGroups(1L, null, null, ScopeType.ZONE, new String[0]))
+                    .thenReturn(zoneDisabledPoolsBySAG);
+            Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, null, StoragePoolStatus.Disabled))
+                    .thenReturn(new ArrayList<>());
+
+            List<StoragePoolVO> clusterDisabledPoolsBySAG = new ArrayList<>();
+            clusterDisabledPoolsBySAG.add(disabledClusterPool);
+            Mockito.when(poolDao.findDisabledPoolsByScopeAndAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, new String[0]))
+                    .thenReturn(clusterDisabledPoolsBySAG);
+            Mockito.when(poolDao.findStoragePoolsByEmptyStorageAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, null, StoragePoolStatus.Disabled))
+                    .thenReturn(new ArrayList<>());
+
+            Mockito.when(storageManager.getStorageAccessGroups(null, null, null, 1L)).thenReturn(new String[0]);
+            Mockito.when(storageManager.findStoragePoolsConnectedToHost(1L)).thenReturn(Collections.emptyList());
+            Mockito.doReturn(true).when(storageManager).connectHostToSharedPool(hostMock, 200L);
+            Mockito.doReturn(true).when(storageManager).connectHostToSharedPool(hostMock, 201L);
+
+            storagePoolMonitor.processConnect(hostMock, startupRoutingCommand, false);
+
+            Mockito.verify(poolDao, Mockito.times(1)).findDisabledPoolsByScopeAndAccessGroups(1L, null, null, ScopeType.ZONE, new String[0]);
+            Mockito.verify(poolDao, Mockito.times(1)).findStoragePoolsByEmptyStorageAccessGroups(1L, null, null, ScopeType.ZONE, null, StoragePoolStatus.Disabled);
+            Mockito.verify(poolDao, Mockito.times(1)).findDisabledPoolsByScopeAndAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, new String[0]);
+            Mockito.verify(poolDao, Mockito.times(1)).findStoragePoolsByEmptyStorageAccessGroups(1L, 1L, 1L, ScopeType.CLUSTER, null, StoragePoolStatus.Disabled);
+
+            Mockito.verify(storageManager, Mockito.times(1)).connectHostToSharedPool(Mockito.eq(hostMock), Mockito.eq(200L));
+            Mockito.verify(storageManager, Mockito.times(1)).connectHostToSharedPool(Mockito.eq(hostMock), Mockito.eq(201L));
+            Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(Mockito.eq(200L));
+            Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(Mockito.eq(201L));
+        }
     }
 }


### PR DESCRIPTION
### Description

The PR addresses the following issue:

During host connect process, management server chooses which storage pool to connect to, using storage pool scope (CLUSTER or ZONE) and storage access group (tags). In the scenario where configuration `mount.disabled.storage.pool` is ON, the behaviour is different/buggy.

- Connect to storage pools in UP state which satisfy the storage access group filter.
- Connect to all storage pools which are in DISABLED state - storage access group filter is not applied here.

The above edge case with the below changes are handled when the config `mount.disabled.storage.pool` is ON:
- Logic for connecting to storage pools in UP state is unchanged.
- Filter storage pools by Disabled State and Storage Access Groups before connecting.

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Scenarios:

1. **mount.disabled.storage.pool is OFF:**
   - Same behaviour as before. Nothing has been changed.

2. **mount.disabled.storage.pool is ON and storage access group of host is "group1":**
   - The host would connect to all groups that it would have connected to if config `mount.disabled.storage.pool` was OFF. Additionally, the host would connect to all storage pools in Disabled state with the below filters:
     - Storage pools with empty storage access groups OR
     - Storage pools with "group1" storage access group.

3. **mount.disabled.storage.pool is ON and storage access group of host is empty:**
   - The host would connect to all groups that it would have connected to if config `mount.disabled.storage.pool` was OFF. Additionally, the host would connect to all storage pools in Disabled state with the below filters:
     - Storage pools with empty storage access groups.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
