### PR TITLE
github: skip Copilot reviews for draft PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -74,7 +74,7 @@ github:
 
   copilot_code_review:
     enabled: true
-    review_drafts: true
+    review_drafts: false
     review_on_push: true
 
 notifications:


### PR DESCRIPTION
## Summary

Disable automatic GitHub Copilot code reviews for **draft** pull requests while keeping automatic review enabled once a PR is ready for review and on subsequent pushes.

## Rationale

A draft PR explicitly represents work that is not yet ready for review. Contributors may use drafts as an incremental remote workspace and push many incomplete commits while developing or testing a change. Running Copilot review on the initial draft and on every push during that phase creates review noise and consumes AI/Actions resources before the author has requested review.

This keeps the useful automatic review behaviour for PRs that are ready for review, including re-review after later pushes.

## Change

```yaml
copilot_code_review:
  enabled: true
  review_drafts: false
  review_on_push: true
```

## Testing

Configuration-only change. Verified the resulting YAML diff changes only `review_drafts` from `true` to `false`.
