### PR TITLE
linstor: grow cloned volumes inside the clone to fix resize race with BalanceAfterClone

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -251,7 +251,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
 
         try
         {
-            ApiCallRcList answers = linstorApi.resourceSnapshotDelete(rscDefName, snapshotName, Collections.emptyList());
+            ApiCallRcList answers = linstorApi.resourceSnapshotDelete(rscDefName, snapshotName, Collections.emptyList(), null);
             if (answers.hasError())
             {
                 for (ApiCallRc answer : answers)

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImpl.java
@@ -403,6 +403,29 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
         }
     }
 
+    /**
+     * Request the target size as part of the clone if the controller supports it.
+     *
+     * A clone reports COMPLETE as soon as every replica can access UpToDate data, which with
+     * Clone/BalanceAfterClone is while the additional replica is still syncing. A resize issued at that
+     * point is rejected with "Cannot resize volume, because we have a non-UpToDate DRBD device".
+     * Controllers with REST API 1.29.1+ take the size in the clone request and grow the volume inside the
+     * clone before the balance placement, so the race cannot occur. Older controllers keep the
+     * clone-then-resize sequence.
+     *
+     * @return true if the caller still has to resize the resource after the clone finished
+     */
+    static boolean applyCloneSize(DevelopersApi api, ResourceDefinitionCloneRequest cloneRequest, Long sizeByte) {
+        if (sizeByte == null || sizeByte <= 0) {
+            return false;
+        }
+        if (LinstorUtil.supportsCloneVolumeSizes(api)) {
+            cloneRequest.setVolumeSizes(Collections.singletonList(sizeByte / 1024));
+            return false;
+        }
+        return true;
+    }
+
     private String cloneResource(long csCloneId, VolumeInfo volumeInfo, StoragePoolVO storagePoolVO) {
         // get the cached template on this storage
         VMTemplateStoragePoolVO tmplPoolRef = _vmTemplatePoolDao.findByPoolTemplate(
@@ -436,6 +459,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
                         cloneRequest.setVolumePassphrases(Collections.singletonList(utf8Passphrase));
                     }
                 }
+                final boolean resizeAfterClone = applyCloneSize(linstorApi, cloneRequest, volumeInfo.getSize());
                 ResourceDefinitionCloneStarted cloneStarted = linstorApi.resourceDefinitionClone(
                     cloneRes, cloneRequest);
 
@@ -447,7 +471,7 @@ public class LinstorPrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver
 
                 logger.info("Clone resource definition " + cloneRes + " to " + rscName + " finished");
 
