### PR TITLE
fix: use auth_client_required instead of removed auth_supported for RBD

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java
@@ -54,9 +54,9 @@ public class KVMPhysicalDisk {
         rbdOpts += ":mon_host=" + composeOptionForMonHosts(monHost, monPort);
 
         if (authUserName == null) {
-            rbdOpts += ":auth_supported=none";
+            rbdOpts += ":auth_client_required=none";
         } else {
-            rbdOpts += ":auth_supported=cephx";
+            rbdOpts += ":auth_client_required=cephx";
             rbdOpts += ":id=" + authUserName;
             rbdOpts += ":key=" + authSecret;
         }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java
@@ -44,7 +44,7 @@ public class KVMPhysicalDiskTest {
         Mockito.doReturn(authUserName).when(kvmStoragePoolMock).getAuthUserName();
         Mockito.doReturn(authSecret).when(kvmStoragePoolMock).getAuthSecret();
 
-        String expected = "rbd:volume1:mon_host=ceph-monitor\\:8000:auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
+        String expected = "rbd:volume1:mon_host=ceph-monitor\\:8000:auth_client_required=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
         String result = KVMPhysicalDisk.RBDStringBuilder(kvmStoragePoolMock, "volume1");
 
         Assert.assertEquals(expected, result);
@@ -62,7 +62,7 @@ public class KVMPhysicalDiskTest {
 
         String expected = "rbd:volume1:" +
                 "mon_host=ceph-monitor1\\:3300\\;ceph-monitor2\\:3300\\;ceph-monitor3\\:3300:" +
-                "auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
+                "auth_client_required=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
         String actualResult = KVMPhysicalDisk.RBDStringBuilder(kvmStoragePoolMock, "volume1");
 
         Assert.assertEquals(expected, actualResult);
@@ -80,7 +80,7 @@ public class KVMPhysicalDiskTest {
 
         String expected = "rbd:volume1:" +
                 "mon_host=[fc00\\:1234\\:\\:1]\\:3300\\;[fc00\\:1234\\:\\:2]\\:3300\\;[fc00\\:1234\\:\\:3]\\:3300:" +
-                "auth_supported=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
+                "auth_client_required=cephx:id=admin:key=supersecret:rbd_default_format=2:client_mount_timeout=30";
         String actualResult = KVMPhysicalDisk.RBDStringBuilder(kvmStoragePoolMock, "volume1");
 
         Assert.assertEquals(expected, actualResult);


### PR DESCRIPTION
Fixes #13989

### Problem
CloudStack builds its RBD connection strings with the legacy Ceph option `auth_supported=cephx` (or `auth_supported=none` when no auth user is configured). This option was removed in Ceph Tentacle 20.2.4. As a result, every RBD operation performed by the KVM agent through librados fails:

```
agent.err: libvirt: Storage Driver error : internal error: failed to set RADOS option: auth_supported
agent.log: Failed to create RBD storage pool: org.libvirt.LibvirtException
```

### Root cause
`KVMPhysicalDisk.RBDStringBuilder` emits `auth_supported` in the RBD URI string passed to qemu/librados. Modern librados no longer accepts this option name.

### Fix
Replace `auth_supported` with `auth_client_required` (values `cephx`/`none`) — the modern option used by the qemu rbd driver (`block/rbd.c` calls `rados_conf_set(cluster, "auth_client_required", ...)`) and accepted by current Ceph releases. The qemu `RbdAuthMode` enum only supports `cephx` and `none`, matching the existing branches.

### Changes
- `plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDisk.java`: emit `auth_client_required=cephx` / `auth_client_required=none`
- `plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/storage/KVMPhysicalDiskTest.java`: update 3 assertions to expect `auth_client_required=cephx`