-                if (volumeInfo.getSize() != null && volumeInfo.getSize() > 0) {
+                if (resizeAfterClone) {
                     resizeResource(linstorApi, rscName, volumeInfo.getSize());
                 }
 

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -101,6 +101,50 @@ public class LinstorUtil {
         return new DevelopersApi(client);
     }
 
+    /**
+     * The REST API version of the connected controller, e.g. "1.29.1", or null if it could not be queried.
+     */
+    @Nullable
+    public static String getRestApiVersion(DevelopersApi api) {
+        try {
+            return api.controllerVersion().getRestApiVersion();
+        } catch (ApiException apiExc) {
+            LOGGER.warn("Unable to query controller API version: {}", apiExc.getBestMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Check if the connected controller accepts volume_sizes on a resource-definition clone request
+     * (REST API 1.29.1, LINSTOR 1.35.0). With it the grow happens inside the clone, before an optional
+     * Clone/BalanceAfterClone placement, so it cannot race the balance replica's sync.
+     */
+    public static boolean supportsCloneVolumeSizes(DevelopersApi api) {
+        return isVersionAtLeast(getRestApiVersion(api), 1, 29, 1);
+    }
+
+    static boolean isVersionAtLeast(String version, int major, int minor, int patch) {
+        if (version == null || version.isEmpty()) {
+            return false;
+        }
+        String[] parts = version.split("\\.");
+        try {
+            int maj = Integer.parseInt(parts[0]);
+            int min = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            int pat = parts.length > 2 ? Integer.parseInt(parts[2]) : 0;
+            if (maj != major) {
+                return maj > major;
+            }
+            if (min != minor) {
+                return min > minor;
+            }
+            return pat >= patch;
+        } catch (NumberFormatException nfExc) {
+            LOGGER.warn("Unable to parse controller API version '{}'", version);
+            return false;
+        }
+    }
+
     public static String getBestErrorMessage(ApiCallRcList answers) {
         return answers != null && !answers.isEmpty() ?
             answers.stream()

--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/snapshot/LinstorVMSnapshotStrategy.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/snapshot/LinstorVMSnapshotStrategy.java
@@ -214,7 +214,7 @@ public class LinstorVMSnapshotStrategy extends DefaultVMSnapshotStrategy {
     private String linstorDeleteSnapshot(final DevelopersApi api, final String rscName, final String snapshotName) {
         String resultMsg = null;
         try {
-            ApiCallRcList answers = api.resourceSnapshotDelete(rscName, snapshotName, Collections.emptyList());
+            ApiCallRcList answers = api.resourceSnapshotDelete(rscName, snapshotName, Collections.emptyList(), null);
             if (answers.hasError()) {
                 resultMsg = LinstorUtil.getBestErrorMessage(answers);
             }

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImplTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/driver/LinstorPrimaryDataStoreDriverImplTest.java
@@ -19,7 +19,9 @@ package org.apache.cloudstack.storage.datastore.driver;
 import com.linbit.linstor.api.ApiException;
 import com.linbit.linstor.api.DevelopersApi;
 import com.linbit.linstor.api.model.AutoSelectFilter;
+import com.linbit.linstor.api.model.ControllerVersion;
 import com.linbit.linstor.api.model.LayerType;
+import com.linbit.linstor.api.model.ResourceDefinitionCloneRequest;
 import com.linbit.linstor.api.model.ResourceGroup;
 
 import java.util.Arrays;
@@ -35,6 +37,8 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -84,5 +88,46 @@ public class LinstorPrimaryDataStoreDriverImplTest {
 
         layers = LinstorUtil.getEncryptedLayerList(api, "EncryptedGrp");
         Assert.assertEquals(Arrays.asList(LayerType.DRBD, LayerType.LUKS, LayerType.STORAGE), layers);
+    }
+
+    private DevelopersApi mockApiWithRestVersion(String restApiVersion) throws ApiException {
+        DevelopersApi apiMock = mock(DevelopersApi.class);
+        ControllerVersion version = new ControllerVersion();
+        version.setRestApiVersion(restApiVersion);
+        when(apiMock.controllerVersion()).thenReturn(version);
+        return apiMock;
+    }
+
+    @Test
+    public void testApplyCloneSizeNewController() throws ApiException {
+        DevelopersApi newCtrl = mockApiWithRestVersion("1.29.1");
+        ResourceDefinitionCloneRequest req = new ResourceDefinitionCloneRequest();
+
+        boolean resizeAfter = LinstorPrimaryDataStoreDriverImpl.applyCloneSize(newCtrl, req, 40L * 1024 * 1024 * 1024);
+
+        Assert.assertFalse(resizeAfter);
+        Assert.assertEquals(Collections.singletonList(40L * 1024 * 1024), req.getVolumeSizes());
+    }
+
+    @Test
+    public void testApplyCloneSizeOldController() throws ApiException {
+        DevelopersApi oldCtrl = mockApiWithRestVersion("1.28.0");
+        ResourceDefinitionCloneRequest req = new ResourceDefinitionCloneRequest();
+
+        boolean resizeAfter = LinstorPrimaryDataStoreDriverImpl.applyCloneSize(oldCtrl, req, 40L * 1024 * 1024 * 1024);
+
+        Assert.assertTrue(resizeAfter);
+        Assert.assertNull(req.getVolumeSizes());
+    }
+
+    @Test
+    public void testApplyCloneSizeWithoutSize() throws ApiException {
+        DevelopersApi newCtrl = mockApiWithRestVersion("1.29.1");
+        ResourceDefinitionCloneRequest req = new ResourceDefinitionCloneRequest();
+
+        Assert.assertFalse(LinstorPrimaryDataStoreDriverImpl.applyCloneSize(newCtrl, req, null));
+        Assert.assertFalse(LinstorPrimaryDataStoreDriverImpl.applyCloneSize(newCtrl, req, 0L));
+        Assert.assertNull(req.getVolumeSizes());
+        verify(newCtrl, never()).controllerVersion();
     }
 }

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.storage.datastore.util;
 import com.linbit.linstor.api.ApiException;
 import com.linbit.linstor.api.DevelopersApi;
 import com.linbit.linstor.api.model.AutoSelectFilter;
+import com.linbit.linstor.api.model.ControllerVersion;
 import com.linbit.linstor.api.model.Node;
 import com.linbit.linstor.api.model.Properties;
 import com.linbit.linstor.api.model.ProviderKind;
@@ -123,5 +124,58 @@ public class LinstorUtilTest {
                 .map(sp -> String.format("%s::%s", sp.getNodeName(), sp.getStoragePoolName()))
                 .collect(Collectors.toList());
         Assert.assertEquals(names, Arrays.asList("nodeA::thinpool", "nodeB::thinpool", "nodeC::thinpool"));
+    }
+
+    @Test
+    public void testIsVersionAtLeast() {
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.29.1", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.29.2", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.30.0", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("2.0.0", 1, 29, 1));
+        Assert.assertTrue(LinstorUtil.isVersionAtLeast("1.30", 1, 29, 1));
+
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("1.29.0", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("1.29", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("1.28.5", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("0.99.9", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast(null, 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("", 1, 29, 1));
+        Assert.assertFalse(LinstorUtil.isVersionAtLeast("garbage", 1, 29, 1));
+    }
+
+    private DevelopersApi mockApi() {
+        return mock(DevelopersApi.class);
+    }
+
+    private ControllerVersion controllerVersion(String restApiVersion) {
+        ControllerVersion version = new ControllerVersion();
+        version.setRestApiVersion(restApiVersion);
+        return version;
+    }
+
+    @Test
+    public void testGetRestApiVersion() throws ApiException {
+        DevelopersApi ctrl = mockApi();
+        when(ctrl.controllerVersion()).thenReturn(controllerVersion("1.29.1"));
+        Assert.assertEquals("1.29.1", LinstorUtil.getRestApiVersion(ctrl));
+
+        DevelopersApi down = mockApi();
+        when(down.controllerVersion()).thenThrow(new ApiException(503, "unavailable"));
+        Assert.assertNull(LinstorUtil.getRestApiVersion(down));
+    }
+
+    @Test
+    public void testSupportsCloneVolumeSizes() throws ApiException {
+        DevelopersApi newCtrl = mockApi();
+        when(newCtrl.controllerVersion()).thenReturn(controllerVersion("1.29.1"));
+        Assert.assertTrue(LinstorUtil.supportsCloneVolumeSizes(newCtrl));
+
+        DevelopersApi oldCtrl = mockApi();
+        when(oldCtrl.controllerVersion()).thenReturn(controllerVersion("1.29.0"));
+        Assert.assertFalse(LinstorUtil.supportsCloneVolumeSizes(oldCtrl));
+
+        DevelopersApi unreachable = mockApi();
+        when(unreachable.controllerVersion()).thenThrow(new ApiException(503, "unavailable"));
+        Assert.assertFalse(LinstorUtil.supportsCloneVolumeSizes(unreachable));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <cs.nitro.version>10.1</cs.nitro.version>
         <cs.opensaml.version>2.6.6</cs.opensaml.version>
         <cs.rados-java.version>0.6.0</cs.rados-java.version>
-        <cs.java-linstor.version>0.7.0</cs.java-linstor.version>
+        <cs.java-linstor.version>0.8.1</cs.java-linstor.version>
         <cs.reflections.version>0.10.2</cs.reflections.version>
         <cs.servicemix.version>3.4.4_1</cs.servicemix.version>
         <cs.servlet.version>4.0.1</cs.servlet.version>

--- a/test/integration/plugins/linstor/test_linstor_volumes.py
+++ b/test/integration/plugins/linstor/test_linstor_volumes.py
@@ -857,7 +857,10 @@ class TestLinstorVolumes(cloudstackTestCase):
         # STEP 3: Reboot VM with detached vol #
         #######################################
 
-        self.virtual_machine.reboot(self.apiClient)
+        # via the helper, which waits for the guest to come back: CloudStack reports
+        # Running as soon as the domain exists, so leaving it un-awaited lets the next
+        # test attach and detach a volume against a guest that has not enumerated it yet
+        TestLinstorVolumes._reboot_vm(self.virtual_machine)
 
         vm = self._get_vm(self.virtual_machine.id)
 


### PR DESCRIPTION
### Description

This PR fixes deploying a VM on LINSTOR primary storage with a root disk larger than its template
when the LINSTOR resource group has `Clone/BalanceAfterClone=true`.

The plugin created such a volume as: clone the template resource-definition, wait for the clone
to report COMPLETE, then `volumeDefinitionModify` to the requested size. LINSTOR reports a clone
COMPLETE as soon as every replica can access UpToDate data - with BalanceAfterClone that is
while the additional balance replica is still syncing - and the resize is rejected because it
requires all diskful replicas to be UpToDate:

```
Linstor: ApiEx - [{"ret_code":-4611686018390686770,
  "message":"Cannot resize volume, because we have a non-UpToDate DRBD device.", ...}]
```

The deploy then fails with a bare `errorcode 530 Unable to orchestrate the start of VM instance`
and the instance is left in Error state. Waiting client-side is not an option, it would block the
deploy for the whole initial sync of the template size.

LINSTOR 1.35.0 (REST API 1.29.1) accepts `volume_sizes` on the clone request and grows the
cloned volume inside the clone, before the balance placement. The plugin now checks the
controller's REST API version, passes the size in the clone request on >= 1.29.1 and skips the
post-clone resize; older controllers keep the previous clone-then-resize sequence unchanged.

java-linstor is updated to 0.8.1 for the new request field; `resourceSnapshotDelete` gained an
optional `delete_empty_resource_definition` parameter which is passed as `null`.

Also includes a small marvin fix: `test_07_detach_volume_reboot_vm` used the bare `reboot()`
instead of the `_reboot_vm` helper that waits for the guest, which made `test_08` detach a volume
from a guest that had not enumerated it yet when a fast-booting template is used.
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Unit tests for the version comparison, the version probe and the clone-size decision
(`LinstorUtilTest`, `LinstorPrimaryDataStoreDriverImplTest`).

3-node KVM cluster, LINSTOR primary storage (LVM-thin, place-count 2):

- LINSTOR 1.34.2 (REST API 1.29.0): `test_linstor_volumes.py` and `test_linstor_encrypted_snapshots.py`
  pass (18/18), the log shows the unchanged clone-then-resize sequence.
- LINSTOR 1.35.0 (REST API 1.29.1) with `Clone/BalanceAfterClone=true` on the resource group:
  deploying VMs with `rootdisksize` larger than the template (512 MiB template, 12/16/20 GiB
  root disks, several in parallel) succeeds every time. No resize call in the log, the
  volume-definition has the requested size and the balance replica is still SyncTarget while the
  VM is already running - the state in which the previous code failed.

Before the fix, on the same cluster with `Clone/BalanceAfterClone=true`, 9/9 such deploys failed
with the error above.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

- Old controller (1.34.2): fallback path is the previous sequence, `volume_sizes` is never sent.
- Controller unreachable during the version probe: falls back to clone-then-resize, the clone
  then fails with the controller's error as before.
- Several deploys in parallel while balance replicas were syncing.
- Size equal to the template size (no-op in LINSTOR), smaller sizes are rejected at clone start
  and CloudStack enforces root size >= template size anyway.
- Version strings with two/three components, empty and garbage input.
<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
